### PR TITLE
Rebalances ancient station, fixes Ancient Engineer occupation populator

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/HardsuitHelmets/PrototypeRIGHardsuitHelmet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/HardsuitHelmets/PrototypeRIGHardsuitHelmet.prefab
@@ -14,6 +14,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2352077745602750771, guid: c60440956ff96af4b84ba3e95e41c3e0,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2352077745602750771, guid: c60440956ff96af4b84ba3e95e41c3e0,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -29,6 +34,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2352077745602750771, guid: c60440956ff96af4b84ba3e95e41c3e0,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2352077745602750771, guid: c60440956ff96af4b84ba3e95e41c3e0,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -41,16 +51,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2352077745602750771, guid: c60440956ff96af4b84ba3e95e41c3e0,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2352077745602750771, guid: c60440956ff96af4b84ba3e95e41c3e0,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2352077745602750771, guid: c60440956ff96af4b84ba3e95e41c3e0,
         type: 3}
@@ -79,23 +79,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2390410913328498099, guid: c60440956ff96af4b84ba3e95e41c3e0,
         type: 3}
-      propertyPath: Resistances.FireProof
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2390410913328498099, guid: c60440956ff96af4b84ba3e95e41c3e0,
-        type: 3}
-      propertyPath: Armor.Melee
-      value: 30
-      objectReference: {fileID: 0}
-    - target: {fileID: 2390410913328498099, guid: c60440956ff96af4b84ba3e95e41c3e0,
-        type: 3}
-      propertyPath: Armor.Energy
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 2390410913328498099, guid: c60440956ff96af4b84ba3e95e41c3e0,
-        type: 3}
-      propertyPath: Armor.Laser
-      value: 5
+      propertyPath: Armor.Rad
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 2390410913328498099, guid: c60440956ff96af4b84ba3e95e41c3e0,
         type: 3}
@@ -104,13 +89,33 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2390410913328498099, guid: c60440956ff96af4b84ba3e95e41c3e0,
         type: 3}
-      propertyPath: Armor.Rad
+      propertyPath: Armor.Fire
       value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 2390410913328498099, guid: c60440956ff96af4b84ba3e95e41c3e0,
         type: 3}
-      propertyPath: Armor.Fire
-      value: 100
+      propertyPath: Armor.Laser
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2390410913328498099, guid: c60440956ff96af4b84ba3e95e41c3e0,
+        type: 3}
+      propertyPath: Armor.Melee
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 2390410913328498099, guid: c60440956ff96af4b84ba3e95e41c3e0,
+        type: 3}
+      propertyPath: Armor.Bullet
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2390410913328498099, guid: c60440956ff96af4b84ba3e95e41c3e0,
+        type: 3}
+      propertyPath: Armor.Energy
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 2390410913328498099, guid: c60440956ff96af4b84ba3e95e41c3e0,
+        type: 3}
+      propertyPath: Resistances.FireProof
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2469720285121718043, guid: c60440956ff96af4b84ba3e95e41c3e0,
         type: 3}
@@ -120,27 +125,27 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 2760341733104991204, guid: c60440956ff96af4b84ba3e95e41c3e0,
         type: 3}
-      propertyPath: toggleSprites.Array.data[1]
-      value: 
-      objectReference: {fileID: 21300000, guid: c437e383e8323b24fadbf4aad6ffff1a,
-        type: 3}
-    - target: {fileID: 2760341733104991204, guid: c60440956ff96af4b84ba3e95e41c3e0,
-        type: 3}
       propertyPath: toggleSprites.Array.data[0]
       value: 
       objectReference: {fileID: 21300000, guid: fd17e85d41effb3459a2f2fab7084414,
         type: 3}
+    - target: {fileID: 2760341733104991204, guid: c60440956ff96af4b84ba3e95e41c3e0,
+        type: 3}
+      propertyPath: toggleSprites.Array.data[1]
+      value: 
+      objectReference: {fileID: 21300000, guid: c437e383e8323b24fadbf4aad6ffff1a,
+        type: 3}
+    - target: {fileID: 2763621013712894757, guid: c60440956ff96af4b84ba3e95e41c3e0,
+        type: 3}
+      propertyPath: initialName
+      value: prototype RIG hardsuit helmet
+      objectReference: {fileID: 0}
     - target: {fileID: 2763621013712894757, guid: c60440956ff96af4b84ba3e95e41c3e0,
         type: 3}
       propertyPath: initialDescription
       value: Early prototype RIG hardsuit helmet, designed to quickly shift over
         a user's head. Design constraints of the helmet mean it has no inbuilt cameras,
         thus it restricts the users visability.
-      objectReference: {fileID: 0}
-    - target: {fileID: 2763621013712894757, guid: c60440956ff96af4b84ba3e95e41c3e0,
-        type: 3}
-      propertyPath: initialName
-      value: prototype RIG hardsuit helmet
       objectReference: {fileID: 0}
     - target: {fileID: 2932610463863930541, guid: c60440956ff96af4b84ba3e95e41c3e0,
         type: 3}
@@ -164,15 +169,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8498819338256920512, guid: c60440956ff96af4b84ba3e95e41c3e0,
         type: 3}
-      propertyPath: SubCatalogue.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8498819338256920512, guid: c60440956ff96af4b84ba3e95e41c3e0,
-        type: 3}
       propertyPath: PresentSpriteSet
       value: 
       objectReference: {fileID: 11400000, guid: 1b5c09bba108a8a41891a8a57ee980ae,
         type: 2}
+    - target: {fileID: 8498819338256920512, guid: c60440956ff96af4b84ba3e95e41c3e0,
+        type: 3}
+      propertyPath: SubCatalogue.Array.size
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 8498819338256920512, guid: c60440956ff96af4b84ba3e95e41c3e0,
         type: 3}
       propertyPath: SubCatalogue.Array.data[0]

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/SpaceSuits/Hardsuits/PrototypeRIGHardsuit.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/SpaceSuits/Hardsuits/PrototypeRIGHardsuit.prefab
@@ -22,12 +22,17 @@ PrefabInstance:
     - target: {fileID: 4120428031018886343, guid: 5da2eb22d55c9c045bd7c22925c9b948,
         type: 3}
       propertyPath: runningSpeedDebuff
-      value: 3
+      value: 2.5
       objectReference: {fileID: 0}
     - target: {fileID: 8702110326122445511, guid: 5da2eb22d55c9c045bd7c22925c9b948,
         type: 3}
       propertyPath: m_Name
       value: PrototypeRIGHardsuit
+      objectReference: {fileID: 0}
+    - target: {fileID: 8707596752211740595, guid: 5da2eb22d55c9c045bd7c22925c9b948,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8707596752211740595, guid: 5da2eb22d55c9c045bd7c22925c9b948,
         type: 3}
@@ -46,6 +51,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8707596752211740595, guid: 5da2eb22d55c9c045bd7c22925c9b948,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8707596752211740595, guid: 5da2eb22d55c9c045bd7c22925c9b948,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -58,16 +68,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8707596752211740595, guid: 5da2eb22d55c9c045bd7c22925c9b948,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8707596752211740595, guid: 5da2eb22d55c9c045bd7c22925c9b948,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8707596752211740595, guid: 5da2eb22d55c9c045bd7c22925c9b948,
         type: 3}
@@ -91,23 +91,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8745895010437983027, guid: 5da2eb22d55c9c045bd7c22925c9b948,
         type: 3}
-      propertyPath: Resistances.FireProof
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8745895010437983027, guid: 5da2eb22d55c9c045bd7c22925c9b948,
-        type: 3}
-      propertyPath: Armor.Melee
-      value: 30
-      objectReference: {fileID: 0}
-    - target: {fileID: 8745895010437983027, guid: 5da2eb22d55c9c045bd7c22925c9b948,
-        type: 3}
-      propertyPath: Armor.Laser
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8745895010437983027, guid: 5da2eb22d55c9c045bd7c22925c9b948,
-        type: 3}
-      propertyPath: Armor.Energy
-      value: 15
+      propertyPath: Armor.Rad
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 8745895010437983027, guid: 5da2eb22d55c9c045bd7c22925c9b948,
         type: 3}
@@ -116,13 +101,33 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8745895010437983027, guid: 5da2eb22d55c9c045bd7c22925c9b948,
         type: 3}
-      propertyPath: Armor.Rad
+      propertyPath: Armor.Fire
       value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 8745895010437983027, guid: 5da2eb22d55c9c045bd7c22925c9b948,
         type: 3}
-      propertyPath: Armor.Fire
-      value: 100
+      propertyPath: Armor.Laser
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745895010437983027, guid: 5da2eb22d55c9c045bd7c22925c9b948,
+        type: 3}
+      propertyPath: Armor.Melee
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745895010437983027, guid: 5da2eb22d55c9c045bd7c22925c9b948,
+        type: 3}
+      propertyPath: Armor.Bullet
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745895010437983027, guid: 5da2eb22d55c9c045bd7c22925c9b948,
+        type: 3}
+      propertyPath: Armor.Energy
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 8745895010437983027, guid: 5da2eb22d55c9c045bd7c22925c9b948,
+        type: 3}
+      propertyPath: Resistances.FireProof
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8806207020331714971, guid: 5da2eb22d55c9c045bd7c22925c9b948,
         type: 3}
@@ -132,15 +137,15 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 9090939745550505381, guid: 5da2eb22d55c9c045bd7c22925c9b948,
         type: 3}
+      propertyPath: initialName
+      value: prototype RIG hardsuit
+      objectReference: {fileID: 0}
+    - target: {fileID: 9090939745550505381, guid: 5da2eb22d55c9c045bd7c22925c9b948,
+        type: 3}
       propertyPath: initialDescription
       value: Prototype powered RIG hardsuit. Provides excellent protection from the
         elements of space while being comfortable to move around in, thanks to the
         powered locomotives. Remains very bulky however.
-      objectReference: {fileID: 0}
-    - target: {fileID: 9090939745550505381, guid: 5da2eb22d55c9c045bd7c22925c9b948,
-        type: 3}
-      propertyPath: initialName
-      value: prototype RIG hardsuit
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5da2eb22d55c9c045bd7c22925c9b948, type: 3}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Occupations/GhostRole/AncientEngineer.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Occupations/GhostRole/AncientEngineer.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   jobType: 56
   isCrewmember: 0
   lateSpawnIsArrivals: 0
-  inventoryPopulator: {fileID: 11400000, guid: aeb66e4be690d4b7e9ca83169dc2871a, type: 2}
+  inventoryPopulator: {fileID: 11400000, guid: 391868f2028d39c4db6e084e224d12a1, type: 2}
   limit: 3
   priority: 1
   allowedAccess: 1a0000001e0000001f00000020000000220000003100000032000000

--- a/UnityProject/Assets/Scenes/AdditionalScenes/AncientStation.unity
+++ b/UnityProject/Assets/Scenes/AdditionalScenes/AncientStation.unity
@@ -740,7 +740,7 @@ PrefabInstance:
     - target: {fileID: 8342472905829387893, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: connectedDevices.Array.size
-      value: 24
+      value: 23
       objectReference: {fileID: 0}
     - target: {fileID: 8342472905829387893, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -35227,7 +35227,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: c39d19bba0ae67943a58040a898fdf54,
+      objectReference: {fileID: 21300000, guid: d04e66db37d051241af5586e1bdfff93,
         type: 3}
     - target: {fileID: 8568672687853555390, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
         type: 3}

--- a/UnityProject/Assets/Scenes/AdditionalScenes/AncientStation.unity
+++ b/UnityProject/Assets/Scenes/AdditionalScenes/AncientStation.unity
@@ -144,7 +144,7 @@ PrefabInstance:
     - target: {fileID: 3718085451752902353, guid: 160baf50e4a27c24a8c1f40b3232c886,
         type: 3}
       propertyPath: m_RootOrder
-      value: 124
+      value: 132
       objectReference: {fileID: 0}
     - target: {fileID: 3718085451752902353, guid: 160baf50e4a27c24a8c1f40b3232c886,
         type: 3}
@@ -219,7 +219,7 @@ PrefabInstance:
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 113
+      value: 121
       objectReference: {fileID: 0}
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
@@ -339,6 +339,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 114923609856049834, guid: 3fdd9b0cc7f8f344585d7ff27eb83dc6,
+        type: 3}
+      propertyPath: pushPullSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     - target: {fileID: 383125038757771000, guid: 3fdd9b0cc7f8f344585d7ff27eb83dc6,
         type: 3}
       propertyPath: sceneId
@@ -379,7 +384,7 @@ PrefabInstance:
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 166
+      value: 171
       objectReference: {fileID: 0}
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
@@ -444,6 +449,86 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 20932869}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &32248914
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 1739785981152468424, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: m_Name
+      value: Bed
+      objectReference: {fileID: 0}
+    - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 185
+      objectReference: {fileID: 0}
+    - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7924408911985682602, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: sceneId
+      value: 3531164646
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5a7af30c589b41a449d0ba74c9e1771c, type: 3}
+--- !u!4 &32248915 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+    type: 3}
+  m_PrefabInstance: {fileID: 32248914}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &34016904
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -457,7 +542,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 74
+      value: 79
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -525,7 +610,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4297268230046392, guid: 69c27c4a07b053d458c6fec363e66403, type: 3}
       propertyPath: m_RootOrder
-      value: 39
+      value: 41
       objectReference: {fileID: 0}
     - target: {fileID: 4297268230046392, guid: 69c27c4a07b053d458c6fec363e66403, type: 3}
       propertyPath: m_LocalPosition.x
@@ -590,7 +675,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 62
+      value: 67
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -776,7 +861,7 @@ PrefabInstance:
         type: 3}
       propertyPath: connectedDevices.Array.data[23]
       value: 
-      objectReference: {fileID: 217183662}
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cd57203a8d3f54f478446e9b0ced6cf9, type: 3}
 --- !u!4 &37847085 stripped
@@ -909,7 +994,7 @@ PrefabInstance:
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 112
+      value: 120
       objectReference: {fileID: 0}
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
@@ -984,7 +1069,7 @@ PrefabInstance:
     - target: {fileID: 2038054705163664627, guid: c9c8ffe7c5a0a044bbe8343e681e1fe2,
         type: 3}
       propertyPath: m_RootOrder
-      value: 146
+      value: 154
       objectReference: {fileID: 0}
     - target: {fileID: 2038054705163664627, guid: c9c8ffe7c5a0a044bbe8343e681e1fe2,
         type: 3}
@@ -1064,7 +1149,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 105
+      value: 110
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -1149,7 +1234,7 @@ PrefabInstance:
     - target: {fileID: 4462439672258080633, guid: c84a09f09199afb48b0d8a0c5c2a5bea,
         type: 3}
       propertyPath: m_RootOrder
-      value: 197
+      value: 214
       objectReference: {fileID: 0}
     - target: {fileID: 4462439672258080633, guid: c84a09f09199afb48b0d8a0c5c2a5bea,
         type: 3}
@@ -1293,7 +1378,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 93
+      value: 98
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -1392,7 +1477,7 @@ PrefabInstance:
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 115
+      value: 123
       objectReference: {fileID: 0}
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
@@ -1464,6 +1549,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1677431542}
     m_Modifications:
+    - target: {fileID: 1835757013911865864, guid: 99fa44696e5676a41bb345c085b3e768,
+        type: 3}
+      propertyPath: soundOnHit.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     - target: {fileID: 1925386106379506438, guid: 99fa44696e5676a41bb345c085b3e768,
         type: 3}
       propertyPath: m_RootOrder
@@ -1519,10 +1609,20 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2611605342679031968, guid: 99fa44696e5676a41bb345c085b3e768,
+        type: 3}
+      propertyPath: butcherSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     - target: {fileID: 3348285834374005981, guid: 99fa44696e5676a41bb345c085b3e768,
         type: 3}
       propertyPath: sceneId
       value: 2621248456
+      objectReference: {fileID: 0}
+    - target: {fileID: 4436606494572318361, guid: 99fa44696e5676a41bb345c085b3e768,
+        type: 3}
+      propertyPath: pushPullSound.AssetAddress
+      value: null
       objectReference: {fileID: 0}
     - target: {fileID: 7144248469089430455, guid: 99fa44696e5676a41bb345c085b3e768,
         type: 3}
@@ -1552,7 +1652,7 @@ PrefabInstance:
     - target: {fileID: 5035675889361153591, guid: 5f29a65f1a758eb4ca895615119e8ff7,
         type: 3}
       propertyPath: m_RootOrder
-      value: 155
+      value: 160
       objectReference: {fileID: 0}
     - target: {fileID: 5035675889361153591, guid: 5f29a65f1a758eb4ca895615119e8ff7,
         type: 3}
@@ -1632,7 +1732,7 @@ PrefabInstance:
     - target: {fileID: 728450015767604076, guid: af583b1807508a84cbd05b036e027d96,
         type: 3}
       propertyPath: m_RootOrder
-      value: 60
+      value: 65
       objectReference: {fileID: 0}
     - target: {fileID: 728450015767604076, guid: af583b1807508a84cbd05b036e027d96,
         type: 3}
@@ -1717,7 +1817,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 224
+      value: 241
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -1809,7 +1909,7 @@ PrefabInstance:
     - target: {fileID: 3546756579768976802, guid: 517c48fc4fc1cba48908d11ec58451ce,
         type: 3}
       propertyPath: m_RootOrder
-      value: 120
+      value: 128
       objectReference: {fileID: 0}
     - target: {fileID: 3546756579768976802, guid: 517c48fc4fc1cba48908d11ec58451ce,
         type: 3}
@@ -1894,7 +1994,7 @@ PrefabInstance:
     - target: {fileID: 3682557958087281322, guid: 6bd9037fbb19a79409aab54675bc363e,
         type: 3}
       propertyPath: m_RootOrder
-      value: 212
+      value: 229
       objectReference: {fileID: 0}
     - target: {fileID: 3682557958087281322, guid: 6bd9037fbb19a79409aab54675bc363e,
         type: 3}
@@ -1964,7 +2064,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 76
+      value: 81
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -2034,7 +2134,7 @@ PrefabInstance:
     - target: {fileID: 8342472905829387893, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: connectedDevices.Array.size
-      value: 1
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 8342472905829387893, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -2045,12 +2145,12 @@ PrefabInstance:
         type: 3}
       propertyPath: connectedDevices.Array.data[1]
       value: 
-      objectReference: {fileID: 1418975194}
+      objectReference: {fileID: 145858473}
     - target: {fileID: 8342472905829387893, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: connectedDevices.Array.data[2]
       value: 
-      objectReference: {fileID: 862482134}
+      objectReference: {fileID: 943837311}
     - target: {fileID: 8342472905829387893, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: connectedDevices.Array.data[3]
@@ -2101,7 +2201,7 @@ PrefabInstance:
     - target: {fileID: 8031874825218677495, guid: 7f7934b263cb23040ade0147d14b39aa,
         type: 3}
       propertyPath: m_RootOrder
-      value: 183
+      value: 200
       objectReference: {fileID: 0}
     - target: {fileID: 8031874825218677495, guid: 7f7934b263cb23040ade0147d14b39aa,
         type: 3}
@@ -2278,7 +2378,7 @@ PrefabInstance:
     - target: {fileID: 3967934396199251458, guid: c0cbb1853d350404685a523d617f3458,
         type: 3}
       propertyPath: m_RootOrder
-      value: 181
+      value: 198
       objectReference: {fileID: 0}
     - target: {fileID: 3967934396199251458, guid: c0cbb1853d350404685a523d617f3458,
         type: 3}
@@ -2363,7 +2463,7 @@ PrefabInstance:
     - target: {fileID: 5167623093684579179, guid: f25a6f263584e6848819e145b53ee65b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 158
+      value: 163
       objectReference: {fileID: 0}
     - target: {fileID: 5167623093684579179, guid: f25a6f263584e6848819e145b53ee65b,
         type: 3}
@@ -2433,7 +2533,7 @@ PrefabInstance:
     - target: {fileID: 2054426006668562447, guid: 08be734c1a459464f9c78d3b21384339,
         type: 3}
       propertyPath: m_RootOrder
-      value: 196
+      value: 213
       objectReference: {fileID: 0}
     - target: {fileID: 2054426006668562447, guid: 08be734c1a459464f9c78d3b21384339,
         type: 3}
@@ -2528,7 +2628,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 293
+      value: 319
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -2665,7 +2765,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4868564961159832, guid: 85791fbcb6be942d1b318907cb2edec3, type: 3}
       propertyPath: m_RootOrder
-      value: 48
+      value: 53
       objectReference: {fileID: 0}
     - target: {fileID: 4868564961159832, guid: 85791fbcb6be942d1b318907cb2edec3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2740,7 +2840,7 @@ PrefabInstance:
     - target: {fileID: 5895499867514145751, guid: dd553da79275dac409d269c0d6ec571c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 248
+      value: 272
       objectReference: {fileID: 0}
     - target: {fileID: 5895499867514145751, guid: dd553da79275dac409d269c0d6ec571c,
         type: 3}
@@ -2810,7 +2910,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 33
+      value: 35
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -2897,6 +2997,188 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &142980105
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 2280489160165172092, guid: 9b996da43261266449d4ad99b2ddac7f,
+        type: 3}
+      propertyPath: m_Name
+      value: ConnectorPort
+      objectReference: {fileID: 0}
+    - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 285
+      objectReference: {fileID: 0}
+    - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 31
+      objectReference: {fileID: 0}
+    - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 36
+      objectReference: {fileID: 0}
+    - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.00000004371139
+      objectReference: {fileID: 0}
+    - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5492738391688622333, guid: 9b996da43261266449d4ad99b2ddac7f,
+        type: 3}
+      propertyPath: InitialDirection
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7671949058047645214, guid: 9b996da43261266449d4ad99b2ddac7f,
+        type: 3}
+      propertyPath: sceneId
+      value: 3419580946
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9b996da43261266449d4ad99b2ddac7f, type: 3}
+--- !u!4 &142980106 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
+    type: 3}
+  m_PrefabInstance: {fileID: 142980105}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &145858472
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 2161439757415737395, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: RelatedAPC
+      value: 
+      objectReference: {fileID: 98801763}
+    - target: {fileID: 3219073340430485023, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_Name
+      value: AirlockPublicWindowed
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 254
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445112791058527101, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: sceneId
+      value: 4127229289
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 54a552cbe4002ac44ae29b958a90e545, type: 3}
+--- !u!114 &145858473 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2161439757415737395, guid: 54a552cbe4002ac44ae29b958a90e545,
+    type: 3}
+  m_PrefabInstance: {fileID: 145858472}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &145858474 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+    type: 3}
+  m_PrefabInstance: {fileID: 145858472}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &151678146
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2917,7 +3199,7 @@ PrefabInstance:
     - target: {fileID: 8182938654540533794, guid: 1a00e842e154f7d43811c5d45328988c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 171
+      value: 188
       objectReference: {fileID: 0}
     - target: {fileID: 8182938654540533794, guid: 1a00e842e154f7d43811c5d45328988c,
         type: 3}
@@ -3014,7 +3296,7 @@ PrefabInstance:
     - target: {fileID: 8031874825218677495, guid: 1002c0247e412884e91c857ce6e51d9c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 178
+      value: 195
       objectReference: {fileID: 0}
     - target: {fileID: 8031874825218677495, guid: 1002c0247e412884e91c857ce6e51d9c,
         type: 3}
@@ -3089,7 +3371,7 @@ PrefabInstance:
     - target: {fileID: 7045011890306318302, guid: 4e067333d18d9724690055be203850b5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 255
+      value: 279
       objectReference: {fileID: 0}
     - target: {fileID: 7045011890306318302, guid: 4e067333d18d9724690055be203850b5,
         type: 3}
@@ -3179,7 +3461,7 @@ PrefabInstance:
     - target: {fileID: 6284585900848704128, guid: a223c02f818b8d74abd3e94371d523d4,
         type: 3}
       propertyPath: m_RootOrder
-      value: 45
+      value: 47
       objectReference: {fileID: 0}
     - target: {fileID: 6284585900848704128, guid: a223c02f818b8d74abd3e94371d523d4,
         type: 3}
@@ -3271,7 +3553,7 @@ PrefabInstance:
     - target: {fileID: 7360425322471321201, guid: bc0cd2a586c78b846a43622b6ea5c953,
         type: 3}
       propertyPath: m_RootOrder
-      value: 156
+      value: 161
       objectReference: {fileID: 0}
     - target: {fileID: 7360425322471321201, guid: bc0cd2a586c78b846a43622b6ea5c953,
         type: 3}
@@ -3355,20 +3637,25 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8082954268645528609}
     m_Modifications:
+    - target: {fileID: 195607162214552374, guid: c0e96760c016b6140ba8c3979e9213f7,
+        type: 3}
+      propertyPath: pushPullSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     - target: {fileID: 3327308291878936282, guid: c0e96760c016b6140ba8c3979e9213f7,
         type: 3}
       propertyPath: m_RootOrder
-      value: 258
+      value: 282
       objectReference: {fileID: 0}
     - target: {fileID: 3327308291878936282, guid: c0e96760c016b6140ba8c3979e9213f7,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 31
+      value: 32
       objectReference: {fileID: 0}
     - target: {fileID: 3327308291878936282, guid: c0e96760c016b6140ba8c3979e9213f7,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 38
+      value: 29
       objectReference: {fileID: 0}
     - target: {fileID: 3327308291878936282, guid: c0e96760c016b6140ba8c3979e9213f7,
         type: 3}
@@ -3448,7 +3735,7 @@ PrefabInstance:
     - target: {fileID: 8605860254165158179, guid: c9d03be44229a74469be1b6738941ec3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 193
+      value: 210
       objectReference: {fileID: 0}
     - target: {fileID: 8605860254165158179, guid: c9d03be44229a74469be1b6738941ec3,
         type: 3}
@@ -3512,6 +3799,188 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8605860254165158179, guid: c9d03be44229a74469be1b6738941ec3,
     type: 3}
   m_PrefabInstance: {fileID: 173062716}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &173253157
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 2161439757415737395, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: RelatedAPC
+      value: 
+      objectReference: {fileID: 914261254}
+    - target: {fileID: 3219073340430485023, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_Name
+      value: AirlockPublicWindowed
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 251
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 27
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445112791058527101, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: sceneId
+      value: 4135457247
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 54a552cbe4002ac44ae29b958a90e545, type: 3}
+--- !u!114 &173253158 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2161439757415737395, guid: 54a552cbe4002ac44ae29b958a90e545,
+    type: 3}
+  m_PrefabInstance: {fileID: 173253157}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &173253159 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+    type: 3}
+  m_PrefabInstance: {fileID: 173253157}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &174202485
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 8399202269906357691, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_Name
+      value: PistolMagazine9mm
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 331
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 35.99
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 17.97
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8438156590381850731, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: snapToGridOnStart
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8438549908676571151, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: sceneId
+      value: 580153173
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 678d8623073f29f4cb23d4cb26359cd4, type: 3}
+--- !u!4 &174202486 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+    type: 3}
+  m_PrefabInstance: {fileID: 174202485}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &179118863
 PrefabInstance:
@@ -3635,12 +4104,12 @@ PrefabInstance:
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 41
+      value: 47
       objectReference: {fileID: 0}
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 8
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
@@ -3839,7 +4308,7 @@ PrefabInstance:
     - target: {fileID: 4751204249681072796, guid: be26d178314bedc419e95cd4466da4e5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 53
+      value: 58
       objectReference: {fileID: 0}
     - target: {fileID: 4751204249681072796, guid: be26d178314bedc419e95cd4466da4e5,
         type: 3}
@@ -3958,7 +4427,7 @@ PrefabInstance:
     - target: {fileID: 3129593617119727172, guid: aca91ff2eea9cc64aa3bb9deb8964ab1,
         type: 3}
       propertyPath: m_RootOrder
-      value: 208
+      value: 225
       objectReference: {fileID: 0}
     - target: {fileID: 3129593617119727172, guid: aca91ff2eea9cc64aa3bb9deb8964ab1,
         type: 3}
@@ -4033,7 +4502,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 65
+      value: 70
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -4170,103 +4639,79 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b795fd3e621e742b0aafdb501b9d36cf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &217183660
+--- !u!1001 &200494453
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 8082954268645528609}
     m_Modifications:
-    - target: {fileID: 1318217816944800549, guid: d56b65cebb41c78479fed5218fb0344c,
-        type: 3}
+    - target: {fileID: 1000011462531918, guid: e1a9ff52d12442f3bf8a03873bcab8ee, type: 3}
       propertyPath: m_Name
-      value: AirVentSelfSufficient
+      value: AirLock
       objectReference: {fileID: 0}
-    - target: {fileID: 1323765633690383871, guid: d56b65cebb41c78479fed5218fb0344c,
-        type: 3}
+    - target: {fileID: 4000012887992874, guid: e1a9ff52d12442f3bf8a03873bcab8ee, type: 3}
       propertyPath: m_RootOrder
-      value: 298
+      value: 270
       objectReference: {fileID: 0}
-    - target: {fileID: 1323765633690383871, guid: d56b65cebb41c78479fed5218fb0344c,
-        type: 3}
+    - target: {fileID: 4000012887992874, guid: e1a9ff52d12442f3bf8a03873bcab8ee, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 25
+      value: 33
       objectReference: {fileID: 0}
-    - target: {fileID: 1323765633690383871, guid: d56b65cebb41c78479fed5218fb0344c,
-        type: 3}
+    - target: {fileID: 4000012887992874, guid: e1a9ff52d12442f3bf8a03873bcab8ee, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 10
+      value: 37
       objectReference: {fileID: 0}
-    - target: {fileID: 1323765633690383871, guid: d56b65cebb41c78479fed5218fb0344c,
-        type: 3}
+    - target: {fileID: 4000012887992874, guid: e1a9ff52d12442f3bf8a03873bcab8ee, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1323765633690383871, guid: d56b65cebb41c78479fed5218fb0344c,
-        type: 3}
+    - target: {fileID: 4000012887992874, guid: e1a9ff52d12442f3bf8a03873bcab8ee, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1323765633690383871, guid: d56b65cebb41c78479fed5218fb0344c,
-        type: 3}
+    - target: {fileID: 4000012887992874, guid: e1a9ff52d12442f3bf8a03873bcab8ee, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 1323765633690383871, guid: d56b65cebb41c78479fed5218fb0344c,
-        type: 3}
+    - target: {fileID: 4000012887992874, guid: e1a9ff52d12442f3bf8a03873bcab8ee, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 1323765633690383871, guid: d56b65cebb41c78479fed5218fb0344c,
-        type: 3}
+    - target: {fileID: 4000012887992874, guid: e1a9ff52d12442f3bf8a03873bcab8ee, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 1323765633690383871, guid: d56b65cebb41c78479fed5218fb0344c,
-        type: 3}
+    - target: {fileID: 4000012887992874, guid: e1a9ff52d12442f3bf8a03873bcab8ee, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1323765633690383871, guid: d56b65cebb41c78479fed5218fb0344c,
-        type: 3}
+    - target: {fileID: 4000012887992874, guid: e1a9ff52d12442f3bf8a03873bcab8ee, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1323765633690383871, guid: d56b65cebb41c78479fed5218fb0344c,
-        type: 3}
+    - target: {fileID: 4000012887992874, guid: e1a9ff52d12442f3bf8a03873bcab8ee, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2529272821103992073, guid: d56b65cebb41c78479fed5218fb0344c,
-        type: 3}
-      propertyPath: RelatedAPC
-      value: 
-      objectReference: {fileID: 37847086}
-    - target: {fileID: 7464313774439220807, guid: d56b65cebb41c78479fed5218fb0344c,
+    - target: {fileID: 114842947250423336, guid: e1a9ff52d12442f3bf8a03873bcab8ee,
         type: 3}
       propertyPath: sceneId
-      value: 2264213713
+      value: 3823302134
+      objectReference: {fileID: 0}
+    - target: {fileID: 114997946200806902, guid: e1a9ff52d12442f3bf8a03873bcab8ee,
+        type: 3}
+      propertyPath: restriction
+      value: 32
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: d56b65cebb41c78479fed5218fb0344c, type: 3}
---- !u!4 &217183661 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: e1a9ff52d12442f3bf8a03873bcab8ee, type: 3}
+--- !u!4 &200494454 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 1323765633690383871, guid: d56b65cebb41c78479fed5218fb0344c,
+  m_CorrespondingSourceObject: {fileID: 4000012887992874, guid: e1a9ff52d12442f3bf8a03873bcab8ee,
     type: 3}
-  m_PrefabInstance: {fileID: 217183660}
+  m_PrefabInstance: {fileID: 200494453}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &217183662 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2529272821103992073, guid: d56b65cebb41c78479fed5218fb0344c,
-    type: 3}
-  m_PrefabInstance: {fileID: 217183660}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &219402035
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4287,7 +4732,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 236
+      value: 259
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -4406,7 +4851,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 296
+      value: 322
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -4577,7 +5022,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 314
+      value: 343
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -4674,7 +5119,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 79
+      value: 84
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4744,7 +5189,7 @@ PrefabInstance:
     - target: {fileID: 629953639410381570, guid: 381f8f36a2bad374a821a168f8e565b6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 191
+      value: 208
       objectReference: {fileID: 0}
     - target: {fileID: 629953639410381570, guid: 381f8f36a2bad374a821a168f8e565b6,
         type: 3}
@@ -4819,7 +5264,7 @@ PrefabInstance:
     - target: {fileID: 1327387949770221707, guid: dbfef72a303adaa489b990c1ac8a96da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 205
+      value: 222
       objectReference: {fileID: 0}
     - target: {fileID: 1327387949770221707, guid: dbfef72a303adaa489b990c1ac8a96da,
         type: 3}
@@ -4968,7 +5413,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 281
+      value: 307
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -5131,7 +5576,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 237
+      value: 260
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -5235,7 +5680,7 @@ PrefabInstance:
     - target: {fileID: 8182938654540533794, guid: 1a00e842e154f7d43811c5d45328988c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 170
+      value: 187
       objectReference: {fileID: 0}
     - target: {fileID: 8182938654540533794, guid: 1a00e842e154f7d43811c5d45328988c,
         type: 3}
@@ -5419,7 +5864,7 @@ PrefabInstance:
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 189
+      value: 206
       objectReference: {fileID: 0}
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
@@ -5494,91 +5939,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 277040262}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &287365755
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 8082954268645528609}
-    m_Modifications:
-    - target: {fileID: 6930305835335021225, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_Name
-      value: 'EnergyPistol '
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 152
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 34
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 17.917
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7041601427722821497, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: snapToGridOnStart
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7041749550512197405, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: sceneId
-      value: 3351299570
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 5a31eb85267283041aa9613772d08f90, type: 3}
---- !u!4 &287365756 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-    type: 3}
-  m_PrefabInstance: {fileID: 287365755}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &288014281
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5594,7 +5954,7 @@ PrefabInstance:
     - target: {fileID: 8131242747770038361, guid: 790a543a09ecd4442acbf99db25be404,
         type: 3}
       propertyPath: m_RootOrder
-      value: 252
+      value: 276
       objectReference: {fileID: 0}
     - target: {fileID: 8131242747770038361, guid: 790a543a09ecd4442acbf99db25be404,
         type: 3}
@@ -5716,7 +6076,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 82
+      value: 87
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -5877,7 +6237,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 239
+      value: 262
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -5961,6 +6321,91 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8cd47c8a7b3ca4905983be3a08c1caf0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &296421509
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 6360831956148715142, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: sceneId
+      value: 2544825634
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 173
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 43
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6472239387987690290, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_Name
+      value: MaintLootx3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7971397566001387407, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: fanOut
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fa63846bcecd1d14b8644f96e78f9888, type: 3}
+--- !u!4 &296421510 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+    type: 3}
+  m_PrefabInstance: {fileID: 296421509}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &297208239
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5971,7 +6416,7 @@ PrefabInstance:
     - target: {fileID: 1925386106379506438, guid: 99fa44696e5676a41bb345c085b3e768,
         type: 3}
       propertyPath: m_RootOrder
-      value: 275
+      value: 301
       objectReference: {fileID: 0}
     - target: {fileID: 1925386106379506438, guid: 99fa44696e5676a41bb345c085b3e768,
         type: 3}
@@ -6056,7 +6501,7 @@ PrefabInstance:
     - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 261
+      value: 287
       objectReference: {fileID: 0}
     - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
         type: 3}
@@ -6136,7 +6581,7 @@ PrefabInstance:
     - target: {fileID: 3327308291878936282, guid: c0e96760c016b6140ba8c3979e9213f7,
         type: 3}
       propertyPath: m_RootOrder
-      value: 259
+      value: 283
       objectReference: {fileID: 0}
     - target: {fileID: 3327308291878936282, guid: c0e96760c016b6140ba8c3979e9213f7,
         type: 3}
@@ -6224,7 +6669,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: b5d421f0156248b4297eecc918b8758a, type: 3}
       propertyPath: m_RootOrder
-      value: 214
+      value: 231
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: b5d421f0156248b4297eecc918b8758a, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6289,7 +6734,7 @@ PrefabInstance:
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 167
+      value: 172
       objectReference: {fileID: 0}
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
@@ -6367,7 +6812,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 68
+      value: 73
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6501,7 +6946,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 310
+      value: 339
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -6610,7 +7055,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 285
+      value: 311
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -6749,7 +7194,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 228
+      value: 247
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -6759,7 +7204,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 24
+      value: 29
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -6933,7 +7378,7 @@ PrefabInstance:
     - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 125
+      value: 133
       objectReference: {fileID: 0}
     - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
         type: 3}
@@ -7028,7 +7473,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 231
+      value: 252
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -7105,6 +7550,103 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &395655432
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 41
+      objectReference: {fileID: 0}
+    - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 48
+      objectReference: {fileID: 0}
+    - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 961030794609655628, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: m_Name
+      value: AirlockGrunge
+      objectReference: {fileID: 0}
+    - target: {fileID: 4324806179047510368, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: RelatedAPC
+      value: 
+      objectReference: {fileID: 1669325242}
+    - target: {fileID: 8686200821697727022, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: sceneId
+      value: 3041184362
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1f10fce737097ce44affadeeb9bea4da, type: 3}
+--- !u!114 &395655433 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4324806179047510368, guid: 1f10fce737097ce44affadeeb9bea4da,
+    type: 3}
+  m_PrefabInstance: {fileID: 395655432}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &395655434 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
+    type: 3}
+  m_PrefabInstance: {fileID: 395655432}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &395820837
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7120,7 +7662,7 @@ PrefabInstance:
     - target: {fileID: 5193296327940958646, guid: 63a58edd1e5377040a9ea82e307c1f04,
         type: 3}
       propertyPath: m_RootOrder
-      value: 160
+      value: 165
       objectReference: {fileID: 0}
     - target: {fileID: 5193296327940958646, guid: 63a58edd1e5377040a9ea82e307c1f04,
         type: 3}
@@ -7423,6 +7965,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8082954268645528609}
     m_Modifications:
+    - target: {fileID: 4954032243301861539, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: snapToGridOnStart
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4954479433304004807, guid: 9363154ec4a288f41b8c9681e3531539,
         type: 3}
       propertyPath: sceneId
@@ -7431,17 +7978,17 @@ PrefabInstance:
     - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
         type: 3}
       propertyPath: m_RootOrder
-      value: 301
+      value: 327
       objectReference: {fileID: 0}
     - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 29.008
+      value: 33.93
       objectReference: {fileID: 0}
     - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 23.945
+      value: 18.12
       objectReference: {fileID: 0}
     - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
         type: 3}
@@ -7743,7 +8290,7 @@ PrefabInstance:
     - target: {fileID: 2484719566607390486, guid: a6a04b99723d3ae42958de4193b9920d,
         type: 3}
       propertyPath: m_RootOrder
-      value: 201
+      value: 218
       objectReference: {fileID: 0}
     - target: {fileID: 2484719566607390486, guid: a6a04b99723d3ae42958de4193b9920d,
         type: 3}
@@ -7823,7 +8370,7 @@ PrefabInstance:
     - target: {fileID: 4316376699312728761, guid: d4a3f41d96f2c4143b8556508db41c57,
         type: 3}
       propertyPath: m_RootOrder
-      value: 54
+      value: 59
       objectReference: {fileID: 0}
     - target: {fileID: 4316376699312728761, guid: d4a3f41d96f2c4143b8556508db41c57,
         type: 3}
@@ -7898,7 +8445,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 26
+      value: 28
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -7995,7 +8542,7 @@ PrefabInstance:
     - target: {fileID: 2038054705163664627, guid: c9c8ffe7c5a0a044bbe8343e681e1fe2,
         type: 3}
       propertyPath: m_RootOrder
-      value: 147
+      value: 155
       objectReference: {fileID: 0}
     - target: {fileID: 2038054705163664627, guid: c9c8ffe7c5a0a044bbe8343e681e1fe2,
         type: 3}
@@ -8085,7 +8632,7 @@ PrefabInstance:
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 114
+      value: 122
       objectReference: {fileID: 0}
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
@@ -8170,7 +8717,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 297
+      value: 323
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -8379,7 +8926,7 @@ PrefabInstance:
     - target: {fileID: 7777312831022217093, guid: 229f1c93e0e4ada439cfe4b781f65997,
         type: 3}
       propertyPath: m_RootOrder
-      value: 175
+      value: 192
       objectReference: {fileID: 0}
     - target: {fileID: 7777312831022217093, guid: 229f1c93e0e4ada439cfe4b781f65997,
         type: 3}
@@ -8551,7 +9098,7 @@ PrefabInstance:
     - target: {fileID: 5674645506955800181, guid: c3e6805b264a935428b0de415ea57943,
         type: 3}
       propertyPath: m_RootOrder
-      value: 139
+      value: 147
       objectReference: {fileID: 0}
     - target: {fileID: 5674645506955800181, guid: c3e6805b264a935428b0de415ea57943,
         type: 3}
@@ -8646,7 +9193,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 294
+      value: 320
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -8894,7 +9441,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 227
+      value: 246
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -9050,7 +9597,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 92
+      value: 97
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -9241,7 +9788,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 30
+      value: 32
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -9338,7 +9885,7 @@ PrefabInstance:
     - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
         type: 3}
       propertyPath: m_RootOrder
-      value: 203
+      value: 220
       objectReference: {fileID: 0}
     - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
         type: 3}
@@ -9423,7 +9970,7 @@ PrefabInstance:
     - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 321
+      value: 352
       objectReference: {fileID: 0}
     - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
         type: 3}
@@ -9496,6 +10043,12 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300006, guid: 1f8fe2981d2d3bb4f8643d0bed83b580,
         type: 3}
+    - target: {fileID: 1689274832931870787, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300006, guid: 1f8fe2981d2d3bb4f8643d0bed83b580,
+        type: 3}
     - target: {fileID: 1943076862554158340, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: sceneId
@@ -9542,6 +10095,12 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300006, guid: 244761d659f269a4793677b4e2651889,
         type: 3}
+    - target: {fileID: 7803294762233930865, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300006, guid: 244761d659f269a4793677b4e2651889,
+        type: 3}
     - target: {fileID: 8010465399013802086, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_Name
@@ -9550,7 +10109,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 316
+      value: 345
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -9746,7 +10305,7 @@ PrefabInstance:
     - target: {fileID: 7662282495583499656, guid: 7f32e42309899114b9c122f261161bc5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 141
+      value: 149
       objectReference: {fileID: 0}
     - target: {fileID: 7662282495583499656, guid: 7f32e42309899114b9c122f261161bc5,
         type: 3}
@@ -9831,7 +10390,7 @@ PrefabInstance:
     - target: {fileID: 9031523234013953791, guid: b087cae0f7059d946a59146ea8d0fb04,
         type: 3}
       propertyPath: m_RootOrder
-      value: 251
+      value: 275
       objectReference: {fileID: 0}
     - target: {fileID: 9031523234013953791, guid: b087cae0f7059d946a59146ea8d0fb04,
         type: 3}
@@ -9901,7 +10460,7 @@ PrefabInstance:
     - target: {fileID: 2054426006668562447, guid: 08be734c1a459464f9c78d3b21384339,
         type: 3}
       propertyPath: m_RootOrder
-      value: 195
+      value: 212
       objectReference: {fileID: 0}
     - target: {fileID: 2054426006668562447, guid: 08be734c1a459464f9c78d3b21384339,
         type: 3}
@@ -10172,7 +10731,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 2
-      m_TileSpriteIndex: 10
+      m_TileSpriteIndex: 11
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -10298,6 +10857,16 @@ Tilemap:
       m_TileObjectToInstantiateIndex: 65535
       dummyAlignment: 0
       m_AllTileFlags: 2147483648
+  - first: {x: 43, y: 13, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 2
+      m_TileSpriteIndex: 11
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
   - first: {x: 21, y: 20, z: 0}
     second:
       serializedVersion: 2
@@ -10312,7 +10881,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 1
-      m_TileSpriteIndex: 2
+      m_TileSpriteIndex: 10
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -10342,7 +10911,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 2
-      m_TileSpriteIndex: 0
+      m_TileSpriteIndex: 2
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -10424,15 +10993,15 @@ Tilemap:
     m_Data: {fileID: 0}
   - m_RefCount: 3
     m_Data: {fileID: 11400000, guid: 71416f6cff737438f9dd90a1cd47c640, type: 2}
-  - m_RefCount: 30
+  - m_RefCount: 31
     m_Data: {fileID: 11400000, guid: cf31da1d9b545944fb7423aac9d9b7d3, type: 2}
   m_TileSpriteArray:
-  - m_RefCount: 1
-    m_Data: {fileID: 21300018, guid: fa4608352c8b8294d9b7cdfbb03f1747, type: 3}
+  - m_RefCount: 0
+    m_Data: {fileID: 0}
   - m_RefCount: 1
     m_Data: {fileID: 21300004, guid: c2a766fe0315373409b87a70f5366f91, type: 3}
   - m_RefCount: 1
-    m_Data: {fileID: 21300008, guid: c2a766fe0315373409b87a70f5366f91, type: 3}
+    m_Data: {fileID: 21300018, guid: fa4608352c8b8294d9b7cdfbb03f1747, type: 3}
   - m_RefCount: 5
     m_Data: {fileID: 21300004, guid: fa4608352c8b8294d9b7cdfbb03f1747, type: 3}
   - m_RefCount: 3
@@ -10448,9 +11017,11 @@ Tilemap:
   - m_RefCount: 1
     m_Data: {fileID: 21300022, guid: c2a766fe0315373409b87a70f5366f91, type: 3}
   - m_RefCount: 1
+    m_Data: {fileID: 21300008, guid: c2a766fe0315373409b87a70f5366f91, type: 3}
+  - m_RefCount: 2
     m_Data: {fileID: 21300000, guid: fa4608352c8b8294d9b7cdfbb03f1747, type: 3}
   m_TileMatrixArray:
-  - m_RefCount: 33
+  - m_RefCount: 34
     m_Data:
       e00: 1
       e01: 0
@@ -10469,13 +11040,13 @@ Tilemap:
       e32: 0
       e33: 1
   m_TileColorArray:
-  - m_RefCount: 33
+  - m_RefCount: 34
     m_Data: {r: 1, g: 1, b: 1, a: 1}
   m_TileObjectToInstantiateArray: []
   m_AnimationFrameRate: 1
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_Origin: {x: -13, y: -3, z: 0}
-  m_Size: {x: 53, y: 28, z: 1}
+  m_Size: {x: 58, y: 28, z: 1}
   m_TileAnchor: {x: 0.5, y: 0.5, z: 0}
   m_TileOrientation: 0
   m_TileOrientationMatrix:
@@ -10520,7 +11091,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 304
+      value: 332
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -10575,7 +11146,7 @@ PrefabInstance:
     - target: {fileID: 5448639519452539588, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: listOfLights.Array.size
-      value: 3
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 5448639519452539588, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -10592,6 +11163,16 @@ PrefabInstance:
       propertyPath: listOfLights.Array.data[2]
       value: 
       objectReference: {fileID: 529858410}
+    - target: {fileID: 5448639519452539588, guid: f2432d244a6b7774ea00ff013beb7dcb,
+        type: 3}
+      propertyPath: listOfLights.Array.data[3]
+      value: 
+      objectReference: {fileID: 1408379519}
+    - target: {fileID: 5448639519452539588, guid: f2432d244a6b7774ea00ff013beb7dcb,
+        type: 3}
+      propertyPath: listOfLights.Array.data[4]
+      value: 
+      objectReference: {fileID: 1922923928}
     - target: {fileID: 8799116497260486352, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: RelatedAPC
@@ -10642,7 +11223,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_RootOrder
-      value: 217
+      value: 234
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_LocalPosition.x
@@ -10717,7 +11298,7 @@ PrefabInstance:
     - target: {fileID: 8066134277105145184, guid: 8edc1f3642b9f28429c21e6c30566791,
         type: 3}
       propertyPath: m_RootOrder
-      value: 253
+      value: 277
       objectReference: {fileID: 0}
     - target: {fileID: 8066134277105145184, guid: 8edc1f3642b9f28429c21e6c30566791,
         type: 3}
@@ -10727,7 +11308,7 @@ PrefabInstance:
     - target: {fileID: 8066134277105145184, guid: 8edc1f3642b9f28429c21e6c30566791,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 24
+      value: 24.01
       objectReference: {fileID: 0}
     - target: {fileID: 8066134277105145184, guid: 8edc1f3642b9f28429c21e6c30566791,
         type: 3}
@@ -10846,7 +11427,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 283
+      value: 309
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -10955,7 +11536,7 @@ PrefabInstance:
     - target: {fileID: 446201704680789046, guid: b09e9d95fbf80594c8bbcf60be9b3f93,
         type: 3}
       propertyPath: m_RootOrder
-      value: 207
+      value: 224
       objectReference: {fileID: 0}
     - target: {fileID: 446201704680789046, guid: b09e9d95fbf80594c8bbcf60be9b3f93,
         type: 3}
@@ -11137,7 +11718,7 @@ PrefabInstance:
     - target: {fileID: 3546756579768976802, guid: 517c48fc4fc1cba48908d11ec58451ce,
         type: 3}
       propertyPath: m_RootOrder
-      value: 121
+      value: 129
       objectReference: {fileID: 0}
     - target: {fileID: 3546756579768976802, guid: 517c48fc4fc1cba48908d11ec58451ce,
         type: 3}
@@ -11224,7 +11805,7 @@ PrefabInstance:
     - target: {fileID: 461637258738260195, guid: d243343741d540446b159becf769231a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 269
+      value: 295
       objectReference: {fileID: 0}
     - target: {fileID: 461637258738260195, guid: d243343741d540446b159becf769231a,
         type: 3}
@@ -12277,8 +12858,8 @@ Tilemap:
   m_TileObjectToInstantiateArray: []
   m_AnimationFrameRate: 1
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_Origin: {x: -6, y: -3, z: 0}
-  m_Size: {x: 13, y: 7, z: 1}
+  m_Origin: {x: -9, y: -3, z: 0}
+  m_Size: {x: 16, y: 7, z: 1}
   m_TileAnchor: {x: 0.5, y: 0.5, z: 0}
   m_TileOrientation: 0
   m_TileOrientationMatrix:
@@ -12308,7 +12889,7 @@ PrefabInstance:
     - target: {fileID: 5218729519462851643, guid: 4a5b6baeb439ba249b1abfcd81f5d624,
         type: 3}
       propertyPath: m_RootOrder
-      value: 176
+      value: 193
       objectReference: {fileID: 0}
     - target: {fileID: 5218729519462851643, guid: 4a5b6baeb439ba249b1abfcd81f5d624,
         type: 3}
@@ -12378,6 +12959,86 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 655676967}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &658114560
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 162552311794462770, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
+        type: 3}
+      propertyPath: sceneId
+      value: 3242013116
+      objectReference: {fileID: 0}
+    - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 117
+      objectReference: {fileID: 0}
+    - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 43
+      objectReference: {fileID: 0}
+    - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 28
+      objectReference: {fileID: 0}
+    - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8618853659674527056, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
+        type: 3}
+      propertyPath: m_Name
+      value: CrateBase
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3, type: 3}
+--- !u!4 &658114561 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
+    type: 3}
+  m_PrefabInstance: {fileID: 658114560}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &658118460
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -12391,7 +13052,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 72
+      value: 77
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -12471,7 +13132,7 @@ PrefabInstance:
     - target: {fileID: 7203165141458395214, guid: 5dce4d3e01518474bb9bb8085b718980,
         type: 3}
       propertyPath: m_RootOrder
-      value: 133
+      value: 141
       objectReference: {fileID: 0}
     - target: {fileID: 7203165141458395214, guid: 5dce4d3e01518474bb9bb8085b718980,
         type: 3}
@@ -12551,7 +13212,7 @@ PrefabInstance:
     - target: {fileID: 9173161790594611747, guid: 25108e21a69d52c46a538e66eb85db0a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 135
+      value: 143
       objectReference: {fileID: 0}
     - target: {fileID: 9173161790594611747, guid: 25108e21a69d52c46a538e66eb85db0a,
         type: 3}
@@ -12631,7 +13292,7 @@ PrefabInstance:
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 116
+      value: 124
       objectReference: {fileID: 0}
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
@@ -12775,7 +13436,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 278
+      value: 304
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -12956,6 +13617,91 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &692799257
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 2039161782966546691, guid: 7147422770216fc47b220e213ce8395c,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 118
+      objectReference: {fileID: 0}
+    - target: {fileID: 2039161782966546691, guid: 7147422770216fc47b220e213ce8395c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 43
+      objectReference: {fileID: 0}
+    - target: {fileID: 2039161782966546691, guid: 7147422770216fc47b220e213ce8395c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 28
+      objectReference: {fileID: 0}
+    - target: {fileID: 2039161782966546691, guid: 7147422770216fc47b220e213ce8395c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2039161782966546691, guid: 7147422770216fc47b220e213ce8395c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2039161782966546691, guid: 7147422770216fc47b220e213ce8395c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2039161782966546691, guid: 7147422770216fc47b220e213ce8395c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2039161782966546691, guid: 7147422770216fc47b220e213ce8395c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2039161782966546691, guid: 7147422770216fc47b220e213ce8395c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2039161782966546691, guid: 7147422770216fc47b220e213ce8395c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2039161782966546691, guid: 7147422770216fc47b220e213ce8395c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2044367008419646583, guid: 7147422770216fc47b220e213ce8395c,
+        type: 3}
+      propertyPath: m_Name
+      value: GoldBar
+      objectReference: {fileID: 0}
+    - target: {fileID: 2146872794114142659, guid: 7147422770216fc47b220e213ce8395c,
+        type: 3}
+      propertyPath: sceneId
+      value: 2259772292
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404633177297349592, guid: 7147422770216fc47b220e213ce8395c,
+        type: 3}
+      propertyPath: initialAmount
+      value: 10
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7147422770216fc47b220e213ce8395c, type: 3}
+--- !u!4 &692799258 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2039161782966546691, guid: 7147422770216fc47b220e213ce8395c,
+    type: 3}
+  m_PrefabInstance: {fileID: 692799257}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &701850605
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -13063,7 +13809,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 256
+      value: 280
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -13225,7 +13971,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 34
+      value: 36
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -13317,7 +14063,7 @@ PrefabInstance:
     - target: {fileID: 2484719566607390486, guid: a6a04b99723d3ae42958de4193b9920d,
         type: 3}
       propertyPath: m_RootOrder
-      value: 200
+      value: 217
       objectReference: {fileID: 0}
     - target: {fileID: 2484719566607390486, guid: a6a04b99723d3ae42958de4193b9920d,
         type: 3}
@@ -13402,7 +14148,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 247
+      value: 271
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -13494,7 +14240,7 @@ PrefabInstance:
     - target: {fileID: 550404675964371356, guid: 89f38936254ca964a85299ce289225ad,
         type: 3}
       propertyPath: m_RootOrder
-      value: 182
+      value: 199
       objectReference: {fileID: 0}
     - target: {fileID: 550404675964371356, guid: 89f38936254ca964a85299ce289225ad,
         type: 3}
@@ -13730,7 +14476,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 291
+      value: 317
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -13854,7 +14600,7 @@ PrefabInstance:
     - target: {fileID: 4751204249681072796, guid: be26d178314bedc419e95cd4466da4e5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 50
+      value: 55
       objectReference: {fileID: 0}
     - target: {fileID: 4751204249681072796, guid: be26d178314bedc419e95cd4466da4e5,
         type: 3}
@@ -13942,6 +14688,92 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 722118016}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &723049159
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 1489681963208858109, guid: 1580d0511eb4e7f4ca8244aea4c99de9,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 51
+      objectReference: {fileID: 0}
+    - target: {fileID: 1489681963208858109, guid: 1580d0511eb4e7f4ca8244aea4c99de9,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 41
+      objectReference: {fileID: 0}
+    - target: {fileID: 1489681963208858109, guid: 1580d0511eb4e7f4ca8244aea4c99de9,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 1489681963208858109, guid: 1580d0511eb4e7f4ca8244aea4c99de9,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1489681963208858109, guid: 1580d0511eb4e7f4ca8244aea4c99de9,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1489681963208858109, guid: 1580d0511eb4e7f4ca8244aea4c99de9,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1489681963208858109, guid: 1580d0511eb4e7f4ca8244aea4c99de9,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1489681963208858109, guid: 1580d0511eb4e7f4ca8244aea4c99de9,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1489681963208858109, guid: 1580d0511eb4e7f4ca8244aea4c99de9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1489681963208858109, guid: 1580d0511eb4e7f4ca8244aea4c99de9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1489681963208858109, guid: 1580d0511eb4e7f4ca8244aea4c99de9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1493466713117105959, guid: 1580d0511eb4e7f4ca8244aea4c99de9,
+        type: 3}
+      propertyPath: m_Name
+      value: ToolCloset
+      objectReference: {fileID: 0}
+    - target: {fileID: 1768382655480569274, guid: 1580d0511eb4e7f4ca8244aea4c99de9,
+        type: 3}
+      propertyPath: initialContents
+      value: 
+      objectReference: {fileID: 11400000, guid: 7e66c8671f95c2b46804509c35e031d6,
+        type: 2}
+    - target: {fileID: 7017749350732507717, guid: 1580d0511eb4e7f4ca8244aea4c99de9,
+        type: 3}
+      propertyPath: sceneId
+      value: 1573797942
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1580d0511eb4e7f4ca8244aea4c99de9, type: 3}
+--- !u!4 &723049160 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1489681963208858109, guid: 1580d0511eb4e7f4ca8244aea4c99de9,
+    type: 3}
+  m_PrefabInstance: {fileID: 723049159}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &723757981
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -13957,7 +14789,7 @@ PrefabInstance:
     - target: {fileID: 228549275771145858, guid: 6d8f04f09fd70254ead647566210cd74,
         type: 3}
       propertyPath: m_RootOrder
-      value: 129
+      value: 137
       objectReference: {fileID: 0}
     - target: {fileID: 228549275771145858, guid: 6d8f04f09fd70254ead647566210cd74,
         type: 3}
@@ -14052,7 +14884,7 @@ PrefabInstance:
     - target: {fileID: 7203165141458395214, guid: 5dce4d3e01518474bb9bb8085b718980,
         type: 3}
       propertyPath: m_RootOrder
-      value: 138
+      value: 146
       objectReference: {fileID: 0}
     - target: {fileID: 7203165141458395214, guid: 5dce4d3e01518474bb9bb8085b718980,
         type: 3}
@@ -14127,7 +14959,7 @@ PrefabInstance:
     - target: {fileID: 296282586161115487, guid: 1849f051284c432478d5aaba34cec853,
         type: 3}
       propertyPath: m_RootOrder
-      value: 265
+      value: 291
       objectReference: {fileID: 0}
     - target: {fileID: 296282586161115487, guid: 1849f051284c432478d5aaba34cec853,
         type: 3}
@@ -14202,7 +15034,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 63
+      value: 68
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -14359,6 +15191,103 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b795fd3e621e742b0aafdb501b9d36cf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &743174083
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 2161439757415737395, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: RelatedAPC
+      value: 
+      objectReference: {fileID: 1833317362}
+    - target: {fileID: 3219073340430485023, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_Name
+      value: AirlockPublicWindowed
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 243
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 34
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445112791058527101, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: sceneId
+      value: 3108044275
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 54a552cbe4002ac44ae29b958a90e545, type: 3}
+--- !u!114 &743174084 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2161439757415737395, guid: 54a552cbe4002ac44ae29b958a90e545,
+    type: 3}
+  m_PrefabInstance: {fileID: 743174083}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &743174085 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+    type: 3}
+  m_PrefabInstance: {fileID: 743174083}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &745942222
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -14369,7 +15298,7 @@ PrefabInstance:
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 106
+      value: 111
       objectReference: {fileID: 0}
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
@@ -14448,7 +15377,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 67647418286998, guid: 4c38ee85ca3f4664f81d94e975c92fc7, type: 3}
       propertyPath: m_RootOrder
-      value: 151
+      value: 159
       objectReference: {fileID: 0}
     - target: {fileID: 67647418286998, guid: 4c38ee85ca3f4664f81d94e975c92fc7, type: 3}
       propertyPath: m_LocalPosition.x
@@ -14507,6 +15436,194 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 756401522}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &757196455
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 2161439757415737395, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: RelatedAPC
+      value: 
+      objectReference: {fileID: 914261254}
+    - target: {fileID: 3219073340430485023, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_Name
+      value: AirlockPublicWindowed
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 250
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 26
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445112791058527101, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: sceneId
+      value: 2212707781
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 54a552cbe4002ac44ae29b958a90e545, type: 3}
+--- !u!114 &757196456 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2161439757415737395, guid: 54a552cbe4002ac44ae29b958a90e545,
+    type: 3}
+  m_PrefabInstance: {fileID: 757196455}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &757196457 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+    type: 3}
+  m_PrefabInstance: {fileID: 757196455}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &770866665
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 4039531135446677770, guid: e947d751522b07a4186cd276fb16eefe,
+        type: 3}
+      propertyPath: sceneId
+      value: 790064158
+      objectReference: {fileID: 0}
+    - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 48
+      objectReference: {fileID: 0}
+    - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5607718071721086056, guid: e947d751522b07a4186cd276fb16eefe,
+        type: 3}
+      propertyPath: m_Name
+      value: Exosuit Fabricator
+      objectReference: {fileID: 0}
+    - target: {fileID: 5670771940237863039, guid: e947d751522b07a4186cd276fb16eefe,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 7dd7012b3105d144fa39633271f2d9da,
+        type: 3}
+    - target: {fileID: 5670771940237863039, guid: e947d751522b07a4186cd276fb16eefe,
+        type: 3}
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e947d751522b07a4186cd276fb16eefe, type: 3}
+--- !u!4 &770866666 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
+    type: 3}
+  m_PrefabInstance: {fileID: 770866665}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &777783576
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -14522,7 +15639,7 @@ PrefabInstance:
     - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 263
+      value: 289
       objectReference: {fileID: 0}
     - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
         type: 3}
@@ -14605,7 +15722,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_RootOrder
-      value: 220
+      value: 237
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_LocalPosition.x
@@ -14670,7 +15787,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 28
+      value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -14770,7 +15887,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_RootOrder
-      value: 218
+      value: 235
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_LocalPosition.x
@@ -14845,7 +15962,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 233
+      value: 255
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -15078,7 +16195,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 222
+      value: 239
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -15185,7 +16302,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 292
+      value: 318
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -15299,6 +16416,91 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 44c43d3fd88f44c684f0d47dbaee2bfa, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &850436100
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 6360831956148715142, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: sceneId
+      value: 4196333728
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 175
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 43
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6472239387987690290, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_Name
+      value: MaintLootx3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7971397566001387407, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: fanOut
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fa63846bcecd1d14b8644f96e78f9888, type: 3}
+--- !u!4 &850436101 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+    type: 3}
+  m_PrefabInstance: {fileID: 850436100}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &862482131
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -15329,7 +16531,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 312
+      value: 341
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -15413,6 +16615,86 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &863739392
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 178
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 43
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 933576176691117832, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_Name
+      value: ClosetBase
+      objectReference: {fileID: 0}
+    - target: {fileID: 8730627397065656938, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: sceneId
+      value: 570908606
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73, type: 3}
+--- !u!4 &863739393 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+    type: 3}
+  m_PrefabInstance: {fileID: 863739392}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &874269397
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -15498,6 +16780,86 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 874269397}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &896370531
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 1739785981152468424, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: m_Name
+      value: Bed
+      objectReference: {fileID: 0}
+    - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 184
+      objectReference: {fileID: 0}
+    - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 47
+      objectReference: {fileID: 0}
+    - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7924408911985682602, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+        type: 3}
+      propertyPath: sceneId
+      value: 2441000259
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5a7af30c589b41a449d0ba74c9e1771c, type: 3}
+--- !u!4 &896370532 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
+    type: 3}
+  m_PrefabInstance: {fileID: 896370531}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &902676792
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -15518,7 +16880,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 276
+      value: 302
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -15622,7 +16984,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 101
+      value: 106
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -15702,7 +17064,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 64
+      value: 69
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -15772,7 +17134,7 @@ PrefabInstance:
     - target: {fileID: 8342472905829387893, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: connectedDevices.Array.size
-      value: 13
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 8342472905829387893, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -15843,12 +17205,12 @@ PrefabInstance:
         type: 3}
       propertyPath: connectedDevices.Array.data[13]
       value: 
-      objectReference: {fileID: 919143042}
+      objectReference: {fileID: 173253158}
     - target: {fileID: 8342472905829387893, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: connectedDevices.Array.data[14]
       value: 
-      objectReference: {fileID: 919143042}
+      objectReference: {fileID: 757196456}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cd57203a8d3f54f478446e9b0ced6cf9, type: 3}
 --- !u!4 &914261253 stripped
@@ -15884,7 +17246,7 @@ PrefabInstance:
     - target: {fileID: 7999698691295358753, guid: f3706893770084a45ae509ebf6836cc9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 40
+      value: 42
       objectReference: {fileID: 0}
     - target: {fileID: 7999698691295358753, guid: f3706893770084a45ae509ebf6836cc9,
         type: 3}
@@ -15962,7 +17324,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4271421665851644, guid: 1581b03bb13b84328a0f9fe743bb5bbf, type: 3}
       propertyPath: m_RootOrder
-      value: 49
+      value: 54
       objectReference: {fileID: 0}
     - target: {fileID: 4271421665851644, guid: 1581b03bb13b84328a0f9fe743bb5bbf, type: 3}
       propertyPath: m_LocalPosition.x
@@ -16210,7 +17572,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 313
+      value: 342
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -16307,7 +17669,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4734855229797344, guid: d72e24d0fc40a7545aad2f4e4f978d33, type: 3}
       propertyPath: m_RootOrder
-      value: 43
+      value: 45
       objectReference: {fileID: 0}
     - target: {fileID: 4734855229797344, guid: d72e24d0fc40a7545aad2f4e4f978d33, type: 3}
       propertyPath: m_LocalPosition.x
@@ -16392,7 +17754,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 288
+      value: 314
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -16506,7 +17868,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 102
+      value: 107
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -16576,6 +17938,157 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 936411201}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &943837309
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 445604691200519404, guid: c937e0abe85aca9499d09951de736ec6,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 0.3067206
+      objectReference: {fileID: 0}
+    - target: {fileID: 445604691200519404, guid: c937e0abe85aca9499d09951de736ec6,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 0.3087062
+      objectReference: {fileID: 0}
+    - target: {fileID: 445604691200519404, guid: c937e0abe85aca9499d09951de736ec6,
+        type: 3}
+      propertyPath: m_Offset.x
+      value: -0.3346747
+      objectReference: {fileID: 0}
+    - target: {fileID: 445604691200519404, guid: c937e0abe85aca9499d09951de736ec6,
+        type: 3}
+      propertyPath: m_Offset.y
+      value: -0.001173973
+      objectReference: {fileID: 0}
+    - target: {fileID: 2089160542943999880, guid: c937e0abe85aca9499d09951de736ec6,
+        type: 3}
+      propertyPath: InitialDirection
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2561115454955776467, guid: c937e0abe85aca9499d09951de736ec6,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300006, guid: 16f408214667adc469ad08e1f9ceacab,
+        type: 3}
+    - target: {fileID: 3318124271617541268, guid: c937e0abe85aca9499d09951de736ec6,
+        type: 3}
+      propertyPath: sceneId
+      value: 3398335147
+      objectReference: {fileID: 0}
+    - target: {fileID: 6093979353265471059, guid: c937e0abe85aca9499d09951de736ec6,
+        type: 3}
+      propertyPath: relatedLightSwitch
+      value: 
+      objectReference: {fileID: 1418975195}
+    - target: {fileID: 6391088716132193761, guid: c937e0abe85aca9499d09951de736ec6,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300006, guid: bd3225efc525643479b237af41876cf0,
+        type: 3}
+    - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 258
+      objectReference: {fileID: 0}
+    - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 43
+      objectReference: {fileID: 0}
+    - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6616220766525010422, guid: c937e0abe85aca9499d09951de736ec6,
+        type: 3}
+      propertyPath: m_Name
+      value: LightBulbFixture
+      objectReference: {fileID: 0}
+    - target: {fileID: 7674979974564601818, guid: c937e0abe85aca9499d09951de736ec6,
+        type: 3}
+      propertyPath: RelatedAPC
+      value: 
+      objectReference: {fileID: 98801763}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c937e0abe85aca9499d09951de736ec6, type: 3}
+--- !u!114 &943837310 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6093979353265471059, guid: c937e0abe85aca9499d09951de736ec6,
+    type: 3}
+  m_PrefabInstance: {fileID: 943837309}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8cd47c8a7b3ca4905983be3a08c1caf0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &943837311 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7674979974564601818, guid: c937e0abe85aca9499d09951de736ec6,
+    type: 3}
+  m_PrefabInstance: {fileID: 943837309}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &943837312 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
+    type: 3}
+  m_PrefabInstance: {fileID: 943837309}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &946254204
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -16586,7 +18099,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 27
+      value: 29
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -16673,6 +18186,91 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &947816811
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 5641461463850146482, guid: 753e37602e1e0194cbe435fda83795c4,
+        type: 3}
+      propertyPath: sceneId
+      value: 528743073
+      objectReference: {fileID: 0}
+    - target: {fileID: 5641855396123593430, guid: 753e37602e1e0194cbe435fda83795c4,
+        type: 3}
+      propertyPath: snapToGridOnStart
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5750473265769192050, guid: 753e37602e1e0194cbe435fda83795c4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 337
+      objectReference: {fileID: 0}
+    - target: {fileID: 5750473265769192050, guid: 753e37602e1e0194cbe435fda83795c4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5750473265769192050, guid: 753e37602e1e0194cbe435fda83795c4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5750473265769192050, guid: 753e37602e1e0194cbe435fda83795c4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5750473265769192050, guid: 753e37602e1e0194cbe435fda83795c4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5750473265769192050, guid: 753e37602e1e0194cbe435fda83795c4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5750473265769192050, guid: 753e37602e1e0194cbe435fda83795c4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5750473265769192050, guid: 753e37602e1e0194cbe435fda83795c4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5750473265769192050, guid: 753e37602e1e0194cbe435fda83795c4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5750473265769192050, guid: 753e37602e1e0194cbe435fda83795c4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5750473265769192050, guid: 753e37602e1e0194cbe435fda83795c4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5755119664705955590, guid: 753e37602e1e0194cbe435fda83795c4,
+        type: 3}
+      propertyPath: m_Name
+      value: RollerBedItem
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 753e37602e1e0194cbe435fda83795c4, type: 3}
+--- !u!4 &947816812 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5750473265769192050, guid: 753e37602e1e0194cbe435fda83795c4,
+    type: 3}
+  m_PrefabInstance: {fileID: 947816811}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &954634788
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -16680,13 +18278,23 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8082954268645528609}
     m_Modifications:
+    - target: {fileID: -8468313094457109945, guid: d72e24d0fc40a7545aad2f4e4f978d33,
+        type: 3}
+      propertyPath: butcherSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
+    - target: {fileID: -476175051414813368, guid: d72e24d0fc40a7545aad2f4e4f978d33,
+        type: 3}
+      propertyPath: soundOnHit.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     - target: {fileID: 1575520830166772, guid: d72e24d0fc40a7545aad2f4e4f978d33, type: 3}
       propertyPath: m_Name
       value: East Department Battery
       objectReference: {fileID: 0}
     - target: {fileID: 4734855229797344, guid: d72e24d0fc40a7545aad2f4e4f978d33, type: 3}
       propertyPath: m_RootOrder
-      value: 42
+      value: 44
       objectReference: {fileID: 0}
     - target: {fileID: 4734855229797344, guid: d72e24d0fc40a7545aad2f4e4f978d33, type: 3}
       propertyPath: m_LocalPosition.x
@@ -16756,7 +18364,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 104
+      value: 109
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -16846,17 +18454,17 @@ PrefabInstance:
     - target: {fileID: 7304379382918517758, guid: e007b4548279217449b704355d9e112b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 56
+      value: 61
       objectReference: {fileID: 0}
     - target: {fileID: 7304379382918517758, guid: e007b4548279217449b704355d9e112b,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 50
+      value: 45.98
       objectReference: {fileID: 0}
     - target: {fileID: 7304379382918517758, guid: e007b4548279217449b704355d9e112b,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 34
+      value: 17.97
       objectReference: {fileID: 0}
     - target: {fileID: 7304379382918517758, guid: e007b4548279217449b704355d9e112b,
         type: 3}
@@ -17023,7 +18631,7 @@ PrefabInstance:
     - target: {fileID: 8605860254165158179, guid: c9d03be44229a74469be1b6738941ec3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 194
+      value: 211
       objectReference: {fileID: 0}
     - target: {fileID: 8605860254165158179, guid: c9d03be44229a74469be1b6738941ec3,
         type: 3}
@@ -17280,7 +18888,7 @@ PrefabInstance:
     - target: {fileID: 1775224900688995769, guid: 64b0546c6b2243241846fced5f70f123,
         type: 3}
       propertyPath: m_RootOrder
-      value: 257
+      value: 281
       objectReference: {fileID: 0}
     - target: {fileID: 1775224900688995769, guid: 64b0546c6b2243241846fced5f70f123,
         type: 3}
@@ -17365,7 +18973,7 @@ PrefabInstance:
     - target: {fileID: 8630552864855298094, guid: d0eb5dacbdcd4844e8c76aabde50434f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 161
+      value: 166
       objectReference: {fileID: 0}
     - target: {fileID: 8630552864855298094, guid: d0eb5dacbdcd4844e8c76aabde50434f,
         type: 3}
@@ -17430,86 +19038,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 981721530}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &985854830
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 8082954268645528609}
-    m_Modifications:
-    - target: {fileID: 6930305835335021225, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_Name
-      value: 'EnergyPistol '
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 153
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 36
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 18
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7041749550512197405, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: sceneId
-      value: 2871393263
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 5a31eb85267283041aa9613772d08f90, type: 3}
---- !u!4 &985854831 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-    type: 3}
-  m_PrefabInstance: {fileID: 985854830}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &988249961
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -17523,7 +19051,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 71
+      value: 76
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -17593,7 +19121,7 @@ PrefabInstance:
     - target: {fileID: 3246771360178382922, guid: cbae9a210d638ba4b9402e836c970fa2,
         type: 3}
       propertyPath: m_RootOrder
-      value: 143
+      value: 151
       objectReference: {fileID: 0}
     - target: {fileID: 3246771360178382922, guid: cbae9a210d638ba4b9402e836c970fa2,
         type: 3}
@@ -17690,7 +19218,7 @@ PrefabInstance:
     - target: {fileID: 4316376699312728761, guid: d4a3f41d96f2c4143b8556508db41c57,
         type: 3}
       propertyPath: m_RootOrder
-      value: 55
+      value: 60
       objectReference: {fileID: 0}
     - target: {fileID: 4316376699312728761, guid: d4a3f41d96f2c4143b8556508db41c57,
         type: 3}
@@ -17872,7 +19400,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 88
+      value: 93
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -18030,7 +19558,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 89
+      value: 94
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -18134,7 +19662,7 @@ PrefabInstance:
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 108
+      value: 113
       objectReference: {fileID: 0}
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
@@ -18234,7 +19762,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 306
+      value: 334
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -18425,7 +19953,7 @@ PrefabInstance:
     - target: {fileID: 1489681963208858109, guid: c1aebfea91112ef4a83ba10f37d3f437,
         type: 3}
       propertyPath: m_RootOrder
-      value: 111
+      value: 116
       objectReference: {fileID: 0}
     - target: {fileID: 1489681963208858109, guid: c1aebfea91112ef4a83ba10f37d3f437,
         type: 3}
@@ -18508,7 +20036,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 70
+      value: 75
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -18573,7 +20101,7 @@ PrefabInstance:
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 109
+      value: 114
       objectReference: {fileID: 0}
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
@@ -18653,7 +20181,7 @@ PrefabInstance:
     - target: {fileID: 8793194575595567163, guid: 7ba0f8027fae0b747803eabaf13523c7,
         type: 3}
       propertyPath: m_RootOrder
-      value: 199
+      value: 216
       objectReference: {fileID: 0}
     - target: {fileID: 8793194575595567163, guid: 7ba0f8027fae0b747803eabaf13523c7,
         type: 3}
@@ -18743,7 +20271,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 232
+      value: 253
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -18840,7 +20368,7 @@ PrefabInstance:
     - target: {fileID: 3295880826340575877, guid: e89c616b1df1e724baef0e39ac0037f3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 174
+      value: 191
       objectReference: {fileID: 0}
     - target: {fileID: 3295880826340575877, guid: e89c616b1df1e724baef0e39ac0037f3,
         type: 3}
@@ -18979,7 +20507,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 240
+      value: 263
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -19078,7 +20606,7 @@ PrefabInstance:
     - target: {fileID: 2194074672386895265, guid: c27cb1a9c87d9c94abaaf3bd9df216df,
         type: 3}
       propertyPath: m_RootOrder
-      value: 274
+      value: 300
       objectReference: {fileID: 0}
     - target: {fileID: 2194074672386895265, guid: c27cb1a9c87d9c94abaaf3bd9df216df,
         type: 3}
@@ -19163,7 +20691,7 @@ PrefabInstance:
     - target: {fileID: 3967934396199251458, guid: c0cbb1853d350404685a523d617f3458,
         type: 3}
       propertyPath: m_RootOrder
-      value: 180
+      value: 197
       objectReference: {fileID: 0}
     - target: {fileID: 3967934396199251458, guid: c0cbb1853d350404685a523d617f3458,
         type: 3}
@@ -19350,7 +20878,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 86
+      value: 91
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -19444,7 +20972,7 @@ PrefabInstance:
     - target: {fileID: 2039161782966546691, guid: 7147422770216fc47b220e213ce8395c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 209
+      value: 226
       objectReference: {fileID: 0}
     - target: {fileID: 2039161782966546691, guid: 7147422770216fc47b220e213ce8395c,
         type: 3}
@@ -19561,7 +21089,7 @@ PrefabInstance:
     - target: {fileID: 7089628496362807847, guid: c5aecb2f211bbae49916919ff6128733,
         type: 3}
       propertyPath: m_RootOrder
-      value: 187
+      value: 204
       objectReference: {fileID: 0}
     - target: {fileID: 7089628496362807847, guid: c5aecb2f211bbae49916919ff6128733,
         type: 3}
@@ -19702,7 +21230,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 277
+      value: 303
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -19957,7 +21485,7 @@ PrefabInstance:
     - target: {fileID: 5730203012241659306, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 185
+      value: 202
       objectReference: {fileID: 0}
     - target: {fileID: 5730203012241659306, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
@@ -20042,7 +21570,7 @@ PrefabInstance:
     - target: {fileID: 7184381825146832964, guid: 2e464f403424dbd409a91b0abbb4121c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 149
+      value: 157
       objectReference: {fileID: 0}
     - target: {fileID: 7184381825146832964, guid: 2e464f403424dbd409a91b0abbb4121c,
         type: 3}
@@ -20127,7 +21655,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 284
+      value: 310
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -20241,7 +21769,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 100
+      value: 105
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -20423,7 +21951,7 @@ PrefabInstance:
     - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 260
+      value: 286
       objectReference: {fileID: 0}
     - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
         type: 3}
@@ -20508,7 +22036,7 @@ PrefabInstance:
     - target: {fileID: 6518921224212731652, guid: f5de4bfc8649c7a428e694010049af77,
         type: 3}
       propertyPath: m_RootOrder
-      value: 202
+      value: 219
       objectReference: {fileID: 0}
     - target: {fileID: 6518921224212731652, guid: f5de4bfc8649c7a428e694010049af77,
         type: 3}
@@ -20593,7 +22121,7 @@ PrefabInstance:
     - target: {fileID: 7777312831022217093, guid: fd2b975bb2d60fb429c193f9ef1d31b0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 144
+      value: 152
       objectReference: {fileID: 0}
     - target: {fileID: 7777312831022217093, guid: fd2b975bb2d60fb429c193f9ef1d31b0,
         type: 3}
@@ -20737,12 +22265,12 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 317
+      value: 348
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 50
+      value: 52
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -20836,7 +22364,7 @@ PrefabInstance:
     - target: {fileID: 4462439672258080633, guid: c84a09f09199afb48b0d8a0c5c2a5bea,
         type: 3}
       propertyPath: m_RootOrder
-      value: 198
+      value: 215
       objectReference: {fileID: 0}
     - target: {fileID: 4462439672258080633, guid: c84a09f09199afb48b0d8a0c5c2a5bea,
         type: 3}
@@ -20911,7 +22439,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 99
+      value: 104
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -21048,7 +22576,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 279
+      value: 305
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -21152,7 +22680,7 @@ PrefabInstance:
     - target: {fileID: 3018541687849032159, guid: d2f2400aac0da54468da76680579c29b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 130
+      value: 138
       objectReference: {fileID: 0}
     - target: {fileID: 3018541687849032159, guid: d2f2400aac0da54468da76680579c29b,
         type: 3}
@@ -21232,7 +22760,7 @@ PrefabInstance:
     - target: {fileID: 728450015767604076, guid: af583b1807508a84cbd05b036e027d96,
         type: 3}
       propertyPath: m_RootOrder
-      value: 61
+      value: 66
       objectReference: {fileID: 0}
     - target: {fileID: 728450015767604076, guid: af583b1807508a84cbd05b036e027d96,
         type: 3}
@@ -21332,6 +22860,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3662677150203288956, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3662677150203288956, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
       propertyPath: m_Offset.x
       value: -0.4367488
       objectReference: {fileID: 0}
@@ -21364,7 +22897,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 307
+      value: 335
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -21374,7 +22907,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 29
+      value: 27
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -21461,7 +22994,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 69
+      value: 74
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -21526,7 +23059,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 96
+      value: 101
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -21596,6 +23129,91 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1203683666}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1208070341
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 4954032243301861539, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: snapToGridOnStart
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4954479433304004807, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: sceneId
+      value: 4254358056
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 326
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 34.16
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 17.92
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4996160304479888755, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_Name
+      value: OP70Handgun
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9363154ec4a288f41b8c9681e3531539, type: 3}
+--- !u!4 &1208070342 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+    type: 3}
+  m_PrefabInstance: {fileID: 1208070341}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1213483931
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -21609,7 +23227,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 77
+      value: 82
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -21684,7 +23302,7 @@ PrefabInstance:
     - target: {fileID: 7304379382918517758, guid: e007b4548279217449b704355d9e112b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 57
+      value: 62
       objectReference: {fileID: 0}
     - target: {fileID: 7304379382918517758, guid: e007b4548279217449b704355d9e112b,
         type: 3}
@@ -21764,7 +23382,7 @@ PrefabInstance:
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 25
+      value: 27
       objectReference: {fileID: 0}
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
@@ -21947,7 +23565,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 67647418286998, guid: 4c38ee85ca3f4664f81d94e975c92fc7, type: 3}
       propertyPath: m_RootOrder
-      value: 150
+      value: 158
       objectReference: {fileID: 0}
     - target: {fileID: 67647418286998, guid: 4c38ee85ca3f4664f81d94e975c92fc7, type: 3}
       propertyPath: m_LocalPosition.x
@@ -22019,6 +23637,12 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300006, guid: 1f8fe2981d2d3bb4f8643d0bed83b580,
         type: 3}
+    - target: {fileID: 1689274832931870787, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300006, guid: 1f8fe2981d2d3bb4f8643d0bed83b580,
+        type: 3}
     - target: {fileID: 1943076862554158340, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: sceneId
@@ -22065,6 +23689,12 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300006, guid: 244761d659f269a4793677b4e2651889,
         type: 3}
+    - target: {fileID: 7803294762233930865, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300006, guid: 244761d659f269a4793677b4e2651889,
+        type: 3}
     - target: {fileID: 8010465399013802086, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_Name
@@ -22073,7 +23703,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 315
+      value: 344
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -22170,7 +23800,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 73
+      value: 78
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -22289,7 +23919,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 235
+      value: 257
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -22398,7 +24028,7 @@ PrefabInstance:
     - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
         type: 3}
       propertyPath: m_RootOrder
-      value: 303
+      value: 330
       objectReference: {fileID: 0}
     - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
         type: 3}
@@ -22483,7 +24113,7 @@ PrefabInstance:
     - target: {fileID: 4049041059155957662, guid: dd86caf1f673b7642be83819773021d8,
         type: 3}
       propertyPath: m_RootOrder
-      value: 271
+      value: 297
       objectReference: {fileID: 0}
     - target: {fileID: 4049041059155957662, guid: dd86caf1f673b7642be83819773021d8,
         type: 3}
@@ -22568,7 +24198,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 35
+      value: 37
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -22645,6 +24275,171 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &1259446359
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 8518771024213410837, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: sceneId
+      value: 2689209608
+      objectReference: {fileID: 0}
+    - target: {fileID: 8623536237055031713, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_Name
+      value: BedSheet Grey
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 47
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3a4418c4707ae5b4fa4fd5f48c06443b, type: 3}
+--- !u!4 &1259446360 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+    type: 3}
+  m_PrefabInstance: {fileID: 1259446359}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1270321808
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 119
+      objectReference: {fileID: 0}
+    - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 43
+      objectReference: {fileID: 0}
+    - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 28
+      objectReference: {fileID: 0}
+    - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5770283965274354279, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: m_Name
+      value: MetalSheet
+      objectReference: {fileID: 0}
+    - target: {fileID: 5872728177783164883, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: sceneId
+      value: 1809083520
+      objectReference: {fileID: 0}
+    - target: {fileID: 7860434352612808136, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: initialAmount
+      value: 30
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b83b68cfa4a201748aeeece963a989c3, type: 3}
+--- !u!4 &1270321809 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
+    type: 3}
+  m_PrefabInstance: {fileID: 1270321808}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1276138651
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -22665,7 +24460,7 @@ PrefabInstance:
     - target: {fileID: 8954212430775875356, guid: 60badd0969907f044819febb546b443f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 122
+      value: 130
       objectReference: {fileID: 0}
     - target: {fileID: 8954212430775875356, guid: 60badd0969907f044819febb546b443f,
         type: 3}
@@ -22740,7 +24535,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 29
+      value: 31
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -22852,7 +24647,7 @@ PrefabInstance:
     - target: {fileID: 6409286586645294639, guid: 133b93fb7d8a5794bbfff599bea64863,
         type: 3}
       propertyPath: m_RootOrder
-      value: 142
+      value: 150
       objectReference: {fileID: 0}
     - target: {fileID: 6409286586645294639, guid: 133b93fb7d8a5794bbfff599bea64863,
         type: 3}
@@ -22956,7 +24751,7 @@ PrefabInstance:
     - target: {fileID: 3130401872829826601, guid: 66f05879999b49141bbfc4e0fdc9903a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 250
+      value: 274
       objectReference: {fileID: 0}
     - target: {fileID: 3130401872829826601, guid: 66f05879999b49141bbfc4e0fdc9903a,
         type: 3}
@@ -23021,6 +24816,86 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1304283805}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1308186309
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 174
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 43
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 933576176691117832, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_Name
+      value: ClosetBase
+      objectReference: {fileID: 0}
+    - target: {fileID: 8730627397065656938, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: sceneId
+      value: 494085623
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73, type: 3}
+--- !u!4 &1308186310 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+    type: 3}
+  m_PrefabInstance: {fileID: 1308186309}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1316575903
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -23031,7 +24906,7 @@ PrefabInstance:
     - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 127
+      value: 135
       objectReference: {fileID: 0}
     - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
         type: 3}
@@ -23106,6 +24981,103 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1316575903}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1318939911
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 48
+      objectReference: {fileID: 0}
+    - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 961030794609655628, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: m_Name
+      value: AirlockGrunge
+      objectReference: {fileID: 0}
+    - target: {fileID: 4324806179047510368, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: RelatedAPC
+      value: 
+      objectReference: {fileID: 1669325242}
+    - target: {fileID: 8686200821697727022, guid: 1f10fce737097ce44affadeeb9bea4da,
+        type: 3}
+      propertyPath: sceneId
+      value: 3645790652
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1f10fce737097ce44affadeeb9bea4da, type: 3}
+--- !u!114 &1318939912 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4324806179047510368, guid: 1f10fce737097ce44affadeeb9bea4da,
+    type: 3}
+  m_PrefabInstance: {fileID: 1318939911}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1318939913 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
+    type: 3}
+  m_PrefabInstance: {fileID: 1318939911}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1324998499
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -23116,7 +25088,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 223
+      value: 240
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -23315,7 +25287,7 @@ PrefabInstance:
     - target: {fileID: 2402019029272391321, guid: a85bb77436de9574c8523fe45acffb14,
         type: 3}
       propertyPath: m_RootOrder
-      value: 118
+      value: 126
       objectReference: {fileID: 0}
     - target: {fileID: 2402019029272391321, guid: a85bb77436de9574c8523fe45acffb14,
         type: 3}
@@ -23400,7 +25372,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 286
+      value: 312
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -23568,7 +25540,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 84
+      value: 89
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -23682,7 +25654,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 295
+      value: 321
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -23865,7 +25837,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 91
+      value: 96
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -23969,7 +25941,7 @@ PrefabInstance:
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 31
+      value: 33
       objectReference: {fileID: 0}
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
@@ -24056,7 +26028,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 221
+      value: 238
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -24146,7 +26118,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 226
+      value: 245
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -24243,7 +26215,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 230
+      value: 249
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -24253,7 +26225,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 24
+      value: 29
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -24350,7 +26322,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 94
+      value: 99
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -24434,6 +26406,205 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8cd47c8a7b3ca4905983be3a08c1caf0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &1391010751
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 6360831956148715142, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: sceneId
+      value: 1753561571
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 177
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 43
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6472239387987690290, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_Name
+      value: MaintLootx3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7971397566001387407, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: fanOut
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fa63846bcecd1d14b8644f96e78f9888, type: 3}
+--- !u!4 &1391010752 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+    type: 3}
+  m_PrefabInstance: {fileID: 1391010751}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1408379517
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 1943076862554158340, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: sceneId
+      value: 1230039425
+      objectReference: {fileID: 0}
+    - target: {fileID: 6807309527984598602, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: RelatedAPC
+      value: 
+      objectReference: {fileID: 1669325242}
+    - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: relatedLightSwitch
+      value: 
+      objectReference: {fileID: 590623775}
+    - target: {fileID: 8010465399013802086, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_Name
+      value: LightTubeFixture
+      objectReference: {fileID: 0}
+    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 347
+      objectReference: {fileID: 0}
+    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 35
+      objectReference: {fileID: 0}
+    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fde32c02abddc814f9366ff1fb21f234, type: 3}
+--- !u!114 &1408379518 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6807309527984598602, guid: fde32c02abddc814f9366ff1fb21f234,
+    type: 3}
+  m_PrefabInstance: {fileID: 1408379517}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1408379519 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
+    type: 3}
+  m_PrefabInstance: {fileID: 1408379517}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8cd47c8a7b3ca4905983be3a08c1caf0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1408379520 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+    type: 3}
+  m_PrefabInstance: {fileID: 1408379517}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1411008774
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -24441,15 +26612,30 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8082954268645528609}
     m_Modifications:
+    - target: {fileID: 1293680155828200777, guid: 703ee43e84da301438311278f13a496f,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1293680155828200777, guid: 703ee43e84da301438311278f13a496f,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2055220064699409015, guid: 703ee43e84da301438311278f13a496f,
+        type: 3}
+      propertyPath: prefabSpriteOrientation
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3063805286163523616, guid: 703ee43e84da301438311278f13a496f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 246
+      value: 269
       objectReference: {fileID: 0}
     - target: {fileID: 3063805286163523616, guid: 703ee43e84da301438311278f13a496f,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 45
+      value: 46
       objectReference: {fileID: 0}
     - target: {fileID: 3063805286163523616, guid: 703ee43e84da301438311278f13a496f,
         type: 3}
@@ -24506,6 +26692,11 @@ PrefabInstance:
       propertyPath: sceneId
       value: 3424223887
       objectReference: {fileID: 0}
+    - target: {fileID: 8460432939705641718, guid: 703ee43e84da301438311278f13a496f,
+        type: 3}
+      propertyPath: InitialDirection
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 703ee43e84da301438311278f13a496f, type: 3}
 --- !u!4 &1411008775 stripped
@@ -24534,7 +26725,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 289
+      value: 315
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -24589,13 +26780,18 @@ PrefabInstance:
     - target: {fileID: 5448639519452539588, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: listOfLights.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 5448639519452539588, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: listOfLights.Array.data[0]
       value: 
       objectReference: {fileID: 1778983189}
+    - target: {fileID: 5448639519452539588, guid: f2432d244a6b7774ea00ff013beb7dcb,
+        type: 3}
+      propertyPath: listOfLights.Array.data[1]
+      value: 
+      objectReference: {fileID: 943837310}
     - target: {fileID: 8799116497260486352, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: RelatedAPC
@@ -24609,18 +26805,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1418975192}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1418975194 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8799116497260486352, guid: f2432d244a6b7774ea00ff013beb7dcb,
-    type: 3}
-  m_PrefabInstance: {fileID: 1418975192}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &1418975195 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5448639519452539588, guid: f2432d244a6b7774ea00ff013beb7dcb,
@@ -24653,7 +26837,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 229
+      value: 248
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -24750,7 +26934,7 @@ PrefabInstance:
     - target: {fileID: 5895499867514145751, guid: dd553da79275dac409d269c0d6ec571c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 249
+      value: 273
       objectReference: {fileID: 0}
     - target: {fileID: 5895499867514145751, guid: dd553da79275dac409d269c0d6ec571c,
         type: 3}
@@ -24877,7 +27061,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 305
+      value: 333
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -25018,7 +27202,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 241
+      value: 264
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -25125,7 +27309,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 78
+      value: 83
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -25280,7 +27464,7 @@ PrefabInstance:
     - target: {fileID: 6439005145208020592, guid: a12add7b219842843b678dec171704cb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 300
+      value: 324
       objectReference: {fileID: 0}
     - target: {fileID: 6439005145208020592, guid: a12add7b219842843b678dec171704cb,
         type: 3}
@@ -25350,7 +27534,7 @@ PrefabInstance:
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 107
+      value: 112
       objectReference: {fileID: 0}
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
@@ -25433,7 +27617,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_RootOrder
-      value: 219
+      value: 236
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_LocalPosition.x
@@ -25508,7 +27692,7 @@ PrefabInstance:
     - target: {fileID: 8182938654540533794, guid: 1a00e842e154f7d43811c5d45328988c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 172
+      value: 189
       objectReference: {fileID: 0}
     - target: {fileID: 8182938654540533794, guid: 1a00e842e154f7d43811c5d45328988c,
         type: 3}
@@ -25602,7 +27786,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 1f98145bcaa7b9947888e1677211ece0,
+      objectReference: {fileID: 21300000, guid: c39d19bba0ae67943a58040a898fdf54,
         type: 3}
     - target: {fileID: 8568672687853555390, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
         type: 3}
@@ -25612,7 +27796,7 @@ PrefabInstance:
     - target: {fileID: 8573033213633377226, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 137
+      value: 145
       objectReference: {fileID: 0}
     - target: {fileID: 8573033213633377226, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
         type: 3}
@@ -25708,7 +27892,7 @@ PrefabInstance:
     - target: {fileID: 8582924881145235216, guid: 66a5287d0bf216847a2f4fe34228a0cf,
         type: 3}
       propertyPath: m_RootOrder
-      value: 132
+      value: 140
       objectReference: {fileID: 0}
     - target: {fileID: 8582924881145235216, guid: 66a5287d0bf216847a2f4fe34228a0cf,
         type: 3}
@@ -25835,7 +28019,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 311
+      value: 340
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -25919,86 +28103,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &1546658233
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 8082954268645528609}
-    m_Modifications:
-    - target: {fileID: 2478198559564463639, guid: 63c4576068eee0e4cb8cb02ef5b3bebf,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 299
-      objectReference: {fileID: 0}
-    - target: {fileID: 2478198559564463639, guid: 63c4576068eee0e4cb8cb02ef5b3bebf,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 22
-      objectReference: {fileID: 0}
-    - target: {fileID: 2478198559564463639, guid: 63c4576068eee0e4cb8cb02ef5b3bebf,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 2478198559564463639, guid: 63c4576068eee0e4cb8cb02ef5b3bebf,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2478198559564463639, guid: 63c4576068eee0e4cb8cb02ef5b3bebf,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2478198559564463639, guid: 63c4576068eee0e4cb8cb02ef5b3bebf,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2478198559564463639, guid: 63c4576068eee0e4cb8cb02ef5b3bebf,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2478198559564463639, guid: 63c4576068eee0e4cb8cb02ef5b3bebf,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2478198559564463639, guid: 63c4576068eee0e4cb8cb02ef5b3bebf,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2478198559564463639, guid: 63c4576068eee0e4cb8cb02ef5b3bebf,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2478198559564463639, guid: 63c4576068eee0e4cb8cb02ef5b3bebf,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2482013084337617101, guid: 63c4576068eee0e4cb8cb02ef5b3bebf,
-        type: 3}
-      propertyPath: m_Name
-      value: AirScrubberSelfSufficient
-      objectReference: {fileID: 0}
-    - target: {fileID: 6317477659479903663, guid: 63c4576068eee0e4cb8cb02ef5b3bebf,
-        type: 3}
-      propertyPath: sceneId
-      value: 3751951603
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 63c4576068eee0e4cb8cb02ef5b3bebf, type: 3}
---- !u!4 &1546658234 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 2478198559564463639, guid: 63c4576068eee0e4cb8cb02ef5b3bebf,
-    type: 3}
-  m_PrefabInstance: {fileID: 1546658233}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1554490277
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -26014,7 +28118,7 @@ PrefabInstance:
     - target: {fileID: 5521070544968489048, guid: a565b378d835ddf478bee7e52e6b95dd,
         type: 3}
       propertyPath: m_RootOrder
-      value: 184
+      value: 201
       objectReference: {fileID: 0}
     - target: {fileID: 5521070544968489048, guid: a565b378d835ddf478bee7e52e6b95dd,
         type: 3}
@@ -26097,7 +28201,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: b5d421f0156248b4297eecc918b8758a, type: 3}
       propertyPath: m_RootOrder
-      value: 215
+      value: 232
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: b5d421f0156248b4297eecc918b8758a, type: 3}
       propertyPath: m_LocalPosition.x
@@ -26157,7 +28261,7 @@ PrefabInstance:
     - target: {fileID: 254800111756226720, guid: c4c22bdc7cdd546479ac1de5589b5617,
         type: 3}
       propertyPath: m_RootOrder
-      value: 47
+      value: 52
       objectReference: {fileID: 0}
     - target: {fileID: 254800111756226720, guid: c4c22bdc7cdd546479ac1de5589b5617,
         type: 3}
@@ -26209,6 +28313,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6671892970691844253, guid: c4c22bdc7cdd546479ac1de5589b5617,
+        type: 3}
+      propertyPath: pushPullSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     - target: {fileID: 8521196810206233368, guid: c4c22bdc7cdd546479ac1de5589b5617,
         type: 3}
       propertyPath: sceneId
@@ -26242,7 +28351,7 @@ PrefabInstance:
     - target: {fileID: 1194072455337391194, guid: 007d9f81d20c55d479d86a1d7d4343db,
         type: 3}
       propertyPath: m_RootOrder
-      value: 119
+      value: 127
       objectReference: {fileID: 0}
     - target: {fileID: 1194072455337391194, guid: 007d9f81d20c55d479d86a1d7d4343db,
         type: 3}
@@ -26307,6 +28416,86 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1574873115}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1580202596
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 4082280636756822623, guid: 3a1c398e56f60c94088993b75a3eb87c,
+        type: 3}
+      propertyPath: sceneId
+      value: 293296300
+      objectReference: {fileID: 0}
+    - target: {fileID: 5579758299179776487, guid: 3a1c398e56f60c94088993b75a3eb87c,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 284
+      objectReference: {fileID: 0}
+    - target: {fileID: 5579758299179776487, guid: 3a1c398e56f60c94088993b75a3eb87c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 31
+      objectReference: {fileID: 0}
+    - target: {fileID: 5579758299179776487, guid: 3a1c398e56f60c94088993b75a3eb87c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 39
+      objectReference: {fileID: 0}
+    - target: {fileID: 5579758299179776487, guid: 3a1c398e56f60c94088993b75a3eb87c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5579758299179776487, guid: 3a1c398e56f60c94088993b75a3eb87c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5579758299179776487, guid: 3a1c398e56f60c94088993b75a3eb87c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5579758299179776487, guid: 3a1c398e56f60c94088993b75a3eb87c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5579758299179776487, guid: 3a1c398e56f60c94088993b75a3eb87c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5579758299179776487, guid: 3a1c398e56f60c94088993b75a3eb87c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5579758299179776487, guid: 3a1c398e56f60c94088993b75a3eb87c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5579758299179776487, guid: 3a1c398e56f60c94088993b75a3eb87c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5583053235923205949, guid: 3a1c398e56f60c94088993b75a3eb87c,
+        type: 3}
+      propertyPath: m_Name
+      value: UnaryVent
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3a1c398e56f60c94088993b75a3eb87c, type: 3}
+--- !u!4 &1580202597 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5579758299179776487, guid: 3a1c398e56f60c94088993b75a3eb87c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1580202596}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1581183776
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -26332,7 +28521,7 @@ PrefabInstance:
     - target: {fileID: 7553721075204866577, guid: 7a167eaa044fd7142ad12de730b62846,
         type: 3}
       propertyPath: m_RootOrder
-      value: 273
+      value: 299
       objectReference: {fileID: 0}
     - target: {fileID: 7553721075204866577, guid: 7a167eaa044fd7142ad12de730b62846,
         type: 3}
@@ -26392,6 +28581,86 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1581183776}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1582351501
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 176
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 43
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 933576176691117832, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: m_Name
+      value: ClosetBase
+      objectReference: {fileID: 0}
+    - target: {fileID: 8730627397065656938, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: sceneId
+      value: 3903475347
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73, type: 3}
+--- !u!4 &1582351502 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+    type: 3}
+  m_PrefabInstance: {fileID: 1582351501}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1586810239
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -26405,7 +28674,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_RootOrder
-      value: 216
+      value: 233
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_LocalPosition.x
@@ -26473,7 +28742,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 75
+      value: 80
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -26543,7 +28812,7 @@ PrefabInstance:
     - target: {fileID: 629953639410381570, guid: 381f8f36a2bad374a821a168f8e565b6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 192
+      value: 209
       objectReference: {fileID: 0}
     - target: {fileID: 629953639410381570, guid: 381f8f36a2bad374a821a168f8e565b6,
         type: 3}
@@ -26638,7 +28907,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 95
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -26747,7 +29016,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 287
+      value: 313
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -26928,6 +29197,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6671892970691844253, guid: c4c22bdc7cdd546479ac1de5589b5617,
+        type: 3}
+      propertyPath: pushPullSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     - target: {fileID: 8521196810206233368, guid: c4c22bdc7cdd546479ac1de5589b5617,
         type: 3}
       propertyPath: sceneId
@@ -27107,7 +29381,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 0
-      m_TileSpriteIndex: 8
+      m_TileSpriteIndex: 7
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -27117,7 +29391,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 0
-      m_TileSpriteIndex: 3
+      m_TileSpriteIndex: 6
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -27127,7 +29401,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 0
-      m_TileSpriteIndex: 3
+      m_TileSpriteIndex: 6
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -27137,7 +29411,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 0
-      m_TileSpriteIndex: 3
+      m_TileSpriteIndex: 6
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -27157,7 +29431,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 0
-      m_TileSpriteIndex: 7
+      m_TileSpriteIndex: 8
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -27204,18 +29478,18 @@ Tilemap:
     m_Data: {fileID: 0}
   - m_RefCount: 2
     m_Data: {fileID: 21300020, guid: fdd35d1a33ff82c4ca893aa00797cb12, type: 3}
-  - m_RefCount: 3
-    m_Data: {fileID: 21300022, guid: fdd35d1a33ff82c4ca893aa00797cb12, type: 3}
+  - m_RefCount: 0
+    m_Data: {fileID: 0}
   - m_RefCount: 0
     m_Data: {fileID: 0}
   - m_RefCount: 2
     m_Data: {fileID: 21300006, guid: fdd35d1a33ff82c4ca893aa00797cb12, type: 3}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 1
-    m_Data: {fileID: 21300016, guid: fdd35d1a33ff82c4ca893aa00797cb12, type: 3}
+  - m_RefCount: 3
+    m_Data: {fileID: 21300022, guid: fdd35d1a33ff82c4ca893aa00797cb12, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300018, guid: fdd35d1a33ff82c4ca893aa00797cb12, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 21300016, guid: fdd35d1a33ff82c4ca893aa00797cb12, type: 3}
   m_TileMatrixArray:
   - m_RefCount: 13
     m_Data:
@@ -27241,8 +29515,8 @@ Tilemap:
   m_TileObjectToInstantiateArray: []
   m_AnimationFrameRate: 1
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_Origin: {x: -1, y: -3, z: 0}
-  m_Size: {x: 8, y: 7, z: 1}
+  m_Origin: {x: -9, y: -3, z: 0}
+  m_Size: {x: 16, y: 7, z: 1}
   m_TileAnchor: {x: 0.5, y: 0.5, z: 0}
   m_TileOrientation: 0
   m_TileOrientationMatrix:
@@ -27341,7 +29615,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 90
+      value: 95
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -27450,7 +29724,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 290
+      value: 316
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -27785,7 +30059,7 @@ PrefabInstance:
     - target: {fileID: 461637258738260195, guid: d243343741d540446b159becf769231a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 267
+      value: 293
       objectReference: {fileID: 0}
     - target: {fileID: 461637258738260195, guid: d243343741d540446b159becf769231a,
         type: 3}
@@ -27887,7 +30161,7 @@ PrefabInstance:
     - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 262
+      value: 288
       objectReference: {fileID: 0}
     - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
         type: 3}
@@ -28014,7 +30288,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 83
+      value: 88
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -28118,7 +30392,7 @@ PrefabInstance:
     - target: {fileID: 1925386106379506438, guid: 99fa44696e5676a41bb345c085b3e768,
         type: 3}
       propertyPath: m_RootOrder
-      value: 38
+      value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 1925386106379506438, guid: 99fa44696e5676a41bb345c085b3e768,
         type: 3}
@@ -28188,6 +30462,86 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1659743420}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1663209712
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 4954479433304004807, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: sceneId
+      value: 3055360752
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 325
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 36
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 18.120117
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4996160304479888755, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_Name
+      value: OP70Handgun
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9363154ec4a288f41b8c9681e3531539, type: 3}
+--- !u!4 &1663209713 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+    type: 3}
+  m_PrefabInstance: {fileID: 1663209712}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1666731705
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -28201,7 +30555,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4549118663027890, guid: 9a960afa1c32b4a208621260530a2d8a, type: 3}
       propertyPath: m_RootOrder
-      value: 177
+      value: 194
       objectReference: {fileID: 0}
     - target: {fileID: 4549118663027890, guid: 9a960afa1c32b4a208621260530a2d8a, type: 3}
       propertyPath: m_LocalPosition.x
@@ -28266,7 +30620,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 67
+      value: 72
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -28331,7 +30685,7 @@ PrefabInstance:
     - target: {fileID: 8342472905829387893, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: connectedDevices.Array.size
-      value: 30
+      value: 34
       objectReference: {fileID: 0}
     - target: {fileID: 8342472905829387893, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -28483,6 +30837,26 @@ PrefabInstance:
       propertyPath: connectedDevices.Array.data[29]
       value: 
       objectReference: {fileID: 590623773}
+    - target: {fileID: 8342472905829387893, guid: cd57203a8d3f54f478446e9b0ced6cf9,
+        type: 3}
+      propertyPath: connectedDevices.Array.data[30]
+      value: 
+      objectReference: {fileID: 1318939912}
+    - target: {fileID: 8342472905829387893, guid: cd57203a8d3f54f478446e9b0ced6cf9,
+        type: 3}
+      propertyPath: connectedDevices.Array.data[31]
+      value: 
+      objectReference: {fileID: 395655433}
+    - target: {fileID: 8342472905829387893, guid: cd57203a8d3f54f478446e9b0ced6cf9,
+        type: 3}
+      propertyPath: connectedDevices.Array.data[32]
+      value: 
+      objectReference: {fileID: 1922923929}
+    - target: {fileID: 8342472905829387893, guid: cd57203a8d3f54f478446e9b0ced6cf9,
+        type: 3}
+      propertyPath: connectedDevices.Array.data[33]
+      value: 
+      objectReference: {fileID: 1408379518}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cd57203a8d3f54f478446e9b0ced6cf9, type: 3}
 --- !u!4 &1669325241 stripped
@@ -28585,7 +30959,7 @@ PrefabInstance:
     - target: {fileID: 5730203012241659306, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 186
+      value: 203
       objectReference: {fileID: 0}
     - target: {fileID: 5730203012241659306, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
@@ -28680,7 +31054,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 87
+      value: 92
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -28779,7 +31153,7 @@ PrefabInstance:
     - target: {fileID: 4249355701057277291, guid: 8fb9b82aab871a54fb9bdb7e4a985821,
         type: 3}
       propertyPath: m_RootOrder
-      value: 254
+      value: 278
       objectReference: {fileID: 0}
     - target: {fileID: 4249355701057277291, guid: 8fb9b82aab871a54fb9bdb7e4a985821,
         type: 3}
@@ -28864,7 +31238,7 @@ PrefabInstance:
     - target: {fileID: 4751204249681072796, guid: be26d178314bedc419e95cd4466da4e5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 51
+      value: 56
       objectReference: {fileID: 0}
     - target: {fileID: 4751204249681072796, guid: be26d178314bedc419e95cd4466da4e5,
         type: 3}
@@ -28968,7 +31342,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 66
+      value: 71
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -29140,7 +31514,7 @@ PrefabInstance:
     - target: {fileID: 7360425322471321201, guid: bc0cd2a586c78b846a43622b6ea5c953,
         type: 3}
       propertyPath: m_RootOrder
-      value: 157
+      value: 162
       objectReference: {fileID: 0}
     - target: {fileID: 7360425322471321201, guid: bc0cd2a586c78b846a43622b6ea5c953,
         type: 3}
@@ -29380,7 +31754,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 280
+      value: 306
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -29474,7 +31848,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 97
+      value: 102
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -29559,7 +31933,7 @@ PrefabInstance:
     - target: {fileID: 4316376699312728761, guid: d4a3f41d96f2c4143b8556508db41c57,
         type: 3}
       propertyPath: m_RootOrder
-      value: 59
+      value: 64
       objectReference: {fileID: 0}
     - target: {fileID: 4316376699312728761, guid: d4a3f41d96f2c4143b8556508db41c57,
         type: 3}
@@ -29634,7 +32008,7 @@ PrefabInstance:
     - target: {fileID: 3956749382267164151, guid: 423cab216aa4e354f8159742cc80d10a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 165
+      value: 170
       objectReference: {fileID: 0}
     - target: {fileID: 3956749382267164151, guid: 423cab216aa4e354f8159742cc80d10a,
         type: 3}
@@ -29703,6 +32077,103 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3956749382267164151, guid: 423cab216aa4e354f8159742cc80d10a,
     type: 3}
   m_PrefabInstance: {fileID: 1713367466}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1726170323
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 2161439757415737395, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: RelatedAPC
+      value: 
+      objectReference: {fileID: 1833317362}
+    - target: {fileID: 3219073340430485023, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_Name
+      value: AirlockPublicWindowed
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 242
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 23
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 34
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6445112791058527101, guid: 54a552cbe4002ac44ae29b958a90e545,
+        type: 3}
+      propertyPath: sceneId
+      value: 1127292494
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 54a552cbe4002ac44ae29b958a90e545, type: 3}
+--- !u!114 &1726170324 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2161439757415737395, guid: 54a552cbe4002ac44ae29b958a90e545,
+    type: 3}
+  m_PrefabInstance: {fileID: 1726170323}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1726170325 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
+    type: 3}
+  m_PrefabInstance: {fileID: 1726170323}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1730118465
 PrefabInstance:
@@ -29821,7 +32292,7 @@ PrefabInstance:
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 24
+      value: 26
       objectReference: {fileID: 0}
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
@@ -30090,7 +32561,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 103
+      value: 108
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -30297,7 +32768,7 @@ PrefabInstance:
     - target: {fileID: 6511207373575406613, guid: 1488f67a55cb9b84098e095e65e5a2b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 188
+      value: 205
       objectReference: {fileID: 0}
     - target: {fileID: 6511207373575406613, guid: 1488f67a55cb9b84098e095e65e5a2b3,
         type: 3}
@@ -30377,7 +32848,7 @@ PrefabInstance:
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 190
+      value: 207
       objectReference: {fileID: 0}
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
@@ -30462,7 +32933,7 @@ PrefabInstance:
     - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
         type: 3}
       propertyPath: m_RootOrder
-      value: 302
+      value: 328
       objectReference: {fileID: 0}
     - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
         type: 3}
@@ -30596,7 +33067,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 243
+      value: 266
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -30700,7 +33171,7 @@ PrefabInstance:
     - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 126
+      value: 134
       objectReference: {fileID: 0}
     - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
         type: 3}
@@ -30805,12 +33276,12 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 234
+      value: 256
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 45
+      value: 46
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -31065,7 +33536,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 245
+      value: 268
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -31164,7 +33635,7 @@ PrefabInstance:
     - target: {fileID: 5193296327940958646, guid: 63a58edd1e5377040a9ea82e307c1f04,
         type: 3}
       propertyPath: m_RootOrder
-      value: 159
+      value: 164
       objectReference: {fileID: 0}
     - target: {fileID: 5193296327940958646, guid: 63a58edd1e5377040a9ea82e307c1f04,
         type: 3}
@@ -31249,7 +33720,7 @@ PrefabInstance:
     - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 319
+      value: 350
       objectReference: {fileID: 0}
     - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
         type: 3}
@@ -31308,97 +33779,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
     type: 3}
   m_PrefabInstance: {fileID: 1800652675}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1802957303
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 8082954268645528609}
-    m_Modifications:
-    - target: {fileID: 4039531135446677770, guid: e947d751522b07a4186cd276fb16eefe,
-        type: 3}
-      propertyPath: sceneId
-      value: 4168330556
-      objectReference: {fileID: 0}
-    - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 46
-      objectReference: {fileID: 0}
-    - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 19
-      objectReference: {fileID: 0}
-    - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 18
-      objectReference: {fileID: 0}
-    - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5607718071721086056, guid: e947d751522b07a4186cd276fb16eefe,
-        type: 3}
-      propertyPath: m_Name
-      value: Exosuit Fabricator
-      objectReference: {fileID: 0}
-    - target: {fileID: 5670771940237863039, guid: e947d751522b07a4186cd276fb16eefe,
-        type: 3}
-      propertyPath: 
-      value: 
-      objectReference: {fileID: 21300000, guid: 7dd7012b3105d144fa39633271f2d9da,
-        type: 3}
-    - target: {fileID: 5670771940237863039, guid: e947d751522b07a4186cd276fb16eefe,
-        type: 3}
-      propertyPath: m_WasSpriteAssigned
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e947d751522b07a4186cd276fb16eefe, type: 3}
---- !u!4 &1802957304 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
-    type: 3}
-  m_PrefabInstance: {fileID: 1802957303}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1807496965
 GameObject:
@@ -31505,15 +33885,39 @@ Tilemap:
   m_Enabled: 1
   m_Tiles: {}
   m_AnimatedTiles: {}
-  m_TileAssetArray: []
-  m_TileSpriteArray: []
-  m_TileMatrixArray: []
-  m_TileColorArray: []
+  m_TileAssetArray:
+  - m_RefCount: 0
+    m_Data: {fileID: 0}
+  m_TileSpriteArray:
+  - m_RefCount: 0
+    m_Data: {fileID: 0}
+  m_TileMatrixArray:
+  - m_RefCount: 0
+    m_Data:
+      e00: -1.3415087e+35
+      e01: 2.0150688e-20
+      e02: 1e-44
+      e03: 0.0000000128831985
+      e10: 1.44e-43
+      e11: 4.5904e-41
+      e12: 0
+      e13: 7.45e-43
+      e20: 2.9696375e-24
+      e21: 6.484018e-10
+      e22: -1.3415546e+35
+      e23: -1.3415546e+35
+      e30: 4.5904e-41
+      e31: 7.48e-43
+      e32: 1.44e-43
+      e33: 1.44e-43
+  m_TileColorArray:
+  - m_RefCount: 0
+    m_Data: {r: 6.4839245e-10, g: 6.4839245e-10, b: 6.4839245e-10, a: 6.4839245e-10}
   m_TileObjectToInstantiateArray: []
   m_AnimationFrameRate: 1
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_Origin: {x: 0, y: 0, z: 0}
-  m_Size: {x: 0, y: 0, z: 1}
+  m_Origin: {x: -21, y: -2, z: 0}
+  m_Size: {x: 21, y: 5, z: 2}
   m_TileAnchor: {x: 0.5, y: 0.5, z: 0}
   m_TileOrientation: 0
   m_TileOrientationMatrix:
@@ -31563,7 +33967,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 244
+      value: 267
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -31647,6 +34051,86 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8cd47c8a7b3ca4905983be3a08c1caf0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &1817986973
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 8518771024213410837, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: sceneId
+      value: 2207358322
+      objectReference: {fileID: 0}
+    - target: {fileID: 8623536237055031713, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_Name
+      value: BedSheet Grey
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 181
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3a4418c4707ae5b4fa4fd5f48c06443b, type: 3}
+--- !u!4 &1817986974 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+    type: 3}
+  m_PrefabInstance: {fileID: 1817986973}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1820062637
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -31669,7 +34153,7 @@ PrefabInstance:
     - target: {fileID: 461637258738260195, guid: d243343741d540446b159becf769231a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 266
+      value: 292
       objectReference: {fileID: 0}
     - target: {fileID: 461637258738260195, guid: d243343741d540446b159becf769231a,
         type: 3}
@@ -31808,7 +34292,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 242
+      value: 265
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -31917,7 +34401,7 @@ PrefabInstance:
     - target: {fileID: 311235556692342817, guid: 7953abf1584ad8241b2281698de84f40,
         type: 3}
       propertyPath: m_RootOrder
-      value: 81
+      value: 86
       objectReference: {fileID: 0}
     - target: {fileID: 311235556692342817, guid: 7953abf1584ad8241b2281698de84f40,
         type: 3}
@@ -32106,7 +34590,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 80
+      value: 85
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -32171,7 +34655,7 @@ PrefabInstance:
     - target: {fileID: 8342472905829387893, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: connectedDevices.Array.size
-      value: 12
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 8342472905829387893, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -32237,12 +34721,12 @@ PrefabInstance:
         type: 3}
       propertyPath: connectedDevices.Array.data[12]
       value: 
-      objectReference: {fileID: 1535765819}
+      objectReference: {fileID: 743174084}
     - target: {fileID: 8342472905829387893, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: connectedDevices.Array.data[13]
       value: 
-      objectReference: {fileID: 1535765819}
+      objectReference: {fileID: 1726170324}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cd57203a8d3f54f478446e9b0ced6cf9, type: 3}
 --- !u!4 &1833317361 stripped
@@ -32278,7 +34762,7 @@ PrefabInstance:
     - target: {fileID: 1194072455337391194, guid: 007d9f81d20c55d479d86a1d7d4343db,
         type: 3}
       propertyPath: m_RootOrder
-      value: 123
+      value: 131
       objectReference: {fileID: 0}
     - target: {fileID: 1194072455337391194, guid: 007d9f81d20c55d479d86a1d7d4343db,
         type: 3}
@@ -32363,7 +34847,7 @@ PrefabInstance:
     - target: {fileID: 4751204249681072796, guid: be26d178314bedc419e95cd4466da4e5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 52
+      value: 57
       objectReference: {fileID: 0}
     - target: {fileID: 4751204249681072796, guid: be26d178314bedc419e95cd4466da4e5,
         type: 3}
@@ -32478,7 +34962,7 @@ PrefabInstance:
     - target: {fileID: 5453087981515002643, guid: 34894a7b128fef84588648dd03311de5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 206
+      value: 223
       objectReference: {fileID: 0}
     - target: {fileID: 5453087981515002643, guid: 34894a7b128fef84588648dd03311de5,
         type: 3}
@@ -32743,7 +35227,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 1f98145bcaa7b9947888e1677211ece0,
+      objectReference: {fileID: 21300000, guid: c39d19bba0ae67943a58040a898fdf54,
         type: 3}
     - target: {fileID: 8568672687853555390, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
         type: 3}
@@ -32753,7 +35237,7 @@ PrefabInstance:
     - target: {fileID: 8573033213633377226, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 136
+      value: 144
       objectReference: {fileID: 0}
     - target: {fileID: 8573033213633377226, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
         type: 3}
@@ -32834,7 +35318,7 @@ PrefabInstance:
     - target: {fileID: 3956749382267164151, guid: 423cab216aa4e354f8159742cc80d10a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 163
+      value: 168
       objectReference: {fileID: 0}
     - target: {fileID: 3956749382267164151, guid: 423cab216aa4e354f8159742cc80d10a,
         type: 3}
@@ -32924,7 +35408,7 @@ PrefabInstance:
     - target: {fileID: 6752097109298067032, guid: 13186a514a60194429e94407b6cf1e0a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 164
+      value: 169
       objectReference: {fileID: 0}
     - target: {fileID: 6752097109298067032, guid: 13186a514a60194429e94407b6cf1e0a,
         type: 3}
@@ -32983,6 +35467,86 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6752097109298067032, guid: 13186a514a60194429e94407b6cf1e0a,
     type: 3}
   m_PrefabInstance: {fileID: 1874777168}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1888346719
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 8518771024213410837, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: sceneId
+      value: 784731855
+      objectReference: {fileID: 0}
+    - target: {fileID: 8623536237055031713, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_Name
+      value: BedSheet Grey
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 183
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 47
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3a4418c4707ae5b4fa4fd5f48c06443b, type: 3}
+--- !u!4 &1888346720 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+    type: 3}
+  m_PrefabInstance: {fileID: 1888346719}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1894410037
 PrefabInstance:
@@ -33150,7 +35714,7 @@ PrefabInstance:
     - target: {fileID: 5327488673359562728, guid: 29ecbf5a1d918574cbcf5853927e0944,
         type: 3}
       propertyPath: m_RootOrder
-      value: 128
+      value: 136
       objectReference: {fileID: 0}
     - target: {fileID: 5327488673359562728, guid: 29ecbf5a1d918574cbcf5853927e0944,
         type: 3}
@@ -33220,6 +35784,96 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1901759282}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1913705404
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 21.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5770283965274354279, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: m_Name
+      value: MetalSheet
+      objectReference: {fileID: 0}
+    - target: {fileID: 5872728177783164883, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: sceneId
+      value: 902836260
+      objectReference: {fileID: 0}
+    - target: {fileID: 5873122659972669367, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: snapToGridOnStart
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7860434352612808136, guid: b83b68cfa4a201748aeeece963a989c3,
+        type: 3}
+      propertyPath: initialAmount
+      value: 20
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b83b68cfa4a201748aeeece963a989c3, type: 3}
+--- !u!4 &1913705405 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
+    type: 3}
+  m_PrefabInstance: {fileID: 1913705404}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1914930188
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -33242,7 +35896,7 @@ PrefabInstance:
     - target: {fileID: 461637258738260195, guid: d243343741d540446b159becf769231a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 268
+      value: 294
       objectReference: {fileID: 0}
     - target: {fileID: 461637258738260195, guid: d243343741d540446b159becf769231a,
         type: 3}
@@ -33344,7 +35998,7 @@ PrefabInstance:
     - target: {fileID: 4316376699312728761, guid: d4a3f41d96f2c4143b8556508db41c57,
         type: 3}
       propertyPath: m_RootOrder
-      value: 58
+      value: 63
       objectReference: {fileID: 0}
     - target: {fileID: 4316376699312728761, guid: d4a3f41d96f2c4143b8556508db41c57,
         type: 3}
@@ -33429,7 +36083,7 @@ PrefabInstance:
     - target: {fileID: 3967934396199251458, guid: c0cbb1853d350404685a523d617f3458,
         type: 3}
       propertyPath: m_RootOrder
-      value: 179
+      value: 196
       objectReference: {fileID: 0}
     - target: {fileID: 3967934396199251458, guid: c0cbb1853d350404685a523d617f3458,
         type: 3}
@@ -33514,7 +36168,7 @@ PrefabInstance:
     - target: {fileID: 8582924881145235216, guid: 66a5287d0bf216847a2f4fe34228a0cf,
         type: 3}
       propertyPath: m_RootOrder
-      value: 131
+      value: 139
       objectReference: {fileID: 0}
     - target: {fileID: 8582924881145235216, guid: 66a5287d0bf216847a2f4fe34228a0cf,
         type: 3}
@@ -33587,7 +36241,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: a6f87f3db636f2c4ba3aa4763aba4c3b, type: 3}
       propertyPath: m_RootOrder
-      value: 41
+      value: 43
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: a6f87f3db636f2c4ba3aa4763aba4c3b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -33642,6 +36296,157 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1920356668}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1922923927
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 1689274832931870787, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 1f8fe2981d2d3bb4f8643d0bed83b580,
+        type: 3}
+    - target: {fileID: 1943076862554158340, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: sceneId
+      value: 3441347035
+      objectReference: {fileID: 0}
+    - target: {fileID: 2883810215281542680, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: InitialDirection
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3662677150203288956, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 0.7500607
+      objectReference: {fileID: 0}
+    - target: {fileID: 3662677150203288956, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 0.1225356
+      objectReference: {fileID: 0}
+    - target: {fileID: 3662677150203288956, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_Offset.x
+      value: 0.002267361
+      objectReference: {fileID: 0}
+    - target: {fileID: 3662677150203288956, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_Offset.y
+      value: -0.4372666
+      objectReference: {fileID: 0}
+    - target: {fileID: 6807309527984598602, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: RelatedAPC
+      value: 
+      objectReference: {fileID: 1669325242}
+    - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: relatedLightSwitch
+      value: 
+      objectReference: {fileID: 590623775}
+    - target: {fileID: 7803294762233930865, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 244761d659f269a4793677b4e2651889,
+        type: 3}
+    - target: {fileID: 8010465399013802086, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_Name
+      value: LightTubeFixture
+      objectReference: {fileID: 0}
+    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 346
+      objectReference: {fileID: 0}
+    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fde32c02abddc814f9366ff1fb21f234, type: 3}
+--- !u!114 &1922923928 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
+    type: 3}
+  m_PrefabInstance: {fileID: 1922923927}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8cd47c8a7b3ca4905983be3a08c1caf0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1922923929 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6807309527984598602, guid: fde32c02abddc814f9366ff1fb21f234,
+    type: 3}
+  m_PrefabInstance: {fileID: 1922923927}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1922923930 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+    type: 3}
+  m_PrefabInstance: {fileID: 1922923927}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1924789900
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -33657,7 +36462,7 @@ PrefabInstance:
     - target: {fileID: 2186281498986418755, guid: 53f6552a4b56f2d49892b40149511a62,
         type: 3}
       propertyPath: m_RootOrder
-      value: 148
+      value: 156
       objectReference: {fileID: 0}
     - target: {fileID: 2186281498986418755, guid: 53f6552a4b56f2d49892b40149511a62,
         type: 3}
@@ -33742,7 +36547,7 @@ PrefabInstance:
     - target: {fileID: 296282586161115487, guid: 1849f051284c432478d5aaba34cec853,
         type: 3}
       propertyPath: m_RootOrder
-      value: 264
+      value: 290
       objectReference: {fileID: 0}
     - target: {fileID: 296282586161115487, guid: 1849f051284c432478d5aaba34cec853,
         type: 3}
@@ -33822,7 +36627,7 @@ PrefabInstance:
     - target: {fileID: 1304001640488763778, guid: 151d489becc4ca64f878f37a991c138e,
         type: 3}
       propertyPath: m_RootOrder
-      value: 211
+      value: 228
       objectReference: {fileID: 0}
     - target: {fileID: 1304001640488763778, guid: 151d489becc4ca64f878f37a991c138e,
         type: 3}
@@ -33886,6 +36691,86 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 1304001640488763778, guid: 151d489becc4ca64f878f37a991c138e,
     type: 3}
   m_PrefabInstance: {fileID: 1934288352}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1940617001
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 8518771024213410837, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: sceneId
+      value: 2581917000
+      objectReference: {fileID: 0}
+    - target: {fileID: 8623536237055031713, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_Name
+      value: BedSheet Grey
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 182
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3a4418c4707ae5b4fa4fd5f48c06443b, type: 3}
+--- !u!4 &1940617002 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8628745860957324501, guid: 3a4418c4707ae5b4fa4fd5f48c06443b,
+    type: 3}
+  m_PrefabInstance: {fileID: 1940617001}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1945989989
 PrefabInstance:
@@ -33966,7 +36851,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 309
+      value: 338
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -34080,7 +36965,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 308
+      value: 336
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -34184,7 +37069,7 @@ PrefabInstance:
     - target: {fileID: 9173161790594611747, guid: 25108e21a69d52c46a538e66eb85db0a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 134
+      value: 142
       objectReference: {fileID: 0}
     - target: {fileID: 9173161790594611747, guid: 25108e21a69d52c46a538e66eb85db0a,
         type: 3}
@@ -34249,6 +37134,91 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1966743400}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1981898868
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 8399202269906357691, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_Name
+      value: PistolMagazine9mm
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 329
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 36.21
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 17.99
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8438156590381850731, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: snapToGridOnStart
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8438549908676571151, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: sceneId
+      value: 1064865358
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 678d8623073f29f4cb23d4cb26359cd4, type: 3}
+--- !u!4 &1981898869 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+    type: 3}
+  m_PrefabInstance: {fileID: 1981898868}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1982867959
 GameObject:
   m_ObjectHideFlags: 0
@@ -34262,7 +37232,7 @@ GameObject:
   - component: {fileID: 1982867963}
   - component: {fileID: 1982867962}
   - component: {fileID: 1982867961}
-  m_Layer: 22
+  m_Layer: 0
   m_Name: Floors
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -34346,9 +37316,9 @@ TilemapRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingLayerID: 322132419
+  m_SortingLayer: 2
+  m_SortingOrder: 2
   m_ChunkSize: {x: 32, y: 32, z: 32}
   m_ChunkCullingBounds: {x: 0, y: 0, z: 0}
   m_MaxChunkCount: 16
@@ -34699,7 +37669,7 @@ PrefabInstance:
     - target: {fileID: 4799658863714516831, guid: fff8b3ada084c1b408e9c34ee1a1dd27,
         type: 3}
       propertyPath: m_RootOrder
-      value: 204
+      value: 221
       objectReference: {fileID: 0}
     - target: {fileID: 4799658863714516831, guid: fff8b3ada084c1b408e9c34ee1a1dd27,
         type: 3}
@@ -34838,7 +37808,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 238
+      value: 261
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -34937,7 +37907,7 @@ PrefabInstance:
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 117
+      value: 125
       objectReference: {fileID: 0}
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
@@ -35017,7 +37987,7 @@ PrefabInstance:
     - target: {fileID: 1304001640488763778, guid: 151d489becc4ca64f878f37a991c138e,
         type: 3}
       propertyPath: m_RootOrder
-      value: 210
+      value: 227
       objectReference: {fileID: 0}
     - target: {fileID: 1304001640488763778, guid: 151d489becc4ca64f878f37a991c138e,
         type: 3}
@@ -35082,6 +38052,91 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1998515046}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2005459986
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 1510522646492316420, guid: d2f2400aac0da54468da76680579c29b,
+        type: 3}
+      propertyPath: initialAmount
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2910367782701455647, guid: d2f2400aac0da54468da76680579c29b,
+        type: 3}
+      propertyPath: sceneId
+      value: 4229940847
+      objectReference: {fileID: 0}
+    - target: {fileID: 3018541687849032159, guid: d2f2400aac0da54468da76680579c29b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 49
+      objectReference: {fileID: 0}
+    - target: {fileID: 3018541687849032159, guid: d2f2400aac0da54468da76680579c29b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 18.96
+      objectReference: {fileID: 0}
+    - target: {fileID: 3018541687849032159, guid: d2f2400aac0da54468da76680579c29b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 3018541687849032159, guid: d2f2400aac0da54468da76680579c29b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3018541687849032159, guid: d2f2400aac0da54468da76680579c29b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3018541687849032159, guid: d2f2400aac0da54468da76680579c29b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3018541687849032159, guid: d2f2400aac0da54468da76680579c29b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3018541687849032159, guid: d2f2400aac0da54468da76680579c29b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3018541687849032159, guid: d2f2400aac0da54468da76680579c29b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3018541687849032159, guid: d2f2400aac0da54468da76680579c29b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3018541687849032159, guid: d2f2400aac0da54468da76680579c29b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3024028113330201771, guid: d2f2400aac0da54468da76680579c29b,
+        type: 3}
+      propertyPath: m_Name
+      value: ReinforcedGlassSheet
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d2f2400aac0da54468da76680579c29b, type: 3}
+--- !u!4 &2005459987 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3018541687849032159, guid: d2f2400aac0da54468da76680579c29b,
+    type: 3}
+  m_PrefabInstance: {fileID: 2005459986}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2008841493
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -35097,7 +38152,7 @@ PrefabInstance:
     - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 318
+      value: 349
       objectReference: {fileID: 0}
     - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
         type: 3}
@@ -35269,12 +38324,12 @@ PrefabInstance:
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 168
+      value: 179
       objectReference: {fileID: 0}
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 44
+      value: 45
       objectReference: {fileID: 0}
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
@@ -35725,7 +38780,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 0
-      m_TileSpriteIndex: 11
+      m_TileSpriteIndex: 15
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -35735,7 +38790,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 0
-      m_TileSpriteIndex: 15
+      m_TileSpriteIndex: 11
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -35789,7 +38844,7 @@ Tilemap:
   - m_RefCount: 2
     m_Data: {fileID: 21300008, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
   - m_RefCount: 1
-    m_Data: {fileID: 21300046, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
+    m_Data: {fileID: 21300048, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300022, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
   - m_RefCount: 1
@@ -35797,7 +38852,7 @@ Tilemap:
   - m_RefCount: 2
     m_Data: {fileID: 21300004, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
   - m_RefCount: 1
-    m_Data: {fileID: 21300048, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
+    m_Data: {fileID: 21300046, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
   - m_RefCount: 2
     m_Data: {fileID: 21300024, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
   - m_RefCount: 6
@@ -35869,7 +38924,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4734855229797344, guid: 35eed4273d90143b0926de4715bbc06e, type: 3}
       propertyPath: m_RootOrder
-      value: 37
+      value: 39
       objectReference: {fileID: 0}
     - target: {fileID: 4734855229797344, guid: 35eed4273d90143b0926de4715bbc06e, type: 3}
       propertyPath: m_LocalPosition.x
@@ -36056,7 +39111,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 225
+      value: 244
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -36153,7 +39208,7 @@ PrefabInstance:
     - target: {fileID: 8182938654540533794, guid: 1a00e842e154f7d43811c5d45328988c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 173
+      value: 190
       objectReference: {fileID: 0}
     - target: {fileID: 8182938654540533794, guid: 1a00e842e154f7d43811c5d45328988c,
         type: 3}
@@ -36240,7 +39295,7 @@ PrefabInstance:
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 110
+      value: 115
       objectReference: {fileID: 0}
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
@@ -36325,7 +39380,7 @@ PrefabInstance:
     - target: {fileID: 1427000246303903125, guid: 288980126acf5f441841169958c31630,
         type: 3}
       propertyPath: m_RootOrder
-      value: 140
+      value: 148
       objectReference: {fileID: 0}
     - target: {fileID: 1427000246303903125, guid: 288980126acf5f441841169958c31630,
         type: 3}
@@ -36400,7 +39455,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 32
+      value: 34
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -36500,7 +39555,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4734855229797344, guid: d72e24d0fc40a7545aad2f4e4f978d33, type: 3}
       propertyPath: m_RootOrder
-      value: 44
+      value: 46
       objectReference: {fileID: 0}
     - target: {fileID: 4734855229797344, guid: d72e24d0fc40a7545aad2f4e4f978d33, type: 3}
       propertyPath: m_LocalPosition.x
@@ -36575,12 +39630,12 @@ PrefabInstance:
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 169
+      value: 186
       objectReference: {fileID: 0}
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 46
+      value: 47
       objectReference: {fileID: 0}
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
@@ -36650,7 +39705,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 98
+      value: 103
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -36735,7 +39790,7 @@ PrefabInstance:
     - target: {fileID: 8630552864855298094, guid: d0eb5dacbdcd4844e8c76aabde50434f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 162
+      value: 167
       objectReference: {fileID: 0}
     - target: {fileID: 8630552864855298094, guid: d0eb5dacbdcd4844e8c76aabde50434f,
         type: 3}
@@ -36799,91 +39854,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8630552864855298094, guid: d0eb5dacbdcd4844e8c76aabde50434f,
     type: 3}
   m_PrefabInstance: {fileID: 2082518343}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &2083813790
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 8082954268645528609}
-    m_Modifications:
-    - target: {fileID: 6930305835335021225, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_Name
-      value: EnergyPistol
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 154
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 33.858
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 18.095
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7041601427722821497, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: snapToGridOnStart
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7041749550512197405, guid: 5a31eb85267283041aa9613772d08f90,
-        type: 3}
-      propertyPath: sceneId
-      value: 1549633854
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 5a31eb85267283041aa9613772d08f90, type: 3}
---- !u!4 &2083813791 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
-    type: 3}
-  m_PrefabInstance: {fileID: 2083813790}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2086551558
 PrefabInstance:
@@ -36954,7 +39924,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 85
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -37063,7 +40033,7 @@ PrefabInstance:
     - target: {fileID: 3050131568678634113, guid: fe66ec36f566be84a9ccbc5a90aacd6f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 145
+      value: 153
       objectReference: {fileID: 0}
     - target: {fileID: 3050131568678634113, guid: fe66ec36f566be84a9ccbc5a90aacd6f,
         type: 3}
@@ -37143,7 +40113,7 @@ PrefabInstance:
     - target: {fileID: 7208238290007470226, guid: 21bb3b22e17572f479870465dd940c9d,
         type: 3}
       propertyPath: m_RootOrder
-      value: 36
+      value: 38
       objectReference: {fileID: 0}
     - target: {fileID: 7208238290007470226, guid: 21bb3b22e17572f479870465dd940c9d,
         type: 3}
@@ -37218,7 +40188,7 @@ PrefabInstance:
     - target: {fileID: 3318137014604025332, guid: 9759789a5180a46419c8a7e2e50748e2,
         type: 3}
       propertyPath: m_RootOrder
-      value: 272
+      value: 298
       objectReference: {fileID: 0}
     - target: {fileID: 3318137014604025332, guid: 9759789a5180a46419c8a7e2e50748e2,
         type: 3}
@@ -37303,7 +40273,7 @@ PrefabInstance:
     - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 320
+      value: 351
       objectReference: {fileID: 0}
     - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
         type: 3}
@@ -37383,7 +40353,7 @@ PrefabInstance:
     - target: {fileID: 3682557958087281322, guid: 6bd9037fbb19a79409aab54675bc363e,
         type: 3}
       propertyPath: m_RootOrder
-      value: 213
+      value: 230
       objectReference: {fileID: 0}
     - target: {fileID: 3682557958087281322, guid: 6bd9037fbb19a79409aab54675bc363e,
         type: 3}
@@ -37510,7 +40480,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 282
+      value: 308
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -37609,7 +40579,7 @@ PrefabInstance:
     - target: {fileID: 4049041059155957662, guid: 9944313d68658b341966d43e2c218eaa,
         type: 3}
       propertyPath: m_RootOrder
-      value: 270
+      value: 296
       objectReference: {fileID: 0}
     - target: {fileID: 4049041059155957662, guid: 9944313d68658b341966d43e2c218eaa,
         type: 3}
@@ -38774,7 +41744,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 0
-      m_TileSpriteIndex: 9
+      m_TileSpriteIndex: 42
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -38784,7 +41754,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 0
-      m_TileSpriteIndex: 11
+      m_TileSpriteIndex: 25
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -38794,7 +41764,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 0
-      m_TileSpriteIndex: 25
+      m_TileSpriteIndex: 11
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -38824,7 +41794,67 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 0
-      m_TileSpriteIndex: 43
+      m_TileSpriteIndex: 47
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 43, y: 7, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 1
+      m_TileSpriteIndex: 44
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 44, y: 7, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 1
+      m_TileSpriteIndex: 44
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 45, y: 7, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 1
+      m_TileSpriteIndex: 44
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 46, y: 7, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 1
+      m_TileSpriteIndex: 44
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 47, y: 7, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 1
+      m_TileSpriteIndex: 44
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 48, y: 7, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 2
+      m_TileSpriteIndex: 39
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -38864,7 +41894,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 0
-      m_TileSpriteIndex: 42
+      m_TileSpriteIndex: 9
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -38990,6 +42020,16 @@ Tilemap:
       m_TileObjectToInstantiateIndex: 65535
       dummyAlignment: 0
       m_AllTileFlags: 2147483648
+  - first: {x: 48, y: 8, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 45
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
   - first: {x: 6, y: 9, z: 0}
     second:
       serializedVersion: 2
@@ -39084,17 +42124,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 0
-      m_TileSpriteIndex: 34
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 2147483648
-  - first: {x: 40, y: 9, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 47
+      m_TileSpriteIndex: 51
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -39104,7 +42134,67 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 0
-      m_TileSpriteIndex: 43
+      m_TileSpriteIndex: 49
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 42, y: 9, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 1
+      m_TileSpriteIndex: 23
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 43, y: 9, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 1
+      m_TileSpriteIndex: 44
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 44, y: 9, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 1
+      m_TileSpriteIndex: 44
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 45, y: 9, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 1
+      m_TileSpriteIndex: 44
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 46, y: 9, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 1
+      m_TileSpriteIndex: 70
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 48, y: 9, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 1
+      m_TileSpriteIndex: 50
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -39220,6 +42310,36 @@ Tilemap:
       m_TileObjectToInstantiateIndex: 65535
       dummyAlignment: 0
       m_AllTileFlags: 2147483648
+  - first: {x: 42, y: 10, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 1
+      m_TileSpriteIndex: 50
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 46, y: 10, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 1
+      m_TileSpriteIndex: 50
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 48, y: 10, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 1
+      m_TileSpriteIndex: 50
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
   - first: {x: 6, y: 11, z: 0}
     second:
       serializedVersion: 2
@@ -39301,6 +42421,36 @@ Tilemap:
       dummyAlignment: 0
       m_AllTileFlags: 2147483648
   - first: {x: 39, y: 11, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 1
+      m_TileSpriteIndex: 50
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 42, y: 11, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 1
+      m_TileSpriteIndex: 50
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 46, y: 11, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 1
+      m_TileSpriteIndex: 50
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 48, y: 11, z: 0}
     second:
       serializedVersion: 2
       m_TileIndex: 1
@@ -39403,8 +42553,8 @@ Tilemap:
   - first: {x: 42, y: 12, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 54
+      m_TileIndex: 1
+      m_TileSpriteIndex: 6
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -39424,17 +42574,37 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 1
-      m_TileSpriteIndex: 44
+      m_TileSpriteIndex: 63
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
       dummyAlignment: 0
       m_AllTileFlags: 2147483648
-  - first: {x: 45, y: 12, z: 0}
+  - first: {x: 46, y: 12, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 1
+      m_TileSpriteIndex: 41
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 48, y: 12, z: 0}
     second:
       serializedVersion: 2
       m_TileIndex: 0
-      m_TileSpriteIndex: 43
+      m_TileSpriteIndex: 37
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 49, y: 12, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 3
+      m_TileSpriteIndex: 7
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -39661,6 +42831,16 @@ Tilemap:
       dummyAlignment: 0
       m_AllTileFlags: 2147483648
   - first: {x: 42, y: 13, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 33
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 49, y: 13, z: 0}
     second:
       serializedVersion: 2
       m_TileIndex: 0
@@ -40900,6 +44080,16 @@ Tilemap:
       m_TileObjectToInstantiateIndex: 65535
       dummyAlignment: 0
       m_AllTileFlags: 2147483648
+  - first: {x: 32, y: 25, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 3
+      m_TileSpriteIndex: 29
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
   - first: {x: 34, y: 25, z: 0}
     second:
       serializedVersion: 2
@@ -41663,8 +44853,8 @@ Tilemap:
   - first: {x: 39, y: 32, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 45
+      m_TileIndex: 3
+      m_TileSpriteIndex: 18
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -41844,7 +45034,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 0
-      m_TileSpriteIndex: 33
+      m_TileSpriteIndex: 45
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -41875,6 +45065,16 @@ Tilemap:
       serializedVersion: 2
       m_TileIndex: 1
       m_TileSpriteIndex: 50
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 22, y: 35, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 45
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -41960,11 +45160,21 @@ Tilemap:
       m_TileObjectToInstantiateIndex: 65535
       dummyAlignment: 0
       m_AllTileFlags: 2147483648
-  - first: {x: 25, y: 36, z: 0}
+  - first: {x: 22, y: 36, z: 0}
     second:
       serializedVersion: 2
       m_TileIndex: 0
       m_TileSpriteIndex: 33
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 25, y: 36, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 45
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -42075,6 +45285,16 @@ Tilemap:
       serializedVersion: 2
       m_TileIndex: 3
       m_TileSpriteIndex: 1
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 25, y: 37, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 33
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -42462,13 +45682,13 @@ Tilemap:
       m_AllTileFlags: 2147483648
   m_AnimatedTiles: {}
   m_TileAssetArray:
-  - m_RefCount: 228
+  - m_RefCount: 230
     m_Data: {fileID: 11400000, guid: 2c5573a92f4b03d4c809a9a90ac4ddac, type: 2}
-  - m_RefCount: 145
+  - m_RefCount: 164
     m_Data: {fileID: 11400000, guid: b2c3d4599a06f42568ff7d6baa90e2e3, type: 2}
-  - m_RefCount: 44
+  - m_RefCount: 45
     m_Data: {fileID: 11400000, guid: cb16a3e06314d4236ac206eaccd4bc45, type: 2}
-  - m_RefCount: 57
+  - m_RefCount: 60
     m_Data: {fileID: 11400000, guid: 0fcc62fe65ef68645b4ef5863b15eaf0, type: 2}
   m_TileSpriteArray:
   - m_RefCount: 4
@@ -42483,18 +45703,18 @@ Tilemap:
     m_Data: {fileID: 0}
   - m_RefCount: 0
     m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 7
+  - m_RefCount: 1
+    m_Data: {fileID: 21300032, guid: 4f0c6985232dd6d4a9c7c0377b4113bd, type: 3}
+  - m_RefCount: 8
     m_Data: {fileID: 21300018, guid: 311271c83c0b5f846884d0b57f9c22bf, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300040, guid: b058b7252e3d4da4b8bd51add65b0930, type: 3}
   - m_RefCount: 1
-    m_Data: {fileID: 21300044, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
+    m_Data: {fileID: 21300056, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
   - m_RefCount: 9
     m_Data: {fileID: 21300002, guid: 4f0c6985232dd6d4a9c7c0377b4113bd, type: 3}
   - m_RefCount: 1
-    m_Data: {fileID: 21300084, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
+    m_Data: {fileID: 21300050, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
   - m_RefCount: 2
     m_Data: {fileID: 21300006, guid: b058b7252e3d4da4b8bd51add65b0930, type: 3}
   - m_RefCount: 1
@@ -42507,7 +45727,7 @@ Tilemap:
     m_Data: {fileID: 21300086, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
   - m_RefCount: 3
     m_Data: {fileID: 21300082, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
-  - m_RefCount: 6
+  - m_RefCount: 7
     m_Data: {fileID: 21300022, guid: 311271c83c0b5f846884d0b57f9c22bf, type: 3}
   - m_RefCount: 2
     m_Data: {fileID: 21300056, guid: 4f0c6985232dd6d4a9c7c0377b4113bd, type: 3}
@@ -42517,19 +45737,19 @@ Tilemap:
     m_Data: {fileID: 21300036, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
   - m_RefCount: 3
     m_Data: {fileID: 21300038, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
-  - m_RefCount: 2
+  - m_RefCount: 3
     m_Data: {fileID: 21300030, guid: 4f0c6985232dd6d4a9c7c0377b4113bd, type: 3}
   - m_RefCount: 3
     m_Data: {fileID: 21300040, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
   - m_RefCount: 1
-    m_Data: {fileID: 21300050, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
+    m_Data: {fileID: 21300084, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300046, guid: b058b7252e3d4da4b8bd51add65b0930, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300034, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
   - m_RefCount: 6
     m_Data: {fileID: 21300020, guid: b058b7252e3d4da4b8bd51add65b0930, type: 3}
-  - m_RefCount: 2
+  - m_RefCount: 3
     m_Data: {fileID: 21300000, guid: 311271c83c0b5f846884d0b57f9c22bf, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300046, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
@@ -42537,31 +45757,31 @@ Tilemap:
     m_Data: {fileID: 21300026, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300038, guid: 4f0c6985232dd6d4a9c7c0377b4113bd, type: 3}
-  - m_RefCount: 13
+  - m_RefCount: 14
     m_Data: {fileID: 21300004, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
-  - m_RefCount: 6
+  - m_RefCount: 5
     m_Data: {fileID: 21300012, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
   - m_RefCount: 3
     m_Data: {fileID: 21300018, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
   - m_RefCount: 4
     m_Data: {fileID: 21300014, guid: 4f0c6985232dd6d4a9c7c0377b4113bd, type: 3}
-  - m_RefCount: 5
+  - m_RefCount: 6
     m_Data: {fileID: 21300014, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300016, guid: 4f0c6985232dd6d4a9c7c0377b4113bd, type: 3}
-  - m_RefCount: 2
+  - m_RefCount: 3
     m_Data: {fileID: 21300018, guid: b058b7252e3d4da4b8bd51add65b0930, type: 3}
   - m_RefCount: 7
     m_Data: {fileID: 21300008, guid: 4f0c6985232dd6d4a9c7c0377b4113bd, type: 3}
-  - m_RefCount: 7
+  - m_RefCount: 8
     m_Data: {fileID: 21300004, guid: 4f0c6985232dd6d4a9c7c0377b4113bd, type: 3}
   - m_RefCount: 1
-    m_Data: {fileID: 21300056, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
-  - m_RefCount: 12
+    m_Data: {fileID: 21300044, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
+  - m_RefCount: 9
     m_Data: {fileID: 21300006, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
-  - m_RefCount: 40
+  - m_RefCount: 47
     m_Data: {fileID: 21300020, guid: 4f0c6985232dd6d4a9c7c0377b4113bd, type: 3}
-  - m_RefCount: 52
+  - m_RefCount: 55
     m_Data: {fileID: 21300022, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300030, guid: b058b7252e3d4da4b8bd51add65b0930, type: 3}
@@ -42569,17 +45789,17 @@ Tilemap:
     m_Data: {fileID: 21300020, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
   - m_RefCount: 3
     m_Data: {fileID: 21300016, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
-  - m_RefCount: 8
-    m_Data: {fileID: 21300002, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
-  - m_RefCount: 51
-    m_Data: {fileID: 21300022, guid: 4f0c6985232dd6d4a9c7c0377b4113bd, type: 3}
   - m_RefCount: 9
+    m_Data: {fileID: 21300002, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
+  - m_RefCount: 58
+    m_Data: {fileID: 21300022, guid: 4f0c6985232dd6d4a9c7c0377b4113bd, type: 3}
+  - m_RefCount: 10
     m_Data: {fileID: 21300008, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
   - m_RefCount: 4
     m_Data: {fileID: 21300002, guid: b058b7252e3d4da4b8bd51add65b0930, type: 3}
   - m_RefCount: 4
     m_Data: {fileID: 21300014, guid: 311271c83c0b5f846884d0b57f9c22bf, type: 3}
-  - m_RefCount: 3
+  - m_RefCount: 2
     m_Data: {fileID: 21300030, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
   - m_RefCount: 4
     m_Data: {fileID: 21300014, guid: b058b7252e3d4da4b8bd51add65b0930, type: 3}
@@ -42597,7 +45817,7 @@ Tilemap:
     m_Data: {fileID: 21300016, guid: 311271c83c0b5f846884d0b57f9c22bf, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300002, guid: 311271c83c0b5f846884d0b57f9c22bf, type: 3}
-  - m_RefCount: 9
+  - m_RefCount: 10
     m_Data: {fileID: 21300006, guid: 4f0c6985232dd6d4a9c7c0377b4113bd, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300024, guid: 311271c83c0b5f846884d0b57f9c22bf, type: 3}
@@ -42611,7 +45831,7 @@ Tilemap:
     m_Data: {fileID: 21300008, guid: b058b7252e3d4da4b8bd51add65b0930, type: 3}
   - m_RefCount: 9
     m_Data: {fileID: 21300022, guid: b058b7252e3d4da4b8bd51add65b0930, type: 3}
-  - m_RefCount: 1
+  - m_RefCount: 2
     m_Data: {fileID: 21300018, guid: 4f0c6985232dd6d4a9c7c0377b4113bd, type: 3}
   - m_RefCount: 5
     m_Data: {fileID: 21300016, guid: b058b7252e3d4da4b8bd51add65b0930, type: 3}
@@ -42626,7 +45846,7 @@ Tilemap:
   - m_RefCount: 1
     m_Data: {fileID: 21300000, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
   m_TileMatrixArray:
-  - m_RefCount: 474
+  - m_RefCount: 499
     m_Data:
       e00: 1
       e01: 0
@@ -42645,7 +45865,7 @@ Tilemap:
       e32: 0
       e33: 1
   m_TileColorArray:
-  - m_RefCount: 474
+  - m_RefCount: 499
     m_Data: {r: 1, g: 1, b: 1, a: 1}
   m_TileObjectToInstantiateArray: []
   m_AnimationFrameRate: 1
@@ -43422,6 +46642,16 @@ Tilemap:
       m_TileObjectToInstantiateIndex: 65535
       dummyAlignment: 0
       m_AllTileFlags: 2147483648
+  - first: {x: 48, y: 18, z: 1}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 24
+      m_TileSpriteIndex: 24
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
   - first: {x: 23, y: 19, z: 1}
     second:
       serializedVersion: 2
@@ -43867,6 +47097,16 @@ Tilemap:
       serializedVersion: 2
       m_TileIndex: 5
       m_TileSpriteIndex: 5
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 45, y: 26, z: 1}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 7
+      m_TileSpriteIndex: 7
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -44492,6 +47732,26 @@ Tilemap:
       m_TileObjectToInstantiateIndex: 65535
       dummyAlignment: 0
       m_AllTileFlags: 2147483648
+  - first: {x: 31, y: 37, z: 1}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 23
+      m_TileSpriteIndex: 23
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 31, y: 38, z: 1}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 23
+      m_TileSpriteIndex: 23
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
   m_AnimatedTiles: {}
   m_TileAssetArray:
   - m_RefCount: 1
@@ -44508,7 +47768,7 @@ Tilemap:
     m_Data: {fileID: 11400000, guid: d286ebf8d3431104296f80c95612c047, type: 2}
   - m_RefCount: 1
     m_Data: {fileID: 11400000, guid: e1ab11091d25e8f44a57632347fd8f6e, type: 2}
-  - m_RefCount: 3
+  - m_RefCount: 4
     m_Data: {fileID: 11400000, guid: 992b8b978896d72419f4fe6592a1004c, type: 2}
   - m_RefCount: 2
     m_Data: {fileID: 11400000, guid: f070c81a27c4ae34e9a923acfa42b3a5, type: 2}
@@ -44540,8 +47800,10 @@ Tilemap:
     m_Data: {fileID: 11400000, guid: 7fbdd8b9ce747b0458abebe9c4367cbe, type: 2}
   - m_RefCount: 6
     m_Data: {fileID: 11400000, guid: 585a81f203e41674388e625afd1d4181, type: 2}
-  - m_RefCount: 6
+  - m_RefCount: 8
     m_Data: {fileID: 11400000, guid: 90e0bee597f2b31498aec997f9c6a1d8, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 16ad86143cbe4fa43a6a7b4c9e394d8a, type: 2}
   m_TileSpriteArray:
   - m_RefCount: 1
     m_Data: {fileID: 21300004, guid: 706a0eb6e1d3d454cbd0ac4547ae48e5, type: 3}
@@ -44557,7 +47819,7 @@ Tilemap:
     m_Data: {fileID: 21300046, guid: 4f85e53cd32a45a4e8e6c6437a668c2e, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300004, guid: 4f85e53cd32a45a4e8e6c6437a668c2e, type: 3}
-  - m_RefCount: 3
+  - m_RefCount: 4
     m_Data: {fileID: 21300010, guid: 4f85e53cd32a45a4e8e6c6437a668c2e, type: 3}
   - m_RefCount: 2
     m_Data: {fileID: 21300018, guid: 4f85e53cd32a45a4e8e6c6437a668c2e, type: 3}
@@ -44589,10 +47851,12 @@ Tilemap:
     m_Data: {fileID: 21300000, guid: c79afa352c73a8b4982e8d6138736aa3, type: 3}
   - m_RefCount: 6
     m_Data: {fileID: 21300008, guid: 902af1734390c1345a9109b0827525b8, type: 3}
-  - m_RefCount: 6
+  - m_RefCount: 8
     m_Data: {fileID: 21300000, guid: 902af1734390c1345a9109b0827525b8, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 21300000, guid: d6c25c040abc0364d9b60ffd14d03531, type: 3}
   m_TileMatrixArray:
-  - m_RefCount: 168
+  - m_RefCount: 172
     m_Data:
       e00: 1
       e01: 0
@@ -44665,13 +47929,13 @@ Tilemap:
       e32: 0
       e33: 1
   m_TileColorArray:
-  - m_RefCount: 175
+  - m_RefCount: 179
     m_Data: {r: 1, g: 1, b: 1, a: 1}
   m_TileObjectToInstantiateArray: []
   m_AnimationFrameRate: 1
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_Origin: {x: 0, y: 0, z: -1}
-  m_Size: {x: 51, y: 36, z: 3}
+  m_Size: {x: 51, y: 39, z: 3}
   m_TileAnchor: {x: 0.5, y: 0.5, z: 0}
   m_TileOrientation: 0
   m_TileOrientationMatrix:
@@ -45564,7 +48828,27 @@ Tilemap:
       m_TileObjectToInstantiateIndex: 65535
       dummyAlignment: 0
       m_AllTileFlags: 2147483648
+  - first: {x: 49, y: 14, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
   - first: {x: 6, y: 15, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 49, y: 15, z: 0}
     second:
       serializedVersion: 2
       m_TileIndex: 0
@@ -45845,16 +49129,6 @@ Tilemap:
       dummyAlignment: 0
       m_AllTileFlags: 2147483648
   - first: {x: 49, y: 24, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 2147483648
-  - first: {x: 32, y: 25, z: 0}
     second:
       serializedVersion: 2
       m_TileIndex: 0
@@ -46256,15 +49530,15 @@ Tilemap:
       m_AllTileFlags: 2147483648
   m_AnimatedTiles: {}
   m_TileAssetArray:
-  - m_RefCount: 95
+  - m_RefCount: 96
     m_Data: {fileID: 11400000, guid: 3975642db6c52ed4fa2086247abc1f28, type: 2}
   - m_RefCount: 1
     m_Data: {fileID: 11400000, guid: c8ad561e454450344bb98886f88965e7, type: 2}
   m_TileSpriteArray:
-  - m_RefCount: 96
+  - m_RefCount: 97
     m_Data: {fileID: 21300000, guid: 10623b9787a8d384b8d9825b3337ea04, type: 3}
   m_TileMatrixArray:
-  - m_RefCount: 96
+  - m_RefCount: 97
     m_Data:
       e00: 1
       e01: 0
@@ -46283,7 +49557,7 @@ Tilemap:
       e32: 0
       e33: 1
   m_TileColorArray:
-  - m_RefCount: 96
+  - m_RefCount: 97
     m_Data: {r: 1, g: 1, b: 1, a: 1}
   m_TileObjectToInstantiateArray: []
   m_AnimationFrameRate: 1
@@ -47648,6 +50922,36 @@ Tilemap:
       m_TileObjectToInstantiateIndex: 65535
       dummyAlignment: 0
       m_AllTileFlags: 2147483648
+  - first: {x: 43, y: 10, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 18
+      m_TileSpriteIndex: 8
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 44, y: 10, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 18
+      m_TileSpriteIndex: 8
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 45, y: 10, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 18
+      m_TileSpriteIndex: 8
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
   - first: {x: 7, y: 11, z: 0}
     second:
       serializedVersion: 2
@@ -47823,6 +51127,36 @@ Tilemap:
       serializedVersion: 2
       m_TileIndex: 2
       m_TileSpriteIndex: 26
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 43, y: 11, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 18
+      m_TileSpriteIndex: 8
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 44, y: 11, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 18
+      m_TileSpriteIndex: 8
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 45, y: 11, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 18
+      m_TileSpriteIndex: 8
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -48013,6 +51347,26 @@ Tilemap:
       serializedVersion: 2
       m_TileIndex: 2
       m_TileSpriteIndex: 26
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 45, y: 12, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 1
+      m_TileSpriteIndex: 25
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 47, y: 12, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 13
+      m_TileSpriteIndex: 13
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -53462,7 +56816,7 @@ Tilemap:
   m_TileAssetArray:
   - m_RefCount: 6
     m_Data: {fileID: 11400000, guid: 5ccd041443b50c848beaa422610c3b56, type: 2}
-  - m_RefCount: 13
+  - m_RefCount: 14
     m_Data: {fileID: 11400000, guid: a064d6a5dbf121742938ce983c687799, type: 2}
   - m_RefCount: 467
     m_Data: {fileID: 11400000, guid: 055e0f95db6960e418ca4012af91afbb, type: 2}
@@ -53486,7 +56840,7 @@ Tilemap:
     m_Data: {fileID: 11400000, guid: e38080d69ce5d284ca70ce0d6699ebe4, type: 2}
   - m_RefCount: 9
     m_Data: {fileID: 11400000, guid: cc435623bb57b15439ae3c5b24d726cc, type: 2}
-  - m_RefCount: 3
+  - m_RefCount: 4
     m_Data: {fileID: 11400000, guid: de0d6feec21a81341ace90e2564e6e14, type: 2}
   - m_RefCount: 4
     m_Data: {fileID: 11400000, guid: de1cd259dc575f4488bfb4ac5a56ca97, type: 2}
@@ -53496,6 +56850,8 @@ Tilemap:
     m_Data: {fileID: 11400000, guid: b32dc93fe501a4542817697004a49b49, type: 2}
   - m_RefCount: 24
     m_Data: {fileID: 11400000, guid: cbfebc76dab096d4a8749d1f3c6fea59, type: 2}
+  - m_RefCount: 6
+    m_Data: {fileID: 11400000, guid: 81a9d8801fc3ad646836cb52af2a839e, type: 2}
   m_TileSpriteArray:
   - m_RefCount: 0
     m_Data: {fileID: 0}
@@ -53513,8 +56869,8 @@ Tilemap:
     m_Data: {fileID: 0}
   - m_RefCount: 0
     m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
+  - m_RefCount: 6
+    m_Data: {fileID: 21300000, guid: 1b46ebd9cc19f8646bd3dceeef8aa7fa, type: 3}
   - m_RefCount: 24
     m_Data: {fileID: 21300000, guid: 4a1e596700dd6774a8b6f24520bd1aab, type: 3}
   - m_RefCount: 1
@@ -53523,7 +56879,7 @@ Tilemap:
     m_Data: {fileID: 21300006, guid: 86cd0997d36f9494abd65c2f75b3ea69, type: 3}
   - m_RefCount: 4
     m_Data: {fileID: 21300004, guid: 86cd0997d36f9494abd65c2f75b3ea69, type: 3}
-  - m_RefCount: 3
+  - m_RefCount: 4
     m_Data: {fileID: 21300000, guid: 86cd0997d36f9494abd65c2f75b3ea69, type: 3}
   - m_RefCount: 9
     m_Data: {fileID: 21300000, guid: 421eb2aa090b5ba4680eb6b71c90418c, type: 3}
@@ -53547,12 +56903,12 @@ Tilemap:
     m_Data: {fileID: 21300000, guid: 36b4b45d7f485b74996352cf5fbad95c, type: 3}
   - m_RefCount: 6
     m_Data: {fileID: 21300000, guid: 6925c713566e0d04da742f87ea982a7a, type: 3}
-  - m_RefCount: 13
+  - m_RefCount: 14
     m_Data: {fileID: 21300000, guid: f6a684f275cb3324b9525afa483d827d, type: 3}
   - m_RefCount: 467
     m_Data: {fileID: 21300000, guid: 9c40283ae28e277438d39ac0f73fbd36, type: 3}
   m_TileMatrixArray:
-  - m_RefCount: 683
+  - m_RefCount: 691
     m_Data:
       e00: 1
       e01: 0
@@ -53571,7 +56927,7 @@ Tilemap:
       e32: 0
       e33: 1
   m_TileColorArray:
-  - m_RefCount: 683
+  - m_RefCount: 691
     m_Data: {r: 1, g: 1, b: 1, a: 1}
   m_TileObjectToInstantiateArray: []
   m_AnimationFrameRate: 1
@@ -53963,7 +57319,27 @@ Tilemap:
       m_TileObjectToInstantiateIndex: 65535
       dummyAlignment: 0
       m_AllTileFlags: 2147483648
+  - first: {x: 49, y: 14, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 6
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
   - first: {x: 6, y: 15, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 5
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 49, y: 15, z: 0}
     second:
       serializedVersion: 2
       m_TileIndex: 0
@@ -54017,7 +57393,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 0
-      m_TileSpriteIndex: 8
+      m_TileSpriteIndex: 7
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -54248,16 +57624,6 @@ Tilemap:
       serializedVersion: 2
       m_TileIndex: 0
       m_TileSpriteIndex: 7
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 2147483648
-  - first: {x: 32, y: 25, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 8
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -54645,7 +58011,7 @@ Tilemap:
       m_AllTileFlags: 2147483648
   m_AnimatedTiles: {}
   m_TileAssetArray:
-  - m_RefCount: 95
+  - m_RefCount: 96
     m_Data: {fileID: 11400000, guid: 0928ea19fb08346cbb0efa5178c62dae, type: 2}
   m_TileSpriteArray:
   - m_RefCount: 0
@@ -54658,13 +58024,13 @@ Tilemap:
     m_Data: {fileID: 0}
   - m_RefCount: 10
     m_Data: {fileID: 21300002, guid: 5bcb9a396405ec14c86e0c583ebc4759, type: 3}
-  - m_RefCount: 16
+  - m_RefCount: 17
     m_Data: {fileID: 21300022, guid: 5bcb9a396405ec14c86e0c583ebc4759, type: 3}
-  - m_RefCount: 12
+  - m_RefCount: 13
     m_Data: {fileID: 21300008, guid: 5bcb9a396405ec14c86e0c583ebc4759, type: 3}
-  - m_RefCount: 14
+  - m_RefCount: 15
     m_Data: {fileID: 21300004, guid: 5bcb9a396405ec14c86e0c583ebc4759, type: 3}
-  - m_RefCount: 10
+  - m_RefCount: 8
     m_Data: {fileID: 21300000, guid: 5bcb9a396405ec14c86e0c583ebc4759, type: 3}
   - m_RefCount: 12
     m_Data: {fileID: 21300006, guid: 5bcb9a396405ec14c86e0c583ebc4759, type: 3}
@@ -54675,7 +58041,7 @@ Tilemap:
   - m_RefCount: 1
     m_Data: {fileID: 21300018, guid: 5bcb9a396405ec14c86e0c583ebc4759, type: 3}
   m_TileMatrixArray:
-  - m_RefCount: 95
+  - m_RefCount: 96
     m_Data:
       e00: 1
       e01: 0
@@ -54694,7 +58060,7 @@ Tilemap:
       e32: 0
       e33: 1
   m_TileColorArray:
-  - m_RefCount: 95
+  - m_RefCount: 96
     m_Data: {r: 1, g: 1, b: 1, a: 1}
   m_TileObjectToInstantiateArray: []
   m_AnimationFrameRate: 1
@@ -57622,8 +60988,58 @@ Tilemap:
   - first: {x: 43, y: 7, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 9
-      m_TileSpriteIndex: 0
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 44, y: 7, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 45, y: 7, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 46, y: 7, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 47, y: 7, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 48, y: 7, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -58009,6 +61425,56 @@ Tilemap:
       m_TileObjectToInstantiateIndex: 65535
       dummyAlignment: 0
       m_AllTileFlags: 2147483648
+  - first: {x: 44, y: 8, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 45, y: 8, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 46, y: 8, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 47, y: 8, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 48, y: 8, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
   - first: {x: 5, y: 9, z: 0}
     second:
       serializedVersion: 2
@@ -58382,8 +61848,8 @@ Tilemap:
   - first: {x: 42, y: 9, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 9
-      m_TileSpriteIndex: 19
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -58392,8 +61858,58 @@ Tilemap:
   - first: {x: 43, y: 9, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 9
-      m_TileSpriteIndex: 6
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 44, y: 9, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 45, y: 9, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 46, y: 9, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 47, y: 9, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 48, y: 9, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -58739,11 +62255,91 @@ Tilemap:
       m_TileObjectToInstantiateIndex: 65535
       dummyAlignment: 0
       m_AllTileFlags: 2147483648
+  - first: {x: 40, y: 10, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
   - first: {x: 41, y: 10, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 9
-      m_TileSpriteIndex: 11
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 42, y: 10, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 43, y: 10, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 44, y: 10, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 45, y: 10, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 46, y: 10, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 47, y: 10, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 48, y: 10, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -59089,11 +62685,91 @@ Tilemap:
       m_TileObjectToInstantiateIndex: 65535
       dummyAlignment: 0
       m_AllTileFlags: 2147483648
+  - first: {x: 40, y: 11, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
   - first: {x: 41, y: 11, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 9
-      m_TileSpriteIndex: 11
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 42, y: 11, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 43, y: 11, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 44, y: 11, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 45, y: 11, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 46, y: 11, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 47, y: 11, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 48, y: 11, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -59502,8 +63178,38 @@ Tilemap:
   - first: {x: 46, y: 12, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 9
-      m_TileSpriteIndex: 0
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 47, y: 12, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 48, y: 12, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 49, y: 12, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -59910,6 +63616,36 @@ Tilemap:
       dummyAlignment: 0
       m_AllTileFlags: 2147483648
   - first: {x: 46, y: 13, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 47, y: 13, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 48, y: 13, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 49, y: 13, z: 0}
     second:
       serializedVersion: 2
       m_TileIndex: 10
@@ -60332,8 +64068,18 @@ Tilemap:
   - first: {x: 47, y: 14, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 9
-      m_TileSpriteIndex: 0
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 48, y: 14, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -60342,8 +64088,8 @@ Tilemap:
   - first: {x: 49, y: 14, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 9
-      m_TileSpriteIndex: 25
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -60772,8 +64518,8 @@ Tilemap:
   - first: {x: 48, y: 15, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 9
-      m_TileSpriteIndex: 22
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -60782,18 +64528,8 @@ Tilemap:
   - first: {x: 49, y: 15, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 9
-      m_TileSpriteIndex: 24
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 2147483648
-  - first: {x: 50, y: 15, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 9
-      m_TileSpriteIndex: 1
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -68472,8 +72208,8 @@ Tilemap:
   - first: {x: 22, y: 35, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 9
-      m_TileSpriteIndex: 23
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -68822,8 +72558,8 @@ Tilemap:
   - first: {x: 22, y: 36, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 9
-      m_TileSpriteIndex: 23
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -69372,8 +73108,8 @@ Tilemap:
   - first: {x: 25, y: 38, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 9
-      m_TileSpriteIndex: 9
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -69549,11 +73285,21 @@ Tilemap:
       m_TileObjectToInstantiateIndex: 65535
       dummyAlignment: 0
       m_AllTileFlags: 2147483648
-  - first: {x: 26, y: 39, z: 0}
+  - first: {x: 25, y: 39, z: 0}
     second:
       serializedVersion: 2
       m_TileIndex: 9
-      m_TileSpriteIndex: 23
+      m_TileSpriteIndex: 9
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 26, y: 39, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -69753,7 +73499,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 9
-      m_TileSpriteIndex: 18
+      m_TileSpriteIndex: 24
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -69773,7 +73519,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 9
-      m_TileSpriteIndex: 17
+      m_TileSpriteIndex: 22
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -70483,7 +74229,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 9
-      m_TileSpriteIndex: 0
+      m_TileSpriteIndex: 18
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -71049,6 +74795,16 @@ Tilemap:
       m_TileObjectToInstantiateIndex: 65535
       dummyAlignment: 0
       m_AllTileFlags: 2147483648
+  - first: {x: 39, y: 49, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 9
+      m_TileSpriteIndex: 9
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
   - first: {x: 40, y: 49, z: 0}
     second:
       serializedVersion: 2
@@ -71129,14 +74885,14 @@ Tilemap:
     m_Data: {fileID: 0}
   - m_RefCount: 0
     m_Data: {fileID: 0}
-  - m_RefCount: 78
+  - m_RefCount: 65
     m_Data: {fileID: 11400000, guid: e8a2685c8a14b7043bf58bde4374c6b1, type: 2}
-  - m_RefCount: 1560
+  - m_RefCount: 1612
     m_Data: {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
   m_TileSpriteArray:
-  - m_RefCount: 4
-    m_Data: {fileID: 21300040, guid: 8e7da7f35b3dad84db92f52b78937239, type: 3}
-  - m_RefCount: 4
+  - m_RefCount: 0
+    m_Data: {fileID: 0}
+  - m_RefCount: 3
     m_Data: {fileID: 21300006, guid: 8e7da7f35b3dad84db92f52b78937239, type: 3}
   - m_RefCount: 4
     m_Data: {fileID: 21300020, guid: 8e7da7f35b3dad84db92f52b78937239, type: 3}
@@ -71146,17 +74902,17 @@ Tilemap:
     m_Data: {fileID: 0}
   - m_RefCount: 0
     m_Data: {fileID: 0}
-  - m_RefCount: 12
+  - m_RefCount: 11
     m_Data: {fileID: 21300038, guid: 8e7da7f35b3dad84db92f52b78937239, type: 3}
   - m_RefCount: 5
     m_Data: {fileID: 21300002, guid: 8e7da7f35b3dad84db92f52b78937239, type: 3}
   - m_RefCount: 5
     m_Data: {fileID: 21300004, guid: 8e7da7f35b3dad84db92f52b78937239, type: 3}
-  - m_RefCount: 9
+  - m_RefCount: 10
     m_Data: {fileID: 21300036, guid: 8e7da7f35b3dad84db92f52b78937239, type: 3}
-  - m_RefCount: 1560
+  - m_RefCount: 1612
     m_Data: {fileID: 21300000, guid: c54314c048f30ff4dac54c38943c0083, type: 3}
-  - m_RefCount: 5
+  - m_RefCount: 3
     m_Data: {fileID: 21300022, guid: 8e7da7f35b3dad84db92f52b78937239, type: 3}
   - m_RefCount: 0
     m_Data: {fileID: 0}
@@ -71168,26 +74924,26 @@ Tilemap:
     m_Data: {fileID: 0}
   - m_RefCount: 0
     m_Data: {fileID: 0}
+  - m_RefCount: 0
+    m_Data: {fileID: 0}
   - m_RefCount: 1
-    m_Data: {fileID: 21300076, guid: 8e7da7f35b3dad84db92f52b78937239, type: 3}
-  - m_RefCount: 1
-    m_Data: {fileID: 21300044, guid: 8e7da7f35b3dad84db92f52b78937239, type: 3}
-  - m_RefCount: 4
+    m_Data: {fileID: 21300040, guid: 8e7da7f35b3dad84db92f52b78937239, type: 3}
+  - m_RefCount: 3
     m_Data: {fileID: 21300084, guid: 8e7da7f35b3dad84db92f52b78937239, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300066, guid: 8e7da7f35b3dad84db92f52b78937239, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300078, guid: 8e7da7f35b3dad84db92f52b78937239, type: 3}
   - m_RefCount: 1
-    m_Data: {fileID: 21300088, guid: 8e7da7f35b3dad84db92f52b78937239, type: 3}
-  - m_RefCount: 7
+    m_Data: {fileID: 21300076, guid: 8e7da7f35b3dad84db92f52b78937239, type: 3}
+  - m_RefCount: 4
     m_Data: {fileID: 21300082, guid: 8e7da7f35b3dad84db92f52b78937239, type: 3}
   - m_RefCount: 1
-    m_Data: {fileID: 21300064, guid: 8e7da7f35b3dad84db92f52b78937239, type: 3}
-  - m_RefCount: 8
+    m_Data: {fileID: 21300044, guid: 8e7da7f35b3dad84db92f52b78937239, type: 3}
+  - m_RefCount: 7
     m_Data: {fileID: 21300008, guid: 8e7da7f35b3dad84db92f52b78937239, type: 3}
   m_TileMatrixArray:
-  - m_RefCount: 1638
+  - m_RefCount: 1677
     m_Data:
       e00: 1
       e01: 0
@@ -71206,7 +74962,7 @@ Tilemap:
       e32: 0
       e33: 1
   m_TileColorArray:
-  - m_RefCount: 1638
+  - m_RefCount: 1677
     m_Data: {r: 1, g: 1, b: 1, a: 1}
   m_TileObjectToInstantiateArray: []
   m_AnimationFrameRate: 1
@@ -71267,6 +75023,8 @@ Transform:
   - {fileID: 1730118466}
   - {fileID: 1133308094}
   - {fileID: 1867382298}
+  - {fileID: 395655434}
+  - {fileID: 1318939913}
   - {fileID: 1736551749}
   - {fileID: 1220232166}
   - {fileID: 449044064}
@@ -71289,7 +75047,10 @@ Transform:
   - {fileID: 934665825}
   - {fileID: 2066003540}
   - {fileID: 158713405}
-  - {fileID: 1802957304}
+  - {fileID: 770866666}
+  - {fileID: 2005459987}
+  - {fileID: 1913705405}
+  - {fileID: 723049160}
   - {fileID: 1570690945}
   - {fileID: 130431992}
   - {fileID: 917333251}
@@ -71355,6 +75116,9 @@ Transform:
   - {fileID: 1020189335}
   - {fileID: 2049263165}
   - {fileID: 1016273908}
+  - {fileID: 658114561}
+  - {fileID: 692799258}
+  - {fileID: 1270321809}
   - {fileID: 40459527}
   - {fileID: 3919058}
   - {fileID: 461010032}
@@ -71395,9 +75159,6 @@ Transform:
   - {fileID: 1111005737}
   - {fileID: 1225845386}
   - {fileID: 756401523}
-  - {fileID: 287365756}
-  - {fileID: 985854831}
-  - {fileID: 2083813791}
   - {fileID: 81505750}
   - {fileID: 160468100}
   - {fileID: 1694999615}
@@ -71411,7 +75172,19 @@ Transform:
   - {fileID: 1713367467}
   - {fileID: 20932870}
   - {fileID: 317884573}
+  - {fileID: 296421510}
+  - {fileID: 1308186310}
+  - {fileID: 850436101}
+  - {fileID: 1582351502}
+  - {fileID: 1391010752}
+  - {fileID: 863739393}
   - {fileID: 2022316752}
+  - {fileID: 1259446360}
+  - {fileID: 1817986974}
+  - {fileID: 1940617002}
+  - {fileID: 1888346720}
+  - {fileID: 896370532}
+  - {fileID: 32248915}
   - {fileID: 2078210547}
   - {fileID: 274260711}
   - {fileID: 151678147}
@@ -71468,17 +75241,23 @@ Transform:
   - {fileID: 820852858}
   - {fileID: 1324998500}
   - {fileID: 85706254}
+  - {fileID: 1726170325}
+  - {fileID: 743174085}
   - {fileID: 2039769979}
   - {fileID: 1374353901}
   - {fileID: 496846265}
   - {fileID: 340250923}
   - {fileID: 1419309376}
   - {fileID: 1382928441}
+  - {fileID: 757196457}
+  - {fileID: 173253159}
   - {fileID: 366926085}
   - {fileID: 1020982648}
+  - {fileID: 145858474}
   - {fileID: 791874172}
   - {fileID: 1778983187}
   - {fileID: 1239295499}
+  - {fileID: 943837312}
   - {fileID: 219402036}
   - {fileID: 269575868}
   - {fileID: 1993081779}
@@ -71490,6 +75269,7 @@ Transform:
   - {fileID: 1810314214}
   - {fileID: 1784698960}
   - {fileID: 1411008775}
+  - {fileID: 200494454}
   - {fileID: 710518628}
   - {fileID: 132125482}
   - {fileID: 1421430648}
@@ -71503,6 +75283,8 @@ Transform:
   - {fileID: 977726720}
   - {fileID: 167717125}
   - {fileID: 298829240}
+  - {fileID: 1580202597}
+  - {fileID: 142980106}
   - {fileID: 1136105647}
   - {fileID: 297785195}
   - {fileID: 1655136990}
@@ -71541,17 +75323,20 @@ Transform:
   - {fileID: 1349632751}
   - {fileID: 232514238}
   - {fileID: 464639822}
-  - {fileID: 217183661}
-  - {fileID: 1546658234}
   - {fileID: 1501292282}
+  - {fileID: 1663209713}
+  - {fileID: 1208070342}
   - {fileID: 414982092}
   - {fileID: 1770617773}
+  - {fileID: 1981898869}
   - {fileID: 1240751655}
+  - {fileID: 174202486}
   - {fileID: 590623774}
   - {fileID: 1426489647}
   - {fileID: 1009124364}
   - {fileID: 1191174595}
   - {fileID: 1958116866}
+  - {fileID: 947816812}
   - {fileID: 1945989990}
   - {fileID: 333964349}
   - {fileID: 1535765817}
@@ -71560,6 +75345,8 @@ Transform:
   - {fileID: 247436633}
   - {fileID: 1227645379}
   - {fileID: 529858408}
+  - {fileID: 1922923930}
+  - {fileID: 1408379520}
   - {fileID: 1160712260}
   - {fileID: 2008841494}
   - {fileID: 1800652676}


### PR DESCRIPTION
### Purpose

Fixes several issues with the Ancient Station map:

- Greatly reduces layout issues with space wind pulling Ancient Engineers uncontrollably out into space.
- atmos room is more usable
- the soul sucking self sufficient scrubbers and vents are removed for the time being until they stop killing people
- added more maint loot, constructions mats, botany tools, and changed out the lasers for 9 mils
- found a work around for not being able to lay cables where you need to (can't lay cables in the rest of the station still)
- changed the job populator for the Ancient Engineer to the correct one.
- Very slightly buffed the RIG suit by reducing it's slowdown from 3 to 2.5 so it's a slightly less awful experience.

### Notes:
makes progress on #5947
