### PR TITLE
Hotfix for a large amount of random mirror errors

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Lifecycle/SpawnSafeThread.cs
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/SpawnSafeThread.cs
@@ -8,21 +8,39 @@ using System.Collections.Concurrent;
 public static class SpawnSafeThread
 {
 	private static ConcurrentQueue<Tuple<Vector3, GameObject>> prefabsToSpawn = new ConcurrentQueue<Tuple<Vector3, GameObject>>();
+	private static ConcurrentQueue<Tuple<uint, Vector3Int, TileType, string, Matrix4x4, Color>> tilesToUpdate = new ConcurrentQueue<Tuple<uint, Vector3Int, TileType, string, Matrix4x4, Color>>();
 
 	public static void Process()
 	{
-		if (prefabsToSpawn.IsEmpty)
-			return;
-
-		Tuple<Vector3, GameObject> tuple;
-		while (prefabsToSpawn.TryDequeue(out tuple))
+		if (!prefabsToSpawn.IsEmpty)
 		{
-			Spawn.ServerPrefab(tuple.Item2, tuple.Item1, MatrixManager.GetDefaultParent(tuple.Item1, true));
+			Tuple<Vector3, GameObject> tuple;
+			while (prefabsToSpawn.TryDequeue(out tuple))
+			{
+				Spawn.ServerPrefab(tuple.Item2, tuple.Item1, MatrixManager.GetDefaultParent(tuple.Item1, true));
+			}
+		}
+
+		if (!tilesToUpdate.IsEmpty)
+		{
+			Tuple<uint, Vector3Int, TileType, string, Matrix4x4, Color> tuple;
+			while (tilesToUpdate.TryDequeue(out tuple))
+			{
+				UpdateTileMessage.Send(tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4, tuple.Item5, tuple.Item6);
+			}
 		}
 	}
 
 	public static void SpawnPrefab(Vector3 tilePos, GameObject prefabObject)
 	{
 		prefabsToSpawn.Enqueue(new Tuple<Vector3, GameObject>(tilePos, prefabObject));
+	}
+
+	public static void UpdateTileMessageSend(uint tileChangeManagerNetID, Vector3Int position, TileType tileType,
+		string tileName, Matrix4x4 transformMatrix, Color colour)
+	{
+		tilesToUpdate.Enqueue(
+			new Tuple<uint, Vector3Int, TileType, string, Matrix4x4, Color>
+				(tileChangeManagerNetID, position, tileType, tileName, transformMatrix, colour));
 	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/TileChangeManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/TileChangeManager.cs
@@ -239,7 +239,7 @@ public class TileChangeManager : NetworkBehaviour
 			transformMatrix = transformMatrix.GetValueOrDefault(Matrix4x4.identity);
 		}
 
-		UpdateTileMessage.Send(networkIdentity.netId, position, tileType, tileName, (Matrix4x4)transformMatrix, (Color)color);
+		SpawnSafeThread.UpdateTileMessageSend(networkIdentity.netId, position, tileType, tileName, (Matrix4x4)transformMatrix, (Color)color);
 	}
 
 	public void InternalUpdateTile(Vector3Int position, TileType tileType, string tileName,


### PR DESCRIPTION
### Purpose
Fixes a large amount of errors that can surge from the atmos thread using mirror by changing the UpdateTileMessage Send() call to the mainthread utilizing the SpawnSafeThread class.


