### PR TITLE
Fixes the emergency light error spam on clients

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Lighting/LightSource.cs
+++ b/UnityProject/Assets/Scripts/Core/Lighting/LightSource.cs
@@ -94,19 +94,6 @@ public class LightSource : ObjectTrigger, ICheckedInteractable<HandApply>, IAPCP
 		}
 	}
 
-	public override void OnStartClient()
-	{
-		//EnsureInit();
-		base.OnStartClient();
-		GetComponent<RegisterTile>().WaitForMatrixInit(InitClientValues);
-
-	}
-
-	void InitClientValues(MatrixInfo matrixInfo)
-	{
-		SyncLightState(mState, mState);
-	}
-
 	private void OnEnable()
 	{
 		integrity.OnApplyDamage.AddListener(OnDamageReceived);


### PR DESCRIPTION
### Purpose
Fixes emergency light script spamming errors on the console after they get removed on clients.

They were being added to the updatemanager twice