### PR TITLE
An assortment of fixes, logging

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Mobs/NPC/Resources/Friendly/NPC_GOD_Friendly.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/NPC/Resources/Friendly/NPC_GOD_Friendly.prefab
@@ -124,7 +124,13 @@ MonoBehaviour:
   registerTile: {fileID: 0}
   floorDecal: {fileID: 0}
   isInitiallyNotPushable: 0
-  pushPullSound: 
+  pushPullSound:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   soundDelayTime: 0
   soundMinimumPitchVariance: 1
   soundMaximumPitchVariance: 1
@@ -149,6 +155,7 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
+  ReachableThrough: 1
   passableExclusionsToThis: []
 --- !u!114 &114386898746361270
 MonoBehaviour:
@@ -180,7 +187,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   isMeleeable: 1
   butcherTime: 2
-  butcherSound: BladeSlice
+  butcherSound:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
 --- !u!114 &114536369792164230
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -280,7 +293,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  spriteHandler: {fileID: 0}
+  spriteHandler: {fileID: 6463072077799225617}
   spriteRend: {fileID: 4890346600101626888}
   aliveSpriteIndex: 0
   deadSpriteIndex: 1
@@ -337,10 +350,12 @@ MonoBehaviour:
   performingAction: 0
   activated: 0
   tickRate: 1
+  CB_REAGENT: {fileID: 0}
   target: 0
   actionPerformTime: 0
   hasFoodPrefereces: 0
   foodPreferences: []
+  IsEmagged: 0
 --- !u!114 &1698261190327922250
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -371,8 +386,18 @@ MonoBehaviour:
   maxTimeBetweenRandomActions: 30
   doRandomActionWhenInTask: 0
   GenericSounds:
-  - god1
-  - god2
+  - SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  - SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   PlaySoundTime: 3
 --- !u!114 &-6191687678756634214
 MonoBehaviour:
@@ -423,7 +448,8 @@ MonoBehaviour:
   indexUp: 1
   indexRight: 2
   indexLeft: 3
-  spriteHandlers: []
+  spriteHandlers:
+  - {fileID: 6463072077799225617}
 --- !u!1 &2123639465450100608
 GameObject:
   m_ObjectHideFlags: 0
@@ -467,17 +493,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ea79a12bc31d4df394067a2be447854d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  BlueDamageMonitorIcon: {fileID: 0}
-  GreenDamageMonitorIcon: {fileID: 0}
-  YellowDamageMonitorIcon: {fileID: 0}
-  OrangeDamageMonitorIcon: {fileID: 0}
-  DarkOrangeDamageMonitorIcon: {fileID: 0}
-  RedDamageMonitorIcon: {fileID: 0}
-  GrayDamageMonitorIcon: {fileID: 0}
-  MaxDamage: 200
+  livingHealthBehaviour: {fileID: 0}
   Type: 0
   isBleeding: 0
-  livingHealthBehaviour: {fileID: 0}
   Severity: 0
   armor:
     Melee: 0
@@ -565,17 +583,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ea79a12bc31d4df394067a2be447854d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  BlueDamageMonitorIcon: {fileID: 0}
-  GreenDamageMonitorIcon: {fileID: 0}
-  YellowDamageMonitorIcon: {fileID: 0}
-  OrangeDamageMonitorIcon: {fileID: 0}
-  DarkOrangeDamageMonitorIcon: {fileID: 0}
-  RedDamageMonitorIcon: {fileID: 0}
-  GrayDamageMonitorIcon: {fileID: 0}
-  MaxDamage: 200
+  livingHealthBehaviour: {fileID: 0}
   Type: 1
   isBleeding: 0
-  livingHealthBehaviour: {fileID: 0}
   Severity: 0
   armor:
     Melee: 0
@@ -598,8 +608,9 @@ GameObject:
   m_Component:
   - component: {fileID: 4152194380817414287}
   - component: {fileID: 4890346600101626888}
+  - component: {fileID: 6463072077799225617}
   m_Layer: 12
-  m_Name: sprite
+  m_Name: Sprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -657,9 +668,9 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -229502157
-  m_SortingLayer: 16
+  m_SortingLayer: 21
   m_SortingOrder: 11
-  m_Sprite: {fileID: 21300002, guid: 106277f633a313a4990add9de887d387, type: 3}
+  m_Sprite: {fileID: 21300072, guid: 106277f633a313a4990add9de887d387, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -670,3 +681,23 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &6463072077799225617
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7921138586108671727}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  NetworkThis: 1
+  SubCatalogue: []
+  PresentSpriteSet: {fileID: 11400000, guid: f0ed5c8e94a4b7a45b995eb61ae73386, type: 2}
+  randomInitialSprite: 0
+  pushTextureOnStartUp: 1
+  variantIndex: 0
+  palette: []
+  Sprites: []

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/IngameMenu.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/IngameMenu.prefab
@@ -164,10 +164,10 @@ RectTransform:
   m_Father: {fileID: 2433242335141130237}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -1, y: 18}
-  m_SizeDelta: {x: 261.87, y: 28.63}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -60}
+  m_SizeDelta: {x: 260, y: 28}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &9196145359179232128
 CanvasRenderer:
@@ -245,10 +245,10 @@ RectTransform:
   m_Father: {fileID: 2433242335141130237}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -2.7, y: -54.999966}
-  m_SizeDelta: {x: 80, y: 31.5}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 22}
+  m_SizeDelta: {x: 80, y: 32}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1787868642597385732
 CanvasRenderer:
@@ -378,7 +378,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -20.87, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2859286666692411216
 CanvasRenderer:
@@ -456,8 +456,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.10003662, y: -0.20600891}
-  m_SizeDelta: {x: -0.2000122, y: -0.41000366}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7648740231992976236
 CanvasRenderer:
@@ -538,8 +538,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 212, y: 314.1}
-  m_SizeDelta: {x: 372.8, y: 153.59}
+  m_AnchoredPosition: {x: 228, y: 160}
+  m_SizeDelta: {x: 372, y: 154}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &5503059279900602835
 MonoBehaviour:
@@ -2037,10 +2037,10 @@ RectTransform:
   m_Father: {fileID: 2433242335141130237}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -3, y: -21.099987}
-  m_SizeDelta: {x: 261.87, y: 28.63}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 55}
+  m_SizeDelta: {x: 260, y: 28}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2135323210151070982
 CanvasRenderer:
@@ -2195,10 +2195,10 @@ RectTransform:
   m_Father: {fileID: 2433242335141130237}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -1.0000114, y: 47.39001}
-  m_SizeDelta: {x: 261.87, y: 28.63}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -30}
+  m_SizeDelta: {x: 260, y: 28}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6300648627024192605
 CanvasRenderer:
@@ -2277,7 +2277,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -20.870003, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4711020569597584357
 CanvasRenderer:
@@ -2355,10 +2355,10 @@ RectTransform:
   m_Father: {fileID: 2433242335141130237}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -109.9, y: -55}
-  m_SizeDelta: {x: 113.39, y: 31.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 80, y: 22}
+  m_SizeDelta: {x: 120, y: 32}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8117565814566272867
 CanvasRenderer:
@@ -2487,10 +2487,10 @@ RectTransform:
   m_Father: {fileID: 2433242335141130237}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 104.8, y: -54.999966}
-  m_SizeDelta: {x: 113.39, y: 31.5}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: -80, y: 22}
+  m_SizeDelta: {x: 120, y: 32}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8010659660394660166
 CanvasRenderer:
@@ -2620,7 +2620,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -20.87, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2832446123879539078
 CanvasRenderer:
@@ -2696,10 +2696,10 @@ RectTransform:
   m_Father: {fileID: 2433242335141130237}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -159.5, y: 51.8}
-  m_SizeDelta: {x: 40.21, y: 30.832}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 25, y: -25}
+  m_SizeDelta: {x: 40, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2400006879437654702
 CanvasRenderer:

--- a/UnityProject/Assets/Scripts/Clothing/BackPack/InteractableStorage.cs
+++ b/UnityProject/Assets/Scripts/Clothing/BackPack/InteractableStorage.cs
@@ -182,7 +182,7 @@ public class InteractableStorage : MonoBehaviour, IClientInteractable<HandActiva
 	public void ServerPerformInteraction(HandApply interaction)
 	{
 		//Reusing mouse drop logic for efficiency
-		ServerPerformInteraction(MouseDrop.ByLocalPlayer(interaction.TargetObject, interaction.Performer));
+		ServerPerformInteraction(MouseDrop.ByClient(interaction.Performer, interaction.TargetObject, interaction.Performer, interaction.Intent));
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Core/Editor/GenerateSpriteSO.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/GenerateSpriteSO.cs
@@ -1,16 +1,13 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using Newtonsoft.Json;
-using System.Linq;
-using System.Reflection;
-using Systems.Botany;
+using Newtonsoft.Json.Linq;
 using Items;
 using Items.Botany;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 public class GenerateSpriteSO : EditorWindow
 {

--- a/UnityProject/Assets/Scripts/Managers/AdminManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/AdminManager.cs
@@ -1,15 +1,5 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using UnityEngine;
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using Pipes;
-using UnityEngine;
-using UnityEngine.SceneManagement;
-using Objects.Wallmounts;
-using System.Collections.Concurrent;
-using Mirror;
 
 public class AdminManager : MonoBehaviour
 {

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.Gateways.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.Gateways.cs
@@ -18,9 +18,9 @@ public partial class SubSceneManager
 
 			Instance.gatewayLinks.Remove(requestee);
 		}
-
-		Instance.gatewayLinks.Add(requestee,
-			Instance.worldGatewayCache[Random.Range(0, Instance.worldGatewayCache.Count)]);
+		var destination = Instance.worldGatewayCache.PickRandom();
+		if (destination == null) return null; // Additional scenes were likely disabled on this build - logged in caller
+		Instance.gatewayLinks.Add(requestee, destination);
 
 		return Instance.gatewayLinks[requestee];
 	}
@@ -35,4 +35,3 @@ public partial class SubSceneManager
 		Instance.worldGatewayCache.Add(gateway);
 	}
 }
-

--- a/UnityProject/Assets/Scripts/Messages/Client/OtherPlayerSlotTransferMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/OtherPlayerSlotTransferMessage.cs
@@ -43,12 +43,13 @@ public class OtherPlayerSlotTransferMessage : ClientMessage
 				$"{playerObject.ExpensiveName()} tries to remove {targetObject.ExpensiveName()}'s {targetSlot.ItemObject.ExpensiveName()}.");
 			speed = 3;
 		}
-		else
+		else if (playerSlot.IsOccupied)
 		{
 			Chat.AddActionMsgToChat(playerObject, $"You try to put the {playerSlot.ItemObject.ExpensiveName()} on {targetObject.ExpensiveName()}...",
 				$"{playerObject.ExpensiveName()} tries to put the {playerSlot.ItemObject.ExpensiveName()} on {targetObject.ExpensiveName()}.");
 			speed = 1;
 		}
+		else return;
 
 		var progressAction = StandardProgressAction.Create(new StandardProgressActionConfig(StandardProgressActionType.ItemTransfer), FinishTransfer);
 		progressAction.ServerStartProgress(targetObject.RegisterTile(), speed, playerObject);

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -121,6 +121,13 @@ public class JoinedViewer : NetworkBehaviour
 		//TODO When we have scene network culling we will need to allow observers
 		// for the whole specific scene and the body before doing the logic below:
 		var netIdentity = loggedOffPlayer.GetComponent<NetworkIdentity>();
+		if (netIdentity == null)
+		{
+			Logger.LogError($"No {nameof(NetworkIdentity)} component on {loggedOffPlayer}! " +
+					"Cannot rejoin that player. Was original player object improperly created? Did we get runtime error while creating it?");
+			// TODO: if this issue persists, should probably send the poor player a message about failing to rejoin.
+			yield break;
+		}
 		while (!netIdentity.observers.ContainsKey(this.connectionToClient.connectionId))
 		{
 			yield return WaitFor.EndOfFrame;

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -184,7 +184,7 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		}
 		else if (playerScript.playerMove.IsTrapped) // Check if trapped.
 		{
-			playerScript.PlayerSync.TryEscapeContainer();
+			playerScript.PlayerSync.ServerTryEscapeContainer();
 		}
 	}
 
@@ -520,6 +520,12 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 				playerScript.mind.occupation = job;
 				break;
 			}
+		}
+
+		if (playerScript.mind.occupation == null)
+		{
+			// Might be a spectator trying to respawn themselves (when server allows this), default to Assistant
+			playerScript.mind.occupation = OccupationList.Instance.Occupations.First();
 		}
 
 		PlayerSpawn.ServerRespawnPlayer(playerScript.mind);

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.cs
@@ -413,37 +413,23 @@ public partial class PlayerSync : NetworkBehaviour, IPushable, IPlayerControllab
 	/// </summary>
 	private bool didWiggle = false;
 
-	[Client]
-	public void TryEscapeContainer()
+	[Command]
+	public void CmdTryEscapeContainer()
 	{
-		if (Camera2DFollow.followControl.target.TryGetComponent(out ClosetControl closet))
-		{
-			CmdTryEscapeCloset();
-		}
-		else if (Camera2DFollow.followControl.target.TryGetComponent(out Objects.Disposals.DisposalVirtualContainer disposalContainer))
-		{
-			CmdTryEscapeDisposals();
-		}
+		ServerTryEscapeContainer();
 	}
 
-	[Command]
-	private void CmdTryEscapeCloset()
+	[Server]
+	public void ServerTryEscapeContainer()
 	{
-		if (pushPull?.parentContainer == null) return;
+		if (pushPull == null || pushPull.parentContainer == null) return;
 		GameObject parentContainer = pushPull.parentContainer.gameObject;
 
 		if (parentContainer.TryGetComponent(out ClosetControl closet))
 		{
 			closet.PlayerTryEscaping(gameObject);
 		}
-	}
-	[Command]
-	private void CmdTryEscapeDisposals()
-	{
-		if (pushPull?.parentContainer == null) return;
-		GameObject parentContainer = pushPull.parentContainer.gameObject;
-
-		if (parentContainer.TryGetComponent(out Objects.Disposals.DisposalVirtualContainer disposalContainer))
+		else if (parentContainer.TryGetComponent(out Objects.Disposals.DisposalVirtualContainer disposalContainer))
 		{
 			disposalContainer.PlayerTryEscaping(gameObject);
 		}
@@ -468,7 +454,7 @@ public partial class PlayerSync : NetworkBehaviour, IPushable, IPlayerControllab
 					// Player inside something
 					else if (Camera2DFollow.followControl.target != PlayerManager.LocalPlayer.transform)
 					{
-						TryEscapeContainer();
+						CmdTryEscapeContainer();
 						didWiggle = true;
 					}
 				}

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobPlayer.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobPlayer.cs
@@ -1508,16 +1508,7 @@ namespace Blob
 				if (factoryBlob.Key == null) continue;
 
 				factoryBlob.Value.Remove(null);
-
-				var spores = factoryBlob.Value;
-
-				foreach (var spore in spores)
-				{
-					if (spore.GetComponent<LivingHealthBehaviour>().IsDead)
-					{
-						factoryBlob.Value.Remove(spore);
-					}
-				}
+				factoryBlob.Value.RemoveWhere(spore => spore.GetComponent<LivingHealthBehaviour>().IsDead);
 
 				//Dont produce spores unless connected
 				if(!factoryBlob.Key.connectedToBlobNet) continue;

--- a/UnityProject/Assets/Scripts/Systems/Botany/PlantData.cs
+++ b/UnityProject/Assets/Scripts/Systems/Botany/PlantData.cs
@@ -187,7 +187,15 @@ namespace Systems.Botany
 			}
 
 			//var oldPlantData = plantData;
-			MutateTo(newPlantData.GetComponent<SeedPacket>().plantData);
+			if (newPlantData.TryGetComponent<SeedPacket>(out var packet))
+			{
+				MutateTo(packet.plantData);
+			}
+			else
+			{
+				Logger.LogError($"{nameof(SeedPacket)} component missing on {newPlantData}! Cannot mutate.");
+			}
+						
 			//UpdatePlant(oldPlantData.Name, Name);
 		}
 

--- a/UnityProject/Assets/StreamingAssets/maps.json
+++ b/UnityProject/Assets/StreamingAssets/maps.json
@@ -1,1 +1,7 @@
-{"lowPopMaps":["FallStation", "SquareStation"], "medPopMaps":["OutpostStation", "BoxStationV1"], "highPopMaps":["OutpostStation", "BoxStationV1"], "medPopMinLimit":15, "highPopMinLimit":30}
+{
+    "lowPopMaps":["FallStation", "SquareStation"],
+    "medPopMaps":["OutpostStation", "BoxStationV1", "PogStation"],
+    "highPopMaps":["OutpostStation", "BoxStationV1", "PogStation"],
+    "medPopMinLimit":15,
+    "highPopMinLimit":30
+}


### PR DESCRIPTION
- Adds `PogStation` back to rotation.
- ~~Moves vote popup window further down so as not to overlap with chat (quick fix, will still overlap if chatting).~~
- Fixes being unable to alt-click pickupable storage containers to view contents (and associated server runtime error) when connected to headless.
- Fixes being unable to respawn as spectator via REVIVE button (on servers where this is allowed) (and associated server runtime error).
- Fixes server runtime error generated by the gateway if no gateway could be found (e.g. disabled additional scenes).
- Fixes server runtime error when someone clicks, inside the examine window, on an empty slot while not holding anything.
- Fixes being unable to break out of a welded locker as a client.
- Fixes server runtime error when blob factory evaluates if spores are dead.
- Fixes server runtime error where plant data attempts to mutate when the seed packet is missing.
- Fixes MigrateClothingSO script (though it seems there is still an issue for the last step of renaming).
- Fixes some editor warnings.
- More logging for when rejoining the game.

CL:Somewhat fixes vote popup window overlap, unable to break out of a welded locker, unable to respawn as spectator and unable to view container contents by alt-click.