### PR TITLE
Audio Fix

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Sound/SoundSpawn.cs
+++ b/UnityProject/Assets/Scripts/Core/Sound/SoundSpawn.cs
@@ -72,7 +72,6 @@ public class SoundSpawn: MonoBehaviour
 		if (!AudioSource.isPlaying)
 		{
 			IsPlaying = false;
-			monitor = false;
 
 			if (Token != string.Empty)
 			{
@@ -85,6 +84,8 @@ public class SoundSpawn: MonoBehaviour
 			}
 			SoundManager.Instance.NonplayingSounds[assetAddress].Add(this);
 		}
+
+		monitor = false;
 	}
 
 	public void SetAudioSource(AudioSource sourceToCopy)


### PR DESCRIPTION
Monitor in Soundspawn.cs was pushing ~50% of all sounds to NonplayingSounds, rather than the intended few.

### Purpose
Currently on PR, many sounds are not getting played.  This is easily testable by spawning a Makarov pistol and firing it repeatedly.  About half of all gun shots will not be heard.  This is being caused by the monitor variable being set to true whenever a sound is played, and not being toggled back to false until a sound is pushed to NonPlayingSounds, causing about a 50% sound loss.  This change makes monitor toggle back to false every time there is a an update to SoundSpawn.cs, and will only push sounds to NonplayingSounds if they are trying to play on the same update as another sound, which I believe was the intended function.

Fixes #5990, #5937
