### PR TITLE
Use bit check to avoid garbage with IsInLayer.

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Utils/Types.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Utils/Types.cs
@@ -59,7 +59,7 @@ public static class LTSUtil
 	public static bool IsLayerIn(LayerTypeSelection SpecifyLayers, LayerType Layer)
 	{
 		LayerTypeSelection LayerCon = LayerType2LayerTypeSelection(Layer);
-		//HasFlag causes boxing, since we are only checking for one layer, a simple bit check is fine here
+		//Bits are set in SpecifyLayers, doing a logical AND with the layer will return either 0 if it doesn't contain it or the layer bit itself. 
 		return (SpecifyLayers & LayerCon) > 0;
 	}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Utils/Types.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Utils/Types.cs
@@ -59,7 +59,8 @@ public static class LTSUtil
 	public static bool IsLayerIn(LayerTypeSelection SpecifyLayers, LayerType Layer)
 	{
 		LayerTypeSelection LayerCon = LayerType2LayerTypeSelection(Layer);
-		return (SpecifyLayers.HasFlag(LayerCon));
+		//HasFlag causes boxing, since we are only checking for one layer, a simple bit check is fine here
+		return (SpecifyLayers & LayerCon) > 0;
 	}
 
 	public static LayerTypeSelection LayerType2LayerTypeSelection(LayerType Layer)


### PR DESCRIPTION
Yoinking this fix from another PR I'm working on. Using HasFlag is unnecessary since we are only checking to see if one layer is in SpecifyLayers. This avoids boxing from using HasFlag.