### PR TITLE
Fixes the sound pooling related fps drop

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Sound/SoundSpawn.cs
+++ b/UnityProject/Assets/Scripts/Core/Sound/SoundSpawn.cs
@@ -72,6 +72,7 @@ public class SoundSpawn: MonoBehaviour
 		if (!AudioSource.isPlaying)
 		{
 			IsPlaying = false;
+			monitor = false;
 
 			if (Token != string.Empty)
 			{
@@ -84,8 +85,6 @@ public class SoundSpawn: MonoBehaviour
 			}
 			SoundManager.Instance.NonplayingSounds[assetAddress].Add(this);
 		}
-
-		monitor = false;
 	}
 
 	public void SetAudioSource(AudioSource sourceToCopy)

--- a/UnityProject/Assets/Scripts/Managers/SoundManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SoundManager.cs
@@ -231,8 +231,11 @@ public class SoundManager : MonoBehaviour
 		{
 			var ToReturn = NonplayingSounds[addressableAudioSource.AssetAddress][0];
 			NonplayingSounds[addressableAudioSource.AssetAddress].RemoveAt(0);
-			ToReturn.Token = soundSpawnToken;
-			SoundSpawns.Add(soundSpawnToken, ToReturn);
+			if (soundSpawnToken != "") //non addressables dont have a token
+			{
+				ToReturn.Token = soundSpawnToken;
+				SoundSpawns.Add(soundSpawnToken, ToReturn);
+			}
 			return ToReturn;
 		}
 


### PR DESCRIPTION
### Purpose
Fixes sound objects failing to join the pool once they finished playing, causing a slow fps drop from the large amount of objects.
Fixes the sound manager from being unable to retrieve sound objects from the pool if they didnt have a token.
