### PR TITLE
Artifact performance improvement

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
@@ -837,9 +837,12 @@ public partial class MatrixManager : MonoBehaviour
 	public static List<T> GetAt<T>(Vector3Int worldPos, bool isServer) where T : MonoBehaviour
 	{
 		List<T> t = new List<T>();
-		for (var i = 0; i < Instance.ActiveMatrices.Count; i++)
+		var activeMatrices = Instance.ActiveMatrices;
+		for (var i = 0; i < activeMatrices.Count; i++)
 		{
-			t.AddRange(Get(i).Matrix.Get<T>(WorldToLocalInt(worldPos, i), isServer));
+			var matrixInfo = activeMatrices[i];
+			var position = WorldToLocalInt(worldPos, matrixInfo);
+			t.AddRange(matrixInfo.Matrix.Get<T>(position, isServer));
 		}
 
 		return t;

--- a/UnityProject/Assets/Scripts/Objects/Research/Artifacts/Effects/TelepaticArtifactEffect.cs
+++ b/UnityProject/Assets/Scripts/Objects/Research/Artifacts/Effects/TelepaticArtifactEffect.cs
@@ -37,13 +37,14 @@ public class TelepaticArtifactEffect : ArtifactEffect
 	private void IndocrinateMessageArea()
 	{
 		var objCenter = gameObject.AssumedWorldPosServer().RoundToInt();
-		var xMin = objCenter.x - auraRadius;
-		var yMin = objCenter.y - auraRadius;
-		var bounds = new BoundsInt(xMin, yMin, 0, 20, 20, 1);
-		foreach (var connected in PlayerList.Instance.InGamePlayers)
+		var hitMask = LayerMask.GetMask("Players");
+		var colliders = Physics2D.OverlapCircleAll(new Vector2(objCenter.x, objCenter.y), auraRadius, hitMask);
+
+		foreach (var connected in colliders)
 		{
-			var player = connected.Script;
-			if (player.IsDeadOrGhost == false && bounds.Contains(player.WorldPos))
+			connected.TryGetComponent<PlayerScript>(out var player);
+
+			if (player == null || player.IsDeadOrGhost)
 			{
 				Indocrinate(player.gameObject);
 			}

--- a/UnityProject/Assets/Scripts/Objects/Research/Artifacts/Effects/TelepaticArtifactEffect.cs
+++ b/UnityProject/Assets/Scripts/Objects/Research/Artifacts/Effects/TelepaticArtifactEffect.cs
@@ -37,7 +37,7 @@ public class TelepaticArtifactEffect : ArtifactEffect
 	private void IndocrinateMessageArea()
 	{
 		var objCenter = gameObject.AssumedWorldPosServer().RoundToInt();
-		var bounds = new BoundsInt(objCenter.x - 10, objCenter.y - 10, 0, 20, 20, 1);
+		var bounds = new BoundsInt(objCenter.x - auraRadius, objCenter.y - auraRadius, 0, 20, 20, 1);
 		var connectedPlayers = PlayerList.Instance.InGamePlayers;
 		foreach (var connected in connectedPlayers)
 		{

--- a/UnityProject/Assets/Scripts/Objects/Research/Artifacts/Effects/TelepaticArtifactEffect.cs
+++ b/UnityProject/Assets/Scripts/Objects/Research/Artifacts/Effects/TelepaticArtifactEffect.cs
@@ -1,7 +1,9 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using Random = UnityEngine.Random;
 
 /// <summary>
 /// This artifact sends telepatic messages
@@ -34,21 +36,15 @@ public class TelepaticArtifactEffect : ArtifactEffect
 
 	private void IndocrinateMessageArea()
 	{
-		// get effect shape around artifact
 		var objCenter = gameObject.AssumedWorldPosServer().RoundToInt();
-		var shape = EffectShape.CreateEffectShape(EffectShapeType.Square, objCenter, auraRadius);
-
-		foreach (var pos in shape)
+		var bounds = new BoundsInt(objCenter.x - 10, objCenter.y - 10, 0, 20, 20, 1);
+		var connectedPlayers = PlayerList.Instance.InGamePlayers;
+		foreach (var connected in connectedPlayers)
 		{
-			// check if tile has any alive player
-			var players = MatrixManager.GetAt<PlayerScript>(pos, true).Distinct();
-			foreach (var player in players)
+			var player = connected.Script;
+			if (bounds.Contains(player.WorldPos) && player.IsDeadOrGhost == false)
 			{
-				if (!player.IsDeadOrGhost)
-				{
-					// send them message
-					Indocrinate(player.gameObject);
-				}
+				Indocrinate(player.gameObject);
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Objects/Research/Artifacts/Effects/TelepaticArtifactEffect.cs
+++ b/UnityProject/Assets/Scripts/Objects/Research/Artifacts/Effects/TelepaticArtifactEffect.cs
@@ -37,9 +37,10 @@ public class TelepaticArtifactEffect : ArtifactEffect
 	private void IndocrinateMessageArea()
 	{
 		var objCenter = gameObject.AssumedWorldPosServer().RoundToInt();
-		var bounds = new BoundsInt(objCenter.x - auraRadius, objCenter.y - auraRadius, 0, 20, 20, 1);
-		var connectedPlayers = PlayerList.Instance.InGamePlayers;
-		foreach (var connected in connectedPlayers)
+		var xMin = objCenter.x - auraRadius;
+		var yMin = objCenter.y - auraRadius;
+		var bounds = new BoundsInt(xMin, yMin, 0, 20, 20, 1);
+		foreach (var connected in PlayerList.Instance.InGamePlayers)
 		{
 			var player = connected.Script;
 			if (bounds.Contains(player.WorldPos) && player.IsDeadOrGhost == false)

--- a/UnityProject/Assets/Scripts/Objects/Research/Artifacts/Effects/TelepaticArtifactEffect.cs
+++ b/UnityProject/Assets/Scripts/Objects/Research/Artifacts/Effects/TelepaticArtifactEffect.cs
@@ -38,11 +38,11 @@ public class TelepaticArtifactEffect : ArtifactEffect
 	{
 		var objCenter = gameObject.AssumedWorldPosServer().RoundToInt();
 		var hitMask = LayerMask.GetMask("Players");
-		var colliders = Physics2D.OverlapCircleAll(new Vector2(objCenter.x, objCenter.y), auraRadius, hitMask);
+		var playerColliders = Physics2D.OverlapCircleAll(new Vector2(objCenter.x, objCenter.y), auraRadius, hitMask);
 
-		foreach (var connected in colliders)
+		foreach (var playerColl in playerColliders)
 		{
-			connected.TryGetComponent<PlayerScript>(out var player);
+			playerColl.TryGetComponent<PlayerScript>(out var player);
 
 			if (player == null || player.IsDeadOrGhost)
 			{

--- a/UnityProject/Assets/Scripts/Objects/Research/Artifacts/Effects/TelepaticArtifactEffect.cs
+++ b/UnityProject/Assets/Scripts/Objects/Research/Artifacts/Effects/TelepaticArtifactEffect.cs
@@ -43,7 +43,7 @@ public class TelepaticArtifactEffect : ArtifactEffect
 		foreach (var connected in PlayerList.Instance.InGamePlayers)
 		{
 			var player = connected.Script;
-			if (bounds.Contains(player.WorldPos) && player.IsDeadOrGhost == false)
+			if (player.IsDeadOrGhost == false && bounds.Contains(player.WorldPos))
 			{
 				Indocrinate(player.gameObject);
 			}


### PR DESCRIPTION
Artifacts caused some frame drops occasionally due to checking all tiles in all matrices in a 20x20 area for players leading to roughly 10-20 thousand calls and a decent amount of garbage (in the order of about 60 kilobytes each call).

![artifacts](https://user-images.githubusercontent.com/2001506/107949420-17a6c300-6f4a-11eb-91c4-7e7f1fb01237.png)

Since it's pretty unlikely there will be 10000+ players, just check if any players are in the artifact bounds. This still creates a little garbage (all methods in PlayerList return new lists) but a couple hundred bytes is a wee bit better.
