### PR TITLE
Audio Parameters Were Not Serializable

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/SoundManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SoundManager.cs
@@ -611,20 +611,16 @@ public class SoundManager : MonoBehaviour
 		Instance.PlaySource(sound, polyphonic, global);
 	}
 
-	private void PlaySource(SoundSpawn source, bool polyphonic = false, bool Global = true, MixerType mixerType = MixerType.Unspecified)
+	private void PlaySource(SoundSpawn source, bool polyphonic = false, bool Global = true, MixerType mixerType = MixerType.Master)
 	{
-		if (mixerType != MixerType.Unspecified)
-		{
-			if (!Global
-			    && PlayerManager.LocalPlayer != null
-			    && (MatrixManager.Linecast(PlayerManager.LocalPlayer.TileWorldPosition().To3Int(),
-					    LayerTypeSelection.Walls, layerMask, source.RegisterTile.WorldPositionClient.To2Int().To3Int())
-				    .ItHit))
+		if (!Global
+		    && PlayerManager.LocalPlayer != null
+		    && (MatrixManager.Linecast(PlayerManager.LocalPlayer.TileWorldPosition().To3Int(),
+			    LayerTypeSelection.Walls, layerMask, source.RegisterTile.WorldPositionClient.To2Int().To3Int())
+			    .ItHit))
 			{
 				source.AudioSource.outputAudioMixerGroup = soundManager.MuffledMixer;
 			}
-		}
-
 		if (polyphonic)
 		{
 			source.PlayOneShot();

--- a/UnityProject/Assets/Scripts/Managers/SoundManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SoundManager.cs
@@ -225,12 +225,16 @@ public class SoundManager : MonoBehaviour
 	private SoundSpawn GetSoundSpawn(AddressableAudioSource addressableAudioSource, AudioSource audioSource,
 		string soundSpawnToken)
 	{
-		if (NonplayingSounds.ContainsKey(addressableAudioSource.AssetAddress) && NonplayingSounds[addressableAudioSource.AssetAddress].Count > 0)
+		if (NonplayingSounds.ContainsKey(addressableAudioSource.AssetAddress) && 
+			NonplayingSounds[addressableAudioSource.AssetAddress].Count > 0)
 		{
 			var ToReturn = NonplayingSounds[addressableAudioSource.AssetAddress][0];
 			NonplayingSounds[addressableAudioSource.AssetAddress].RemoveAt(0);
-			ToReturn.Token = soundSpawnToken;
-			SoundSpawns.Add(soundSpawnToken, ToReturn);
+			if (soundSpawnToken != "") //non addressables dont have a token
+			{
+				ToReturn.Token = soundSpawnToken;
+				SoundSpawns.Add(soundSpawnToken, ToReturn);
+			}
 			return ToReturn;
 		}
 

--- a/UnityProject/Assets/Scripts/Managers/SoundManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SoundManager.cs
@@ -188,7 +188,6 @@ public class SoundManager : MonoBehaviour
 			{
 				continue;
 			}
-
 			sound.Value.AudioSource.Stop();
 		}
 
@@ -226,16 +225,12 @@ public class SoundManager : MonoBehaviour
 	private SoundSpawn GetSoundSpawn(AddressableAudioSource addressableAudioSource, AudioSource audioSource,
 		string soundSpawnToken)
 	{
-		if (NonplayingSounds.ContainsKey(addressableAudioSource.AssetAddress) &&
-		    NonplayingSounds[addressableAudioSource.AssetAddress].Count > 0)
+		if (NonplayingSounds.ContainsKey(addressableAudioSource.AssetAddress) && NonplayingSounds[addressableAudioSource.AssetAddress].Count > 0)
 		{
 			var ToReturn = NonplayingSounds[addressableAudioSource.AssetAddress][0];
 			NonplayingSounds[addressableAudioSource.AssetAddress].RemoveAt(0);
-			if (soundSpawnToken != "") //non addressables dont have a token
-			{
-				ToReturn.Token = soundSpawnToken;
-				SoundSpawns.Add(soundSpawnToken, ToReturn);
-			}
+			ToReturn.Token = soundSpawnToken;
+			SoundSpawns.Add(soundSpawnToken, ToReturn);
 			return ToReturn;
 		}
 
@@ -441,7 +436,7 @@ public class SoundManager : MonoBehaviour
 	}
 
 	public static async Task PlayNetworkedForPlayer(GameObject recipient,
-		AddressableAudioSource addressableAudioSources, float? pitch = null,
+		AddressableAudioSource addressableAudioSources, float pitch = -1,
 		bool polyphonic = false,
 		bool shakeGround = false, byte shakeIntensity = 64, int shakeRange = 30, GameObject sourceObj = null)
 	{
@@ -465,9 +460,9 @@ public class SoundManager : MonoBehaviour
 	/// </summary>
 	/// <param name="recipient">The player that will receive the sound</param>
 	/// <param name="addressableAudioSources">The sound to be played.  If more than one is specified, one will be picked at random.</param>
-	/// <param name="pitch">The pitch variation of the sound.  Null for default pitch.</param>
+	/// <param name="pitch">The pitch variation of the sound.  -1 for default pitch.</param>
 	public static async Task PlayNetworkedForPlayer(GameObject recipient,
-		List<AddressableAudioSource> addressableAudioSources, float? pitch = null,
+		List<AddressableAudioSource> addressableAudioSources, float pitch = -1,
 		bool polyphonic = false,
 		bool shakeGround = false, byte shakeIntensity = 64, int shakeRange = 30, GameObject sourceObj = null)
 	{
@@ -483,7 +478,7 @@ public class SoundManager : MonoBehaviour
 		}
 
 		AudioSourceParameters audioSourceParameters = null;
-		if (pitch != null)
+		if (pitch > 0)
 		{
 			audioSourceParameters = new AudioSourceParameters
 			{
@@ -680,22 +675,12 @@ public class SoundManager : MonoBehaviour
 		if (!forceMixer)
 		{
 			if (!Global
-			    && PlayerManager.LocalPlayer != null)
+			    && PlayerManager.LocalPlayer != null
+			    && (MatrixManager.Linecast(PlayerManager.LocalPlayer.TileWorldPosition().To3Int(),
+					    LayerTypeSelection.Walls, layerMask, source.RegisterTile.WorldPositionClient.To2Int().To3Int())
+				    .ItHit))
 			{
-				if ((Vector2.Distance(PlayerManager.LocalPlayer.TileWorldPosition(),source.RegisterTile.WorldPositionClient.To2Int()) < 50))
-				{
-					if (MatrixManager.Linecast(PlayerManager.LocalPlayer.TileWorldPosition().To3Int(),
-							LayerTypeSelection.Walls, layerMask,
-							source.RegisterTile.WorldPositionClient.To2Int().To3Int())
-						.ItHit)
-					{
-						source.AudioSource.outputAudioMixerGroup = soundManager.MuffledMixer;
-					}
-				}
-				else
-				{
-					source.AudioSource.outputAudioMixerGroup = soundManager.MuffledMixer;
-				}
+				source.AudioSource.outputAudioMixerGroup = soundManager.MuffledMixer;
 			}
 		}
 
@@ -834,31 +819,31 @@ public class SoundManager : MonoBehaviour
 					? Instance.DefaultMixer
 					: Instance.MuffledMixer;
 
-			if (audioSourceParameters.Pitch != null)
-				audioSource.pitch = audioSourceParameters.Pitch.Value;
+			if (audioSourceParameters.Pitch >= 0)
+				audioSource.pitch = audioSourceParameters.Pitch;
 			else
 				audioSource.pitch = 1;
 
-			if (audioSourceParameters.Time != null)
-				audioSource.time = audioSourceParameters.Time.Value;
+			if (audioSourceParameters.Time >= 0)
+				audioSource.time = audioSourceParameters.Time;
 
-			if (audioSourceParameters.Volume != null)
-				audioSource.volume = audioSourceParameters.Volume.Value;
+			if (audioSourceParameters.Volume >= 0)
+				audioSource.volume = audioSourceParameters.Volume;
 
-			if (audioSourceParameters.Pan != null)
-				audioSource.panStereo = audioSourceParameters.Pan.Value;
+			if (audioSourceParameters.Pan >= 0)
+				audioSource.panStereo = audioSourceParameters.Pan;
 
-			if (audioSourceParameters.SpatialBlend != null)
-				audioSource.spatialBlend = audioSourceParameters.SpatialBlend.Value;
+			if (audioSourceParameters.SpatialBlend >= 0)
+				audioSource.spatialBlend = audioSourceParameters.SpatialBlend;
 
-			if (audioSourceParameters.MinDistance != null)
-				audioSource.minDistance = audioSourceParameters.MinDistance.Value;
+			if (audioSourceParameters.MinDistance >= 0)
+				audioSource.minDistance = audioSourceParameters.MinDistance;
 
-			if (audioSourceParameters.MaxDistance != null)
-				audioSource.maxDistance = audioSourceParameters.MaxDistance.Value;
+			if (audioSourceParameters.MaxDistance >= 0)
+				audioSource.maxDistance = audioSourceParameters.MaxDistance;
 
-			if (audioSourceParameters.Spread != null)
-				audioSource.spread = audioSourceParameters.Spread.Value;
+			if (audioSourceParameters.Spread >= 0)
+				audioSource.spread = audioSourceParameters.Spread;
 
 			switch (audioSourceParameters.VolumeRolloffType)
 			{

--- a/UnityProject/Assets/Scripts/Managers/SoundManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SoundManager.cs
@@ -241,7 +241,7 @@ public class SoundManager : MonoBehaviour
 		return GetNewSoundSpawn(addressableAudioSource, audioSource, soundSpawnToken);
 	}
 
-	public static void PlayNetworked(string addressableAudioSources, float pitch = -1,
+	public static void PlayNetworked(string addressableAudioSources, float pitch = 0,
 		bool polyphonic = false,
 		bool shakeGround = false, byte shakeIntensity = 64, int shakeRange = 30)
 	{
@@ -254,8 +254,8 @@ public class SoundManager : MonoBehaviour
 	/// If more than one sound is specified, one will be picked at random.
 	/// </summary>
 	/// <param name="addressableAudioSources">List of sounds to be played.  If more than one sound is specified, one will be picked at random</param>
-	public static async Task PlayNetworked(AddressableAudioSource addressableAudioSources, float pitch = -1,
-		bool polyphonic = false,
+	public static async Task PlayNetworked(AddressableAudioSource addressableAudioSources, 
+		float pitch = 0, bool polyphonic = false,
 		bool shakeGround = false, byte shakeIntensity = 64, int shakeRange = 30)
 	{
 		if (addressableAudioSources == null || addressableAudioSources.AssetAddress == string.Empty)
@@ -275,29 +275,14 @@ public class SoundManager : MonoBehaviour
 	/// If more than one sound is specified, one will be picked at random.
 	/// </summary>
 	/// <param name="addressableAudioSources">List of sounds to be played.  If more than one sound is specified, one will be picked at random</param>
-	public static async Task PlayNetworked(List<AddressableAudioSource> addressableAudioSources, float pitch = -1,
-		bool polyphonic = false,
-		bool shakeGround = false, byte shakeIntensity = 64, int shakeRange = 30)
+	public static async Task PlayNetworked(List<AddressableAudioSource> addressableAudioSources, 
+		float pitch = 0, bool polyphonic = false, bool shakeGround = false, 
+		byte shakeIntensity = 64, int shakeRange = 30)
 	{
-		ShakeParameters shakeParameters = null;
-		if (shakeGround == true)
-		{
-			shakeParameters = new ShakeParameters
-			{
-				ShakeGround = shakeGround,
-				ShakeIntensity = shakeIntensity,
-				ShakeRange = shakeRange
-			};
-		}
+		ShakeParameters shakeParameters = new ShakeParameters(shakeGround, shakeIntensity, shakeRange);
 
-		AudioSourceParameters audioSourceParameters = null;
-		if (pitch > 0)
-		{
-			audioSourceParameters = new AudioSourceParameters
-			{
-				Pitch = pitch
-			};
-		}
+		AudioSourceParameters audioSourceParameters = new AudioSourceParameters();
+		audioSourceParameters.Pitch = pitch;
 
 		AddressableAudioSource addressableAudioSource =
 			await GetAddressableAudioSourceFromCache(addressableAudioSources);
@@ -309,7 +294,7 @@ public class SoundManager : MonoBehaviour
 	public static string PlayNetworkedAtPos(string addressableAudioSource, Vector3 worldPos,
 		AudioSourceParameters audioSourceParameters,
 		bool polyphonic = false, bool Global = true, GameObject sourceObj = null,
-		ShakeParameters shakeParameters = null)
+		ShakeParameters shakeParameters = new ShakeParameters())
 	{
 		Logger.LogWarning("Sound needs to be converted to addressables " + addressableAudioSource);
 		return "";
@@ -329,7 +314,7 @@ public class SoundManager : MonoBehaviour
 	public static Task<string> PlayNetworkedAtPos(AddressableAudioSource addressableAudioSource, Vector3 worldPos,
 		AudioSourceParameters audioSourceParameters,
 		bool polyphonic = false, bool Global = true, GameObject sourceObj = null,
-		ShakeParameters shakeParameters = null)
+		ShakeParameters shakeParameters = new ShakeParameters())
 	{
 		if (addressableAudioSource == null || addressableAudioSource.AssetAddress == string.Empty)
 		{
@@ -357,7 +342,7 @@ public class SoundManager : MonoBehaviour
 	public static async Task<string> PlayNetworkedAtPos(List<AddressableAudioSource> addressableAudioSources,
 		Vector3 worldPos, AudioSourceParameters audioSourceParameters,
 		bool polyphonic = false, bool Global = true, GameObject sourceObj = null,
-		ShakeParameters shakeParameters = null)
+		ShakeParameters shakeParameters = new ShakeParameters())
 	{
 		AddressableAudioSource addressableAudioSource =
 			await GetAddressableAudioSourceFromCache(addressableAudioSources);
@@ -375,7 +360,7 @@ public class SoundManager : MonoBehaviour
 	}
 
 
-	public static void PlayNetworkedAtPos(string addressableAudioSource, Vector3 worldPos, float pitch = -1,
+	public static void PlayNetworkedAtPos(string addressableAudioSource, Vector3 worldPos, float pitch = 0,
 		bool polyphonic = false, bool shakeGround = false, byte shakeIntensity = 64, int shakeRange = 30,
 		bool global = true, GameObject sourceObj = null)
 	{
@@ -390,7 +375,7 @@ public class SoundManager : MonoBehaviour
 	/// If more than one is specified, one will be picked at random.
 	/// <param name="addressableAudioSource">The sound to be played.</param>
 	public static void PlayNetworkedAtPos(AddressableAudioSource addressableAudioSource, Vector3 worldPos,
-		float pitch = -1,
+		float pitch = 0,
 		bool polyphonic = false, bool shakeGround = false, byte shakeIntensity = 64, int shakeRange = 30,
 		bool global = true, GameObject sourceObj = null)
 	{
@@ -411,36 +396,22 @@ public class SoundManager : MonoBehaviour
 	/// If more than one is specified, one will be picked at random.
 	/// <param name="addressableAudioSources">The sound to be played.  If more than one is specified, one will be picked at random.</param>
 	public static void PlayNetworkedAtPos(List<AddressableAudioSource> addressableAudioSources, Vector3 worldPos,
-		float pitch = -1,
+		float pitch = 0,
 		bool polyphonic = false, bool shakeGround = false, byte shakeIntensity = 64, int shakeRange = 30,
 		bool global = true, GameObject sourceObj = null)
 	{
-		ShakeParameters shakeParameters = null;
-		if (shakeGround == true)
-		{
-			shakeParameters = new ShakeParameters
-			{
-				ShakeGround = shakeGround,
-				ShakeIntensity = shakeIntensity,
-				ShakeRange = shakeRange
-			};
-		}
+		ShakeParameters shakeParameters = new ShakeParameters(shakeGround, shakeIntensity, shakeRange);
 
-		AudioSourceParameters audioSourceParameters = null;
-		if (pitch > 0)
-		{
-			audioSourceParameters = new AudioSourceParameters
-			{
-				Pitch = pitch
-			};
-		}
+		AudioSourceParameters audioSourceParameters = new AudioSourceParameters();
+		audioSourceParameters.Pitch = pitch;
+
 
 		PlayNetworkedAtPos(addressableAudioSources, worldPos, audioSourceParameters, polyphonic, global, sourceObj,
 			shakeParameters);
 	}
 
 	public static async Task PlayNetworkedForPlayer(GameObject recipient,
-		AddressableAudioSource addressableAudioSources, float pitch = -1,
+		AddressableAudioSource addressableAudioSources, float pitch = 0,
 		bool polyphonic = false,
 		bool shakeGround = false, byte shakeIntensity = 64, int shakeRange = 30, GameObject sourceObj = null)
 	{
@@ -466,40 +437,24 @@ public class SoundManager : MonoBehaviour
 	/// <param name="addressableAudioSources">The sound to be played.  If more than one is specified, one will be picked at random.</param>
 	/// <param name="pitch">The pitch variation of the sound.  -1 for default pitch.</param>
 	public static async Task PlayNetworkedForPlayer(GameObject recipient,
-		List<AddressableAudioSource> addressableAudioSources, float pitch = -1,
+		List<AddressableAudioSource> addressableAudioSources, float pitch = 0,
 		bool polyphonic = false,
 		bool shakeGround = false, byte shakeIntensity = 64, int shakeRange = 30, GameObject sourceObj = null)
 	{
-		ShakeParameters shakeParameters = null;
-		if (shakeGround == true)
-		{
-			shakeParameters = new ShakeParameters
-			{
-				ShakeGround = shakeGround,
-				ShakeIntensity = shakeIntensity,
-				ShakeRange = shakeRange
-			};
-		}
+		ShakeParameters shakeParameters = new ShakeParameters(shakeGround, shakeIntensity, shakeRange);
 
-		AudioSourceParameters audioSourceParameters = null;
-		if (pitch > 0)
-		{
-			audioSourceParameters = new AudioSourceParameters
-			{
-				Pitch = pitch
-			};
-		}
+		AudioSourceParameters audioSourceParameters = new AudioSourceParameters();
+		audioSourceParameters.Pitch = pitch;
 
 		AddressableAudioSource addressableAudioSource =
 			await GetAddressableAudioSourceFromCache(addressableAudioSources);
-		PlaySoundMessage.Send(recipient, addressableAudioSource, TransformState.HiddenPos, polyphonic, sourceObj,
-			shakeParameters, audioSourceParameters);
+
+		PlaySoundMessage.Send(recipient, addressableAudioSource, TransformState.HiddenPos, polyphonic, 
+			sourceObj, shakeParameters, audioSourceParameters);
 	}
 
 	public static async Task PlayNetworkedForPlayerAtPos(GameObject recipient, Vector3 worldPos,
-		string addressableAudioSources,
-		float pitch = -1,
-		bool polyphonic = false,
+		string addressableAudioSources, float pitch = 0, bool polyphonic = false,
 		bool shakeGround = false, byte shakeIntensity = 64, int shakeRange = 30, GameObject sourceObj = null)
 	{
 		Logger.LogWarning("Sound needs to be converted to addressables " + addressableAudioSources);
@@ -513,30 +468,13 @@ public class SoundManager : MonoBehaviour
 	/// </summary>
 	/// <param name="addressableAudioSources">The sound to be played.  If more than one is specified, one will be picked at random.</param>
 	public static async Task PlayNetworkedForPlayerAtPos(GameObject recipient, Vector3 worldPos,
-		List<AddressableAudioSource> addressableAudioSources,
-		float pitch = -1,
-		bool polyphonic = false,
+		List<AddressableAudioSource> addressableAudioSources, float pitch = 0,	bool polyphonic = false,
 		bool shakeGround = false, byte shakeIntensity = 64, int shakeRange = 30, GameObject sourceObj = null)
 	{
-		ShakeParameters shakeParameters = null;
-		if (shakeGround)
-		{
-			shakeParameters = new ShakeParameters
-			{
-				ShakeGround = shakeGround,
-				ShakeIntensity = shakeIntensity,
-				ShakeRange = shakeRange
-			};
-		}
+		ShakeParameters shakeParameters = new ShakeParameters(shakeGround, shakeIntensity, shakeRange);
 
-		AudioSourceParameters audioSourceParameters = null;
-		if (pitch > 0)
-		{
-			audioSourceParameters = new AudioSourceParameters
-			{
-				Pitch = pitch
-			};
-		}
+		AudioSourceParameters audioSourceParameters = new AudioSourceParameters();
+		audioSourceParameters.Pitch = pitch;
 
 		AddressableAudioSource addressableAudioSource =
 			await GetAddressableAudioSourceFromCache(addressableAudioSources);
@@ -583,13 +521,12 @@ public class SoundManager : MonoBehaviour
 			Instance.GetSoundSpawn(addressableAudioSource, addressableAudioSource.AudioSource, soundSpawnToken);
 		ApplyAudioSourceParameters(audioSourceParameters, soundSpawn);
 
-		Instance.PlaySource(soundSpawn, polyphonic,
-			forceMixer: audioSourceParameters != null && audioSourceParameters.MixerType != MixerType.Unspecified);
+		Instance.PlaySource(soundSpawn, polyphonic, false, audioSourceParameters.MixerType);
 	}
 
 
 	public static async Task Play(AddressableAudioSource addressableAudioSources, string soundSpawnToken,
-		float volume, float pitch = -1, float time = 0, bool oneShot = false,
+		float volume, float pitch = 0, float time = 0, bool oneShot = false,
 		float pan = 0)
 	{
 		if (addressableAudioSources.AssetAddress == string.Empty)
@@ -611,7 +548,7 @@ public class SoundManager : MonoBehaviour
 	/// <param name="addressableAudioSources">The sound to be played.  If more than one is specified, one will be picked at random.</param>
 	/// <param name="soundSpawnToken">The SoundSpawn Token that identifies the same sound spawn instance across server and clients</returns>
 	public static async Task Play(List<AddressableAudioSource> addressableAudioSources, string soundSpawnToken,
-		float volume, float pitch = -1, float time = 0, bool oneShot = false,
+		float volume, float pitch = 0, float time = 0, bool oneShot = false,
 		float pan = 0)
 	{
 		AddressableAudioSource addressableAudioSource =
@@ -674,9 +611,9 @@ public class SoundManager : MonoBehaviour
 		Instance.PlaySource(sound, polyphonic, global);
 	}
 
-	private void PlaySource(SoundSpawn source, bool polyphonic = false, bool Global = true, bool forceMixer = false)
+	private void PlaySource(SoundSpawn source, bool polyphonic = false, bool Global = true, MixerType mixerType = MixerType.Unspecified)
 	{
-		if (!forceMixer)
+		if (mixerType != MixerType.Unspecified)
 		{
 			if (!Global
 			    && PlayerManager.LocalPlayer != null
@@ -700,10 +637,8 @@ public class SoundManager : MonoBehaviour
 
 	/// <param name="soundSpawnToken">The SoundSpawn Token that identifies the same sound spawn instance across server and clients</returns>
 	public static void PlayAtPosition(AddressableAudioSource addressableAudioSource, string soundSpawnToken,
-		Vector3 worldPos, GameObject sourceObj,
-		bool polyphonic = false,
-		bool isGlobal = false,
-		AudioSourceParameters audioSourceParameters = null)
+		Vector3 worldPos, GameObject sourceObj,	bool polyphonic = false, bool isGlobal = false,
+		AudioSourceParameters audioSourceParameters = new AudioSourceParameters())
 	{
 		if (addressableAudioSource.AssetAddress == string.Empty)
 		{
@@ -726,10 +661,8 @@ public class SoundManager : MonoBehaviour
 	/// <param name="addressableAudioSources">Sound to be played.  If more than one is specified, one will be picked at random.</param>
 	/// <param name="soundSpawnToken">The SoundSpawn Token that identifies the same sound spawn instance across server and clients</returns>
 	public static void PlayAtPosition(List<AddressableAudioSource> addressableAudioSources, string soundSpawnToken,
-		Vector3 worldPos, GameObject sourceObj,
-		bool polyphonic = false,
-		bool isGlobal = false,
-		AudioSourceParameters audioSourceParameters = null)
+		Vector3 worldPos, GameObject sourceObj,	bool polyphonic = false, bool isGlobal = false,
+		AudioSourceParameters audioSourceParameters = new AudioSourceParameters())
 	{
 		var netId = NetId.Empty;
 		if (sourceObj != null)
@@ -753,7 +686,7 @@ public class SoundManager : MonoBehaviour
 	/// <param name="soundSpawnToken">The SoundSpawn Token that identifies the same sound spawn instance across server and clients</returns>
 	public static async Task PlayAtPosition(AddressableAudioSource addressableAudioSource, Vector3 worldPos,
 		GameObject gameObject = null, string soundSpawnToken = "", bool polyphonic = false,
-		bool isGlobal = false, AudioSourceParameters audioSourceParameters = null)
+		bool isGlobal = false, AudioSourceParameters audioSourceParameters = new AudioSourceParameters())
 	{
 		uint netId = NetId.Empty;
 		if (gameObject != null)
@@ -780,7 +713,7 @@ public class SoundManager : MonoBehaviour
 	/// <param name="soundSpawnToken">The token that identifies the SoundSpawn uniquely among the server and all clients </param>
 	public static async Task PlayAtPosition(List<AddressableAudioSource> addressableAudioSources,
 		string soundSpawnToken, Vector3 worldPos, bool polyphonic = false,
-		bool isGlobal = false, uint netId = NetId.Empty, AudioSourceParameters audioSourceParameters = null)
+		bool isGlobal = false, uint netId = NetId.Empty, AudioSourceParameters audioSourceParameters = new AudioSourceParameters())
 	{
 		AddressableAudioSource addressableAudioSource =
 			await GetAddressableAudioSourceFromCache(addressableAudioSources);
@@ -808,61 +741,115 @@ public class SoundManager : MonoBehaviour
 			soundSpawn.transform.position = worldPos;
 		}
 
-		Instance.PlaySource(soundSpawn, polyphonic, isGlobal,
-			audioSourceParameters != null && audioSourceParameters.MixerType != MixerType.Unspecified);
+		Instance.PlaySource(soundSpawn, polyphonic, isGlobal, audioSourceParameters.MixerType);
 	}
 
+	/// <Summary>
+	/// Used to apply incomplete AudioSourceParameters to a Sound, such as changing pitch or volume.
+	/// As a Struct, AudioSourceParameters initializes zeroed out, so to prevent sounds from getting
+	/// messed up some limitations apply.  For complete control use ForceAudioSourceParameters.
+	/// </Summary>
 	private static void ApplyAudioSourceParameters(AudioSourceParameters audioSourceParameters, SoundSpawn soundSpawn)
 	{
 		AudioSource audioSource = soundSpawn.AudioSource;
 
-		if (audioSourceParameters != null)
+		//Volume can be 0 for two reasons: it is uninitialized or it is supposed to be 0.
+		//If it is supposed to be 0, IsMute should be set to true.  If its not 0, that's the value
+		//we want, otherwise no changes.
+		if(audioSourceParameters.IsMute == true)
 		{
-			if (audioSourceParameters.MixerType != MixerType.Unspecified)
-				audioSource.outputAudioMixerGroup = audioSourceParameters.MixerType == MixerType.Master
-					? Instance.DefaultMixer
-					: Instance.MuffledMixer;
+			audioSource.volume = 0;
+		}
+		else if(audioSourceParameters.Volume > 0)
+		{
+			audioSource.volume = audioSourceParameters.Volume;	
+		}
 
-			if (audioSourceParameters.Pitch >= 0)
-				audioSource.pitch = audioSourceParameters.Pitch;
-			else
-				audioSource.pitch = 1;
+		//Pitch should never be 0.  A negative pitch plays the sound backwards.
+		if(audioSourceParameters.Pitch != 0)
+			audioSource.pitch = audioSourceParameters.Pitch;
+		else if(audioSource.pitch == 0)
+			audioSource.pitch = 1;
 
-			if (audioSourceParameters.Time >= 0)
-				audioSource.time = audioSourceParameters.Time;
+		//The following parameters have some limitations that shouldn't really come up
+		//Note if the sound's default value for a parameter is 0, the limitation does not apply.
 
-			if (audioSourceParameters.Volume >= 0)
-				audioSource.volume = audioSourceParameters.Volume;
+		//Cannot seek to timestamp 0 for a sound that does not start at the beginning by default
+		if(audioSourceParameters.Time != 0)
+			audioSource.time = audioSourceParameters.Time;
 
-			if (audioSourceParameters.Pan >= 0)
-				audioSource.panStereo = audioSourceParameters.Pan;
+		//-1 is left, 0 is center, 1 is right.
+		//Cannot pan to center for sounds that are panned by default
+		if(audioSourceParameters.Pan != 0)
+			audioSource.panStereo = audioSourceParameters.Pan;
+		
+		//0 is 2D and ignores max/min distance, 1 is 3d and obeys them
+		//Cannot convert sounds that are 3D by default to 2D
+		if(audioSourceParameters.SpatialBlend != 0)
+			audioSource.spatialBlend = audioSourceParameters.SpatialBlend;
 
-			if (audioSourceParameters.SpatialBlend >= 0)
-				audioSource.spatialBlend = audioSourceParameters.SpatialBlend;
+		//Cannot change the minimum distance for audio falloff to 0
+		if(audioSourceParameters.MinDistance != 0)		
+			audioSource.minDistance = audioSourceParameters.MinDistance;
 
-			if (audioSourceParameters.MinDistance >= 0)
-				audioSource.minDistance = audioSourceParameters.MinDistance;
+		//Cannot change the max distance for falloff to 0 (why would you want that?)
+		if(audioSourceParameters.MaxDistance != 0)
+			audioSource.maxDistance = audioSourceParameters.MaxDistance;
+		
+		//Cannot convert non-mono sounds to mono
+		if(audioSourceParameters.Spread != 0)
+			audioSource.spread = audioSourceParameters.Spread;
 
-			if (audioSourceParameters.MaxDistance >= 0)
-				audioSource.maxDistance = audioSourceParameters.MaxDistance;
+		audioSource.outputAudioMixerGroup = audioSourceParameters.MixerType == MixerType.Master
+				? Instance.DefaultMixer : Instance.MuffledMixer;
 
-			if (audioSourceParameters.Spread >= 0)
-				audioSource.spread = audioSourceParameters.Spread;
+		switch (audioSourceParameters.VolumeRolloffType)
+		{
+			case VolumeRolloffType.EaseInAndOut:
+				audioSource.rolloffMode = AudioRolloffMode.Custom;
+				audioSource.SetCustomCurve(AudioSourceCurveType.CustomRolloff,
+					AnimationCurve.EaseInOut(0, 1, 1, 0));
+				break;
+			case VolumeRolloffType.Linear:
+				audioSource.rolloffMode = AudioRolloffMode.Linear;
+				break;
+			case VolumeRolloffType.Logarithmic:
+				audioSource.rolloffMode = AudioRolloffMode.Logarithmic;
+				break;
+		}
+	}
 
-			switch (audioSourceParameters.VolumeRolloffType)
-			{
-				case VolumeRolloffType.EaseInAndOut:
-					audioSource.rolloffMode = AudioRolloffMode.Custom;
-					audioSource.SetCustomCurve(AudioSourceCurveType.CustomRolloff,
-						AnimationCurve.EaseInOut(0, 1, 1, 0));
-					break;
-				case VolumeRolloffType.Linear:
-					audioSource.rolloffMode = AudioRolloffMode.Linear;
-					break;
-				case VolumeRolloffType.Logarithmic:
-					audioSource.rolloffMode = AudioRolloffMode.Logarithmic;
-					break;
-			}
+	/// <Summary>
+	/// Completely overwrites AudioSourceParameters of a Sound to any value.
+	/// Only use this if you have a known entry for all parameters, otherwise the sound will
+	/// not play properly (eg, having no entry for pitch will make the sound never start or finish)
+	/// </Summary>
+	private static void ForceAudioSourceParameters(AudioSourceParameters audioSourceParameters, SoundSpawn soundSpawn){
+		AudioSource audioSource = soundSpawn.AudioSource;
+
+		audioSource.volume = audioSourceParameters.Volume;
+		audioSource.pitch = audioSourceParameters.Pitch;
+		audioSource.time = audioSourceParameters.Time;
+		audioSource.panStereo = audioSourceParameters.Pan;
+		audioSource.spatialBlend = audioSourceParameters.SpatialBlend;
+		audioSource.minDistance = audioSourceParameters.MinDistance;
+		audioSource.maxDistance = audioSourceParameters.MaxDistance;
+		audioSource.spread = audioSourceParameters.Spread;
+		audioSource.outputAudioMixerGroup = audioSourceParameters.MixerType == MixerType.Master
+			? Instance.DefaultMixer : Instance.MuffledMixer;
+		switch (audioSourceParameters.VolumeRolloffType)
+		{
+			case VolumeRolloffType.EaseInAndOut:
+				audioSource.rolloffMode = AudioRolloffMode.Custom;
+				audioSource.SetCustomCurve(AudioSourceCurveType.CustomRolloff,
+					AnimationCurve.EaseInOut(0, 1, 1, 0));
+				break;
+			case VolumeRolloffType.Linear:
+				audioSource.rolloffMode = AudioRolloffMode.Linear;
+				break;
+			case VolumeRolloffType.Logarithmic:
+				audioSource.rolloffMode = AudioRolloffMode.Logarithmic;
+				break;
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Messages/Server/SoundMessages/AudioSourceParameters.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/SoundMessages/AudioSourceParameters.cs
@@ -19,49 +19,65 @@ namespace Assets.Scripts.Messages.Server.SoundMessages
 
 	/// <summary>
 	/// Structure to provide any AudioSource special parameters when playing a sound with the PlaySoundMessage
+	/// All parameters are 0, false, and undefined by default.
 	/// </summary>
-	public class AudioSourceParameters
+	public struct AudioSourceParameters
 	{
-		public float Volume = -1f;
-		public float Time = -1f;
-		public float Pan = -1f;
+		public float Volume;
+		public float Time;
+		public float Pan;
 
 		// The Output Mixer to use
-		public MixerType MixerType = MixerType.Unspecified;
+		public MixerType MixerType;
 
 		// Pitch of the sound
-		public float Pitch = -1f;
+		public float Pitch;
 
 		// Spatial blend of the audio source (0 for 2D, 1 for 3D)
 		// Note:  2D spatial blend doesn't attenuate with distance
-		public float SpatialBlend = -1f;
+		public float SpatialBlend;
 
 		//Sets the spread angle (in degrees) of a 3d stereo or multichannel sound in speaker space. (0 - 360f)
-		public float Spread = -1f;
+		public float Spread;
 
 		// Minimum distance in which the sound is at maximum volume
-		public float MinDistance = -1f;
+		public float MinDistance;
 
 		// MaxDistance is the distance a sound stops attenuating at.
-		public float MaxDistance = -1f;
+		public float MaxDistance;
 
 		// The type of curve to attenuate the sound in 3D audio.
-		public VolumeRolloffType VolumeRolloffType = VolumeRolloffType.Unspecified;
+		public VolumeRolloffType VolumeRolloffType;
+
+		// True if volume is supposed to be 0.
+		// We need this because structs always initilize with with all variables equal to 0.
+		public bool IsMute;
+		
+		/// <Summary>
+		/// Constructor for the AudioSourceParameters Struct
+		/// </Summary>
+		public AudioSourceParameters(float volume, float time, float pan, float pitch,
+			float spatialBlend, float spread, float minDistance, float maxDistance, MixerType mixerType, VolumeRolloffType volumeRolloffType, bool isMute)
+		{
+			Volume = volume;
+			Time = time;
+			Pan = pan;
+			Pitch = pitch;
+			SpatialBlend = spatialBlend;
+			Spread = spread;
+			MinDistance = minDistance;
+			MaxDistance = maxDistance;
+			MixerType = mixerType;
+			VolumeRolloffType = volumeRolloffType;
+			IsMute = isMute;
+		}
 
 		public override string ToString()
 		{
-			string volumeValue = Volume.ToString();
-			string timeValue = Time.ToString();
-			string panValue = Pan.ToString();
 			string mixerTypeValue = MixerType.ToString();
-			string pitchValue = Pitch.ToString();
-			string spatialBlendValue = SpatialBlend.ToString();
-			string spreadValue = Spread.ToString();
-			string minDistanceValue = MinDistance.ToString();
-			string maxDistanceValue = MaxDistance.ToString();
 			string volumeRolloffTypeValue = VolumeRolloffType.ToString();
 
-			return $"{nameof(Volume)}: {volumeValue}, {nameof(Time)}: {timeValue}, {nameof(Pan)}: {panValue}, {nameof(MixerType)}: {mixerTypeValue}, {nameof(Pitch)}: {pitchValue}, {nameof(SpatialBlend)}: {spatialBlendValue}, {nameof(Spread)}: {spreadValue}, {nameof(MinDistance)}: {minDistanceValue}, {nameof(MaxDistance)}: {maxDistanceValue}, {nameof(VolumeRolloffType)}: {volumeRolloffTypeValue}";
+			return $"{nameof(Volume)}: {Volume}, {nameof(Time)}: {Time}, {nameof(Pan)}: {Pan}, {nameof(MixerType)}: {mixerTypeValue}, {nameof(Pitch)}: {Pitch}, {nameof(SpatialBlend)}: {SpatialBlend}, {nameof(Spread)}: {Spread}, {nameof(MinDistance)}: {MinDistance}, {nameof(MaxDistance)}: {MaxDistance}, {nameof(VolumeRolloffType)}: {volumeRolloffTypeValue}";
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Messages/Server/SoundMessages/AudioSourceParameters.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/SoundMessages/AudioSourceParameters.cs
@@ -4,16 +4,14 @@ namespace Assets.Scripts.Messages.Server.SoundMessages
 {
 	public enum MixerType
 	{
-		Unspecified,
 		Master,
 		Muffled
 	}
 
 	public enum VolumeRolloffType
 	{
-		Unspecified,
-		Logarithmic,
 		Linear,
+		Logarithmic,
 		EaseInAndOut
 	}
 

--- a/UnityProject/Assets/Scripts/Messages/Server/SoundMessages/AudioSourceParameters.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/SoundMessages/AudioSourceParameters.cs
@@ -22,43 +22,43 @@ namespace Assets.Scripts.Messages.Server.SoundMessages
 	/// </summary>
 	public class AudioSourceParameters
 	{
-		public float? Volume { get; set; } = null;
-		public float? Time { get; set; } = null;
-		public float? Pan { get; set; } = null;
+		public float Volume = -1f;
+		public float Time = -1f;
+		public float Pan = -1f;
 
 		// The Output Mixer to use
-		public MixerType MixerType { get; set; } = MixerType.Unspecified;
+		public MixerType MixerType = MixerType.Unspecified;
 
 		// Pitch of the sound
-		public float? Pitch { get; set; } = null;
+		public float Pitch = -1f;
 
 		// Spatial blend of the audio source (0 for 2D, 1 for 3D)
 		// Note:  2D spatial blend doesn't attenuate with distance
-		public float? SpatialBlend { get; set; } = null;
+		public float SpatialBlend = -1f;
 
 		//Sets the spread angle (in degrees) of a 3d stereo or multichannel sound in speaker space. (0 - 360f)
-		public float? Spread { get; set; } = null;
+		public float Spread = -1f;
 
 		// Minimum distance in which the sound is at maximum volume
-		public float? MinDistance { get; set; } = null;
+		public float MinDistance = -1f;
 
 		// MaxDistance is the distance a sound stops attenuating at.
-		public float? MaxDistance { get; set; } = null;
+		public float MaxDistance = -1f;
 
 		// The type of curve to attenuate the sound in 3D audio.
-		public VolumeRolloffType VolumeRolloffType { get; set; } = VolumeRolloffType.Unspecified;
+		public VolumeRolloffType VolumeRolloffType = VolumeRolloffType.Unspecified;
 
 		public override string ToString()
 		{
-			string volumeValue = Volume.HasValue ? Volume.Value.ToString() : "Null";
-			string timeValue = Time.HasValue ? Time.Value.ToString() : "Null";
-			string panValue = Pan.HasValue ? Pan.Value.ToString() : "Null";
+			string volumeValue = Volume.ToString();
+			string timeValue = Time.ToString();
+			string panValue = Pan.ToString();
 			string mixerTypeValue = MixerType.ToString();
-			string pitchValue = Pitch.HasValue ? Pitch.Value.ToString() : "Null";
-			string spatialBlendValue = SpatialBlend.HasValue ? SpatialBlend.Value.ToString() : "Null";
-			string spreadValue = Spread.HasValue ? Spread.Value.ToString() : "Null";
-			string minDistanceValue = MinDistance.HasValue ? MinDistance.Value.ToString() : "Null";
-			string maxDistanceValue = MaxDistance.HasValue ? MaxDistance.Value.ToString() : "Null";
+			string pitchValue = Pitch.ToString();
+			string spatialBlendValue = SpatialBlend.ToString();
+			string spreadValue = Spread.ToString();
+			string minDistanceValue = MinDistance.ToString();
+			string maxDistanceValue = MaxDistance.ToString();
 			string volumeRolloffTypeValue = VolumeRolloffType.ToString();
 
 			return $"{nameof(Volume)}: {volumeValue}, {nameof(Time)}: {timeValue}, {nameof(Pan)}: {panValue}, {nameof(MixerType)}: {mixerTypeValue}, {nameof(Pitch)}: {pitchValue}, {nameof(SpatialBlend)}: {spatialBlendValue}, {nameof(Spread)}: {spreadValue}, {nameof(MinDistance)}: {minDistanceValue}, {nameof(MaxDistance)}: {maxDistanceValue}, {nameof(VolumeRolloffType)}: {volumeRolloffTypeValue}";

--- a/UnityProject/Assets/Scripts/Messages/Server/SoundMessages/ChangeAudioSourceParametersMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/SoundMessages/ChangeAudioSourceParametersMessage.cs
@@ -60,7 +60,7 @@ namespace Assets.Scripts.Messages.Server.SoundMessages
 
 		public override string ToString()
 		{
-			string audioSourceParametersValue = (AudioSourceParameters == null) ? "Null" : AudioSourceParameters.ToString();
+			string audioSourceParametersValue = AudioSourceParameters.ToString();
 			return $"{nameof(SoundSpawnToken)}: {SoundSpawnToken}, {nameof(AudioSourceParameters)}: {audioSourceParametersValue}";
 		}
 	}

--- a/UnityProject/Assets/Scripts/Messages/Server/SoundMessages/PlaySoundMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/SoundMessages/PlaySoundMessage.cs
@@ -20,10 +20,10 @@ namespace Assets.Scripts.Messages.Server.SoundMessages
 		public string SoundSpawnToken;
 
 		// Allow to perform a camera shake effect along with the sound.
-		public ShakeParameters ShakeParameters { get; set; }
+		public ShakeParameters ShakeParameters;
 
 		// Allow to personalize Audio Source parameters for any sound to play.
-		public AudioSourceParameters AudioSourceParameters { get; set; }
+		public AudioSourceParameters AudioSourceParameters;
 
 		public override void Process()
 		{

--- a/UnityProject/Assets/Scripts/Messages/Server/SoundMessages/PlaySoundMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/SoundMessages/PlaySoundMessage.cs
@@ -23,7 +23,7 @@ namespace Assets.Scripts.Messages.Server.SoundMessages
 		public ShakeParameters ShakeParameters;
 
 		// Allow to personalize Audio Source parameters for any sound to play.
-		public AudioSourceParameters AudioSourceParameters;
+		public AudioSourceParameters AudioParameters;
 
 		public override void Process()
 		{
@@ -35,22 +35,19 @@ namespace Assets.Scripts.Messages.Server.SoundMessages
 
 			bool isPositionProvided = Position.RoundToInt() != TransformState.HiddenPos;
 
-			if (AudioSourceParameters == null)
-				AudioSourceParameters = new AudioSourceParameters();
-
-			// Recompose a list of a single AddressableAudioSoure from its primart key (Guid)
+			// Recompose a list of a single AddressableAudioSource from its primary key (Guid)
 			List<AddressableAudioSource> addressableAudioSources = new List<AddressableAudioSource>() { new AddressableAudioSource(SoundAddressablePath) };
 
 			if (isPositionProvided)
 			{
-				SoundManager.PlayAtPosition(addressableAudioSources, SoundSpawnToken, Position, Polyphonic, netId: TargetNetId, audioSourceParameters: AudioSourceParameters );
+				SoundManager.PlayAtPosition(addressableAudioSources, SoundSpawnToken, Position, Polyphonic, netId: TargetNetId, audioSourceParameters: AudioParameters);
 			}
 			else
 			{
-				SoundManager.Play(addressableAudioSources, SoundSpawnToken, AudioSourceParameters, Polyphonic);
+				SoundManager.Play(addressableAudioSources, SoundSpawnToken, AudioParameters, Polyphonic);
 			}
 
-			if (ShakeParameters != null && ShakeParameters.ShakeGround)
+			if (ShakeParameters.ShakeGround)
 			{
 				if (isPositionProvided
 				 && PlayerManager.LocalPlayerScript
@@ -69,10 +66,9 @@ namespace Assets.Scripts.Messages.Server.SoundMessages
 		/// </summary>
 		/// <returns>The SoundSpawn Token generated that identifies the same sound spawn instance across server and clients</returns>
 		public static string SendToNearbyPlayers(AddressableAudioSource addressableAudioSource, Vector3 pos,
-			bool polyphonic = false,
-			GameObject sourceObj = null,
-			ShakeParameters shakeParameters = null,
-			AudioSourceParameters audioSourceParameters = null)
+			bool polyphonic = false, GameObject sourceObj = null, 
+			ShakeParameters shakeParameters = new ShakeParameters(),
+			AudioSourceParameters audioSourceParameters = new AudioSourceParameters())
 		{
 			var netId = NetId.Empty;
 			if (sourceObj != null)
@@ -93,7 +89,7 @@ namespace Assets.Scripts.Messages.Server.SoundMessages
 				Polyphonic = polyphonic,
 				TargetNetId = netId,
 				ShakeParameters = shakeParameters,
-				AudioSourceParameters = audioSourceParameters,
+				AudioParameters = audioSourceParameters,
 				SoundSpawnToken = soundSpawnToken
 			};
 
@@ -106,10 +102,9 @@ namespace Assets.Scripts.Messages.Server.SoundMessages
 		/// </summary>
 		/// <returns>The SoundSpawn Token generated that identifies the same sound spawn instance across server and clients</returns>
 		public static string SendToAll(AddressableAudioSource addressableAudioSource, Vector3 pos,
-			bool polyphonic = false,
-			GameObject sourceObj = null,
-			ShakeParameters shakeParameters = null,
-			AudioSourceParameters audioSourceParameters = null)
+			bool polyphonic = false, GameObject sourceObj = null, 
+			ShakeParameters shakeParameters = new ShakeParameters(),
+			AudioSourceParameters audioSourceParameters = new AudioSourceParameters())
 		{
 			var netId = NetId.Empty;
 			if (sourceObj != null)
@@ -130,10 +125,10 @@ namespace Assets.Scripts.Messages.Server.SoundMessages
 				Polyphonic = polyphonic,
 				TargetNetId = netId,
 				ShakeParameters = shakeParameters,
-				AudioSourceParameters = audioSourceParameters,
+				AudioParameters = audioSourceParameters,
 				SoundSpawnToken = soundSpawnToken
 			};
-
+			
 			msg.SendToAll();
 
 			return soundSpawnToken;
@@ -144,10 +139,9 @@ namespace Assets.Scripts.Messages.Server.SoundMessages
 		/// </summary>
 		/// <returns>The SoundSpawn Token generated that identifies the same sound spawn instance across server and clients</returns>
 		public static string Send(GameObject recipient, AddressableAudioSource addressableAudioSource, Vector3 pos,
-			bool polyphonic = false,
-			GameObject sourceObj = null,
-			ShakeParameters shakeParameters = null,
-			AudioSourceParameters audioSourceParameters = null)
+			bool polyphonic = false, GameObject sourceObj = null, 
+			ShakeParameters shakeParameters = new ShakeParameters(),
+			AudioSourceParameters audioSourceParameters = new AudioSourceParameters())
 		{
 			var netId = NetId.Empty;
 			if (sourceObj != null)
@@ -168,7 +162,7 @@ namespace Assets.Scripts.Messages.Server.SoundMessages
 				Polyphonic = polyphonic,
 				TargetNetId = netId,
 				ShakeParameters = shakeParameters,
-				AudioSourceParameters = audioSourceParameters,
+				AudioParameters = audioSourceParameters,
 				SoundSpawnToken = soundSpawnToken
 			};
 
@@ -179,8 +173,8 @@ namespace Assets.Scripts.Messages.Server.SoundMessages
 
 		public override string ToString()
 		{
-			string audioSourceParametersValue = (AudioSourceParameters == null) ? "Null" : AudioSourceParameters.ToString();
-			string shakeParametersValue = (ShakeParameters == null) ? "Null" : ShakeParameters.ToString();
+			string audioSourceParametersValue = AudioParameters.ToString();
+			string shakeParametersValue = ShakeParameters.ToString();
 			return $"{nameof(SoundAddressablePath)}: {SoundAddressablePath}, {nameof(Position)}: {Position}, {nameof(Polyphonic)}: {Polyphonic}, {nameof(ShakeParameters)}: {shakeParametersValue}, {nameof(AudioSourceParameters)}: {audioSourceParametersValue}";
 		}
 	}

--- a/UnityProject/Assets/Scripts/Messages/Server/SoundMessages/ShakeParameters.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/SoundMessages/ShakeParameters.cs
@@ -3,22 +3,32 @@
 	/// <summary>
 	/// Parameters to shake the ground when playing a sound.
 	/// </summary>
-	public class ShakeParameters
+	public struct ShakeParameters
 	{
 		/// <summary>
 		/// Should the ground shake?
 		/// </summary>
-		public bool ShakeGround = false;
+		public bool ShakeGround;
 
 		/// <summary>
 		/// At what intensity should the ground shake?
 		/// </summary>
-		public byte ShakeIntensity = 64;
+		public byte ShakeIntensity;
 
 		/// <summary>
 		/// At what distance should the shake be perceived?
 		/// </summary>
-		public int ShakeRange = 30;
+		public int ShakeRange;
+
+		/// <summary>
+		/// Constructor for the ShakeParameters Struct
+		/// </summary>
+		public ShakeParameters(bool shakeGround, byte shakeIntensity, int shakeRange)
+		{
+			ShakeGround = shakeGround;
+			ShakeIntensity = shakeIntensity;
+			ShakeRange = shakeRange;
+		}
 
 		public override string ToString()
 		{

--- a/UnityProject/Assets/Scripts/Messages/Server/SoundMessages/ShakeParameters.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/SoundMessages/ShakeParameters.cs
@@ -8,17 +8,17 @@
 		/// <summary>
 		/// Should the ground shake?
 		/// </summary>
-		public bool ShakeGround { get; set; } = false;
+		public bool ShakeGround = false;
 
 		/// <summary>
 		/// At what intensity should the ground shake?
 		/// </summary>
-		public byte ShakeIntensity { get; set; } = 64;
+		public byte ShakeIntensity = 64;
 
 		/// <summary>
 		/// At what distance should the shake be perceived?
 		/// </summary>
-		public int ShakeRange { get; set; } = 30;
+		public int ShakeRange = 30;
 
 		public override string ToString()
 		{

--- a/UnityProject/Assets/Scripts/NPC/AI/MobExplore.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobExplore.cs
@@ -192,7 +192,7 @@ namespace Systems.MobAIs
 				}
 
 				// Send the sound to all nearby clients
-				SoundManager.PlayNetworkedAtPos(eatFoodSound, transform.position, null, false, false, gameObject);
+				SoundManager.PlayNetworkedAtPos(eatFoodSound, transform.position, sourceObj: gameObject);
 
 				Despawn.ServerSingle(food.gameObject);
 				FoodEatenEvent?.Invoke();

--- a/UnityProject/Assets/Scripts/Objects/Machines/Jukebox.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/Jukebox.cs
@@ -55,6 +55,8 @@ namespace Objects
 		[Range(0, 360)]
 		private float Spread = 0;
 
+		private AudioSourceParameters audioSourceParameters;
+
 		[SerializeField]
 		private AudioClipsArray adminMusic = null;
 
@@ -177,6 +179,9 @@ namespace Objects
 			registerTile = GetComponent<RegisterTile>();
 			integrity = GetComponent<Integrity>();
 			integrity.OnApplyDamage.AddListener(OnDamageReceived);
+
+			audioSourceParameters =	new AudioSourceParameters(Volume, 0, 0, 0, 1, Spread, 
+				MinSoundDistance, MaxSoundDistance, MixerType.Muffled, VolumeRolloffType.EaseInAndOut, false);
 		}
 
 		private void Update()
@@ -199,19 +204,6 @@ namespace Objects
 				SoundManager.StopNetworked(guid);
 				IsPlaying = true;
 				spriteHandler.SetSpriteSO(SpritePlaying);
-
-				AudioSourceParameters audioSourceParameters = new AudioSourceParameters
-				{
-					MixerType = MixerType.Muffled,
-					SpatialBlend = 1, // 3D, we need it to attenuate with distance
-					Volume = Volume,
-					MinDistance = MinSoundDistance,
-					MaxDistance = MaxSoundDistance,
-					VolumeRolloffType = VolumeRolloffType.EaseInAndOut,
-					Spread = Spread
-
-				};
-
 				guid  = await SoundManager.PlayNetworkedAtPos(musics[currentSongTrackIndex], registerTile.WorldPositionServer, audioSourceParameters, false, true, gameObject);
 				startPlayTime = Time.time;
 				UpdateGUI();
@@ -268,12 +260,10 @@ namespace Objects
 
 		public void VolumeChange(float newVolume)
 		{
-			Volume = newVolume;
+			audioSourceParameters.Volume = newVolume;
 
-			AudioSourceParameters audioSourceParameters = new AudioSourceParameters
-			{
-				Volume = newVolume,
-			};
+			if( newVolume == 0)
+				audioSourceParameters.IsMute = true;
 
 			ChangeAudioSourceParametersMessage.SendToAll(guid, audioSourceParameters);
 		}


### PR DESCRIPTION
PlaySoundMessage attempts to serialize the AudioSourceParameters it receives through the send/sendToAll/sendToNearbyPlayers methods as part of its sending messages to clients.  However, because AudioSourceParameters was using nullable variables and non-serialized get/setters it could not be serialized due to the limitations of the engine.  This resulted in all AudioSourceParameters being ignored and reset to the default null values.  

### Purpose
This fix changes the nullable variables in AudioSourceParameters to normal variables, and instead uses the value of -1 to represent a "default" value.  All code that references AudioSourceParameters using null values has been changed to reflect this.  This change permits all related already existing code to function as intended.  This fix also adjusts ShakeParameters to also be serializable as well, as it was it always produced the same, default shake.

Fixes #5981

### Notes:
Note that this bug impacted almost all code that made changes to pitch, volume, pan, spread, and spatial blending, as any code that played sound through PlaySoundMessage was being reset to default values.  Because of this, many sounds are changed with this fix.