### PR TITLE
Fix reversed artifact logic.

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Research/Artifacts/Effects/TelepaticArtifactEffect.cs
+++ b/UnityProject/Assets/Scripts/Objects/Research/Artifacts/Effects/TelepaticArtifactEffect.cs
@@ -44,10 +44,9 @@ public class TelepaticArtifactEffect : ArtifactEffect
 		{
 			playerColl.TryGetComponent<PlayerScript>(out var player);
 
-			if (player == null || player.IsDeadOrGhost)
-			{
-				Indocrinate(player.gameObject);
-			}
+			if (player == null || player.IsDeadOrGhost) continue;
+
+			Indocrinate(player.gameObject);
 		}
 	}
 


### PR DESCRIPTION
Woke up after realizing I unintentionally reversed the logic for artifacts after switching to using physics2d to search for players. Now I was activating it on dead players or if it was null. Whoops.
