### PR TITLE
Fixes muffled sounds

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/SoundManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SoundManager.cs
@@ -599,7 +599,7 @@ public class SoundManager : MonoBehaviour
 		if (!Global
 		    && PlayerManager.LocalPlayer != null
 		    && (MatrixManager.Linecast(PlayerManager.LocalPlayer.TileWorldPosition().To3Int(),
-			    LayerTypeSelection.Walls, layerMask, source.RegisterTile.WorldPositionClient.To2Int().To3Int())
+			    LayerTypeSelection.Walls, layerMask, source.transform.position.To2Int().To3Int())
 			    .ItHit))
 			{
 				source.AudioSource.outputAudioMixerGroup = soundManager.MuffledMixer;


### PR DESCRIPTION
### Purpose
Fixes sounds being muffled when they weren't supposed to

The registertile position is never set and the raycast to check for a wall was always aiming at hiddenpos