### PR TITLE
adds toolbelt to roboticist

### DIFF
--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/RoboticistPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/RoboticistPopulator.asset
@@ -29,6 +29,9 @@ MonoBehaviour:
     Prefab: {fileID: 5064226321362517998, guid: 08cfe1b88b57ef54480353de29933380,
       type: 3}
   - NamedSlot: 1
+    Prefab: {fileID: 8560762587041295364, guid: a8b7436d80686f9448b83d34621b9e6d,
+      type: 3}
+  - NamedSlot: 16
     Prefab: {fileID: 2255089484867526446, guid: 7ec661cb1c2fa694a83b107497f9ccae,
       type: 3}
   skirtVariant: {fileID: 6710415053653577436, guid: 676e9af4e37de5645a97d7ad338cfcef,


### PR DESCRIPTION

### Purpose

adds toolbelt to the Roboticist's populator, moving the PDA to the pockets just like engineers and atmos techs. closes #5296 

