### PR TITLE
Lobby Autoplay Fixes

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/LobbyManager/MusicManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/LobbyManager/MusicManager.cs
@@ -111,7 +111,7 @@ namespace Audio.Containers
 		{
 			if (Instance.currentLobbyAudioSource != null
 			    && Instance.currentLobbyAudioSource.isPlaying
-			    || !(SunVox.sv_end_of_song((int) Slot.Music) == 1))
+			    || !(SunVox.sv_end_of_song((int) Slot.Music) == 0))
 			{
 				return true;
 			}

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/SongTracker.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/SongTracker.cs
@@ -73,7 +73,6 @@ namespace Audio.Containers
 			if (CustomNetworkManager.IsHeadless) return;
 
 			PlayingRandomPlayList = true;
-			PlayRandomTrack();
 			ToggleUI(true);
 		}
 


### PR DESCRIPTION
The music player in Lobby was not playing music automatically, nor would it play the next track automatically.

### Purpose
This PR corrects a line in MusicManager that would incorrectly return that music was playing when it was not, thus preventing autoplay.
It also removes a line in SongTracker that was attempting to play music before AddressableAssets had finished loading the music files.

### Notes:
This solution did not implement a way to play music precisely the moment that AddressableAssets has finished loading, and instead simply tries to play a song after 2 seconds (and every 2 seconds thereafter if music still hasn't loaded), as if a song had just finished playing.  This is a functional, but not perfect, solution that minimally impacts existing code.
