### PR TITLE
Fixes doors not having the correct sprite and collider on clients

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/MachineDoors/MachineDoorBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/MachineDoors/MachineDoorBase.prefab
@@ -98,7 +98,6 @@ MonoBehaviour:
   ignorePassableChecks: 0
   IsAutomatic: 1
   conType: 7
-  connectedDoorSwitch: {fileID: 0}
   isPerformingAction: 0
   isWindowedDoor: 0
   useSimpleLightAnimation: 0
@@ -158,7 +157,7 @@ PrefabInstance:
     - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
       propertyPath: m_SortingLayer
-      value: 25
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -243,6 +242,11 @@ PrefabInstance:
     - target: {fileID: 5432513913519741094, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
       propertyPath: m_IsTrigger
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6109775972905365350, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: pushTextureOnStartUp
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7153803037707514078, guid: b69bfc56f39849d4ba9139d2d51bedb6,

--- a/UnityProject/Assets/Scripts/Objects/Doors/DoorController.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/DoorController.cs
@@ -580,7 +580,11 @@ namespace Doors
 		/// </summary>
 		public void UpdateNewPlayer(NetworkConnection playerConn)
 		{
-			if (IsClosed == false)
+			if (IsClosed)
+			{
+				DoorUpdateMessage.Send(playerConn, gameObject, DoorUpdateType.Close, true);
+			}
+			else
 			{
 				DoorUpdateMessage.Send(playerConn, gameObject, DoorUpdateType.Open, true);
 			}

--- a/UnityProject/Assets/Scripts/Objects/Doors/GeneralDoorAnimator.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/GeneralDoorAnimator.cs
@@ -53,19 +53,6 @@ namespace Doors
 			tileChangeManager = GetComponentInParent<TileChangeManager>();
 		}
 
-		public void Start()
-		{
-			//Call doorController after awake so it has a chance to init
-			if (doorController.IsClosed)
-			{
-				doorbase.sprite = sprites[closeFrame + (int)direction];
-			}
-			else
-			{
-				doorbase.sprite = sprites[openFrame + (int)direction];
-			}
-		}
-
 		public override void OpenDoor(bool skipAnimation)
 		{
 			if (skipAnimation == false)


### PR DESCRIPTION
### Purpose
Fixes doors not having the correct sprite and collider on clients.

When the client asked for the message, they were only receiving it back if the door was open, also both spritehandler and one of the animator scripts were setting the sprite at start, depending on the connection to the server, they could set it after the message arrives