### PR TITLE
fix players being able to revive themselves when they shouldn't

### DIFF
--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -495,13 +495,16 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 	//Respawn action for Deathmatch v 0.1.3
 
 	[Command]
-	public void CmdRespawnPlayer()
+	public void CmdRespawnPlayer(string adminID, string adminToken)
 	{
-		if (CustomNetworkManager.IsServer
-				|| PlayerList.Instance.IsAdmin(gameObject.Player())
-				|| GameManager.Instance.RespawnCurrentlyAllowed)
+		if (GameManager.Instance.RespawnCurrentlyAllowed ||
+		    PlayerList.Instance.GetAdmin(adminID, adminToken))
 		{
 			ServerRespawnPlayer();
+		}
+		else
+		{
+			Logger.LogWarning($"Player with user id {adminID} tried to revive themselves while server has not allowed and they are not admin.");
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_GhostOptions.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_GhostOptions.cs
@@ -72,7 +72,7 @@ namespace UI.Systems.Ghost
 
 		public void Respawn()
 		{
-			PlayerManager.LocalPlayerScript.playerNetworkActions.CmdRespawnPlayer();
+			PlayerManager.LocalPlayerScript.playerNetworkActions.CmdRespawnPlayer(ServerData.UserID, PlayerList.Instance.AdminToken);
 		}
 
 		public void ToggleAllowCloning()


### PR DESCRIPTION
### Purpose
Players were able to revive themselves even when they weren't admin and the server config didn't allow it because of a bad check for server. This PR fixes the issue while keeping the intended behaviour.