### PR TITLE
Lobby Music Autoplay and Various Addressable Audio fixes

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Addressables/Types/AddressableReference.cs
+++ b/UnityProject/Assets/Scripts/Core/Addressables/Types/AddressableReference.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
@@ -60,7 +60,11 @@ namespace AddressableReferences
 			}
 			catch
 			{
-				if(!await HasValidAddress()) return null;
+				if (string.IsNullOrEmpty(AssetAddress))
+				{
+					Logger.LogError("Address is null for " + AssetReference.SubObjectName);
+					return null;
+				}
 
 				var AsynchronousHandle = Addressables.LoadAssetAsync<T>(AssetAddress);
 				await AsynchronousHandle.Task;
@@ -148,6 +152,7 @@ namespace AddressableReferences
 		/// <summary>
 		/// Validates an addressable's address to ensure it points to an addressable asset
 		/// </summary>
+		/// <returns>True if the addressable has a valid address, False if it does not.</returns>
 		public async Task<bool> HasValidAddress()
 		{
 			var validate = Addressables.LoadResourceLocationsAsync(AssetAddress);

--- a/UnityProject/Assets/Scripts/Core/Addressables/Types/AddressableReference.cs
+++ b/UnityProject/Assets/Scripts/Core/Addressables/Types/AddressableReference.cs
@@ -60,11 +60,8 @@ namespace AddressableReferences
 			}
 			catch
 			{
-				if (string.IsNullOrEmpty(AssetAddress))
-				{
-					Logger.LogError("Address is null for " + AssetReference.SubObjectName);
-					return null;
-				}
+				if(!await HasValidAddress()) return null;
+
 				var AsynchronousHandle = Addressables.LoadAssetAsync<T>(AssetAddress);
 				await AsynchronousHandle.Task;
 				StoredLoadedReference = AsynchronousHandle.Result;
@@ -147,6 +144,23 @@ namespace AddressableReferences
 				Logger.Log("Not implemented yet");
 			}
 		}
+
+		/// <summary>
+		/// Validates an addressable's address to ensure it points to an addressable asset
+		/// </summary>
+		public async Task<bool> HasValidAddress()
+		{
+			var validate = Addressables.LoadResourceLocationsAsync(AssetAddress);
+			await validate.Task;
+			if (validate.Status == AsyncOperationStatus.Succeeded) {
+       			if (validate.Result.Count > 0) {
+					   return true;
+				}
+			}
+			Logger.LogError("Addressable Address is invalid: " + AssetAddress, Category.Addressables);
+			return false;
+        }
+
 		#endregion
 	}
 

--- a/UnityProject/Assets/Scripts/Managers/LobbyManager/MusicManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/LobbyManager/MusicManager.cs
@@ -116,7 +116,7 @@ namespace Audio.Containers
 		{
 			if (Instance.currentLobbyAudioSource != null
 			    && Instance.currentLobbyAudioSource.isPlaying
-			    || !(SunVox.sv_end_of_song((int) Slot.Music) == 0))
+			    || (SunVox.sv_end_of_song((int) Slot.Music) != 0))
 			{
 				return true;
 			}

--- a/UnityProject/Assets/Scripts/Managers/LobbyManager/MusicManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/LobbyManager/MusicManager.cs
@@ -80,6 +80,11 @@ namespace Audio.Containers
 			StopMusic();
 			if (currentLobbyAudioSource == null) Init();
 			var audioSource = await SoundManager.GetAddressableAudioSourceFromCache(new List<AddressableAudioSource>{audioClips.GetRandomClip()});
+			if(audioSource == null)
+			{
+				Logger.LogError("MusicManager failed to load a song, is Addressables loaded?", Category.Addressables);
+				return null;
+			}
 			currentLobbyAudioSource.clip = audioSource.AudioSource.clip;
 			currentLobbyAudioSource.mute = isMusicMute;
 			currentLobbyAudioSource.volume = Instance.MusicVolume;
@@ -111,7 +116,7 @@ namespace Audio.Containers
 		{
 			if (Instance.currentLobbyAudioSource != null
 			    && Instance.currentLobbyAudioSource.isPlaying
-			    || !(SunVox.sv_end_of_song((int) Slot.Music) == 1))
+			    || !(SunVox.sv_end_of_song((int) Slot.Music) == 0))
 			{
 				return true;
 			}

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/SongTracker.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/SongTracker.cs
@@ -71,9 +71,7 @@ namespace Audio.Containers
 		public void StartPlayingRandomPlaylist()
 		{
 			if (CustomNetworkManager.IsHeadless) return;
-
 			PlayingRandomPlayList = true;
-			PlayRandomTrack();
 			ToggleUI(true);
 		}
 
@@ -134,15 +132,18 @@ namespace Audio.Containers
 			if (CustomNetworkManager.IsHeadless) return;
 
 			var songInfo = await MusicManager.Instance.PlayRandomTrack();
-			trackName.text = songInfo[0];
-			// If the name of the artist is included, add it as well
-			if (songInfo.Length == 2)
-			{
-				artist.text = songInfo[1];
-			}
-			else
-			{
-				artist.text = "";
+
+			if(songInfo != null){
+				trackName.text = songInfo[0];
+				// If the name of the artist is included, add it as well
+				if (songInfo.Length == 2)
+				{
+					artist.text = songInfo[1];
+				}
+				else
+				{
+					artist.text = "";
+				}
 			}
 		}
 


### PR DESCRIPTION
### Purpose
This PR addresses two sets of problems, and since they deal with related code I have included them together.  First, the PR addresses several underlying problems that was preventing Lobby Music from playing properly:

1. MusicManager.isLobbyMusicPlaying() as written would always return true, preventing Lobby Music from autoplaying.

2. SongTracker was calling for music to begin playing before Addressables had finished loading, throwing an exception.

3. MusicManager and SoundTracker had no null handling in case of failure.

4. AddressableReference had no means of identifying a non-null, non-valid Addressable Address.  This was solved by adding a new method, HasValidAddress(), which can be safely called to check whether an addressable can be found at its address.

5. Several LogError calls where attempting to use information from an addressable whose data could not be read to report that its data could not be read, throwing exceptions that broke the await statements.

This PR addresses all of the above issues, and additionally makes changes to GetAddressableAudioSourceFromCache and EnsureAddressableAudioSourceFromCache.  

1. Separating these methods did nothing, as the former was simply an await statement for the latter to finish.  Since any method calling the former would have to have an await statement to await the former awaiting the latter, one might as well just skip the middleman.

2. EnsureAddressableAudioSourceFromCache was not actually doing its namesake, it was building a cache but ultimately did nothing with it.  This PR implements that functionality, in testing I observed an approximate 30% reduction in paused Audio Sources with these changes.

### Notes
Lobby Music is now working for me consistently after build, but not the first run when using "Build And Play" in UnityProject.  I suspect there may still be another underlying problem related to the Addressable Catalogue code that I could not find.