### PR TITLE
Fixes door buttons being hard to click

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Wallmounts/Switches/DoorSwitch.cs
+++ b/UnityProject/Assets/Scripts/Objects/Wallmounts/Switches/DoorSwitch.cs
@@ -93,20 +93,16 @@ namespace Objects.Wallmounts
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
 			if (!DefaultWillInteract.Default(interaction, side)) return false;
-			//this validation is only done client side for their convenience - they can't
-			//press button while it's animating.
-			if (side == NetworkSide.Client)
-			{
-				if (buttonCoolDown) return false;
-				buttonCoolDown = true;
-				StartCoroutine(CoolDown());
-			}
-
 			return true;
 		}
 
 		public void ServerPerformInteraction(HandApply interaction)
 		{
+			if (buttonCoolDown)
+				return;
+			buttonCoolDown = true;
+			StartCoroutine(CoolDown());
+
 			if (accessRestrictions != null && restricted)
 			{
 				if (!accessRestrictions.CheckAccess(interaction.Performer))


### PR DESCRIPTION
### Purpose
Fixes not working if the mouse clicked them too fast after a mouseover.

The willinteract was running on mouseover, triggering the cooldown. Moved it to serverside instead.