### PR TITLE
Fixes the crit screen being stuck after ghosting

### DIFF
--- a/UnityProject/Assets/Scripts/Player/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerScript.cs
@@ -237,7 +237,10 @@ public class PlayerScript : ManagedNetworkBehaviour, IMatrixRotation, IAdminInfo
 
 			if (IsGhost && !IsPlayerSemiGhost)
 			{
-				UIManager.LinkUISlots(ItemStorageLinkOrigin.adminGhost);
+				if (PlayerList.Instance.IsClientAdmin)
+				{
+					UIManager.LinkUISlots(ItemStorageLinkOrigin.adminGhost);
+				}
 				//stop the crit notification and change overlay to ghost mode
 				SoundManager.Stop("Critstate");
 				UIManager.PlayerHealthUI.heartMonitor.overlayCrits.SetState(OverlayState.death);


### PR DESCRIPTION
### Purpose
Fixes the crit screen being stuck after ghosting

Clients were trying to initialize admin ghost UI even if they werent admins, it threw a runtime and ghost initialization never finished



