### PR TITLE
Fixes atmos stopping after a new scene load

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Pipes/Devices/AirVent.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/Devices/AirVent.cs
@@ -18,22 +18,11 @@ namespace Pipes
 		private MetaDataNode metaNode;
 		private MetaDataLayer metaDataLayer;
 
-
-		public override void Start()
-		{
-			pipeData.PipeAction = new MonoActions();
-			base.Start();
-		}
-
-		private void Awake()
-		{
-			registerTile = GetComponent<RegisterTile>();
-		}
-
-		public void OnSpawnServer(SpawnInfo info)
+		public override void OnSpawnServer(SpawnInfo info)
 		{
 			metaDataLayer = MatrixManager.AtPoint(registerTile.WorldPositionServer, true).MetaDataLayer;
 			metaNode = metaDataLayer.Get(registerTile.LocalPositionServer, false);
+			base.OnSpawnServer(info);
 		}
 
 		public override void TickUpdate()

--- a/UnityProject/Assets/Scripts/Objects/Pipes/Devices/Connector.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/Devices/Connector.cs
@@ -9,12 +9,6 @@ namespace Pipes
 	{
 		private Canister canister;
 
-		public override void Start()
-		{
-			pipeData.PipeAction = new MonoActions();
-			base.Start();
-		}
-
 		public override void TickUpdate()
 		{
 			// TODO: the connector now considers if the valve is open, but it should also take into

--- a/UnityProject/Assets/Scripts/Objects/Pipes/Devices/Filter.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/Devices/Filter.cs
@@ -62,11 +62,9 @@ namespace Pipes
 		public Gas GasIndex = Gas.Oxygen;
 		public Chemistry.Reagent FilterReagent;
 
-		public override void Start()
+		public override void OnSpawnServer(SpawnInfo info)
 		{
 			GasIndex = CapableFiltering[initalFilterValue.ToString()];
-			pipeData.PipeAction = new MonoActions();
-			base.Start();
 
 			if (IsOn)
 			{
@@ -76,6 +74,7 @@ namespace Pipes
 			{
 				spriteHandlerOverlay.PushClear();
 			}
+			base.OnSpawnServer(info);
 		}
 
 		public void TogglePower()

--- a/UnityProject/Assets/Scripts/Objects/Pipes/Devices/Mixer.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/Devices/Mixer.cs
@@ -19,11 +19,8 @@ namespace Pipes
 		public bool IsOn = false;
 
 
-		public override void Start()
+		public override void OnSpawnServer(SpawnInfo info)
 		{
-			pipeData.PipeAction = new MonoActions();
-			base.Start();
-
 			if (IsOn)
 			{
 				spriteHandlerOverlay.PushTexture();
@@ -32,6 +29,7 @@ namespace Pipes
 			{
 				spriteHandlerOverlay.PushClear();
 			}
+			base.OnSpawnServer(info);
 		}
 
 		public void TogglePower()

--- a/UnityProject/Assets/Scripts/Objects/Pipes/Devices/Pump.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/Devices/Pump.cs
@@ -15,11 +15,8 @@ namespace Pipes
 
 		public bool IsOn = false;
 
-		public override void Start()
+		public override void OnSpawnServer(SpawnInfo info)
 		{
-			pipeData.PipeAction = new MonoActions();
-			base.Start();
-
 			if (IsOn)
 			{
 				spriteHandlerOverlay.PushTexture();
@@ -28,6 +25,7 @@ namespace Pipes
 			{
 				spriteHandlerOverlay.PushClear();
 			}
+			base.OnSpawnServer(info);
 		}
 
 		public override void Interaction(HandApply interaction)

--- a/UnityProject/Assets/Scripts/Objects/Pipes/Devices/ReservoirTank.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/Devices/ReservoirTank.cs
@@ -11,11 +11,11 @@ namespace Pipes
 		public Chemistry.Reagent Water;
 		public ReagentContainer Container;
 
-		public override void Start()
+		public override void OnSpawnServer(SpawnInfo info)
 		{
 			pipeData.PipeAction = new ReservoirAction();
 			pipeData.GetMixAndVolume.GetReagentMix().Add(Water, 1000);
-			base.Start();
+			base.OnSpawnServer(info);
 		}
 
 		public override bool WillInteract(HandApply interaction, NetworkSide side )

--- a/UnityProject/Assets/Scripts/Objects/Pipes/Devices/Scrubber.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/Devices/Scrubber.cs
@@ -18,22 +18,11 @@ namespace Pipes
 		private MetaDataNode metaNode;
 		private MetaDataLayer metaDataLayer;
 
-
-		public override void Start()
-		{
-			pipeData.PipeAction = new MonoActions();
-			base.Start();
-		}
-
-		private void Awake()
-		{
-			registerTile = GetComponent<RegisterTile>();
-		}
-
-		public void OnSpawnServer(SpawnInfo info)
+		public override void OnSpawnServer(SpawnInfo info)
 		{
 			metaDataLayer = MatrixManager.AtPoint(registerTile.WorldPositionServer, true).MetaDataLayer;
 			metaNode = metaDataLayer.Get(registerTile.LocalPositionServer, false);
+			base.OnSpawnServer(info);
 		}
 
 		public override void TickUpdate()

--- a/UnityProject/Assets/Scripts/Objects/Pipes/Devices/WaterPump.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/Devices/WaterPump.cs
@@ -14,10 +14,10 @@ namespace Pipes
 		public int UnitPerTick = 100;
 		public int PowerPercentage = 100;
 
-		public override void Start()
+		public override void OnSpawnServer(SpawnInfo info)
 		{
 			pipeData.PipeAction = new WaterPumpAction();
-			base.Start();
+			base.OnSpawnServer(info);
 		}
 
 		public override void TickUpdate()

--- a/UnityProject/Assets/Scripts/Objects/Pipes/MonoPipe.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/MonoPipe.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace Pipes
 {
-	public class MonoPipe : MonoBehaviour, IServerDespawn, ICheckedInteractable<HandApply>
+	public class MonoPipe : MonoBehaviour, IServerLifecycle, ICheckedInteractable<HandApply>
 	{
 		public SpriteHandler spritehandler;
 		public GameObject SpawnOnDeconstruct;
@@ -15,40 +15,35 @@ namespace Pipes
 
 		public Color Colour = Color.white;
 
-		public virtual void Start()
-		{
-			EnsureInit();
-		}
-
 		public void SetColour(Color newColour)
 		{
 			Colour = newColour;
 			spritehandler.SetColor(Colour);
 		}
 
-		private void EnsureInit()
+		private void Awake()
 		{
-			if (registerTile == null)
-			{
-				registerTile = GetComponent<RegisterTile>();
-			}
-
-			registerTile.SetPipeData(pipeData);
-			pipeData.MonoPipe = this;
-			int Offset = PipeFunctions.GetOffsetAngle(this.transform.localRotation.eulerAngles.z);
-			pipeData.Connections.Rotate(Offset);
-			pipeData.OnEnable();
-			spritehandler?.SetColor(Colour);
-		}
-
-		void OnEnable()
-		{
-
+			registerTile = GetComponent<RegisterTile>();
 		}
 
 		public virtual void TickUpdate()
 		{
 		}
+
+		public virtual void OnSpawnServer(SpawnInfo info)
+		{
+			if (pipeData.PipeAction == null)
+			{
+				pipeData.PipeAction = new MonoActions();
+			}
+			registerTile.SetPipeData(pipeData);
+			pipeData.MonoPipe = this;
+			int Offset = PipeFunctions.GetOffsetAngle(transform.localRotation.eulerAngles.z);
+			pipeData.Connections.Rotate(Offset);
+			pipeData.OnEnable();
+			spritehandler?.SetColor(Colour);
+		}
+
 		/// <summary>
 		/// is the function to denote that it will be pooled or destroyed immediately after this function is finished, Used for cleaning up anything that needs to be cleaned up before this happens
 		/// </summary>

--- a/UnityProject/Assets/Scripts/Objects/Pipes/ReactorPipe.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/ReactorPipe.cs
@@ -8,11 +8,11 @@ namespace Pipes
 	{
 		public Chemistry.Reagent Water;
 		public List<ReactorPipe> ConnectedCores = new List<ReactorPipe>(); //needs To check properly
-		public override void Start()
+		public override void OnSpawnServer(SpawnInfo info)
 		{
 			pipeData.PipeAction = new ReservoirAction();
 			pipeData.GetMixAndVolume.GetReagentMix().Add(Water, 100);
-			base.Start();
+			base.OnSpawnServer(info);
 		}
 
 		public override void TickUpdate()


### PR DESCRIPTION
### Purpose
Simplifies the initialization of pipe devices, moving everything to OnSpawnServer()
Mid-round new scenes will no longer halt the atmos thread by trying to run devices not yet initialized.