### PR TITLE
Fixes nuke operatives receiving the wrong nuke code

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.SceneList.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.SceneList.cs
@@ -241,6 +241,7 @@ public partial class SubSceneManager
 		});
 
 		PokeClientSubScene.SendToAll( pickedMap);
+		SyndicateScene = SceneManager.GetSceneByName(pickedMap);
 		yield return StartCoroutine(RunOnSpawnServer(pickedMap));
 		SyndicateLoaded = true;
 	}

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.cs
@@ -23,6 +23,7 @@ public partial class SubSceneManager : NetworkBehaviour
 	public bool MainStationLoaded { get; private set; }
 
 	public bool SyndicateLoaded { get; private set; }
+	public Scene SyndicateScene { get; private set; }
 	public bool WizardLoaded { get; private set; }
 
 	void Awake()

--- a/UnityProject/Assets/Scripts/Objects/Nuke.cs
+++ b/UnityProject/Assets/Scripts/Objects/Nuke.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using Mirror;
 using UnityEngine.Events;
 using AddressableReferences;
+using Antagonists;
 using Managers;
 
 namespace Objects.Command
@@ -11,7 +12,7 @@ namespace Objects.Command
 	/// <summary>
 	/// Main component for nuke.
 	/// </summary>
-	public class Nuke : NetworkBehaviour, ICheckedInteractable<HandApply>, IAdminInfo
+	public class Nuke : NetworkBehaviour, ICheckedInteractable<HandApply>, IAdminInfo, IServerSpawn
 	{
 		public NukeTimerEvent OnTimerUpdate = new NukeTimerEvent();
 
@@ -76,18 +77,26 @@ namespace Objects.Command
 			itemNuke = GetComponent<ItemStorage>();
 			nukeSlot = itemNuke.GetIndexedItemSlot(0);
 		}
-		public override void OnStartServer()
+
+		public void OnSpawnServer(SpawnInfo info)
 		{
-			//calling the code generator and setting up a 10 second timer to post the code in syndicate chat
-			CodeGenerator();
-			base.OnStartServer();
+			if (SubSceneManager.Instance.SyndicateScene == gameObject.scene)
+			{
+				nukeCode = AntagManager.SyndiNukeCode;
+				name = name + " - " + nukeCode.ToString();
+				Debug.Log($"aran debug code SYNDIE {nukeCode}");
+			}
+			else
+			{
+				nukeCode = CodeGenerator();
+				name = name + " - " + nukeCode.ToString();
+				Debug.Log($"aran debug code is generated {nukeCode}");
+			}
 		}
 
-		[Server]
-		public void CodeGenerator()
+		public static int CodeGenerator()
 		{
-			nukeCode = Random.Range(1000, 9999);
-			//Debug.Log("NUKE CODE: " + nukeCode + " POS: " + transform.position);
+			return Random.Range(1000, 9999);
 		}
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)

--- a/UnityProject/Assets/Scripts/Objects/Nuke.cs
+++ b/UnityProject/Assets/Scripts/Objects/Nuke.cs
@@ -83,14 +83,10 @@ namespace Objects.Command
 			if (SubSceneManager.Instance.SyndicateScene == gameObject.scene)
 			{
 				nukeCode = AntagManager.SyndiNukeCode;
-				name = name + " - " + nukeCode.ToString();
-				Debug.Log($"aran debug code SYNDIE {nukeCode}");
 			}
 			else
 			{
 				nukeCode = CodeGenerator();
-				name = name + " - " + nukeCode.ToString();
-				Debug.Log($"aran debug code is generated {nukeCode}");
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/AntagManager.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/AntagManager.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using DiscordWebhook;
 using DatabaseAPI;
 using Messages.Server.LocalGuiMessages;
+using Objects.Command;
+using UnityEngine.SceneManagement;
 
 namespace Antagonists
 {
@@ -35,6 +37,8 @@ namespace Antagonists
 		/// </summary>
 		[NonSerialized] public List<GameObject> TargetedItems = new List<GameObject>();
 
+		public static int SyndiNukeCode;
+
 		public GameObject blobPlayerViewer = null;
 
 		private void Awake()
@@ -51,12 +55,19 @@ namespace Antagonists
 
 		void OnEnable()
 		{
+			SceneManager.activeSceneChanged += OnSceneChange;
 			EventManager.AddHandler(EVENT.RoundEnded, OnRoundEnd);
 		}
 
 		void OnDisable()
 		{
+			SceneManager.activeSceneChanged -= OnSceneChange;
 			EventManager.RemoveHandler(EVENT.RoundEnded, OnRoundEnd);
+		}
+
+		void OnSceneChange(Scene oldScene, Scene newScene)
+		{
+			SyndiNukeCode = Nuke.CodeGenerator();
 		}
 
 		void OnRoundEnd()

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/NuclearOperative.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/NuclearOperative.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using Objects.Command;
 
 namespace Antagonists
 {
@@ -12,20 +11,8 @@ namespace Antagonists
 
 		public override void AfterSpawn(ConnectedPlayer player)
 		{
-			// add any NuclearOperative specific logic here
-
-			//send the code:
-			//Check to see if there is a nuke and communicate the nuke code:
-			Nuke[] nuke = FindObjectsOfType<Nuke>();
-			foreach (Nuke obj in nuke)
-			{
-				if (obj.IsAncharable)
-				{
-					UpdateChatMessage.Send(player.GameObject, ChatChannel.Syndicate, ChatModifier.None,
-					$"We have intercepted the code for the nuclear weapon: <b>{obj.NukeCode}</b>.");
-					break;
-				}				
-			}
+			UpdateChatMessage.Send(player.GameObject, ChatChannel.Syndicate, ChatModifier.None,
+				$"We have intercepted the code for the nuclear weapon: <b>{AntagManager.SyndiNukeCode}</b>.");
 
 			AntagManager.TryInstallPDAUplink(player, initialTC);
 		}


### PR DESCRIPTION
### Purpose
Fixes nuke ops from having the incorrect nuke code based on map differences.

The antag manager will now create the nuke code at roundstart, the operatives will receive this code, as for the nuke itself, it'll check on which scene its spawning to decide if it should create a new code or get the one from the antag manager in the case of being in the syndicate scene.
FindObjectsOfType will no longer be used on each nuke op spawn.