### PR TITLE
Update PDA Sounds to Addressable

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/PDA/PDAs/PDABase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/PDA/PDAs/PDABase.prefab
@@ -144,6 +144,14 @@ MonoBehaviour:
   syncInterval: 0.1
   cartridgePrefab: {fileID: 0}
   defaultRingtone: TwoBeep
+  ringtones:
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/Effects/TwoBeep.prefab
+    AssetReference:
+      m_AssetGUID:
+      m_SubObjectName:
+      m_SubObjectType:
+  denialSound: BuzzDeny
   willResetName: 0
   UIBG: {r: 0.63529414, g: 0.7058824, b: 0.8117647, a: 1}
   UIOVER: {r: 0, g: 0, b: 0, a: 0}

--- a/UnityProject/Assets/Scripts/Items/PDA/PDALogic.cs
+++ b/UnityProject/Assets/Scripts/Items/PDA/PDALogic.cs
@@ -207,7 +207,7 @@ namespace Items.PDA
 
 		public void SetRingtone(string newRingtone)
 		{
-			AddressableAudioSource toSend = ringtones.Find(x => x.AssetReference.Contains("/" + newRingtone + ".prefab"));
+			AddressableAudioSource toSend = ringtones.Find(x => x.AssetAddress.Contains("/" + newRingtone + ".prefab"));
 
 			if(toSend != default(AddressableAudioSource))
 				SetRingtone(toSend);

--- a/UnityProject/Assets/Scripts/Items/PDA/PDALogic.cs
+++ b/UnityProject/Assets/Scripts/Items/PDA/PDALogic.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 using Mirror;
 using NaughtyAttributes;
 using Random = UnityEngine.Random;
 using UI.Action;
+using AddressableReferences;
 
 namespace Items.PDA
 {
@@ -23,7 +25,15 @@ namespace Items.PDA
 
 		[Tooltip("The default ringtone to play")]
 		[SerializeField, BoxGroup("Settings")]
-		private string defaultRingtone = "TwoBeep";
+		private AddressableAudioSource defaultRingtone;
+
+		[Tooltip("A list of all available ringtones")]
+		[SerializeField, BoxGroup("Settings")]
+		private List<AddressableAudioSource> ringtones;
+
+		[Tooltip("The denial sound")]
+		[SerializeField, BoxGroup("Settings")]
+		private AddressableAudioSource denialSound;
 
 		[Tooltip("Reset registered name on FactoryReset?")]
 		[SerializeField, BoxGroup("Settings")]
@@ -61,7 +71,7 @@ namespace Items.PDA
 		public IDCard IDCard { get; private set; }
 		/// <summary> The name of the currently registered player (since the last PDA reset) </summary>
 		public string RegisteredPlayerName { get; private set; }
-		public string Ringtone { get; private set; }
+		public AddressableAudioSource Ringtone { get; private set; }
 		/// <summary> The string that must be entered into the ringtone slot for the uplink </summary>
 		public string UplinkUnlockCode { get; private set; }
 		public bool IsUplinkCapable { get; private set; } = false;
@@ -190,9 +200,17 @@ namespace Items.PDA
 
 		#region Sounds
 
-		public void SetRingtone(string newRingtone)
+		public void SetRingtone(AddressableAudioSource newRingtone)
 		{
 			Ringtone = newRingtone;
+		}
+
+		public void SetRingtone(string newRingtone)
+		{
+			AddressableAudioSource toSend = ringtones.Find(x => x.AssetReference.Contains("/" + newRingtone + ".prefab"));
+
+			if(toSend != default(AddressableAudioSource))
+				SetRingtone(toSend);
 		}
 
 		public void PlayRingtone()
@@ -202,10 +220,10 @@ namespace Items.PDA
 
 		public void PlayDenyTone()
 		{
-			PlaySound("BuzzDeny");
+			PlaySound(denialSound);
 		}
 
-		public void PlaySound(string soundName)
+		public void PlaySound(AddressableAudioSource soundName)
 		{
 			GameObject sourceObject = gameObject;
 
@@ -218,7 +236,7 @@ namespace Items.PDA
 			SoundManager.PlayNetworkedAtPos(soundName, sourceObject.AssumedWorldPosServer(), sourceObj: sourceObject);
 		}
 
-		public void PlaySoundPrivate(string soundName)
+		public void PlaySoundPrivate(AddressableAudioSource soundName)
 		{
 			var player = GetPlayerByParentInventory();
 			if (player == null) return;

--- a/UnityProject/Assets/Scripts/Managers/SoundManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SoundManager.cs
@@ -331,16 +331,6 @@ public class SoundManager : MonoBehaviour
 		}
 	}
 
-
-	public static void PlayNetworkedAtPos(string addressableAudioSource, Vector3 worldPos, float pitch = 0,
-		bool polyphonic = false, bool shakeGround = false, byte shakeIntensity = 64, int shakeRange = 30,
-		bool global = true, GameObject sourceObj = null)
-	{
-		Logger.LogWarning("Sound needs to be converted to addressables " + addressableAudioSource);
-		return;
-	}
-
-
 	/// <summary>
 	/// Play sound at given position for all clients.
 	/// </summary>
@@ -426,10 +416,19 @@ public class SoundManager : MonoBehaviour
 	}
 
 	public static async Task PlayNetworkedForPlayerAtPos(GameObject recipient, Vector3 worldPos,
-		string addressableAudioSources, float pitch = 0, bool polyphonic = false,
+		AddressableAudioSource addressableAudioSources, float pitch = 0, bool polyphonic = false,
 		bool shakeGround = false, byte shakeIntensity = 64, int shakeRange = 30, GameObject sourceObj = null)
 	{
-		Logger.LogWarning("Sound needs to be converted to addressables " + addressableAudioSources);
+		if (addressableAudioSources == null || addressableAudioSources.AssetAddress == string.Empty)
+		{
+			Logger.LogWarning(
+				"Addressable audio sources not set/path is not present, look at log trace for responsible component");
+			return;
+		}
+
+		var Toplay = new List<AddressableAudioSource>();
+		Toplay.Add(addressableAudioSources);
+		PlayNetworkedForPlayerAtPos(recipient, worldPos, Toplay, pitch, polyphonic, shakeGround, shakeIntensity, shakeRange, sourceObj);
 		return;
 	}
 

--- a/UnityProject/Assets/Scripts/UI/Items/PDA/GUI_PDASettingMenu.cs
+++ b/UnityProject/Assets/Scripts/UI/Items/PDA/GUI_PDASettingMenu.cs
@@ -19,7 +19,7 @@ namespace UI.Items.PDA
 
 		public void SetRingtone(string ringtone)
 		{
-			if (ringtone == default) return;
+			if (ringtone == "") return;
 
 			if (controller.PDA.IsUplinkCapable)
 			{

--- a/UnityProject/Assets/Scripts/UI/Items/PDA/GUI_PDASettingMenu.cs
+++ b/UnityProject/Assets/Scripts/UI/Items/PDA/GUI_PDASettingMenu.cs
@@ -19,7 +19,7 @@ namespace UI.Items.PDA
 
 		public void SetRingtone(string ringtone)
 		{
-			if (ringtone == "") return;
+			if (String.IsNullOrEmpty(ringtone)) return;
 
 			if (controller.PDA.IsUplinkCapable)
 			{


### PR DESCRIPTION
### Purpose
Changes PDALogic to use AddressableAudioSources, fixes a bug where GUI_PDASettingMenu.setRingtone was allowing empty strings, and removed now unused placeholder overloads in SoundManager

### Notes:
Currently, there is only one ringtone enabled for PDAs, TwoBeep.  I tested the code with other sound effects and it worked, so we should be fine to expand the list.  Also, as implemented the ringtone that you need to enter into the PDA is the file name of the prefab and is case sensitive, we may want to change that.
