### PR TITLE
TilemapDamage Tweak

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
@@ -82,7 +82,8 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 
 		data.AddTileDamage(Layer.LayerType, damageTaken);
 
-		SoundManager.PlayNetworkedAtPos(basicTile.SoundOnHit, worldPosition);
+		if(basicTile.SoundOnHit.AssetAddress != null)
+			SoundManager.PlayNetworkedAtPos(basicTile.SoundOnHit, worldPosition);
 
 		var totalDamageTaken = data.GetTileDamage(Layer.LayerType);
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
@@ -84,6 +84,9 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 
 		if(basicTile.SoundOnHit.AssetAddress != null)
 			SoundManager.PlayNetworkedAtPos(basicTile.SoundOnHit, worldPosition);
+		else{
+			Logger.LogError($"Tried to play SoundOnHit for {basicTile.DisplayName}, but it was null!", Category.Addressables);
+		}
 
 		var totalDamageTaken = data.GetTileDamage(Layer.LayerType);
 

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/Wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/Wall.asset
@@ -52,7 +52,7 @@ MonoBehaviour:
   damageOverlayList: {fileID: 0}
   soundOnHit:
     SetLoadSetting: 0
-    AssetAddress: null
+    AssetAddress:
     AssetReference:
       m_AssetGUID: 
       m_SubObjectName: 


### PR DESCRIPTION
Currently, many tiles do not have a SoundOnHit defined yet, but TilemapDamage was trying to play them anyway, resulting in an error.  This PR prevents that from happening.  Also, Wall's SoundOnHit was set to the string "null".