### PR TITLE
Fixes ghost positioning related interactions

### DIFF
--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -414,6 +414,7 @@ public partial class PlayerSync
 			pushPull.InformHead(pushPull.PulledBy);
 			//			InformPullMessage.Send( pushPull.PulledBy, this.pushPull, pushPull.PulledBy );
 		}
+		UpdateClientState(serverState);
 	}
 
 	/// Clears server pending actions queue


### PR DESCRIPTION
### Purpose
The server will now always update its own values of PlayerSync.Client, fixing ghost serverside positioning and its position related interactions.


PlayerSync is a mess serverside with what it claims as clientside only variables being a key into the whole system to work, let alone the class being almost 2400 lines long inbetween three files of partial classes.
It might need a rewrite or rework

its important to notice that the clientside of PlayerSync changes the transform.position of an object, which is fed into the registertile, making it a serverside alteration
