### PR TITLE
Fixes a server infinite loop related to remaking pipenets.

### DIFF
--- a/UnityProject/Assets/Scripts/Systems/Fluids/LiquidPipeNet.cs
+++ b/UnityProject/Assets/Scripts/Systems/Fluids/LiquidPipeNet.cs
@@ -112,7 +112,7 @@ namespace Pipes
 				for (int i = 0; i < foundPipe.ConnectedPipes.Count; i++)
 				{
 					var nextPipe = foundPipe.ConnectedPipes[i];
-					if (nextPipe.NetCompatible && nextPipe.OnNet == null)
+					if (nextPipe.NetCompatible && nextPipe.OnNet == null && !foundPipes.Contains((nextPipe)))
 					{
 						foundPipes.Add(nextPipe);
 					}


### PR DESCRIPTION
### Purpose
Fixes a server infinite loop related to remaking pipenets.


basically if the pipes are still doing a loop after you deconstruct something, the server gets stuck in an infinite loop adding pipes and its adjacents pipes to a list
props to thatdan who did most of the investigation on getting the exact trigger spot