### PR TITLE
ExplosionNode Violating Thermodynamics Fix

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/SoundManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SoundManager.cs
@@ -118,12 +118,12 @@ public class SoundManager : MonoBehaviour
 		}
 		if (string.IsNullOrEmpty(addressableAudioSource.AssetAddress))
 		{
-			Logger.LogWarning($"{addressableAudioSource.AudioSource.name} has a null address, and could not be played!", Category.Addressables);
+			Logger.LogWarning("SoundManager received a null address for an addressable, look at log trace for responsible component", Category.Addressables);
 			return null;
 		}
 		if (addressableAudioSource.AssetAddress == "null")
 		{
-			Logger.LogWarning($"{addressableAudioSource.AudioSource.name} has an address set to the string null, and could not be played!", Category.Addressables);
+			Logger.LogWarning("SoundManager received an addressable with an address set to the string 'null', look at log trace for responsible component", Category.Addressables);
 			return null;
 		}
 		if(await addressableAudioSource.HasValidAddress() == false) return null;
@@ -280,6 +280,14 @@ public class SoundManager : MonoBehaviour
 		AudioSourceParameters audioSourceParameters = new AudioSourceParameters(), bool polyphonic = false, bool global = true,
 		ShakeParameters shakeParameters = new ShakeParameters(), GameObject sourceObj = null)
 	{
+		if (addressableAudioSource == null || string.IsNullOrEmpty(addressableAudioSource.AssetAddress) || 
+			addressableAudioSource.AssetAddress == "null")
+		{
+			Logger.LogWarning($"SoundManager received a null AudioSource to be played at World Position: {worldPos}",
+				Category.Addressables);
+			return null;
+		}
+
 		await GetAddressableAudioSourceFromCache(addressableAudioSource).ConfigureAwait(false);
 
 		if (global)
@@ -330,6 +338,13 @@ public class SoundManager : MonoBehaviour
 		AudioSourceParameters audioSourceParameters = new AudioSourceParameters(), bool polyphonic = false,
 		ShakeParameters shakeParameters = new ShakeParameters(), GameObject sourceObj = null)
 	{
+		if (addressableAudioSource == null || string.IsNullOrEmpty(addressableAudioSource.AssetAddress) || 
+			addressableAudioSource.AssetAddress == "null")
+		{
+			Logger.LogWarning($"SoundManager received a null AudioSource to be played for: {recipient.name}",
+				Category.Addressables);
+			return;
+		}
 		PlaySoundMessage.Send(recipient, addressableAudioSource, TransformState.HiddenPos, polyphonic,
 			sourceObj, shakeParameters, audioSourceParameters);
 	}
@@ -367,7 +382,13 @@ public class SoundManager : MonoBehaviour
 		AddressableAudioSource addressableAudioSource, AudioSourceParameters audioSourceParameters = new AudioSourceParameters(),	
 		bool polyphonic = false, ShakeParameters shakeParameters = new ShakeParameters(), GameObject sourceObj = null)
 	{
-
+		if (addressableAudioSource == null || string.IsNullOrEmpty(addressableAudioSource.AssetAddress) || 
+			addressableAudioSource.AssetAddress == "null")
+		{
+			Logger.LogWarning($"SoundManager received a null AudioSource to be played for: {recipient.name} at position: {worldPos}",
+				Category.Addressables);
+			return;
+		}
 		addressableAudioSource = await GetAddressableAudioSourceFromCache(addressableAudioSource).ConfigureAwait(false);
 		PlaySoundMessage.Send(recipient, addressableAudioSource, worldPos, polyphonic, sourceObj, shakeParameters,
 			audioSourceParameters);

--- a/UnityProject/Assets/Scripts/Systems/Explosions/ExplosionNode.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/ExplosionNode.cs
@@ -36,6 +36,10 @@ namespace Systems.Explosions
 			EnergyExpended = metaTileMap.ApplyDamage(v3int, Damagedealt,
 			MatrixManager.LocalToWorldInt(v3int, matrix.MatrixInfo), AttackType.Bomb) * 0.375f;
 
+			// Prevents a perpetual motion explosion
+			if(EnergyExpended <= 0)
+				EnergyExpended = 1;
+
 			if (Damagedealt > 100)
 			{
 				var Node = matrix.GetMetaDataNode(v3int);

--- a/UnityProject/Assets/Scripts/Systems/Explosions/ExplosionNode.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/ExplosionNode.cs
@@ -37,8 +37,8 @@ namespace Systems.Explosions
 			MatrixManager.LocalToWorldInt(v3int, matrix.MatrixInfo), AttackType.Bomb) * 0.375f;
 
 			// Prevents a perpetual motion explosion
-			if(EnergyExpended <= 0)
-				EnergyExpended = 1;
+			if(EnergyExpended <= 0.375f)
+				EnergyExpended = 0.375f;
 
 			if (Damagedealt > 100)
 			{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
@@ -87,7 +87,8 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 
 		if(basicTile.SoundOnHit != null && !string.IsNullOrEmpty(basicTile.SoundOnHit.AssetAddress) && basicTile.SoundOnHit.AssetAddress != "null")
 		{
-			SoundManager.PlayNetworkedAtPos(basicTile.SoundOnHit, worldPosition);
+			if(damage >= 1)
+				SoundManager.PlayNetworkedAtPos(basicTile.SoundOnHit, worldPosition);
 		}
 		else
 		{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
@@ -85,9 +85,12 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 
 		data.AddTileDamage(Layer.LayerType, damageTaken);
 
-		if(basicTile.SoundOnHit.AssetAddress != null)
+		if(basicTile.SoundOnHit != null && !string.IsNullOrEmpty(basicTile.SoundOnHit.AssetAddress) && basicTile.SoundOnHit.AssetAddress != "null")
+		{
 			SoundManager.PlayNetworkedAtPos(basicTile.SoundOnHit, worldPosition);
-		else{
+		}
+		else
+		{
 			Logger.LogError($"Tried to play SoundOnHit for {basicTile.DisplayName}, but it was null!", Category.Addressables);
 		}
 
@@ -163,6 +166,11 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 		if (basicTile.MaxHealth < basicTile.MaxHealth - totalDamageTaken)
 		{
 			data.ResetDamage(Layer.LayerType);
+		}
+
+		if (damageTaken > totalDamageTaken){
+			Logger.LogError($"Applying damage to {basicTile.DisplayName} increased the damage to be dealt, when it should have decreased!", Category.TileMaps);
+			return totalDamageTaken;
 		}
 
 		//Return how much damage is left


### PR DESCRIPTION
Currently, ExplosionNode.cs is written so if an explosion does not expend energy by damaging a tile or object, it continues to expand outward with the same energy forever. This spams the server with TileMapDamage.DealDamageAt calls after an explosion, as each tile it passes through is checked to see if it can be damaged.  A test reactor explosion on Square Station resulted in 388012 calls, only 15600 of which were non-null tiles.

### Purpose
This PR attempts to alleviate this problem by implementing a minimum energy expenditure per tile expanded on an explosion.  With the variables currently set, this gives all tiles a minimum hp of 1 for purposes of explosions.  This reduces the number of calls of TileMapDamage.DealDamageAt with the same explosion to 119828, 8818 are non-null, cutting the tiles checked by 70% and the number of sounds attempting to play by half.  Examining the explosion pattern, the change in explosion radius is actually very minor, many of the explosion lines sent out have little damage remaining, see attached image (warning, high res).
![ExplosionNodeComparison](https://user-images.githubusercontent.com/41650265/108921192-d7e77780-75ea-11eb-89af-4b8d86f7b605.png)

The explosion still lags the server, but this should reduce it significantly, maybe preventing crashes.  I've tested other numbers as well, but obviously as you increase the minimum expenditure, the explosion radius goes down as well.  Here is the result of setting it to `if(EnergyExpended <= 0.375f) EnergyExpended = 10f;`
![ExplosionNode10](https://user-images.githubusercontent.com/41650265/108921489-47f5fd80-75eb-11eb-8f0f-726a5748bc2e.png)
With these settings, the server was barely affected, but at the cost of a much smaller explosion.

Also included some error logging tweaks.

### Physics
As an aside for those who may be wondering about the realism of this change, while objects in space do not change velocity over time in space (and that code is unaffected by this, any object propelled through space by the explosion will move at its speed until it hits something else), explosions will degrade rapidly as they expand into a vacuum, as the gas that is expanding (the source of the concussive blast and conveyor of thermal energy) becomes extremely diffuse as it reaches equilibrium with the vacuum.
One could argue that the explosion's damage value is also encompassing fast moving tiny debris like screws and glass shards not otherwise covered by the code, but one could then also argue that as you get farther from the explosion, the probability of you being hit by that debris falls off, and the easiest way to factor that is to have damage fall off over distance.