### PR TITLE
Fixes overlapping pipes in map breaking pipenets

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Pipes/PipeTile.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/PipeTile.cs
@@ -19,19 +19,21 @@ namespace Pipes
 		public Sprite sprite;
 		public override Sprite PreviewSprite => sprite;
 
+		public static Connections GetRotatedConnection(PipeTile pipeTile, Matrix4x4 matrixStruct)
+		{
+			var offset = PipeFunctions.GetOffsetAngle(matrixStruct.rotation.eulerAngles.z);
+			var connection = pipeTile.Connections.Copy();
+			connection.Rotate(offset);
+			return connection;
+		}
+
 		public override bool AreUnderfloorSame(Matrix4x4 thisTransformMatrix,BasicTile basicTile, Matrix4x4 TransformMatrix)
 		{
 			if ((basicTile as PipeTile) != null)
 			{
 				var TilePipeTile = (PipeTile) basicTile;
-				var TheConnection = TilePipeTile.Connections.Copy();
-				int Offset = PipeFunctions.GetOffsetAngle(TransformMatrix.rotation.eulerAngles.z);
-				TheConnection.Rotate(Offset);
-
-				var thisConnection = Connections.Copy();
-				int thisOffset = PipeFunctions.GetOffsetAngle(thisTransformMatrix.rotation.eulerAngles.z);
-				thisConnection.Rotate(thisOffset);
-
+				var TheConnection = GetRotatedConnection(TilePipeTile, TransformMatrix);
+				var thisConnection = GetRotatedConnection(this, thisTransformMatrix);
 				for (int i = 0; i < thisConnection.Directions.Length; i++)
 				{
 					if (thisConnection.Directions[i].Bool && TheConnection.Directions[i].Bool)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/UnderFloorLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/UnderFloorLayer.cs
@@ -21,6 +21,7 @@ public class UnderFloorLayer : Layer
 			for (int p = bounds.yMin; p < bounds.yMax; p++)
 			{
 				Vector3Int localPlace = (new Vector3Int(n, p, 0));
+				bool[] PipeDirCheck = new bool[4];
 
 				for (int i = 0; i < 50; i++)
 				{
@@ -44,7 +45,28 @@ public class UnderFloorLayer : Layer
 						var PipeTile = getTile as PipeTile;
 						if (PipeTile != null)
 						{
-							PipeTile.InitialiseNode(new Vector3Int(n, p, localPlace.z), matrix);
+							var matrixStruct = matrix.UnderFloorLayer.Tilemap.GetTransformMatrix(localPlace);
+							var connection = PipeTile.GetRotatedConnection(PipeTile, matrixStruct);
+							var pipeDir = connection.Directions;
+							var canInitializePipe = true;
+							for (var d = 0; d < pipeDir.Length; d++)
+							{
+								if (pipeDir[d].Bool)
+								{
+									if (PipeDirCheck[d])
+									{
+										canInitializePipe = false;
+										Debug.LogError($"A pipe is overlapping its connection at ({n}, {p}) in {matrix.gameObject.scene.name} - {matrix.name} with another pipe, removing one");
+										tilemap.SetTile(localPlace, null);
+										break;
+									}
+									PipeDirCheck[d] = true;
+								}
+							}
+							if (canInitializePipe)
+							{
+								PipeTile.InitialiseNode(localPlace, matrix);
+							}
 						}
 					}
 				}


### PR DESCRIPTION
### Purpose
Pipes will now check if there's already a present pipe on the same tile connecting towards the same direction, if thats the case, the pipe will be removed and an error will be printed out.