### PR TITLE
Revert PlayNetworkedAtPosition to Synchronous

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/SoundManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SoundManager.cs
@@ -276,7 +276,7 @@ public class SoundManager : MonoBehaviour
 	/// <param name="shakeParameters">Camera shake effect associated with this sound</param>
 	/// <param name="sourceObj">The object that is the source of the sound</param>
 	/// <returns>The SoundSpawn Token generated that identifies the same sound spawn instance across server and clients</returns>
-	public static async Task<string> PlayNetworkedAtPos(AddressableAudioSource addressableAudioSource, Vector3 worldPos,
+	public static string PlayNetworkedAtPos(AddressableAudioSource addressableAudioSource, Vector3 worldPos,
 		AudioSourceParameters audioSourceParameters = new AudioSourceParameters(), bool polyphonic = false, bool global = true,
 		ShakeParameters shakeParameters = new ShakeParameters(), GameObject sourceObj = null)
 	{
@@ -288,7 +288,7 @@ public class SoundManager : MonoBehaviour
 			return null;
 		}
 
-		await GetAddressableAudioSourceFromCache(addressableAudioSource).ConfigureAwait(false);
+		GetAddressableAudioSourceFromCache(addressableAudioSource);
 
 		if (global)
 		{
@@ -314,14 +314,14 @@ public class SoundManager : MonoBehaviour
 	/// <param name="sourceObj">The object that is the source of the sound</param>
 	/// <param name="shakeParameters">Camera shake effect associated with this sound</param>
 	/// <returns>The SoundSpawn Token generated that identifies the same sound spawn instance across server and clients</returns>
-	public static async Task<string> PlayNetworkedAtPos(List<AddressableAudioSource> addressableAudioSources,
+	public static string PlayNetworkedAtPos(List<AddressableAudioSource> addressableAudioSources,
 		Vector3 worldPos, AudioSourceParameters audioSourceParameters = new AudioSourceParameters(),
 		bool polyphonic = false, bool global = true, ShakeParameters shakeParameters = new ShakeParameters(),
 		GameObject sourceObj = null)
 	{
 		AddressableAudioSource addressableAudioSource = addressableAudioSources.PickRandom();
-		return await PlayNetworkedAtPos(addressableAudioSource, worldPos, audioSourceParameters, polyphonic, 
-			global, shakeParameters, sourceObj).ConfigureAwait(false);
+		return PlayNetworkedAtPos(addressableAudioSource, worldPos, audioSourceParameters, polyphonic, 
+			global, shakeParameters, sourceObj);
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Managers/SoundManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SoundManager.cs
@@ -175,7 +175,7 @@ public class SoundManager : MonoBehaviour
 	public static async Task<AddressableAudioSource> GetAddressableAudioSourceFromCache(List<AddressableAudioSource> addressableAudioSources)
 	{
 		AddressableAudioSource addressableAudioSource = addressableAudioSources.PickRandom();
-		addressableAudioSource = await GetAddressableAudioSourceFromCache(addressableAudioSource).ConfigureAwait(false);
+		addressableAudioSource = await GetAddressableAudioSourceFromCache(addressableAudioSource);
 		return addressableAudioSource;
 	}
 
@@ -245,7 +245,7 @@ public class SoundManager : MonoBehaviour
 		AudioSourceParameters audioSourceParameters = new AudioSourceParameters(), bool polyphonic = false,
 		ShakeParameters shakeParameters = new ShakeParameters())
 	{
-		addressableAudioSource = await GetAddressableAudioSourceFromCache(addressableAudioSource).ConfigureAwait(false);
+		addressableAudioSource = await GetAddressableAudioSourceFromCache(addressableAudioSource);
 		PlaySoundMessage.SendToAll(addressableAudioSource, TransformState.HiddenPos, polyphonic, null, shakeParameters, audioSourceParameters);
 	}
 
@@ -262,7 +262,7 @@ public class SoundManager : MonoBehaviour
 		ShakeParameters shakeParameters = new ShakeParameters())
 	{
 		AddressableAudioSource addressableAudioSource = addressableAudioSources.PickRandom();
-		await PlayNetworked(addressableAudioSource, audioSourceParameters, polyphonic, shakeParameters).ConfigureAwait(false);
+		await PlayNetworked(addressableAudioSource, audioSourceParameters, polyphonic, shakeParameters);
 	}
 
 	/// <summary>
@@ -288,7 +288,7 @@ public class SoundManager : MonoBehaviour
 			return null;
 		}
 
-		addressableAudioSource = await GetAddressableAudioSourceFromCache(addressableAudioSource).ConfigureAwait(false);;
+		addressableAudioSource = await GetAddressableAudioSourceFromCache(addressableAudioSource);;
 
 		if (global)
 		{
@@ -412,7 +412,7 @@ public class SoundManager : MonoBehaviour
 	{
 		AddressableAudioSource addressableAudioSource = addressableAudioSources.PickRandom();
 		await PlayNetworkedForPlayer(recipient, addressableAudioSource, audioSourceParameters, 
-			polyphonic, shakeParameters, sourceObj).ConfigureAwait(false);
+			polyphonic, shakeParameters, sourceObj);
 	}
 
 	/// <summary>
@@ -436,7 +436,7 @@ public class SoundManager : MonoBehaviour
 				Category.Addressables);
 			return;
 		}
-		addressableAudioSource = await GetAddressableAudioSourceFromCache(addressableAudioSource).ConfigureAwait(false);
+		addressableAudioSource = await GetAddressableAudioSourceFromCache(addressableAudioSource);
 		PlaySoundMessage.Send(recipient, addressableAudioSource, worldPos, polyphonic, sourceObj, shakeParameters,
 			audioSourceParameters);
 	}
@@ -458,7 +458,7 @@ public class SoundManager : MonoBehaviour
 	{
 		AddressableAudioSource addressableAudioSource = addressableAudioSources.PickRandom();
 		await PlayNetworkedForPlayerAtPos(recipient, worldPos, addressableAudioSource, audioSourceParameters, 
-			polyphonic, shakeParameters, sourceObj).ConfigureAwait(false);
+			polyphonic, shakeParameters, sourceObj);
 	}
 
 	/// <summary>
@@ -471,7 +471,7 @@ public class SoundManager : MonoBehaviour
 	public static async Task Play(AddressableAudioSource addressableAudioSource, string soundSpawnToken = "",
 		AudioSourceParameters audioSourceParameters = new AudioSourceParameters(), bool polyphonic = false)
 	{
-		addressableAudioSource = await GetAddressableAudioSourceFromCache(addressableAudioSource).ConfigureAwait(false);
+		addressableAudioSource = await GetAddressableAudioSourceFromCache(addressableAudioSource);
 		SoundSpawn soundSpawn =
 			Instance.GetSoundSpawn(addressableAudioSource, addressableAudioSource.AudioSource, soundSpawnToken);
 		ApplyAudioSourceParameters(audioSourceParameters, soundSpawn);
@@ -490,7 +490,7 @@ public class SoundManager : MonoBehaviour
 		AudioSourceParameters audioSourceParameters = new AudioSourceParameters(), bool polyphonic = false)
 	{
 		AddressableAudioSource addressableAudioSource = addressableAudioSources.PickRandom();
-		await Play(addressableAudioSource, soundSpawnToken, audioSourceParameters, polyphonic).ConfigureAwait(false);
+		await Play(addressableAudioSource, soundSpawnToken, audioSourceParameters, polyphonic);
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Managers/SoundManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SoundManager.cs
@@ -276,7 +276,7 @@ public class SoundManager : MonoBehaviour
 	/// <param name="shakeParameters">Camera shake effect associated with this sound</param>
 	/// <param name="sourceObj">The object that is the source of the sound</param>
 	/// <returns>The SoundSpawn Token generated that identifies the same sound spawn instance across server and clients</returns>
-	public static string PlayNetworkedAtPos(AddressableAudioSource addressableAudioSource, Vector3 worldPos,
+	public static async Task<string> PlayNetworkedAtPosAsync(AddressableAudioSource addressableAudioSource, Vector3 worldPos,
 		AudioSourceParameters audioSourceParameters = new AudioSourceParameters(), bool polyphonic = false, bool global = true,
 		ShakeParameters shakeParameters = new ShakeParameters(), GameObject sourceObj = null)
 	{
@@ -288,7 +288,7 @@ public class SoundManager : MonoBehaviour
 			return null;
 		}
 
-		GetAddressableAudioSourceFromCache(addressableAudioSource);
+		addressableAudioSource = await GetAddressableAudioSourceFromCache(addressableAudioSource).ConfigureAwait(false);;
 
 		if (global)
 		{
@@ -306,6 +306,50 @@ public class SoundManager : MonoBehaviour
 	/// Serverside: Play sound at given position for all clients.
 	/// If more than one sound is specified, the sound will be chosen at random
 	/// </summary>
+	/// <param name="addressableAudioSource">The sound to be played.</param>
+	/// <param name="worldPos">The position at which the sound is played</param>
+	/// <param name="audioSourceParameters">Extra parameters of the audio source.</param>
+	/// <param name="polyphonic">Is the sound to be played polyphonic</param>
+	/// <param name="global">Does everyone will receive the sound our just nearby players</param>	
+	/// <param name="shakeParameters">Camera shake effect associated with this sound</param>
+	/// <param name="sourceObj">The object that is the source of the sound</param>
+	/// <returns>The SoundSpawn Token generated that identifies the same sound spawn instance across server and clients</returns>
+	public static async Task<string> PlayNetworkedAtPosAsync(List<AddressableAudioSource> addressableAudioSources,
+		Vector3 worldPos, AudioSourceParameters audioSourceParameters = new AudioSourceParameters(),
+		bool polyphonic = false, bool global = true, ShakeParameters shakeParameters = new ShakeParameters(),
+		GameObject sourceObj = null)
+	{
+		AddressableAudioSource addressableAudioSource = addressableAudioSources.PickRandom();
+		return await PlayNetworkedAtPosAsync(addressableAudioSource, worldPos, audioSourceParameters, polyphonic, 
+			global, shakeParameters, sourceObj);
+	}
+
+	/// <summary>
+	/// Serverside: Play sound at given position for all clients.
+	/// Please use PlayNetworkedAtPosAsync if possible.
+	/// </summary>
+	/// <param name="addressableAudioSource">The sound to be played.</param>
+	/// <param name="worldPos">The position at which the sound is played</param>
+	/// <param name="audioSourceParameters">Extra parameters of the audio source.</param>
+	/// <param name="polyphonic">Is the sound to be played polyphonic</param>
+	/// <param name="global">Does everyone will receive the sound our just nearby players</param>	
+	/// <param name="shakeParameters">Camera shake effect associated with this sound</param>
+	/// <param name="sourceObj">The object that is the source of the sound</param>
+	/// <returns>The SoundSpawn Token generated that identifies the same sound spawn instance across server and clients</returns>
+	public static void PlayNetworkedAtPos(AddressableAudioSource addressableAudioSource, Vector3 worldPos,
+		AudioSourceParameters audioSourceParameters = new AudioSourceParameters(), bool polyphonic = false, bool global = true,
+		ShakeParameters shakeParameters = new ShakeParameters(), GameObject sourceObj = null)
+	{
+		PlayNetworkedAtPosAsync(addressableAudioSource, worldPos, audioSourceParameters, polyphonic, 
+			global, shakeParameters, sourceObj);
+		return;
+	}
+
+	/// <summary>
+	/// Serverside: Play sound at given position for all clients.
+	/// If more than one sound is specified, the sound will be chosen at random
+	/// Please use PlayNetworkedAtPosAsync if possible.
+	/// </summary>
 	/// <param name="addressableAudioSources">A list of sounds.  One will be played at random</param>
 	/// <param name="worldPos">The position at which the sound is played</param>
 	/// <param name="audioSourceParameters">Extra parameters of the audio source.</param>
@@ -314,15 +358,17 @@ public class SoundManager : MonoBehaviour
 	/// <param name="sourceObj">The object that is the source of the sound</param>
 	/// <param name="shakeParameters">Camera shake effect associated with this sound</param>
 	/// <returns>The SoundSpawn Token generated that identifies the same sound spawn instance across server and clients</returns>
-	public static string PlayNetworkedAtPos(List<AddressableAudioSource> addressableAudioSources,
+	public static void PlayNetworkedAtPos(List<AddressableAudioSource> addressableAudioSources,
 		Vector3 worldPos, AudioSourceParameters audioSourceParameters = new AudioSourceParameters(),
 		bool polyphonic = false, bool global = true, ShakeParameters shakeParameters = new ShakeParameters(),
 		GameObject sourceObj = null)
 	{
 		AddressableAudioSource addressableAudioSource = addressableAudioSources.PickRandom();
-		return PlayNetworkedAtPos(addressableAudioSource, worldPos, audioSourceParameters, polyphonic, 
+		PlayNetworkedAtPosAsync(addressableAudioSource, worldPos, audioSourceParameters, polyphonic, 
 			global, shakeParameters, sourceObj);
+		return;
 	}
+
 
 	/// <summary>
 	/// Play sound for particular player.
@@ -365,7 +411,8 @@ public class SoundManager : MonoBehaviour
 		ShakeParameters shakeParameters = new ShakeParameters(), GameObject sourceObj = null)
 	{
 		AddressableAudioSource addressableAudioSource = addressableAudioSources.PickRandom();
-		await PlayNetworkedForPlayer(recipient, addressableAudioSource, audioSourceParameters, polyphonic, shakeParameters, sourceObj).ConfigureAwait(false);
+		await PlayNetworkedForPlayer(recipient, addressableAudioSource, audioSourceParameters, 
+			polyphonic, shakeParameters, sourceObj).ConfigureAwait(false);
 	}
 
 	/// <summary>
@@ -554,7 +601,7 @@ public class SoundManager : MonoBehaviour
 		bool isGlobal = false, uint netId = NetId.Empty, AudioSourceParameters audioSourceParameters = new AudioSourceParameters())
 	{
 		AddressableAudioSource addressableAudioSource =
-			await GetAddressableAudioSourceFromCache(addressableAudioSources).ConfigureAwait(false);
+			await GetAddressableAudioSourceFromCache(addressableAudioSources);
 		SoundSpawn soundSpawn =
 			Instance.GetSoundSpawn(addressableAudioSource, addressableAudioSource.AudioSource, soundSpawnToken);
 

--- a/UnityProject/Assets/Scripts/Objects/Machines/Jukebox.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/Jukebox.cs
@@ -204,7 +204,7 @@ namespace Objects
 				SoundManager.StopNetworked(guid);
 				IsPlaying = true;
 				spriteHandler.SetSpriteSO(SpritePlaying);
-				guid  = SoundManager.PlayNetworkedAtPos(musics[currentSongTrackIndex], registerTile.WorldPositionServer, audioSourceParameters, false, true, sourceObj: gameObject);
+				guid  = await SoundManager.PlayNetworkedAtPosAsync(musics[currentSongTrackIndex], registerTile.WorldPositionServer, audioSourceParameters, false, true, sourceObj: gameObject);
 				startPlayTime = Time.time;
 				UpdateGUI();
 			}

--- a/UnityProject/Assets/Scripts/Objects/Machines/Jukebox.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/Jukebox.cs
@@ -180,8 +180,9 @@ namespace Objects
 			integrity = GetComponent<Integrity>();
 			integrity.OnApplyDamage.AddListener(OnDamageReceived);
 
-			audioSourceParameters =	new AudioSourceParameters(1, Volume, 0, 0, 0, Spread, 
-				MinSoundDistance, MaxSoundDistance, MixerType.Muffled, VolumeRolloffType.EaseInAndOut, false);
+			audioSourceParameters =	new AudioSourceParameters(volume: Volume, spatialBlend: 1, spread: Spread, 
+				minDistance: MinSoundDistance, maxDistance: MaxSoundDistance,mixerType: MixerType.Muffled, 
+				volumeRolloffType: VolumeRolloffType.EaseInAndOut);
 		}
 
 		private void Update()

--- a/UnityProject/Assets/Scripts/Objects/Machines/Jukebox.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/Jukebox.cs
@@ -204,7 +204,7 @@ namespace Objects
 				SoundManager.StopNetworked(guid);
 				IsPlaying = true;
 				spriteHandler.SetSpriteSO(SpritePlaying);
-				guid  = await SoundManager.PlayNetworkedAtPos(musics[currentSongTrackIndex], registerTile.WorldPositionServer, audioSourceParameters, false, true, sourceObj: gameObject);
+				guid  = SoundManager.PlayNetworkedAtPos(musics[currentSongTrackIndex], registerTile.WorldPositionServer, audioSourceParameters, false, true, sourceObj: gameObject);
 				startPlayTime = Time.time;
 				UpdateGUI();
 			}


### PR DESCRIPTION
When I updated SoundManager to the new setup, I merged all versions of PlayNetworkedAtPosition into the async task.  However, most of the code is set up to handle calling the code synchronously.  This PR reverts the change to a synchronous method.  Jukebox was the only code using PlayNetworkedAtPosition asynchronously, and did not need to.