### PR TITLE
Radiation penetration is now affected by tile stats and bundle is given a unique name each build to prevent collisions

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Editor/Addressable editor/AddressablesDevBuildSetup.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/Addressable editor/AddressablesDevBuildSetup.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -81,10 +82,10 @@ public class AddressablesDevBuildSetup : IPreprocessBuild
 			}
 
 
-
-			System.IO.File.Copy(FoundFile, newendpath + Path.GetFileName(FoundFile));
-			System.IO.File.Copy(FoundFile.Replace(".json", ".hash"), (newendpath + Path.GetFileName(FoundFile)).Replace(".json", ".hash"));
-			JObject o1 = JObject.Parse(File.ReadAllText((@newendpath + Path.GetFileName(FoundFile).Replace("/", @"\"))));
+			var Stringtime = DateTime.Now.Ticks.ToString();
+			System.IO.File.Copy(FoundFile, newendpath + Stringtime+ ".json");
+			System.IO.File.Copy(FoundFile.Replace(".json", ".hash"), (newendpath + Stringtime+ ".hash" ));
+			JObject o1 = JObject.Parse(File.ReadAllText((@newendpath +  Stringtime+ ".json".Replace("/", @"\"))));
 
 			var IDs = (JArray) o1["m_InternalIds"];
 			for (int i = 0; i < IDs.Count; i++)
@@ -97,7 +98,7 @@ public class AddressablesDevBuildSetup : IPreprocessBuild
 				IDs[i] = newID;
 			}
 
-			File.WriteAllText(newendpath + Path.GetFileName(FoundFile),
+			File.WriteAllText(newendpath +  Stringtime+ ".json",
 				Newtonsoft.Json.JsonConvert.SerializeObject(o1, Newtonsoft.Json.Formatting.None));
 		}
 

--- a/UnityProject/Assets/Scripts/Systems/Radiation/RadiationManager.cs
+++ b/UnityProject/Assets/Scripts/Systems/Radiation/RadiationManager.cs
@@ -220,11 +220,15 @@ namespace Systems.Radiation
 				var RadiationNode = NodePoint?.RadiationNode;
 				if (RadiationNode != null)
 				{
-					if (NodePoint.IsOccupied)
+					foreach (var Layer in Pulse.Matrix.MetaTileMap.Layers)
 					{
-						RadiationOnStep *= 0.15f;
+						if (Layer.Key == LayerType.Underfloor) continue;
+						var BasicTile_ = Pulse.Matrix.MetaTileMap.GetTile(new Vector2Int(x0, y0).To3Int(), Layer.Key ) as BasicTile;
+						if (BasicTile_ != null)
+						{
+							RadiationOnStep *= BasicTile_.RadiationPassability;
+						}
 					}
-					//RadiationOnStep *= RadiationNode.RadiationPassability;
 
 					CircleArea.Add(RadiationNode);
 					RadiationNode.MidCalculationNumbers += RadiationOnStep;
@@ -244,7 +248,6 @@ namespace Systems.Radiation
 				}
 			}
 		}
-
 		public void RequestPulse(Matrix Matrix, Vector3Int Location, float Strength, int InSourceID)
 		{
 			lock (PulseQueue)

--- a/UnityProject/Assets/Scripts/Tilemaps/Tiles/BasicTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Tiles/BasicTile.cs
@@ -34,6 +34,10 @@ public abstract class BasicTile : LayerTile
 	[Tooltip("Can this tile be mined?")] [FormerlySerializedAs("Mineable")] [SerializeField]
 	private bool mineable = false;
 
+
+	[Tooltip("RadiationPassability 0 = 100% Resistant")] [SerializeField]
+	public float RadiationPassability = 1;
+
 	/// <summary>
 	/// Can this tile be mined?
 	/// </summary>

--- a/UnityProject/Assets/Scripts/Tilemaps/Tiles/BasicTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Tiles/BasicTile.cs
@@ -35,7 +35,7 @@ public abstract class BasicTile : LayerTile
 	private bool mineable = false;
 
 
-	[Tooltip("RadiationPassability 0 = 100% Resistant")] [SerializeField]
+	[Range(0.0f, 1f)] [Tooltip("RadiationPassability 0 = 100% Resistant")] [SerializeField]
 	public float RadiationPassability = 1;
 
 	/// <summary>

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/AdminWall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/AdminWall.asset
@@ -24,6 +24,7 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 1
   passableException:
@@ -46,6 +47,9 @@ MonoBehaviour:
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0
   lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
   soundOnHit:
     SetLoadSetting: 0
     AssetAddress: null

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallAnchorBolts.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallAnchorBolts.asset
@@ -24,6 +24,7 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  RadiationPassability: 0.15
   doesReflectBullet: 0
   indestructible: 0
   passableException:
@@ -50,6 +51,8 @@ MonoBehaviour:
   lootOnDespawn: {fileID: 0}
   toTileWhenDestroyed: {fileID: 11400000, guid: b43b0c919cddd46bea60e744d7d6e757,
     type: 2}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
   soundOnHit:
     SetLoadSetting: 0
     AssetAddress: 

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallCover.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallCover.asset
@@ -24,6 +24,7 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  RadiationPassability: 0.15
   doesReflectBullet: 0
   indestructible: 0
   passableException:
@@ -50,6 +51,8 @@ MonoBehaviour:
   lootOnDespawn: {fileID: 0}
   toTileWhenDestroyed: {fileID: 11400000, guid: c93afca023a824669a8b47ba373b0df0,
     type: 2}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
   soundOnHit:
     SetLoadSetting: 0
     AssetAddress: 

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallCutCover.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallCutCover.asset
@@ -24,6 +24,7 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  RadiationPassability: 0.15
   doesReflectBullet: 0
   indestructible: 0
   passableException:
@@ -50,6 +51,8 @@ MonoBehaviour:
   lootOnDespawn: {fileID: 0}
   toTileWhenDestroyed: {fileID: 11400000, guid: 1ca46934f095c48c9a3c4e6c8807c778,
     type: 2}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
   soundOnHit:
     SetLoadSetting: 0
     AssetAddress: 

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallSheath.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallSheath.asset
@@ -24,6 +24,7 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  RadiationPassability: 0.15
   doesReflectBullet: 0
   indestructible: 0
   passableException:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallSupportLines.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallSupportLines.asset
@@ -24,6 +24,7 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  RadiationPassability: 0.15
   doesReflectBullet: 0
   indestructible: 0
   passableException:
@@ -50,6 +51,8 @@ MonoBehaviour:
   lootOnDespawn: {fileID: 0}
   toTileWhenDestroyed: {fileID: 11400000, guid: b7583dfb4987e426bb04eebe68910ac0,
     type: 2}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
   soundOnHit:
     SetLoadSetting: 0
     AssetAddress: null

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallSupportRods.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallSupportRods.asset
@@ -24,6 +24,7 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  RadiationPassability: 0.15
   doesReflectBullet: 0
   indestructible: 0
   passableException:
@@ -50,6 +51,8 @@ MonoBehaviour:
   lootOnDespawn: {fileID: 0}
   toTileWhenDestroyed: {fileID: 11400000, guid: 00d99f77a27b4456e894ffd3c27fca26,
     type: 2}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
   soundOnHit:
     SetLoadSetting: 0
     AssetAddress: null

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/ReinforcedWall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/ReinforcedWall.asset
@@ -24,6 +24,7 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  RadiationPassability: 0.15
   doesReflectBullet: 0
   indestructible: 0
   passableException:
@@ -49,6 +50,8 @@ MonoBehaviour:
   lootOnDespawn: {fileID: 0}
   toTileWhenDestroyed: {fileID: 11400000, guid: e5521a40048af4964ad58c041a5dc7f4,
     type: 2}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
   soundOnHit:
     SetLoadSetting: 0
     AssetAddress: 

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/Wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/Wall.asset
@@ -24,6 +24,7 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
   passableException:
@@ -52,7 +53,7 @@ MonoBehaviour:
   damageOverlayList: {fileID: 0}
   soundOnHit:
     SetLoadSetting: 0
-    AssetAddress:
+    AssetAddress: 
     AssetReference:
       m_AssetGUID: 
       m_SubObjectName: 

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/abductor_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/abductor_wall.asset
@@ -17,18 +17,21 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
+  doesReflectBullet: 0
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
   maxHealth: 100
+  damageDeflection: 0
   armor:
     Melee: 90
     Bullet: 90
@@ -40,20 +43,20 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/bananium_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/bananium_wall.asset
@@ -17,18 +17,21 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
+  doesReflectBullet: 0
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
   maxHealth: 100
+  damageDeflection: 0
   armor:
     Melee: 90
     Bullet: 90
@@ -40,20 +43,20 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/blank_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/blank_wall.asset
@@ -16,18 +16,21 @@ MonoBehaviour:
   LayerType: 0
   TileType: 1
   RequiredTiles: []
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 0
   isSealed: 1
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
+  doesReflectBullet: 0
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
   maxHealth: 500
+  damageDeflection: 0
   armor:
     Melee: 100
     Bullet: 100
@@ -39,20 +42,20 @@ MonoBehaviour:
     Acid: 100
     Magic: 100
     Bio: 100
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 1
-    FireProof: 1
-    Flammable: 0
-    UnAcidable: 1
-    AcidProof: 1
-    Indestructable: 1
-    FreezeProof: 1
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   connectCategory: 4
   connectType: 2
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/clockwork_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/clockwork_wall.asset
@@ -17,18 +17,21 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
+  doesReflectBullet: 0
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
   maxHealth: 100
+  damageDeflection: 0
   armor:
     Melee: 90
     Bullet: 90
@@ -40,20 +43,20 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/cult_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/cult_wall.asset
@@ -17,18 +17,21 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
+  doesReflectBullet: 0
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
   maxHealth: 100
+  damageDeflection: 0
   armor:
     Melee: 90
     Bullet: 90
@@ -40,20 +43,20 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/diamond_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/diamond_wall.asset
@@ -17,18 +17,21 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
+  doesReflectBullet: 0
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
   maxHealth: 100
+  damageDeflection: 0
   armor:
     Melee: 90
     Bullet: 90
@@ -40,20 +43,20 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/false_open.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/false_open.asset
@@ -17,18 +17,21 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 1
   isSealed: 1
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 1
   mineable: 0
+  RadiationPassability: 0.35
+  doesReflectBullet: 0
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
   maxHealth: 100
+  damageDeflection: 0
   armor:
     Melee: 90
     Bullet: 90
@@ -40,21 +43,21 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions:
   - {fileID: 11400000, guid: bb76dc79372e14705abf68e3caa3e0f9, type: 2}
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/gold_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/gold_wall.asset
@@ -17,18 +17,21 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
+  doesReflectBullet: 0
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
   maxHealth: 100
+  damageDeflection: 0
   armor:
     Melee: 90
     Bullet: 90
@@ -40,20 +43,20 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/hierophant_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/hierophant_wall.asset
@@ -17,18 +17,21 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
+  doesReflectBullet: 0
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
   maxHealth: 100
+  damageDeflection: 0
   armor:
     Melee: 90
     Bullet: 90
@@ -40,20 +43,20 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/iron_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/iron_wall.asset
@@ -17,18 +17,21 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
+  doesReflectBullet: 0
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
   maxHealth: 100
+  damageDeflection: 0
   armor:
     Melee: 90
     Bullet: 90
@@ -40,20 +43,20 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/plasma_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/plasma_wall.asset
@@ -17,18 +17,21 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
+  doesReflectBullet: 0
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
   maxHealth: 100
+  damageDeflection: 0
   armor:
     Melee: 90
     Bullet: 90
@@ -40,20 +43,20 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/plastitanium_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/plastitanium_wall.asset
@@ -17,18 +17,21 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
+  doesReflectBullet: 0
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
   maxHealth: 100
+  damageDeflection: 0
   armor:
     Melee: 90
     Bullet: 90
@@ -40,20 +43,20 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/plastitanium_wall_corner.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/plastitanium_wall_corner.asset
@@ -16,18 +16,21 @@ MonoBehaviour:
   LayerType: 0
   TileType: 1
   RequiredTiles: []
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
+  doesReflectBullet: 0
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
   maxHealth: 100
+  damageDeflection: 0
   armor:
     Melee: 90
     Bullet: 90
@@ -39,20 +42,20 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/pod_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/pod_wall.asset
@@ -17,18 +17,21 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
+  doesReflectBullet: 0
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
   maxHealth: 100
+  damageDeflection: 0
   armor:
     Melee: 90
     Bullet: 90
@@ -40,20 +43,20 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/resin_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/resin_wall.asset
@@ -17,18 +17,21 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
+  doesReflectBullet: 0
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
   maxHealth: 100
+  damageDeflection: 0
   armor:
     Melee: 90
     Bullet: 90
@@ -40,20 +43,20 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/rock_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/rock_wall.asset
@@ -16,18 +16,21 @@ MonoBehaviour:
   LayerType: 0
   TileType: 1
   RequiredTiles: []
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 1
-  oreCategory: 2
-  HealthStates: []
   passable: 0
   mineable: 1
+  RadiationPassability: 0.35
+  doesReflectBullet: 0
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
   maxHealth: 100
+  damageDeflection: 0
   armor:
     Melee: 90
     Bullet: 90
@@ -39,20 +42,20 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/rusty_reinforced_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/rusty_reinforced_wall.asset
@@ -17,18 +17,21 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
+  doesReflectBullet: 0
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
   maxHealth: 100
+  damageDeflection: 0
   armor:
     Melee: 90
     Bullet: 90
@@ -40,20 +43,20 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/rusty_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/rusty_wall.asset
@@ -24,6 +24,7 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
   passableException:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/sandstone_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/sandstone_wall.asset
@@ -24,6 +24,7 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
   passableException:
@@ -47,6 +48,8 @@ MonoBehaviour:
   spawnAmountOnDeconstruct: 1
   lootOnDespawn: {fileID: 0}
   toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
   soundOnHit:
     SetLoadSetting: 0
     AssetAddress: null

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/shuttle_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/shuttle_wall.asset
@@ -17,13 +17,16 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
   doesReflectBullet: 1
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
@@ -44,7 +47,16 @@ MonoBehaviour:
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
   lootOnDespawn: {fileID: 0}
-  soundOnHit: 
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/shuttle_wall_corner.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/shuttle_wall_corner.asset
@@ -16,13 +16,16 @@ MonoBehaviour:
   LayerType: 0
   TileType: 1
   RequiredTiles: []
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
   doesReflectBullet: 1
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
@@ -43,7 +46,16 @@ MonoBehaviour:
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
   lootOnDespawn: {fileID: 0}
-  soundOnHit: 
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/silver_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/silver_wall.asset
@@ -17,18 +17,21 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
+  doesReflectBullet: 0
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
   maxHealth: 100
+  damageDeflection: 0
   armor:
     Melee: 90
     Bullet: 90
@@ -40,20 +43,20 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 90
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/smooth_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/smooth_wall.asset
@@ -17,18 +17,21 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
+  doesReflectBullet: 0
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
   maxHealth: 100
+  damageDeflection: 0
   armor:
     Melee: 90
     Bullet: 90
@@ -40,20 +43,20 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 90
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/snow_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/snow_wall.asset
@@ -17,18 +17,21 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
+  doesReflectBullet: 0
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
   maxHealth: 100
+  damageDeflection: 0
   armor:
     Melee: 90
     Bullet: 90
@@ -40,20 +43,20 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 90
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/survival_pod_walls.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/survival_pod_walls.asset
@@ -17,18 +17,21 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
+  doesReflectBullet: 0
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
   maxHealth: 100
+  damageDeflection: 0
   armor:
     Melee: 90
     Bullet: 90
@@ -40,20 +43,20 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 90
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/uranium_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/uranium_wall.asset
@@ -17,18 +17,21 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
+  doesReflectBullet: 0
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
   maxHealth: 100
+  damageDeflection: 0
   armor:
     Melee: 90
     Bullet: 90
@@ -40,20 +43,20 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 90
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/wood_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/wood_wall.asset
@@ -17,18 +17,21 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 0
   mineable: 0
+  RadiationPassability: 0.35
+  doesReflectBullet: 0
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
   maxHealth: 100
+  damageDeflection: 0
   armor:
     Melee: 90
     Bullet: 90
@@ -40,20 +43,20 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 90
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/WindowPlasma.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/WindowPlasma.asset
@@ -24,6 +24,7 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  RadiationPassability: 0.1
   doesReflectBullet: 0
   indestructible: 0
   passableException:
@@ -59,7 +60,6 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
-  currentEffect: {fileID: 0}
   connectCategory: 1
   connectType: 1
   spriteSheet:


### PR DESCRIPTION
yay thread safe tile access


local bundles are given a unique name to prevent cached collisions tho it did break again but restarting the built client fixed it for some reason

NOTE: someone needs to go through and set appropriate values for tiles  I did it for the basic walls and reinforced walls and plasma windows

### Changelog:
CL: radiation now penetrates differently depending on the tile
