### PR TITLE
APC sounds will now be played locally

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Engineering/APC.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/APC.cs
@@ -241,10 +241,7 @@ namespace Objects.Engineering
 				case APCState.Critical:
 					loadedScreenSprites = criticalSprites;
 					EmergencyState = true;
-					if (isServer)
-					{
-						SoundManager.PlayNetworkedAtPos(NoPowerSound, gameObject.WorldPosServer());
-					}
+					SoundManager.PlayAtPosition(NoPowerSound, gameObject.WorldPosServer());
 					if (!RefreshDisplay) StartRefresh();
 					break;
 				case APCState.Dead:


### PR DESCRIPTION
### Purpose
APC sounds will now be played locally avoiding sound manager messages

since the logic already has everything on each client I just changed the way the sound is played, patching some potential high CPU usage