### PR TITLE
Removes an error log from tile onhit

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
@@ -90,10 +90,6 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 			if(damage >= 1)
 				SoundManager.PlayNetworkedAtPos(basicTile.SoundOnHit, worldPosition);
 		}
-		else
-		{
-			Logger.LogError($"Tried to play SoundOnHit for {basicTile.DisplayName}, but it was null!", Category.Addressables);
-		}
 
 		var totalDamageTaken = data.GetTileDamage(Layer.LayerType);
 


### PR DESCRIPTION
### Purpose
Removes the error message for when a tile without SoundOnHit is hit, it generated too much cpu and gc usage on fires and explosions.

