### PR TITLE
Updates Maximum Moles Value on tank prefabs to fix air tank fullness bar

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Tanks/AnestheticTank.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tanks/AnestheticTank.prefab
@@ -9,6 +9,16 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1214260697378847585, guid: 34ecf2817a168de479d040f2ad8b9473,
         type: 3}
+      propertyPath: initialName
+      value: anesthetic tank
+      objectReference: {fileID: 0}
+    - target: {fileID: 1214260697378847585, guid: 34ecf2817a168de479d040f2ad8b9473,
+        type: 3}
+      propertyPath: initialDescription
+      value: A tank with an N2O/O2 gas mix.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1214260697378847585, guid: 34ecf2817a168de479d040f2ad8b9473,
+        type: 3}
       propertyPath: itemSprites.SpriteLeftHand
       value: 
       objectReference: {fileID: 11400000, guid: 91e8d86ff751b014a9b138a85758b8d9,
@@ -19,22 +29,17 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: c5dd42c85c271064a8402a2e5cc3acb7,
         type: 2}
-    - target: {fileID: 1214260697378847585, guid: 34ecf2817a168de479d040f2ad8b9473,
-        type: 3}
-      propertyPath: initialDescription
-      value: A tank with an N2O/O2 gas mix.
-      objectReference: {fileID: 0}
-    - target: {fileID: 1214260697378847585, guid: 34ecf2817a168de479d040f2ad8b9473,
-        type: 3}
-      propertyPath: initialName
-      value: anesthetic tank
-      objectReference: {fileID: 0}
     - target: {fileID: 1496748151134168927, guid: 34ecf2817a168de479d040f2ad8b9473,
         type: 3}
       propertyPath: m_Sprite
       value: 
       objectReference: {fileID: 21300000, guid: 927c928d9a5ffa140ad1999f51c2b906,
         type: 3}
+    - target: {fileID: 1596512047604066679, guid: 34ecf2817a168de479d040f2ad8b9473,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1596512047604066679, guid: 34ecf2817a168de479d040f2ad8b9473,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -52,6 +57,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1596512047604066679, guid: 34ecf2817a168de479d040f2ad8b9473,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1596512047604066679, guid: 34ecf2817a168de479d040f2ad8b9473,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -64,16 +74,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1596512047604066679, guid: 34ecf2817a168de479d040f2ad8b9473,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1596512047604066679, guid: 34ecf2817a168de479d040f2ad8b9473,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1596512047604066679, guid: 34ecf2817a168de479d040f2ad8b9473,
         type: 3}
@@ -114,7 +114,7 @@ PrefabInstance:
     - target: {fileID: 6805590453308241792, guid: 34ecf2817a168de479d040f2ad8b9473,
         type: 3}
       propertyPath: Gases.Array.data[4]
-      value: 6.9003654
+      value: 6.900366
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 34ecf2817a168de479d040f2ad8b9473, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tanks/EmergencyOxygenTank.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tanks/EmergencyOxygenTank.prefab
@@ -19,6 +19,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2410773065630705748, guid: 48d3c058a9e5a42418875499b82cc5e3,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2410773065630705748, guid: 48d3c058a9e5a42418875499b82cc5e3,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -34,6 +39,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2410773065630705748, guid: 48d3c058a9e5a42418875499b82cc5e3,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2410773065630705748, guid: 48d3c058a9e5a42418875499b82cc5e3,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -46,16 +56,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2410773065630705748, guid: 48d3c058a9e5a42418875499b82cc5e3,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2410773065630705748, guid: 48d3c058a9e5a42418875499b82cc5e3,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2410773065630705748, guid: 48d3c058a9e5a42418875499b82cc5e3,
         type: 3}
@@ -78,10 +78,20 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 3961953bf239e8247b8ffb44ba6c5ffc,
         type: 3}
+    - target: {fileID: 2564446943044314748, guid: 48d3c058a9e5a42418875499b82cc5e3,
+        type: 3}
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 2849320339179502146, guid: 48d3c058a9e5a42418875499b82cc5e3,
         type: 3}
       propertyPath: hitDamage
       value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2849320339179502146, guid: 48d3c058a9e5a42418875499b82cc5e3,
+        type: 3}
+      propertyPath: initialName
+      value: emergency oxygen tank
       objectReference: {fileID: 0}
     - target: {fileID: 2849320339179502146, guid: 48d3c058a9e5a42418875499b82cc5e3,
         type: 3}
@@ -90,10 +100,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2849320339179502146, guid: 48d3c058a9e5a42418875499b82cc5e3,
         type: 3}
-      propertyPath: initialTraits.Array.data[1]
-      value: 
-      objectReference: {fileID: 11400000, guid: 5eafba0d7388d428c8e08ed1b5d5d260,
-        type: 2}
+      propertyPath: initialDescription
+      value: Used for emergencies. Contains very little oxygen, so try to conserve
+        it until you actually need it.
+      objectReference: {fileID: 0}
     - target: {fileID: 2849320339179502146, guid: 48d3c058a9e5a42418875499b82cc5e3,
         type: 3}
       propertyPath: itemSprites.SpriteLeftHand
@@ -102,20 +112,25 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 2849320339179502146, guid: 48d3c058a9e5a42418875499b82cc5e3,
         type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 5eafba0d7388d428c8e08ed1b5d5d260,
+        type: 2}
+    - target: {fileID: 2849320339179502146, guid: 48d3c058a9e5a42418875499b82cc5e3,
+        type: 3}
       propertyPath: itemSprites.SpriteRightHand
       value: 
       objectReference: {fileID: 11400000, guid: 6e18312d02e687248ad625b0b5ec3ca8,
         type: 2}
-    - target: {fileID: 2849320339179502146, guid: 48d3c058a9e5a42418875499b82cc5e3,
+    - target: {fileID: 7575452727574476451, guid: 48d3c058a9e5a42418875499b82cc5e3,
         type: 3}
-      propertyPath: initialDescription
-      value: Used for emergencies. Contains very little oxygen, so try to conserve
-        it until you actually need it.
+      propertyPath: Volume
+      value: 0.00100054
       objectReference: {fileID: 0}
-    - target: {fileID: 2849320339179502146, guid: 48d3c058a9e5a42418875499b82cc5e3,
+    - target: {fileID: 7575452727574476451, guid: 48d3c058a9e5a42418875499b82cc5e3,
         type: 3}
-      propertyPath: initialName
-      value: emergency oxygen tank
+      propertyPath: MaximumMoles
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 7575452727574476451, guid: 48d3c058a9e5a42418875499b82cc5e3,
         type: 3}
@@ -126,11 +141,6 @@ PrefabInstance:
         type: 3}
       propertyPath: Gases.Array.data[1]
       value: 0.415935
-      objectReference: {fileID: 0}
-    - target: {fileID: 7575452727574476451, guid: 48d3c058a9e5a42418875499b82cc5e3,
-        type: 3}
-      propertyPath: Volume
-      value: 0.00100054
       objectReference: {fileID: 0}
     - target: {fileID: 8368062230162943655, guid: 48d3c058a9e5a42418875499b82cc5e3,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tanks/EmergencyOxygenTankDouble.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tanks/EmergencyOxygenTankDouble.prefab
@@ -15,13 +15,23 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 3519444805694504380, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
         type: 3}
-      propertyPath: Gases.Array.data[1]
-      value: 3.32748
+      propertyPath: Volume
+      value: 0.00800429
       objectReference: {fileID: 0}
     - target: {fileID: 3519444805694504380, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
         type: 3}
-      propertyPath: Volume
-      value: 0.00800429
+      propertyPath: MaximumMoles
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 3519444805694504380, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
+        type: 3}
+      propertyPath: Gases.Array.data[1]
+      value: 3.32748
+      objectReference: {fileID: 0}
+    - target: {fileID: 8683563700070376267, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8683563700070376267, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
         type: 3}
@@ -40,6 +50,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8683563700070376267, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8683563700070376267, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -52,16 +67,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8683563700070376267, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8683563700070376267, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8683563700070376267, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
         type: 3}
@@ -96,6 +101,11 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 9114212219146629469, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
         type: 3}
+      propertyPath: initialName
+      value: double emergency oxygen tank
+      objectReference: {fileID: 0}
+    - target: {fileID: 9114212219146629469, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
+        type: 3}
       propertyPath: itemSprites.SpriteLeftHand
       value: 
       objectReference: {fileID: 11400000, guid: 7335808bfdf794f40a9e4a2b475c9870,
@@ -106,10 +116,5 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: d36c552d52628744f9329654bbdf563b,
         type: 2}
-    - target: {fileID: 9114212219146629469, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
-        type: 3}
-      propertyPath: initialName
-      value: double emergency oxygen tank
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tanks/EmergencyOxygenTankDoubleEmpty.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tanks/EmergencyOxygenTankDoubleEmpty.prefab
@@ -14,6 +14,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7782571377670902918, guid: 559a6395df37aa249a2e1407680afd35,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7782571377670902918, guid: 559a6395df37aa249a2e1407680afd35,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -29,6 +34,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7782571377670902918, guid: 559a6395df37aa249a2e1407680afd35,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7782571377670902918, guid: 559a6395df37aa249a2e1407680afd35,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -41,16 +51,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7782571377670902918, guid: 559a6395df37aa249a2e1407680afd35,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7782571377670902918, guid: 559a6395df37aa249a2e1407680afd35,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7782571377670902918, guid: 559a6395df37aa249a2e1407680afd35,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tanks/EmergencyOxygenTankEmpty.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tanks/EmergencyOxygenTankEmpty.prefab
@@ -14,6 +14,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8683563700070376267, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8683563700070376267, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -29,6 +34,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8683563700070376267, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8683563700070376267, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -41,16 +51,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8683563700070376267, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8683563700070376267, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8683563700070376267, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tanks/EmergencyOxygenTankExtendedCapacity.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tanks/EmergencyOxygenTankExtendedCapacity.prefab
@@ -15,13 +15,18 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 3519444805694504380, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
         type: 3}
-      propertyPath: Gases.Array.data[1]
-      value: 0.83187
+      propertyPath: Volume
+      value: 0.00200107
       objectReference: {fileID: 0}
     - target: {fileID: 3519444805694504380, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
         type: 3}
-      propertyPath: Volume
-      value: 0.00200107
+      propertyPath: Gases.Array.data[1]
+      value: 0.83187
+      objectReference: {fileID: 0}
+    - target: {fileID: 8683563700070376267, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8683563700070376267, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
         type: 3}
@@ -40,6 +45,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8683563700070376267, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8683563700070376267, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -52,16 +62,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8683563700070376267, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8683563700070376267, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8683563700070376267, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
         type: 3}
@@ -96,6 +96,11 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 9114212219146629469, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
         type: 3}
+      propertyPath: initialName
+      value: extended-capacity emergency oxygen tank
+      objectReference: {fileID: 0}
+    - target: {fileID: 9114212219146629469, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
+        type: 3}
       propertyPath: itemSprites.SpriteLeftHand
       value: 
       objectReference: {fileID: 11400000, guid: 7335808bfdf794f40a9e4a2b475c9870,
@@ -106,10 +111,5 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: d36c552d52628744f9329654bbdf563b,
         type: 2}
-    - target: {fileID: 9114212219146629469, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
-        type: 3}
-      propertyPath: initialName
-      value: extended-capacity emergency oxygen tank
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tanks/OxygenTank.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tanks/OxygenTank.prefab
@@ -9,6 +9,16 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1214260697378847585, guid: 34ecf2817a168de479d040f2ad8b9473,
         type: 3}
+      propertyPath: initialName
+      value: oxygen tank
+      objectReference: {fileID: 0}
+    - target: {fileID: 1214260697378847585, guid: 34ecf2817a168de479d040f2ad8b9473,
+        type: 3}
+      propertyPath: initialDescription
+      value: A tank of oxygen, this one is blue.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1214260697378847585, guid: 34ecf2817a168de479d040f2ad8b9473,
+        type: 3}
       propertyPath: itemSprites.SpriteLeftHand
       value: 
       objectReference: {fileID: 11400000, guid: 7d9346d69d1e624469bcf82dea2460ca,
@@ -19,22 +29,17 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 443242374c007f849a52d60061669976,
         type: 2}
-    - target: {fileID: 1214260697378847585, guid: 34ecf2817a168de479d040f2ad8b9473,
-        type: 3}
-      propertyPath: initialDescription
-      value: A tank of oxygen, this one is blue.
-      objectReference: {fileID: 0}
-    - target: {fileID: 1214260697378847585, guid: 34ecf2817a168de479d040f2ad8b9473,
-        type: 3}
-      propertyPath: initialName
-      value: oxygen tank
-      objectReference: {fileID: 0}
     - target: {fileID: 1496748151134168927, guid: 34ecf2817a168de479d040f2ad8b9473,
         type: 3}
       propertyPath: m_Sprite
       value: 
       objectReference: {fileID: 21300000, guid: 8af1429ca219da24f893aa9ad0584dc6,
         type: 3}
+    - target: {fileID: 1596512047604066679, guid: 34ecf2817a168de479d040f2ad8b9473,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1596512047604066679, guid: 34ecf2817a168de479d040f2ad8b9473,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -52,6 +57,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1596512047604066679, guid: 34ecf2817a168de479d040f2ad8b9473,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1596512047604066679, guid: 34ecf2817a168de479d040f2ad8b9473,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -64,16 +74,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1596512047604066679, guid: 34ecf2817a168de479d040f2ad8b9473,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1596512047604066679, guid: 34ecf2817a168de479d040f2ad8b9473,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1596512047604066679, guid: 34ecf2817a168de479d040f2ad8b9473,
         type: 3}
@@ -106,6 +106,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 84eec8c9524b1694e95c0ca646db3184,
         type: 2}
+    - target: {fileID: 6805590453308241792, guid: 34ecf2817a168de479d040f2ad8b9473,
+        type: 3}
+      propertyPath: MaximumMoles
+      value: 20
+      objectReference: {fileID: 0}
     - target: {fileID: 6805590453308241792, guid: 34ecf2817a168de479d040f2ad8b9473,
         type: 3}
       propertyPath: Gases.Array.data[1]

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tanks/PlasmaInternalsTank.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tanks/PlasmaInternalsTank.prefab
@@ -19,6 +19,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2410773065630705748, guid: 48d3c058a9e5a42418875499b82cc5e3,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2410773065630705748, guid: 48d3c058a9e5a42418875499b82cc5e3,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -34,6 +39,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2410773065630705748, guid: 48d3c058a9e5a42418875499b82cc5e3,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2410773065630705748, guid: 48d3c058a9e5a42418875499b82cc5e3,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -46,16 +56,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2410773065630705748, guid: 48d3c058a9e5a42418875499b82cc5e3,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2410773065630705748, guid: 48d3c058a9e5a42418875499b82cc5e3,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2410773065630705748, guid: 48d3c058a9e5a42418875499b82cc5e3,
         type: 3}
@@ -78,17 +78,27 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: b205bcba27045da4ca80318d6c4176e2,
         type: 3}
+    - target: {fileID: 2564446943044314748, guid: 48d3c058a9e5a42418875499b82cc5e3,
+        type: 3}
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2849320339179502146, guid: 48d3c058a9e5a42418875499b82cc5e3,
+        type: 3}
+      propertyPath: hitDamage
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2849320339179502146, guid: 48d3c058a9e5a42418875499b82cc5e3,
+        type: 3}
+      propertyPath: initialName
+      value: plasma internals tank
+      objectReference: {fileID: 0}
     - target: {fileID: 2849320339179502146, guid: 48d3c058a9e5a42418875499b82cc5e3,
         type: 3}
       propertyPath: initialDescription
       value: A tank of plasma gas designed specifically for use as internals, particularly
         for plasma-based lifeforms. If you're not a Plasmaman, you probably shouldn't
         use this.
-      objectReference: {fileID: 0}
-    - target: {fileID: 2849320339179502146, guid: 48d3c058a9e5a42418875499b82cc5e3,
-        type: 3}
-      propertyPath: initialName
-      value: plasma internals tank
       objectReference: {fileID: 0}
     - target: {fileID: 2849320339179502146, guid: 48d3c058a9e5a42418875499b82cc5e3,
         type: 3}
@@ -102,20 +112,20 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 3588da14e1cf29c4cae8052f9a1144b3,
         type: 2}
-    - target: {fileID: 2849320339179502146, guid: 48d3c058a9e5a42418875499b82cc5e3,
-        type: 3}
-      propertyPath: hitDamage
-      value: 10
-      objectReference: {fileID: 0}
     - target: {fileID: 7575452727574476451, guid: 48d3c058a9e5a42418875499b82cc5e3,
         type: 3}
-      propertyPath: Gases.Array.data[0]
-      value: 8.73464
+      propertyPath: MaximumMoles
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 7575452727574476451, guid: 48d3c058a9e5a42418875499b82cc5e3,
         type: 3}
       propertyPath: ReleasePressure
       value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 7575452727574476451, guid: 48d3c058a9e5a42418875499b82cc5e3,
+        type: 3}
+      propertyPath: Gases.Array.data[0]
+      value: 8.73464
       objectReference: {fileID: 0}
     - target: {fileID: 8368062230162943655, guid: 48d3c058a9e5a42418875499b82cc5e3,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tanks/PlasmaInternalsTankFull.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tanks/PlasmaInternalsTankFull.prefab
@@ -9,6 +9,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 256375122203596789, guid: 38587331617a9c747832658ce8bee272,
         type: 3}
+      propertyPath: MaximumMoles
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 256375122203596789, guid: 38587331617a9c747832658ce8bee272,
+        type: 3}
       propertyPath: Gases.Array.data[0]
       value: 29.1155
       objectReference: {fileID: 0}
@@ -21,6 +26,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: PlasmaInternalsTankFull
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466086382375602434, guid: 38587331617a9c747832658ce8bee272,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5466086382375602434, guid: 38587331617a9c747832658ce8bee272,
         type: 3}
@@ -39,6 +49,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5466086382375602434, guid: 38587331617a9c747832658ce8bee272,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5466086382375602434, guid: 38587331617a9c747832658ce8bee272,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -51,16 +66,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5466086382375602434, guid: 38587331617a9c747832658ce8bee272,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5466086382375602434, guid: 38587331617a9c747832658ce8bee272,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5466086382375602434, guid: 38587331617a9c747832658ce8bee272,
         type: 3}


### PR DESCRIPTION
### Purpose
Updates Maximum Moles Value on all the emergency oxygen tanks and similar prefabs so that the air tank fullness bar correctly updates itself when the player has it equipped. Before it was showing nothing.
