### PR TITLE
Variable Pickaxe Speeds

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/PickaxeCompact.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/PickaxeCompact.prefab
@@ -9,8 +9,13 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
-      propertyPath: initialTraits.Array.size
-      value: 2
+      propertyPath: hitDamage
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
+        type: 3}
+      propertyPath: initialName
+      value: compact pickaxe
       objectReference: {fileID: 0}
     - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
@@ -19,8 +24,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
-      propertyPath: hitDamage
-      value: 10
+      propertyPath: throwDamage
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
+        type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
@@ -29,19 +39,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
-      propertyPath: throwDamage
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
-        type: 3}
       propertyPath: itemSprites.SpriteInventoryIcon
       value: 
       objectReference: {fileID: 11400000, guid: f5ea5b3cd2bd0204cac22194a8bb4a6e,
         type: 2}
-    - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
+    - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
-      propertyPath: initialName
-      value: compact pickaxe
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
@@ -60,6 +65,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -72,16 +82,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
@@ -114,6 +114,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: ce99046cb32f8f84cac096bd35f77fe1,
         type: 3}
+    - target: {fileID: 7675473296682472099, guid: 82cb1c39112974a498a9756981eb07d0,
+        type: 3}
+      propertyPath: timeMultiplier
+      value: 1.05
+      objectReference: {fileID: 0}
     - target: {fileID: 8184022938753632022, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/PickaxeCompact.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/PickaxeCompact.prefab
@@ -117,7 +117,7 @@ PrefabInstance:
     - target: {fileID: 7675473296682472099, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
       propertyPath: timeMultiplier
-      value: 1.05
+      value: 1.1
       objectReference: {fileID: 0}
     - target: {fileID: 8184022938753632022, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/PickaxeDiamondTipped.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/PickaxeDiamondTipped.prefab
@@ -9,8 +9,18 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
+      propertyPath: hitDamage
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
+        type: 3}
       propertyPath: initialName
       value: diamond-tipped pickaxe
+      objectReference: {fileID: 0}
+    - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
+        type: 3}
+      propertyPath: throwDamage
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
@@ -18,12 +28,6 @@ PrefabInstance:
       value: A pickaxe with a diamond pick head. Extremely robust at cracking rock
         walls and digging up dirt.
       objectReference: {fileID: 0}
-    - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
-        type: 3}
-      propertyPath: itemSprites.SpriteInventoryIcon
-      value: 
-      objectReference: {fileID: 11400000, guid: 11f4063bc48a2f24495e774f47aa8ec8,
-        type: 2}
     - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
       propertyPath: itemSprites.SpriteLeftHand
@@ -36,6 +40,17 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: c587b6f012777244a973801cb6a12660,
         type: 2}
+    - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
+        type: 3}
+      propertyPath: itemSprites.SpriteInventoryIcon
+      value: 
+      objectReference: {fileID: 11400000, guid: 11f4063bc48a2f24495e774f47aa8ec8,
+        type: 2}
+    - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -53,6 +68,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -65,16 +85,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
@@ -107,6 +117,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 62ceda4db9b861f4da9c9991c64d74a9,
         type: 3}
+    - target: {fileID: 7675473296682472099, guid: 82cb1c39112974a498a9756981eb07d0,
+        type: 3}
+      propertyPath: timeMultiplier
+      value: 0.7
+      objectReference: {fileID: 0}
     - target: {fileID: 8184022938753632022, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/PickaxeDiamondTipped.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/PickaxeDiamondTipped.prefab
@@ -10,7 +10,7 @@ PrefabInstance:
     - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
       propertyPath: hitDamage
-      value: 18
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
@@ -120,7 +120,7 @@ PrefabInstance:
     - target: {fileID: 7675473296682472099, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
       propertyPath: timeMultiplier
-      value: 0.7
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 8184022938753632022, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/PickaxeImprovised.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/PickaxeImprovised.prefab
@@ -135,7 +135,7 @@ PrefabInstance:
     - target: {fileID: 7675473296682472099, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
       propertyPath: timeMultiplier
-      value: 1.2
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 8184022938753632022, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/PickaxeImprovised.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/PickaxeImprovised.prefab
@@ -9,8 +9,23 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
-      propertyPath: initialTraits.Array.size
-      value: 2
+      propertyPath: hitDamage
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
+        type: 3}
+      propertyPath: initialName
+      value: improvised pickaxe
+      objectReference: {fileID: 0}
+    - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
+        type: 3}
+      propertyPath: initialSize
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
+        type: 3}
+      propertyPath: throwDamage
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
@@ -20,20 +35,9 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
-      propertyPath: initialName
-      value: improvised pickaxe
+      propertyPath: initialTraits.Array.size
+      value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
-        type: 3}
-      propertyPath: initialTraits.Array.data[2]
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
-        type: 3}
-      propertyPath: itemSprites.SpriteInventoryIcon
-      value: 
-      objectReference: {fileID: 11400000, guid: 08c47ddbe9b22aa459d18a5b09db4ee2,
-        type: 2}
     - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
       propertyPath: itemSprites.SpriteLeftHand
@@ -42,24 +46,25 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
+      propertyPath: initialTraits.Array.data[2]
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
+        type: 3}
       propertyPath: itemSprites.SpriteRightHand
       value: 
       objectReference: {fileID: 11400000, guid: e8638db9ef9efda48b6537247ebc81cd,
         type: 2}
     - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
-      propertyPath: initialSize
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
+      propertyPath: itemSprites.SpriteInventoryIcon
+      value: 
+      objectReference: {fileID: 11400000, guid: 08c47ddbe9b22aa459d18a5b09db4ee2,
+        type: 2}
+    - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
-      propertyPath: hitDamage
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
-        type: 3}
-      propertyPath: throwDamage
-      value: 7
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
@@ -78,6 +83,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -90,16 +100,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
@@ -132,6 +132,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: d9f1dd352f4da12428afd205ff9b1bcb,
         type: 3}
+    - target: {fileID: 7675473296682472099, guid: 82cb1c39112974a498a9756981eb07d0,
+        type: 3}
+      propertyPath: timeMultiplier
+      value: 1.2
+      objectReference: {fileID: 0}
     - target: {fileID: 8184022938753632022, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/PickaxeSilverPlated.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/PickaxeSilverPlated.prefab
@@ -14,20 +14,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
-      propertyPath: initialDescription
-      value: A silver-plated pickaxe that mines slightly faster than standard-issue.
-      objectReference: {fileID: 0}
-    - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
-        type: 3}
       propertyPath: initialName
       value: silver-plated pickaxe
       objectReference: {fileID: 0}
     - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
-      propertyPath: itemSprites.SpriteInventoryIcon
-      value: 
-      objectReference: {fileID: 11400000, guid: f54780ab5295ad84ca0cc0619f4f50c4,
-        type: 2}
+      propertyPath: throwDamage
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
+        type: 3}
+      propertyPath: initialDescription
+      value: A silver-plated pickaxe that mines slightly faster than standard-issue.
+      objectReference: {fileID: 0}
     - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
       propertyPath: itemSprites.SpriteLeftHand
@@ -40,6 +39,17 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 987cbb23b16b1374e8dfcc64a9c19e29,
         type: 2}
+    - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
+        type: 3}
+      propertyPath: itemSprites.SpriteInventoryIcon
+      value: 
+      objectReference: {fileID: 11400000, guid: f54780ab5295ad84ca0cc0619f4f50c4,
+        type: 2}
+    - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -57,6 +67,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -69,16 +84,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
@@ -111,6 +116,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 023ce8d4b3b44a74698dd17641f7a240,
         type: 3}
+    - target: {fileID: 7675473296682472099, guid: 82cb1c39112974a498a9756981eb07d0,
+        type: 3}
+      propertyPath: timeMultiplier
+      value: 0.85
+      objectReference: {fileID: 0}
     - target: {fileID: 8184022938753632022, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/PickaxeSilverPlated.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/PickaxeSilverPlated.prefab
@@ -119,7 +119,7 @@ PrefabInstance:
     - target: {fileID: 7675473296682472099, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
       propertyPath: timeMultiplier
-      value: 0.85
+      value: 0.75
       objectReference: {fileID: 0}
     - target: {fileID: 8184022938753632022, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Mining/mining_machines_54.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Mining/mining_machines_54.prefab
@@ -99,6 +99,7 @@ MonoBehaviour:
   NetworkThis: 1
   SubCatalogue: []
   PresentSpriteSet: {fileID: 11400000, guid: d03d262ab7838bc49870a54711f8cb2c, type: 2}
+  randomInitialSprite: 0
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
@@ -235,6 +236,9 @@ MonoBehaviour:
   - ItemName: Proto-Kinetic Accelerator
     Item: {fileID: 4132242788693647151, guid: ad527ba4de069794796e314f236794f4, type: 3}
     Stock: 5
+  - ItemName: Silver Plated Pickaxe
+    Item: {fileID: 320759090315932535, guid: 9ebdd8fb093d8434db3fe4a38f8100c6, type: 3}
+    Stock: 1
   HullColor: {r: 0.5882353, g: 0.4392157, b: 0.19607843, a: 1}
   EjectObjects: 0
   EjectDirection: 0
@@ -355,7 +359,9 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
+    LightningDamageProof: 0
   HeatResistance: 100
+  ExplosionsDamage: 100
 --- !u!114 &114430213137055408
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Core/Input System/MouseInputController.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/MouseInputController.cs
@@ -16,30 +16,37 @@ public class MouseInputController : MonoBehaviour
 
 
 	[Tooltip("When mouse button is pressed down and held for longer than this duration, we will" +
-			 " not perform a click on mouse up.")]
+	         " not perform a click on mouse up.")]
 	public float MaxClickDuration = 1f;
+
 	//tracks how long we've had the button down
 	private float clickDuration;
 
 	[Tooltip("Distance to travel from initial click position before a drag (of a MouseDraggable) is initiated.")]
 	public float MouseDragDeadzone = 0.2f;
+
 	//tracks the start position (vector which points from the center of currentDraggable) to compare with above
 	private Vector2 dragStartOffset;
+
 	//when we click down on a draggable, stores it so we can check if we should click interact or drag interact
 	private MouseDraggable potentialDraggable;
 
 	[Tooltip("Seconds to wait before trying to trigger an aim apply while mouse is being held. There is" +
-			 " no need to re-trigger aim apply every frame and sometimes those triggers can be expensive, so" +
-			 " this can be set to avoid that. It should be set low enough so that every AimApply interaction" +
-			 " triggers frequently enough (for example, based on the fastest-firing gun).")]
+	         " no need to re-trigger aim apply every frame and sometimes those triggers can be expensive, so" +
+	         " this can be set to avoid that. It should be set low enough so that every AimApply interaction" +
+	         " triggers frequently enough (for example, based on the fastest-firing gun).")]
 	public float AimApplyInterval = 0.01f;
+
 	//value used to check against the above while mouse is being held down.
 	private float secondsSinceLastAimApplyTrigger;
 
-	private readonly Dictionary<Vector2, Tuple<Color, float>> RecentTouches = new Dictionary<Vector2, Tuple<Color, float>>();
+	private readonly Dictionary<Vector2, Tuple<Color, float>> RecentTouches =
+		new Dictionary<Vector2, Tuple<Color, float>>();
+
 	private readonly List<Vector2> touchesToDitch = new List<Vector2>();
 	private PlayerMove playerMove;
 	private Directional playerDirectional;
+
 	/// reference to the global lighting system, used to check occlusion
 	private LightingSystem lightingSystem;
 
@@ -56,13 +63,13 @@ public class MouseInputController : MonoBehaviour
 
 	private void OnDrawGizmos()
 	{
-
 		if (touchesToDitch.Count > 0)
 		{
 			foreach (var touch in touchesToDitch)
 			{
 				RecentTouches.Remove(touch);
 			}
+
 			touchesToDitch.Clear();
 		}
 
@@ -84,7 +91,6 @@ public class MouseInputController : MonoBehaviour
 				touchesToDitch.Add(info.Key);
 			}
 		}
-
 	}
 
 	public virtual void Start()
@@ -121,7 +127,6 @@ public class MouseInputController : MonoBehaviour
 
 		if (CommonInput.GetMouseButtonDown(0))
 		{
-
 			//check ctrl+click for dragging
 			if (KeyboardInputManager.IsControlPressed())
 			{
@@ -173,7 +178,6 @@ public class MouseInputController : MonoBehaviour
 					//no possibility of dragging something, proceed to normal click logic
 					CheckClickInteractions(true);
 				}
-
 			}
 		}
 		else if (CommonInput.GetMouseButton(0))
@@ -188,7 +192,7 @@ public class MouseInputController : MonoBehaviour
 				if (!(UIManager.CurrentIntent == Intent.Harm) && !(UIManager.CurrentIntent == Intent.Disarm))
 				{
 					var currentOffset = MouseWorldPosition - potentialDraggable.transform.position;
-					if (((Vector2)currentOffset - dragStartOffset).magnitude > MouseDragDeadzone)
+					if (((Vector2) currentOffset - dragStartOffset).magnitude > MouseDragDeadzone)
 					{
 						potentialDraggable.BeginDrag();
 						potentialDraggable = null;
@@ -198,7 +202,6 @@ public class MouseInputController : MonoBehaviour
 
 			//continue to trigger the aim apply if it was initially triggered
 			CheckAimApply(MouseButtonState.HOLD);
-
 		}
 		else if (CommonInput.GetMouseButtonUp(0))
 		{
@@ -305,6 +308,7 @@ public class MouseInputController : MonoBehaviour
 				{
 					lastHoveredThing.transform.SendMessageUpwards("OnHoverEnd", SendMessageOptions.DontRequireReceiver);
 				}
+
 				hit.transform.SendMessageUpwards("OnHoverStart", SendMessageOptions.DontRequireReceiver);
 				transform.SendMessage("OnHoverStart", SendMessageOptions.DontRequireReceiver);
 				lastHoveredThing = hit;
@@ -317,7 +321,8 @@ public class MouseInputController : MonoBehaviour
 
 	private void TrySlide()
 	{
-		if (PlayerManager.PlayerScript.IsGhost || PlayerManager.PlayerScript.playerHealth.ConsciousState != ConsciousState.CONSCIOUS)
+		if (PlayerManager.PlayerScript.IsGhost ||
+		    PlayerManager.PlayerScript.playerHealth.ConsciousState != ConsciousState.CONSCIOUS)
 			return;
 		PlayerManager.PlayerScript.playerNetworkActions.CmdSlideItem(Vector3Int.RoundToInt(MouseWorldPosition));
 	}
@@ -348,8 +353,12 @@ public class MouseInputController : MonoBehaviour
 			{
 				if (CheckHandApply(applyTarget)) return true;
 			}
+
 			//check empty space positional hand apply
-			var posHandApply = PositionalHandApply.ByLocalPlayer(null);
+			var posHandApply = PositionalHandApply.ByLocalPlayer(MatrixManager
+				.AtPoint(
+					(Camera.main.ScreenToWorldPoint(CommonInput.mousePosition) -
+					 PlayerManager.LocalPlayer.transform.position).RoundToInt(), false).GameObject.transform.parent.gameObject);
 			if (posHandApply.HandObject != null)
 			{
 				var handAppliables = posHandApply.HandObject.GetComponents<IBaseInteractable<PositionalHandApply>>()
@@ -379,7 +388,8 @@ public class MouseInputController : MonoBehaviour
 		{
 			//get all components that can handapply or PositionalHandApply
 			var handAppliables = handApply.HandObject.GetComponents<MonoBehaviour>()
-				.Where(c => c != null && c.enabled && (c is IBaseInteractable<HandApply> || c is IBaseInteractable<PositionalHandApply>));
+				.Where(c => c != null && c.enabled &&
+				            (c is IBaseInteractable<HandApply> || c is IBaseInteractable<PositionalHandApply>));
 			Logger.LogTraceFormat("Checking HandApply / PositionalHandApply interactions from {0} targeting {1}",
 				Category.Interaction, handApply.HandObject.name, target.name);
 
@@ -400,7 +410,8 @@ public class MouseInputController : MonoBehaviour
 
 		//call the hand apply interaction methods on the target object if it has any
 		var targetHandAppliables = handApply.TargetObject.GetComponents<MonoBehaviour>()
-			.Where(c => c != null && c.enabled && (c is IBaseInteractable<HandApply> || c is IBaseInteractable<PositionalHandApply>));
+			.Where(c => c != null && c.enabled &&
+			            (c is IBaseInteractable<HandApply> || c is IBaseInteractable<PositionalHandApply>));
 		foreach (var targetHandAppliable in targetHandAppliables.Reverse())
 		{
 			if (targetHandAppliable is IBaseInteractable<HandApply>)
@@ -508,7 +519,8 @@ public class MouseInputController : MonoBehaviour
 	{
 		var clickedObject = MouseUtils.GetOrderedObjectsUnderMouse(null, null).FirstOrDefault();
 		if (!clickedObject) return;
-		if (PlayerManager.PlayerScript.IsGhost || PlayerManager.PlayerScript.playerHealth.ConsciousState != ConsciousState.CONSCIOUS)
+		if (PlayerManager.PlayerScript.IsGhost ||
+		    PlayerManager.PlayerScript.playerHealth.ConsciousState != ConsciousState.CONSCIOUS)
 			return;
 		PlayerManager.PlayerScript.playerNetworkActions.CmdPoint(clickedObject, MouseWorldPosition);
 	}
@@ -547,7 +559,8 @@ public class MouseInputController : MonoBehaviour
 					objects.RemoveAll(obj =>
 						obj.GetComponent<WallmountBehavior>() != null &&
 						obj.GetComponent<WallmountBehavior>().IsHiddenFromLocalPlayer() ||
-						obj.TryGetComponent(out NetworkedMatrix netMatrix)); // Test to see if station (or shuttle) itself.
+						obj.TryGetComponent(
+							out NetworkedMatrix netMatrix)); // Test to see if station (or shuttle) itself.
 					LayerTile tile = UITileList.GetTileAtPosition(position);
 					ControlTabs.ShowItemListTab(objects, tile, position);
 				}
@@ -559,13 +572,16 @@ public class MouseInputController : MonoBehaviour
 				MatrixManager.ForMatrixAt(position, true, (matrix, localPos) =>
 				{
 					matrix.SubsystemManager.UpdateAt(localPos);
-					Logger.LogFormat($"Forcefully updated atmos at worldPos {position}/ localPos {localPos} of {matrix.Name}");
+					Logger.LogFormat(
+						$"Forcefully updated atmos at worldPos {position}/ localPos {localPos} of {matrix.Name}");
 				});
 
 				Chat.AddLocalMsgToChat("Ping " + DateTime.Now.ToFileTimeUtc(), PlayerManager.LocalPlayer);
 			}
+
 			return true;
 		}
+
 		return false;
 	}
 
@@ -578,6 +594,7 @@ public class MouseInputController : MonoBehaviour
 			{
 				return false;
 			}
+
 			Vector3 targetPosition = MouseWorldPosition;
 			targetPosition.z = 0f;
 
@@ -586,12 +603,13 @@ public class MouseInputController : MonoBehaviour
 			Vector3 targetVector = targetPosition - PlayerManager.LocalPlayer.transform.position;
 
 			PlayerManager.LocalPlayerScript.playerNetworkActions.CmdThrow(currentSlot.NamedSlot,
-				targetVector, (int)UIManager.DamageZone);
+				targetVector, (int) UIManager.DamageZone);
 
 			//Disabling throw button
 			UIManager.Action.Throw();
 			return true;
 		}
+
 		return false;
 	}
 
@@ -611,11 +629,10 @@ public class MouseInputController : MonoBehaviour
 
 	#region Cursor Textures
 
-	[Header("Examine Cursor Settings")]
-	[SerializeField]
+	[Header("Examine Cursor Settings")] [SerializeField]
 	private Texture2D examineCursor = default;
-	[SerializeField]
-	private Vector2 cursorOffset = Vector2.zero;
+
+	[SerializeField] private Vector2 cursorOffset = Vector2.zero;
 
 	private bool isShowingExamineCursor = false;
 	private static Texture2D currentCursorTexture = null;

--- a/UnityProject/Assets/Scripts/Items/Tool/Pickaxe.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/Pickaxe.cs
@@ -8,6 +8,11 @@ using AddressableReferences;
 public class Pickaxe : MonoBehaviour, ICheckedInteractable<PositionalHandApply>
 {
 	[SerializeField] private AddressableAudioSource pickaxeSound = null;
+
+	[Tooltip("How much does this tool multiply mining time")] [SerializeField]
+	private float timeMultiplier = 1f;
+	public float TimeMultiplier => timeMultiplier;
+
 	private static readonly StandardProgressActionConfig ProgressConfig =
 		new StandardProgressActionConfig(StandardProgressActionType.Construction, true);
 
@@ -33,10 +38,11 @@ public class Pickaxe : MonoBehaviour, ICheckedInteractable<PositionalHandApply>
 		//technically pickaxe is deconstruction, so it would interrupt any construction / deconstruction being done
 		//on that tile
 		//TODO: Refactor this to use ToolUtils once that's merged in
+		var interactableTiles = interaction.TargetObject.GetComponent<InteractableTiles>();
+		var wallTile = interactableTiles.MetaTileMap.GetTileAtWorldPos(interaction.WorldPositionTarget, LayerType.Walls) as BasicTile;
+		var calculatedTime = wallTile.MiningTime * timeMultiplier;
 
-		var bar = StandardProgressAction.Create(ProgressConfig, ProgressComplete)
-			.ServerStartProgress(interaction.WorldPositionTarget.RoundToInt(),
-				5f, interaction.Performer);
+		var bar = StandardProgressAction.Create(ProgressConfig, ProgressComplete).ServerStartProgress(interaction.WorldPositionTarget.RoundToInt(), calculatedTime, interaction.Performer);
 		if (bar != null)
 		{
 			SoundManager.PlayNetworkedAtPos(pickaxeSound, interaction.WorldPositionTarget, sourceObj: interaction.Performer);

--- a/UnityProject/Assets/Scripts/Objects/Mining/PickaxeMineable.cs
+++ b/UnityProject/Assets/Scripts/Objects/Mining/PickaxeMineable.cs
@@ -1,42 +1,15 @@
-﻿using System.Collections;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace Objects.Mining
 {
 	/// <summary>
 	/// Simple script to allow objects to be mined. Destroys the object upon completion.
 	/// </summary>
-	public class PickaxeMineable : MonoBehaviour, ICheckedInteractable<HandApply>
+	public class PickaxeMineable : MonoBehaviour
 	{
-		[SerializeField]
-		private float mineTime = 3;
+		[SerializeField] private float mineTime = 3;
+		public float MineTime => mineTime;
 
-		private string objectName;
-
-		public bool WillInteract(HandApply interaction, NetworkSide side)
-		{
-			objectName = gameObject.ExpensiveName();
-
-			if (DefaultWillInteract.Default(interaction, side) == false) return false;
-
-			return Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.Pickaxe);
-		}
-
-		public void ServerPerformInteraction(HandApply interaction)
-		{
-			var calculatedMineTime = interaction.HandObject.GetComponent<Pickaxe>().TimeMultiplier * mineTime;
-
-			ToolUtils.ServerUseToolWithActionMessages(
-					interaction, calculatedMineTime,
-					$"You start mining the {objectName}...",
-					$"{interaction.Performer.ExpensiveName()} starts mining the {objectName}...",
-					default, default,
-					() =>
-					{
-						SoundManager.PlayNetworkedAtPos(SingletonSOSounds.Instance.BreakStone,
-								interaction.PerformerPlayerScript.WorldPos, sourceObj: interaction.Performer);
-						Despawn.ServerSingle(gameObject);
-					});
-		}
+	
 	}
 }

--- a/UnityProject/Assets/Scripts/Objects/Mining/PickaxeMineable.cs
+++ b/UnityProject/Assets/Scripts/Objects/Mining/PickaxeMineable.cs
@@ -24,8 +24,10 @@ namespace Objects.Mining
 
 		public void ServerPerformInteraction(HandApply interaction)
 		{
+			var calculatedMineTime = interaction.HandObject.GetComponent<Pickaxe>().TimeMultiplier * mineTime;
+
 			ToolUtils.ServerUseToolWithActionMessages(
-					interaction, mineTime,
+					interaction, calculatedMineTime,
 					$"You start mining the {objectName}...",
 					$"{interaction.Performer.ExpensiveName()} starts mining the {objectName}...",
 					default, default,

--- a/UnityProject/Assets/Scripts/Tilemaps/Tiles/BasicTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Tiles/BasicTile.cs
@@ -33,7 +33,8 @@ public abstract class BasicTile : LayerTile
 
 	[Tooltip("Can this tile be mined?")] [FormerlySerializedAs("Mineable")] [SerializeField]
 	private bool mineable = false;
-
+	[Tooltip("How long does it take to mine this tile?")] [SerializeField] [ShowIf(nameof(mineable))]
+	private float miningTime = 5f;
 
 	[Range(0.0f, 1f)] [Tooltip("RadiationPassability 0 = 100% Resistant")] [SerializeField]
 	public float RadiationPassability = 1;
@@ -42,6 +43,7 @@ public abstract class BasicTile : LayerTile
 	/// Can this tile be mined?
 	/// </summary>
 	public bool Mineable => mineable;
+	public float MiningTime => miningTime;
 
 	[Tooltip("Will bullets bounce from this tile?")] [SerializeField]
 	private bool doesReflectBullet = false;


### PR DESCRIPTION
### Purpose
This PR addresses the pickaxe half of #4901. Rather than mining speed being static, each tile can have a configurable mining speed and the quality of the pickaxe being used modifies that speed.

### Notes:

- Tiles have a configurable mining time. Default is the same as what the static mining time was (5 seconds).
- Pickaxes have a mining speed modifier
- Different pickaxes also had their damage numbers modified to mirror their /tg/ counterparts (most were already correct)
- This update also works with PickaxeMineable objects
- The Mining Vendor prefab now includes a single silver plated pickaxe for one lucky miner.

Tested smashing rocks and rock walls in editor, and it works. Thanks for the help, @corp-0!

### Changelog:

CL: Different tiers of pickaxes have varying mining speeds.

