### PR TITLE
Fix bug where single instances of stackable items couldn't be put in food processors.

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Machines/FoodProcessor.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/FoodProcessor.cs
@@ -195,7 +195,7 @@ namespace Objects.Kitchen
 
 			//If there's a stackable component, add one at a time.
 			Stackable stack = fromSlot.ItemObject.GetComponent<Stackable>();
-			if (stack == null)
+			if (stack == null || stack.Amount == 1)
 			{
 				Inventory.ServerTransfer(fromSlot, storage.GetNextFreeIndexedSlot());
 			}


### PR DESCRIPTION
### Purpose
- Title. For some reason, if you had just one cutlet you couldn't put it into a food processor but if you had more then you could.