### PR TITLE
Gun fire delay, grille, and wall mount adjustments.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/PlasmaCutter.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/PlasmaCutter.prefab
@@ -218,6 +218,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6648593666208859230, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
+      propertyPath: FireDelay
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6648593666208859230, guid: 143d3926d4a5fa84f95f987c152b33a2,
+        type: 3}
       propertyPath: Projectile
       value: 
       objectReference: {fileID: 5076580856386662130, guid: f65f1f0bd0295df468272b3d767985a7,

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/PlasmaCutterAdvanced.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/PlasmaCutterAdvanced.prefab
@@ -15,10 +15,20 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 4097648565813734964, guid: a12add7b219842843b678dec171704cb,
         type: 3}
+      propertyPath: FireDelay
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4097648565813734964, guid: a12add7b219842843b678dec171704cb,
+        type: 3}
       propertyPath: Projectile
       value: 
       objectReference: {fileID: 1791094763296440269, guid: 8671f227240c2ab468b1568a2a321d0d,
         type: 3}
+    - target: {fileID: 4097648565813734964, guid: a12add7b219842843b678dec171704cb,
+        type: 3}
+      propertyPath: firemodeUsage.Array.data[0]
+      value: 100
+      objectReference: {fileID: 0}
     - target: {fileID: 4097648565813734964, guid: a12add7b219842843b678dec171704cb,
         type: 3}
       propertyPath: firemodeProjectiles.Array.data[0]
@@ -31,11 +41,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1791094763296440269, guid: 8671f227240c2ab468b1568a2a321d0d,
         type: 3}
-    - target: {fileID: 4097648565813734964, guid: a12add7b219842843b678dec171704cb,
-        type: 3}
-      propertyPath: firemodeUsage.Array.data[0]
-      value: 100
-      objectReference: {fileID: 0}
     - target: {fileID: 5865673803328853950, guid: a12add7b219842843b678dec171704cb,
         type: 3}
       propertyPath: oreEff
@@ -58,6 +63,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6439005145208020592, guid: a12add7b219842843b678dec171704cb,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6439005145208020592, guid: a12add7b219842843b678dec171704cb,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -73,6 +83,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6439005145208020592, guid: a12add7b219842843b678dec171704cb,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6439005145208020592, guid: a12add7b219842843b678dec171704cb,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -85,16 +100,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6439005145208020592, guid: a12add7b219842843b678dec171704cb,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6439005145208020592, guid: a12add7b219842843b678dec171704cb,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6439005145208020592, guid: a12add7b219842843b678dec171704cb,
         type: 3}
@@ -119,10 +124,14 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 6892171559748815974, guid: a12add7b219842843b678dec171704cb,
         type: 3}
-      propertyPath: itemSprites.SpriteInventoryIcon
-      value: 
-      objectReference: {fileID: 11400000, guid: aceda5d47f145de4e836cbc3609f1e39,
-        type: 2}
+      propertyPath: hitDamage
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 6892171559748815974, guid: a12add7b219842843b678dec171704cb,
+        type: 3}
+      propertyPath: initialName
+      value: advanced plasma cutter
+      objectReference: {fileID: 0}
     - target: {fileID: 6892171559748815974, guid: a12add7b219842843b678dec171704cb,
         type: 3}
       propertyPath: itemSprites.SpriteLeftHand
@@ -137,14 +146,10 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 6892171559748815974, guid: a12add7b219842843b678dec171704cb,
         type: 3}
-      propertyPath: hitDamage
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 6892171559748815974, guid: a12add7b219842843b678dec171704cb,
-        type: 3}
-      propertyPath: initialName
-      value: advanced plasma cutter
-      objectReference: {fileID: 0}
+      propertyPath: itemSprites.SpriteInventoryIcon
+      value: 
+      objectReference: {fileID: 11400000, guid: aceda5d47f145de4e836cbc3609f1e39,
+        type: 2}
     - target: {fileID: 7503013728425484879, guid: a12add7b219842843b678dec171704cb,
         type: 3}
       propertyPath: Projectile

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/ProtoKineticAccelerator.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/ProtoKineticAccelerator.prefab
@@ -48,7 +48,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
-  FireRate: 1
+  FireDelay: 0
   MaxRecoilVariance: 0
   ProjectileVelocity: 20
   CameraRecoilConfig:
@@ -61,7 +61,7 @@ MonoBehaviour:
   isSuppressible: 0
   Projectile: {fileID: 7081206667275519994, guid: a4c2debd67d612549b05801d1e37121a,
     type: 3}
-  rechargeTime: 2
+  rechargeTime: 1.6
 --- !u!1001 &326958216201229889
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ArcaneBarrage.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ArcaneBarrage.prefab
@@ -29,15 +29,10 @@ PrefabInstance:
       propertyPath: FiringSoundA.AssetAddress
       value: Assets/Prefabs/Weapons/Emitter1.prefab
       objectReference: {fileID: 0}
-    - target: {fileID: 6970262102394163030, guid: 9d7a1224aab0bcf4bb04bf191b1b92ab,
-        type: 3}
-      propertyPath: FiringSoundA.AssetAddress
-      value: Assets/Prefabs/GunShots/ShootGun01.prefab
-      objectReference: {fileID: 0}
     - target: {fileID: 6286671915031241087, guid: 9d7a1224aab0bcf4bb04bf191b1b92ab,
         type: 3}
       propertyPath: SuppressedSoundA.AssetAddress
-      value: Assets/Prefabs/GunShots/ShootHeavySuppressed.prefab
+      value: null
       objectReference: {fileID: 0}
     - target: {fileID: 6970262102394163030, guid: 9d7a1224aab0bcf4bb04bf191b1b92ab,
         type: 3}
@@ -53,6 +48,11 @@ PrefabInstance:
         type: 3}
       propertyPath: initialTraits.Array.size
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6970262102394163030, guid: 9d7a1224aab0bcf4bb04bf191b1b92ab,
+        type: 3}
+      propertyPath: FiringSoundA.AssetAddress
+      value: Assets/Prefabs/GunShots/ShootGun01.prefab
       objectReference: {fileID: 0}
     - target: {fileID: 6970262102394163030, guid: 9d7a1224aab0bcf4bb04bf191b1b92ab,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/BuzzsawLMG.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/BuzzsawLMG.prefab
@@ -372,6 +372,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
+      propertyPath: allowPinSwap
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
       propertyPath: MaxRecoilVariance
       value: 0.1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/BuzzsawLMG.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/BuzzsawLMG.prefab
@@ -339,6 +339,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
+      propertyPath: FireDelay
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
       propertyPath: pinPrefab
       value: 
       objectReference: {fileID: 109032868588680718, guid: 445a2ff9261814a549e8c255bb2580aa,
@@ -364,11 +369,6 @@ PrefabInstance:
         type: 3}
       propertyPath: FiringSound
       value: ShootLMG
-      objectReference: {fileID: 0}
-    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
-        type: 3}
-      propertyPath: allowPinSwap
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/BuzzsawLMGUnrestricted.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/BuzzsawLMGUnrestricted.prefab
@@ -13,11 +13,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 6004521592186936485, guid: 0c0328cbf94ffe648a0903cfc375ab91,
         type: 3}
-    - target: {fileID: 1324267755354293044, guid: 24274bda3be42c049b4bbb150f6e1220,
-        type: 3}
-      propertyPath: allowPinSwap
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 2494139950867988427, guid: 24274bda3be42c049b4bbb150f6e1220,
         type: 3}
       propertyPath: m_AssetId

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/BuzzsawLMGUnrestricted.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/BuzzsawLMGUnrestricted.prefab
@@ -13,6 +13,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 6004521592186936485, guid: 0c0328cbf94ffe648a0903cfc375ab91,
         type: 3}
+    - target: {fileID: 1324267755354293044, guid: 24274bda3be42c049b4bbb150f6e1220,
+        type: 3}
+      propertyPath: allowPinSwap
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 2494139950867988427, guid: 24274bda3be42c049b4bbb150f6e1220,
         type: 3}
       propertyPath: m_AssetId

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/GyrojetPistol.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/GyrojetPistol.prefab
@@ -98,6 +98,7 @@ MonoBehaviour:
   NetworkThis: 1
   SubCatalogue: []
   PresentSpriteSet: {fileID: 11400000, guid: 68d6204907c89fb458b2c20d5cac9e29, type: 2}
+  randomInitialSprite: 0
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
@@ -117,6 +118,16 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
+      propertyPath: ammoType
+      value: 22
+      objectReference: {fileID: 0}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
+      propertyPath: FireDelay
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
       propertyPath: Projectile
       value: 
       objectReference: {fileID: 8845835597986653018, guid: fe456d0652b2f9f4ea2de10cb9d53f46,
@@ -127,11 +138,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 8247028017654424761, guid: 48fb45b026de3524f96ca5d6436a248b,
         type: 3}
-    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
-        type: 3}
-      propertyPath: ammoType
-      value: 22
-      objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
       propertyPath: FiringSoundA.AssetAddress
@@ -155,6 +161,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -170,6 +181,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -182,16 +198,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
@@ -216,13 +222,13 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 8614656532152377136, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
-      propertyPath: initialDescription
-      value: A prototype pistol designed to fire self propelled rockets.
+      propertyPath: initialName
+      value: gyrojet pistol
       objectReference: {fileID: 0}
     - target: {fileID: 8614656532152377136, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
-      propertyPath: initialName
-      value: gyrojet pistol
+      propertyPath: initialDescription
+      value: A prototype pistol designed to fire self propelled rockets.
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a940a8ef1ee65024fb0a322703040d98, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/M1928ThompsonSMG.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/M1928ThompsonSMG.prefab
@@ -133,6 +133,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
+      propertyPath: FireDelay
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
       propertyPath: Projectile
       value: 
       objectReference: {fileID: 3824486057130847694, guid: 9287d438528b5ee41a03791cf9fcebb0,

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/M90glCarbine.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/M90glCarbine.prefab
@@ -264,11 +264,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
-      propertyPath: allowPinSwap
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
-        type: 3}
       propertyPath: MaxRecoilVariance
       value: 0.08
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Migraine50SniperRifle.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Migraine50SniperRifle.prefab
@@ -285,6 +285,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
+      propertyPath: allowPinSwap
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
       propertyPath: ProjectileVelocity
       value: 40
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Migraine50SniperRifle.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Migraine50SniperRifle.prefab
@@ -220,9 +220,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  currentClothData: {fileID: 11400000, guid: 5f1350a734e527941bd7c6eec964a984, type: 2}
   allClothingData:
   - {fileID: 11400000, guid: acc8946229aa8834f8dd2ea8533648ff, type: 2}
+  CurrentClothIndex: 0
   randomInitialClothData: 0
   hidesIdentity: 0
   hidesSlots: 0
@@ -257,6 +257,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
+      propertyPath: FireDelay
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
       propertyPath: pinPrefab
       value: 
       objectReference: {fileID: 109032868588680718, guid: 445a2ff9261814a549e8c255bb2580aa,
@@ -277,11 +282,6 @@ PrefabInstance:
         type: 3}
       propertyPath: FiringSound
       value: ShootLMG
-      objectReference: {fileID: 0}
-    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
-        type: 3}
-      propertyPath: allowPinSwap
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Migraine50SniperRifleUnrestricted.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Migraine50SniperRifleUnrestricted.prefab
@@ -88,5 +88,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 6004521592186936485, guid: 0c0328cbf94ffe648a0903cfc375ab91,
         type: 3}
+    - target: {fileID: 7753174079917532174, guid: 24b21da59a1c48248805096709dceca1,
+        type: 3}
+      propertyPath: allowPinSwap
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 24b21da59a1c48248805096709dceca1, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Migraine50SniperRifleUnrestricted.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Migraine50SniperRifleUnrestricted.prefab
@@ -88,10 +88,5 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 6004521592186936485, guid: 0c0328cbf94ffe648a0903cfc375ab91,
         type: 3}
-    - target: {fileID: 7753174079917532174, guid: 24b21da59a1c48248805096709dceca1,
-        type: 3}
-      propertyPath: allowPinSwap
-      value: 1
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 24b21da59a1c48248805096709dceca1, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/MosinNagantM1891.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/MosinNagantM1891.prefab
@@ -117,14 +117,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  currentClothData: {fileID: 11400000, guid: 3a3fee0c989e9fb41a6aa909ffd71fdc, type: 2}
   allClothingData:
   - {fileID: 11400000, guid: 48a85cb1bc55f854c868e47536157d9c, type: 2}
+  CurrentClothIndex: 0
   randomInitialClothData: 0
   hidesIdentity: 0
   hidesSlots: 0
   hideClothingFlags: 0
-  SpriteDataSO: []
 --- !u!114 &4221194372170591464
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -161,6 +160,11 @@ PrefabInstance:
         type: 3}
       propertyPath: ammoType
       value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 1126689358047389511, guid: f0c995ee924eb904dae952cd56a8c1d6,
+        type: 3}
+      propertyPath: FireDelay
+      value: 1.5
       objectReference: {fileID: 0}
     - target: {fileID: 1126689358047389511, guid: f0c995ee924eb904dae952cd56a8c1d6,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Pistols/MakarovPistol.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Pistols/MakarovPistol.prefab
@@ -330,6 +330,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
+      propertyPath: FireDelay
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
       propertyPath: Projectile
       value: 
       objectReference: {fileID: 6911475130857718571, guid: 40ea4aea218be439eaf29f853612870c,

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Pistols/Punisher44Mag.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Pistols/Punisher44Mag.prefab
@@ -9,6 +9,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1176912263951196322, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
         type: 3}
+      propertyPath: hitDamage
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 1176912263951196322, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
+        type: 3}
       propertyPath: initialName
       value: Punisher .44 Mag pistol
       objectReference: {fileID: 0}
@@ -16,11 +21,6 @@ PrefabInstance:
         type: 3}
       propertyPath: initialDescription
       value: A robust .44 handgun.
-      objectReference: {fileID: 0}
-    - target: {fileID: 1176912263951196322, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
-        type: 3}
-      propertyPath: hitDamage
-      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 1305095031322091924, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
         type: 3}
@@ -33,6 +33,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 013fe2712ccbda146924992ee4e22f32,
         type: 3}
+    - target: {fileID: 1633438751717143220, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1633438751717143220, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -50,6 +55,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1633438751717143220, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1633438751717143220, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -62,16 +72,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1633438751717143220, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1633438751717143220, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1633438751717143220, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
         type: 3}
@@ -111,19 +111,25 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 2869036814349520523, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
         type: 3}
+      propertyPath: FireRate
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2869036814349520523, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
+        type: 3}
       propertyPath: ammoType
       value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 2869036814349520523, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
         type: 3}
-      propertyPath: FiringSound
-      value: ShootGun04
+      propertyPath: FireDelay
+      value: 0.75
       objectReference: {fileID: 0}
     - target: {fileID: 2869036814349520523, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
         type: 3}
-      propertyPath: FireRate
-      value: 3
-      objectReference: {fileID: 0}
+      propertyPath: Projectile
+      value: 
+      objectReference: {fileID: 21396104557255652, guid: b050e4c5d57a78745b27d25436f42c04,
+        type: 3}
     - target: {fileID: 2869036814349520523, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
         type: 3}
       propertyPath: ammoPrefab
@@ -132,10 +138,9 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 2869036814349520523, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
         type: 3}
-      propertyPath: Projectile
-      value: 
-      objectReference: {fileID: 21396104557255652, guid: b050e4c5d57a78745b27d25436f42c04,
-        type: 3}
+      propertyPath: FiringSound
+      value: ShootGun04
+      objectReference: {fileID: 0}
     - target: {fileID: 2869036814349520523, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
         type: 3}
       propertyPath: FiringSoundA.AssetAddress

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Pistols/StechkinMachinePistol.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Pistols/StechkinMachinePistol.prefab
@@ -9,14 +9,14 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1176912263951196322, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
         type: 3}
-      propertyPath: initialDescription
-      value: An old Soviet machine pistol. It fires quickly, but kicks like a mule.
-        Uses 9mm ammo. Has a threaded barrel for suppressors.
+      propertyPath: initialName
+      value: Stechkin machine pistol
       objectReference: {fileID: 0}
     - target: {fileID: 1176912263951196322, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
         type: 3}
-      propertyPath: initialName
-      value: Stechkin machine pistol
+      propertyPath: initialDescription
+      value: An old Soviet machine pistol. It fires quickly, but kicks like a mule.
+        Uses 9mm ammo. Has a threaded barrel for suppressors.
       objectReference: {fileID: 0}
     - target: {fileID: 1461792321626733724, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
         type: 3}
@@ -24,6 +24,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 845e0a00f7a66664ab47921e9672c123,
         type: 3}
+    - target: {fileID: 1633438751717143220, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1633438751717143220, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -41,6 +46,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1633438751717143220, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1633438751717143220, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -53,16 +63,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1633438751717143220, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1633438751717143220, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1633438751717143220, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
         type: 3}
@@ -97,25 +97,35 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 2869036814349520523, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
         type: 3}
+      propertyPath: FireRate
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2869036814349520523, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
+        type: 3}
       propertyPath: ammoType
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2869036814349520523, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
         type: 3}
-      propertyPath: FireRate
-      value: 3
+      propertyPath: FireDelay
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2869036814349520523, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
+        type: 3}
+      propertyPath: Projectile
+      value: 
+      objectReference: {fileID: 6911475130857718571, guid: 40ea4aea218be439eaf29f853612870c,
+        type: 3}
+    - target: {fileID: 2869036814349520523, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
+        type: 3}
+      propertyPath: WeaponType
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 2869036814349520523, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
         type: 3}
       propertyPath: ammoPrefab
       value: 
       objectReference: {fileID: 1104235240792570141, guid: 623189688b8953843aa87c899f5b0c31,
-        type: 3}
-    - target: {fileID: 2869036814349520523, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
-        type: 3}
-      propertyPath: Projectile
-      value: 
-      objectReference: {fileID: 6911475130857718571, guid: 40ea4aea218be439eaf29f853612870c,
         type: 3}
     - target: {fileID: 4621994112007018205, guid: 29de35ce9f3e2ae4daa8de0460cc3009,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Revolvers/Lucifer357Mag.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Revolvers/Lucifer357Mag.prefab
@@ -26,6 +26,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5749777290144094747, guid: b17740819c0bf4b44a53be1e477dc4d5,
         type: 3}
+      propertyPath: FireDelay
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5749777290144094747, guid: b17740819c0bf4b44a53be1e477dc4d5,
+        type: 3}
       propertyPath: ammoPrefab
       value: 
       objectReference: {fileID: 782836474257692363, guid: 697318e0925068143a28d0a4fb8b5f10,

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Revolvers/P238Revolver.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Revolvers/P238Revolver.prefab
@@ -14,9 +14,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 597710880480496247, guid: 538cebc4fa9119344aa630d0f273bced,
         type: 3}
-      propertyPath: FiringSound
-      value: ShootGun04
-      objectReference: {fileID: 0}
+      propertyPath: Projectile
+      value: 
+      objectReference: {fileID: 5028489969333880017, guid: 7b41205052d6c7e4895869394631a735,
+        type: 3}
     - target: {fileID: 597710880480496247, guid: 538cebc4fa9119344aa630d0f273bced,
         type: 3}
       propertyPath: ammoPrefab
@@ -25,10 +26,9 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 597710880480496247, guid: 538cebc4fa9119344aa630d0f273bced,
         type: 3}
-      propertyPath: Projectile
-      value: 
-      objectReference: {fileID: 5028489969333880017, guid: 7b41205052d6c7e4895869394631a735,
-        type: 3}
+      propertyPath: FiringSound
+      value: ShootGun04
+      objectReference: {fileID: 0}
     - target: {fileID: 597710880480496247, guid: 538cebc4fa9119344aa630d0f273bced,
         type: 3}
       propertyPath: FiringSoundA.AssetAddress
@@ -43,6 +43,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: P238Revolver
+      objectReference: {fileID: 0}
+    - target: {fileID: 4120935267568350792, guid: 538cebc4fa9119344aa630d0f273bced,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4120935267568350792, guid: 538cebc4fa9119344aa630d0f273bced,
         type: 3}
@@ -61,6 +66,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4120935267568350792, guid: 538cebc4fa9119344aa630d0f273bced,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4120935267568350792, guid: 538cebc4fa9119344aa630d0f273bced,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -73,16 +83,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4120935267568350792, guid: 538cebc4fa9119344aa630d0f273bced,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4120935267568350792, guid: 538cebc4fa9119344aa630d0f273bced,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4120935267568350792, guid: 538cebc4fa9119344aa630d0f273bced,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/BulldozerShotgun.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/BulldozerShotgun.prefab
@@ -217,14 +217,12 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: 8c6ea41dc1f28f648bd3059e51b5272c,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 502150733691229820, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
       propertyPath: currentClothData
       value: 
-      objectReference: {fileID: 11400000, guid: 8c6ea41dc1f28f648bd3059e51b5272c,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 502150733691229820, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
       propertyPath: allClothingData.Array.data[0]
@@ -235,6 +233,11 @@ PrefabInstance:
         type: 3}
       propertyPath: FireRate
       value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
+      propertyPath: FireDelay
+      value: 0.2
       objectReference: {fileID: 0}
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
@@ -255,18 +258,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
-      propertyPath: allowPinSwap
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
-        type: 3}
       propertyPath: allowMagazineRemoval
       value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
-        type: 3}
-      propertyPath: DryFireSound.AssetAddress
-      value: null
       objectReference: {fileID: 0}
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/BulldozerShotgun.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/BulldozerShotgun.prefab
@@ -72,7 +72,7 @@ SpriteRenderer:
   m_SortingLayerID: -1463207863
   m_SortingLayer: 13
   m_SortingOrder: 41
-  m_Sprite: {fileID: 21300000, guid: 8a744ce4a899148499067592fdd98461, type: 3}
+  m_Sprite: {fileID: 21300002, guid: 8a744ce4a899148499067592fdd98461, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -254,6 +254,11 @@ PrefabInstance:
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
       propertyPath: MagInternal
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
+      propertyPath: allowPinSwap
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/RiotShotgun.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/RiotShotgun.prefab
@@ -44,6 +44,11 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
+      propertyPath: FireDelay
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
       propertyPath: Projectile
       value: 
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/S24CombatShotgun.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/S24CombatShotgun.prefab
@@ -106,6 +106,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3184326003018196787, guid: 0ed41d7e8ee57b545bf808b775a1f78c,
         type: 3}
+      propertyPath: FireDelay
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3184326003018196787, guid: 0ed41d7e8ee57b545bf808b775a1f78c,
+        type: 3}
       propertyPath: Projectile
       value: 
       objectReference: {fileID: 2003804624138751089, guid: 4adcadc588a9b69449a7184abef7ad19,
@@ -131,14 +136,12 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: fab86e3523e77e64a92d71c0fc8a9c96,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 3787017684866724271, guid: 0ed41d7e8ee57b545bf808b775a1f78c,
         type: 3}
       propertyPath: currentClothData
       value: 
-      objectReference: {fileID: 11400000, guid: fab86e3523e77e64a92d71c0fc8a9c96,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 3787017684866724271, guid: 0ed41d7e8ee57b545bf808b775a1f78c,
         type: 3}
       propertyPath: allClothingData.Array.data[0]

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/S3HunterShotgun.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/S3HunterShotgun.prefab
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 80ea89a879a2d3c8ba477fca535a2332, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ammoBackfire: 1
   sawnSize: 3
   sawnMaxRecoilVariance: 0.1
   SawnCameraRecoilConfig:
@@ -27,14 +28,13 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 502150733691229820, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
-      propertyPath: clothData
-      value: 
-      objectReference: {fileID: 11400000, guid: 2f7921bc922fa33468d86d1f6f8edd77,
-        type: 2}
-    - target: {fileID: 502150733691229820, guid: 3da1d244806a96340a48e959ecc816e4,
-        type: 3}
       propertyPath: MagSize
       value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 502150733691229820, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
+      propertyPath: clothData
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
@@ -48,15 +48,20 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
+      propertyPath: FireDelay
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
       propertyPath: Projectile
       value: 
       objectReference: {fileID: 2003804624138751089, guid: 0db28ea7632de0b4593a32bba473e844,
         type: 3}
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
-      propertyPath: Projectile
+      propertyPath: ammoPrefab
       value: 
-      objectReference: {fileID: 2003804624138751089, guid: 0db28ea7632de0b4593a32bba473e844,
+      objectReference: {fileID: 3210688012413455863, guid: 7920d9c4fad7b044c99cec907164f7e8,
         type: 3}
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/StalkerSMG.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/StalkerSMG.prefab
@@ -470,11 +470,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
-      propertyPath: allowPinSwap
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
-        type: 3}
       propertyPath: MaxRecoilVariance
       value: 0.05
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/StalkerSMG.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/StalkerSMG.prefab
@@ -470,6 +470,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
+      propertyPath: allowPinSwap
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
       propertyPath: MaxRecoilVariance
       value: 0.05
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/SurplusRifle.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/SurplusRifle.prefab
@@ -1,26 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &6964865487867032592
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 331383614235509145}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8e15827970984ba78808f03bc3f01586, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  currentClothData: {fileID: 11400000, guid: 3a3fee0c989e9fb41a6aa909ffd71fdc, type: 2}
-  allClothingData:
-  - {fileID: 11400000, guid: 48a85cb1bc55f854c868e47536157d9c, type: 2}
-  randomInitialClothData: 0
-  hidesIdentity: 0
-  hidesSlots: 0
-  hideClothingFlags: 0
 --- !u!1 &7211338498965613066
 GameObject:
   m_ObjectHideFlags: 0
@@ -124,6 +103,27 @@ MonoBehaviour:
   variantIndex: 0
   palette: []
   Sprites: []
+--- !u!114 &6964865487867032592
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 331383614235509145}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8e15827970984ba78808f03bc3f01586, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  allClothingData:
+  - {fileID: 11400000, guid: 48a85cb1bc55f854c868e47536157d9c, type: 2}
+  CurrentClothIndex: 0
+  randomInitialClothData: 0
+  hidesIdentity: 0
+  hidesSlots: 0
+  hideClothingFlags: 0
 --- !u!1001 &8501034030556885451
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -146,6 +146,11 @@ PrefabInstance:
         type: 3}
       propertyPath: ammoType
       value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
+      propertyPath: FireDelay
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/FoamForceShotgun.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/FoamForceShotgun.prefab
@@ -117,6 +117,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
+      propertyPath: FireDelay
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
       propertyPath: pinPrefab
       value: 
       objectReference: {fileID: 2924494414112422035, guid: 12279ffb7a1786457b2cb1622619a80c,

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/_GunBallisticAutomaticBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/_GunBallisticAutomaticBase.prefab
@@ -9,6 +9,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 5749777290144094747, guid: b17740819c0bf4b44a53be1e477dc4d5,
         type: 3}
+      propertyPath: FireDelay
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5749777290144094747, guid: b17740819c0bf4b44a53be1e477dc4d5,
+        type: 3}
       propertyPath: FiringSoundA.AssetAddress
       value: Assets/Prefabs/Weapons/Gun/SMG/SMGShot.prefab
       objectReference: {fileID: 0}
@@ -41,6 +46,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9128991954208744996, guid: b17740819c0bf4b44a53be1e477dc4d5,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9128991954208744996, guid: b17740819c0bf4b44a53be1e477dc4d5,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -56,6 +66,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9128991954208744996, guid: b17740819c0bf4b44a53be1e477dc4d5,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9128991954208744996, guid: b17740819c0bf4b44a53be1e477dc4d5,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -68,16 +83,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9128991954208744996, guid: b17740819c0bf4b44a53be1e477dc4d5,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9128991954208744996, guid: b17740819c0bf4b44a53be1e477dc4d5,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9128991954208744996, guid: b17740819c0bf4b44a53be1e477dc4d5,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/_GunBallisticBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/_GunBallisticBase.prefab
@@ -51,16 +51,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 2422759989583602921, guid: d819938d5d7681c4ba69845f60102a8c,
         type: 3}
-    - target: {fileID: 4644871529314044369, guid: da85b7a590e7c8444af73629fcb5dd22,
-        type: 3}
-      propertyPath: FiringSoundA.AssetAddress
-      value: Assets/Prefabs/GunShots/ShootGun01.prefab
-      objectReference: {fileID: 0}
-    - target: {fileID: 4644871529314044369, guid: da85b7a590e7c8444af73629fcb5dd22,
-        type: 3}
-      propertyPath: SuppressedSoundA.AssetAddress
-      value: Assets/Prefabs/GunShots/ShootHeavySuppressed.prefab
-      objectReference: {fileID: 0}
     - target: {fileID: 8109205671878849838, guid: da85b7a590e7c8444af73629fcb5dd22,
         type: 3}
       propertyPath: m_AssetId

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/_GunBallisticBoltActionBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/_GunBallisticBoltActionBase.prefab
@@ -12,21 +12,31 @@ PrefabInstance:
       propertyPath: FiringSoundA.AssetAddress
       value: Assets/Prefabs/Weapons/Gun/Rifle/RifleShot.prefab
       objectReference: {fileID: 0}
-    - target: {fileID: 8669052444454122546, guid: b17740819c0bf4b44a53be1e477dc4d5,
+    - target: {fileID: 5749777290144094747, guid: b17740819c0bf4b44a53be1e477dc4d5,
         type: 3}
-      propertyPath: initialDescription
-      value: Some kind of bolt action rifle. You get the feeling you shouldn't have
-        this.
+      propertyPath: SuppressedSoundA.AssetAddress
+      value: null
       objectReference: {fileID: 0}
     - target: {fileID: 8669052444454122546, guid: b17740819c0bf4b44a53be1e477dc4d5,
         type: 3}
       propertyPath: initialName
       value: Bolt Rifle
       objectReference: {fileID: 0}
+    - target: {fileID: 8669052444454122546, guid: b17740819c0bf4b44a53be1e477dc4d5,
+        type: 3}
+      propertyPath: initialDescription
+      value: Some kind of bolt action rifle. You get the feeling you shouldn't have
+        this.
+      objectReference: {fileID: 0}
     - target: {fileID: 9125194378051492688, guid: b17740819c0bf4b44a53be1e477dc4d5,
         type: 3}
       propertyPath: m_Name
       value: _GunBallisticBoltActionBase
+      objectReference: {fileID: 0}
+    - target: {fileID: 9128991954208744996, guid: b17740819c0bf4b44a53be1e477dc4d5,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9128991954208744996, guid: b17740819c0bf4b44a53be1e477dc4d5,
         type: 3}
@@ -45,6 +55,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9128991954208744996, guid: b17740819c0bf4b44a53be1e477dc4d5,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9128991954208744996, guid: b17740819c0bf4b44a53be1e477dc4d5,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -57,16 +72,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9128991954208744996, guid: b17740819c0bf4b44a53be1e477dc4d5,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9128991954208744996, guid: b17740819c0bf4b44a53be1e477dc4d5,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9128991954208744996, guid: b17740819c0bf4b44a53be1e477dc4d5,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Energy/EnergyCrossbowMini.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Energy/EnergyCrossbowMini.prefab
@@ -30,6 +30,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 177576810467860530, guid: ad527ba4de069794796e314f236794f4,
         type: 3}
+      propertyPath: rechargeTime
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 177576810467860530, guid: ad527ba4de069794796e314f236794f4,
+        type: 3}
       propertyPath: FiringSoundA.AssetAddress
       value: Assets/Prefabs/Weapons/Gun/General/GeneralHeavyShotSuppressed.prefab
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Energy/TaserHybridV43.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Energy/TaserHybridV43.prefab
@@ -37,13 +37,24 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 4387921172387687617, guid: d589c17f6fd91da4190edfdd2cb5aa53,
         type: 3}
-      propertyPath: firemodeProjectiles.Array.size
+      propertyPath: FireRate
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4387921172387687617, guid: d589c17f6fd91da4190edfdd2cb5aa53,
+        type: 3}
+      propertyPath: FireDelay
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4387921172387687617, guid: d589c17f6fd91da4190edfdd2cb5aa53,
         type: 3}
-      propertyPath: firemodeFiringSound.Array.size
-      value: 2
+      propertyPath: Projectile
+      value: 
+      objectReference: {fileID: 5951038657140010356, guid: 00552b9802a37ba4bbe1aca46515b240,
+        type: 3}
+    - target: {fileID: 4387921172387687617, guid: d589c17f6fd91da4190edfdd2cb5aa53,
+        type: 3}
+      propertyPath: FiringSound
+      value: ShootTazer
       objectReference: {fileID: 0}
     - target: {fileID: 4387921172387687617, guid: d589c17f6fd91da4190edfdd2cb5aa53,
         type: 3}
@@ -57,40 +68,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4387921172387687617, guid: d589c17f6fd91da4190edfdd2cb5aa53,
         type: 3}
-      propertyPath: FiringSound
-      value: ShootTazer
+      propertyPath: FiringSoundA.AssetAddress
+      value: Assets/Prefabs/Weapons/Taser1.prefab
       objectReference: {fileID: 0}
-    - target: {fileID: 4387921172387687617, guid: d589c17f6fd91da4190edfdd2cb5aa53,
-        type: 3}
-      propertyPath: FireRate
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4387921172387687617, guid: d589c17f6fd91da4190edfdd2cb5aa53,
-        type: 3}
-      propertyPath: firemodeFiringSound.Array.data[0]
-      value: ShootTazer
-      objectReference: {fileID: 0}
-    - target: {fileID: 4387921172387687617, guid: d589c17f6fd91da4190edfdd2cb5aa53,
-        type: 3}
-      propertyPath: Projectile
-      value: 
-      objectReference: {fileID: 5951038657140010356, guid: 00552b9802a37ba4bbe1aca46515b240,
-        type: 3}
-    - target: {fileID: 4387921172387687617, guid: d589c17f6fd91da4190edfdd2cb5aa53,
-        type: 3}
-      propertyPath: firemodeProjectiles.Array.data[0]
-      value: 
-      objectReference: {fileID: 5951038657140010356, guid: 00552b9802a37ba4bbe1aca46515b240,
-        type: 3}
     - target: {fileID: 4387921172387687617, guid: d589c17f6fd91da4190edfdd2cb5aa53,
         type: 3}
       propertyPath: firemodeName.Array.data[0]
       value: Stun
-      objectReference: {fileID: 0}
-    - target: {fileID: 4387921172387687617, guid: d589c17f6fd91da4190edfdd2cb5aa53,
-        type: 3}
-      propertyPath: firemodeFiringSound.Array.data[1]
-      value: ShootLaser
       objectReference: {fileID: 0}
     - target: {fileID: 4387921172387687617, guid: d589c17f6fd91da4190edfdd2cb5aa53,
         type: 3}
@@ -99,15 +83,41 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4387921172387687617, guid: d589c17f6fd91da4190edfdd2cb5aa53,
         type: 3}
+      propertyPath: firemodeUsage.Array.data[1]
+      value: 500
+      objectReference: {fileID: 0}
+    - target: {fileID: 4387921172387687617, guid: d589c17f6fd91da4190edfdd2cb5aa53,
+        type: 3}
+      propertyPath: firemodeFiringSound.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4387921172387687617, guid: d589c17f6fd91da4190edfdd2cb5aa53,
+        type: 3}
+      propertyPath: firemodeProjectiles.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4387921172387687617, guid: d589c17f6fd91da4190edfdd2cb5aa53,
+        type: 3}
+      propertyPath: firemodeFiringSound.Array.data[0]
+      value: ShootTazer
+      objectReference: {fileID: 0}
+    - target: {fileID: 4387921172387687617, guid: d589c17f6fd91da4190edfdd2cb5aa53,
+        type: 3}
+      propertyPath: firemodeFiringSound.Array.data[1]
+      value: ShootLaser
+      objectReference: {fileID: 0}
+    - target: {fileID: 4387921172387687617, guid: d589c17f6fd91da4190edfdd2cb5aa53,
+        type: 3}
+      propertyPath: firemodeProjectiles.Array.data[0]
+      value: 
+      objectReference: {fileID: 5951038657140010356, guid: 00552b9802a37ba4bbe1aca46515b240,
+        type: 3}
+    - target: {fileID: 4387921172387687617, guid: d589c17f6fd91da4190edfdd2cb5aa53,
+        type: 3}
       propertyPath: firemodeProjectiles.Array.data[1]
       value: 
       objectReference: {fileID: 5418626791516505491, guid: b4492e96cb32b8941a4cf47edcf7c3cc,
         type: 3}
-    - target: {fileID: 4387921172387687617, guid: d589c17f6fd91da4190edfdd2cb5aa53,
-        type: 3}
-      propertyPath: firemodeUsage.Array.data[1]
-      value: 500
-      objectReference: {fileID: 0}
     - target: {fileID: 4387921172387687617, guid: d589c17f6fd91da4190edfdd2cb5aa53,
         type: 3}
       propertyPath: firemodeFiringSound.Array.data[0].AssetAddress
@@ -117,11 +127,6 @@ PrefabInstance:
         type: 3}
       propertyPath: firemodeFiringSound.Array.data[1].AssetAddress
       value: Assets/Prefabs/Weapons/Taser2.prefab
-      objectReference: {fileID: 0}
-    - target: {fileID: 4387921172387687617, guid: d589c17f6fd91da4190edfdd2cb5aa53,
-        type: 3}
-      propertyPath: FiringSoundA.AssetAddress
-      value: Assets/Prefabs/Weapons/Taser1.prefab
       objectReference: {fileID: 0}
     - target: {fileID: 4979405696378388488, guid: d589c17f6fd91da4190edfdd2cb5aa53,
         type: 3}
@@ -142,13 +147,13 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 6601480061218639507, guid: d589c17f6fd91da4190edfdd2cb5aa53,
         type: 3}
-      propertyPath: initialTraits.Array.size
-      value: 4
+      propertyPath: initialName
+      value: hybrid taser v43
       objectReference: {fileID: 0}
     - target: {fileID: 6601480061218639507, guid: d589c17f6fd91da4190edfdd2cb5aa53,
         type: 3}
-      propertyPath: initialName
-      value: hybrid taser v43
+      propertyPath: initialSize
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6601480061218639507, guid: d589c17f6fd91da4190edfdd2cb5aa53,
         type: 3}
@@ -158,9 +163,20 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6601480061218639507, guid: d589c17f6fd91da4190edfdd2cb5aa53,
         type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6601480061218639507, guid: d589c17f6fd91da4190edfdd2cb5aa53,
+        type: 3}
       propertyPath: itemSprites.SpriteLeftHand
       value: 
       objectReference: {fileID: 11400000, guid: afca2ad5a55c4684e99cb2b9394407ee,
+        type: 2}
+    - target: {fileID: 6601480061218639507, guid: d589c17f6fd91da4190edfdd2cb5aa53,
+        type: 3}
+      propertyPath: initialTraits.Array.data[3]
+      value: 
+      objectReference: {fileID: 11400000, guid: 54f3eb2e915e0724cb547bca694b7157,
         type: 2}
     - target: {fileID: 6601480061218639507, guid: d589c17f6fd91da4190edfdd2cb5aa53,
         type: 3}
@@ -168,21 +184,15 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: fb4ec893cf4767741a7c3cae4df348c3,
         type: 2}
-    - target: {fileID: 6601480061218639507, guid: d589c17f6fd91da4190edfdd2cb5aa53,
-        type: 3}
-      propertyPath: initialSize
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 6601480061218639507, guid: d589c17f6fd91da4190edfdd2cb5aa53,
-        type: 3}
-      propertyPath: initialTraits.Array.data[3]
-      value: 
-      objectReference: {fileID: 11400000, guid: 54f3eb2e915e0724cb547bca694b7157,
-        type: 2}
     - target: {fileID: 6693620148964760645, guid: d589c17f6fd91da4190edfdd2cb5aa53,
         type: 3}
       propertyPath: m_AssetId
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6729279132081544325, guid: d589c17f6fd91da4190edfdd2cb5aa53,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6729279132081544325, guid: d589c17f6fd91da4190edfdd2cb5aa53,
         type: 3}
@@ -201,6 +211,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6729279132081544325, guid: d589c17f6fd91da4190edfdd2cb5aa53,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6729279132081544325, guid: d589c17f6fd91da4190edfdd2cb5aa53,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -213,16 +228,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6729279132081544325, guid: d589c17f6fd91da4190edfdd2cb5aa53,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6729279132081544325, guid: d589c17f6fd91da4190edfdd2cb5aa53,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6729279132081544325, guid: d589c17f6fd91da4190edfdd2cb5aa53,
         type: 3}
@@ -276,18 +281,13 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 7789201627290542266, guid: d589c17f6fd91da4190edfdd2cb5aa53,
         type: 3}
-      propertyPath: SmartGun
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7789201627290542266, guid: d589c17f6fd91da4190edfdd2cb5aa53,
-        type: 3}
-      propertyPath: FiringSound
-      value: ShootTazer
-      objectReference: {fileID: 0}
-    - target: {fileID: 7789201627290542266, guid: d589c17f6fd91da4190edfdd2cb5aa53,
-        type: 3}
       propertyPath: FireRate
       value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7789201627290542266, guid: d589c17f6fd91da4190edfdd2cb5aa53,
+        type: 3}
+      propertyPath: SmartGun
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7789201627290542266, guid: d589c17f6fd91da4190edfdd2cb5aa53,
         type: 3}
@@ -301,6 +301,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 5913760418817138735, guid: 3b4b277bf203d4347a0a5a182890e0bf,
         type: 3}
+    - target: {fileID: 7789201627290542266, guid: d589c17f6fd91da4190edfdd2cb5aa53,
+        type: 3}
+      propertyPath: FiringSound
+      value: ShootTazer
+      objectReference: {fileID: 0}
     - target: {fileID: 8316631766976624318, guid: d589c17f6fd91da4190edfdd2cb5aa53,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Energy/TaserV42.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Energy/TaserV42.prefab
@@ -37,18 +37,8 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 916841119618418725, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
-      propertyPath: FiringSound
-      value: ShootTazer
-      objectReference: {fileID: 0}
-    - target: {fileID: 916841119618418725, guid: 143d3926d4a5fa84f95f987c152b33a2,
-        type: 3}
       propertyPath: FireRate
       value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 916841119618418725, guid: 143d3926d4a5fa84f95f987c152b33a2,
-        type: 3}
-      propertyPath: ProjectilesFired
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 916841119618418725, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
@@ -62,6 +52,16 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 5913760418817138735, guid: 3b4b277bf203d4347a0a5a182890e0bf,
         type: 3}
+    - target: {fileID: 916841119618418725, guid: 143d3926d4a5fa84f95f987c152b33a2,
+        type: 3}
+      propertyPath: FiringSound
+      value: ShootTazer
+      objectReference: {fileID: 0}
+    - target: {fileID: 916841119618418725, guid: 143d3926d4a5fa84f95f987c152b33a2,
+        type: 3}
+      propertyPath: ProjectilesFired
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1848979366670267442, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
       propertyPath: m_Sprite
@@ -92,8 +92,13 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 4268463137979442700, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
-      propertyPath: initialTraits.Array.size
-      value: 4
+      propertyPath: initialName
+      value: taser v42
+      objectReference: {fileID: 0}
+    - target: {fileID: 4268463137979442700, guid: 143d3926d4a5fa84f95f987c152b33a2,
+        type: 3}
+      propertyPath: initialSize
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4268463137979442700, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
@@ -103,8 +108,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4268463137979442700, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
-      propertyPath: initialName
-      value: taser v42
+      propertyPath: initialTraits.Array.size
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 4268463137979442700, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
@@ -114,20 +119,15 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 4268463137979442700, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
-      propertyPath: itemSprites.SpriteRightHand
-      value: 
-      objectReference: {fileID: 11400000, guid: c9b1927a5c90d1b4ba3b0466ed19d213,
-        type: 2}
-    - target: {fileID: 4268463137979442700, guid: 143d3926d4a5fa84f95f987c152b33a2,
-        type: 3}
-      propertyPath: initialSize
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 4268463137979442700, guid: 143d3926d4a5fa84f95f987c152b33a2,
-        type: 3}
       propertyPath: initialTraits.Array.data[3]
       value: 
       objectReference: {fileID: 11400000, guid: 54f3eb2e915e0724cb547bca694b7157,
+        type: 2}
+    - target: {fileID: 4268463137979442700, guid: 143d3926d4a5fa84f95f987c152b33a2,
+        type: 3}
+      propertyPath: itemSprites.SpriteRightHand
+      value: 
+      objectReference: {fileID: 11400000, guid: c9b1927a5c90d1b4ba3b0466ed19d213,
         type: 2}
     - target: {fileID: 4318467024818780366, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
@@ -138,6 +138,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AssetId
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 4450321759764526106, guid: 143d3926d4a5fa84f95f987c152b33a2,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4450321759764526106, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
@@ -156,6 +161,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4450321759764526106, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4450321759764526106, guid: 143d3926d4a5fa84f95f987c152b33a2,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -168,16 +178,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4450321759764526106, guid: 143d3926d4a5fa84f95f987c152b33a2,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4450321759764526106, guid: 143d3926d4a5fa84f95f987c152b33a2,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4450321759764526106, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
@@ -224,28 +224,17 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 6648593666208859230, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
-      propertyPath: firemodeProjectiles.Array.size
-      value: 1
+      propertyPath: FireRate
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 6648593666208859230, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
-      propertyPath: firemodeFiringSound.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6648593666208859230, guid: 143d3926d4a5fa84f95f987c152b33a2,
-        type: 3}
-      propertyPath: firemodeName.Array.size
-      value: 1
+      propertyPath: FireDelay
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6648593666208859230, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
       propertyPath: Projectile
-      value: 
-      objectReference: {fileID: 5951038657140010356, guid: 00552b9802a37ba4bbe1aca46515b240,
-        type: 3}
-    - target: {fileID: 6648593666208859230, guid: 143d3926d4a5fa84f95f987c152b33a2,
-        type: 3}
-      propertyPath: firemodeProjectiles.Array.data[0]
       value: 
       objectReference: {fileID: 5951038657140010356, guid: 00552b9802a37ba4bbe1aca46515b240,
         type: 3}
@@ -256,24 +245,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6648593666208859230, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
-      propertyPath: FireRate
-      value: 0.5
+      propertyPath: countFiremode
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6648593666208859230, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
-      propertyPath: firemodeFiringSound.Array.data[0]
-      value: ShootTazer
+      propertyPath: firemodeName.Array.size
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6648593666208859230, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
-      propertyPath: firemodeProjectiles.Array.data[1]
-      value: 
-      objectReference: {fileID: 5951038657140010356, guid: 00552b9802a37ba4bbe1aca46515b240,
-        type: 3}
-    - target: {fileID: 6648593666208859230, guid: 143d3926d4a5fa84f95f987c152b33a2,
-        type: 3}
-      propertyPath: firemodeFiringSound.Array.data[1]
-      value: ShootTazer
+      propertyPath: FiringSoundA.AssetAddress
+      value: Assets/Prefabs/Weapons/Taser1.prefab
       objectReference: {fileID: 0}
     - target: {fileID: 6648593666208859230, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
@@ -287,17 +270,39 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6648593666208859230, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
-      propertyPath: countFiremode
-      value: 2
+      propertyPath: firemodeFiringSound.Array.size
+      value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 6648593666208859230, guid: 143d3926d4a5fa84f95f987c152b33a2,
+        type: 3}
+      propertyPath: firemodeProjectiles.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6648593666208859230, guid: 143d3926d4a5fa84f95f987c152b33a2,
+        type: 3}
+      propertyPath: firemodeFiringSound.Array.data[0]
+      value: ShootTazer
+      objectReference: {fileID: 0}
+    - target: {fileID: 6648593666208859230, guid: 143d3926d4a5fa84f95f987c152b33a2,
+        type: 3}
+      propertyPath: firemodeFiringSound.Array.data[1]
+      value: ShootTazer
+      objectReference: {fileID: 0}
+    - target: {fileID: 6648593666208859230, guid: 143d3926d4a5fa84f95f987c152b33a2,
+        type: 3}
+      propertyPath: firemodeProjectiles.Array.data[0]
+      value: 
+      objectReference: {fileID: 5951038657140010356, guid: 00552b9802a37ba4bbe1aca46515b240,
+        type: 3}
+    - target: {fileID: 6648593666208859230, guid: 143d3926d4a5fa84f95f987c152b33a2,
+        type: 3}
+      propertyPath: firemodeProjectiles.Array.data[1]
+      value: 
+      objectReference: {fileID: 5951038657140010356, guid: 00552b9802a37ba4bbe1aca46515b240,
+        type: 3}
     - target: {fileID: 6648593666208859230, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
       propertyPath: firemodeFiringSound.Array.data[0].AssetAddress
-      value: Assets/Prefabs/Weapons/Taser1.prefab
-      objectReference: {fileID: 0}
-    - target: {fileID: 6648593666208859230, guid: 143d3926d4a5fa84f95f987c152b33a2,
-        type: 3}
-      propertyPath: FiringSoundA.AssetAddress
       value: Assets/Prefabs/Weapons/Taser1.prefab
       objectReference: {fileID: 0}
     - target: {fileID: 7536533288437052137, guid: 143d3926d4a5fa84f95f987c152b33a2,

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Energy/_GunEnergyBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Energy/_GunEnergyBase.prefab
@@ -98,6 +98,7 @@ MonoBehaviour:
   NetworkThis: 1
   SubCatalogue: []
   PresentSpriteSet: {fileID: 0}
+  randomInitialSprite: 0
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
@@ -200,6 +201,7 @@ MonoBehaviour:
   NetworkThis: 1
   SubCatalogue: []
   PresentSpriteSet: {fileID: 0}
+  randomInitialSprite: 0
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
@@ -264,7 +266,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
-  FireRate: 2
+  FireDelay: 0.5
   MaxRecoilVariance: 0
   ProjectileVelocity: 20
   CameraRecoilConfig:
@@ -272,6 +274,7 @@ MonoBehaviour:
     RecoilDuration: 0
     RecoveryDuration: 0
   WeaponType: 0
+  allowPinSwap: 1
   isSuppressed: 0
   isSuppressible: 0
   firemodeProjectiles:
@@ -385,6 +388,7 @@ MonoBehaviour:
   NetworkThis: 1
   SubCatalogue: []
   PresentSpriteSet: {fileID: 0}
+  randomInitialSprite: 0
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
@@ -487,6 +491,7 @@ MonoBehaviour:
   NetworkThis: 1
   SubCatalogue: []
   PresentSpriteSet: {fileID: 0}
+  randomInitialSprite: 0
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
@@ -506,25 +511,25 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 4644871529314044369, guid: da85b7a590e7c8444af73629fcb5dd22,
         type: 3}
-      propertyPath: SpawnsCasing
-      value: 0
+      propertyPath: ammoType
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 4644871529314044369, guid: da85b7a590e7c8444af73629fcb5dd22,
         type: 3}
-      propertyPath: ammoType
-      value: 14
+      propertyPath: ammoPrefab
+      value: 
+      objectReference: {fileID: 1089748232968454180, guid: a910878bd30ff5d439b94cd12e623762,
+        type: 3}
+    - target: {fileID: 4644871529314044369, guid: da85b7a590e7c8444af73629fcb5dd22,
+        type: 3}
+      propertyPath: SpawnsCasing
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4644871529314044369, guid: da85b7a590e7c8444af73629fcb5dd22,
         type: 3}
       propertyPath: genericInternalMag
       value: 
       objectReference: {fileID: 2422759989583602921, guid: d819938d5d7681c4ba69845f60102a8c,
-        type: 3}
-    - target: {fileID: 4644871529314044369, guid: da85b7a590e7c8444af73629fcb5dd22,
-        type: 3}
-      propertyPath: ammoPrefab
-      value: 
-      objectReference: {fileID: 1089748232968454180, guid: a910878bd30ff5d439b94cd12e623762,
         type: 3}
     - target: {fileID: 4644871529314044369, guid: da85b7a590e7c8444af73629fcb5dd22,
         type: 3}
@@ -535,6 +540,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AssetId
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8146475302025016814, guid: da85b7a590e7c8444af73629fcb5dd22,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8146475302025016814, guid: da85b7a590e7c8444af73629fcb5dd22,
         type: 3}
@@ -553,6 +563,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8146475302025016814, guid: da85b7a590e7c8444af73629fcb5dd22,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8146475302025016814, guid: da85b7a590e7c8444af73629fcb5dd22,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -565,16 +580,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8146475302025016814, guid: da85b7a590e7c8444af73629fcb5dd22,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8146475302025016814, guid: da85b7a590e7c8444af73629fcb5dd22,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8146475302025016814, guid: da85b7a590e7c8444af73629fcb5dd22,
         type: 3}
@@ -598,8 +603,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8642408458191644664, guid: da85b7a590e7c8444af73629fcb5dd22,
         type: 3}
-      propertyPath: initialTraits.Array.size
-      value: 3
+      propertyPath: initialName
+      value: energy gun
       objectReference: {fileID: 0}
     - target: {fileID: 8642408458191644664, guid: da85b7a590e7c8444af73629fcb5dd22,
         type: 3}
@@ -608,8 +613,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8642408458191644664, guid: da85b7a590e7c8444af73629fcb5dd22,
         type: 3}
-      propertyPath: initialName
-      value: energy gun
+      propertyPath: initialTraits.Array.size
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 8642408458191644664, guid: da85b7a590e7c8444af73629fcb5dd22,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/_GunBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/_GunBase.prefab
@@ -63,7 +63,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
-  FireRate: 0
+  FireDelay: 0.5
   MaxRecoilVariance: 0
   ProjectileVelocity: 20
   CameraRecoilConfig:
@@ -71,6 +71,7 @@ MonoBehaviour:
     RecoilDuration: 0
     RecoveryDuration: 0
   WeaponType: 0
+  allowPinSwap: 1
   isSuppressed: 0
   isSuppressible: 0
 --- !u!1001 &8150967651737613344
@@ -146,16 +147,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
-      propertyPath: attackVerbs.Array.size
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: initialTraits.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
       propertyPath: hitDamage
       value: 5
       objectReference: {fileID: 0}
@@ -188,6 +179,16 @@ PrefabInstance:
         type: 3}
       propertyPath: initialDescription
       value: It's a gun. It's pretty terrible, though.
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: attackVerbs.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/PipeObjects/GasFlowMeter.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/PipeObjects/GasFlowMeter.prefab
@@ -323,6 +323,11 @@ PrefabInstance:
       propertyPath: Resistances.FireProof
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 7946340047006197236, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: Passable
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 8232375373487905420, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
       propertyPath: initialName

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Construction/GrilleObject.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Construction/GrilleObject.prefab
@@ -46,6 +46,7 @@ SpriteRenderer:
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -68,7 +69,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 142874271
-  m_SortingLayer: 10
+  m_SortingLayer: 12
   m_SortingOrder: 1
   m_Sprite: {fileID: 21300000, guid: 10623b9787a8d384b8d9825b3337ea04, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -167,6 +168,8 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
+  ReachableThrough: 1
+  passableExclusionsToThis: []
 --- !u!114 &7478891196200289026
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -197,7 +200,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   isMeleeable: 1
   butcherTime: 2
-  butcherSound: BladeSlice
+  butcherSound:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
 --- !u!114 &114475937421885612
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -227,7 +236,13 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   initialIntegrity: 50
-  soundOnHit: GrillHit
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   damageDeflection: 0
   Armor:
     Melee: 50
@@ -248,7 +263,9 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
+    LightningDamageProof: 0
   HeatResistance: 100
+  ExplosionsDamage: 100
 --- !u!114 &114876689548865824
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -282,7 +299,13 @@ MonoBehaviour:
   registerTile: {fileID: 0}
   floorDecal: {fileID: 0}
   isInitiallyNotPushable: 0
-  pushPullSound: 
+  pushPullSound:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   soundDelayTime: 0
   soundMinimumPitchVariance: 1
   soundMaximumPitchVariance: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Construction/GrilleObjectBroken.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Construction/GrilleObjectBroken.prefab
@@ -7,6 +7,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 114590610092742494, guid: e7a19fe59d5bcfe49a1d885d7fedab6e,
+        type: 3}
+      propertyPath: soundOnHit.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     - target: {fileID: 114876689548865824, guid: e7a19fe59d5bcfe49a1d885d7fedab6e,
         type: 3}
       propertyPath: m_AssetId
@@ -19,13 +24,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4456424331474363299, guid: e7a19fe59d5bcfe49a1d885d7fedab6e,
         type: 3}
-      propertyPath: initialDescription
-      value: A broken mess of twisted rods.
+      propertyPath: initialName
+      value: broken grille
       objectReference: {fileID: 0}
     - target: {fileID: 4456424331474363299, guid: e7a19fe59d5bcfe49a1d885d7fedab6e,
         type: 3}
-      propertyPath: initialName
-      value: broken grille
+      propertyPath: initialDescription
+      value: A broken mess of twisted rods.
       objectReference: {fileID: 0}
     - target: {fileID: 7254393612801982914, guid: e7a19fe59d5bcfe49a1d885d7fedab6e,
         type: 3}
@@ -33,6 +38,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 2f1b3e8d6fb118b41889deb99ae48c0d,
         type: 3}
+    - target: {fileID: 7373467433817843582, guid: e7a19fe59d5bcfe49a1d885d7fedab6e,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7373467433817843582, guid: e7a19fe59d5bcfe49a1d885d7fedab6e,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -50,6 +60,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7373467433817843582, guid: e7a19fe59d5bcfe49a1d885d7fedab6e,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7373467433817843582, guid: e7a19fe59d5bcfe49a1d885d7fedab6e,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -62,16 +77,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0.00000014901144
-      objectReference: {fileID: 0}
-    - target: {fileID: 7373467433817843582, guid: e7a19fe59d5bcfe49a1d885d7fedab6e,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7373467433817843582, guid: e7a19fe59d5bcfe49a1d885d7fedab6e,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7373467433817843582, guid: e7a19fe59d5bcfe49a1d885d7fedab6e,
         type: 3}
@@ -106,15 +111,20 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 8402624206278935752, guid: e7a19fe59d5bcfe49a1d885d7fedab6e,
         type: 3}
-      propertyPath: transformToPrefab
-      value: 
-      objectReference: {fileID: 7198241665461443898, guid: 5dce4d3e01518474bb9bb8085b718980,
-        type: 3}
-    - target: {fileID: 8402624206278935752, guid: e7a19fe59d5bcfe49a1d885d7fedab6e,
-        type: 3}
       propertyPath: layerTile
       value: 
       objectReference: {fileID: 11400000, guid: c87a62cb7a026433f9d4e361d2740cbc,
         type: 2}
+    - target: {fileID: 8402624206278935752, guid: e7a19fe59d5bcfe49a1d885d7fedab6e,
+        type: 3}
+      propertyPath: transformToPrefab
+      value: 
+      objectReference: {fileID: 7198241665461443898, guid: 5dce4d3e01518474bb9bb8085b718980,
+        type: 3}
+    - target: {fileID: 8501056774758602355, guid: e7a19fe59d5bcfe49a1d885d7fedab6e,
+        type: 3}
+      propertyPath: pushPullSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e7a19fe59d5bcfe49a1d885d7fedab6e, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/WallProtrusions/CameraAssembly.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/WallProtrusions/CameraAssembly.prefab
@@ -63,6 +63,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 338588115043544032, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
+      objectReference: {fileID: 0}
     - target: {fileID: 929166672355850642, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
       propertyPath: Passable
@@ -75,13 +80,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1197192003336439530, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
-      propertyPath: initialDescription
-      value: The basic construction for Nanotrasen-Always-Watching-You cameras.
+      propertyPath: initialName
+      value: camera assembly
       objectReference: {fileID: 0}
     - target: {fileID: 1197192003336439530, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
-      propertyPath: initialName
-      value: camera assembly
+      propertyPath: initialDescription
+      value: The basic construction for Nanotrasen-Always-Watching-You cameras.
       objectReference: {fileID: 0}
     - target: {fileID: 3920465809857098496, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
@@ -89,6 +94,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 39fd8c927184fa9408b8fbd2b4337023,
         type: 2}
+    - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -106,6 +116,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -118,16 +133,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
@@ -149,12 +154,22 @@ PrefabInstance:
       propertyPath: m_Name
       value: CameraAssembly
       objectReference: {fileID: 0}
+    - target: {fileID: 8374648283101600218, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
+      objectReference: {fileID: 0}
     - target: {fileID: 8599771746108915149, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
       propertyPath: m_Sprite
       value: 
       objectReference: {fileID: 21300000, guid: 433142443e214c24bb71c5416cc64610,
         type: 3}
+    - target: {fileID: 8599771746108915149, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a7af28adb717b4c44b8b2002b27670bd, type: 3}
 --- !u!1 &8082919958197055211 stripped

--- a/UnityProject/Assets/Resources/Prefabs/Objects/WallProtrusions/LightBulbFixture.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/WallProtrusions/LightBulbFixture.prefab
@@ -15,13 +15,13 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 832917580050276182, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
-      propertyPath: initialDescription
-      value: A small lighting fixture.
+      propertyPath: initialName
+      value: light bulb fixture
       objectReference: {fileID: 0}
     - target: {fileID: 832917580050276182, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
-      propertyPath: initialName
-      value: light bulb fixture
+      propertyPath: initialDescription
+      value: A small lighting fixture.
       objectReference: {fileID: 0}
     - target: {fileID: 1689274832931870787, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -47,16 +47,6 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 3662677150203288956, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
-      propertyPath: m_Offset.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3662677150203288956, guid: fde32c02abddc814f9366ff1fb21f234,
-        type: 3}
-      propertyPath: m_Offset.y
-      value: 0.3642767
-      objectReference: {fileID: 0}
-    - target: {fileID: 3662677150203288956, guid: fde32c02abddc814f9366ff1fb21f234,
-        type: 3}
       propertyPath: m_Size.x
       value: 0.2374755
       objectReference: {fileID: 0}
@@ -65,6 +55,16 @@ PrefabInstance:
       propertyPath: m_Size.y
       value: 0.2779311
       objectReference: {fileID: 0}
+    - target: {fileID: 3662677150203288956, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_Offset.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3662677150203288956, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_Offset.y
+      value: 0.3642767
+      objectReference: {fileID: 0}
     - target: {fileID: 6807309527984598602, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: wattusage
@@ -72,48 +72,33 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
+      propertyPath: boxColl
+      value: 
+      objectReference: {fileID: 445604691200519404}
+    - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: integrity
+      value: 
+      objectReference: {fileID: 2323088392600845931}
+    - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
       propertyPath: ONColour.a
       value: 0.32156864
       objectReference: {fileID: 0}
     - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
-      propertyPath: collDownSetting.x
-      value: 0
-      objectReference: {fileID: 0}
+      propertyPath: directional
+      value: 
+      objectReference: {fileID: 2089160542943999880}
     - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
-      propertyPath: collDownSetting.y
-      value: 0.3642767
-      objectReference: {fileID: 0}
+      propertyPath: spriteRenderer
+      value: 
+      objectReference: {fileID: 6391088716132193761}
     - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
-      propertyPath: collDownSetting.z
-      value: 0.2374755
-      objectReference: {fileID: 0}
-    - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
-        type: 3}
-      propertyPath: collDownSetting.w
-      value: 0.2779311
-      objectReference: {fileID: 0}
-    - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
-        type: 3}
-      propertyPath: collRightSetting.x
-      value: -0.3346747
-      objectReference: {fileID: 0}
-    - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
-        type: 3}
-      propertyPath: collRightSetting.y
-      value: -0.001173973
-      objectReference: {fileID: 0}
-    - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
-        type: 3}
-      propertyPath: collRightSetting.z
-      value: 0.3067206
-      objectReference: {fileID: 0}
-    - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
-        type: 3}
-      propertyPath: collRightSetting.w
-      value: 0.3087062
+      propertyPath: collUpSetting.w
+      value: 0.3010119
       objectReference: {fileID: 0}
     - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -132,8 +117,28 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
-      propertyPath: collUpSetting.w
-      value: 0.3010119
+      propertyPath: collDownSetting.w
+      value: 0.2779311
+      objectReference: {fileID: 0}
+    - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: collDownSetting.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: collDownSetting.y
+      value: 0.3642767
+      objectReference: {fileID: 0}
+    - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: collDownSetting.z
+      value: 0.2374755
+      objectReference: {fileID: 0}
+    - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: collLeftSetting.w
+      value: 0.304859
       objectReference: {fileID: 0}
     - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -152,14 +157,36 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
-      propertyPath: collLeftSetting.w
-      value: 0.304859
+      propertyPath: collRightSetting.w
+      value: 0.3087062
       objectReference: {fileID: 0}
     - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
-      propertyPath: spriteRenderer
+      propertyPath: collRightSetting.x
+      value: -0.3346747
+      objectReference: {fileID: 0}
+    - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: collRightSetting.y
+      value: -0.001173973
+      objectReference: {fileID: 0}
+    - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: collRightSetting.z
+      value: 0.3067206
+      objectReference: {fileID: 0}
+    - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: mountStatesMachine
       value: 
-      objectReference: {fileID: 6391088716132193761}
+      objectReference: {fileID: 11400000, guid: 3bd2d676f24e6864dbff58a5436afb74,
+        type: 2}
+    - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: spritesStateOnEffect
+      value: 
+      objectReference: {fileID: 11400000, guid: 726dca084060d4241bf0ffddd39509fe,
+        type: 2}
     - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: spriteRendererLightOn
@@ -170,33 +197,6 @@ PrefabInstance:
       propertyPath: emergencyLightAnimator
       value: 
       objectReference: {fileID: 8220138473564574690}
-    - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
-        type: 3}
-      propertyPath: integrity
-      value: 
-      objectReference: {fileID: 2323088392600845931}
-    - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
-        type: 3}
-      propertyPath: directional
-      value: 
-      objectReference: {fileID: 2089160542943999880}
-    - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
-        type: 3}
-      propertyPath: boxColl
-      value: 
-      objectReference: {fileID: 445604691200519404}
-    - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
-        type: 3}
-      propertyPath: spritesStateOnEffect
-      value: 
-      objectReference: {fileID: 11400000, guid: 726dca084060d4241bf0ffddd39509fe,
-        type: 2}
-    - target: {fileID: 6947158127070171075, guid: fde32c02abddc814f9366ff1fb21f234,
-        type: 3}
-      propertyPath: mountStatesMachine
-      value: 
-      objectReference: {fileID: 11400000, guid: 3bd2d676f24e6864dbff58a5436afb74,
-        type: 2}
     - target: {fileID: 7803294762233930865, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_Sprite
@@ -207,6 +207,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: LightBulbFixture
+      objectReference: {fileID: 0}
+    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -225,6 +230,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -237,16 +247,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/WallProtrusions/LightBulbFixtureFrame.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/WallProtrusions/LightBulbFixtureFrame.prefab
@@ -15,6 +15,11 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 3063805286163523616, guid: 703ee43e84da301438311278f13a496f,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3063805286163523616, guid: 703ee43e84da301438311278f13a496f,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -30,6 +35,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3063805286163523616, guid: 703ee43e84da301438311278f13a496f,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3063805286163523616, guid: 703ee43e84da301438311278f13a496f,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -42,16 +52,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3063805286163523616, guid: 703ee43e84da301438311278f13a496f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3063805286163523616, guid: 703ee43e84da301438311278f13a496f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3063805286163523616, guid: 703ee43e84da301438311278f13a496f,
         type: 3}
@@ -71,7 +71,7 @@ PrefabInstance:
     - target: {fileID: 3067346511363075834, guid: 703ee43e84da301438311278f13a496f,
         type: 3}
       propertyPath: m_Name
-      value: LightFixtureFrameSmall
+      value: LightBulbFixtureFrame
       objectReference: {fileID: 0}
     - target: {fileID: 5635298977466413514, guid: 703ee43e84da301438311278f13a496f,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/WallProtrusions/LightTubeFixture.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/WallProtrusions/LightTubeFixture.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5173863171863889205}
   - component: {fileID: 1689274832931870787}
-  m_Layer: 13
+  m_Layer: 19
   m_Name: LightOn
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -69,7 +69,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1964781063
-  m_SortingLayer: 24
+  m_SortingLayer: 25
   m_SortingOrder: 1
   m_Sprite: {fileID: 21300002, guid: 1f8fe2981d2d3bb4f8643d0bed83b580, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -203,7 +203,7 @@ PrefabInstance:
     - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
       propertyPath: m_SortingLayer
-      value: 24
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -280,6 +280,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: LightTubeFixture
       objectReference: {fileID: 0}
+    - target: {fileID: 1628816798482564540, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
+      objectReference: {fileID: 0}
     - target: {fileID: 5432513913519741094, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
       propertyPath: m_Size.x
@@ -319,7 +324,7 @@ PrefabInstance:
     - target: {fileID: 7354635586586802054, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
       propertyPath: m_Layer
-      value: 13
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/WallProtrusions/LightTubeFixtureFrame.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/WallProtrusions/LightTubeFixtureFrame.prefab
@@ -57,6 +57,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 338588115043544032, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
+      objectReference: {fileID: 0}
     - target: {fileID: 929166672355850642, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
       propertyPath: Passable
@@ -64,8 +69,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1140667517167752775, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
-      propertyPath: initialIntegrity
-      value: 200
+      propertyPath: Armor.Fire
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140667517167752775, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
+      propertyPath: Armor.Laser
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 1140667517167752775, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
@@ -79,13 +89,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1140667517167752775, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
-      propertyPath: Armor.Laser
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 1140667517167752775, guid: a7af28adb717b4c44b8b2002b27670bd,
-        type: 3}
-      propertyPath: Armor.Fire
-      value: 80
+      propertyPath: initialIntegrity
+      value: 200
       objectReference: {fileID: 0}
     - target: {fileID: 1197192003336439530, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
@@ -105,6 +110,11 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -120,6 +130,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -132,16 +147,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
@@ -163,6 +168,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: LightTubeFixtureFrame
       objectReference: {fileID: 0}
+    - target: {fileID: 8374648283101600218, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
+      objectReference: {fileID: 0}
     - target: {fileID: 8599771746108915149, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
       propertyPath: m_Sprite
@@ -171,13 +181,18 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 8599771746108915149, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
+      propertyPath: m_SortingLayer
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 8599771746108915149, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
       propertyPath: m_SortingLayerID
       value: -1964781063
       objectReference: {fileID: 0}
     - target: {fileID: 8599771746108915149, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
-      propertyPath: m_SortingLayer
-      value: 19
+      propertyPath: m_WasSpriteAssigned
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a7af28adb717b4c44b8b2002b27670bd, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/WallProtrusions/SecurityCamera.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/WallProtrusions/SecurityCamera.prefab
@@ -71,17 +71,27 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
+      propertyPath: m_SortingLayer
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
       propertyPath: m_SortingLayerID
       value: -1964781063
       objectReference: {fileID: 0}
     - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: m_SortingLayer
-      value: 19
+      propertyPath: m_WasSpriteAssigned
+      value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: m_SortingOrder
+      propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
@@ -101,6 +111,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -113,16 +128,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -144,6 +149,16 @@ PrefabInstance:
       propertyPath: m_Name
       value: SecurityCamera
       objectReference: {fileID: 0}
+    - target: {fileID: 1628816798482564540, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 3314592590375341583, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3314592590375341583, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
       propertyPath: m_LocalRotation.x
@@ -159,11 +174,6 @@ PrefabInstance:
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 3314592590375341583, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 6109775972905365350, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
       propertyPath: PresentSpriteSet
@@ -175,20 +185,30 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+    - target: {fileID: 7354635586586802054, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: Resistances.FireProof
-      value: 1
+      propertyPath: m_Layer
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: Armor.Melee
+      propertyPath: Armor.Acid
       value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: Armor.Fire
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
       propertyPath: Armor.Laser
       value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: Armor.Melee
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -202,13 +222,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: Armor.Fire
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: Armor.Acid
-      value: 50
+      propertyPath: Resistances.FireProof
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7946340047006197236, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/WallProtrusions/emergency_lights.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/WallProtrusions/emergency_lights.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4185858802756340}
   - component: {fileID: 114345252666061426}
-  m_Layer: 21
+  m_Layer: 19
   m_Name: Light2D
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -67,7 +67,7 @@ GameObject:
   - component: {fileID: 758924461821250246}
   - component: {fileID: 5799307951154937464}
   - component: {fileID: 3853657128741492507}
-  m_Layer: 13
+  m_Layer: 19
   m_Name: emergency_lights
   m_TagString: EmergencyLight
   m_Icon: {fileID: 0}
@@ -108,6 +108,8 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
+  ReachableThrough: 1
+  passableExclusionsToThis: []
 --- !u!114 &8902598492986650915
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -122,6 +124,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  snapToGridOnStart: 1
   IsFixedMatrix: 0
 --- !u!114 &114736272981376494
 MonoBehaviour:
@@ -135,8 +138,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isMeleeable: 1
   butcherTime: 2
-  butcherSound: BladeSlice
+  butcherSound:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
 --- !u!114 &114987107583708958
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -151,7 +161,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  soundOnHit: 
+  initialIntegrity: 100
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  damageDeflection: 0
   Armor:
     Melee: 0
     Bullet: 0
@@ -171,8 +189,9 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
+    LightningDamageProof: 0
   HeatResistance: 100
-  initialIntegrity: 100
+  ExplosionsDamage: 100
 --- !u!114 &114993487225253824
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -185,7 +204,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  serverSpawned: 0
   isDirty: 0
   sceneId: 0
   serverOnly: 0
@@ -216,12 +234,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  isDebug: 0
   InitialDirection: 0
   onEditorDirectionChange:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 3853657128741492507}
+        m_TargetAssemblyTypeName: 
         m_MethodName: EditorDirectionChanged
         m_Mode: 1
         m_Arguments:
@@ -270,7 +288,7 @@ GameObject:
   - component: {fileID: 4213808793575886}
   - component: {fileID: 212947661580411708}
   - component: {fileID: 2040331232730013965}
-  m_Layer: 13
+  m_Layer: 19
   m_Name: Sprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -306,6 +324,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -328,7 +347,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 1085623217
-  m_SortingLayer: 19
+  m_SortingLayer: 27
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300006, guid: fa2d2371153209c428649172a3e3d2a5, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/AirAlarm.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/AirAlarm.prefab
@@ -58,13 +58,23 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
+      propertyPath: m_SortingLayer
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
       propertyPath: m_SortingLayerID
       value: -1618464505
       objectReference: {fileID: 0}
     - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: m_SortingLayer
-      value: 15
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -83,6 +93,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -95,16 +110,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -125,6 +130,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: AirAlarm
+      objectReference: {fileID: 0}
+    - target: {fileID: 1628816798482564540, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 3314592590375341583, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -152,35 +162,10 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+    - target: {fileID: 7354635586586802054, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: initialIntegrity
-      value: 250
-      objectReference: {fileID: 0}
-    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: Resistances.FireProof
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: Armor.Melee
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: Armor.Bullet
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: Armor.Laser
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: Armor.Energy
-      value: 100
+      propertyPath: m_Layer
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -194,13 +179,43 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
+      propertyPath: Armor.Acid
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
       propertyPath: Armor.Fire
       value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: Armor.Acid
-      value: 30
+      propertyPath: Armor.Laser
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: Armor.Melee
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: Armor.Bullet
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: Armor.Energy
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: initialIntegrity
+      value: 250
+      objectReference: {fileID: 0}
+    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: Resistances.FireProof
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7946340047006197236, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/Button.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/Button.prefab
@@ -74,13 +74,23 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
+      propertyPath: m_SortingLayer
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
       propertyPath: m_SortingLayerID
       value: -1618464505
       objectReference: {fileID: 0}
     - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: m_SortingLayer
-      value: 15
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -99,6 +109,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -111,16 +126,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -141,6 +146,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Button
+      objectReference: {fileID: 0}
+    - target: {fileID: 1628816798482564540, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 3314592590375341583, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -168,40 +178,10 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+    - target: {fileID: 7354635586586802054, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: Resistances.LavaProof
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: Resistances.FireProof
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: Armor.Melee
-      value: 50
-      objectReference: {fileID: 0}
-    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: Armor.Bullet
-      value: 50
-      objectReference: {fileID: 0}
-    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: Armor.Laser
-      value: 50
-      objectReference: {fileID: 0}
-    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: Armor.Energy
-      value: 50
-      objectReference: {fileID: 0}
-    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: Armor.Bomb
-      value: 10
+      propertyPath: m_Layer
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -215,8 +195,43 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
+      propertyPath: Armor.Bomb
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
       propertyPath: Armor.Fire
       value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: Armor.Laser
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: Armor.Melee
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: Armor.Bullet
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: Armor.Energy
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: Resistances.FireProof
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: Resistances.LavaProof
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7946340047006197236, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -225,13 +240,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8232375373487905420, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: initialDescription
-      value: A remote control switch.
+      propertyPath: initialName
+      value: button
       objectReference: {fileID: 0}
     - target: {fileID: 8232375373487905420, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: initialName
-      value: button
+      propertyPath: initialDescription
+      value: A remote control switch.
       objectReference: {fileID: 0}
     - target: {fileID: 9081488544171091012, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/ButtonDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/ButtonDoor.prefab
@@ -35,18 +35,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1829154482585634221, guid: 7ff56f8e13078c1419de4821c2b5ecfd,
         type: 3}
-      propertyPath: initialDescription
-      value: A door remote control switch.
+      propertyPath: initialName
+      value: door button
       objectReference: {fileID: 0}
     - target: {fileID: 1829154482585634221, guid: 7ff56f8e13078c1419de4821c2b5ecfd,
         type: 3}
-      propertyPath: initialName
-      value: door button
+      propertyPath: initialDescription
+      value: A door remote control switch.
       objectReference: {fileID: 0}
     - target: {fileID: 9063366402093685405, guid: 7ff56f8e13078c1419de4821c2b5ecfd,
         type: 3}
       propertyPath: m_Name
       value: ButtonDoor
+      objectReference: {fileID: 0}
+    - target: {fileID: 9066377664841440327, guid: 7ff56f8e13078c1419de4821c2b5ecfd,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9066377664841440327, guid: 7ff56f8e13078c1419de4821c2b5ecfd,
         type: 3}
@@ -65,6 +70,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9066377664841440327, guid: 7ff56f8e13078c1419de4821c2b5ecfd,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9066377664841440327, guid: 7ff56f8e13078c1419de4821c2b5ecfd,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -77,16 +87,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9066377664841440327, guid: 7ff56f8e13078c1419de4821c2b5ecfd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9066377664841440327, guid: 7ff56f8e13078c1419de4821c2b5ecfd,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9066377664841440327, guid: 7ff56f8e13078c1419de4821c2b5ecfd,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/ButtonMassDriver.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/ButtonMassDriver.prefab
@@ -14,13 +14,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1829154482585634221, guid: 7ff56f8e13078c1419de4821c2b5ecfd,
         type: 3}
-      propertyPath: initialDescription
-      value: A remote control switch for a mass driver.
+      propertyPath: initialName
+      value: mass driver button
       objectReference: {fileID: 0}
     - target: {fileID: 1829154482585634221, guid: 7ff56f8e13078c1419de4821c2b5ecfd,
         type: 3}
-      propertyPath: initialName
-      value: mass driver button
+      propertyPath: initialDescription
+      value: A remote control switch for a mass driver.
       objectReference: {fileID: 0}
     - target: {fileID: 4582266827605979207, guid: 7ff56f8e13078c1419de4821c2b5ecfd,
         type: 3}
@@ -28,6 +28,12 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: bb005794cd4452a4da89af86370532f1,
         type: 2}
+    - target: {fileID: 4863277160209273534, guid: 7ff56f8e13078c1419de4821c2b5ecfd,
+        type: 3}
+      propertyPath: offSprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 38c53ab71671bd84b92cf09c1f7fc133,
+        type: 3}
     - target: {fileID: 4863277160209273534, guid: 7ff56f8e13078c1419de4821c2b5ecfd,
         type: 3}
       propertyPath: redSprite
@@ -40,16 +46,15 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 31ea1fd913623ca4b949e675592fbd7a,
         type: 3}
-    - target: {fileID: 4863277160209273534, guid: 7ff56f8e13078c1419de4821c2b5ecfd,
-        type: 3}
-      propertyPath: offSprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 38c53ab71671bd84b92cf09c1f7fc133,
-        type: 3}
     - target: {fileID: 9063366402093685405, guid: 7ff56f8e13078c1419de4821c2b5ecfd,
         type: 3}
       propertyPath: m_Name
       value: ButtonMassDriver
+      objectReference: {fileID: 0}
+    - target: {fileID: 9066377664841440327, guid: 7ff56f8e13078c1419de4821c2b5ecfd,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9066377664841440327, guid: 7ff56f8e13078c1419de4821c2b5ecfd,
         type: 3}
@@ -68,6 +73,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9066377664841440327, guid: 7ff56f8e13078c1419de4821c2b5ecfd,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9066377664841440327, guid: 7ff56f8e13078c1419de4821c2b5ecfd,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -80,16 +90,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9066377664841440327, guid: 7ff56f8e13078c1419de4821c2b5ecfd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9066377664841440327, guid: 7ff56f8e13078c1419de4821c2b5ecfd,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9066377664841440327, guid: 7ff56f8e13078c1419de4821c2b5ecfd,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/DefibrillatorMount.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/DefibrillatorMount.prefab
@@ -53,13 +53,23 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
+      propertyPath: m_SortingLayer
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
       propertyPath: m_SortingLayerID
       value: -1618464505
       objectReference: {fileID: 0}
     - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: m_SortingLayer
-      value: 15
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -78,6 +88,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -90,16 +105,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -120,6 +125,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: DefibrillatorMount
+      objectReference: {fileID: 0}
+    - target: {fileID: 1628816798482564540, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 3314592590375341583, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -147,6 +157,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 7354635586586802054, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
+      objectReference: {fileID: 0}
     - target: {fileID: 7946340047006197236, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
       propertyPath: Passable
@@ -154,13 +169,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8232375373487905420, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: initialDescription
-      value: Holds defibrillators. You can grab the paddles if one is mounted.
+      propertyPath: initialName
+      value: defibrillator mount
       objectReference: {fileID: 0}
     - target: {fileID: 8232375373487905420, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: initialName
-      value: defibrillator mount
+      propertyPath: initialDescription
+      value: Holds defibrillators. You can grab the paddles if one is mounted.
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 768889878625444157, guid: b69bfc56f39849d4ba9139d2d51bedb6, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/ExtinguisherCabinet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/ExtinguisherCabinet.prefab
@@ -86,6 +86,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 338588115043544032, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
+      objectReference: {fileID: 0}
     - target: {fileID: 929166672355850642, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
       propertyPath: Passable
@@ -98,18 +103,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1197192003336439530, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
-      propertyPath: initialDescription
-      value: A small wall mounted cabinet designed to hold a fire extinguisher.
-      objectReference: {fileID: 0}
-    - target: {fileID: 1197192003336439530, guid: a7af28adb717b4c44b8b2002b27670bd,
-        type: 3}
       propertyPath: initialName
       value: extinguisher cabinet
       objectReference: {fileID: 0}
-    - target: {fileID: 3920465809857098496, guid: a7af28adb717b4c44b8b2002b27670bd,
+    - target: {fileID: 1197192003336439530, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
-      propertyPath: SubCatalogue.Array.size
-      value: 4
+      propertyPath: initialDescription
+      value: A small wall mounted cabinet designed to hold a fire extinguisher.
       objectReference: {fileID: 0}
     - target: {fileID: 3920465809857098496, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
@@ -117,6 +117,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: dd6b907e4d87b644fbc22a5256ce14b8,
         type: 2}
+    - target: {fileID: 3920465809857098496, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
+      propertyPath: SubCatalogue.Array.size
+      value: 4
+      objectReference: {fileID: 0}
     - target: {fileID: 3920465809857098496, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
       propertyPath: SubCatalogue.Array.data[0]
@@ -143,6 +148,11 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -158,6 +168,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -170,16 +185,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
@@ -201,6 +206,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: ExtinguisherCabinet
       objectReference: {fileID: 0}
+    - target: {fileID: 8374648283101600218, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
+      objectReference: {fileID: 0}
     - target: {fileID: 8599771746108915149, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
       propertyPath: m_Sprite
@@ -209,13 +219,13 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 8599771746108915149, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
-      propertyPath: m_SortingLayerID
-      value: -1964781063
+      propertyPath: m_SortingLayer
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 8599771746108915149, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
-      propertyPath: m_SortingLayer
-      value: 24
+      propertyPath: m_SortingLayerID
+      value: -1964781063
       objectReference: {fileID: 0}
     - target: {fileID: 8599771746108915149, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/FireAlarm.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/FireAlarm.prefab
@@ -414,6 +414,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: FireAlarm
       objectReference: {fileID: 0}
+    - target: {fileID: 1628816798482564540, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
+      objectReference: {fileID: 0}
     - target: {fileID: 6109775972905365350, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
       propertyPath: PresentSpriteSet
@@ -424,6 +429,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AssetId
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7354635586586802054, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -478,9 +488,9 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 768889878625444157, guid: b69bfc56f39849d4ba9139d2d51bedb6, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: b69bfc56f39849d4ba9139d2d51bedb6, type: 3}
---- !u!1 &5529437522813867580 stripped
+--- !u!1 &4338884022056035334 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 7354635586586802054, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+  m_CorrespondingSourceObject: {fileID: 1628816798482564540, guid: b69bfc56f39849d4ba9139d2d51bedb6,
     type: 3}
   m_PrefabInstance: {fileID: 3074947235549192634}
   m_PrefabAsset: {fileID: 0}
@@ -490,9 +500,9 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 3074947235549192634}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &4338884022056035334 stripped
+--- !u!1 &5529437522813867580 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 1628816798482564540, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+  m_CorrespondingSourceObject: {fileID: 7354635586586802054, guid: b69bfc56f39849d4ba9139d2d51bedb6,
     type: 3}
   m_PrefabInstance: {fileID: 3074947235549192634}
   m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/LightSwitch.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/LightSwitch.prefab
@@ -64,13 +64,13 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: -6356777978426299504, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: deviceType
-      value: 1
+      propertyPath: wattusage
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -6356777978426299504, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: wattusage
-      value: 0
+      propertyPath: deviceType
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -80,13 +80,23 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
+      propertyPath: m_SortingLayer
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
       propertyPath: m_SortingLayerID
       value: -1618464505
       objectReference: {fileID: 0}
     - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: m_SortingLayer
-      value: 15
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -105,6 +115,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -117,16 +132,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -148,6 +153,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: LightSwitch
       objectReference: {fileID: 0}
+    - target: {fileID: 1628816798482564540, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
+      objectReference: {fileID: 0}
     - target: {fileID: 6109775972905365350, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
       propertyPath: PresentSpriteSet
@@ -159,6 +169,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 7354635586586802054, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
+      objectReference: {fileID: 0}
     - target: {fileID: 7946340047006197236, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
       propertyPath: Passable
@@ -166,13 +181,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8232375373487905420, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: initialDescription
-      value: Make dark.
+      propertyPath: initialName
+      value: light switch
       objectReference: {fileID: 0}
     - target: {fileID: 8232375373487905420, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: initialName
-      value: light switch
+      propertyPath: initialDescription
+      value: Make dark.
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 768889878625444157, guid: b69bfc56f39849d4ba9139d2d51bedb6, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/MagicMirror.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/MagicMirror.prefab
@@ -96,13 +96,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1197192003336439530, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
-      propertyPath: initialDescription
-      value: A small wall mounted cabinet designed to hold a fire extinguisher.
+      propertyPath: initialName
+      value: extinguisher cabinet
       objectReference: {fileID: 0}
     - target: {fileID: 1197192003336439530, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
-      propertyPath: initialName
-      value: extinguisher cabinet
+      propertyPath: initialDescription
+      value: A small wall mounted cabinet designed to hold a fire extinguisher.
       objectReference: {fileID: 0}
     - target: {fileID: 3920465809857098496, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
@@ -148,13 +148,13 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 8599771746108915149, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
-      propertyPath: m_SortingLayerID
-      value: -1618464505
+      propertyPath: m_SortingLayer
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 8599771746108915149, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
-      propertyPath: m_SortingLayer
-      value: 19
+      propertyPath: m_SortingLayerID
+      value: -1618464505
       objectReference: {fileID: 0}
     - target: {fileID: 8599771746108915149, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/MountedFlash.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/MountedFlash.prefab
@@ -48,13 +48,23 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
+      propertyPath: m_SortingLayer
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
       propertyPath: m_SortingLayerID
       value: -1618464505
       objectReference: {fileID: 0}
     - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: m_SortingLayer
-      value: 15
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -73,6 +83,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -85,16 +100,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -115,6 +120,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: MountedFlash
+      objectReference: {fileID: 0}
+    - target: {fileID: 1628816798482564540, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 3314592590375341583, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -142,6 +152,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 7354635586586802054, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
+      objectReference: {fileID: 0}
     - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
       propertyPath: damageDeflection
@@ -159,13 +174,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8232375373487905420, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: initialDescription
-      value: A wall-mounted flashbulb device.
+      propertyPath: initialName
+      value: mounted flash
       objectReference: {fileID: 0}
     - target: {fileID: 8232375373487905420, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: initialName
-      value: mounted flash
+      propertyPath: initialDescription
+      value: A wall-mounted flashbulb device.
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 768889878625444157, guid: b69bfc56f39849d4ba9139d2d51bedb6, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/Painting.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/Painting.prefab
@@ -7,6 +7,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 682753206656512624, guid: 2d5ef1e4279414f4798d5cf1542d9388,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
+      objectReference: {fileID: 0}
     - target: {fileID: 877678010874754344, guid: 2d5ef1e4279414f4798d5cf1542d9388,
         type: 3}
       propertyPath: m_AssetId
@@ -14,13 +19,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2113894379060813690, guid: 2d5ef1e4279414f4798d5cf1542d9388,
         type: 3}
-      propertyPath: initialDescription
-      value: Art or "Art"? You decide.
+      propertyPath: initialName
+      value: Painting
       objectReference: {fileID: 0}
     - target: {fileID: 2113894379060813690, guid: 2d5ef1e4279414f4798d5cf1542d9388,
         type: 3}
-      propertyPath: initialName
-      value: Painting
+      propertyPath: initialDescription
+      value: Art or "Art"? You decide.
       objectReference: {fileID: 0}
     - target: {fileID: 4297281311582415504, guid: 2d5ef1e4279414f4798d5cf1542d9388,
         type: 3}
@@ -28,6 +33,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 128a50c4cf2fcc942a0c043ab618b12d,
         type: 2}
+    - target: {fileID: 8783786739138365072, guid: 2d5ef1e4279414f4798d5cf1542d9388,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8783786739138365072, guid: 2d5ef1e4279414f4798d5cf1542d9388,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -45,6 +55,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8783786739138365072, guid: 2d5ef1e4279414f4798d5cf1542d9388,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8783786739138365072, guid: 2d5ef1e4279414f4798d5cf1542d9388,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -57,16 +72,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8783786739138365072, guid: 2d5ef1e4279414f4798d5cf1542d9388,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8783786739138365072, guid: 2d5ef1e4279414f4798d5cf1542d9388,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8783786739138365072, guid: 2d5ef1e4279414f4798d5cf1542d9388,
         type: 3}
@@ -88,11 +93,21 @@ PrefabInstance:
       propertyPath: m_Name
       value: Painting
       objectReference: {fileID: 0}
+    - target: {fileID: 8787633699505619018, guid: 2d5ef1e4279414f4798d5cf1542d9388,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
+      objectReference: {fileID: 0}
     - target: {fileID: 8832630492572476509, guid: 2d5ef1e4279414f4798d5cf1542d9388,
         type: 3}
       propertyPath: m_Sprite
       value: 
       objectReference: {fileID: 21300000, guid: dc0a14c2dfca29143ab1bbdeb8c4b714,
         type: 3}
+    - target: {fileID: 8832630492572476509, guid: 2d5ef1e4279414f4798d5cf1542d9388,
+        type: 3}
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2d5ef1e4279414f4798d5cf1542d9388, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/PictureFrame.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/PictureFrame.prefab
@@ -7,6 +7,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 682753206656512624, guid: 2d5ef1e4279414f4798d5cf1542d9388,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
+      objectReference: {fileID: 0}
     - target: {fileID: 877678010874754344, guid: 2d5ef1e4279414f4798d5cf1542d9388,
         type: 3}
       propertyPath: m_AssetId
@@ -14,13 +19,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2113894379060813690, guid: 2d5ef1e4279414f4798d5cf1542d9388,
         type: 3}
-      propertyPath: initialDescription
-      value: Every time you look it makes you laugh.
+      propertyPath: initialName
+      value: picture frame
       objectReference: {fileID: 0}
     - target: {fileID: 2113894379060813690, guid: 2d5ef1e4279414f4798d5cf1542d9388,
         type: 3}
-      propertyPath: initialName
-      value: picture frame
+      propertyPath: initialDescription
+      value: Every time you look it makes you laugh.
       objectReference: {fileID: 0}
     - target: {fileID: 4297281311582415504, guid: 2d5ef1e4279414f4798d5cf1542d9388,
         type: 3}
@@ -28,6 +33,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 128a50c4cf2fcc942a0c043ab618b12d,
         type: 2}
+    - target: {fileID: 8783786739138365072, guid: 2d5ef1e4279414f4798d5cf1542d9388,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8783786739138365072, guid: 2d5ef1e4279414f4798d5cf1542d9388,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -45,6 +55,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8783786739138365072, guid: 2d5ef1e4279414f4798d5cf1542d9388,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8783786739138365072, guid: 2d5ef1e4279414f4798d5cf1542d9388,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -57,16 +72,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8783786739138365072, guid: 2d5ef1e4279414f4798d5cf1542d9388,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8783786739138365072, guid: 2d5ef1e4279414f4798d5cf1542d9388,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8783786739138365072, guid: 2d5ef1e4279414f4798d5cf1542d9388,
         type: 3}
@@ -88,11 +93,21 @@ PrefabInstance:
       propertyPath: m_Name
       value: PictureFrame
       objectReference: {fileID: 0}
+    - target: {fileID: 8787633699505619018, guid: 2d5ef1e4279414f4798d5cf1542d9388,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
+      objectReference: {fileID: 0}
     - target: {fileID: 8832630492572476509, guid: 2d5ef1e4279414f4798d5cf1542d9388,
         type: 3}
       propertyPath: m_Sprite
       value: 
       objectReference: {fileID: 21300000, guid: dc0a14c2dfca29143ab1bbdeb8c4b714,
         type: 3}
+    - target: {fileID: 8832630492572476509, guid: 2d5ef1e4279414f4798d5cf1542d9388,
+        type: 3}
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2d5ef1e4279414f4798d5cf1542d9388, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/Poster.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/Poster.prefab
@@ -770,7 +770,9 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
+    LightningDamageProof: 0
   HeatResistance: 100
+  ExplosionsDamage: 100
 --- !u!114 &1567170016700135650
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/RequestConsole.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/RequestConsole.prefab
@@ -122,7 +122,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   isMeleeable: 1
   butcherTime: 2
-  butcherSound: BladeSlice
+  butcherSound:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
 --- !u!114 &114961671854977668
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -214,7 +220,13 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   initialIntegrity: 100
-  soundOnHit: 
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   damageDeflection: 0
   Armor:
     Melee: 0
@@ -235,7 +247,9 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
+    LightningDamageProof: 0
   HeatResistance: 100
+  ExplosionsDamage: 100
 --- !u!114 &114665882604199916
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -334,7 +348,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1618464505
-  m_SortingLayer: 15
+  m_SortingLayer: 19
   m_SortingOrder: 10
   m_Sprite: {fileID: 21300000, guid: 93c12dca6be8a194d9c892778366fd45, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -362,6 +376,7 @@ MonoBehaviour:
   NetworkThis: 1
   SubCatalogue: []
   PresentSpriteSet: {fileID: 11400000, guid: 2239f0e1ffe994648a228ff07314c6a5, type: 2}
+  randomInitialSprite: 0
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/Signs/_SignBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/Signs/_SignBase.prefab
@@ -45,6 +45,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 338588115043544032, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
+      objectReference: {fileID: 0}
     - target: {fileID: 929166672355850642, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
       propertyPath: Passable
@@ -52,13 +57,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1140667517167752775, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
-      propertyPath: initialIntegrity
-      value: 100
+      propertyPath: Armor.Melee
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 1140667517167752775, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
-      propertyPath: Armor.Melee
-      value: 50
+      propertyPath: initialIntegrity
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 1140667517167752775, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
@@ -82,6 +87,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -97,6 +107,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -109,16 +124,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
@@ -140,15 +145,20 @@ PrefabInstance:
       propertyPath: m_Name
       value: _SignBase
       objectReference: {fileID: 0}
-    - target: {fileID: 8599771746108915149, guid: a7af28adb717b4c44b8b2002b27670bd,
+    - target: {fileID: 8374648283101600218, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
-      propertyPath: m_SortingLayerID
-      value: 1855317293
+      propertyPath: m_Layer
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 8599771746108915149, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
       propertyPath: m_SortingLayer
-      value: 14
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 8599771746108915149, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
+      propertyPath: m_SortingLayerID
+      value: 1855317293
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a7af28adb717b4c44b8b2002b27670bd, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/StationIntercom.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/StationIntercom.prefab
@@ -56,6 +56,21 @@ PrefabInstance:
       propertyPath: m_Name
       value: StationIntercom
       objectReference: {fileID: 0}
+    - target: {fileID: 8361325896675593486, guid: 23a0b694284152342b2ec0817fade0d6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 8362680152250046504, guid: 23a0b694284152342b2ec0817fade0d6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 8366254045131436154, guid: 23a0b694284152342b2ec0817fade0d6,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8366254045131436154, guid: 23a0b694284152342b2ec0817fade0d6,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -73,6 +88,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8366254045131436154, guid: 23a0b694284152342b2ec0817fade0d6,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8366254045131436154, guid: 23a0b694284152342b2ec0817fade0d6,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -85,16 +105,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8366254045131436154, guid: 23a0b694284152342b2ec0817fade0d6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8366254045131436154, guid: 23a0b694284152342b2ec0817fade0d6,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8366254045131436154, guid: 23a0b694284152342b2ec0817fade0d6,
         type: 3}
@@ -134,13 +144,13 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 8572760248345607762, guid: 23a0b694284152342b2ec0817fade0d6,
         type: 3}
-      propertyPath: m_SortingLayerID
-      value: -1618464505
+      propertyPath: m_SortingLayer
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 8572760248345607762, guid: 23a0b694284152342b2ec0817fade0d6,
         type: 3}
-      propertyPath: m_SortingLayer
-      value: 15
+      propertyPath: m_SortingLayerID
+      value: -1618464505
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 23a0b694284152342b2ec0817fade0d6, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/StationIntercomUnfastened.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/StationIntercomUnfastened.prefab
@@ -9,13 +9,18 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 633079008322250563, guid: 37832ac0101fb324aa588e3b400229fe,
         type: 3}
-      propertyPath: m_SortingLayerID
-      value: -1618464505
+      propertyPath: m_SortingLayer
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 633079008322250563, guid: 37832ac0101fb324aa588e3b400229fe,
         type: 3}
-      propertyPath: m_SortingLayer
-      value: 15
+      propertyPath: m_SortingLayerID
+      value: -1618464505
+      objectReference: {fileID: 0}
+    - target: {fileID: 732769233117423979, guid: 37832ac0101fb324aa588e3b400229fe,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 732769233117423979, guid: 37832ac0101fb324aa588e3b400229fe,
         type: 3}
@@ -34,6 +39,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 732769233117423979, guid: 37832ac0101fb324aa588e3b400229fe,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 732769233117423979, guid: 37832ac0101fb324aa588e3b400229fe,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -46,16 +56,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 732769233117423979, guid: 37832ac0101fb324aa588e3b400229fe,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 732769233117423979, guid: 37832ac0101fb324aa588e3b400229fe,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 732769233117423979, guid: 37832ac0101fb324aa588e3b400229fe,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/StatusDisplay.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/StatusDisplay.prefab
@@ -1,42 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!222 &6514531138547576961
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1826008233054429714}
-  m_CullTransparentMesh: 0
---- !u!114 &8622336101324248381
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1826008233054429714}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 565edd107a0f4d95b9b8e032eaa654b3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  textField: {fileID: 8315174962581895961}
-  stateSync: 0
-  hasCables: 1
-  MonitorSpriteHandler: {fileID: 6559413761007306952}
-  DisplaySpriteHandler: {fileID: 1852327771054836181}
-  openEmpty: {fileID: 21300000, guid: dd877a0b53912f6448b02714240bd9b2, type: 3}
-  openCabled: {fileID: 21300000, guid: ffe91d76691c7b240a3c58915e2b3594, type: 3}
-  closedOff: {fileID: 21300000, guid: 04bf384246499214baf7542e07b7019e, type: 3}
-  joeNews: {fileID: 11400000, guid: 0627b5d10aa2ee24988d240b94b47ec2, type: 2}
-  doorControllers: []
-  centComm: {fileID: 0}
-  currentTimerSeconds: 0
-  countingDown: 0
-  channel: 1
-  conType: 7
 --- !u!1 &1757062059131953751
 GameObject:
   m_ObjectHideFlags: 0
@@ -107,7 +70,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1618464505
-  m_SortingLayer: 15
+  m_SortingLayer: 19
   m_SortingOrder: 11
   m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -135,10 +98,48 @@ MonoBehaviour:
   NetworkThis: 1
   SubCatalogue: []
   PresentSpriteSet: {fileID: 0}
+  randomInitialSprite: 0
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
   Sprites: []
+--- !u!222 &6514531138547576961
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1826008233054429714}
+  m_CullTransparentMesh: 0
+--- !u!114 &8622336101324248381
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1826008233054429714}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 565edd107a0f4d95b9b8e032eaa654b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  textField: {fileID: 8315174962581895961}
+  stateSync: 0
+  hasCables: 1
+  MonitorSpriteHandler: {fileID: 6559413761007306952}
+  DisplaySpriteHandler: {fileID: 1852327771054836181}
+  openEmpty: {fileID: 21300000, guid: dd877a0b53912f6448b02714240bd9b2, type: 3}
+  openCabled: {fileID: 21300000, guid: ffe91d76691c7b240a3c58915e2b3594, type: 3}
+  closedOff: {fileID: 21300000, guid: 04bf384246499214baf7542e07b7019e, type: 3}
+  joeNews: {fileID: 11400000, guid: 0627b5d10aa2ee24988d240b94b47ec2, type: 2}
+  doorControllers: []
+  centComm: {fileID: 0}
+  currentTimerSeconds: 0
+  countingDown: 0
+  channel: 1
+  conType: 7
 --- !u!1 &6551633036436676155
 GameObject:
   m_ObjectHideFlags: 0
@@ -296,13 +297,23 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
+      propertyPath: m_SortingLayer
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
       propertyPath: m_SortingLayerID
       value: -1618464505
       objectReference: {fileID: 0}
     - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: m_SortingLayer
-      value: 15
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -321,6 +332,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -333,16 +349,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -363,6 +369,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: StatusDisplay
+      objectReference: {fileID: 0}
+    - target: {fileID: 1628816798482564540, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 3314592590375341583, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -394,6 +405,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: MonitorSprite
+      objectReference: {fileID: 0}
+    - target: {fileID: 7354635586586802054, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 7946340047006197236, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/TurretControlPanel.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/TurretControlPanel.prefab
@@ -53,13 +53,23 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
+      propertyPath: m_SortingLayer
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
       propertyPath: m_SortingLayerID
       value: -1618464505
       objectReference: {fileID: 0}
     - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: m_SortingLayer
-      value: 15
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -78,6 +88,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -90,16 +105,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -120,6 +125,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: TurretControlPanel
+      objectReference: {fileID: 0}
+    - target: {fileID: 1628816798482564540, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 3314592590375341583, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
@@ -147,9 +157,14 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 7354635586586802054, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 19
+      objectReference: {fileID: 0}
     - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: Resistances.LavaProof
+      propertyPath: Resistances.AcidProof
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
@@ -159,17 +174,17 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: Resistances.AcidProof
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
-        type: 3}
-      propertyPath: Resistances.Indestructable
+      propertyPath: Resistances.LavaProof
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
       propertyPath: Resistances.UnAcidable
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: Resistances.Indestructable
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7946340047006197236, guid: b69bfc56f39849d4ba9139d2d51bedb6,
@@ -179,13 +194,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8232375373487905420, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: initialDescription
-      value: Used to control a room's automated defenses.
+      propertyPath: initialName
+      value: turret control panel
       objectReference: {fileID: 0}
     - target: {fileID: 8232375373487905420, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
-      propertyPath: initialName
-      value: turret control panel
+      propertyPath: initialDescription
+      value: Used to control a room's automated defenses.
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 768889878625444157, guid: b69bfc56f39849d4ba9139d2d51bedb6, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/UnitystationPoster3.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/UnitystationPoster3.prefab
@@ -85,6 +85,8 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
+  ReachableThrough: 1
+  passableExclusionsToThis: []
 --- !u!114 &114342113035124884
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -97,6 +99,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f227cc6622a9ad44f981a39d11d3d343, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  directional: {fileID: 0}
 --- !u!114 &114755547600207878
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -112,6 +115,9 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   InitialDirection: 3
+  onEditorDirectionChange:
+    m_PersistentCalls:
+      m_Calls: []
   ChangeDirectionWithMatrix: 1
   DisableSyncing: 0
 --- !u!114 &114728076805570486
@@ -128,6 +134,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  snapToGridOnStart: 1
   IsFixedMatrix: 0
 --- !u!114 &114802099853820208
 MonoBehaviour:
@@ -141,8 +148,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isMeleeable: 1
   butcherTime: 2
-  butcherSound: BladeSlice
+  butcherSound:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
 --- !u!114 &114931094214022604
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -157,7 +171,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  soundOnHit: 
+  initialIntegrity: 100
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  damageDeflection: 0
   Armor:
     Melee: 0
     Bullet: 0
@@ -177,8 +199,9 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
+    LightningDamageProof: 0
   HeatResistance: 100
-  initialIntegrity: 100
+  ExplosionsDamage: 100
 --- !u!114 &114477464032290438
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -220,9 +243,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 62cc3ef7cd9082443aaf3c255851d15a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  forceHidden: 0
 --- !u!1 &1000013907114358
 GameObject:
   m_ObjectHideFlags: 0
@@ -271,6 +291,7 @@ SpriteRenderer:
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -293,7 +314,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 142874271
-  m_SortingLayer: 10
+  m_SortingLayer: 12
   m_SortingOrder: 10
   m_Sprite: {fileID: 21300162, guid: b03991443a05d4c4f86dd5ac5fb16132, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/UnitystationSign.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/UnitystationSign.prefab
@@ -106,6 +106,8 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
+  ReachableThrough: 1
+  passableExclusionsToThis: []
 --- !u!114 &114190295728345252
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -118,6 +120,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f227cc6622a9ad44f981a39d11d3d343, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  directional: {fileID: 0}
 --- !u!114 &114136265959939624
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -147,6 +150,9 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   InitialDirection: 3
+  onEditorDirectionChange:
+    m_PersistentCalls:
+      m_Calls: []
   ChangeDirectionWithMatrix: 1
   DisableSyncing: 0
 --- !u!114 &114896115685743358
@@ -163,6 +169,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  snapToGridOnStart: 1
   IsFixedMatrix: 0
 --- !u!114 &114252885189391182
 MonoBehaviour:
@@ -176,8 +183,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isMeleeable: 1
   butcherTime: 2
-  butcherSound: BladeSlice
+  butcherSound:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
 --- !u!114 &114536965082524360
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -192,7 +206,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  soundOnHit: 
+  initialIntegrity: 100
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  damageDeflection: 0
   Armor:
     Melee: 0
     Bullet: 0
@@ -212,8 +234,9 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
+    LightningDamageProof: 0
   HeatResistance: 100
-  initialIntegrity: 100
+  ExplosionsDamage: 100
 --- !u!114 &114281701036864274
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -262,9 +285,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 62cc3ef7cd9082443aaf3c255851d15a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  forceHidden: 0
 --- !u!1 &1000013907114358
 GameObject:
   m_ObjectHideFlags: 0
@@ -312,6 +332,7 @@ SpriteRenderer:
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -334,7 +355,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 142874271
-  m_SortingLayer: 10
+  m_SortingLayer: 12
   m_SortingOrder: 10
   m_Sprite: {fileID: 21300000, guid: b03991443a05d4c4f86dd5ac5fb16132, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/UnitystationSign2.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/UnitystationSign2.prefab
@@ -106,6 +106,8 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
+  ReachableThrough: 1
+  passableExclusionsToThis: []
 --- !u!114 &114620317380750088
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -118,6 +120,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f227cc6622a9ad44f981a39d11d3d343, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  directional: {fileID: 0}
 --- !u!114 &114377926562527894
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -147,6 +150,9 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   InitialDirection: 3
+  onEditorDirectionChange:
+    m_PersistentCalls:
+      m_Calls: []
   ChangeDirectionWithMatrix: 1
   DisableSyncing: 0
 --- !u!114 &114537108118862576
@@ -163,6 +169,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  snapToGridOnStart: 1
   IsFixedMatrix: 0
 --- !u!114 &114471239075507338
 MonoBehaviour:
@@ -176,8 +183,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isMeleeable: 1
   butcherTime: 2
-  butcherSound: BladeSlice
+  butcherSound:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
 --- !u!114 &114110670182460418
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -192,7 +206,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  soundOnHit: 
+  initialIntegrity: 100
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  damageDeflection: 0
   Armor:
     Melee: 0
     Bullet: 0
@@ -212,8 +234,9 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
+    LightningDamageProof: 0
   HeatResistance: 100
-  initialIntegrity: 100
+  ExplosionsDamage: 100
 --- !u!114 &114540546283986936
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -262,9 +285,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 62cc3ef7cd9082443aaf3c255851d15a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  forceHidden: 0
 --- !u!1 &1000013907114358
 GameObject:
   m_ObjectHideFlags: 0
@@ -312,6 +332,7 @@ SpriteRenderer:
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -334,7 +355,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 142874271
-  m_SortingLayer: 10
+  m_SortingLayer: 12
   m_SortingOrder: 10
   m_Sprite: {fileID: 21300098, guid: b03991443a05d4c4f86dd5ac5fb16132, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/UnitystationSign3.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/UnitystationSign3.prefab
@@ -106,6 +106,8 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
+  ReachableThrough: 1
+  passableExclusionsToThis: []
 --- !u!114 &114731318519112812
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -118,6 +120,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f227cc6622a9ad44f981a39d11d3d343, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  directional: {fileID: 0}
 --- !u!114 &114346909182757630
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -147,6 +150,9 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   InitialDirection: 3
+  onEditorDirectionChange:
+    m_PersistentCalls:
+      m_Calls: []
   ChangeDirectionWithMatrix: 1
   DisableSyncing: 0
 --- !u!114 &114098454942565874
@@ -163,6 +169,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  snapToGridOnStart: 1
   IsFixedMatrix: 0
 --- !u!114 &114213073453988466
 MonoBehaviour:
@@ -176,8 +183,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isMeleeable: 1
   butcherTime: 2
-  butcherSound: BladeSlice
+  butcherSound:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
 --- !u!114 &114923429385349424
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -192,7 +206,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  soundOnHit: 
+  initialIntegrity: 100
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  damageDeflection: 0
   Armor:
     Melee: 0
     Bullet: 0
@@ -212,8 +234,9 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
+    LightningDamageProof: 0
   HeatResistance: 100
-  initialIntegrity: 100
+  ExplosionsDamage: 100
 --- !u!114 &114881631371079200
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -262,9 +285,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 62cc3ef7cd9082443aaf3c255851d15a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  forceHidden: 0
 --- !u!1 &1000013907114358
 GameObject:
   m_ObjectHideFlags: 0
@@ -312,6 +332,7 @@ SpriteRenderer:
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -334,7 +355,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 142874271
-  m_SortingLayer: 10
+  m_SortingLayer: 12
   m_SortingOrder: 10
   m_Sprite: {fileID: 21300108, guid: b03991443a05d4c4f86dd5ac5fb16132, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
@@ -130,10 +130,10 @@ namespace Weapons
 		public AddressableAudioSource DryFireSound;
 
 		/// <summary>
-		/// The amount of times per second this weapon can fire
+		/// The time in seconds before this weapon can fire again.
 		/// </summary>
-		[Tooltip("The amount of times per second this weapon can fire")]
-		public double FireRate;
+		[Tooltip("The time in seconds before this weapon can fire again.")]
+		public double FireDelay = 0;
 
 		/// <summary>
 		/// If suicide shooting should be prevented (for when user inadvertently drags over themselves during a burst)
@@ -842,7 +842,7 @@ namespace Weapons
 			if (shooter == PlayerManager.LocalPlayer)
 			{
 				//this is our gun so we need to update our predictions
-				FireCountDown += 1.0 / FireRate;
+				FireCountDown = FireDelay;
 				//add additional recoil after shooting for the next round
 				AppendRecoil();
 

--- a/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
@@ -133,7 +133,7 @@ namespace Weapons
 		/// The time in seconds before this weapon can fire again.
 		/// </summary>
 		[Tooltip("The time in seconds before this weapon can fire again.")]
-		public double FireDelay = 0;
+		public double FireDelay = 0.5;
 
 		/// <summary>
 		/// If suicide shooting should be prevented (for when user inadvertently drags over themselves during a burst)

--- a/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
@@ -133,7 +133,7 @@ namespace Weapons
 		/// The time in seconds before this weapon can fire again.
 		/// </summary>
 		[Tooltip("The time in seconds before this weapon can fire again.")]
-		public double FireDelay = 0.5;
+		public double FireDelay += 0.5;
 
 		/// <summary>
 		/// If suicide shooting should be prevented (for when user inadvertently drags over themselves during a burst)

--- a/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
@@ -133,7 +133,7 @@ namespace Weapons
 		/// The time in seconds before this weapon can fire again.
 		/// </summary>
 		[Tooltip("The time in seconds before this weapon can fire again.")]
-		public double FireDelay += 0.5;
+		public double FireDelay = 0.5;
 
 		/// <summary>
 		/// If suicide shooting should be prevented (for when user inadvertently drags over themselves during a burst)
@@ -842,7 +842,7 @@ namespace Weapons
 			if (shooter == PlayerManager.LocalPlayer)
 			{
 				//this is our gun so we need to update our predictions
-				FireCountDown = FireDelay;
+				FireCountDown += FireDelay;
 				//add additional recoil after shooting for the next round
 				AppendRecoil();
 

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Grilles/BrokenGrill.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Grilles/BrokenGrill.asset
@@ -12,10 +12,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: BrokenGrill
   m_EditorClassIdentifier: 
-  displayName: broken Grill
-  LayerType: 5
+  displayName: broken grille
+  LayerType: 3
   TileType: 6
-  RequiredTiles: []
+  RequiredTiles:
+  - {fileID: 11400000, guid: e8a2685c8a14b7043bf58bde4374c6b1, type: 2}
   floorTileSounds: {fileID: 0}
   CanSoundOverride: 0
   atmosPassable: 1
@@ -23,29 +24,34 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 1
   mineable: 0
+  RadiationPassability: 1
   doesReflectBullet: 0
   indestructible: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 50
+  maxHealth: 20
   damageDeflection: 0
   armor:
-    Melee: 90
-    Bullet: 90
-    Laser: 90
-    Energy: 90
-    Bomb: 90
+    Melee: 50
+    Bullet: 70
+    Laser: 70
+    Energy: 100
+    Bomb: 10
     Rad: 100
-    Fire: 100
-    Acid: 90
+    Fire: 0
+    Acid: 0
     Magic: 0
     Bio: 100
-  tileInteractions: []
+  tileInteractions:
+  - {fileID: 11400000, guid: 433fa20f26ef08d4a844cf98c3a923f3, type: 2}
+  - {fileID: 11400000, guid: 10228000f4d0b45ccbe54926e21b9cb0, type: 2}
   spawnOnDeconstruct: {fileID: 0}
-  spawnAmountOnDeconstruct: 1
+  spawnAmountOnDeconstruct: 0
   lootOnDespawn: {fileID: 0}
   toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
   soundOnHit:
     SetLoadSetting: 0
     AssetAddress: Assets/Prefabs/Effects/GrillHit.prefab

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Grilles/GrilleDestroyed.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Grilles/GrilleDestroyed.asset
@@ -13,21 +13,24 @@ MonoBehaviour:
   m_Name: GrilleDestroyed
   m_EditorClassIdentifier: 
   displayName: broken grille
-  LayerType: 5
+  LayerType: 3
   TileType: 6
   RequiredTiles:
   - {fileID: 11400000, guid: e8a2685c8a14b7043bf58bde4374c6b1, type: 2}
-  floorTileType: 0
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
   atmosPassable: 1
   isSealed: 0
   SpawnWithNoAir: 0
   passable: 1
   mineable: 0
+  RadiationPassability: 1
   doesReflectBullet: 0
+  indestructible: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 50
+  maxHealth: 20
   damageDeflection: 0
   armor:
     Melee: 50
@@ -43,10 +46,12 @@ MonoBehaviour:
   tileInteractions:
   - {fileID: 11400000, guid: 433fa20f26ef08d4a844cf98c3a923f3, type: 2}
   - {fileID: 11400000, guid: 10228000f4d0b45ccbe54926e21b9cb0, type: 2}
-  spawnOnDeconstruct: {fileID: 7198241665461443898, guid: 5dce4d3e01518474bb9bb8085b718980,
-    type: 3}
-  spawnAmountOnDeconstruct: 1
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 0
   lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
   soundOnHit:
     SetLoadSetting: 0
     AssetAddress: Assets/Prefabs/Effects/GrillHit.prefab


### PR DESCRIPTION
### Purpose
- Replaces the FireRate variable in Gun.cs with FireDelay, which is the time in seconds that a gun can fire again as opposed to FireRate being how many times a gun can fire in a second. Done as FireDelay is more similar to how /tg/ (and CM) does it.
  - Tweaks for fire delays across the board.
- Makes broken grilles less durable. Stops bullets from colliding with them.
- _Hopefully_ makes wall-mounted objects no longer block projectiles
- Makes air meters no longer block movement.