### PR TITLE
NPC AI Fixes and adjustments

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Mobs/Living/SimpleAnimals/Hostile/_SimpleAnimalHostileBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/Living/SimpleAnimals/Hostile/_SimpleAnimalHostileBase.prefab
@@ -16,7 +16,7 @@ MonoBehaviour:
   knockedDownRotation: 0
   deathSounds: []
   randomSounds: []
-  playRandomSoundTimer: 0
+  playRandomSoundTimer: 3
   randomSoundProbability: 0
   searchTickRate: 0.5
   currentStatus: 0

--- a/UnityProject/Assets/Resources/Prefabs/Mobs/NPC/Resources/Hostile/Xenomorph/NPC_Facehugger.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/NPC/Resources/Hostile/Xenomorph/NPC_Facehugger.prefab
@@ -280,12 +280,12 @@ GameObject:
   - component: {fileID: 4826045711076760867}
   - component: {fileID: 3493423571535560689}
   - component: {fileID: 3651291330810827203}
+  - component: {fileID: 6377642271645965250}
   - component: {fileID: 2052235574987344614}
   - component: {fileID: 3611455284223927780}
   - component: {fileID: 1894956765386061361}
   - component: {fileID: 700465870708930573}
   - component: {fileID: 8234615412304531865}
-  - component: {fileID: 6377642271645965250}
   m_Layer: 12
   m_Name: NPC_Facehugger
   m_TagString: Untagged
@@ -587,6 +587,46 @@ MonoBehaviour:
   hasFoodPrefereces: 0
   foodPreferences: []
   IsEmagged: 0
+--- !u!114 &6377642271645965250
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4827737755655954553}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a10a3248df701d54a8766c917e03aa80, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  brain: {fileID: 11400000, guid: ee57f96de53d4b0489799717352da07e, type: 2}
+  agentParameters:
+    agentCameras: []
+    agentRenderTextures: []
+    maxStep: 0
+    resetOnDone: 1
+    onDemandDecision: 1
+    numberOfActionsBetweenDecisions: 1
+  performingDecision: 0
+  performingAction: 0
+  activated: 0
+  tickRate: 0.3
+  FollowTarget: {fileID: 0}
+  targetOtherPlayersWhoGetInWay: 1
+  onlyActOnTarget: 0
+  doLerpOnAction: 1
+  spriteHolder: {fileID: 3392343644113499114}
+  actionCooldown: 1
+  mobAI: {fileID: 0}
+  maskObject: {fileID: 8320299039891337921, guid: 6fecf534029349145b17735e15c9498c,
+    type: 3}
+  bite:
+    SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/NPC/Facehugger.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
 --- !u!114 &2052235574987344614
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -698,42 +738,3 @@ MonoBehaviour:
   indexLeft: 3
   spriteHandlers:
   - {fileID: 6879569256576700587}
---- !u!114 &6377642271645965250
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4827737755655954553}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a10a3248df701d54a8766c917e03aa80, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  brain: {fileID: 11400000, guid: ee57f96de53d4b0489799717352da07e, type: 2}
-  agentParameters:
-    agentCameras: []
-    agentRenderTextures: []
-    maxStep: 0
-    resetOnDone: 1
-    onDemandDecision: 1
-    numberOfActionsBetweenDecisions: 1
-  performingDecision: 0
-  performingAction: 0
-  activated: 0
-  tickRate: 0.3
-  FollowTarget: {fileID: 0}
-  targetOtherPlayersWhoGetInWay: 1
-  onlyActOnTarget: 0
-  doLerpOnAction: 1
-  spriteHolder: {fileID: 3392343644113499114}
-  actionCooldown: 1
-  mobAI: {fileID: 0}
-  maskObject: {fileID: 0}
-  bite:
-    SetLoadSetting: 0
-    AssetAddress: null
-    AssetReference:
-      m_AssetGUID: 
-      m_SubObjectName: 
-      m_SubObjectType: 

--- a/UnityProject/Assets/Resources/Prefabs/Mobs/NPC/Resources/Hostile/Xenomorph/NPC_Facehugger.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/NPC/Resources/Hostile/Xenomorph/NPC_Facehugger.prefab
@@ -72,7 +72,7 @@ SpriteRenderer:
   m_SortingLayerID: -229502157
   m_SortingLayer: 21
   m_SortingOrder: 11
-  m_Sprite: {fileID: 21300016, guid: 4866054b12864074ca72678ebef13a7c, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 4866054b12864074ca72678ebef13a7c, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -152,10 +152,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ea79a12bc31d4df394067a2be447854d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  MaxDamage: 25
+  livingHealthBehaviour: {fileID: 0}
   Type: 1
   isBleeding: 0
-  livingHealthBehaviour: {fileID: 0}
   Severity: 0
   armor:
     Melee: 0
@@ -211,10 +210,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ea79a12bc31d4df394067a2be447854d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  MaxDamage: 25
+  livingHealthBehaviour: {fileID: 0}
   Type: 0
   isBleeding: 0
-  livingHealthBehaviour: {fileID: 0}
   Severity: 0
   armor:
     Melee: 0
@@ -287,6 +285,7 @@ GameObject:
   - component: {fileID: 1894956765386061361}
   - component: {fileID: 700465870708930573}
   - component: {fileID: 8234615412304531865}
+  - component: {fileID: 6377642271645965250}
   m_Layer: 12
   m_Name: NPC_Facehugger
   m_TagString: Untagged
@@ -385,7 +384,7 @@ MonoBehaviour:
   isInitiallyNotPushable: 0
   pushPullSound:
     SetLoadSetting: 0
-    AssetAddress: 
+    AssetAddress: null
     AssetReference:
       m_AssetGUID: 
       m_SubObjectName: 
@@ -446,13 +445,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   isMeleeable: 1
   butcherTime: 2
-  butcherSound:
-    SetLoadSetting: 0
-    AssetAddress: 
-    AssetReference:
-      m_AssetGUID: 
-      m_SubObjectName: 
-      m_SubObjectType: 
+  butcherSound: 
 --- !u!114 &4859213822428636291
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -493,6 +486,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 0
   ignoreExtraRotation: []
+  RotateParent: {fileID: 0}
 --- !u!114 &4859335736327027429
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -508,7 +502,9 @@ MonoBehaviour:
   isDirty: 0
   sceneId: 0
   serverOnly: 0
+  visible: 0
   m_AssetId: 
+  hasSpawned: 0
 --- !u!114 &4826045711076760864
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -585,13 +581,6 @@ MonoBehaviour:
   performingAction: 0
   activated: 0
   tickRate: 1
-  EatFoodA:
-    SetLoadSetting: 0
-    AssetAddress: 
-    AssetReference:
-      m_AssetGUID: 
-      m_SubObjectName: 
-      m_SubObjectType: 
   CB_REAGENT: {fileID: 0}
   target: 0
   actionPerformTime: 0
@@ -622,12 +611,13 @@ MonoBehaviour:
   performingAction: 0
   activated: 0
   tickRate: 0.3
-  followTarget: {fileID: 0}
+  FollowTarget: {fileID: 0}
   targetOtherPlayersWhoGetInWay: 1
   onlyActOnTarget: 0
   doLerpOnAction: 1
   spriteHolder: {fileID: 3392343644113499114}
   actionCooldown: 1
+  mobAI: {fileID: 0}
 --- !u!114 &3611455284223927780
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -649,26 +639,12 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
-  randomSound:
-  - SetLoadSetting: 0
-    AssetAddress: Assets/Prefabs/NPC/Facehugger.prefab
-    AssetReference:
-      m_AssetGUID: 
-      m_SubObjectName: 
-      m_SubObjectType: 
+  randomSounds: []
   playRandomSoundTimer: 3
   randomSoundProbability: 20
-  bite:
-    SetLoadSetting: 0
-    AssetAddress: Assets/Prefabs/NPC/Facehugger.prefab
-    AssetReference:
-      m_AssetGUID: 
-      m_SubObjectName: 
-      m_SubObjectType: 
   searchTickRate: 0.5
   currentStatus: 0
-  maskObject: {fileID: 8320299039891337921, guid: 6fecf534029349145b17735e15c9498c,
-    type: 3}
+  ignoreInQueenCount: 0
 --- !u!114 &1894956765386061361
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -681,6 +657,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 62cc3ef7cd9082443aaf3c255851d15a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
 --- !u!114 &700465870708930573
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -720,3 +698,42 @@ MonoBehaviour:
   indexLeft: 3
   spriteHandlers:
   - {fileID: 6879569256576700587}
+--- !u!114 &6377642271645965250
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4827737755655954553}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a10a3248df701d54a8766c917e03aa80, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  brain: {fileID: 11400000, guid: ee57f96de53d4b0489799717352da07e, type: 2}
+  agentParameters:
+    agentCameras: []
+    agentRenderTextures: []
+    maxStep: 0
+    resetOnDone: 1
+    onDemandDecision: 1
+    numberOfActionsBetweenDecisions: 1
+  performingDecision: 0
+  performingAction: 0
+  activated: 0
+  tickRate: 0.3
+  FollowTarget: {fileID: 0}
+  targetOtherPlayersWhoGetInWay: 1
+  onlyActOnTarget: 0
+  doLerpOnAction: 1
+  spriteHolder: {fileID: 3392343644113499114}
+  actionCooldown: 1
+  mobAI: {fileID: 0}
+  maskObject: {fileID: 0}
+  bite:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 

--- a/UnityProject/Assets/Scripts/NPC/AI/Friendly/CatAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Friendly/CatAI.cs
@@ -90,7 +90,7 @@ namespace Systems.MobAIs
 				if (coll.GameObject == null) continue;
 
 				if (coll.GameObject != gameObject && coll.GameObject.GetComponent<MouseAI>() != null
-				                                  && !coll.GameObject.GetComponent<LivingHealthBehaviour>().IsDead)
+				                                  && !coll.GameObject.GetComponent<LivingHealthMasterBase>().IsDead)
 				{
 					return coll.GameObject.GetComponent<MouseAI>();
 				}
@@ -101,10 +101,10 @@ namespace Systems.MobAIs
 		private void HuntMouse(MouseAI mouse)
 		{
 			//Random chance of going nuts and destroying whatever is in the way
-			mobAttack.onlyHitTarget = Random.value != 0.1f;
+			mobAttack.onlyActOnTarget = Random.value != 0.1f;
 
 			Hiss(mouse.gameObject);
-			mobAttack.StartFollowing(mouse.transform);
+			mobAttack.StartFollowing(mouse.gameObject);
 		}
 
 		private void Purr(GameObject purred = null)

--- a/UnityProject/Assets/Scripts/NPC/AI/Friendly/CatAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Friendly/CatAI.cs
@@ -2,7 +2,6 @@ using System.Collections;
 using UnityEngine;
 using AddressableReferences;
 using Messages.Server.SoundMessages;
-using HealthV2;
 
 
 namespace Systems.MobAIs
@@ -91,7 +90,7 @@ namespace Systems.MobAIs
 				if (coll.GameObject == null) continue;
 
 				if (coll.GameObject != gameObject && coll.GameObject.GetComponent<MouseAI>() != null
-				                                  && !coll.GameObject.GetComponent<LivingHealthMasterBase>().IsDead)
+				                                  && !coll.GameObject.GetComponent<LivingHealthBehaviour>().IsDead)
 				{
 					return coll.GameObject.GetComponent<MouseAI>();
 				}

--- a/UnityProject/Assets/Scripts/NPC/AI/Friendly/CatAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Friendly/CatAI.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using UnityEngine;
 using AddressableReferences;
 using Messages.Server.SoundMessages;
+using HealthV2;
 
 
 namespace Systems.MobAIs

--- a/UnityProject/Assets/Scripts/NPC/AI/Friendly/CorgiAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Friendly/CorgiAI.cs
@@ -120,7 +120,7 @@ namespace Systems.MobAIs
 					SingleBark();
 				}
 
-				FollowTarget(speaker.GameObject.transform);
+				FollowTarget(speaker.GameObject);
 				yield break;
 			}
 
@@ -202,7 +202,7 @@ namespace Systems.MobAIs
 				if (coll.GameObject == null) continue;
 
 				if (coll.GameObject != gameObject && coll.GameObject.GetComponent<CatAI>() != null
-				                                  && !coll.GameObject.GetComponent<LivingHealthBehaviour>().IsDead)
+				                                  && !coll.GameObject.GetComponent<LivingHealthMasterBase>().IsDead)
 				{
 					return coll.GameObject.GetComponent<CatAI>();
 				}
@@ -218,7 +218,7 @@ namespace Systems.MobAIs
 
 			//Make the cat flee!
 			cat.RunFromDog(gameObject.transform);
-			FollowTarget(cat.gameObject.transform, 5f);
+			FollowTarget(cat.gameObject, 5f);
 			StartCoroutine(RandomBarks());
 		}
 

--- a/UnityProject/Assets/Scripts/NPC/AI/Friendly/CorgiAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Friendly/CorgiAI.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using AddressableReferences;
 using Messages.Server.SoundMessages;
 using UnityEngine;
+using HealthV2;
 
 
 namespace Systems.MobAIs

--- a/UnityProject/Assets/Scripts/NPC/AI/Friendly/CorgiAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Friendly/CorgiAI.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using AddressableReferences;
 using Messages.Server.SoundMessages;
 using UnityEngine;
-using HealthV2;
 
 
 namespace Systems.MobAIs
@@ -203,7 +202,7 @@ namespace Systems.MobAIs
 				if (coll.GameObject == null) continue;
 
 				if (coll.GameObject != gameObject && coll.GameObject.GetComponent<CatAI>() != null
-				                                  && !coll.GameObject.GetComponent<LivingHealthMasterBase>().IsDead)
+				                                  && !coll.GameObject.GetComponent<LivingHealthBehaviour>().IsDead)
 				{
 					return coll.GameObject.GetComponent<CatAI>();
 				}

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHugAction.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHugAction.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Generic;
+using Clothing;
+using UnityEngine;
+using Doors;
+using Systems.Mob;
+using Random = UnityEngine.Random;
+using AddressableReferences;
+using HealthV2;
+using Messages.Server.SoundMessages;
+using UnityEngine.Serialization;
+
+
+namespace Systems.MobAIs
+{
+	public class FaceHugAction : MobMeleeAction
+	{
+		[SerializeField] private GameObject maskObject = null;
+		public GameObject MaskObject {get{return maskObject;}}
+		[FormerlySerializedAs("Bite")] [SerializeField] private AddressableAudioSource bite = null;
+
+		protected override void ActOnLivingV2(Vector3 dir, LivingHealthMasterBase healthBehaviour)
+		{
+			TryFacehug(dir, healthBehaviour);
+		}
+		private void TryFacehug(Vector3 dir, LivingHealthMasterBase player)
+		{
+			var playerInventory = player.gameObject.GetComponent<PlayerScript>()?.Equipment;
+
+			if (playerInventory == null)
+			{
+				return;
+			}
+
+			string verb;
+			bool success;
+
+			if (HasAntihuggerItem(playerInventory))
+			{
+				verb = "tried to hug";
+				success = false;
+			}
+			else
+			{
+				verb = "hugged";
+				success = true;
+			}
+
+			ServerDoLerpAnimation(dir);
+
+			Chat.AddAttackMsgToChat(
+				gameObject,
+				player.gameObject,
+				BodyPartType.Head,
+				null,
+				verb);
+
+			AudioSourceParameters audioSourceParameters = new AudioSourceParameters(pitch: 1f);
+			SoundManager.PlayNetworkedAtPos(bite, player.gameObject.RegisterTile().WorldPositionServer,
+				audioSourceParameters, true, player.gameObject);
+
+			if (success)
+			{
+				RegisterPlayer registerPlayer = player.gameObject.GetComponent<RegisterPlayer>();
+				Facehug(playerInventory, registerPlayer);
+			}
+
+		}
+		private void Facehug(Equipment playerInventory, RegisterPlayer player)
+		{
+			var result = Spawn.ServerPrefab(maskObject);
+			var mask = result.GameObject;
+
+			Inventory.ServerAdd(
+				mask,
+				playerInventory.ItemStorage.GetNamedItemSlot(NamedSlot.mask),
+				ReplacementStrategy.DespawnOther);
+
+			Despawn.ServerSingle(gameObject);
+		}
+
+		/// <summary>
+		/// Check the player inventory for an item in head, mask or eyes slots with
+		/// Antifacehugger trait. It also drops all items that doesn't have the trait.
+		/// </summary>
+		/// <param name="equipment"></param>
+		/// <returns>True if the player is protected against huggers, false it not</returns>
+		private bool HasAntihuggerItem(Equipment equipment)
+		{
+			bool antiHugger = false;
+
+			foreach (var slot in faceSlots)
+			{
+				var item = equipment.ItemStorage.GetNamedItemSlot(slot)?.Item;
+				if (item == null || item.gameObject == null)
+				{
+					continue;
+				}
+
+				if (!Validations.HasItemTrait(item.gameObject, CommonTraits.Instance.AntiFacehugger))
+				{
+					Inventory.ServerDrop(equipment.ItemStorage.GetNamedItemSlot(slot));
+				}
+				else
+				{
+					var integrity = item.gameObject.GetComponent<Integrity>();
+					if (integrity != null)
+					{
+						// Your protection might break!
+						integrity.ApplyDamage(7.5f, AttackType.Melee, DamageType.Brute);
+					}
+					antiHugger = true;
+				}
+			}
+			return antiHugger;
+		}
+		private readonly List<NamedSlot> faceSlots = new List<NamedSlot>()
+		{
+			NamedSlot.eyes,
+			NamedSlot.head,
+			NamedSlot.mask
+		};
+	}
+}

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHugAction.cs.meta
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHugAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a10a3248df701d54a8766c917e03aa80
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHuggerAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHuggerAI.cs
@@ -13,43 +13,15 @@ using UnityEngine.Serialization;
 
 namespace Systems.MobAIs
 {
-	public class FaceHuggerAI : MobAI, ICheckedInteractable<HandApply>, IServerSpawn
+	public class FaceHuggerAI : GenericHostileAI, ICheckedInteractable<HandApply>, IServerSpawn
 	{
 		[SerializeField]
 		[Tooltip("If true, this hugger won't be counted for the cap Queens use for lying eggs.")]
 		private bool ignoreInQueenCount = false;
-
-		[SerializeField] private List<AddressableAudioSource> deathSounds = default;
-
-		[SerializeField] private List<AddressableAudioSource> randomSound = default;
-
-		[SerializeField]
-		[Tooltip("Amount of time to wait between each random sound. Decreasing this value could affect performance!")]
-		private int playRandomSoundTimer = 3;
-
-		[SerializeField]
-		[Range(0,100)]
-		private int randomSoundProbability = 20;
-
 		[FormerlySerializedAs("Bite")] [SerializeField]
 		private AddressableAudioSource bite = null;
-
-		[SerializeField] private float searchTickRate = 0.5f;
-
-		private float movementTickRate = 1f;
-		private float moveWaitTime = 0f;
-		private float searchWaitTime = 0f;
-		private bool deathSoundPlayed = false;
-		[SerializeField] private MobStatus currentStatus;
-		public MobStatus CurrentStatus => currentStatus;
-
 		[SerializeField] private GameObject maskObject = null;
-
-		private LayerMask hitMask;
-		private int playersLayer;
 		private MobMeleeAction mobMeleeAction;
-		private ConeOfSight coneOfSight;
-		private SimpleAnimal simpleAnimal;
 
 		protected override void Awake()
 		{
@@ -61,58 +33,13 @@ namespace Systems.MobAIs
 		{
 			base.OnEnable();
 			mobMeleeAction = gameObject.GetComponent<MobMeleeAction>();
-			hitMask = LayerMask.GetMask( "Players");
-			playersLayer = LayerMask.NameToLayer("Players");
-			coneOfSight = GetComponent<ConeOfSight>();
-			PlayRandomSound();
-		}
-
-		protected override void AIStartServer()
-		{
-			movementTickRate = Random.Range(1f, 3f);
-			BeginSearch();
-		}
-
-		/// <summary>
-		/// Declare the current state of the mob as Searching.
-		/// </summary>
-		private void BeginSearch()
-		{
-			searchWaitTime = 0f;
-			currentStatus = MobStatus.Searching;
-		}
-
-		/// <summary>
-		/// Declare the current state of the mob as attacking.
-		/// </summary>
-		/// <param name="target">Gameobject that this mob will target to attack</param>
-		private void BeginAttack(GameObject target)
-		{
-			currentStatus = MobStatus.Attacking;
-			FollowTarget(target.transform);
-		}
-
-		protected override void ResetBehaviours()
-		{
-			base.ResetBehaviours();
-			mobFollow.followTarget = null;
-			currentStatus = MobStatus.None;
-			searchWaitTime = 0f;
-		}
-
-		private void MonitorIdleness()
-		{
-			if (!mobMeleeAction.performingDecision && mobMeleeAction.followTarget == null)
-			{
-				BeginSearch();
-			}
 		}
 
 		/// <summary>
 		/// Looks around and tries to find players to target
 		/// </summary>
 		/// <returns>Gameobject of the first player it found</returns>
-		protected virtual GameObject SearchForTarget()
+		protected override GameObject SearchForTarget()
 		{
 			var hits = coneOfSight.GetObjectsInSight(hitMask, LayerTypeSelection.Walls , directional.CurrentDirection.Vector, 10f, 20);
 			if (hits.Count == 0)
@@ -134,186 +61,15 @@ namespace Systems.MobAIs
 		}
 
 		/// <summary>
-		/// Makes the mob move to a random direction
-		/// </summary>
-		protected virtual void DoRandomMove()
-		{
-			var nudgeDir = GetNudgeDirFromInt(Random.Range(0, 8));
-			if (registerObject.Matrix.IsSpaceAt(registerObject.LocalPosition + nudgeDir.To3Int(), true))
-			{
-				for (int i = 0; i < 8; i++)
-				{
-					var testDir = GetNudgeDirFromInt(i);
-					var checkTile = registerObject.LocalPosition + testDir.To3Int();
-					if (registerObject.Matrix.IsSpaceAt(checkTile, true))
-					{
-						continue;
-					}
-					if (registerObject.Matrix.IsPassableAtOneMatrixOneTile(checkTile, true))
-					{
-						nudgeDir = testDir;
-						break;
-					}
-					else
-					{
-						if (!registerObject.Matrix.GetFirst<DoorController>(checkTile, true))
-						{
-							continue;
-						}
-						nudgeDir = testDir;
-						break;
-					}
-				}
-			}
-
-			NudgeInDirection(nudgeDir);
-			movementTickRate = Random.Range(1f, 3f);
-		}
-
-		protected virtual void PlayRandomSound(bool force = false)
-		{
-			if (IsDead || IsUnconscious || randomSound.Count <= 0)
-			{
-				return;
-			}
-
-			if (!force)
-			{
-				if (!DMMath.Prob(randomSoundProbability))
-				{
-					return;
-				}
-			}
-
-			AudioSourceParameters audioSourceParameters = new AudioSourceParameters(pitch: Random.Range(0.9f, 1.1f));
-			SoundManager.PlayNetworkedAtPos(randomSound.PickRandom(), transform.position,
-				audioSourceParameters, sourceObj: gameObject);
-
-			Invoke(nameof(PlayRandomSound), playRandomSoundTimer);
-		}
-
-		/// <summary>
 		/// What happens when the mob dies or is unconscious
 		/// </summary>
-		protected virtual void HandleDeathOrUnconscious()
+		protected override void HandleDeathOrUnconscious()
 		{
-			if (!IsDead || deathSoundPlayed || deathSounds.Count <= 0) return;
-			deathSoundPlayed = true;
-
-			AudioSourceParameters audioSourceParameters = new AudioSourceParameters(pitch: Random.Range(0.9f, 1.1f));
-			SoundManager.PlayNetworkedAtPos(deathSounds.PickRandom(), transform.position,
-				audioSourceParameters, sourceObj: gameObject);
+			base.HandleDeathOrUnconscious();
 
 			if (ignoreInQueenCount == false)
 			{
 				XenoQueenAI.RemoveFacehuggerFromCount();
-			}
-		}
-
-		/// <summary>
-		/// What happens if the mob is searching
-		/// </summary>
-		protected virtual void HandleSearch()
-		{
-			moveWaitTime += Time.deltaTime;
-			if (moveWaitTime >= movementTickRate)
-			{
-				moveWaitTime = 0f;
-				DoRandomMove();
-			}
-
-			searchWaitTime += Time.deltaTime;
-			if (!(searchWaitTime >= searchTickRate)) return;
-			searchWaitTime = 0f;
-			var findTarget = SearchForTarget();
-			if (findTarget != null)
-			{
-				BeginAttack(findTarget);
-			}
-			else
-			{
-				BeginSearch();
-			}
-		}
-
-		protected override void UpdateMe()
-		{
-			base.UpdateMe();
-
-			if (!isServer) return;
-
-			if (IsDead || IsUnconscious)
-			{
-				HandleDeathOrUnconscious();
-				return;
-			}
-
-			switch (currentStatus)
-			{
-				case MobStatus.Searching:
-					HandleSearch();
-					return;
-				case MobStatus.Attacking:
-					MonitorIdleness();
-					break;
-				case MobStatus.None:
-					MonitorIdleness();
-					break;
-				default:
-					MonitorIdleness();
-					break;
-			}
-		}
-
-		protected override void OnAttackReceived(GameObject damagedBy = null)
-		{
-			if (damagedBy == null)
-			{
-				StartFleeing(damagedBy);
-				return;
-			}
-
-			if (health.OverallHealth < -20f)
-			{
-				//30% chance the mob decides to flee:
-				if (Random.value < 0.3f)
-				{
-					StartFleeing(damagedBy, 5f);
-					return;
-				}
-			}
-
-			if (damagedBy.transform == mobMeleeAction.followTarget)
-			{
-				return;
-			}
-			//80% chance the mob decides to attack the new attacker
-			if (Random.value > 0.8f)
-			{
-				return;
-			}
-			var playerScript = damagedBy.GetComponent<PlayerScript>();
-			if (playerScript != null)
-			{
-				BeginAttack(damagedBy);
-			}
-		}
-
-		public override void LocalChatReceived(ChatEvent chatEvent)
-		{
-			if (chatEvent.originator == null) return;
-
-			if (currentStatus != MobStatus.Searching && currentStatus != MobStatus.None) return;
-
-			//face towards the origin:
-			var dir = (chatEvent.originator.transform.position - transform.position).normalized;
-			directional.FaceDirection(Orientation.From(dir));
-
-			//Then scan to see if anyone is there:
-			var findTarget = SearchForTarget();
-			if (findTarget != null)
-			{
-				BeginAttack(findTarget);
 			}
 		}
 
@@ -439,26 +195,15 @@ namespace Systems.MobAIs
 			Despawn.ServerSingle(gameObject);
 		}
 
-		public void OnSpawnServer(SpawnInfo info)
+		public override void OnSpawnServer(SpawnInfo info)
 		{
 			if (ignoreInQueenCount == false)
 			{
 				XenoQueenAI.AddFacehuggerToCount();
 			}
-
-			mobSprite.SetToNPCLayer();
-			registerObject.RestoreAllToDefault();
-			simpleAnimal.SetDeadState(false);
+			base.OnSpawnServer(info);
 			ResetBehaviours();
 			BeginSearch();
-		}
-
-		public override void OnDespawnServer(DespawnInfo info)
-		{
-			base.OnDespawnServer(info);
-			mobSprite.SetToBodyLayer();
-			deathSoundPlayed = false;
-			registerObject.Passable = true;
 		}
 
 		private readonly List<NamedSlot> faceSlots = new List<NamedSlot>()
@@ -467,12 +212,5 @@ namespace Systems.MobAIs
 			NamedSlot.head,
 			NamedSlot.mask
 		};
-
-		public enum MobStatus
-		{
-			None,
-			Searching,
-			Attacking
-		}
 	}
 }

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/GenericHostileAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/GenericHostileAI.cs
@@ -18,7 +18,7 @@ namespace Systems.MobAIs
 	/// in its sight. Hostile AI's should inherit this one and
 	/// override its methods!
 	/// </summary>
-	[RequireComponent(typeof(MobMeleeAttack))]
+	[RequireComponent(typeof(MobMeleeAction))]
 	[RequireComponent(typeof(ConeOfSight))]
 	public class GenericHostileAI : MobAI, IServerSpawn
 	{
@@ -48,7 +48,7 @@ namespace Systems.MobAIs
 
 		protected LayerMask hitMask;
 		protected int playersLayer;
-		protected MobMeleeAttack mobMeleeAttack;
+		protected MobMeleeAction mobMeleeAction;
 		protected ConeOfSight coneOfSight;
 		protected SimpleAnimal simpleAnimal;
 		protected int fleeChance = 30;
@@ -59,7 +59,7 @@ namespace Systems.MobAIs
 			base.OnEnable();
 			hitMask = LayerMask.GetMask( "Players");
 			playersLayer = LayerMask.NameToLayer("Players");
-			mobMeleeAttack = GetComponent<MobMeleeAttack>();
+			mobMeleeAction = GetComponent<MobMeleeAction>();
 			coneOfSight = GetComponent<ConeOfSight>();
 			simpleAnimal = GetComponent<SimpleAnimal>();
 			PlayRandomSound();
@@ -94,14 +94,14 @@ namespace Systems.MobAIs
 		protected override void ResetBehaviours()
 		{
 			base.ResetBehaviours();
-			mobFollow.FollowTarget = null;
+			mobMeleeAction.FollowTarget = null;
 			currentStatus = MobStatus.None;
 			searchWaitTime = 0f;
 		}
 
 		protected virtual void MonitorIdleness()
 		{
-			if (!mobFollow.performingDecision && mobFollow.FollowTarget == null)
+			if (!mobMeleeAction.performingDecision && mobMeleeAction.FollowTarget == null)
 			{
 				BeginSearch();
 			}
@@ -278,7 +278,7 @@ namespace Systems.MobAIs
 				}
 			}
 
-			if ((damagedBy is null) != false || damagedBy == mobFollow.FollowTarget)
+			if ((damagedBy is null) != false || damagedBy == mobMeleeAction.FollowTarget)
 			{
 				return;
 			}

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/GenericHostileAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/GenericHostileAI.cs
@@ -101,7 +101,7 @@ namespace Systems.MobAIs
 
 		protected virtual void MonitorIdleness()
 		{
-			if (!mobMeleeAttack.performingDecision && mobMeleeAttack.FollowTarget == null)
+			if (!mobFollow.performingDecision && mobFollow.FollowTarget == null)
 			{
 				BeginSearch();
 			}
@@ -278,7 +278,7 @@ namespace Systems.MobAIs
 				}
 			}
 
-			if ((damagedBy is null) != false || damagedBy == mobMeleeAttack.FollowTarget)
+			if ((damagedBy is null) != false || damagedBy == mobFollow.FollowTarget)
 			{
 				return;
 			}

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/StatueAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/StatueAI.cs
@@ -9,7 +9,7 @@ namespace Systems.MobAIs
 	/// Enemy Statue NPC's
 	/// Will attack any human that they see
 	/// </summary>
-	[RequireComponent(typeof(MobMeleeAttack))]
+	[RequireComponent(typeof(MobMeleeAction))]
 	[RequireComponent(typeof(ConeOfSight))]
 	public class StatueAI : GenericHostileAI
 	{
@@ -84,7 +84,7 @@ namespace Systems.MobAIs
 		protected override void MonitorIdleness()
 		{
 
-			if (!mobMeleeAttack.performingDecision && mobMeleeAttack.FollowTarget == null && !IsSomeoneLookingAtMe())
+			if (!mobMeleeAction.performingDecision && mobMeleeAction.FollowTarget == null && !IsSomeoneLookingAtMe())
 			{
 				BeginSearch();
 			}
@@ -94,7 +94,7 @@ namespace Systems.MobAIs
 		{
 			ResetBehaviours();
 			currentStatus = MobStatus.None;
-			mobMeleeAttack.FollowTarget = null;
+			mobMeleeAction.FollowTarget = null;
 		}
 
 		protected override void BeginAttack(GameObject target)
@@ -108,9 +108,9 @@ namespace Systems.MobAIs
 		{
 			while (!IsSomeoneLookingAtMe())
 			{
-				if(mobMeleeAttack.FollowTarget == null)
+				if(mobMeleeAction.FollowTarget == null)
 				{
-					mobMeleeAttack.StartFollowing(stalked);
+					mobMeleeAction.StartFollowing(stalked);
 				}
 				yield return WaitFor.Seconds(.2f);
 			}

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/StatueAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/StatueAI.cs
@@ -84,7 +84,7 @@ namespace Systems.MobAIs
 		protected override void MonitorIdleness()
 		{
 
-			if (!mobMeleeAttack.performingDecision && mobMeleeAttack.followTarget == null && !IsSomeoneLookingAtMe())
+			if (!mobMeleeAttack.performingDecision && mobMeleeAttack.FollowTarget == null && !IsSomeoneLookingAtMe())
 			{
 				BeginSearch();
 			}
@@ -94,21 +94,21 @@ namespace Systems.MobAIs
 		{
 			ResetBehaviours();
 			currentStatus = MobStatus.None;
-			mobMeleeAttack.followTarget = null;
+			mobMeleeAttack.FollowTarget = null;
 		}
 
 		protected override void BeginAttack(GameObject target)
 		{
 			ResetBehaviours();
 			currentStatus = MobStatus.Attacking;
-			StartCoroutine(StatueStalk(target.transform));
+			StartCoroutine(StatueStalk(target));
 		}
 
-		IEnumerator StatueStalk(Transform stalked)
+		IEnumerator StatueStalk(GameObject stalked)
 		{
 			while (!IsSomeoneLookingAtMe())
 			{
-				if(mobMeleeAttack.followTarget == null)
+				if(mobMeleeAttack.FollowTarget == null)
 				{
 					mobMeleeAttack.StartFollowing(stalked);
 				}

--- a/UnityProject/Assets/Scripts/NPC/AI/MobAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobAI.cs
@@ -243,7 +243,7 @@ namespace Systems.MobAIs
 		/// </summary>
 		/// <param name="target"></param>
 		/// <param name="followDuration"></param>
-		protected void FollowTarget(Transform target, float followDuration = -1f)
+		protected void FollowTarget(GameObject target, float followDuration = -1f)
 		{
 			ResetBehaviours();
 			followTimeMax = followDuration;

--- a/UnityProject/Assets/Scripts/NPC/AI/MobAgent.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobAgent.cs
@@ -275,7 +275,7 @@ namespace Systems.MobAIs
 		/// This observation method uses 8 observation vectors. So remember to
 		/// add them to your brain
 		/// </summary>
-		protected void ObserveAdjacentTiles(bool allowTargetPush = false, Transform target = null)
+		protected void ObserveAdjacentTiles(bool allowTargetPush = false, RegisterTile target = null)
 		{
 			var curPos = registerObj.LocalPositionServer;
 
@@ -309,7 +309,7 @@ namespace Systems.MobAIs
 							{
 								if (target != null)
 								{
-									if (checkPos == Vector3Int.RoundToInt(target.localPosition))
+									if (checkPos == target.LocalPositionServer)
 									{
 										//it is our target! Allow mob to attempt to walk into it (can be used for attacking)
 										AddVectorObs(true);

--- a/UnityProject/Assets/Scripts/NPC/AI/MobAgent.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobAgent.cs
@@ -32,6 +32,7 @@ namespace Systems.MobAIs
 		private float decisionTimeOut;
 
 		public bool Pause { get; set; }
+		public RegisterTile OriginTile;
 
 		void Awake()
 		{
@@ -76,7 +77,8 @@ namespace Systems.MobAIs
 			{
 				UpdateManager.Add(CallbackType.UPDATE, ServerUpdateMe);
 				cnt.OnTileReached().AddListener(OnTileReached);
-				startPos = transform.position;
+				OriginTile = GetComponent<RegisterTile>();
+				startPos = OriginTile.WorldPositionServer;
 				isServer = true;
 				registerObj = GetComponent<RegisterObject>();
 				registerObj.WaitForMatrixInit(StartServerAgent);

--- a/UnityProject/Assets/Scripts/NPC/AI/MobAgent.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobAgent.cs
@@ -32,7 +32,7 @@ namespace Systems.MobAIs
 		private float decisionTimeOut;
 
 		public bool Pause { get; set; }
-		public RegisterTile OriginTile;
+		protected RegisterTile OriginTile;
 
 		void Awake()
 		{

--- a/UnityProject/Assets/Scripts/NPC/AI/MobFollow.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobFollow.cs
@@ -8,10 +8,16 @@ namespace Systems.MobAIs
 	/// </summary>
 	public class MobFollow : MobAgent
 	{
-		public Transform followTarget;
+		public GameObject FollowTarget;
+		public RegisterTile TargetTile;
 
 		private float distanceCache = 0;
 
+		public override void OnEnable()
+		{
+			base.OnEnable();
+			OriginTile = GetComponent<RegisterTile>();
+		}
 		public override void AgentReset()
 		{
 			distanceCache = 0;
@@ -21,7 +27,7 @@ namespace Systems.MobAIs
 		protected override void AgentServerStart()
 		{
 			//begin following:
-			if (followTarget != null)
+			if (FollowTarget != null)
 			{
 				activated = true;
 			}
@@ -30,10 +36,19 @@ namespace Systems.MobAIs
 		/// <summary>
 		/// Make the mob start following a target
 		/// </summary>
-		public void StartFollowing(Transform target)
+		public void StartFollowing(GameObject target)
 		{
-			followTarget = target;
+			FollowTarget = target;
+			TargetTile = FollowTarget.GetComponent<RegisterTile>();
 			Activate();
+		}
+
+		/// <summary>
+		/// Returns the distance between the mob and the target
+		/// </summary>
+		public float TargetDistance()
+		{
+			return Vector3.Distance(TargetTile.WorldPositionServer, OriginTile.WorldPositionServer);
 		}
 
 		public override void CollectObservations()
@@ -41,7 +56,7 @@ namespace Systems.MobAIs
 			//You need to feed ML agents null obs
 			//if the follow target is null
 			//otherwise ML agents will break
-			if (followTarget == null)
+			if (FollowTarget == null)
 			{
 				AddVectorObs(0f);
 				AddVectorObs(0f);
@@ -50,7 +65,7 @@ namespace Systems.MobAIs
 				return;
 			}
 
-			var curDist = Vector2.Distance(followTarget.transform.position, transform.position);
+			var curDist = TargetDistance();
 			if (distanceCache == 0)
 			{
 				distanceCache = curDist;
@@ -59,21 +74,21 @@ namespace Systems.MobAIs
 			AddVectorObs(curDist / 100f);
 			AddVectorObs(distanceCache / 100f);
 			//Observe the direction to target
-			AddVectorObs(((Vector2)(followTarget.transform.position - transform.position)).normalized);
+			AddVectorObs((TargetTile.WorldPositionServer - OriginTile.WorldPositionServer).NormalizeTo2Int());
 
-			ObserveAdjacentTiles(true, followTarget);
+			ObserveAdjacentTiles(true, FollowTarget.transform);
 		}
 
 		public override void AgentAction(float[] vectorAction, string textAction)
 		{
-			if (followTarget == null) return;
+			if (FollowTarget == null) return;
 
 			PerformMoveAction(Mathf.FloorToInt(vectorAction[0]));
 		}
 
 		protected override void OnPushSolid(Vector3Int destination)
 		{
-			if (destination == Vector3Int.RoundToInt(followTarget.transform.localPosition))
+			if (destination == Vector3Int.RoundToInt(FollowTarget.transform.localPosition))
 			{
 				SetReward(1f);
 			}
@@ -81,9 +96,9 @@ namespace Systems.MobAIs
 
 		protected override void OnTileReached(Vector3Int tilePos)
 		{
-			if (!activated || followTarget == null) return;
+			if (!activated || FollowTarget == null) return;
 
-			var compareDist = Vector2.Distance(followTarget.transform.position, transform.position);
+			var compareDist = TargetDistance();
 
 			if (compareDist < distanceCache)
 			{

--- a/UnityProject/Assets/Scripts/NPC/AI/MobFollow.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobFollow.cs
@@ -111,7 +111,6 @@ namespace Systems.MobAIs
 				Done();
 				SetReward(2f);
 			}
-
 			base.OnTileReached(tilePos);
 		}
 

--- a/UnityProject/Assets/Scripts/NPC/AI/MobFollow.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobFollow.cs
@@ -76,7 +76,7 @@ namespace Systems.MobAIs
 			//Observe the direction to target
 			AddVectorObs((TargetTile.WorldPositionServer - OriginTile.WorldPositionServer).NormalizeTo2Int());
 
-			ObserveAdjacentTiles(true, FollowTarget.transform);
+			ObserveAdjacentTiles(true, TargetTile);
 		}
 
 		public override void AgentAction(float[] vectorAction, string textAction)
@@ -88,7 +88,7 @@ namespace Systems.MobAIs
 
 		protected override void OnPushSolid(Vector3Int destination)
 		{
-			if (destination == Vector3Int.RoundToInt(FollowTarget.transform.localPosition))
+			if (destination == Vector3Int.RoundToInt(TargetTile.WorldPositionServer))
 			{
 				SetReward(1f);
 			}

--- a/UnityProject/Assets/Scripts/NPC/AI/MobFollow.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobFollow.cs
@@ -9,7 +9,7 @@ namespace Systems.MobAIs
 	public class MobFollow : MobAgent
 	{
 		public GameObject FollowTarget;
-		public RegisterTile TargetTile;
+		protected RegisterTile TargetTile;
 
 		private float distanceCache = 0;
 

--- a/UnityProject/Assets/Scripts/NPC/AI/MobMeleeAction.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobMeleeAction.cs
@@ -184,7 +184,6 @@ namespace Systems.MobAIs
 				{
 					return false;
 				}
-
 				ActOnLivingV2(dir, healthBehaviour);
 
 				if (FollowTarget.gameObject.layer != playersLayer)

--- a/UnityProject/Assets/Scripts/NPC/AI/MobMeleeAction.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobMeleeAction.cs
@@ -9,20 +9,20 @@ using Random = UnityEngine.Random;
 namespace Systems.MobAIs
 {
 	/// <summary>
-	/// Derives from MobMeleeAttack but instead of attacking, performs an action
-	/// on tile reached. You can override the method for your own stuff.
+	/// Basic MobAI for following and acting in melee.
+	/// You can override the method for your own stuff.
 	/// </summary>
 	public class MobMeleeAction : MobFollow
 	{
 		[Tooltip("If a player gets close to this mob and blocks the mobs path to the target," +
-		         "should the mob then focus on the human blocking it?. Only works if mob is targeting" +
-		         "a player originally.")]
+				 "should the mob then focus on the human blocking it?. Only works if mob is targeting" +
+				 "a player originally.")]
 		[SerializeField]
-		private bool targetOtherPlayersWhoGetInWay = true;
+		public bool targetOtherPlayersWhoGetInWay = true;
 
 		[Tooltip("Act on nothing but the target. No players in the way, no tiles, nada.")]
 		[SerializeField]
-		private bool onlyActOnTarget = false;
+		public bool onlyActOnTarget = false;
 
 		[SerializeField]
 		private bool doLerpOnAction;
@@ -33,11 +33,11 @@ namespace Systems.MobAIs
 		[SerializeField]
 		private float actionCooldown = 1f;
 
-		private LayerMask checkMask;
-		private int playersLayer;
-		private int npcLayer;
+		public LayerMask checkMask;
+		public int playersLayer;
+		public int npcLayer;
 
-		private MobAI mobAI;
+		public MobAI mobAI;
 
 		private bool isForLerpBack;
 		private Vector3 lerpFrom;
@@ -45,6 +45,11 @@ namespace Systems.MobAIs
 		private float lerpProgress;
 		private bool lerping;
 		private bool isActing = false;
+
+		/// <summary>
+		/// Maximum range that the mob will continue to try to act on the target
+		/// </summary>
+		public float TetherRange = 30f;
 
 		public override void OnEnable()
 		{
@@ -66,134 +71,187 @@ namespace Systems.MobAIs
 			CheckForTargetAction();
 		}
 
+		/// <summary>
+		/// Determines if the target of the action can be acted upon and what kind of target it is.
+		/// Then performs the appropriate action. Action methods are individually overridable for flexibility.
+		/// </summary>
 		protected virtual bool CheckForTargetAction()
 		{
-			if (followTarget == null)
-			{
-				return false;
-			}
-
-			if (mobAI.IsDead || mobAI.IsUnconscious)
-			{
-				Deactivate();
-				followTarget = null;
-				return false;
-			}
-
-			var followLivingBehaviour = followTarget.GetComponent<LivingHealthMasterBase>();
-			var distanceToTarget = Vector3.Distance(followTarget.transform.position, transform.position);
-			if (followLivingBehaviour != null)
-			{
-				//When to stop following on the server:
-				if (followLivingBehaviour.IsDead || distanceToTarget > 30f)
-				{
-					Deactivate();
-					followTarget = null;
-					return false;
-				}
-			}
-
-			var dirToTarget = (followTarget.position - transform.position).normalized;
-			var hitInfo = MatrixManager.Linecast(
-				transform.position + dirToTarget, LayerTypeSelection.Windows,checkMask,
-				followTarget.position);
-
+			var hitInfo = ValidateTarget();
 			if (hitInfo.ItHit == false)
 			{
 				return false;
 			}
-
-			if ((Vector3.Distance(transform.position, hitInfo.TileHitWorld) >= 1.5f))
-			{
-				return false;
-			}
-
-			var dir = ((Vector3) hitInfo.TileHitWorld - transform.position).normalized;
-
+			var dir = (hitInfo.TileHitWorld - OriginTile.WorldPositionServer).normalized;
 			if (hitInfo.CollisionHit.GameObject != null)
 			{
-				//Only hit target
 				if (onlyActOnTarget)
 				{
-					var healthBehaviour = hitInfo.CollisionHit.GameObject.transform.GetComponent<LivingHealthMasterBase>();
-					if (hitInfo.CollisionHit.GameObject.transform != followTarget || healthBehaviour.IsDead)
-					{
-						return false;
-					}
-					else
-					{
-						mobAI.ActOnLiving(dir, healthBehaviour);
-						return true;
-					}
+					return PerformActionOnlyOnTarget(hitInfo, dir);
 				}
 
-				//What to do with player hit?
-				if (hitInfo.CollisionHit.GameObject.transform.gameObject.layer == playersLayer)
+				if (hitInfo.CollisionHit.GameObject.layer == playersLayer)
 				{
-					var healthBehaviour = hitInfo.CollisionHit.GameObject.transform.GetComponent<LivingHealthMasterBase>();
-					if (healthBehaviour != null && healthBehaviour.IsDead)
-					{
-						return false;
-					}
-
-					mobAI.ActOnLiving(dir, healthBehaviour);
-
-					if (followTarget == null) return false;
-
-					if (followTarget.gameObject.layer != playersLayer)
-					{
-						return true;
-					}
-
-					if (followTarget == hitInfo.CollisionHit.GameObject.transform)
-					{
-						return true;
-					}
-
-					if (targetOtherPlayersWhoGetInWay)
-					{
-						followTarget = hitInfo.CollisionHit.GameObject.transform;
-					}
-
-					return true;
+					return PerformActionPlayer(hitInfo, dir);
 				}
 
-				//What to do with NPC hit?
-				if (hitInfo.CollisionHit.GameObject.transform.gameObject.layer == npcLayer)
+				if (hitInfo.CollisionHit.GameObject.layer == npcLayer)
 				{
-					var mobAi = hitInfo.CollisionHit.GameObject.transform.GetComponent<MobAI>();
-					if (mobAi != null && mobAI != null)
+					return PerformActionNpc(hitInfo, dir);
+				}
+			}
+			return PerformActionTile(hitInfo, dir);
+		}
+
+		/// <summary>
+		/// Determines if the target is valid
+		/// </summary>
+		/// <returns>A CustomPhysicsHit result of a Line Cast to the target, or a default one if the target is invalid</returns>
+		protected virtual MatrixManager.CustomPhysicsHit ValidateTarget()
+		{
+			if (FollowTarget != null)
+			{
+				if (mobAI.IsDead == false && mobAI.IsUnconscious == false)
+				{
+					var followLivingBehaviour = FollowTarget.GetComponent<LivingHealthMasterBase>();
+					if (followLivingBehaviour != null)
 					{
-						if (mobAi.mobName.Equals(mobAI.mobName, StringComparison.OrdinalIgnoreCase))
+						if (followLivingBehaviour.IsDead)
 						{
-							return false;
+							FollowTarget = null;
 						}
 					}
 
-					var healthBehaviour = hitInfo.CollisionHit.GameObject.transform.GetComponent<LivingHealthMasterBase>();
-					if (healthBehaviour != null)
+					//Continue if it still exists and is in range
+					if (FollowTarget != null && TargetDistance() < TetherRange)
 					{
-						if (healthBehaviour.IsDead) return false;
+						Vector3 dir = (TargetTile.WorldPositionServer - OriginTile.WorldPositionServer).Normalize();
+						var hitInfo = MatrixManager.Linecast(OriginTile.WorldPositionServer + dir, LayerTypeSelection.Windows, checkMask, TargetTile.WorldPositionServer);
 
-						mobAI.ActOnLiving(dir, healthBehaviour);
-						return true;
+						if (hitInfo.ItHit == true && Vector3.Distance(OriginTile.WorldPositionServer,
+							hitInfo.TileHitWorld) <= 1.5f)
+						{
+							return hitInfo;
+						}
 					}
+				}
+				FollowTarget = null;
+			}
+
+			Deactivate();
+			return new MatrixManager.CustomPhysicsHit();
+		}
+
+		/// <summary>
+		/// What to do if the Mob will only act on the target
+		/// </summary>
+		protected virtual bool PerformActionOnlyOnTarget(MatrixManager.CustomPhysicsHit hitInfo, Vector3 dir)
+		{
+			var healthBehaviour = hitInfo.CollisionHit.GameObject.GetComponent<LivingHealthMasterBase>();
+			if (healthBehaviour != null)
+			{
+				if (hitInfo.CollisionHit.GameObject.transform == FollowTarget && healthBehaviour.IsDead == false)
+				{
+					ActOnLiving(dir, healthBehaviour);
+					return true;
+				}
+			}
+			return false;
+		}
+
+		/// <summary>
+		/// What to do if the Mob is trying to act on a Player
+		/// </summary>
+		protected virtual bool PerformActionPlayer(MatrixManager.CustomPhysicsHit hitInfo, Vector3 dir)
+		{
+			var healthBehaviour = hitInfo.CollisionHit.GameObject.GetComponent<LivingHealthMasterBase>();
+			if (healthBehaviour != null)
+			{
+				if (healthBehaviour.IsDead)
+				{
+					return false;
+				}
+
+				ActOnLiving(dir, healthBehaviour);
+
+				if (FollowTarget.gameObject.layer != playersLayer)
+				{
+					return true;
+				}
+
+				if (FollowTarget == hitInfo.CollisionHit.GameObject)
+				{
+					return true;
+				}
+
+				if (targetOtherPlayersWhoGetInWay)
+				{
+					FollowTarget = hitInfo.CollisionHit.GameObject;
+					return true;
 				}
 			}
 
+			return false;
+		}
 
-			//What to do with Tile hits?
-			if (distanceToTarget > 4.5f)
+
+		/// <summary>
+		/// What to do if the Mob is trying to act on an NPC
+		/// </summary>
+		protected virtual bool PerformActionNpc(MatrixManager.CustomPhysicsHit hitInfo, Vector3 dir)
+		{
+			var target = hitInfo.CollisionHit.GameObject.GetComponent<MobAI>();
+
+			//Prevent the mob from acting on itself and those like it
+			if (target != null && mobAI != null)
+			{
+				if (target.mobName.Equals(mobAI.mobName, StringComparison.OrdinalIgnoreCase))
+				{
+					return false;
+				}
+			}
+
+			var healthBehaviour = hitInfo.CollisionHit.GameObject.GetComponent<LivingHealthMasterBase>();
+			if (healthBehaviour != null)
+			{
+				if (healthBehaviour.IsDead)
+				{
+					return false;
+				}
+
+				ActOnLiving(dir, healthBehaviour);
+				return true;
+			}
+
+			return false;
+		}
+
+		/// <summary>
+		/// What to do if the Mob is trying to act on a Tile
+		/// </summary>
+		protected virtual bool PerformActionTile(MatrixManager.CustomPhysicsHit hitInfo, Vector3 dir)
+		{
+			if (TargetDistance() > 4.5f)
 			{
 				//Don't bother, the target is too far away to warrant a decision to break a tile
 				return false;
 			}
 
-			mobAI.ActOnTile(hitInfo.TileHitWorld.RoundToInt(), dir);
+			ActOnTile(hitInfo.TileHitWorld.RoundToInt(), dir);
 			return true;
 		}
 
-		public void ServerDoLerpAnimation(Vector2 dir)
+		/// <summary>
+		/// Virtual method to override on extensions of this class for acting on living targets
+		protected virtual void ActOnLiving(Vector3 dir, LivingHealthMasterBase healthBehaviour) { }
+		/// <summary>
+		/// Virtual method to override on extensions of this class for acting on tiles
+		/// </summary>
+		protected virtual void ActOnTile(Vector3Int roundToInt, Vector3 dir) { }
+
+
+
+		public virtual void ServerDoLerpAnimation(Vector2 dir)
 		{
 			directional.FaceDirection(Orientation.From(dir));
 
@@ -220,7 +278,7 @@ namespace Systems.MobAIs
 			DeterminePostAction();
 		}
 
-		private void DeterminePostAction()
+		protected virtual void DeterminePostAction()
 		{
 			if (Random.value > 0.2f) //80% chance of hitting the target again
 			{
@@ -238,7 +296,7 @@ namespace Systems.MobAIs
 		public void ClientDoLerpAnimation(Vector2 dir)
 		{
 			lerpFrom = spriteHolder.transform.localPosition;
-			lerpTo = spriteHolder.transform.localPosition + (Vector3) (dir * 0.5f);
+			lerpTo = spriteHolder.transform.localPosition + (Vector3)(dir * 0.5f);
 
 			lerpProgress = 0f;
 			isForLerpBack = true;

--- a/UnityProject/Assets/Scripts/NPC/AI/MobMeleeAction.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobMeleeAction.cs
@@ -18,7 +18,7 @@ namespace Systems.MobAIs
 				 "should the mob then focus on the human blocking it?. Only works if mob is targeting" +
 				 "a player originally.")]
 		[SerializeField]
-		public bool targetOtherPlayersWhoGetInWay = true;
+		protected bool targetOtherPlayersWhoGetInWay = true;
 
 		[Tooltip("Act on nothing but the target. No players in the way, no tiles, nada.")]
 		[SerializeField]
@@ -33,9 +33,9 @@ namespace Systems.MobAIs
 		[SerializeField]
 		private float actionCooldown = 1f;
 
-		public LayerMask checkMask;
-		public int playersLayer;
-		public int npcLayer;
+		protected LayerMask checkMask;
+		protected int playersLayer;
+		protected int npcLayer;
 
 		public MobAI mobAI;
 
@@ -49,7 +49,7 @@ namespace Systems.MobAIs
 		/// <summary>
 		/// Maximum range that the mob will continue to try to act on the target
 		/// </summary>
-		public float TetherRange = 30f;
+		protected float TetherRange = 30f;
 
 		public override void OnEnable()
 		{
@@ -147,13 +147,26 @@ namespace Systems.MobAIs
 		/// </summary>
 		protected virtual bool PerformActionOnlyOnTarget(MatrixManager.CustomPhysicsHit hitInfo, Vector3 dir)
 		{
-			var healthBehaviour = hitInfo.CollisionHit.GameObject.GetComponent<LivingHealthMasterBase>();
-			if (healthBehaviour != null)
+			var healthBehaviourV2 = hitInfo.CollisionHit.GameObject.GetComponent<LivingHealthMasterBase>();
+			if (healthBehaviourV2 != null)
 			{
-				if (hitInfo.CollisionHit.GameObject.transform == FollowTarget && healthBehaviour.IsDead == false)
+				if (hitInfo.CollisionHit.GameObject.transform == FollowTarget && healthBehaviourV2.IsDead == false)
 				{
-					ActOnLiving(dir, healthBehaviour);
+					ActOnLivingV2(dir, healthBehaviourV2);
 					return true;
+				}
+
+			}
+			else
+			{
+				var healthBehaviour = hitInfo.CollisionHit.GameObject.GetComponent<LivingHealthBehaviour>();
+				if (healthBehaviour != null)
+				{
+					if (hitInfo.CollisionHit.GameObject.transform == FollowTarget && healthBehaviour.IsDead == false)
+					{
+						ActOnLiving(dir, healthBehaviour);
+						return true;
+					}
 				}
 			}
 			return false;
@@ -172,7 +185,7 @@ namespace Systems.MobAIs
 					return false;
 				}
 
-				ActOnLiving(dir, healthBehaviour);
+				ActOnLivingV2(dir, healthBehaviour);
 
 				if (FollowTarget.gameObject.layer != playersLayer)
 				{
@@ -211,7 +224,9 @@ namespace Systems.MobAIs
 				}
 			}
 
-			var healthBehaviour = hitInfo.CollisionHit.GameObject.GetComponent<LivingHealthMasterBase>();
+			var healthBehaviour = hitInfo.CollisionHit.GameObject.GetComponent<LivingHealthBehaviour>();
+
+
 			if (healthBehaviour != null)
 			{
 				if (healthBehaviour.IsDead)
@@ -221,6 +236,21 @@ namespace Systems.MobAIs
 
 				ActOnLiving(dir, healthBehaviour);
 				return true;
+			}
+			else
+			{
+				//Safety catch in case the NPC is using the new health system
+				var healthBehaviourV2 = hitInfo.CollisionHit.GameObject.GetComponent<LivingHealthMasterBase>();
+				if (healthBehaviourV2 != null)
+				{
+					if (healthBehaviourV2.IsDead)
+					{
+						return false;
+					}
+
+					ActOnLivingV2(dir, healthBehaviourV2);
+					return true;
+				}
 			}
 
 			return false;
@@ -242,8 +272,16 @@ namespace Systems.MobAIs
 		}
 
 		/// <summary>
-		/// Virtual method to override on extensions of this class for acting on living targets
-		protected virtual void ActOnLiving(Vector3 dir, LivingHealthMasterBase healthBehaviour) { }
+		/// Virtual method to override on extensions of this class for acting on living targets using the old health system
+		/// </summary>
+		protected virtual void ActOnLiving(Vector3 dir, LivingHealthBehaviour healthBehaviour) { }
+
+		/// <summary>
+		/// Virtual method to override on extensions of this class for acting on living targets using the new health system
+		/// </summary>
+		protected virtual void ActOnLivingV2(Vector3 dir, LivingHealthMasterBase healthBehaviour) { }
+
+
 		/// <summary>
 		/// Virtual method to override on extensions of this class for acting on tiles
 		/// </summary>

--- a/UnityProject/Assets/Scripts/NPC/AI/MobMeleeAttack.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobMeleeAttack.cs
@@ -45,7 +45,7 @@ namespace Systems.MobAIs
 			if (PlayerManager.LocalPlayerScript != null
 				&& PlayerManager.LocalPlayerScript.playerHealth != null
 				&& PlayerManager.LocalPlayerScript.playerHealth == targetHealthV2 ||
-				rtt == 0f)
+				rtt < 0.02f)
 			{
 				//Wait until the end of the frame
 				await Task.Delay(1);

--- a/UnityProject/Assets/Scripts/NPC/AI/MobMeleeAttack.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobMeleeAttack.cs
@@ -61,14 +61,12 @@ namespace Systems.MobAIs
 			{
 				if(targetHealth != null)
 				{
-					Debug.Log("Hey! Targethealth was not null!");
 					targetHealth.ApplyDamageToBodypart(gameObject, hitDamage, AttackType.Melee, DamageType.Brute,
 						defaultTarget.Randomize());
 					Chat.AddAttackMsgToChat(gameObject, targetHealth.gameObject, defaultTarget, null, attackVerb);
 				}
 				else
 				{
-					Debug.Log("Huh? Doing Damage?");
 					targetHealthV2.ApplyDamageToBodypart(gameObject, hitDamage, AttackType.Melee, DamageType.Brute,
 						defaultTarget.Randomize());
 					Chat.AddAttackMsgToChat(gameObject, targetHealthV2.gameObject, defaultTarget, null, attackVerb);

--- a/UnityProject/Assets/Scripts/NPC/AI/MobMeleeAttack.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobMeleeAttack.cs
@@ -73,7 +73,6 @@ namespace Systems.MobAIs
 				}
 				SoundManager.PlayNetworkedAtPos(attackSound, OriginTile.WorldPositionServer, sourceObj: gameObject);
 			}
-			return;
 		}
 
 		protected override void ActOnTile(Vector3Int worldPos, Vector3 dir)

--- a/UnityProject/Assets/Scripts/NPC/AI/MobMeleeAttack.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobMeleeAttack.cs
@@ -1,189 +1,23 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.Generic;
 using Mirror;
 using UnityEngine;
-using Random = UnityEngine.Random;
 using AddressableReferences;
 using HealthV2;
-using Messages.Server;
 
 namespace Systems.MobAIs
 {
 	/// <summary>
-	/// Basic AI behaviour for following and melee attacking a target
+	/// Derives from MobMeleeAction, with the specific action of attacking
 	/// </summary>
-	// [RequireComponent(typeof(MobAI))]
-	public class MobMeleeAttack : MobFollow
+	public class MobMeleeAttack : MobMeleeAction
 	{
-		[Tooltip("The sprites gameobject. Needs to be a child of the prefab root")]
-		public GameObject spriteHolder;
-
-		[Tooltip("If a player gets close to this mob and blocks the mobs path to the target," +
-				 "should the mob then focus on the human blocking it?. Only works if mob is targeting" +
-				 "a player originally.")]
-		public bool targetOtherPlayersWhoGetInWay;
-
-		[Tooltip("Attack nothing but the target. No players in the way, no tiles, nada.")]
-		public bool onlyHitTarget;
-
 		[SerializeField] private AddressableAudioSource attackSound = null;
-
-
 		public int hitDamage = 30;
 		public string attackVerb;
 		public BodyPartType defaultTarget;
-		public float meleeCoolDown = 1f;
 
-		private LayerMask checkMask;
-		private int playersLayer;
-		private int npcLayer;
-
-		private MobAI mobAI;
-
-		private bool isForLerpBack;
-		private Vector3 lerpFrom;
-		private Vector3 lerpTo;
-		private float lerpProgress;
-		private bool lerping;
-		private bool isAttacking = false;
-
-
-		public override void OnEnable()
-		{
-			base.OnEnable();
-			playersLayer = LayerMask.NameToLayer("Players");
-			npcLayer = LayerMask.NameToLayer("NPC");
-			checkMask = LayerMask.GetMask("Players", "NPC", "Objects");
-			mobAI = GetComponent<MobAI>();
-		}
-
-		protected override void OnPushSolid(Vector3Int destination)
-		{
-			CheckForAttackTarget();
-		}
-
-		protected override void OnTileReached(Vector3Int tilePos)
-		{
-			base.OnTileReached(tilePos);
-			CheckForAttackTarget();
-		}
-
-		//Where is the target? Is there something in the way we can break
-		//to get to the target?
-		private bool CheckForAttackTarget()
-		{
-			if (followTarget != null)
-			{
-				if (mobAI.IsDead || mobAI.IsUnconscious)
-				{
-					Deactivate();
-					followTarget = null;
-					return false;
-				}
-
-				var followLivingBehaviour = followTarget.GetComponent<LivingHealthMasterBase>();
-				var distanceToTarget = Vector3.Distance(followTarget.transform.position, transform.position);
-				if (followLivingBehaviour != null)
-				{
-					//When to stop following on the server:
-					if (followLivingBehaviour.IsDead || distanceToTarget > 30f)
-					{
-						Deactivate();
-						followTarget = null;
-						return false;
-					}
-				}
-
-				var dirToTarget = (followTarget.position - transform.position).normalized;
-				var hitInfo =
-					MatrixManager.Linecast(transform.position + dirToTarget, LayerTypeSelection.Windows, checkMask, followTarget.position);
-				//	Debug.DrawLine(transform.position + dirToTarget, followTarget.position, Color.blue, 10f);
-				if (hitInfo.CollisionHit.GameObject != null)
-				{
-					if (Vector3.Distance(transform.position, hitInfo.TileHitWorld) < 1.5f)
-					{
-						var dir = (hitInfo.TileHitWorld - transform.position).normalized;
-
-						//Only hit target
-						if (onlyHitTarget)
-						{
-							var healthBehaviour = hitInfo.CollisionHit.GameObject.transform.GetComponent<LivingHealthMasterBase>();
-							if (hitInfo.CollisionHit.GameObject.transform != followTarget || healthBehaviour.IsDead)
-							{
-								return false;
-							}
-							else
-							{
-								AttackFlesh(dir, healthBehaviour);
-								return true;
-							}
-						}
-
-						//What to do with player hit?
-						if (hitInfo.CollisionHit.GameObject.transform.gameObject.layer == playersLayer)
-						{
-							var healthBehaviour = hitInfo.CollisionHit.GameObject.transform.GetComponent<LivingHealthMasterBase>();
-							if (healthBehaviour.IsDead)
-							{
-								return false;
-							}
-
-							AttackFlesh(dir, healthBehaviour);
-
-							if (followTarget.gameObject.layer == playersLayer)
-							{
-								if (followTarget != hitInfo.CollisionHit.GameObject.transform)
-								{
-									if (targetOtherPlayersWhoGetInWay)
-									{
-										followTarget = hitInfo.CollisionHit.GameObject.transform;
-									}
-								}
-							}
-
-							return true;
-						}
-
-						//What to do with NPC hit?
-						if (hitInfo.CollisionHit.GameObject.transform.gameObject.layer == npcLayer)
-						{
-							var mobAi = hitInfo.CollisionHit.GameObject.transform.GetComponent<MobAI>();
-							if (mobAi != null && mobAI != null)
-							{
-								if (mobAi.mobName.Equals(mobAI.mobName, StringComparison.OrdinalIgnoreCase))
-								{
-									return false;
-								}
-							}
-
-							var healthBehaviour = hitInfo.CollisionHit.GameObject.transform.GetComponent<LivingHealthMasterBase>();
-							if (healthBehaviour != null)
-							{
-								if (healthBehaviour.IsDead) return false;
-
-								AttackFlesh(dir, healthBehaviour);
-								return true;
-							}
-						}
-
-						//What to do with Tile hits?
-						if (distanceToTarget > 4.5f)
-						{
-							//Don't bother, the target is too far away to warrant a decision to break a tile
-							return false;
-						}
-
-						AttackTile(hitInfo.TileHitWorld.RoundToInt(), dir);
-						return true;
-					}
-				}
-			}
-
-			return false;
-		}
-
-		private void AttackFlesh(Vector2 dir, LivingHealthMasterBase healthBehaviour)
+		protected override void ActOnLiving(Vector3 dir, LivingHealthMasterBase healthBehaviour)
 		{
 			StartCoroutine(AttackFleshRoutine(dir, healthBehaviour));
 		}
@@ -214,119 +48,20 @@ namespace Systems.MobAIs
 				yield return WaitFor.Seconds(healthBehaviour.RTT / 2f);
 			}
 
-			if (Vector3.Distance(transform.position, healthBehaviour.transform.position) < 1.5f)
+			if (Vector3.Distance(OriginTile.WorldPositionServer, healthBehaviour.RegisterTile.WorldPositionServer) < 1.5f)
 			{
 				healthBehaviour.ApplyDamageToBodypart(gameObject, hitDamage, AttackType.Melee, DamageType.Brute,
 					defaultTarget.Randomize());
 				Chat.AddAttackMsgToChat(gameObject, healthBehaviour.gameObject, defaultTarget, null, attackVerb);
-				SoundManager.PlayNetworkedAtPos(attackSound, transform.position, sourceObj: gameObject);
+				SoundManager.PlayNetworkedAtPos(attackSound, OriginTile.WorldPositionServer, sourceObj: gameObject);
 			}
 		}
 
-		private void AttackTile(Vector3Int worldPos, Vector2 dir)
+		protected override void ActOnTile(Vector3Int worldPos, Vector3 dir)
 		{
 			var matrix = MatrixManager.AtPoint(worldPos, true);
 			matrix.MetaTileMap.ApplyDamage(MatrixManager.WorldToLocalInt(worldPos, matrix), hitDamage * 2, worldPos);
 			ServerDoLerpAnimation(dir);
-		}
-
-		private void ServerDoLerpAnimation(Vector2 dir)
-		{
-			directional.FaceDirection(Orientation.From(dir));
-
-			Pause = true;
-			isAttacking = true;
-			MobMeleeLerpMessage.Send(gameObject, dir);
-			StartCoroutine(WaitForLerp());
-		}
-
-		IEnumerator WaitForLerp()
-		{
-			float timeElapsed = 0f;
-			while (isAttacking)
-			{
-				timeElapsed += Time.deltaTime;
-
-				if (timeElapsed > 3f)
-				{
-					isAttacking = false;
-				}
-
-				yield return WaitFor.EndOfFrame;
-			}
-
-			yield return WaitFor.Seconds(meleeCoolDown);
-
-			DeterminePostAttackActions();
-		}
-
-		//What should the Mob do after an attack action has finished:
-		private void DeterminePostAttackActions()
-		{
-			if (Random.value > 0.2f) //80% chance of hitting the target again
-			{
-				if (!CheckForAttackTarget())
-				{
-					Pause = false;
-				}
-			}
-			else
-			{
-				Pause = false;
-			}
-		}
-
-		public void ClientDoLerpAnimation(Vector2 dir)
-		{
-			lerpFrom = spriteHolder.transform.localPosition;
-			lerpTo = spriteHolder.transform.localPosition + (Vector3)(dir * 0.5f);
-
-			lerpProgress = 0f;
-			isForLerpBack = true;
-			lerping = true;
-		}
-
-		private void ResetLerp()
-		{
-			lerpProgress = 0f;
-			lerping = false;
-			isForLerpBack = false;
-		}
-
-		protected override void ServerUpdateMe()
-		{
-			CheckLerping();
-			base.ServerUpdateMe();
-		}
-
-		void CheckLerping()
-		{
-			if (lerping)
-			{
-				lerpProgress += Time.deltaTime;
-				spriteHolder.transform.localPosition = Vector3.Lerp(lerpFrom, lerpTo, lerpProgress * 7f);
-				if (spriteHolder.transform.localPosition == lerpTo || lerpProgress >= 1f)
-				{
-					if (!isForLerpBack)
-					{
-						ResetLerp();
-						spriteHolder.transform.localPosition = Vector3.zero;
-
-						if (isServer)
-						{
-							isAttacking = false;
-						}
-					}
-					else
-					{
-						//To lerp back
-						ResetLerp();
-						lerpTo = lerpFrom;
-						lerpFrom = spriteHolder.transform.localPosition;
-						lerping = true;
-					}
-				}
-			}
 		}
 	}
 }


### PR DESCRIPTION
Fixed Hostile AIs to play sounds properly, using an async rather than a coroutinue to reduce allocations.  Removed many uses of transform references and replaced them with register tile references.

I also rebased MobMeleeAttack on MobMeleeAction and  FaceHuggerAi on GenericHostileAI.   These scripts had a lot of overlap, doing this simplified them greatly.  MobMeleeAction was made more configurable by subdividing CheckForTargetAction into methods for validating the target, always acting on target, acting on players, acting on npcs, and acting on tiles.  This will allow programmers to more easily add mobs that act generally like another mob, but interact differently with one group of targets.  Also, in the process some AI bugs were potentially fixed.

Fixed some health stuff from the health update.