### PR TITLE
Mineral silos

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Machines/Autolathe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Machines/Autolathe.prefab
@@ -45,7 +45,7 @@ MonoBehaviour:
   productionSprite: {fileID: 11400000, guid: 6453b4f4edb12784eafebe700d4dc3e3, type: 2}
   acceptingMaterialsSprite: {fileID: 11400000, guid: 7988fd4d8b0936249bca1529ef12f9d6,
     type: 2}
-  materialStorage: {fileID: 3971876006832429833}
+  materialStorageLink: {fileID: 0}
   autolatheProducts: {fileID: 11400000, guid: d1a052e3f8a86d0409f54e6f2f803fa5, type: 2}
 --- !u!114 &3971876006832429833
 MonoBehaviour:
@@ -59,16 +59,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9cbbddbea96e4804186a58b019b786fb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  materials: []
-  cm3PerSheet: 2000
   infiniteStorage: 0
-  materialsInMachines: {fileID: 11400000, guid: b6e83d10ca1eed247949504321b25658,
-    type: 2}
   maximumResources: 1000000
-  currentResources: 0
-  getthislistfromsomewhere: []
+--- !u!114 &4397833373819759390
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6278827525492321370}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01e266b02032c5442b067c162ae425c1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  usedStorage: {fileID: 0}
 --- !u!114 &4515876064805449849
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -151,7 +156,7 @@ PrefabInstance:
     - target: {fileID: 4197940402254186057, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
       propertyPath: m_Name
-      value: Autolathe
+      value: Autolathe AYYLMAO AYYLMAO AYYLMAO AYYLMAO AYYLMAO
       objectReference: {fileID: 0}
     - target: {fileID: 4204006106222477459, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Machines/Mining.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Machines/Mining.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e7ad4a0b078a2fe4581a0e25527c1e20
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Machines/Mining/MaterialSilo.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Machines/Mining/MaterialSilo.prefab
@@ -1,0 +1,137 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-3741180520651062395
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8808594067259233453}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 550208171e0da2341a370f011c486eb9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  linkedStorages: []
+  materialStorage: {fileID: 0}
+--- !u!114 &7548568334678346801
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8808594067259233453}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9cbbddbea96e4804186a58b019b786fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  infiniteStorage: 1
+  maximumResources: 0
+--- !u!1001 &7828612527874871569
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: c7b594666b57a684ea9192b73d61c079,
+        type: 3}
+    - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625533340043428710, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1628816798482564540, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_Name
+      value: MaterialSilo
+      objectReference: {fileID: 0}
+    - target: {fileID: 6109775972905365350, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 1c22c898582131a4cbd75cd6eb2dc280,
+        type: 2}
+    - target: {fileID: 7153803037707514078, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b69bfc56f39849d4ba9139d2d51bedb6, type: 3}
+--- !u!1 &8808594067259233453 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1628816798482564540, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+    type: 3}
+  m_PrefabInstance: {fileID: 7828612527874871569}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Machines/Mining/MaterialSilo.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Machines/Mining/MaterialSilo.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 60ca8a399a7aa194dae1560980333f3b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Research/Exosuit Fabricator.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Research/Exosuit Fabricator.prefab
@@ -13,11 +13,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   MachineParts: {fileID: 11400000, guid: cef0acf9fcd0bf340ab79662a60de428, type: 2}
-  framePrefab: {fileID: 8621073510343042932, guid: c4c22bdc7cdd546479ac1de5589b5617,
-    type: 3}
   machineBoardPrefab: {fileID: 5118904567897562044, guid: 85745799887db29418a4ddc4fe68d535,
     type: 3}
   canNotBeDeconstructed: 0
+  mustBeUnanchored: 0
   secondsToScrewdrive: 2
 --- !u!114 &4345289403541654959
 MonoBehaviour:
@@ -31,10 +30,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9cbbddbea96e4804186a58b019b786fb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  materialsInMachines: {fileID: 11400000, guid: b6e83d10ca1eed247949504321b25658,
-    type: 2}
+  infiniteStorage: 0
   maximumResources: 1000000
 --- !u!114 &4434257373069083471
 MonoBehaviour:
@@ -78,13 +74,25 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  spriteHandler: {fileID: 1117575778632656562}
   idleSprite: {fileID: 11400000, guid: c28dca4f44ef37849a23ff6d8976a5bc, type: 2}
   acceptingMaterialsSprite: {fileID: 11400000, guid: 2dc805ead8817ae449f66efb16c4a809,
     type: 2}
   productionSprite: {fileID: 11400000, guid: 0e601845f1e569f45abe3c93b83a4ddb, type: 2}
-  materialStorage: {fileID: 4345289403541654959}
+  materialStorageLink: {fileID: 0}
   exoFabProducts: {fileID: 11400000, guid: 5de8c3642d9b41742bd0f830d07a5bd7, type: 2}
+--- !u!114 &-6688608445877633530
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5607718071721086056}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01e266b02032c5442b067c162ae425c1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  usedStorage: {fileID: 0}
 --- !u!1001 &8615537192462600737
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -237,15 +245,3 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 8615537192462600737}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1117575778632656562 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8652228875761003667, guid: ebb08cf966efc084aa918bd8d9429604,
-    type: 3}
-  m_PrefabInstance: {fileID: 8615537192462600737}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Scripts/Managers/CraftingManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/CraftingManager.cs
@@ -2,6 +2,7 @@
 using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
+using Objects.Machines;
 
 public class CraftingManager : MonoBehaviour
 {
@@ -18,6 +19,7 @@ public class CraftingManager : MonoBehaviour
 	[SerializeField]
 	private List<MaterialSheet> MaterialSheetList;
 	public static Dictionary<ItemTrait, MaterialSheet> MaterialSheetData = new Dictionary<ItemTrait, MaterialSheet>();
+	public static MaterialSilo RoundstartStationSilo;
 
 	public static CraftingDatabase Meals => Instance.meals;
 	public static CraftingDatabase Cuts => Instance.cuts;

--- a/UnityProject/Assets/Scripts/Objects/ExosuitFabricator.cs
+++ b/UnityProject/Assets/Scripts/Objects/ExosuitFabricator.cs
@@ -20,7 +20,7 @@ namespace Objects.Robotics
 		[SerializeField] private SpriteDataSO acceptingMaterialsSprite;
 		[SerializeField] private SpriteDataSO productionSprite;
 		private RegisterObject registerObject;
-		public MaterialStorage materialStorage;
+		public MaterialStorageLink materialStorageLink;
 		public MachineProductsCollection exoFabProducts;
 		private ItemTrait InsertedMaterialType;
 		private IEnumerator currentProduction;
@@ -54,7 +54,7 @@ namespace Objects.Robotics
 		{
 			registerObject = GetComponent<RegisterObject>();
 			spriteHandler = GetComponentInChildren<SpriteHandler>();
-			materialStorage = GetComponent<MaterialStorage>();
+			materialStorageLink = GetComponent<MaterialStorageLink>();
 		}
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)
@@ -62,7 +62,7 @@ namespace Objects.Robotics
 			if (interaction.HandSlot.IsEmpty) return false;
 			if (!DefaultWillInteract.Default(interaction, side)) return false;
 
-			InsertedMaterialType = materialStorage.FindMaterial(interaction.HandObject);
+			InsertedMaterialType = materialStorageLink.usedStorage.FindMaterial(interaction.HandObject);
 			if (InsertedMaterialType != null)
 			{
 				return true;
@@ -80,7 +80,7 @@ namespace Objects.Robotics
 			if (stateSync != ExosuitFabricatorState.Production)
 			{
 				int materialSheetAmount = interaction.HandSlot.Item.GetComponent<Stackable>().Amount;
-				if (materialStorage.TryAddSheet(InsertedMaterialType, materialSheetAmount))
+				if (materialStorageLink.usedStorage.TryAddSheet(InsertedMaterialType, materialSheetAmount))
 				{
 					Inventory.ServerDespawn(interaction.HandObject);
 					if (stateSync == ExosuitFabricatorState.Idle)
@@ -113,7 +113,7 @@ namespace Objects.Robotics
 
 		public void DispenseMaterialSheet(int amountOfSheets, ItemTrait materialType)
 		{
-			materialStorage.DispenseSheet(amountOfSheets, materialType);
+			materialStorageLink.usedStorage.DispenseSheet(amountOfSheets, materialType);
 			UpdateGUI();
 		}
 
@@ -122,7 +122,7 @@ namespace Objects.Robotics
 		/// </summary>
 		public bool CanProcessProduct(MachineProduct product)
 		{
-			if (materialStorage.TryConsumeList(product.materialToAmounts))
+			if (materialStorageLink.usedStorage.TryConsumeList(product.materialToAmounts))
 			{
 				currentProduction = ProcessProduction(product.Product, product.ProductionTime);
 				StartCoroutine(currentProduction);
@@ -170,7 +170,7 @@ namespace Objects.Robotics
 				currentProduction = null;
 			}
 
-			materialStorage.DropAllMaterials();
+			materialStorageLink.usedStorage.DropAllMaterials();
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Objects/Machines/Autolathe/Autolathe.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/Autolathe/Autolathe.cs
@@ -6,7 +6,7 @@ using Systems.Electricity;
 
 namespace Objects.Machines
 {
-	public class Autolathe : NetworkBehaviour, ICheckedInteractable<HandApply>, IServerSpawn, IServerDespawn, IAPCPowered, IMaterialSiloLink
+	public class Autolathe : NetworkBehaviour, ICheckedInteractable<HandApply>, IServerSpawn, IServerDespawn, IAPCPowered
 	{
 
 		public PowerStates PoweredState;

--- a/UnityProject/Assets/Scripts/Objects/Machines/MaterialStorage.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/MaterialStorage.cs
@@ -7,7 +7,7 @@ namespace Objects.Machines
 	public class MaterialStorage : MonoBehaviour
 	{
 		public Dictionary<ItemTrait, int> MaterialList = new Dictionary<ItemTrait, int>();
-		public int currentResources;
+		private int currentResources;
 
 		public bool infiniteStorage;
 		//wont appear to be edited if the storage is infinite
@@ -15,7 +15,7 @@ namespace Objects.Machines
 		public int maximumResources;
 
 		//2000cm per sheet is standard for SS13
-		private int Cm3PerSheet = 2000;
+		private static readonly int Cm3PerSheet = 2000;
 
 		private void Awake()
 		{

--- a/UnityProject/Assets/Scripts/Objects/Machines/MaterialStorageLink.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/MaterialStorageLink.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Objects.Machines
+{
+	/// <summary>
+	/// links machines with their own material storage or material silo
+	/// </summary>
+	public class MaterialStorageLink : MonoBehaviour
+	{
+		private bool IsUsingSilo;
+		public MaterialStorage usedStorage;
+		private MaterialStorage selfStorage;
+
+
+		private void Awake()
+		{
+			selfStorage = GetComponent<MaterialStorage>();
+			usedStorage = selfStorage;
+		}
+
+		public bool TryAddSheet(ItemTrait InsertedMaterialType, int materialSheetAmount)
+		{
+			return usedStorage.TryAddSheet(InsertedMaterialType, materialSheetAmount);
+		}
+
+
+		public void ConnectToSilo(MaterialStorage silo)
+		{
+			usedStorage = silo;
+			IsUsingSilo = true;
+		}
+
+		public void DisconnectFromSilo()
+		{
+			usedStorage = selfStorage;
+			IsUsingSilo = false;
+		}
+
+		public void Despawn()
+		{
+			if (IsUsingSilo)
+				return;
+			usedStorage.DropAllMaterials();
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Objects/Machines/MaterialStorageLink.cs.meta
+++ b/UnityProject/Assets/Scripts/Objects/Machines/MaterialStorageLink.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 01e266b02032c5442b067c162ae425c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Objects/Mining/MaterialSilo.cs
+++ b/UnityProject/Assets/Scripts/Objects/Mining/MaterialSilo.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Objects.Machines
+{
+	public class MaterialSilo : MonoBehaviour, ICheckedInteractable<HandApply>, IServerLifecycle
+	{
+
+		public List<MaterialStorageLink> linkedStorages = new List<MaterialStorageLink>();
+
+		private ItemTrait InsertedMaterialType;
+		public MaterialStorage materialStorage;
+
+		private void Awake()
+		{
+			materialStorage = GetComponent<MaterialStorage>();
+			CraftingManager.RoundstartStationSilo = this;
+		}
+
+		public void OnSpawnServer(SpawnInfo info)
+		{
+			var array = FindObjectsOfType<MaterialStorageLink>();
+			foreach (var otherStorage in array)
+			{
+				var registerObject = otherStorage.GetComponent<RegisterObject>();
+				if (registerObject.Matrix.IsMainStation)
+				{
+					otherStorage.ConnectToSilo(materialStorage);
+					linkedStorages.Add(otherStorage);
+				}
+			}
+
+		}
+
+		public bool WillInteract(HandApply interaction, NetworkSide side)
+		{
+			if (!DefaultWillInteract.Default(interaction, side))
+				return false;
+
+			InsertedMaterialType = materialStorage.FindMaterial(interaction.HandObject);
+			if (InsertedMaterialType != null)
+			{
+				return true;
+			}
+			return false;
+		}
+
+		public void ServerPerformInteraction(HandApply interaction)
+		{
+			var stackable = interaction.HandObject.GetComponent<Stackable>();
+			materialStorage.TryAddSheet(InsertedMaterialType, stackable.Amount);
+			Inventory.ServerDespawn(interaction.HandObject);
+		}
+
+		public void OnDespawnServer(DespawnInfo info)
+		{
+			materialStorage.DropAllMaterials();
+			foreach (var linkedMat in linkedStorages)
+			{
+				if (linkedMat == null) //they were destroyed at some point, irrelevant to us
+				{
+					continue;
+				}
+				linkedMat.DisconnectFromSilo();
+			}
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Objects/Mining/MaterialSilo.cs.meta
+++ b/UnityProject/Assets/Scripts/Objects/Mining/MaterialSilo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 550208171e0da2341a370f011c486eb9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/UI/Objects/Commons/Autolathe/GUI_Autolathe.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Commons/Autolathe/GUI_Autolathe.cs
@@ -112,14 +112,14 @@ namespace UI.Objects
 			//Subscribes to the MaterialsManipulated event
 			Autolathe.MaterialsManipulated += UpdateMaterialsDisplay;
 
-			materialsAndCategoryDisplay.InitMaterialList(autolathe.MaterialStorage);
+			materialsAndCategoryDisplay.InitMaterialList(autolathe.materialStorageLink.usedStorage);
 			materialsAndCategoryDisplay.InitCategories(autolathe.AutolatheProducts);
 			OnTabOpened.AddListener(UpdateGUIForPeepers);
 		}
 
 		public void UpdateMaterialsDisplay()
 		{
-			materialsAndCategoryDisplay.UpdateMaterialList(autolathe.MaterialStorage);
+			materialsAndCategoryDisplay.UpdateMaterialList(autolathe.materialStorageLink.usedStorage);
 		}
 
 		//Everytime someone new looks at the tab, update the tab for the client
@@ -135,7 +135,7 @@ namespace UI.Objects
 		private IEnumerator WaitForClient()
 		{
 			yield return new WaitForSeconds(0.2f);
-			materialsAndCategoryDisplay.UpdateMaterialList(autolathe.MaterialStorage);
+			materialsAndCategoryDisplay.UpdateMaterialList(autolathe.materialStorageLink.usedStorage);
 			queueDisplay.UpdateQueue();
 			isUpdating = false;
 		}

--- a/UnityProject/Assets/Scripts/UI/Objects/Robotics/ExosuitFabricator/GUI_ExosuitFabricator.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Robotics/ExosuitFabricator/GUI_ExosuitFabricator.cs
@@ -112,14 +112,14 @@ namespace UI.Objects.Robotics
 			//Subscribes to the MaterialsManipulated event
 			ExosuitFabricator.MaterialsManipulated += UpdateMaterialsDisplay;
 
-			materialsAndCategoryDisplay.InitMaterialList(exosuitFabricator.materialStorage);
+			materialsAndCategoryDisplay.InitMaterialList(exosuitFabricator.materialStorageLink.usedStorage);
 			materialsAndCategoryDisplay.InitCategories(exosuitFabricator.exoFabProducts);
 			OnTabOpened.AddListener(UpdateGUIForPeepers);
 		}
 
 		public void UpdateMaterialsDisplay()
 		{
-			materialsAndCategoryDisplay.UpdateMaterialList(exosuitFabricator.materialStorage);
+			materialsAndCategoryDisplay.UpdateMaterialList(exosuitFabricator.materialStorageLink.usedStorage);
 		}
 
 		//Everytime someone new looks at the tab, update the tab for the client
@@ -135,7 +135,7 @@ namespace UI.Objects.Robotics
 		private IEnumerator WaitForClient()
 		{
 			yield return new WaitForSeconds(0.2f);
-			materialsAndCategoryDisplay.UpdateMaterialList(exosuitFabricator.materialStorage);
+			materialsAndCategoryDisplay.UpdateMaterialList(exosuitFabricator.materialStorageLink.usedStorage);
 			queueDisplay.UpdateQueue();
 			isUpdating = false;
 		}


### PR DESCRIPTION
### Purpose
Adds the material silo, also known as the ore silo. This early implementation of the machine, if added on the maps, will link autolathes and exosuit fabricators with itself, making them use the minerals inside the silo.
The silo has an infinite storage space.
Storing minerals on machines linked to the silo will store them in the silo.
In case of the silo not existing or being destroyed, the machines will use their own storage.
The original name is ore silo but they dont actually store ores so I assumed a namechange would be fitting.

### Notes
There's no way to remove minerals from the silo using the silo itself as it has no interface
It is impossible to build one
Admin spawned silos won't link existing machines and will only link with ones spawned afterwards 

