### PR TITLE
Labor points

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Machines/VendingMachines/MiningEquipment.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Machines/VendingMachines/MiningEquipment.prefab
@@ -1,0 +1,130 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &71688443645419623
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 854479238589397880, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919541056858231082, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: initialName
+      value: Mining equipment vendor
+      objectReference: {fileID: 0}
+    - target: {fileID: 1919541056858231082, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: initialDescription
+      value: An equipment vendor for miners, points collected at an ore redemption
+        machine can be spent here.
+      objectReference: {fileID: 0}
+    - target: {fileID: 4347831001461171392, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: d03d262ab7838bc49870a54711f8cb2c,
+        type: 2}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[0].Item
+      value: 
+      objectReference: {fileID: 2682969197072638538, guid: 41e0ac9a8c075b4448f636dcb03d7d3a,
+        type: 3}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[0].Price
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[0].Stock
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[0].Currency
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[0].ItemName
+      value: Toy Sord TEST ITEM
+      objectReference: {fileID: 0}
+    - target: {fileID: 9036003665837402637, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: -6081254568108422908, guid: bda7920541767e54a8a9cedc46df6f9b,
+        type: 3}
+    - target: {fileID: 9081061823247388186, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: m_Name
+      value: MiningEquipment
+      objectReference: {fileID: 0}
+    - target: {fileID: 9084847140033546432, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9084847140033546432, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9084847140033546432, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9084847140033546432, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9084847140033546432, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9084847140033546432, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9084847140033546432, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9084847140033546432, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9084847140033546432, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9084847140033546432, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9084847140033546432, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2f2954acc32d9d3468c620e34a625966, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Machines/VendingMachines/MiningEquipment.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Machines/VendingMachines/MiningEquipment.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b195e4a9a7ac92b4e9c2f5aa2f002535
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/UI/Tabs/Resources/TabOreRedemptionMachine.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/UI/Tabs/Resources/TabOreRedemptionMachine.prefab
@@ -365,6 +365,7 @@ MonoBehaviour:
   ProviderRegisterTile: {fileID: 0}
   Type: 35
   materialsListDisplay: {fileID: 1815899555180757094}
+  laborPointsLabel: {fileID: 4159848316621143485}
 --- !u!1 &5370860064539535629
 GameObject:
   m_ObjectHideFlags: 0
@@ -460,7 +461,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &5914426841277353365
 RectTransform:
   m_ObjectHideFlags: 0
@@ -521,7 +522,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 1
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: You have 10 points to claim
+  m_Text: 'Unclaimed points: 10'
 --- !u!114 &4159848316621143485
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -860,13 +861,14 @@ GameObject:
   - component: {fileID: 9148647480223803888}
   - component: {fileID: 7559357163178935421}
   - component: {fileID: 2565594833102910402}
+  - component: {fileID: 2292375802329778207}
   m_Layer: 5
   m_Name: ClaimButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &4777924441665517838
 RectTransform:
   m_ObjectHideFlags: 0
@@ -884,7 +886,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 617, y: -75}
+  m_AnchoredPosition: {x: 537, y: -75}
   m_SizeDelta: {x: 200.18, y: 43}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6925779240122656439
@@ -983,10 +985,37 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: 
+      - m_Target: {fileID: 2292375802329778207}
+        m_TargetAssemblyTypeName: NetUIElement`1[[System.String, mscorlib
         m_MethodName: ExecuteClient
         m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &2292375802329778207
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8710442241119043883}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f41ce54e3adddc243a63e91303c43614, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ServerMethod:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 3914321362406773978}
+        m_TargetAssemblyTypeName: Objects.Mining.GUI_OreRedemptionMachine, Assets
+        m_MethodName: ClaimLaborPoints
+        m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine

--- a/UnityProject/Assets/Resources/Prefabs/UI/Tabs/Resources/VendorEntry.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/UI/Tabs/Resources/VendorEntry.prefab
@@ -31,14 +31,14 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 3706269908385880579}
+  - {fileID: 5056411601754966835}
   m_Father: {fileID: 3930125230363745104}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 165.78, y: 0}
-  m_SizeDelta: {x: 99.51, y: 45}
+  m_AnchoredPosition: {x: 169.58, y: 0}
+  m_SizeDelta: {x: 133.43958, y: 45}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5930595930881405012
 CanvasRenderer:
@@ -63,6 +63,8 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -120,6 +122,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 3674742737576757580}
+        m_TargetAssemblyTypeName: 
         m_MethodName: ExecuteClient
         m_Mode: 1
         m_Arguments:
@@ -146,6 +149,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 2261207741470223167}
+        m_TargetAssemblyTypeName: 
         m_MethodName: OnVendItemButtonPressed
         m_Mode: 0
         m_Arguments:
@@ -217,6 +221,8 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 0.5754717, g: 0.5754717, b: 0.5754717, a: 0.37254903}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -242,7 +248,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ea513a57707b421f8f2880e64ddbfd96, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &6858017132713618875
+--- !u!1 &6919382159209816276
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -250,23 +256,24 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 3706269908385880579}
-  - component: {fileID: 949471946871727636}
-  - component: {fileID: 3024232502998933317}
+  - component: {fileID: 5056411601754966835}
+  - component: {fileID: 305578055463114508}
+  - component: {fileID: 5649459936100171341}
+  - component: {fileID: 5860680144363330651}
   m_Layer: 5
-  m_Name: BuyText
+  m_Name: PriceTagLabel
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &3706269908385880579
+--- !u!224 &5056411601754966835
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6858017132713618875}
+  m_GameObject: {fileID: 6919382159209816276}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -276,24 +283,24 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 290.59, y: 45}
+  m_AnchoredPosition: {x: 0.28, y: 0}
+  m_SizeDelta: {x: 125.44733, y: 45}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &949471946871727636
+--- !u!222 &305578055463114508
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6858017132713618875}
+  m_GameObject: {fileID: 6919382159209816276}
   m_CullTransparentMesh: 0
---- !u!114 &3024232502998933317
+--- !u!114 &5649459936100171341
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6858017132713618875}
+  m_GameObject: {fileID: 6919382159209816276}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
@@ -302,23 +309,37 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
   m_FontData:
     m_Font: {fileID: 12800000, guid: b8471550233548f5a8aecb61061a2263, type: 3}
-    m_FontSize: 16
+    m_FontSize: 12
     m_FontStyle: 0
     m_BestFit: 0
-    m_MinSize: 1
-    m_MaxSize: 40
+    m_MinSize: 10
+    m_MaxSize: 16
     m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: BUY
+  m_Text: Free
+--- !u!114 &5860680144363330651
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6919382159209816276}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 21afa0ea296b4f4091642a323912e6e5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &6963804004137641361
 GameObject:
   m_ObjectHideFlags: 0
@@ -380,6 +401,8 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -466,6 +489,8 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -530,7 +555,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 83.26, y: 0}
+  m_AnchoredPosition: {x: 71.9, y: 0}
   m_SizeDelta: {x: 65.53, y: 45}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1389500331630533336
@@ -556,6 +581,8 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -650,9 +677,13 @@ MonoBehaviour:
   regularColor: {r: 0.5764706, g: 0.5764706, b: 0.5764706, a: 0.37254903}
   emptyStockColor: {r: 0.38679248, g: 0.38679248, b: 0.38679248, a: 0.15294118}
   vendorItem:
+    ItemName: 
     Item: {fileID: 0}
     Stock: 0
+    Currency: 0
+    Price: 0
   itemName: {fileID: 2138705174456770129}
   itemCount: {fileID: 5403648510788221165}
   itemIcon: {fileID: 7972774968059638083}
   itemBackground: {fileID: 1833044372855726578}
+  priceTag: {fileID: 5860680144363330651}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Mining/BananiumMaterial.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Mining/BananiumMaterial.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 03e121b26b644f546ba7e3b9678dd3a3, type: 3}
   m_Name: BananiumMaterial
   m_EditorClassIdentifier: 
+  laborPoint: 60
   oreTrait: {fileID: 11400000, guid: 1e8921a11f65f9640afc3446c7cb9320, type: 2}
   displayName: Bananium
   RefinedPrefab: {fileID: 1455605835710910032, guid: 4f841c65f76fe974880847c01e7a432d,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Mining/BluespaceCrystalMaterial.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Mining/BluespaceCrystalMaterial.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 03e121b26b644f546ba7e3b9678dd3a3, type: 3}
   m_Name: BluespaceCrystalMaterial
   m_EditorClassIdentifier: 
+  laborPoint: 50
   oreTrait: {fileID: 11400000, guid: 5454ae301f8f02a43ae7496ed16f70bc, type: 2}
   displayName: Bluespace Crystal
   RefinedPrefab: {fileID: 8887578544498410888, guid: 680b02587c8343542a4b918d0dbae089,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Mining/DiamondMaterial.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Mining/DiamondMaterial.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 03e121b26b644f546ba7e3b9678dd3a3, type: 3}
   m_Name: DiamondMaterial
   m_EditorClassIdentifier: 
+  laborPoint: 50
   oreTrait: {fileID: 11400000, guid: 66ee6ece9a2945342a3013068032cc61, type: 2}
   displayName: Diamond
   RefinedPrefab: {fileID: 6138400208043822838, guid: 340757c52c1e3c040900e72e4d4fc9c0,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Mining/GlassMaterial.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Mining/GlassMaterial.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 03e121b26b644f546ba7e3b9678dd3a3, type: 3}
   m_Name: GlassMaterial
   m_EditorClassIdentifier: 
+  laborPoint: 1
   oreTrait: {fileID: 11400000, guid: 6097f8423a1b255468e2285de46bc3d3, type: 2}
   displayName: Glass
   RefinedPrefab: {fileID: 8579127030982015588, guid: 66a5287d0bf216847a2f4fe34228a0cf,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Mining/GoldMaterial.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Mining/GoldMaterial.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 03e121b26b644f546ba7e3b9678dd3a3, type: 3}
   m_Name: GoldMaterial
   m_EditorClassIdentifier: 
+  laborPoint: 18
   oreTrait: {fileID: 11400000, guid: b6d7aeb207e8c9d47a7744da79141799, type: 2}
   displayName: Gold
   RefinedPrefab: {fileID: 2044367008419646583, guid: 7147422770216fc47b220e213ce8395c,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Mining/MetalMaterial.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Mining/MetalMaterial.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 03e121b26b644f546ba7e3b9678dd3a3, type: 3}
   m_Name: MetalMaterial
   m_EditorClassIdentifier: 
+  laborPoint: 1
   oreTrait: {fileID: 11400000, guid: 3d402a2b597113b4a97ee3710288b408, type: 2}
   displayName: Iron
   RefinedPrefab: {fileID: 5770283965274354279, guid: b83b68cfa4a201748aeeece963a989c3,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Mining/PlasmaMaterial.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Mining/PlasmaMaterial.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 03e121b26b644f546ba7e3b9678dd3a3, type: 3}
   m_Name: PlasmaMaterial
   m_EditorClassIdentifier: 
+  laborPoint: 15
   oreTrait: {fileID: 11400000, guid: 9f843295728958e48bcfe5215296ee90, type: 2}
   displayName: Plasma
   RefinedPrefab: {fileID: 9177804066296137559, guid: 25108e21a69d52c46a538e66eb85db0a,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Mining/SilverMaterial.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Mining/SilverMaterial.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 03e121b26b644f546ba7e3b9678dd3a3, type: 3}
   m_Name: SilverMaterial
   m_EditorClassIdentifier: 
+  laborPoint: 16
   oreTrait: {fileID: 11400000, guid: b52339a75d4b045469c79bd102bc98ea, type: 2}
   displayName: Silver
   RefinedPrefab: {fileID: 3133677340243276592, guid: aca91ff2eea9cc64aa3bb9deb8964ab1,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Mining/TitaniumMaterial.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Mining/TitaniumMaterial.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 03e121b26b644f546ba7e3b9678dd3a3, type: 3}
   m_Name: TitaniumMaterial
   m_EditorClassIdentifier: 
+  laborPoint: 30
   oreTrait: {fileID: 11400000, guid: e76a2305b1eac4c4786986115a5eb555, type: 2}
   displayName: Titanium
   RefinedPrefab: {fileID: 50811173315437471, guid: 25625619713dba04296304a60f5f37c1,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Mining/UraniumMaterial.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Mining/UraniumMaterial.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 03e121b26b644f546ba7e3b9678dd3a3, type: 3}
   m_Name: UraniumMaterial
   m_EditorClassIdentifier: 
+  laborPoint: 30
   oreTrait: {fileID: 11400000, guid: d3b5f22c1469bf34a81e377227b2acf5, type: 2}
   displayName: Uranium
   RefinedPrefab: {fileID: 5079880465429418907, guid: e85621ccf37627c47bb04b501d86fb83,

--- a/UnityProject/Assets/Scripts/Items/IDCard.cs
+++ b/UnityProject/Assets/Scripts/Items/IDCard.cs
@@ -10,7 +10,7 @@ using WebSocketSharp;
 /// <summary>
 ///     ID card properties
 /// </summary>
-public class IDCard : NetworkBehaviour, IServerInventoryMove, IServerSpawn, IInteractable<HandActivate>
+public class IDCard : NetworkBehaviour, IServerInventoryMove, IServerSpawn, IInteractable<HandActivate>, IExaminable
 {
 
 	[Tooltip("Sprite to use when the card is a normal card")]
@@ -57,6 +57,7 @@ public class IDCard : NetworkBehaviour, IServerInventoryMove, IServerSpawn, IInt
 	[SyncVar(hook = nameof(SyncName))]
 	private string registeredName;
 
+	public int[] currencies = new int[(int)CurrencyType.Total];
 
 	//The actual list of access allowed set via the server and synced to all clients
 	private SyncListInt accessSyncList = new SyncListInt();
@@ -273,4 +274,17 @@ public class IDCard : NetworkBehaviour, IServerInventoryMove, IServerSpawn, IInt
 	{
 		SyncName(registeredName, newName);
 	}
+
+	public string Examine(Vector3 pos)
+	{
+		return $"The account linked to the ID belongs to '{registeredName}' and reports a balance of {currencies[(int)CurrencyType.Credits]} cr. " +
+		       $"The mining budget reports a balance of {currencies[(int)CurrencyType.LaborPoints]} points.";
+	}
+}
+
+public enum CurrencyType
+{
+	Credits,
+	LaborPoints,
+	Total
 }

--- a/UnityProject/Assets/Scripts/Items/MaterialSheet.cs
+++ b/UnityProject/Assets/Scripts/Items/MaterialSheet.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 [CreateAssetMenu(fileName = "MaterialsInMachineStorage", menuName = "ScriptableObjects/Mining/MaterialSheet")]
 public class MaterialSheet : ScriptableObject
 {
+	public int laborPoint;
 	public ItemTrait oreTrait;
 	public string displayName;
 	public GameObject RefinedPrefab;

--- a/UnityProject/Assets/Scripts/Objects/Mining/OreRedemptionMachine.cs
+++ b/UnityProject/Assets/Scripts/Objects/Mining/OreRedemptionMachine.cs
@@ -14,7 +14,9 @@ namespace Objects.Mining
 	public class OreRedemptionMachine : MonoBehaviour, ICheckedInteractable<HandApply>
 	{
 		private RegisterObject registerObject;
-		private MaterialStorageLink materialStorageLink;
+		public MaterialStorageLink materialStorageLink;
+		public GUI_OreRedemptionMachine oreRedemptiomMachineGUI;
+		public int laborPoints;
 
 		private void Awake()
 		{
@@ -45,6 +47,11 @@ namespace Objects.Mining
 					AddOre(item.gameObject);
 				}
 			}
+
+			if (oreRedemptiomMachineGUI)
+			{
+				oreRedemptiomMachineGUI.UpdateLaborPoints(laborPoints);
+			}
 		}
 
 		private void AddOre(GameObject ore)
@@ -54,10 +61,21 @@ namespace Objects.Mining
 				if (Validations.HasItemTrait(ore, materialSheet.oreTrait))
 				{
 					var inStackable = ore.GetComponent<Stackable>();
+					laborPoints += inStackable.Amount * materialSheet.laborPoint;
 					materialStorageLink.TryAddSheet(materialSheet.materialTrait, inStackable.Amount);
 					Despawn.ServerSingle(ore);
 				}
 			}
+		}
+
+		public void ClaimLaborPoints(GameObject player)
+		{
+			var playerStorage = player.GetComponent<ItemStorage>();
+			var idCardObj = playerStorage.GetNamedItemSlot(NamedSlot.id).ItemObject;
+			var idCard = AccessRestrictions.GetIDCard(idCardObj);
+			idCard.currencies[(int)CurrencyType.LaborPoints] += laborPoints;
+			laborPoints = 0;
+			oreRedemptiomMachineGUI.UpdateLaborPoints(laborPoints);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Objects/Vendor.cs
+++ b/UnityProject/Assets/Scripts/Objects/Vendor.cs
@@ -43,6 +43,8 @@ namespace Objects
 		[SerializeField]
 		private string noAccessMessage = "Access denied!";
 
+		private string tooExpensiveMessage = "This is too expensive!";
+
 		public bool isEmagged;
 
 		[HideInInspector]
@@ -171,6 +173,22 @@ namespace Objects
 				}
 			}
 
+			if (itemToSpawn.Price > 0)
+			{
+				var playerStorage = player.GameObject.GetComponent<ItemStorage>();
+				var idCardObj = playerStorage.GetNamedItemSlot(NamedSlot.id).ItemObject;
+				var idCard = AccessRestrictions.GetIDCard(idCardObj);
+				if (idCard.currencies[(int) itemToSpawn.Currency] >= itemToSpawn.Price)
+				{
+					idCard.currencies[(int) itemToSpawn.Currency] -= itemToSpawn.Price;
+				}
+				else
+				{
+					Chat.AddWarningMsgFromServer(player.GameObject, tooExpensiveMessage);
+					return false;
+				}
+			}
+
 			return isSelectionValid;
 		}
 
@@ -263,12 +281,16 @@ namespace Objects
 		public string ItemName;
 		public GameObject Item;
 		public int Stock = 5;
+		public CurrencyType Currency = CurrencyType.Credits;
+		public int Price = 0;
 
 		public VendorItem(VendorItem item)
 		{
-			this.Item = item.Item;
-			this.Stock = item.Stock;
-			this.ItemName = Item.name;
+			Item = item.Item;
+			Stock = item.Stock;
+			ItemName = item.ItemName;
+			Currency = item.Currency;
+			Price = item.Price;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Occupations/AccessRestrictions.cs
+++ b/UnityProject/Assets/Scripts/Systems/Occupations/AccessRestrictions.cs
@@ -29,17 +29,30 @@ public class AccessRestrictions : MonoBehaviour
 
 	public bool CheckAccessCard(GameObject idCardObj)
 	{
-		if (idCardObj == null) return false;
-		var idcard = idCardObj.GetComponent<IDCard>();
-		var pda = idCardObj.GetComponent<PDALogic>();
-		if (idcard != null) return idcard.HasAccess(restriction);
-		// Not an ID card? Perhaps its a PDA.
-		if (pda != null && pda.IDCard != null)
+		if (idCardObj == null)
+			return false;
+		var idCard = GetIDCard(idCardObj);
+		if (idCard)
 		{
-			// Its a PDA, check the contents.
-			return pda.IDCard.HasAccess(restriction);
+			return idCard.HasAccess(restriction);
 		}
-		//The hell did it detect then?
 		return false;
+	}
+
+	public static IDCard GetIDCard(GameObject idCardObj)
+	{
+		var idCard = idCardObj.GetComponent<IDCard>();
+		var pda = idCardObj.GetComponent<PDALogic>();
+		if (idCard != null)
+		{
+			return idCard;
+		}
+
+		if (pda != null)
+		{
+			return pda.IDCard;
+		}
+
+		return null;
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Objects/Commons/Vending/VendorItemEntry.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Commons/Vending/VendorItemEntry.cs
@@ -23,6 +23,8 @@ namespace UI.Objects
 		private NetPrefabImage itemIcon = null;
 		[SerializeField]
 		private NetColorChanger itemBackground = null;
+		[SerializeField]
+		private NetLabel priceTag;
 
 		public void SetItem(VendorItem item, GUI_Vendor correspondingWindow)
 		{
@@ -56,6 +58,23 @@ namespace UI.Objects
 			else
 			{
 				itemBackground.SetValueServer(regularColor);
+			}
+
+			if (vendorItem.Price == 0)
+			{
+				priceTag.SetValueServer("Free");
+			}
+			else
+			{
+				if (vendorItem.Currency == CurrencyType.Credits)
+				{
+					priceTag.SetValueServer($"{vendorItem.Price} cr");
+				}
+				else
+				{
+					priceTag.SetValueServer($"{vendorItem.Price} Points");
+				}
+
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/UI/Objects/Mining/Ore Redemption Machine/GUI_MaterialEntry.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Mining/Ore Redemption Machine/GUI_MaterialEntry.cs
@@ -7,7 +7,6 @@ public class GUI_MaterialEntry : DynamicEntry
 	private GUI_MaterialsList materialList;
 
 	private ItemTrait materialType;
-	//private int currentAmount;
 
 	public NetLabel labelName;
 	public NetLabel labelAmount;
@@ -19,7 +18,6 @@ public class GUI_MaterialEntry : DynamicEntry
 	public void SetValues(ItemTrait material, int amount, GUI_MaterialsList matListDisplay)
 	{
 		materialList = matListDisplay;
-		//currentAmount = amount;
 		materialType = material;
 		labelAmount.SetValueServer($"{amount} cm3");
 		labelName.SetValueServer(material.name);

--- a/UnityProject/Assets/Scripts/UI/Objects/Mining/Ore Redemption Machine/GUI_MaterialsList.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Mining/Ore Redemption Machine/GUI_MaterialsList.cs
@@ -8,8 +8,6 @@ using Objects.Machines;
 public class GUI_MaterialsList : NetPage
 {
 	[SerializeField] private EmptyItemList materialList = null;
-	private int numberOfCategoriesInFirstColumn = 0;
-	private int numberOfCategoriesInSecondColumn = 0;
 	public MaterialStorageLink materialStorageLink;
 
 	public void UpdateMaterialList()

--- a/UnityProject/Assets/Scripts/UI/Objects/Mining/Ore Redemption Machine/GUI_OreRedemptionMachine.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Mining/Ore Redemption Machine/GUI_OreRedemptionMachine.cs
@@ -10,6 +10,9 @@ namespace Objects.Mining
 		[SerializeField]
 		private GUI_MaterialsList materialsListDisplay = null;
 
+		private OreRedemptionMachine oreRedemptionMachine;
+
+		public NetLabel laborPointsLabel;
 		protected override void InitServer()
 		{
 			StartCoroutine(WaitForProvider());
@@ -21,9 +24,23 @@ namespace Objects.Mining
 			{
 				yield return WaitFor.EndOfFrame;
 			}
-			materialsListDisplay.materialStorageLink = Provider.GetComponent<MaterialStorageLink>();
+
+			oreRedemptionMachine = Provider.GetComponent<OreRedemptionMachine>();
+			UpdateLaborPoints(oreRedemptionMachine.laborPoints);
+			oreRedemptionMachine.oreRedemptiomMachineGUI = this;
+			materialsListDisplay.materialStorageLink = oreRedemptionMachine.materialStorageLink;
 			materialsListDisplay.materialStorageLink.materialListGUI = materialsListDisplay;
 			materialsListDisplay.UpdateMaterialList();
+		}
+
+		public void UpdateLaborPoints(int laborPoints)
+		{
+			laborPointsLabel.SetValueServer($"Unclaimed points: {laborPoints.ToString()}");
+		}
+
+		public void ClaimLaborPoints(ConnectedPlayer connectedPlayer)
+		{
+			oreRedemptionMachine.ClaimLaborPoints(connectedPlayer.GameObject);
 		}
 	}
 }


### PR DESCRIPTION
### Purpose
Adds credits and labor points to IDs, examination will show its amounts.
Vendors can now have a price tag on their items, picking from different currencies.
The ORM will now generate labor points after obtaining ores, these can be claimed with a button on its UI.
Adds a mining equipment vendor machine, populated by only a toy sword marked as test item. It costs 10 labor points.
Fixes vendors not showing their set display name.

