### PR TITLE
Simplifies map picking

### DIFF
--- a/UnityProject/Assets/Scripts/Map/MapList.cs
+++ b/UnityProject/Assets/Scripts/Map/MapList.cs
@@ -13,26 +13,29 @@ public class MapList
 
 	public string GetRandomMap()
 	{
-		var mapsToChooseFrom = new List<string>(lowPopMaps);
 		var playerCount = PlayerList.LastRoundPlayerCount;
-
 		if (playerCount < PlayerList.Instance.ConnectionCount)
 		{
 			playerCount = PlayerList.Instance.ConnectionCount;
 		}
 
-		if (playerCount <= medPopMinLimit && lowPopMaps.Count > 0)
+		List<string> mapsToChooseFrom;
+
+		if (playerCount < medPopMinLimit)
 		{
-			return mapsToChooseFrom[Random.Range(0, mapsToChooseFrom.Count)];
+			mapsToChooseFrom = lowPopMaps;
+		}
+		else if (playerCount < highPopMinLimit)
+		{
+			mapsToChooseFrom = medPopMaps;
+		}
+		else
+		{
+			mapsToChooseFrom = highPopMaps;
 		}
 
-		mapsToChooseFrom = new List<string>(medPopMaps);
-		if (playerCount >= highPopMinLimit)
-		{
-			mapsToChooseFrom.AddRange(highPopMaps);
-		}
+		return mapsToChooseFrom[Random.Range(0, mapsToChooseFrom.Count)];
 
-		var rand = Random.Range(0, mapsToChooseFrom.Count);
-		return mapsToChooseFrom[rand];
+
 	}
 }

--- a/UnityProject/Assets/StreamingAssets/maps.json
+++ b/UnityProject/Assets/StreamingAssets/maps.json
@@ -1,6 +1,6 @@
 {
     "lowPopMaps":["FallStation", "SquareStation", "UnRealStation"],
-    "medPopMaps":["OutpostStation", "BoxStationV1", "PogStation"],
+    "medPopMaps":["FallStation", "SquareStation", "UnRealStation", "OutpostStation", "PogStation"],
     "highPopMaps":["OutpostStation", "BoxStationV1", "PogStation"],
     "medPopMinLimit":15,
     "highPopMinLimit":30


### PR DESCRIPTION
### Purpose
Removes box from med pop maps, now it'll only be highpop (30 pop or more)
Includes all lowpop maps on the medium map list.
Simplifies map picking, now it'll only pick maps from only one list based on population instead of mixing them up.

