### PR TITLE
Reverts #6105

### DIFF
--- a/UnityProject/Assets/Scripts/Systems/Fluids/LiquidPipeNet.cs
+++ b/UnityProject/Assets/Scripts/Systems/Fluids/LiquidPipeNet.cs
@@ -112,7 +112,7 @@ namespace Pipes
 				for (int i = 0; i < foundPipe.ConnectedPipes.Count; i++)
 				{
 					var nextPipe = foundPipe.ConnectedPipes[i];
-					if (nextPipe.NetCompatible && nextPipe.OnNet == null && !foundPipes.Contains((nextPipe)))
+					if (nextPipe.NetCompatible && nextPipe.OnNet == null)
 					{
 						foundPipes.Add(nextPipe);
 					}


### PR DESCRIPTION
### Purpose
Removes an unneeded check when looping through pipes after one is deconstructed.

### Notes:
Context: I took a wrong assumption and the actual fix was done in #6113, while this check avoided the infinite loop in this exact moment, the main issue persisted due to how pipes were double-connecting with eachother.
