### PR TITLE
Ore boxes

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Mining/OreBox.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Mining/OreBox.prefab
@@ -1,0 +1,162 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &4050554866728414490
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8309667075700373638}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fdce8a163088453ca593c0e98f2c5f07, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemStorageStructure: {fileID: 11400000, guid: 441bbe778728cb24ea74e1aa6e32b1e8,
+    type: 2}
+  itemStorageCapacity: {fileID: 11400000, guid: 23aa0f5ba50a14241a263edcac31a37b,
+    type: 2}
+  itemStoragePopulator: {fileID: 0}
+  dropItemsOnDespawn: 1
+  UesAddlistPopulater: 0
+  Populater:
+    MergeMode: 0
+    Contents: []
+--- !u!114 &9207613236471661794
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8309667075700373638}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6308000544d615945b8e4c6a317329a7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  matsOnDestroy: {fileID: 2663802320431471963, guid: 9ae38f6aa43b5cd4ba608cd31b462b24,
+    type: 3}
+--- !u!1001 &8743123124189539590
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 676721839806558615, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 676721839806558615, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 676721839806558615, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 78a15694d85dd644798b941c2a816bf9,
+        type: 3}
+    - target: {fileID: 676721839806558615, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 721717256067945856, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_Name
+      value: OreBox
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212070883374448474, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 87b04ca94248e6c40928abdd996d48bc,
+        type: 2}
+    - target: {fileID: 7971921043980192432, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: initialName
+      value: Ore box
+      objectReference: {fileID: 0}
+    - target: {fileID: 7971921043980192432, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: initialDescription
+      value: A heavy wooden box, which can be filled with a lot of ores.
+      objectReference: {fileID: 0}
+    - target: {fileID: 9212640593017544930, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: isDirty
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9212640593017544930, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b06b702714bab49b9ad949eab1ca4534, type: 3}
+--- !u!1 &8309667075700373638 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 721717256067945856, guid: b06b702714bab49b9ad949eab1ca4534,
+    type: 3}
+  m_PrefabInstance: {fileID: 8743123124189539590}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Mining/OreBox.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Mining/OreBox.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f5de2b6011113f0469b27cd8289f2d8b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/Construction/BuildList/WoodenPlankConstructionList.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Construction/BuildList/WoodenPlankConstructionList.asset
@@ -59,3 +59,10 @@ MonoBehaviour:
     buildTime: 15
     spawnAmount: 1
     onePerTile: 1
+  - name: Ore Box
+    prefab: {fileID: 8309667075700373638, guid: f5de2b6011113f0469b27cd8289f2d8b,
+      type: 3}
+    cost: 4
+    buildTime: 5
+    spawnAmount: 1
+    onePerTile: 1

--- a/UnityProject/Assets/Scripts/Objects/Mining/OreBox.cs
+++ b/UnityProject/Assets/Scripts/Objects/Mining/OreBox.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Mirror;
+
+public class OreBox : NetworkBehaviour, ICheckedInteractable<HandApply>, IServerDespawn
+{
+	private ItemStorage oreBoxItemStorage;
+	public GameObject matsOnDestroy;
+	private void Awake()
+	{
+		oreBoxItemStorage = GetComponent<ItemStorage>();
+	}
+
+	public bool WillInteract(HandApply interaction, NetworkSide side)
+	{
+		if (!DefaultWillInteract.Default(interaction, side))
+			return false;
+		if (interaction.HandSlot.IsEmpty)
+			return false;
+		if (Validations.HasItemTrait(interaction.HandSlot.ItemObject, CommonTraits.Instance.Crowbar))
+			return true;
+		if (Validations.HasItemTrait(interaction.HandSlot.ItemObject, CommonTraits.Instance.OreGeneral))
+			return true;
+		if (interaction.HandSlot.ItemObject.GetComponent<ItemStorage>())
+			return true;
+
+		return false;
+	}
+
+	public void ServerPerformInteraction(HandApply interaction)
+	{
+		var itemObject = interaction.HandSlot.ItemObject;
+		if (Validations.HasItemTrait(itemObject, CommonTraits.Instance.Crowbar))
+		{
+			oreBoxItemStorage.ServerDropAll();
+		}
+		else if (Validations.HasItemTrait(itemObject, CommonTraits.Instance.OreGeneral))
+		{
+			TransferOre(interaction.HandSlot);
+		}
+		else
+		{
+			var itemStorage = itemObject.GetComponent<ItemStorage>();
+			var itemSlotList = itemStorage.GetItemSlots();
+			foreach (var itemSlot in itemSlotList)
+			{
+				if (itemSlot.IsEmpty)
+				{
+					continue;
+				}
+				TransferOre(itemSlot);
+			}
+		}
+	}
+
+	private void TransferOre(ItemSlot itemSlot)
+	{
+		var oreBoxSlot = oreBoxItemStorage.GetBestSlotFor(itemSlot.Item);
+		if (oreBoxSlot != null)
+		{
+			Inventory.ServerTransfer(itemSlot, oreBoxSlot);
+		}
+	}
+
+	public void OnDespawnServer(DespawnInfo info)
+	{
+		Spawn.ServerPrefab(matsOnDestroy, gameObject.TileWorldPosition().To3Int(), transform.parent, count: 4,
+			scatterRadius: Spawn.DefaultScatterRadius, cancelIfImpassable: true);
+	}
+
+}

--- a/UnityProject/Assets/Scripts/Objects/Mining/OreBox.cs.meta
+++ b/UnityProject/Assets/Scripts/Objects/Mining/OreBox.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6308000544d615945b8e4c6a317329a7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Systems/Inventory/ItemStorage.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/ItemStorage.cs
@@ -65,6 +65,9 @@ public class ItemStorage : MonoBehaviour, IServerLifecycle, IServerInventoryMove
 	//It can be null, or it can be a pickupable.(Health V2)
 	public event Action<Pickupable, Pickupable> ServerInventoryItemSlotSet;
 
+	[SerializeField]
+	private bool dropItemsOnDespawn;
+
 	public bool UesAddlistPopulater = false;
 
 	[ShowIf(nameof(UesAddlistPopulater))] public PrefabListPopulater Populater;
@@ -97,6 +100,9 @@ public class ItemStorage : MonoBehaviour, IServerLifecycle, IServerInventoryMove
 		{
 			ServerRemoveObserverPlayer(gameObject);
 		}
+		if(dropItemsOnDespawn)
+			ServerDropAll();
+
 		//reclaim the space in the slot pool.
 		ItemSlot.Free(this);
 	}


### PR DESCRIPTION
### Purpose
Adds ore boxes.
Adds a bool in itemstorage for objects to drop all items on despawn, the ore box will have it enabled.
The ore box will accept interactions from ores, crowbar and any type of bags which will add all its ores to it.
Ore boxes can now be buildable using wooden planks.

### Notes:
No movement-related implementations yet
