### PR TITLE
Copies log entry text when clicked.

### DIFF
--- a/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogItem.cs
+++ b/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogItem.cs
@@ -118,8 +118,12 @@ namespace IngameDebugConsole
 				}
 			}
 			else
+			{
+				CopyLogText();
 				manager.OnLogItemClicked( this );
+			}
 #else
+			CopyLogText();
 			manager.OnLogItemClicked( this );
 #endif
 		}
@@ -147,6 +151,11 @@ namespace IngameDebugConsole
 		public override string ToString()
 		{
 			return logEntry.ToString();
+		}
+
+		private void CopyLogText()
+		{
+			GUIUtility.systemCopyBuffer = logEntry.ToString();
 		}
 	}
 }


### PR DESCRIPTION
### Purpose
closes #6194 
Allows players and devs to copy log entry text from the in-game console.

### Changelog:
CL: Logs can now be copied from the in-game console by just left clicking on them.
