### PR TITLE
Makes deathsquad troopers non-targetable by antags

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/Occupations/Centcom/Deathsquad.asset
+++ b/UnityProject/Assets/ScriptableObjects/Occupations/Centcom/Deathsquad.asset
@@ -52,7 +52,7 @@ MonoBehaviour:
   customProperties:
     m_keys: []
     m_values: 
-  isTargeteable: 1
+  isTargeteable: 0
   playSound: 1
   spawnSound:
     SetLoadSetting: 0


### PR DESCRIPTION
### Purpose
The title explains it, makes deathsquad troopers non-targetable by antags, now it is guarenteed that you will not get a ghost role as an objective.

### Changelog:
-Made deathsquad troopers non-targetable. 


### Notes
This is legit the smallest PR I have ever made lol