### PR TITLE
Thread safe list wrapper with no allocations on iteration

### DIFF
--- a/UnityProject/Assets/Scripts/Util/ThreadSafeList.cs
+++ b/UnityProject/Assets/Scripts/Util/ThreadSafeList.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-public delegate void GenericDelegate<T>(T item);
+public delegate void GenericDelegate<in T>(T item);
 
 public class ThreadSafeList<T>
 {

--- a/UnityProject/Assets/Scripts/Util/ThreadSafeList.cs
+++ b/UnityProject/Assets/Scripts/Util/ThreadSafeList.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+
+public delegate void GenericDelegate<T>(T item);
+
+public class ThreadSafeList<T>
+{
+	private List<T> list = new List<T>();
+	public event GenericDelegate<T> Event;
+
+	public void Iterate(GenericDelegate<T> thingToCall)
+	{
+		lock (list)
+		{
+			Event += thingToCall;
+			for (int i = list.Count -1; i >= 0; i--)
+			{
+				Event(list[i]);
+			}
+			Event -= thingToCall;
+		}
+	}
+
+	public void Add(T item)
+	{
+		lock (list)
+		{
+			list.Add(item);
+		}
+	}
+
+	public bool Remove(T item)
+	{
+		lock (list)
+		{
+			return list.Remove(item);
+		}
+	}
+
+	public void Clear()
+	{
+		lock (list)
+		{
+			list.Clear();
+		}
+	}
+
+
+}

--- a/UnityProject/Assets/Scripts/Util/ThreadSafeList.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/ThreadSafeList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9bf4e7b209f4e83438cfad859c13c713
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
Adds ThreadSafeList, a thread safe list wrapper that can be iterated without allocations.
Fixes the atmos manager removing a random pipe from its list instead of the assigned one.
