### PR TITLE
Fixes admins ghost sprite visibility

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/AdminManager/AdminGhostItemStorageHolder.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/AdminManager/AdminGhostItemStorageHolder.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 23326758832184870}
   - component: {fileID: 167825772313686640}
   - component: {fileID: -8464927437020319508}
-  - component: {fileID: -13344008857534692}
   m_Layer: 0
   m_Name: AdminGhostItemStorageHolder
   m_TagString: Untagged
@@ -50,6 +49,11 @@ MonoBehaviour:
   itemStorageCapacity: {fileID: 11400000, guid: 0520f8d83b72b3242943ceac3f902484,
     type: 2}
   itemStoragePopulator: {fileID: 0}
+  dropItemsOnDespawn: 0
+  UesAddlistPopulater: 0
+  Populater:
+    MergeMode: 0
+    Contents: []
 --- !u!114 &-8464927437020319508
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -68,15 +72,3 @@ MonoBehaviour:
   visible: 2
   m_AssetId: 
   hasSpawned: 0
---- !u!114 &-13344008857534692
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5719856537884556532}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 62cc3ef7cd9082443aaf3c255851d15a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 


### PR DESCRIPTION
### Purpose
Fixes admins ghost sprite visibility.
Removes CustomNetSceneChecker from the AdminGhostItemStorageHolder since they're in a manager, not a scene.

