### PR TITLE
Adds multiple character selection

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
@@ -3568,6 +3568,7 @@ MonoBehaviour:
   SurfaceSprite: []
   SelectedSpecies: 0
   SerialiseData: {fileID: 5117563973470917019}
+  snapCapturer: {fileID: 3608206203887922948}
   WindowName: {fileID: 4616484289738564357}
   SlotsUsed: {fileID: 1235902433222566057}
   CharacterPreviewName: {fileID: 2379072935745182127}
@@ -8838,6 +8839,7 @@ GameObject:
   - component: {fileID: 3272705599764375333}
   - component: {fileID: 1533079639694616771}
   - component: {fileID: 3608206203887922948}
+  - component: {fileID: 7727240642779787147}
   m_Layer: 5
   m_Name: Camera
   m_TagString: Untagged
@@ -8924,6 +8926,26 @@ MonoBehaviour:
   height: 312
   Path: /SNAPS
   FileName: capture.PNG
+--- !u!114 &7727240642779787147
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8517848032023236467}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6a160d838ff8b4b4693ac20007e008c7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AssetsPPU: 100
+  m_RefResolutionX: 320
+  m_RefResolutionY: 180
+  m_UpscaleRT: 0
+  m_PixelSnapping: 0
+  m_CropFrameX: 0
+  m_CropFrameY: 0
+  m_StretchFill: 0
 --- !u!1 &8541443077353848735
 GameObject:
   m_ObjectHideFlags: 0
@@ -10743,6 +10765,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 916ee089a0d7b63419075f91e1c657ec, type: 3}
+--- !u!224 &532022409019164951 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 22448498, guid: 916ee089a0d7b63419075f91e1c657ec,
+    type: 3}
+  m_PrefabInstance: {fileID: 532022409041281125}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &532022409047985889 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 11423364, guid: 916ee089a0d7b63419075f91e1c657ec,
@@ -10755,9 +10783,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8262e4a8322117f4da079921eaa72834, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &532022409019164951 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 22448498, guid: 916ee089a0d7b63419075f91e1c657ec,
-    type: 3}
-  m_PrefabInstance: {fileID: 532022409041281125}
-  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
@@ -38,6 +38,138 @@ RectTransform:
   m_AnchoredPosition: {x: -295, y: 346.6}
   m_SizeDelta: {x: 100, y: 193.22675}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &328033210676926905
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6808618693128956931}
+  - component: {fileID: 6352367155911204584}
+  - component: {fileID: 1489829480653107110}
+  - component: {fileID: 8298080950317740411}
+  m_Layer: 5
+  m_Name: GoBackToCharacterSelector
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &6808618693128956931
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 328033210676926905}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 3677948888576165940}
+  m_Father: {fileID: 4616484289440412185}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -627, y: 0}
+  m_SizeDelta: {x: 180, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6352367155911204584
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 328033210676926905}
+  m_CullTransparentMesh: 0
+--- !u!114 &1489829480653107110
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 328033210676926905}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 00b9f947b2ed79743a4a1d83880a5901, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &8298080950317740411
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 328033210676926905}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1489829480653107110}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 4616484289766084577}
+        m_TargetAssemblyTypeName: Lobby.CharacterCustomization, Assets
+        m_MethodName: ShowCharacterSelectorPage
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &416983496042668919
 GameObject:
   m_ObjectHideFlags: 0
@@ -381,6 +513,111 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: 'Body:'
+--- !u!1 &906672242732106874
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1996233511173570630}
+  - component: {fileID: 8045431650833016367}
+  - component: {fileID: 524590273757372877}
+  - component: {fileID: 4680677007114103711}
+  m_Layer: 5
+  m_Name: leftscroll
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1996233511173570630
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 906672242732106874}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 135921120669185814}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 82, y: 374}
+  m_SizeDelta: {x: 160.19687, y: 83.24756}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8045431650833016367
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 906672242732106874}
+  m_CullTransparentMesh: 0
+--- !u!114 &524590273757372877
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 906672242732106874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 14e6372fa8171884ebcc2dd0371f9ca0, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &4680677007114103711
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 906672242732106874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates:
+  - eventID: 2
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 4616484289766084577}
+          m_TargetAssemblyTypeName: Lobby.CharacterCustomization, Assets
+          m_MethodName: scrollSelectorLeft
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
 --- !u!1 &1067065174834834937
 GameObject:
   m_ObjectHideFlags: 0
@@ -411,6 +648,7 @@ RectTransform:
   - {fileID: 5497606065763137208}
   - {fileID: 8290421142549044400}
   - {fileID: 5692817288222078180}
+  - {fileID: 2001351546468756302}
   m_Father: {fileID: 4616484291191486528}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -683,6 +921,111 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!1 &1109667993898598252
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4459021652447467624}
+  - component: {fileID: 6528749004774214593}
+  - component: {fileID: 4113272246248219458}
+  - component: {fileID: 1349481123673661179}
+  m_Layer: 5
+  m_Name: rightscroll
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4459021652447467624
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1109667993898598252}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 135921120669185814}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 1370.402, y: 374.00003}
+  m_SizeDelta: {x: 175.31595, y: 83.24756}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6528749004774214593
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1109667993898598252}
+  m_CullTransparentMesh: 0
+--- !u!114 &4113272246248219458
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1109667993898598252}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 583965b72b405c9479e1303ccafce60e, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1349481123673661179
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1109667993898598252}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates:
+  - eventID: 2
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 4616484289766084577}
+          m_TargetAssemblyTypeName: Lobby.CharacterCustomization, Assets
+          m_MethodName: scrollSelectorRight
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
 --- !u!1 &1152174177124484012
 GameObject:
   m_ObjectHideFlags: 0
@@ -742,7 +1085,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -800,6 +1143,85 @@ RectTransform:
   m_AnchoredPosition: {x: -253.00002, y: 296.8}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1329304354362532822
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8141665984931505794}
+  - component: {fileID: 2942777668197017709}
+  - component: {fileID: 369449508620937038}
+  m_Layer: 5
+  m_Name: RacePreviewText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8141665984931505794
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1329304354362532822}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4709261932871980771}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 530.5365, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2942777668197017709
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1329304354362532822}
+  m_CullTransparentMesh: 0
+--- !u!114 &369449508620937038
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1329304354362532822}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: f6a745ad29e1c2f4caa9737278b850c0, type: 2}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 3
+    m_MaxSize: 40
+    m_Alignment: 1
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Race
 --- !u!1 &1405478393861318509
 GameObject:
   m_ObjectHideFlags: 0
@@ -916,6 +1338,160 @@ RectTransform:
   m_AnchoredPosition: {x: 11, y: -181}
   m_SizeDelta: {x: 0, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1910996161435359195
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7450167192545002417}
+  - component: {fileID: 8618607545985737537}
+  - component: {fileID: 1235902433222566057}
+  m_Layer: 5
+  m_Name: Slots
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7450167192545002417
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1910996161435359195}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5360320989633759644}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 543.6974, y: 50.201355}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8618607545985737537
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1910996161435359195}
+  m_CullTransparentMesh: 0
+--- !u!114 &1235902433222566057
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1910996161435359195}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: f6a745ad29e1c2f4caa9737278b850c0, type: 2}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Slots 0/35
+--- !u!1 &1937390950188382194
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 342587767384402498}
+  m_Layer: 5
+  m_Name: ApperancePage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &342587767384402498
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1937390950188382194}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4616484289415138354}
+  - {fileID: 4616484289987147772}
+  m_Father: {fileID: 4616484290072915384}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 9.398, y: 6.100006}
+  m_SizeDelta: {x: 1442.5883, y: 884.53656}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1987631841530705084
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 135921120669185814}
+  m_Layer: 5
+  m_Name: ControlsGroup
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &135921120669185814
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1987631841530705084}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1996233511173570630}
+  - {fileID: 4459021652447467624}
+  - {fileID: 5360320989633759644}
+  m_Father: {fileID: 3613743343164779589}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -9.4249, y: -461}
+  m_SizeDelta: {x: 1456.1196, y: 88.06185}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1988620665013936506
 GameObject:
   m_ObjectHideFlags: 0
@@ -1011,7 +1587,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -1065,10 +1641,10 @@ RectTransform:
   m_Father: {fileID: 2001351546468756302}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 730.6919, y: -40}
+  m_SizeDelta: {x: 270.27676, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &798348551892643631
 CanvasRenderer:
@@ -1196,7 +1772,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: -0.00012207031}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -1238,6 +1814,138 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3296757793400434710
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2131542466299034472}
+  - component: {fileID: 5294788050697315860}
+  - component: {fileID: 7057175505340602966}
+  - component: {fileID: 6260620736820184813}
+  m_Layer: 5
+  m_Name: CreateCharacter
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2131542466299034472
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3296757793400434710}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7854004385588924412}
+  m_Father: {fileID: 5360320989633759644}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 431.69736, y: 41.544548}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5294788050697315860
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3296757793400434710}
+  m_CullTransparentMesh: 0
+--- !u!114 &7057175505340602966
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3296757793400434710}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.3278302, g: 0.41883424, b: 0.5, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: cc3b2d94fa0a81a42899ff1375633780, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &6260620736820184813
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3296757793400434710}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 7057175505340602966}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 4616484289766084577}
+        m_TargetAssemblyTypeName: Lobby.CharacterCustomization, Assets
+        m_MethodName: CreateCharacter
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &3371642551616808639
 GameObject:
   m_ObjectHideFlags: 0
@@ -1297,7 +2005,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -1350,7 +2058,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: -0.00012207031}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -1392,6 +2100,322 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3493563668641879862
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6681814605387333497}
+  m_Layer: 5
+  m_Name: Characters
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6681814605387333497
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3493563668641879862}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 532853186223996705}
+  - {fileID: 1423441795467222215}
+  m_Father: {fileID: 3613743343164779589}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -9.4203, y: -27.1}
+  m_SizeDelta: {x: 1456.1288, y: 887.9683}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &3507772626339055157
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4709261932871980771}
+  - component: {fileID: 4003751137709469787}
+  m_Layer: 5
+  m_Name: Info
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4709261932871980771
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3507772626339055157}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7885454758424910156}
+  - {fileID: 6282411419536445397}
+  - {fileID: 8141665984931505794}
+  - {fileID: 5665895941591982491}
+  m_Father: {fileID: 532853186223996705}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.000035763, y: -64}
+  m_SizeDelta: {x: 532.54315, y: 746.8265}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &4003751137709469787
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3507772626339055157}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 0
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!1 &3620917793680120573
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3677948888576165940}
+  - component: {fileID: 4611281920860574537}
+  - component: {fileID: 5973844894484729735}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3677948888576165940
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3620917793680120573}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1.1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6808618693128956931}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: -20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4611281920860574537
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3620917793680120573}
+  m_CullTransparentMesh: 0
+--- !u!114 &5973844894484729735
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3620917793680120573}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Back
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 3655783871
+  m_fontColor: {r: 0.7473733, g: 0.8345668, b: 0.90099996, a: 0.8509804}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 1
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &3634500428685722192
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7854004385588924412}
+  - component: {fileID: 7716008889970776516}
+  - component: {fileID: 6784131799984094074}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7854004385588924412
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3634500428685722192}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2131542466299034472}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 132, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7716008889970776516
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3634500428685722192}
+  m_CullTransparentMesh: 0
+--- !u!114 &6784131799984094074
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3634500428685722192}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 40
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 50
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Create Character
 --- !u!1 &3994899225903891388
 GameObject:
   m_ObjectHideFlags: 0
@@ -1426,13 +2450,13 @@ RectTransform:
   - {fileID: 1901841704336856641}
   - {fileID: 4616484290753241638}
   - {fileID: 4616484291446804124}
-  m_Father: {fileID: 4616484289766084576}
-  m_RootOrder: 2
+  m_Father: {fileID: 9011797635498828644}
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 0, y: 13.5}
-  m_SizeDelta: {x: 0, y: 85}
+  m_AnchoredPosition: {x: 41.308105, y: -683.89087}
+  m_SizeDelta: {x: 1361.3838, y: 85}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!222 &1111714649766955303
 CanvasRenderer:
@@ -1531,7 +2555,8 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 3272705599764375333}
   m_Father: {fileID: 4616484291191486528}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1713,19 +2738,19 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4616484289415138349}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.71000004, y: 0.7100001, z: 0.7100001}
   m_Children:
   - {fileID: 4616484290996402401}
   - {fileID: 4616484290269533403}
-  m_Father: {fileID: 4616484290072915384}
+  m_Father: {fileID: 342587767384402498}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 18.799988, y: 49.2}
-  m_SizeDelta: {x: 1987.5981, y: 199.59998}
+  m_AnchoredPosition: {x: 0.004211426, y: 43.099976}
+  m_SizeDelta: {x: 1987.5981, y: 211.8634}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &4616484289415138352
 CanvasRenderer:
@@ -1749,7 +2774,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.120238535, g: 0.120238535, b: 0.13207549, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -1824,7 +2849,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -1874,6 +2899,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4616484289738564363}
+  - {fileID: 6808618693128956931}
   m_Father: {fileID: 4616484289766084576}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1904,7 +2930,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.19246174, g: 0.20330858, b: 0.23584908, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -2058,7 +3084,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -2213,7 +3239,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.19215687, g: 0.20392157, b: 0.23529412, a: 0.5019608}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -2303,7 +3329,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -2358,13 +3384,13 @@ RectTransform:
   m_Children:
   - {fileID: 4616484289440412185}
   - {fileID: 4616484290072915384}
-  - {fileID: 2001351546468756302}
+  - {fileID: 3613743343164779589}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -5, y: 57}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 1461.3838, y: 1059.0193}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4616484289766084586
@@ -2542,6 +3568,17 @@ MonoBehaviour:
   SurfaceSprite: []
   SelectedSpecies: 0
   SerialiseData: {fileID: 5117563973470917019}
+  WindowName: {fileID: 4616484289738564357}
+  SlotsUsed: {fileID: 1235902433222566057}
+  CharacterPreviewName: {fileID: 2379072935745182127}
+  CharacterPreviewRace: {fileID: 369449508620937038}
+  CharacterPreviewBodyType: {fileID: 2486416645686578486}
+  CharacterPreviewImg: {fileID: 3405283805252071630}
+  CharacterPreviews: {fileID: 8988093448107136569}
+  NoCharactersError: {fileID: 9048310144479258054}
+  GoBackButton: {fileID: 328033210676926905}
+  CharacterSelectorPage: {fileID: 8248689287685672263}
+  CharacterCreatorPage: {fileID: 4616484290072915387}
 --- !u!1 &4616484289772122947
 GameObject:
   m_ObjectHideFlags: 0
@@ -2809,18 +3846,18 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4616484289987147775}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4616484291191486528}
-  m_Father: {fileID: 4616484290072915384}
+  m_Father: {fileID: 342587767384402498}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -723, y: -0.012451172}
-  m_SizeDelta: {x: 1116, y: 0.024902}
+  m_AnchoredPosition: {x: -723.00024, y: -6.1124573}
+  m_SizeDelta: {x: 1116, y: 12.28833}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &4616484290072915387
 GameObject:
@@ -2840,7 +3877,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &4616484290072915384
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2852,8 +3889,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.9999975, y: 0.9999975, z: 0.9999975}
   m_Children:
-  - {fileID: 4616484289415138354}
-  - {fileID: 4616484289987147772}
+  - {fileID: 342587767384402498}
   m_Father: {fileID: 4616484289766084576}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3011,7 +4047,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.4528302, g: 0.4528302, b: 0.4528302, a: 0.416}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -3086,7 +4122,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0, b: 0, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -3165,7 +4201,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.32941177, g: 0.41960785, b: 0.5019608, a: 0.5019608}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -3240,7 +4276,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -3294,10 +4330,10 @@ RectTransform:
   m_Father: {fileID: 2001351546468756302}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 1020.9687, y: -40}
+  m_SizeDelta: {x: 270.27676, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4616484290753241637
 CanvasRenderer:
@@ -3488,7 +4524,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -3826,7 +4862,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -3906,7 +4942,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -4222,7 +5258,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0.105882354}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -4438,12 +5474,68 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &4616484291191486528
+--- !u!224 &4616484290833444690
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4616484290833444685}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4616484290785075766}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -166.3, y: -37.5}
+  m_SizeDelta: {x: -300.5, y: 60}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!222 &4616484290833444688
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4616484290833444685}
+  m_CullTransparentMesh: 0
+--- !u!114 &4616484290833444691
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4616484290833444685}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 56
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 56
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Age:'
+--- !u!1 &4616484290965557748
   m_GameObject: {fileID: 4616484291191486531}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -4630,6 +5722,70 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 75f2c271ea20df14b816d846846217a8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.105882354}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: af20367e8cd964d82a9d30ba5f34eb8a, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4616484291063229299
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4616484291063229296}
+  - component: {fileID: 4616484291063229302}
+  - component: {fileID: 4616484291063229297}
+  m_Layer: 5
+  m_Name: InputLabel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4616484291063229296
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4616484291063229299}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4616484290268993179}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: -152, y: 3.1}
+  m_SizeDelta: {x: -235.65, y: 60}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!222 &4616484291063229302
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4616484291063229299}
+  m_CullTransparentMesh: 0
+--- !u!114 &4616484291063229297
   label: {fileID: 4616484289466361095}
 --- !u!114 &4616484291287029853
 MonoBehaviour:
@@ -4640,6 +5796,32 @@ MonoBehaviour:
   m_GameObject: {fileID: 4616484291287029855}
   m_Enabled: 1
   m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 55
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 56
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Gender:'
+--- !u!1 &4616484291146125579
   m_Script: {fileID: 11500000, guid: 6fece9ea9fe8f46a1bcbbc9844d908f3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
@@ -4785,10 +5967,10 @@ RectTransform:
   m_Father: {fileID: 2001351546468756302}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 150.13838, y: -40}
+  m_SizeDelta: {x: 270.27676, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4616484291389767592
 CanvasRenderer:
@@ -4917,10 +6099,10 @@ RectTransform:
   m_Father: {fileID: 2001351546468756302}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 1311.2455, y: -40}
+  m_SizeDelta: {x: 270.27676, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4616484291446804195
 CanvasRenderer:
@@ -5074,7 +6256,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -5153,7 +6335,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -5232,7 +6414,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -5384,6 +6566,71 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!1 &5290555954304905310
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5360320989633759644}
+  - component: {fileID: 3617995363554174451}
+  m_Layer: 5
+  m_Name: Controls
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5360320989633759644
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5290555954304905310}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2131542466299034472}
+  - {fileID: 7450167192545002417}
+  - {fileID: 3656274372782485251}
+  m_Father: {fileID: 135921120669185814}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.0000019073, y: -17.005}
+  m_SizeDelta: {x: 1407.092, y: 54.05262}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &3617995363554174451
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5290555954304905310}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
 --- !u!1 &5408466828360986867
 GameObject:
   m_ObjectHideFlags: 0
@@ -5418,6 +6665,52 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -152.33499, y: -38}
+  m_SizeDelta: {x: -244.66998, y: 64}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!222 &7458750837548770884
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4930529332528869450}
+  m_CullTransparentMesh: 0
+--- !u!114 &6967046868821126392
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4930529332528869450}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 56
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 56
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Accent:'
+--- !u!1 &4937045918359471588
   m_AnchoredPosition: {x: 10.999955, y: -220.99998}
   m_SizeDelta: {x: 0, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -5536,6 +6829,292 @@ RectTransform:
   m_AnchoredPosition: {x: 11, y: -94.69992}
   m_SizeDelta: {x: -0.0049743652, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &5623409178127911932
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6282411419536445397}
+  - component: {fileID: 2207819112428250186}
+  - component: {fileID: 3405283805252071630}
+  m_Layer: 5
+  m_Name: Picture
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6282411419536445397
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5623409178127911932}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4709261932871980771}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 530.96124, y: 635.43616}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2207819112428250186
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5623409178127911932}
+  m_CullTransparentMesh: 0
+--- !u!114 &3405283805252071630
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5623409178127911932}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5774422873272561806
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3656274372782485251}
+  - component: {fileID: 5840157356741946307}
+  - component: {fileID: 3967425108405070216}
+  - component: {fileID: 1228489573489785811}
+  m_Layer: 5
+  m_Name: EditCharacter
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3656274372782485251
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5774422873272561806}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1791602284446438306}
+  m_Father: {fileID: 5360320989633759644}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 431.69736, y: 41.544548}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5840157356741946307
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5774422873272561806}
+  m_CullTransparentMesh: 0
+--- !u!114 &3967425108405070216
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5774422873272561806}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.3278302, g: 0.41883424, b: 0.5, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: cc3b2d94fa0a81a42899ff1375633780, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1228489573489785811
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5774422873272561806}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 3967425108405070216}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 4616484289766084577}
+        m_TargetAssemblyTypeName: Lobby.CharacterCustomization, Assets
+        m_MethodName: EditCharacter
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &5827939130447082303
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1791602284446438306}
+  - component: {fileID: 6412179641360420610}
+  - component: {fileID: 8001897525390968167}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1791602284446438306
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5827939130447082303}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3656274372782485251}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 132, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6412179641360420610
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5827939130447082303}
+  m_CullTransparentMesh: 0
+--- !u!114 &8001897525390968167
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5827939130447082303}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 40
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 50
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Edit Character
 --- !u!1 &5928433498955394351
 GameObject:
   m_ObjectHideFlags: 0
@@ -5570,10 +7149,10 @@ RectTransform:
   m_Father: {fileID: 2001351546468756302}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 440.41516, y: -40}
+  m_SizeDelta: {x: 270.27676, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8405106599432818181
 CanvasRenderer:
@@ -7096,6 +8675,43 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &8248689287685672263
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3613743343164779589}
+  m_Layer: 5
+  m_Name: CharacterSelectorPage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3613743343164779589
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8248689287685672263}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 6681814605387333497}
+  - {fileID: 135921120669185814}
+  m_Father: {fileID: 4616484289766084576}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 6.7927, y: -0.000031471}
+  m_SizeDelta: {x: 1474.9692, y: 1059.0193}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &8340436402569142241
 GameObject:
   m_ObjectHideFlags: 0
@@ -7211,6 +8827,103 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0.00012207031}
   m_SizeDelta: {x: -20, y: -20}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &8517848032023236467
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3272705599764375333}
+  - component: {fileID: 1533079639694616771}
+  - component: {fileID: 3608206203887922948}
+  m_Layer: 5
+  m_Name: Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3272705599764375333
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8517848032023236467}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4616484289348060919}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 2.6459, y: -0.6}
+  m_SizeDelta: {x: 430.80814, y: 312.3812}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!20 &1533079639694616771
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8517848032023236467}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!114 &3608206203887922948
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8517848032023236467}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d58ec411547b33b4ea8524c458ad180c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 1533079639694616771}
+  width: 430
+  height: 312
+  Path: /SNAPS
+  FileName: capture.PNG
 --- !u!1 &8541443077353848735
 GameObject:
   m_ObjectHideFlags: 0
@@ -7369,6 +9082,85 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: Colour
+--- !u!1 &8698062227010979321
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7885454758424910156}
+  - component: {fileID: 4429383063774632566}
+  - component: {fileID: 2379072935745182127}
+  m_Layer: 5
+  m_Name: TextPreviewName
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7885454758424910156
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8698062227010979321}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4709261932871980771}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 530.5365, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4429383063774632566
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8698062227010979321}
+  m_CullTransparentMesh: 0
+--- !u!114 &2379072935745182127
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8698062227010979321}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: f6a745ad29e1c2f4caa9737278b850c0, type: 2}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 3
+    m_MaxSize: 40
+    m_Alignment: 1
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Name
 --- !u!1 &8776922093135300697
 GameObject:
   m_ObjectHideFlags: 0
@@ -7484,6 +9276,42 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: Load
+--- !u!1 &8988093448107136569
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 532853186223996705}
+  m_Layer: 5
+  m_Name: Previews
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &532853186223996705
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8988093448107136569}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4709261932871980771}
+  m_Father: {fileID: 6681814605387333497}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 728.06, y: -416.51}
+  m_SizeDelta: {x: 1221.2448, y: 833.0292}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &9044581207544383376
 GameObject:
   m_ObjectHideFlags: 0
@@ -7616,6 +9444,168 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!1 &9048310144479258054
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1423441795467222215}
+  - component: {fileID: 2038564735654279241}
+  - component: {fileID: 1419745185113634476}
+  m_Layer: 5
+  m_Name: NoCharactersError
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1423441795467222215
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9048310144479258054}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6681814605387333497}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 41, y: -0.000011086}
+  m_SizeDelta: {x: 768.04785, y: 137.82239}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2038564735654279241
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9048310144479258054}
+  m_CullTransparentMesh: 0
+--- !u!114 &1419745185113634476
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9048310144479258054}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 40
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 4
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Create a new character
+
+    Or
+
+    Load a character sheet from JSON'
+--- !u!1 &9063037737193597336
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5665895941591982491}
+  - component: {fileID: 4243578063408248750}
+  - component: {fileID: 2486416645686578486}
+  m_Layer: 5
+  m_Name: BodyTypePreviewText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5665895941591982491
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9063037737193597336}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4709261932871980771}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 530.5365, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4243578063408248750
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9063037737193597336}
+  m_CullTransparentMesh: 0
+--- !u!114 &2486416645686578486
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9063037737193597336}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: f6a745ad29e1c2f4caa9737278b850c0, type: 2}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 3
+    m_MaxSize: 40
+    m_Alignment: 1
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: BodyType
 --- !u!1001 &532022409041281125
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
@@ -3568,7 +3568,7 @@ MonoBehaviour:
   SurfaceSprite: []
   SelectedSpecies: 0
   SerialiseData: {fileID: 5117563973470917019}
-  snapCapturer: {fileID: 0}
+  snapCapturer: {fileID: 3608206203887922948}
   WindowName: {fileID: 4616484289738564357}
   SlotsUsed: {fileID: 1235902433222566057}
   CharacterPreviewName: {fileID: 2379072935745182127}

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
@@ -2705,6 +2705,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   UI_ToCapture: {fileID: 4616484289348060919}
+  zoomLevel: 2.2
   Path: /SNAPS
   FileName: filename.PNG
 --- !u!1 &4616484289408088670
@@ -2768,7 +2769,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.32941177, g: 0.41960788, b: 0.5019608, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
@@ -38,6 +38,85 @@ RectTransform:
   m_AnchoredPosition: {x: -295, y: 346.6}
   m_SizeDelta: {x: 100, y: 193.22675}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &270966547563557207
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1393052611068894572}
+  - component: {fileID: 157690838796510051}
+  - component: {fileID: 5029900244105262135}
+  m_Layer: 5
+  m_Name: PreviewImageError
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1393052611068894572
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 270966547563557207}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6282411419536445397}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 265.48074, y: -317.72}
+  m_SizeDelta: {x: 530.9615, y: 70.020836}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &157690838796510051
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 270966547563557207}
+  m_CullTransparentMesh: 0
+--- !u!114 &5029900244105262135
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 270966547563557207}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 3
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: No preview image avaliable
 --- !u!1 &328033210676926905
 GameObject:
   m_ObjectHideFlags: 0
@@ -3576,7 +3655,8 @@ MonoBehaviour:
   CharacterPreviewBodyType: {fileID: 2486416645686578486}
   CharacterPreviewImg: {fileID: 3405283805252071630}
   CharacterPreviews: {fileID: 8988093448107136569}
-  NoCharactersError: {fileID: 9048310144479258054}
+  NoCharactersError: {fileID: 270966547563557207}
+  PreviewImageError: {fileID: 0}
   GoBackButton: {fileID: 328033210676926905}
   CharacterSelectorPage: {fileID: 8248689287685672263}
   CharacterCreatorPage: {fileID: 4616484290072915387}
@@ -6666,7 +6746,8 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 1393052611068894572}
   m_Father: {fileID: 4709261932871980771}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -10552,6 +10633,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 916ee089a0d7b63419075f91e1c657ec, type: 3}
+--- !u!224 &532022409019164951 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 22448498, guid: 916ee089a0d7b63419075f91e1c657ec,
+    type: 3}
+  m_PrefabInstance: {fileID: 532022409041281125}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &532022409047985889 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 11423364, guid: 916ee089a0d7b63419075f91e1c657ec,
@@ -10564,9 +10651,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8262e4a8322117f4da079921eaa72834, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &532022409019164951 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 22448498, guid: 916ee089a0d7b63419075f91e1c657ec,
-    type: 3}
-  m_PrefabInstance: {fileID: 532022409041281125}
-  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
@@ -2617,6 +2617,9 @@ GameObject:
   m_Component:
   - component: {fileID: 4616484289348060919}
   - component: {fileID: 4616484289348060916}
+  - component: {fileID: 1266496891167085404}
+  - component: {fileID: 4222684632738570452}
+  - component: {fileID: 2302452495548790279}
   m_Layer: 5
   m_Name: CHARACTERVIEW
   m_TagString: Untagged
@@ -2634,8 +2637,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 3272705599764375333}
+  m_Children: []
   m_Father: {fileID: 4616484291191486528}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2660,6 +2662,50 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   currentDir: 0
+--- !u!223 &1266496891167085404
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4616484289348060918}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 1
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 1
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!222 &4222684632738570452
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4616484289348060918}
+  m_CullTransparentMesh: 0
+--- !u!114 &2302452495548790279
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4616484289348060918}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6368115214c985840a7eefb6d518fa1b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  UI_ToCapture: {fileID: 4616484289348060919}
+  Path: /SNAPS
+  FileName: filename.PNG
 --- !u!1 &4616484289408088670
 GameObject:
   m_ObjectHideFlags: 0
@@ -3647,7 +3693,7 @@ MonoBehaviour:
   SurfaceSprite: []
   SelectedSpecies: 0
   SerialiseData: {fileID: 5117563973470917019}
-  snapCapturer: {fileID: 3608206203887922948}
+  snapCapturer: {fileID: 4616484289348060918}
   WindowName: {fileID: 4616484289738564357}
   SlotsUsed: {fileID: 1235902433222566057}
   CharacterPreviewName: {fileID: 2379072935745182127}
@@ -3656,7 +3702,6 @@ MonoBehaviour:
   CharacterPreviewImg: {fileID: 3405283805252071630}
   CharacterPreviews: {fileID: 8988093448107136569}
   NoCharactersError: {fileID: 270966547563557207}
-  PreviewImageError: {fileID: 0}
   GoBackButton: {fileID: 328033210676926905}
   CharacterSelectorPage: {fileID: 8248689287685672263}
   CharacterCreatorPage: {fileID: 4616484290072915387}
@@ -8717,103 +8762,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0.00012207031}
   m_SizeDelta: {x: -20, y: -20}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &8517848032023236467
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3272705599764375333}
-  - component: {fileID: 1533079639694616771}
-  - component: {fileID: 3608206203887922948}
-  m_Layer: 5
-  m_Name: Camera
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &3272705599764375333
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8517848032023236467}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 4616484289348060919}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 2.6459, y: -0.6}
-  m_SizeDelta: {x: 430.80814, y: 312.3812}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!20 &1533079639694616771
-Camera:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8517848032023236467}
-  m_Enabled: 1
-  serializedVersion: 2
-  m_ClearFlags: 1
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
-  m_projectionMatrixMode: 1
-  m_GateFitMode: 2
-  m_FOVAxisMode: 0
-  m_SensorSize: {x: 36, y: 24}
-  m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 50
-  m_NormalizedViewPortRect:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1
-    height: 1
-  near clip plane: 0.3
-  far clip plane: 1000
-  field of view: 60
-  orthographic: 0
-  orthographic size: 5
-  m_Depth: 0
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RenderingPath: -1
-  m_TargetTexture: {fileID: 0}
-  m_TargetDisplay: 0
-  m_TargetEye: 3
-  m_HDR: 1
-  m_AllowMSAA: 1
-  m_AllowDynamicResolution: 0
-  m_ForceIntoRT: 0
-  m_OcclusionCulling: 1
-  m_StereoConvergence: 10
-  m_StereoSeparation: 0.022
---- !u!114 &3608206203887922948
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8517848032023236467}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d58ec411547b33b4ea8524c458ad180c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  cam: {fileID: 1533079639694616771}
-  width: 430
-  height: 312
-  Path: /SNAPS
-  FileName: capture.PNG
 --- !u!1 &8541443077353848735
 GameObject:
   m_ObjectHideFlags: 0
@@ -10633,12 +10581,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 916ee089a0d7b63419075f91e1c657ec, type: 3}
---- !u!224 &532022409019164951 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 22448498, guid: 916ee089a0d7b63419075f91e1c657ec,
-    type: 3}
-  m_PrefabInstance: {fileID: 532022409041281125}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &532022409047985889 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 11423364, guid: 916ee089a0d7b63419075f91e1c657ec,
@@ -10651,3 +10593,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8262e4a8322117f4da079921eaa72834, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &532022409019164951 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 22448498, guid: 916ee089a0d7b63419075f91e1c657ec,
+    type: 3}
+  m_PrefabInstance: {fileID: 532022409041281125}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
@@ -8839,7 +8839,6 @@ GameObject:
   - component: {fileID: 3272705599764375333}
   - component: {fileID: 1533079639694616771}
   - component: {fileID: 3608206203887922948}
-  - component: {fileID: 7727240642779787147}
   m_Layer: 5
   m_Name: Camera
   m_TagString: Untagged
@@ -8906,7 +8905,7 @@ Camera:
   m_AllowMSAA: 1
   m_AllowDynamicResolution: 0
   m_ForceIntoRT: 0
-  m_OcclusionCulling: 1
+  m_OcclusionCulling: 0
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
 --- !u!114 &3608206203887922948
@@ -8926,26 +8925,6 @@ MonoBehaviour:
   height: 312
   Path: /SNAPS
   FileName: capture.PNG
---- !u!114 &7727240642779787147
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8517848032023236467}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6a160d838ff8b4b4693ac20007e008c7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_AssetsPPU: 100
-  m_RefResolutionX: 320
-  m_RefResolutionY: 180
-  m_UpscaleRT: 0
-  m_PixelSnapping: 0
-  m_CropFrameX: 0
-  m_CropFrameY: 0
-  m_StretchFill: 0
 --- !u!1 &8541443077353848735
 GameObject:
   m_ObjectHideFlags: 0
@@ -10765,12 +10744,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 916ee089a0d7b63419075f91e1c657ec, type: 3}
---- !u!224 &532022409019164951 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 22448498, guid: 916ee089a0d7b63419075f91e1c657ec,
-    type: 3}
-  m_PrefabInstance: {fileID: 532022409041281125}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &532022409047985889 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 11423364, guid: 916ee089a0d7b63419075f91e1c657ec,
@@ -10783,3 +10756,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8262e4a8322117f4da079921eaa72834, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &532022409019164951 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 22448498, guid: 916ee089a0d7b63419075f91e1c657ec,
+    type: 3}
+  m_PrefabInstance: {fileID: 532022409041281125}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
@@ -2641,7 +2641,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0.32941177, g: 0.41960788, b: 0.5019608, a: 1}
   m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
@@ -4943,7 +4943,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
@@ -981,7 +981,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -2641,8 +2641,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.3278302, g: 0.41883424, b: 0.5, a: 1}
-  m_RaycastTarget: 1
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -3568,7 +3568,7 @@ MonoBehaviour:
   SurfaceSprite: []
   SelectedSpecies: 0
   SerialiseData: {fileID: 5117563973470917019}
-  snapCapturer: {fileID: 3608206203887922948}
+  snapCapturer: {fileID: 0}
   WindowName: {fileID: 4616484289738564357}
   SlotsUsed: {fileID: 1235902433222566057}
   CharacterPreviewName: {fileID: 2379072935745182127}
@@ -5475,68 +5475,12 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &4616484290833444690
+--- !u!224 &4616484291191486528
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4616484290833444685}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.5, y: 0.5, z: 1}
-  m_Children: []
-  m_Father: {fileID: 4616484290785075766}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -166.3, y: -37.5}
-  m_SizeDelta: {x: -300.5, y: 60}
-  m_Pivot: {x: 0.5, y: 1}
---- !u!222 &4616484290833444688
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4616484290833444685}
-  m_CullTransparentMesh: 0
---- !u!114 &4616484290833444691
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4616484290833444685}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
-    m_FontSize: 56
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 1
-    m_MaxSize: 56
-    m_Alignment: 3
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: 'Age:'
---- !u!1 &4616484290965557748
   m_GameObject: {fileID: 4616484291191486531}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -5723,70 +5667,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 75f2c271ea20df14b816d846846217a8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.105882354}
-  m_RaycastTarget: 0
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: af20367e8cd964d82a9d30ba5f34eb8a, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 1
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!1 &4616484291063229299
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4616484291063229296}
-  - component: {fileID: 4616484291063229302}
-  - component: {fileID: 4616484291063229297}
-  m_Layer: 5
-  m_Name: InputLabel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &4616484291063229296
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4616484291063229299}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.5, y: 0.5, z: 1}
-  m_Children: []
-  m_Father: {fileID: 4616484290268993179}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
-  m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: -152, y: 3.1}
-  m_SizeDelta: {x: -235.65, y: 60}
-  m_Pivot: {x: 0.5, y: 1}
---- !u!222 &4616484291063229302
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4616484291063229299}
-  m_CullTransparentMesh: 0
---- !u!114 &4616484291063229297
   label: {fileID: 4616484289466361095}
 --- !u!114 &4616484291287029853
 MonoBehaviour:
@@ -5797,32 +5677,6 @@ MonoBehaviour:
   m_GameObject: {fileID: 4616484291287029855}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
-    m_FontSize: 55
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 1
-    m_MaxSize: 56
-    m_Alignment: 3
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: 'Gender:'
---- !u!1 &4616484291146125579
   m_Script: {fileID: 11500000, guid: 6fece9ea9fe8f46a1bcbbc9844d908f3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
@@ -6666,52 +6520,6 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -152.33499, y: -38}
-  m_SizeDelta: {x: -244.66998, y: 64}
-  m_Pivot: {x: 0.5, y: 1}
---- !u!222 &7458750837548770884
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4930529332528869450}
-  m_CullTransparentMesh: 0
---- !u!114 &6967046868821126392
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4930529332528869450}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
-    m_FontSize: 56
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 1
-    m_MaxSize: 56
-    m_Alignment: 3
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: 'Accent:'
---- !u!1 &4937045918359471588
   m_AnchoredPosition: {x: 10.999955, y: -220.99998}
   m_SizeDelta: {x: 0, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -8905,7 +8713,7 @@ Camera:
   m_AllowMSAA: 1
   m_AllowDynamicResolution: 0
   m_ForceIntoRT: 0
-  m_OcclusionCulling: 0
+  m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
 --- !u!114 &3608206203887922948

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
@@ -55,7 +55,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1393052611068894572
 RectTransform:
   m_ObjectHideFlags: 0
@@ -67,13 +67,13 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 6282411419536445397}
-  m_RootOrder: 0
+  m_Father: {fileID: 4709261932871980771}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 265.48074, y: -317.72}
-  m_SizeDelta: {x: 530.9615, y: 70.020836}
+  m_AnchoredPosition: {x: 265.48074, y: -353.06}
+  m_SizeDelta: {x: 530.9615, y: 635.43317}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &157690838796510051
 CanvasRenderer:
@@ -1252,7 +1252,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4709261932871980771}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -2245,6 +2245,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 7885454758424910156}
+  - {fileID: 1393052611068894572}
   - {fileID: 6282411419536445397}
   - {fileID: 8141665984931505794}
   - {fileID: 5665895941591982491}
@@ -2253,8 +2254,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.000035763, y: -64}
-  m_SizeDelta: {x: 532.54315, y: 746.8265}
+  m_AnchoredPosition: {x: 0.000035763, y: -2.5}
+  m_SizeDelta: {x: 1179.6091, y: 804.77277}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &4003751137709469787
 MonoBehaviour:
@@ -2273,9 +2274,9 @@ MonoBehaviour:
     m_Right: 0
     m_Top: 0
     m_Bottom: 0
-  m_ChildAlignment: 0
+  m_ChildAlignment: 4
   m_Spacing: 0
-  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandWidth: 0
   m_ChildForceExpandHeight: 1
   m_ChildControlWidth: 0
   m_ChildControlHeight: 0
@@ -3699,9 +3700,10 @@ MonoBehaviour:
   CharacterPreviewName: {fileID: 2379072935745182127}
   CharacterPreviewRace: {fileID: 369449508620937038}
   CharacterPreviewBodyType: {fileID: 2486416645686578486}
-  CharacterPreviewImg: {fileID: 3405283805252071630}
+  CharacterPreviewImg: {fileID: 7637634721812784694}
   CharacterPreviews: {fileID: 8988093448107136569}
-  NoCharactersError: {fileID: 270966547563557207}
+  NoCharactersError: {fileID: 9048310144479258054}
+  NoPreviewError: {fileID: 270966547563557207}
   GoBackButton: {fileID: 328033210676926905}
   CharacterSelectorPage: {fileID: 8248689287685672263}
   CharacterCreatorPage: {fileID: 4616484290072915387}
@@ -6773,7 +6775,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6282411419536445397}
   - component: {fileID: 2207819112428250186}
-  - component: {fileID: 3405283805252071630}
+  - component: {fileID: 7637634721812784694}
   m_Layer: 5
   m_Name: Picture
   m_TagString: Untagged
@@ -6791,15 +6793,14 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1393052611068894572}
+  m_Children: []
   m_Father: {fileID: 4709261932871980771}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 530.96124, y: 635.43616}
+  m_SizeDelta: {x: 928.8586, y: 635.43616}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2207819112428250186
 CanvasRenderer:
@@ -6809,7 +6810,7 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5623409178127911932}
   m_CullTransparentMesh: 0
---- !u!114 &3405283805252071630
+--- !u!114 &7637634721812784694
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -6818,27 +6819,24 @@ MonoBehaviour:
   m_GameObject: {fileID: 5623409178127911932}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
 --- !u!1 &5774422873272561806
 GameObject:
   m_ObjectHideFlags: 0
@@ -9395,7 +9393,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4709261932871980771}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
@@ -1495,7 +1495,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Slots 0/35
+  m_Text: 0/0
 --- !u!1 &1937390950188382194
 GameObject:
   m_ObjectHideFlags: 0
@@ -9359,11 +9359,9 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: 'Create a new character
+  m_Text: 'Please create a new character
 
-    Or
-
-    Load a character sheet from JSON'
+'
 --- !u!1 &9063037737193597336
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
@@ -687,7 +687,7 @@ MonoBehaviour:
         m_Calls:
         - m_Target: {fileID: 4616484289766084577}
           m_TargetAssemblyTypeName: Lobby.CharacterCustomization, Assets
-          m_MethodName: scrollSelectorLeft
+          m_MethodName: ScrollSelectorLeft
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -1095,7 +1095,7 @@ MonoBehaviour:
         m_Calls:
         - m_Target: {fileID: 4616484289766084577}
           m_TargetAssemblyTypeName: Lobby.CharacterCustomization, Assets
-          m_MethodName: scrollSelectorRight
+          m_MethodName: ScrollSelectorRight
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/character customisation/DropDownOrganReplacement.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/character customisation/DropDownOrganReplacement.prefab
@@ -759,7 +759,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.03137255, g: 0.03137255, b: 0.050980397, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/character customisation/Item.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/character customisation/Item.prefab
@@ -469,7 +469,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.03137255, g: 0.03137255, b: 0.050980397, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -544,7 +544,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 1, b: 0.005622387, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/HairStyle.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/HairStyle.prefab
@@ -1127,6 +1127,7 @@ MonoBehaviour:
   spriteOrder:
     Orders: 00000000000000000000000000000000
   spriteHandlerNorder: {fileID: 3087728318779941642}
+  canRandomizeColors: 0
 --- !u!1 &4043889440604183277
 GameObject:
   m_ObjectHideFlags: 0
@@ -1732,7 +1733,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.03137255, g: 0.03137255, b: 0.050980397, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:

--- a/UnityProject/Assets/Scripts/Core/Camera/CaptureScreen.cs
+++ b/UnityProject/Assets/Scripts/Core/Camera/CaptureScreen.cs
@@ -1,8 +1,10 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 using UnityEngine;
 
+/// <summary>
+/// Take a picture from the game then stores it to a place in %APPDATA%/LocalLow/unitystation.
+/// This script takes transparancy into account.
+/// </summary>
 public class CaptureScreen : MonoBehaviour
 {
 	public Camera cam;
@@ -15,9 +17,11 @@ public class CaptureScreen : MonoBehaviour
 
 	private bool takingScreenshot = false;
 
-
 	private void Awake()
 	{
+		//Make sure there is a camera avaliable so the game doesn't throw an error.
+		//Though it's best to setup your own camera with it's own position and size for
+		//specifc use cases that does not require taking an entire picture of the screen.
 		if(cam == null)
 		{
 			cam = Camera.main;

--- a/UnityProject/Assets/Scripts/Core/Camera/CaptureScreen.cs
+++ b/UnityProject/Assets/Scripts/Core/Camera/CaptureScreen.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+[RequireComponent(typeof(Camera))]
+public class CaptureScreen : MonoBehaviour
+{
+	public Camera cam;
+
+	public int width;
+	public int height;
+
+	public string Path = "/SNAPS";
+	public string FileName = "filename.PNG";
+
+	private bool takingScreenshot = false;
+
+
+	private void Awake()
+	{
+		if(cam == null)
+		{
+			cam = Camera.main;
+		}
+	}
+
+	private void OnPostRender()
+	{
+		if (takingScreenshot)
+		{
+			takingScreenshot = false;
+			RenderTexture texture = cam.targetTexture;
+			Texture2D result = new Texture2D(texture.width, texture.height, TextureFormat.ARGB32, false);
+
+			Rect rect = new Rect(0, 0, texture.width, texture.height);
+			result.ReadPixels(rect, 0, 0);
+
+			byte[] byteArray = result.EncodeToPNG();
+			File.WriteAllBytes(Application.persistentDataPath + Path + "/" + FileName, byteArray);
+
+			RenderTexture.ReleaseTemporary(texture);
+			cam.targetTexture = null;
+		}
+	}
+
+	public void TakeScreenshot()
+	{
+		cam.targetTexture = RenderTexture.GetTemporary(width, height, 16);
+		takingScreenshot = true;
+	}
+}

--- a/UnityProject/Assets/Scripts/Core/Camera/CaptureScreen.cs
+++ b/UnityProject/Assets/Scripts/Core/Camera/CaptureScreen.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
 
-[RequireComponent(typeof(Camera))]
 public class CaptureScreen : MonoBehaviour
 {
 	public Camera cam;

--- a/UnityProject/Assets/Scripts/Core/Camera/CaptureScreen.cs
+++ b/UnityProject/Assets/Scripts/Core/Camera/CaptureScreen.cs
@@ -2,62 +2,73 @@
 using UnityEngine;
 
 /// <summary>
-/// Take a picture from the game then stores it to a place in %APPDATA%/LocalLow/unitystation.
+/// Take a picture from a part of the game then stores it to a place in %APPDATA%/LocalLow/unitystation.
 /// This script takes transparancy into account.
 /// </summary>
-public class CaptureScreen : MonoBehaviour
+///
+namespace Core.Cam
 {
-	public Camera cam;
-
-	public int width;
-	public int height;
-
-	public string Path = "/SNAPS";
-	public string FileName = "filename.PNG";
-
-	private bool takingScreenshot = false;
-
-	private void Awake()
+	public class CaptureScreen : MonoBehaviour
 	{
-		//Make sure there is a camera avaliable so the game doesn't throw an error.
-		//Though it's best to setup your own camera with it's own position and size for
-		//specifc use cases that does not require taking an entire picture of the screen.
-		if(cam == null)
+		public Camera cam;
+
+		public int width;
+		public int height;
+
+		public string Path = "/SNAPS";
+		public string FileName = "filename.PNG";
+
+		private bool takingScreenshot = false;
+
+		private void Awake()
 		{
-			cam = Camera.main;
+			//Make sure there is a camera avaliable so the game doesn't throw an error.
+			//Though it's best to setup your own camera with it's own position and size for
+			//specifc use cases that does not require taking an entire picture of the screen.
+			if(cam == null)
+			{
+				cam = Camera.main;
+			}
 		}
-	}
 
-	private void OnPostRender()
-	{
-		if (takingScreenshot)
+		private void OnPostRender()
 		{
-			takingScreenshot = false;
-			RenderTexture texture = cam.targetTexture;
-			Texture2D result = new Texture2D(texture.width, texture.height, TextureFormat.ARGB32, false);
-
-			Rect rect = new Rect(0, 0, texture.width, texture.height);
-			result.ReadPixels(rect, 0, 0);
-
-			byte[] byteArray = result.EncodeToPNG();
-			if(Directory.Exists(Application.persistentDataPath + Path))
+			if (takingScreenshot)
 			{
-				File.WriteAllBytes(Application.persistentDataPath + Path + "/" + FileName, byteArray);
-			}
-			else
-			{
-				Directory.CreateDirectory(Application.persistentDataPath + Path);
-				File.WriteAllBytes(Application.persistentDataPath + Path + "/" + FileName, byteArray);
-			}
+				takingScreenshot = false;
+				RenderTexture texture = cam.targetTexture;
+				Texture2D result = new Texture2D(texture.width, texture.height, TextureFormat.ARGB32, false);
 
-			RenderTexture.ReleaseTemporary(texture);
-			cam.targetTexture = null;
+				Rect rect = new Rect(0, 0, texture.width, texture.height);
+				result.ReadPixels(rect, 0, 0);
+
+				byte[] byteArray = result.EncodeToPNG();
+				if(Directory.Exists(Application.persistentDataPath + Path))
+				{
+					File.WriteAllBytes(Application.persistentDataPath + Path + "/" + FileName, byteArray);
+				}
+				else
+				{
+					Directory.CreateDirectory(Application.persistentDataPath + Path);
+					File.WriteAllBytes(Application.persistentDataPath + Path + "/" + FileName, byteArray);
+				}
+
+				RenderTexture.ReleaseTemporary(texture);
+				cam.targetTexture = null;
+			}
 		}
-	}
 
-	public void TakeScreenshot()
-	{
-		cam.targetTexture = RenderTexture.GetTemporary(width, height, 16);
-		takingScreenshot = true;
+		/// <summary>
+		/// Takes a screen of a specfied preset area.
+		/// </summary>
+		/// <param name="w">Width of the picture</param>
+		/// <param name="h">Height of the picture</param>
+		public void TakeScreenshot(int w, int h)
+		{
+			width = w;
+			height = h;
+			cam.targetTexture = RenderTexture.GetTemporary(width, height, 16);
+			takingScreenshot = true;
+		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Core/Camera/CaptureScreen.cs
+++ b/UnityProject/Assets/Scripts/Core/Camera/CaptureScreen.cs
@@ -37,7 +37,15 @@ public class CaptureScreen : MonoBehaviour
 			result.ReadPixels(rect, 0, 0);
 
 			byte[] byteArray = result.EncodeToPNG();
-			File.WriteAllBytes(Application.persistentDataPath + Path + "/" + FileName, byteArray);
+			if(Directory.Exists(Application.persistentDataPath + Path))
+			{
+				File.WriteAllBytes(Application.persistentDataPath + Path + "/" + FileName, byteArray);
+			}
+			else
+			{
+				Directory.CreateDirectory(Application.persistentDataPath + Path);
+				File.WriteAllBytes(Application.persistentDataPath + Path + "/" + FileName, byteArray);
+			}
 
 			RenderTexture.ReleaseTemporary(texture);
 			cam.targetTexture = null;

--- a/UnityProject/Assets/Scripts/Core/Camera/CaptureScreen.cs.meta
+++ b/UnityProject/Assets/Scripts/Core/Camera/CaptureScreen.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d58ec411547b33b4ea8524c458ad180c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -1376,7 +1376,10 @@ namespace Lobby
 				Customisation.Refresh();
 			}
 
+
 			RefreshRace();
+
+			OnSurfaceColourChange();
 		}
 
 		private void RefreshRace()

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -964,8 +964,8 @@ namespace Lobby
 
 			if(File.Exists(path + "characters.json"))
 			{
-				CharacterPreviews.SetActive(false);
-				NoCharactersError.SetActive(true);
+				CharacterPreviews.SetActive(true);
+				NoCharactersError.SetActive(false);
 				string json = File.ReadAllText(path + "characters.json");
 				var characters = JsonConvert.DeserializeObject<List<CharacterSettings>>(json);
 

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -205,18 +205,17 @@ namespace Lobby
 
 		public void CreateCharacter()
 		{
-			CharacterSettings character = currentCharacter;
+			CharacterSettings character = new CharacterSettings();
 			PlayerCharacters.Add(character);
 			currentCharacterIndex = PlayerCharacters.Count() - 1;
 			currentCharacter = PlayerCharacters[currentCharacterIndex];
-			RollRandomCharacter();
 			showCharacterCreator();
+			DoInitChecks();
 			RefreshAll();
 		}
 
 		public void EditCharacter()
 		{
-			currentCharacter = PlayerCharacters[currentCharacterIndex];
 			SetAllDropdowns();
 			showCharacterCreator();
 			RefreshAll();

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -96,6 +96,8 @@ namespace Lobby
 
 		public InputField SerialiseData;
 
+		[SerializeField] private CaptureScreen snapCapturer;
+
 		[Header("Character Selector")]
 		[SerializeField] private Text WindowName;
 
@@ -841,7 +843,20 @@ namespace Lobby
 			PlayerManager.CurrentCharacterSettings = currentCharacter;
 			ServerData.UpdateCharacterProfile(currentCharacter); // TODO Consider adding await. Otherwise this causes a compile warning.
 			SaveCurrentCharacter(currentCharacter);
-			Logger.Log($"{PlayerCharacters.Count()}");
+			SaveCurrentCharacterSnaps();
+		}
+
+		private void SaveCurrentCharacterSnaps()
+		{
+			int dir = 0;
+			snapCapturer.Path = $"/{currentCharacter.Username}/{currentCharacter.Name}"; //Note, we need to add IDs for currentCharacters later to avoid characters who have the same name overriding themselves.
+			while(dir < 4)
+			{
+				snapCapturer.FileName = $"{currentDir}_{currentCharacter.Name}.PNG";
+				snapCapturer.TakeScreenshot();
+				RightRotate();
+				dir++;
+			}
 		}
 
 		private void SaveCurrentCharacter(CharacterSettings settings)

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -862,6 +862,8 @@ namespace Lobby
 		private void SaveCurrentCharacter(CharacterSettings settings)
 		{
 			PlayerCharacters[currentCharacterIndex] = settings;
+			PlayerPrefs.SetInt("lastCharacter", currentCharacterIndex);
+			PlayerPrefs.Save();
 			SaveCharacters();
 		}
 
@@ -886,6 +888,7 @@ namespace Lobby
 				{
 					PlayerCharacters.Add(c);
 				}
+				currentCharacterIndex = PlayerPrefs.GetInt("lastCharacter", currentCharacterIndex);
 				RefreshSelectorData();
 			}
 			else

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -217,6 +217,10 @@ namespace Lobby
 			showCharacterCreator();
 		}
 
+
+		/// <summary>
+		/// Responsible for refreshing all data in the character selector page.
+		/// </summary>
 		private void RefreshSelectorData()
 		{
 			CharacterPreviewName.text = PlayerCharacters[currentCharacterIndex].Name;
@@ -230,6 +234,7 @@ namespace Lobby
 
 		/// <summary>
 		/// If there is no sprite, show an error.
+		/// If there is a sprite, display it.
 		/// </summary>
 		private void CheckPreviewImage()
 		{
@@ -249,7 +254,11 @@ namespace Lobby
 			}
 		}
 
-
+		/// <summary>
+		/// Loads an image from a localpath or from a server.
+		/// </summary>
+		/// <param name="path">The path to the image that will be used as a texture.</param>
+		/// <returns></returns>
 		private IEnumerator<UnityWebRequestAsyncOperation> GetPreviewImage(string path)
 		{
 			using (UnityWebRequest uwr = UnityWebRequestTexture.GetTexture(path))
@@ -944,16 +953,16 @@ namespace Lobby
 		}
 
 		/// <summary>
-		/// Get all characters that are saved.
+		/// Get all characters that are saved in %APPDATA%/Locallow/unitystation/characters.json
 		/// </summary>
 		private void GetSavedCharacters()
 		{
 			PlayerCharacters.Clear(); //Clear all entries so we don't have duplicates when re-opening the character page.
 			string path = Application.persistentDataPath;
 
-			if(System.IO.File.Exists(path + "characters.json"))
+			if(File.Exists(path + "characters.json"))
 			{
-				string json = System.IO.File.ReadAllText(path + "characters.json");
+				string json = File.ReadAllText(path + "characters.json");
 				var characters = JsonConvert.DeserializeObject<List<CharacterSettings>>(json);
 
 				foreach (var c in characters)

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -187,7 +187,7 @@ namespace Lobby
 			NoCharactersError.SetActive(true);
 		}
 
-		private void showCharacterCreator()
+		private void ShowCharacterCreator()
 		{
 			WindowName.text = "Character Settings";
 			CharacterSelectorPage.SetActive(false);
@@ -209,7 +209,7 @@ namespace Lobby
 			PlayerCharacters.Add(character);
 			currentCharacterIndex = PlayerCharacters.Count() - 1;
 			currentCharacter = PlayerCharacters[currentCharacterIndex];
-			showCharacterCreator();
+			ShowCharacterCreator();
 			DoInitChecks();
 			RefreshAll();
 		}
@@ -217,7 +217,7 @@ namespace Lobby
 		public void EditCharacter()
 		{
 			SetAllDropdowns();
-			showCharacterCreator();
+			ShowCharacterCreator();
 			RefreshAll();
 		}
 

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -193,6 +193,7 @@ namespace Lobby
 			CharacterSelectorPage.SetActive(false);
 			CharacterCreatorPage.SetActive(true);
 			GoBackButton.SetActive(true);
+			SoundManager.Play(SingletonSOSounds.Instance.Click01);
 		}
 
 		public void ShowCharacterSelectorPage()
@@ -201,6 +202,7 @@ namespace Lobby
 			CharacterSelectorPage.SetActive(true);
 			CharacterCreatorPage.SetActive(false);
 			GoBackButton.SetActive(false);
+			SoundManager.Play(SingletonSOSounds.Instance.Click01);
 		}
 
 		public void CreateCharacter()
@@ -212,10 +214,12 @@ namespace Lobby
 			ShowCharacterCreator();
 			DoInitChecks();
 			RefreshAll();
+			SoundManager.Play(SingletonSOSounds.Instance.Click01);
 		}
 
 		public void EditCharacter()
 		{
+			SoundManager.Play(SingletonSOSounds.Instance.Click01);
 			SetAllDropdowns();
 			ShowCharacterCreator();
 			RefreshAll();
@@ -296,6 +300,7 @@ namespace Lobby
 			RefreshSelectorData();
 			RefreshAll();
 			SaveLastCharacterIndex();
+			SoundManager.Play(SingletonSOSounds.Instance.Click01);
 		}
 		public void ScrollSelectorRight()
 		{
@@ -312,6 +317,7 @@ namespace Lobby
 			RefreshSelectorData();
 			RefreshAll();
 			SaveLastCharacterIndex();
+			SoundManager.Play(SingletonSOSounds.Instance.Click01);
 		}
 
 		private void LoadSettings(CharacterSettings inCharacterSettings)
@@ -1065,6 +1071,7 @@ namespace Lobby
 			catch (InvalidOperationException e)
 			{
 				Logger.LogFormat("Invalid character settings: {0}", Category.Character, e.Message);
+				SoundManager.Play(SingletonSOSounds.Instance.AccessDenied);
 				DisplayErrorText(e.Message);
 				return;
 			}
@@ -1073,6 +1080,7 @@ namespace Lobby
 
 			SaveData();
 			ShowCharacterSelectorPage();
+			SoundManager.Play(SingletonSOSounds.Instance.Click01);
 			gameObject.SetActive(false);
 		}
 

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -205,7 +205,7 @@ namespace Lobby
 		public void CreateCharacter()
 		{
 			PlayerCharacters.Add(currentCharacter);
-			currentCharacterIndex = PlayerCharacters.Count();
+			currentCharacterIndex = PlayerCharacters.Count() - 1;
 			RollRandomCharacter();
 			showCharacterCreator();
 		}

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -181,7 +181,7 @@ namespace Lobby
 			SurfaceSprite.Clear();
 		}
 
-		private void showNoCharacterError()
+		private void ShowNoCharacterError()
 		{
 			CharacterPreviews.SetActive(false);
 			NoCharactersError.SetActive(true);
@@ -282,7 +282,7 @@ namespace Lobby
 			}
 		}
 
-		public void scrollSelectorLeft()
+		public void ScrollSelectorLeft()
 		{
 			if (currentCharacterIndex != 0)
 			{
@@ -298,7 +298,7 @@ namespace Lobby
 			RefreshAll();
 			SaveLastCharacterIndex();
 		}
-		public void scrollSelectorRight()
+		public void ScrollSelectorRight()
 		{
 			if (currentCharacterIndex < PlayerCharacters.Count() - 1)
 			{
@@ -983,7 +983,7 @@ namespace Lobby
 			}
 			else
 			{
-				showNoCharacterError();
+				ShowNoCharacterError();
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -123,7 +123,7 @@ namespace Lobby
 
 		void OnEnable()
 		{
-			getSavedCharacters();
+			GetSavedCharacters();
 			WindowName.text = "Select your character";
 			LoadSettings(PlayerManager.CurrentCharacterSettings);
 			var copyStr = JsonConvert.SerializeObject(currentCharacter);
@@ -221,7 +221,7 @@ namespace Lobby
 			CharacterPreviewRace.text = PlayerCharacters[currentCharacterIndex].Species;
 			CharacterPreviewBodyType.text = PlayerCharacters[currentCharacterIndex].BodyType.ToString();
 			SlotsUsed.text = $"{currentCharacterIndex + 1} / {PlayerCharacters.Count()}";
-			saveLastCharacterIndex();
+			SaveLastCharacterIndex();
 			checkPreviewImage();
 		}
 
@@ -869,7 +869,7 @@ namespace Lobby
 		/// <summary>
 		/// Takes 4 pictures of the character from all sides and stores them in %AppData%/Locallow/unitystation
 		/// </summary>
-		private IEnumerator<WaitForEndOfFrame> saveCurrentCharacterSnaps()
+		private IEnumerator<WaitForEndOfFrame> SaveCurrentCharacterSnaps()
 		{
 			savingPictures = true;
 			Util.CaptureUI capture = snapCapturer.GetComponent<Util.CaptureUI>();
@@ -893,14 +893,14 @@ namespace Lobby
 		private void saveCurrentCharacter(CharacterSettings settings)
 		{
 			PlayerCharacters[currentCharacterIndex] = settings;
-			saveLastCharacterIndex(); //Remember the current character index, prevents a bug for newly created characters.
-			saveCharacters();
+			SaveLastCharacterIndex(); //Remember the current character index, prevents a bug for newly created characters.
+			SaveCharacters();
 		}
 
 		/// <summary>
 		/// Remembers what was the last character the player chose in the character selector screen.
 		/// </summary>
-		private void saveLastCharacterIndex()
+		private void SaveLastCharacterIndex()
 		{
 			PlayerPrefs.SetInt("lastCharacter", currentCharacterIndex);
 			PlayerPrefs.Save();
@@ -909,7 +909,7 @@ namespace Lobby
 		/// <summary>
 		/// Save all characters in a json file.
 		/// </summary>
-		private void saveCharacters()
+		private void SaveCharacters()
 		{
 			string json = JsonConvert.SerializeObject(PlayerCharacters);
 			string path = Application.persistentDataPath;
@@ -919,7 +919,7 @@ namespace Lobby
 		/// <summary>
 		/// Get all characters that are saved.
 		/// </summary>
-		private void getSavedCharacters()
+		private void GetSavedCharacters()
 		{
 			PlayerCharacters.Clear(); //Clear all entries so we don't have duplicates when re-opening the character page.
 			string path = Application.persistentDataPath;
@@ -1007,7 +1007,7 @@ namespace Lobby
 
 		public async void OnApplyBtn()
 		{
-			StartCoroutine(saveCurrentCharacterSnaps());
+			StartCoroutine(SaveCurrentCharacterSnaps());
 
 
 			//A hacky solution to be able to get character snaps before the UI shuts itself and hides/deletes the player. 

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -1061,7 +1061,12 @@ namespace Lobby
 		//SAVE & CANCEL BUTTONS:
 		//------------------
 
-		public async Task OnApplyBtn()
+		public void OnApplyBtn()
+		{
+			OnApplyBtnLogic();
+		}
+
+		private async Task OnApplyBtnLogic()
 		{
 			StartCoroutine(SaveCurrentCharacterSnaps());
 

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -204,8 +204,10 @@ namespace Lobby
 
 		public void CreateCharacter()
 		{
-			PlayerCharacters.Add(currentCharacter);
+			CharacterSettings character = currentCharacter;
+			PlayerCharacters.Add(character);
 			currentCharacterIndex = PlayerCharacters.Count() - 1;
+			currentCharacter = PlayerCharacters[currentCharacterIndex];
 			RollRandomCharacter();
 			showCharacterCreator();
 			RefreshAll();

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -964,6 +964,8 @@ namespace Lobby
 
 			if(File.Exists(path + "characters.json"))
 			{
+				CharacterPreviews.SetActive(false);
+				NoCharactersError.SetActive(true);
 				string json = File.ReadAllText(path + "characters.json");
 				var characters = JsonConvert.DeserializeObject<List<CharacterSettings>>(json);
 

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -96,7 +96,7 @@ namespace Lobby
 
 		public InputField SerialiseData;
 
-		[SerializeField] private CaptureScreen snapCapturer;
+		[SerializeField] private GameObject snapCapturer;
 
 		[Header("Character Selector")]
 		[SerializeField] private Text WindowName;
@@ -870,13 +870,14 @@ namespace Lobby
 		/// </summary>
 		private void saveCurrentCharacterSnaps()
 		{
+			Util.CaptureUI capture = snapCapturer.GetComponent<Util.CaptureUI>();
 			int dir = 0;
-			snapCapturer.Path = $"/{currentCharacter.Username}/{currentCharacter.Name}"; //Note, we need to add IDs for currentCharacters later to avoid characters who have the same name overriding themselves.
+			capture.Path = $"/{currentCharacter.Username}/{currentCharacter.Name}"; //Note, we need to add IDs for currentCharacters later to avoid characters who have the same name overriding themselves.
 			while(dir < 3)
 			{
 				RightRotate();
-				snapCapturer.FileName = $"{currentDir}_{currentCharacter.Name}.PNG";
-				snapCapturer.TakeScreenshot();
+				capture.FileName = $"{currentDir}_{currentCharacter.Name}.PNG";
+				capture.StartCoroutine(capture.TakeScreenShot());
 				dir++;
 			}
 		}

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -231,7 +231,6 @@ namespace Lobby
 			CharacterPreviewRace.text = PlayerCharacters[currentCharacterIndex].Species;
 			CharacterPreviewBodyType.text = PlayerCharacters[currentCharacterIndex].BodyType.ToString();
 			SlotsUsed.text = $"{currentCharacterIndex + 1} / {PlayerCharacters.Count()}";
-			currentCharacter = PlayerCharacters[currentCharacterIndex];
 			SaveLastCharacterIndex();
 			CheckPreviewImage();
 		}

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -852,9 +852,9 @@ namespace Lobby
 			snapCapturer.Path = $"/{currentCharacter.Username}/{currentCharacter.Name}"; //Note, we need to add IDs for currentCharacters later to avoid characters who have the same name overriding themselves.
 			while(dir < 4)
 			{
+				RightRotate();
 				snapCapturer.FileName = $"{currentDir}_{currentCharacter.Name}.PNG";
 				snapCapturer.TakeScreenshot();
-				RightRotate();
 				dir++;
 			}
 		}

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -1061,7 +1061,7 @@ namespace Lobby
 		//SAVE & CANCEL BUTTONS:
 		//------------------
 
-		public async void OnApplyBtn()
+		public async Task OnApplyBtn()
 		{
 			StartCoroutine(SaveCurrentCharacterSnaps());
 

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -193,6 +193,9 @@ namespace Lobby
 			CharacterSelectorPage.SetActive(false);
 			CharacterCreatorPage.SetActive(true);
 			GoBackButton.SetActive(true);
+			Cleanup();
+			LoadSettings(currentCharacter);
+			RefreshAll();
 			SoundManager.Play(SingletonSOSounds.Instance.Click01);
 		}
 
@@ -220,7 +223,6 @@ namespace Lobby
 		public void EditCharacter()
 		{
 			SoundManager.Play(SingletonSOSounds.Instance.Click01);
-			SetAllDropdowns();
 			ShowCharacterCreator();
 			RefreshAll();
 		}

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -231,7 +231,6 @@ namespace Lobby
 			CharacterPreviewRace.text = PlayerCharacters[currentCharacterIndex].Species;
 			CharacterPreviewBodyType.text = PlayerCharacters[currentCharacterIndex].BodyType.ToString();
 			SlotsUsed.text = $"{currentCharacterIndex + 1} / {PlayerCharacters.Count()}";
-			SaveLastCharacterIndex();
 			CheckPreviewImage();
 		}
 
@@ -284,18 +283,19 @@ namespace Lobby
 
 		public void scrollSelectorLeft()
 		{
-			if (currentCharacterIndex > 0)
+			if (currentCharacterIndex != 0)
 			{
 				currentCharacterIndex--;
 				currentCharacter = PlayerCharacters[currentCharacterIndex];
 			}
 			else
 			{
-				currentCharacterIndex = PlayerCharacters.Count();
+				currentCharacterIndex = PlayerCharacters.Count() - 1;
 				currentCharacter = PlayerCharacters[currentCharacterIndex];
 			}
 			RefreshSelectorData();
 			RefreshAll();
+			SaveLastCharacterIndex();
 		}
 		public void scrollSelectorRight()
 		{
@@ -311,6 +311,7 @@ namespace Lobby
 			}
 			RefreshSelectorData();
 			RefreshAll();
+			SaveLastCharacterIndex();
 		}
 
 		private void LoadSettings(CharacterSettings inCharacterSettings)

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -105,8 +105,8 @@ namespace Lobby
 		[SerializeField] private Text CharacterPreviewName;
 		[SerializeField] private Text CharacterPreviewRace;
 		[SerializeField] private Text CharacterPreviewBodyType;
+		[SerializeField] private Image CharacterPreviewImg;
 
-		public Image CharacterPreviewImg;
 		[SerializeField] private GameObject CharacterPreviews;
 		[SerializeField] private GameObject NoCharactersError;
 		[SerializeField] private GameObject GoBackButton;
@@ -221,18 +221,36 @@ namespace Lobby
 			CharacterPreviewBodyType.text = PlayerCharacters[currentCharacterIndex].BodyType.ToString();
 			SlotsUsed.text = $"{currentCharacterIndex + 1} / {PlayerCharacters.Count()}";
 			saveLastCharacterIndex();
+			checkPreviewImage();
+		}
+
+
+		/// <summary>
+		/// If there is no sprite, show an error.
+		/// The error is hidden inside the white space ;)
+		/// </summary>
+		private void checkPreviewImage()
+		{
+			if(CharacterPreviewImg.sprite == null)
+			{
+				CharacterPreviewImg.color = new Color(0f, 0f, 0f, 0f);
+			}
+			else
+			{
+				CharacterPreviewImg.color = new Color(1f, 1f, 1f, 1f);
+			}
 		}
 
 		public void scrollSelectorLeft()
 		{
-			if (currentCharacterIndex >= PlayerCharacters.Count() - 1)
+			if (currentCharacterIndex > 0)
 			{
-				currentCharacterIndex = PlayerCharacters.Count();
+				currentCharacterIndex--;
 				currentCharacter = PlayerCharacters[currentCharacterIndex];
 			}
 			else
 			{
-				currentCharacterIndex--;
+				currentCharacterIndex = PlayerCharacters.Count();
 				currentCharacter = PlayerCharacters[currentCharacterIndex];
 			}
 			RefreshSelectorData();

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -362,6 +362,7 @@ namespace Lobby
 			ThisSetRace = SetRace;
 
 			availableSkinColors = SetRace.Base.SkinColours;
+			currentCharacter.SkinTone = inCharacterSettings.SkinTone;
 			SetUpSpeciesBody(SetRace);
 			PopulateAllDropdowns(SetRace);
 			DoInitChecks();
@@ -1078,7 +1079,13 @@ namespace Lobby
 				return;
 			}
 
+
+
 			PlayerCharacters[currentCharacterIndex] = currentCharacter;
+
+			//Ensure that the character skin tone is assigned when saving the character
+			string skintone = currentCharacter.SkinTone = "#" + ColorUtility.ToHtmlStringRGB(CurrentSurfaceColour);
+			PlayerCharacters[currentCharacterIndex].SkinTone = skintone;
 
 			SaveData();
 			ShowCharacterSelectorPage();
@@ -1189,7 +1196,6 @@ namespace Lobby
 		//------------------
 		//AGE:
 		//------------------
-
 		private void RefreshAge()
 		{
 			ageField.text = currentCharacter.Age.ToString();

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -231,6 +231,7 @@ namespace Lobby
 			CharacterPreviewRace.text = PlayerCharacters[currentCharacterIndex].Species;
 			CharacterPreviewBodyType.text = PlayerCharacters[currentCharacterIndex].BodyType.ToString();
 			SlotsUsed.text = $"{currentCharacterIndex + 1} / {PlayerCharacters.Count()}";
+			currentCharacter = PlayerCharacters[currentCharacterIndex];
 			SaveLastCharacterIndex();
 			CheckPreviewImage();
 		}
@@ -901,9 +902,9 @@ namespace Lobby
 			Logger.Log(JsonConvert.SerializeObject(ExternalCustomisationStorage), Category.Character);
 
 			PlayerManager.CurrentCharacterSettings = currentCharacter;
-			ServerData.UpdateCharacterProfile(currentCharacter);
 			// TODO Consider adding await. Otherwise this causes a compile warning.
-			SaveCurrentCharacter(currentCharacter);
+			ServerData.UpdateCharacterProfile(currentCharacter);
+			SaveCharacters();
 		}
 
 		/// <summary>
@@ -926,17 +927,6 @@ namespace Lobby
 			savingPictures = false;
 		}
 
-
-		/// <summary>
-		/// Saves this current character that's being created/edited to the characters list
-		/// </summary>
-		private void SaveCurrentCharacter(CharacterSettings settings)
-		{
-			PlayerCharacters[currentCharacterIndex] = settings;
-			SaveLastCharacterIndex(); //Remember the current character index, prevents a bug for newly created characters.
-			SaveCharacters();
-		}
-
 		/// <summary>
 		/// Remembers what was the last character the player chose in the character selector screen.
 		/// </summary>
@@ -951,9 +941,14 @@ namespace Lobby
 		/// </summary>
 		private void SaveCharacters()
 		{
+			SaveLastCharacterIndex(); //Remember the current character index, prevents a bug for newly created characters.
 			string json = JsonConvert.SerializeObject(PlayerCharacters);
-			string path = Application.persistentDataPath;
-			System.IO.File.WriteAllText(path + "characters.json", json);
+			string path = Application.persistentDataPath + "characters.json";
+			if(File.Exists(path))
+			{
+				File.Delete(path);
+			}
+			File.WriteAllText(path, json);
 		}
 
 		/// <summary>
@@ -1066,6 +1061,8 @@ namespace Lobby
 				DisplayErrorText(e.Message);
 				return;
 			}
+
+			PlayerCharacters[currentCharacterIndex] = currentCharacter;
 
 			SaveData();
 			ShowCharacterSelectorPage();

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -1045,7 +1045,7 @@ namespace Lobby
 		{
 			StartCoroutine(SaveCurrentCharacterSnaps());
 
-
+			DisplayErrorText("Saving..");
 			//A hacky solution to be able to get character snaps before the UI shuts itself and hides/deletes the player. 
 			await Task.Delay(500);
 

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -208,6 +208,7 @@ namespace Lobby
 			currentCharacterIndex = PlayerCharacters.Count() - 1;
 			RollRandomCharacter();
 			showCharacterCreator();
+			RefreshAll();
 		}
 
 		public void EditCharacter()
@@ -215,6 +216,7 @@ namespace Lobby
 			currentCharacter = PlayerCharacters[currentCharacterIndex];
 			SetAllDropdowns();
 			showCharacterCreator();
+			RefreshAll();
 		}
 
 

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -9,6 +9,7 @@ using Newtonsoft.Json;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.Networking;
+using Newtonsoft;
 
 namespace Lobby
 {
@@ -941,8 +942,15 @@ namespace Lobby
 		/// </summary>
 		private void SaveCharacters()
 		{
+			var settings = new JsonSerializerSettings
+			{
+				PreserveReferencesHandling = PreserveReferencesHandling.All,
+				NullValueHandling = NullValueHandling.Ignore,
+				ReferenceLoopHandling = ReferenceLoopHandling.Serialize,
+				Formatting = Formatting.Indented
+			};
 			SaveLastCharacterIndex(); //Remember the current character index, prevents a bug for newly created characters.
-			string json = JsonConvert.SerializeObject(PlayerCharacters);
+			string json = JsonConvert.SerializeObject(PlayerCharacters, settings);
 			string path = Application.persistentDataPath + "characters.json";
 			if(File.Exists(path))
 			{

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -1342,7 +1342,6 @@ namespace Lobby
 			currentCharacter.Species = RaceSOSingleton.Instance.Races[SelectedSpecies].name;
 
 			Cleanup();
-			SaveData();
 			var SetRace = RaceSOSingleton.Instance.Races[SelectedSpecies];
 			availableSkinColors = SetRace.Base.SkinColours;
 			SetUpSpeciesBody(SetRace);

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -863,7 +863,7 @@ namespace Lobby
 			PlayerManager.CurrentCharacterSettings = currentCharacter;
 			ServerData.UpdateCharacterProfile(currentCharacter);
 			// TODO Consider adding await. Otherwise this causes a compile warning.
-			saveCurrentCharacter(currentCharacter);
+			SaveCurrentCharacter(currentCharacter);
 		}
 
 		/// <summary>
@@ -890,7 +890,7 @@ namespace Lobby
 		/// <summary>
 		/// Saves this current character that's being created/edited to the characters list
 		/// </summary>
-		private void saveCurrentCharacter(CharacterSettings settings)
+		private void SaveCurrentCharacter(CharacterSettings settings)
 		{
 			PlayerCharacters[currentCharacterIndex] = settings;
 			SaveLastCharacterIndex(); //Remember the current character index, prevents a bug for newly created characters.

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -929,6 +929,9 @@ namespace Lobby
 			{
 				RightRotate();
 				capture.FileName = $"{currentDir}_{currentCharacter.Name}.PNG";
+				//Wait for 3 frames to make sure that all sprites have been loaded and layered correctly when rotating.
+				yield return WaitFor.EndOfFrame;
+				yield return WaitFor.EndOfFrame;
 				yield return WaitFor.EndOfFrame;
 				capture.TakeScreenShot();
 				dir++;

--- a/UnityProject/Assets/Scripts/Util/CaptureUI.cs
+++ b/UnityProject/Assets/Scripts/Util/CaptureUI.cs
@@ -1,0 +1,60 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+namespace Util{
+
+	/// <summary>
+	/// Takes a picture of the UI then stores it to a place in %APPDATA%/LocalLow/unitystation.
+	/// </summary>
+
+	public class CaptureUI : MonoBehaviour
+	{
+		public RectTransform UI_ToCapture;
+
+		private int width;
+		private int height;
+
+		public string Path = "/SNAPS";
+		public string FileName = "filename.PNG";
+
+		private void Awake()
+		{
+			width = System.Convert.ToInt32(UI_ToCapture.rect.width / 2.2f);
+			height = System.Convert.ToInt32(UI_ToCapture.rect.height / 2.2f);
+			Debug.Log(width + height);
+		}
+
+		public IEnumerator TakeScreenShot()
+		{
+
+			Vector2 temp = UI_ToCapture.transform.position;
+			var startX = temp.x - width / 2;
+			var startY = temp.y - height / 2;
+
+			Debug.Log(temp);
+
+			yield return WaitFor.EndOfFrame;
+
+			var tex = new Texture2D(width, height, TextureFormat.RGB24, false);
+			tex.ReadPixels(new Rect(startX, startY, width, height), 0, 0);
+			tex.Apply();
+
+			// Encode texture into PNG
+			var bytes = tex.EncodeToPNG();
+			Destroy(tex);
+
+			if (Directory.Exists(Application.persistentDataPath + Path))
+			{
+				File.WriteAllBytes(Application.persistentDataPath + Path + "/" + FileName, bytes);
+				Debug.Log(Application.persistentDataPath + Path);
+			}
+			else
+			{
+				Directory.CreateDirectory(Application.persistentDataPath + Path);
+				File.WriteAllBytes(Application.persistentDataPath + Path + "/" + FileName, bytes);
+			}
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/CaptureUI.cs
+++ b/UnityProject/Assets/Scripts/Util/CaptureUI.cs
@@ -1,9 +1,10 @@
 ﻿using System.Collections;
-using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
+using Unity.EditorCoroutines.Editor;
 
-namespace Util{
+namespace Util
+{
 
 	/// <summary>
 	/// Takes a picture of the UI then stores it to a place in %APPDATA%/LocalLow/unitystation.
@@ -26,17 +27,11 @@ namespace Util{
 			Debug.Log(width + height);
 		}
 
-		public IEnumerator TakeScreenShot()
+		public void TakeScreenShot()
 		{
-
 			Vector2 temp = UI_ToCapture.transform.position;
 			var startX = temp.x - width / 2;
 			var startY = temp.y - height / 2;
-
-			Debug.Log(temp);
-
-			yield return WaitFor.EndOfFrame;
-
 			var tex = new Texture2D(width, height, TextureFormat.RGB24, false);
 			tex.ReadPixels(new Rect(startX, startY, width, height), 0, 0);
 			tex.Apply();

--- a/UnityProject/Assets/Scripts/Util/CaptureUI.cs
+++ b/UnityProject/Assets/Scripts/Util/CaptureUI.cs
@@ -1,7 +1,5 @@
-﻿using System.Collections;
-using System.IO;
+﻿using System.IO;
 using UnityEngine;
-using Unity.EditorCoroutines.Editor;
 
 namespace Util
 {
@@ -16,14 +14,15 @@ namespace Util
 
 		private int width;
 		private int height;
+		[SerializeField] private float zoomLevel = 2.2f;
 
 		public string Path = "/SNAPS";
 		public string FileName = "filename.PNG";
 
 		private void Awake()
 		{
-			width = System.Convert.ToInt32(UI_ToCapture.rect.width / 2.2f);
-			height = System.Convert.ToInt32(UI_ToCapture.rect.height / 2.2f);
+			width = System.Convert.ToInt32(UI_ToCapture.rect.width / zoomLevel);
+			height = System.Convert.ToInt32(UI_ToCapture.rect.height / zoomLevel);
 			Debug.Log(width + height);
 		}
 

--- a/UnityProject/Assets/Scripts/Util/CaptureUI.cs
+++ b/UnityProject/Assets/Scripts/Util/CaptureUI.cs
@@ -23,7 +23,6 @@ namespace Util
 		{
 			width = System.Convert.ToInt32(UI_ToCapture.rect.width / zoomLevel);
 			height = System.Convert.ToInt32(UI_ToCapture.rect.height / zoomLevel);
-			Debug.Log(width + height);
 		}
 
 		public void TakeScreenShot()
@@ -35,14 +34,12 @@ namespace Util
 			tex.ReadPixels(new Rect(startX, startY, width, height), 0, 0);
 			tex.Apply();
 
-			// Encode texture into PNG
 			var bytes = tex.EncodeToPNG();
 			Destroy(tex);
 
 			if (Directory.Exists(Application.persistentDataPath + Path))
 			{
 				File.WriteAllBytes(Application.persistentDataPath + Path + "/" + FileName, bytes);
-				Debug.Log(Application.persistentDataPath + Path);
 			}
 			else
 			{

--- a/UnityProject/Assets/Scripts/Util/CaptureUI.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/CaptureUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6368115214c985840a7eefb6d518fa1b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
Ticks one box from #6276 
Adds multiple characters support and the ability to select between them.

### Notes:

After a bit of struggling with unity's cameras and loading images, It's done! Players now can create an unlimited amount of characters to choose from to roleplay as!

How does this work? All characters are currently stored in a JSON file with all their data and customizations, when the character page opens it loads that JSON file and adds all characters to a list that the player can browse in a new (functional but not all that pretty) UI. Just land on the character you want to use then that's your character that you'll be using for this round.
Don't have a character? Want to edit your current character? no worries, you can do that from the two buttons at the bottom of the the character selector page.

This PR doesn't just come with a character selector, I've also added in two scripts at the request of Bod to capture pictures of the game/UI. This can be used later when we work on fixing the security console and add in some functionality to cameras so we can say cheese. 

PS : I've been told that the UI/UX peeps will handle the looks of this later so I've prioritized functionality over shininess.

### Changelog:
CL: Multiple character sheets are now supported.
CL: Humans will no longer have wrong skin tones when switching between species.