### PR TITLE
Making ScriptableObject tests work again.

### DIFF
--- a/UnityProject/Assets/Tests/Asset/MissingAssetReferences.cs
+++ b/UnityProject/Assets/Tests/Asset/MissingAssetReferences.cs
@@ -99,20 +99,19 @@ namespace Tests
 		/// <summary>
 		/// Check if there are scriptable objects that lost their script
 		/// </summary>
-		[Test]
-		public void CheckMissingScriptableObjects()
+		private void CheckMissingScriptableObjects(string path)
 		{
 			// Get all assets paths
 			var allResourcesPaths = AssetDatabase.GetAllAssetPaths()
-				.Where(p => p.Contains("ScriptableObjects/"));
+				.Where(p => p.Contains(path));
 
 			// Find all .asset (almost always it is SO)
 			var allAssetPaths = allResourcesPaths.Where((a) => a.EndsWith(".asset")).ToArray();
 
 			var listResults = new List<string>();
-			foreach (var path in allAssetPaths)
+			foreach (var lookUpPath in allAssetPaths)
 			{
-				var asset = AssetDatabase.LoadMainAssetAtPath(path);
+				var asset = AssetDatabase.LoadMainAssetAtPath(lookUpPath);
 
 				// if we can't load it - something bad happend with SO
 				if (!asset)
@@ -135,20 +134,19 @@ namespace Tests
 		/// <summary>
 		/// Check if there are scriptable objects that has missing reference fields 
 		/// </summary>
-		[Test]
-		public void CheckMissingRefenceFieldsScriptableObjects()
+		private void CheckMissingRefenceFieldsScriptableObjects(string path)
 		{
 			// Get all assets paths
 			var allResourcesPaths = AssetDatabase.GetAllAssetPaths()
-				.Where(p => p.Contains("ScriptableObjects/"));
+				.Where(p => p.Contains(path));
 
 			// Find all .asset (almost always it is SO)
 			var allAssetPaths = allResourcesPaths.Where((a) => a.EndsWith(".asset")).ToArray();
 
 			var listResults = new List<(string, string)>();
-			foreach (var path in allAssetPaths)
+			foreach (var lookUpPath in allAssetPaths)
 			{
-				var asset = AssetDatabase.LoadMainAssetAtPath(path);
+				var asset = AssetDatabase.LoadMainAssetAtPath(lookUpPath);
 
 				// skip invalid assets
 				if (!asset || !(asset is ScriptableObject))
@@ -170,6 +168,20 @@ namespace Tests
 			}
 
 			Assert.IsEmpty(listResults, report.ToString());
+		}
+
+		[Test]
+		public void TestScriptableObjects()
+		{
+			CheckMissingScriptableObjects("ScriptableObjects");
+			CheckMissingRefenceFieldsScriptableObjects("ScriptableObjects");
+		}
+
+		[Test]
+		public void TestSingletonScriptableObjects()
+		{
+			CheckMissingScriptableObjects("Resources/ScriptableObjectsSingletons");
+			CheckMissingRefenceFieldsScriptableObjects("Resources/ScriptableObjectsSingletons");
 		}
 
 

--- a/UnityProject/Assets/Tests/Asset/MissingAssetReferences.cs
+++ b/UnityProject/Assets/Tests/Asset/MissingAssetReferences.cs
@@ -100,11 +100,11 @@ namespace Tests
 		/// Check if there are scriptable objects that lost their script
 		/// </summary>
 		[Test]
-		public void CheckMissingScritpableObjects()
+		public void CheckMissingScriptableObjects()
 		{
 			// Get all assets paths
 			var allResourcesPaths = AssetDatabase.GetAllAssetPaths()
-				.Where(p => p.Contains("Resources/"));
+				.Where(p => p.Contains("ScriptableObjects/"));
 
 			// Find all .asset (almost always it is SO)
 			var allAssetPaths = allResourcesPaths.Where((a) => a.EndsWith(".asset")).ToArray();
@@ -136,11 +136,11 @@ namespace Tests
 		/// Check if there are scriptable objects that has missing reference fields 
 		/// </summary>
 		[Test]
-		public void CheckMissingRefenceFieldsScritpableObjects()
+		public void CheckMissingRefenceFieldsScriptableObjects()
 		{
 			// Get all assets paths
 			var allResourcesPaths = AssetDatabase.GetAllAssetPaths()
-				.Where(p => p.Contains("Resources/"));
+				.Where(p => p.Contains("ScriptableObjects/"));
 
 			// Find all .asset (almost always it is SO)
 			var allAssetPaths = allResourcesPaths.Where((a) => a.EndsWith(".asset")).ToArray();


### PR DESCRIPTION
### Purpose
- Makes the tests for scriptable objects work again by pathing to the proper folder.
- Fixes typos in the test names.