### PR TITLE
Adjusting flashlight size to small.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Lights/Flashlight.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Lights/Flashlight.prefab
@@ -206,6 +206,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
         type: 3}
+      propertyPath: initialSize
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
       propertyPath: initialDescription
       value: A hand-held emergency light.
       objectReference: {fileID: 0}


### PR DESCRIPTION
### Purpose
- Makes flashlights small in size so that they will now fit in pockets. Also affects other light sources including glowsticks, lanterns, and flares. Does not alter the size of desk lamps.