### PR TITLE
Fixes the gigantic GC production of wind

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
@@ -36,7 +36,7 @@ namespace Systems.Atmospherics
 		private Matrix matrix;
 
 		private ConcurrentDictionary<Vector3Int, MetaDataNode> hotspots;
-		private ThreadSafeList<MetaDataNode> windsTwo;
+		private ThreadSafeList<MetaDataNode> winds;
 		private GenericDelegate<MetaDataNode> windsNodeDelegator;
 
 		private List<Hotspot> hotspotsToAdd;
@@ -59,7 +59,7 @@ namespace Systems.Atmospherics
 			matrix = GetComponent<Matrix>();
 
 			hotspots = new ConcurrentDictionary<Vector3Int, MetaDataNode>();
-			windsTwo =  new ThreadSafeList<MetaDataNode>();
+			winds =  new ThreadSafeList<MetaDataNode>();
 			windsNodeDelegator = ProcessWindNodes;
 
 			hotspotsToRemove = new List<Vector3Int>();
@@ -76,7 +76,7 @@ namespace Systems.Atmospherics
 		private void Update()
 		{
 			Profiler.BeginSample("Wind");
-			windsTwo.Iterate(windsNodeDelegator);
+			winds.Iterate(windsNodeDelegator);
 			Profiler.EndSample();
 
 			Profiler.BeginSample("HotspotModify");
@@ -191,7 +191,7 @@ namespace Systems.Atmospherics
 			windyNode.WindForce = (windyNode.WindForce * ((RollingAverageN - 1) / RollingAverageN));
 			if (windyNode.WindForce < 0.5f * (1f / PushMultiplier))
 			{
-				windsTwo.Remove(windyNode);
+				winds.Remove(windyNode);
 				windyNode.WindForce = 0;
 				windyNode.WindDirection = Vector2Int.zero;
 			}
@@ -345,7 +345,7 @@ namespace Systems.Atmospherics
 			if (node != MetaDataNode.None && pressureDifference > AtmosConstants.MinWindForce
 										  && windDirection != Vector2Int.zero)
 			{
-				windsTwo.AddIfMissing(node);
+				winds.AddIfMissing(node);
 
 				node.WindForce = (node.WindForce * ((RollingAverageN - 1) / RollingAverageN)) +
 				                 pressureDifference / RollingAverageN;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
@@ -36,7 +36,8 @@ namespace Systems.Atmospherics
 		private Matrix matrix;
 
 		private ConcurrentDictionary<Vector3Int, MetaDataNode> hotspots;
-		private UniqueQueue<MetaDataNode> winds;
+		private ThreadSafeList<MetaDataNode> windsTwo;
+		private GenericDelegate<MetaDataNode> windsNodeDelegator;
 
 		private List<Hotspot> hotspotsToAdd;
 		private List<Vector3Int> hotspotsToRemove;
@@ -58,7 +59,8 @@ namespace Systems.Atmospherics
 			matrix = GetComponent<Matrix>();
 
 			hotspots = new ConcurrentDictionary<Vector3Int, MetaDataNode>();
-			winds = new UniqueQueue<MetaDataNode>();
+			windsTwo =  new ThreadSafeList<MetaDataNode>();
+			windsNodeDelegator = ProcessWindNodes;
 
 			hotspotsToRemove = new List<Vector3Int>();
 			hotspotsToAdd = new List<Hotspot>();
@@ -73,58 +75,9 @@ namespace Systems.Atmospherics
 
 		private void Update()
 		{
-			#region wind
-
 			Profiler.BeginSample("Wind");
-
-			for (int i = 0; i < winds.Count; i++)
-			{
-				if (winds.TryDequeue(out var windyNode))
-				{
-					foreach (var pushable in matrix.Get<PushPull>(windyNode.Position, true))
-					{
-						float correctedForce = (windyNode.WindForce * PushMultiplier) / (int)pushable.Pushable.Size;
-						if (correctedForce >= AtmosConstants.MinPushForce)
-						{
-							if (pushable.Pushable.IsTileSnap)
-							{
-								byte pushes = (byte)Mathf.Clamp((int)correctedForce / 10, 1, 10);
-								for (byte j = 0; j < pushes; j++)
-								{
-									//converting push to world coords because winddirection is in local coords
-									pushable.QueuePush((transform.rotation * windyNode.WindDirection.To3Int()).To2Int(),
-										Random.Range((float)(correctedForce * 0.8), correctedForce));
-								}
-							}
-							else
-							{
-								pushable.Pushable.Nudge(new NudgeInfo
-								{
-									OriginPos = pushable.Pushable.ServerPosition,
-									Trajectory = (Vector2)windyNode.WindDirection,
-									SpinMode = SpinMode.None,
-									SpinMultiplier = 1,
-									InitialSpeed = correctedForce,
-								});
-							}
-						}
-					}
-
-					windyNode.WindForce = (windyNode.WindForce * ((RollingAverageN - 1) / RollingAverageN));
-					if (windyNode.WindForce >= 0.5f * (1f / PushMultiplier))
-					{
-						winds.Enqueue(windyNode);
-					}
-					else
-					{
-						windyNode.WindForce = 0;
-						windyNode.WindDirection = Vector2Int.zero;
-					}
-				}
-			}
-
+			windsTwo.Iterate(windsNodeDelegator);
 			Profiler.EndSample();
-			#endregion
 
 			Profiler.BeginSample("HotspotModify");
 			//perform the actual logic that needs to happen for adding / removing hotspots that have been
@@ -204,6 +157,45 @@ namespace Systems.Atmospherics
 			Profiler.EndSample();
 		}
 
+		private void ProcessWindNodes(MetaDataNode windyNode)
+		{
+			foreach (var pushable in matrix.Get<PushPull>(windyNode.Position, true))
+			{
+				float correctedForce = (windyNode.WindForce * PushMultiplier) / (int)pushable.Pushable.Size;
+				if (correctedForce >= AtmosConstants.MinPushForce)
+				{
+					if (pushable.Pushable.IsTileSnap)
+					{
+						byte pushes = (byte)Mathf.Clamp((int)correctedForce / 10, 1, 10);
+						for (byte j = 0; j < pushes; j++)
+						{
+							//converting push to world coords because winddirection is in local coords
+							pushable.QueuePush((transform.rotation * windyNode.WindDirection.To3Int()).To2Int(),
+								Random.Range((float)(correctedForce * 0.8), correctedForce));
+						}
+					}
+					else
+					{
+						pushable.Pushable.Nudge(new NudgeInfo
+						{
+							OriginPos = pushable.Pushable.ServerPosition,
+							Trajectory = (Vector2)windyNode.WindDirection,
+							SpinMode = SpinMode.None,
+							SpinMultiplier = 1,
+							InitialSpeed = correctedForce,
+						});
+					}
+				}
+			}
+
+			windyNode.WindForce = (windyNode.WindForce * ((RollingAverageN - 1) / RollingAverageN));
+			if (windyNode.WindForce < 0.5f * (1f / PushMultiplier))
+			{
+				windsTwo.Remove(windyNode);
+				windyNode.WindForce = 0;
+				windyNode.WindDirection = Vector2Int.zero;
+			}
+		}
 
 		public void DoTick()
 		{
@@ -353,13 +345,10 @@ namespace Systems.Atmospherics
 			if (node != MetaDataNode.None && pressureDifference > AtmosConstants.MinWindForce
 										  && windDirection != Vector2Int.zero)
 			{
-				if (winds.Contains(node) == false)
-				{
-					winds.Enqueue(node);
-				}
+				windsTwo.AddIfMissing(node);
 
 				node.WindForce = (node.WindForce * ((RollingAverageN - 1) / RollingAverageN)) +
-								 pressureDifference / RollingAverageN;
+				                 pressureDifference / RollingAverageN;
 				node.WindDirection = windDirection;
 			}
 		}

--- a/UnityProject/Assets/Scripts/Util/ThreadSafeList.cs
+++ b/UnityProject/Assets/Scripts/Util/ThreadSafeList.cs
@@ -36,6 +36,17 @@ public class ThreadSafeList<T>
 		}
 	}
 
+	public void AddIfMissing(T item)
+	{
+		lock (list)
+		{
+			if (list.Contains(item) == false)
+			{
+				list.Add(item);
+			}
+		}
+	}
+
 	public void Clear()
 	{
 		lock (list)


### PR DESCRIPTION
### Purpose
Wind nodes will now use ThreadSafeList instead of UniqueQueue with the purpose of lowering its allocations.

### Notes:

![image](https://user-images.githubusercontent.com/701959/114072172-55ec9e80-9878-11eb-9266-b84402dbe239.png)
before 

![image](https://user-images.githubusercontent.com/701959/114072433-a82dbf80-9878-11eb-932b-c040fc7ba427.png)
after

this is happening on each frame, there's still some important GC going on but this PR reduces it by around 90%