### PR TITLE
Fixed Autolathe destruction bug

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Machines/Autolathe/Autolathe.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/Autolathe/Autolathe.cs
@@ -174,7 +174,10 @@ namespace Objects.Machines
 				StopCoroutine(currentProduction);
 				currentProduction = null;
 			}
-			materialStorageLink.Despawn();
+			if (materialStorageLink != null)
+			{
+				materialStorageLink.Despawn();
+			}
 		}
 
 		public void PowerNetworkUpdate(float Voltage) { }


### PR DESCRIPTION
### Purpose
Fixes #6348. When the server hooks were being removed, Autolathes/Circuit Imprintors with no materialStorageLink would cause an error in the despawning process. 

### Changelog:
CL: Fixed Autolathes not being destroyed when not connected to a material silo or storage.
