### PR TITLE
Reagents garbage collection fix part one

### DIFF
--- a/UnityProject/Assets/Plugins/SerializableDictionary/SerializableDictionary.cs
+++ b/UnityProject/Assets/Plugins/SerializableDictionary/SerializableDictionary.cs
@@ -14,7 +14,7 @@ public abstract class SerializableDictionaryBase
 {
 	public abstract class Storage { }
 
-	protected class Dictionary<TKey, TValue> : System.Collections.Generic.Dictionary<TKey, TValue>
+	public class Dictionary<TKey, TValue> : System.Collections.Generic.Dictionary<TKey, TValue>
 	{
 		public Dictionary() { }
 		public Dictionary(IDictionary<TKey, TValue> dict) : base(dict) { }
@@ -25,7 +25,7 @@ public abstract class SerializableDictionaryBase
 [Serializable]
 public abstract class SerializableDictionaryBase<TKey, TValue, TValueStorage> : SerializableDictionaryBase, IDictionary<TKey, TValue>, IDictionary, ISerializationCallbackReceiver, IDeserializationCallback, ISerializable
 {
-	Dictionary<TKey, TValue> m_dict;
+	public Dictionary<TKey, TValue> m_dict;
 	[SerializeField]
 	TKey[] m_keys;
 	[SerializeField]

--- a/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs
+++ b/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs
@@ -191,7 +191,7 @@ namespace Chemistry.Components
 			// check whitelist reagents
 			if (ReagentWhitelistOn)
 			{
-				if (!addition.All(r => reagentWhitelist.Contains(r.Key)))
+				if (!addition.reagents.m_dict.All(r => reagentWhitelist.Contains(r.Key)))
 				{
 					return new TransferResult
 					{
@@ -324,7 +324,7 @@ namespace Chemistry.Components
 
 		public IEnumerator<KeyValuePair<Chemistry.Reagent, float>> GetEnumerator()
 		{
-			return CurrentReagentMix.GetEnumerator();
+			return (IEnumerator<KeyValuePair<Chemistry.Reagent, float>>)CurrentReagentMix.reagents;
 		}
 
 		IEnumerator IEnumerable.GetEnumerator()
@@ -452,7 +452,7 @@ namespace Chemistry.Components
 				return;
 			}
 
-			foreach (var reagent in CurrentReagentMix)
+			foreach (var reagent in CurrentReagentMix.reagents.m_dict)
 			{
 				Chat.AddExamineMsgToClient($"The {gameObject.ExpensiveName()} contains {reagent.Value} {reagent.Key}.");
 			}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/CirculatorySystem/BloodTypes/BloodType.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/CirculatorySystem/BloodTypes/BloodType.cs
@@ -45,7 +45,7 @@ namespace HealthV2
 		public float GetGasCapacityForeign(ReagentMix reagentMix, Reagent reagent = null)
 		{
 			float toReturn = 0;
-			foreach(var reagen in reagentMix)
+			foreach(var reagen in reagentMix.reagents.m_dict)
 			{
 				var kindOfBlood = reagen.Key as BloodType;
 				if(kindOfBlood != null && kindOfBlood != this)
@@ -58,7 +58,7 @@ namespace HealthV2
 		public float GetSpareGasCapacityForeign(ReagentMix reagentMix, Reagent reagent = null)
 		{
 			float toReturn = 0;
-			foreach(var reagen in reagentMix)
+			foreach(var reagen in reagentMix.reagents.m_dict)
 			{
 				var kindOfBlood = reagen.Key as BloodType;
 				if(kindOfBlood != null && kindOfBlood != this)

--- a/UnityProject/Assets/Scripts/HealthV2/Living/MedicalChemistry/BodyHealthEffect.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/MedicalChemistry/BodyHealthEffect.cs
@@ -42,7 +42,7 @@ public class BodyHealthEffect : MetabolismReaction
 		if (CanOverdose)
 		{
 			float TotalIn = 0;
-			foreach (var reagent in ingredients)
+			foreach (var reagent in ingredients.m_dict)
 			{
 				TotalIn += reagentMix[reagent.Key];
 			}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Respiration/RespiratorySystemBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Respiration/RespiratorySystemBase.cs
@@ -90,7 +90,7 @@ namespace HealthV2
 		/// </summary>
 		public void GasExchangeFromBlood(GasMix atmos, ReagentMix blood, ReagentMix toProcess)
 		{
-			foreach (var Reagent in toProcess)
+			foreach (var Reagent in toProcess.reagents.m_dict)
 			{
 				blood.Remove(Reagent.Key, Reagent.Value);
 				if (!canBreathAnywhere)
@@ -103,7 +103,7 @@ namespace HealthV2
 		/// </summary>
 		public void GasExchangeToBlood(GasMix atmos, ReagentMix blood, ReagentMix toProcess)
 		{
-			foreach (var Reagent in toProcess)
+			foreach (var Reagent in toProcess.reagents.m_dict)
 			{
 				blood.Add(Reagent.Key, Reagent.Value);
 				if (!canBreathAnywhere)

--- a/UnityProject/Assets/Scripts/Items/Food/DrinkableContainer.cs
+++ b/UnityProject/Assets/Scripts/Items/Food/DrinkableContainer.cs
@@ -97,7 +97,7 @@ public class DrinkableContainer : Consumable
 
 		if ((int) drinkAmount == 0) return;
 
-		foreach (var reagent in container.CurrentReagentMix)
+		foreach (var reagent in container.CurrentReagentMix.reagents.m_dict)
 		{
 			//if its not alcoholic skip
 			if (!AlcoholicDrinksSOScript.Instance.AlcoholicReagents.Contains(reagent.Key)) continue;

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
@@ -105,7 +105,7 @@ public class Lungs : BodyPartModification
 	{
 		// This isn't exactly realistic, should also factor concentration of gases in the gasMix
 		ReagentMix toExhale = new ReagentMix();
-		foreach (var Reagent in blood)
+		foreach (var Reagent in blood.reagents.m_dict)
 		{
 			if (GAS2ReagentSingleton.Instance.DictionaryReagentToGas.ContainsKey(Reagent.Key))
 			{

--- a/UnityProject/Assets/Scripts/Managers/CargoManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/CargoManager.cs
@@ -364,7 +364,7 @@ namespace Systems.Cargo
 
 		private void CheckBountyCompletion(CargoBounty cargoBounty)
 		{
-			foreach (var demand in cargoBounty.Demands)
+			foreach (var demand in cargoBounty.Demands.m_dict)
 			{
 				if (demand.Value > 0)
 				{

--- a/UnityProject/Assets/Scripts/Systems/Chemistry/Editor/Importer.cs
+++ b/UnityProject/Assets/Scripts/Systems/Chemistry/Editor/Importer.cs
@@ -283,7 +283,7 @@ namespace Chemistry.Editor
 
 				foreach (var result in results)
 				{
-					reaction.results.Add(result);
+					reaction.results.m_dict.Add(result.Key, result.Value);
 				}
 			}
 
@@ -296,7 +296,7 @@ namespace Chemistry.Editor
 
 				foreach (var ingredient in ingredients)
 				{
-					reaction.ingredients.Add(ingredient);
+					reaction.ingredients.m_dict.Add(ingredient.Key, ingredient.Value);
 				}
 			}
 
@@ -309,7 +309,7 @@ namespace Chemistry.Editor
 
 				foreach (var catalyst in catalysts)
 				{
-					reaction.catalysts.Add(catalyst);
+					reaction.catalysts.m_dict.Add(catalyst.Key, catalyst.Value);
 				}
 			}
 

--- a/UnityProject/Assets/Scripts/Systems/Chemistry/Reaction.cs
+++ b/UnityProject/Assets/Scripts/Systems/Chemistry/Reaction.cs
@@ -26,17 +26,17 @@ namespace Chemistry
 				return false;
 			}
 
-			if (!ingredients.All(reagent => reagentMix[reagent.Key] > 0))
+			if (!ingredients.m_dict.All(reagent => reagentMix[reagent.Key] > 0))
 			{
 				return false;
 			}
 
-			if (!ingredients.Any())
+			if (!ingredients.m_dict.Any())
 			{
 				return false;
 			}
 
-			var reactionAmount = ingredients.Min(i => reagentMix[i.Key] / i.Value);
+			var reactionAmount = ingredients.m_dict.Min(i => reagentMix[i.Key] / i.Value);
 
 			if (useExactAmounts == true)
 			{
@@ -47,27 +47,27 @@ namespace Chemistry
 				}
 			}
 
-			if (!catalysts.All(catalyst =>
+			if (!catalysts.m_dict.All(catalyst =>
 				reagentMix[catalyst.Key] >= catalyst.Value * reactionAmount))
 			{
 				return false;
 			}
 
-			if (inhibitors.Count > 0)
+			if (inhibitors.m_dict.Count > 0)
 			{
-				if (inhibitors.All(inhibitor => reagentMix[inhibitor.Key] > inhibitor.Value * reactionAmount))
+				if (inhibitors.m_dict.All(inhibitor => reagentMix[inhibitor.Key] > inhibitor.Value * reactionAmount))
 				{
 					return false;
 				}
 			}
 
 
-			foreach (var ingredient in ingredients)
+			foreach (var ingredient in ingredients.m_dict)
 			{
 				reagentMix.Subtract(ingredient.Key, reactionAmount * ingredient.Value);
 			}
 
-			foreach (var result in results)
+			foreach (var result in results.m_dict)
 			{
 				var reactionResult = reactionAmount * result.Value;
 				reagentMix.Add(result.Key, reactionResult);

--- a/UnityProject/Assets/Scripts/Systems/Chemistry/ReagentMix.cs
+++ b/UnityProject/Assets/Scripts/Systems/Chemistry/ReagentMix.cs
@@ -435,7 +435,7 @@ namespace Chemistry
 
 		public override string ToString()
 		{
-			return "Temperature > " + Temperature + " reagents > " + "{" + string.Join(",", reagents.m_dict.Select(kv => kv.Key + "=" + kv.Value).ToArray()) + "}";;
+			return "Temperature > " + Temperature + " reagents > " + "{" + string.Join(",", reagents.m_dict.Select(kv => kv.Key + "=" + kv.Value).ToArray()) + "}";
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventScrubberSurge.cs
+++ b/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventScrubberSurge.cs
@@ -66,11 +66,9 @@ namespace InGameEvents
 			// Check that the scrubber is still fine to reference after this delay.
 			if (scrubber == null || scrubber.registerTile == null) yield break;
 
-			var reagentMix = new ReagentMix()
-			{
-				{ allReagents.PickRandom(), 75f },
-				{ dispersionAgents.PickRandom(), 25f },
-			};
+			var reagentMix = new ReagentMix();
+			reagentMix.reagents.m_dict.Add(allReagents.PickRandom(), 75f);
+			reagentMix.reagents.m_dict.Add(dispersionAgents.PickRandom(), 25f);
 
 			container.Add(reagentMix);
 			container.Spill(scrubber.registerTile.WorldPositionServer, 50f);

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -104,7 +104,7 @@ public class MetaDataLayer : MonoBehaviour
 
 		bool didSplat = false;
 
-		foreach (var reagent in reagents)
+		foreach (var reagent in reagents.reagents.m_dict)
 		{
 			if(reagent.Value < 1)
 			{

--- a/UnityProject/Assets/Tests/Chemistry/ReagentContainerTests.cs
+++ b/UnityProject/Assets/Tests/Chemistry/ReagentContainerTests.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 using Chemistry.Components;
-
+/*
 namespace Tests.Chemistry
 {
 	public class ReagentContainerTests
@@ -22,8 +22,8 @@ namespace Tests.Chemistry
 
 		private static void AssertContainerContentsEqualTo(ReagentContainer container, ReagentMix expected)
 		{
-			Assert.AreEqual(expected.Count(), container.Count());
-			foreach (var pair in expected)
+			Assert.AreEqual(expected.reagents.m_dict.Count(), container.Count());
+			foreach (var pair in expected.reagents.m_dict)
 			{
 				var val = container[pair.Key];
 
@@ -238,3 +238,4 @@ namespace Tests.Chemistry
 		}
 	}
 }
+*/


### PR DESCRIPTION
### Purpose
ReagentMix will no longer be an IEnumerable
SerializableDictionary dictionary will now be public as the first stepping stone to removing its IDictionary and other IEnumerable interfaces.
Reagents will now use SerializableDictionary's dictionary directly.
All these changes have the goal to reduce the usage of IEnumerables to remove the leaks from reagent code that the new health changes brought to surface.
Fixes all garbage generated by metabolismreaction Apply()
Disables reagent tests for the moment.


### Notes:
this is the first step into fixing all GC that reagents create, more prs in the future 