### PR TITLE
Prefab spawn error fixes

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Factories/EffectsFactory.cs
+++ b/UnityProject/Assets/Scripts/Core/Factories/EffectsFactory.cs
@@ -4,14 +4,9 @@ using Objects.Construction;
 
 public static class EffectsFactory
 {
-
-	private static GameObject fireTile;
-
 	private static GameObject smallBloodTile;
 	private static GameObject mediumBloodTile;
 	private static GameObject largeBloodTile;
-	private static GameObject largeAshTile;
-	private static GameObject smallAshTile;
 	private static GameObject waterTile;
 	private static GameObject chemTile;
 
@@ -21,15 +16,12 @@ public static class EffectsFactory
 
 	private static void EnsureInit()
 	{
-		if (fireTile == null)
+		if (smallBloodTile == null)
 		{
 			//Do init stuff
-			fireTile = CustomNetworkManager.Instance.GetSpawnablePrefabFromName("FireTile");
 			smallBloodTile = CustomNetworkManager.Instance.GetSpawnablePrefabFromName("SmallBloodSplat");
 			mediumBloodTile = CustomNetworkManager.Instance.GetSpawnablePrefabFromName("MediumBloodSplat");
 			largeBloodTile = CustomNetworkManager.Instance.GetSpawnablePrefabFromName("LargeBloodSplat");
-			largeAshTile = CustomNetworkManager.Instance.GetSpawnablePrefabFromName("LargeAsh");
-			smallAshTile = CustomNetworkManager.Instance.GetSpawnablePrefabFromName("SmallAsh");
 			waterTile = CustomNetworkManager.Instance.GetSpawnablePrefabFromName("WaterSplat");
 			chemTile = CustomNetworkManager.Instance.GetSpawnablePrefabFromName("ChemSplat");
 			smallXenoBloodTile = CustomNetworkManager.Instance.GetSpawnablePrefabFromName("SmallXenoBloodSplat");

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -162,7 +162,8 @@ public class CustomNetworkManager : NetworkManager, IInitialise
 			return prefab[0];
 		}
 
-		Logger.LogError($"There is no spawnable prefab with the name: {prefabName}, can only find prefabs which have net identities using this method");
+		Logger.LogError($"There is no prefab with the name: {prefabName} inside the AllSpawnablePrefabs list in the network manager," +
+		                " all prefabs must be in this list if they need to be spawnable");
 
 		return null;
 	}


### PR DESCRIPTION
-Fixes the errors when ash, and fire tile objects are initialised as they are no longer prefabs

-Updates error logging for missing prefabs
