### PR TITLE
Lizards' tails will now share colors with their skintones.

### DIFF
--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Lizard/Lizard.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Lizard/Lizard.asset
@@ -44,3 +44,9 @@ MonoBehaviour:
     BloodType: {fileID: 11400000, guid: efcde740e9b85074485bcd68a7a21816, type: 2}
     RootImplantProcedure: {fileID: 11400000, guid: 042d01452f7f9ec4aa0e9ca6ea309242,
       type: 2}
+    BodyPartsThatShareTheSkinTone:
+    - Hair
+    - LizardSnout
+    - LizardTail
+    - FacialHair
+    - Horns

--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Lizard/Lizard.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Lizard/Lizard.asset
@@ -45,8 +45,7 @@ MonoBehaviour:
     RootImplantProcedure: {fileID: 11400000, guid: 042d01452f7f9ec4aa0e9ca6ea309242,
       type: 2}
     BodyPartsThatShareTheSkinTone:
-    - Hair
-    - LizardSnout
-    - LizardTail
-    - FacialHair
-    - Horns
+    - {fileID: 3445963405511484685, guid: 43e80b782d31dac4384d245df9f34dcd, type: 3}
+    - {fileID: 1644536323247627075, guid: f145adb7bc76bfc4a86a8612714230d1, type: 3}
+    - {fileID: 3601734041678046290, guid: 2e6e8409def4d76428e3e72233ab61c6, type: 3}
+    - {fileID: 1723238164438836345, guid: 6c6b9b73c0bb8d14c9329b24820e0a9a, type: 3}

--- a/UnityProject/Assets/Scripts/Player/PlayerHealthData.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerHealthData.cs
@@ -40,7 +40,7 @@ public class RaceHealthData
 
 	public ImplantProcedure RootImplantProcedure;
 
-	public List<string> BodyPartsThatShareTheSkinTone = new List<string>();
+	public List<HealthV2.BodyPart> BodyPartsThatShareTheSkinTone = new List<HealthV2.BodyPart>();
 }
 
 

--- a/UnityProject/Assets/Scripts/Player/PlayerHealthData.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerHealthData.cs
@@ -39,6 +39,8 @@ public class RaceHealthData
 	public BloodType BloodType;
 
 	public ImplantProcedure RootImplantProcedure;
+
+	public List<string> BodyPartsThatShareTheSkinTone = new List<string>();
 }
 
 

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -1226,6 +1226,7 @@ namespace UI.CharacterCreator
 		private void OnColorChange(Color newColor)
 		{
 			colorChangedEvent.Invoke(newColor);
+			RefreshAllSkinSharedSkinColoredBodyParts();
 		}
 
 		#endregion
@@ -1391,8 +1392,6 @@ namespace UI.CharacterCreator
 
 			RefreshRace();
 
-			OnSurfaceColourChange();
-
 			foreach (var Race in RaceSOSingleton.Instance.Races)
 			{
 				if (Race.name == currentCharacter.Species)
@@ -1400,6 +1399,8 @@ namespace UI.CharacterCreator
 					ThisSetRace = Race;
 				}
 			}
+
+			OnSurfaceColourChange();
 		}
 
 		private void RefreshRace()

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -65,7 +65,7 @@ namespace UI.CharacterCreator
 
 		[SerializeField] private List<Color> availableSkinColors;
 		private CharacterSettings currentCharacter;
-		public CharacterSettings CurrentCharacter { get { return currentCharacter; } private set { new CharacterSettings(); } }
+		public CharacterSettings CurrentCharacter { get { return currentCharacter; } }
 
 		public ColorPicker colorPicker;
 

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -65,6 +65,7 @@ namespace UI.CharacterCreator
 
 		[SerializeField] private List<Color> availableSkinColors;
 		private CharacterSettings currentCharacter;
+		public CharacterSettings CurrentCharacter { get { return currentCharacter; } private set { new CharacterSettings(); } }
 
 		public ColorPicker colorPicker;
 
@@ -1349,6 +1350,14 @@ namespace UI.CharacterCreator
 			currentCharacter.SkinTone = "#" + ColorUtility.ToHtmlStringRGB(CurrentSurfaceColour);
 		}
 
+		public void RefreshAllSkinSharedSkinColoredBodyParts()
+		{
+			foreach (var Customisation in GetComponentsInChildren<BodyPartCustomisationBase>())
+			{
+				Customisation.Refresh();
+			}
+		}
+
 		#region Race Preference
 		// This will be a temporal thing until we have proper character traits
 
@@ -1383,6 +1392,14 @@ namespace UI.CharacterCreator
 			RefreshRace();
 
 			OnSurfaceColourChange();
+
+			foreach (var Race in RaceSOSingleton.Instance.Races)
+			{
+				if (Race.name == currentCharacter.Species)
+				{
+					ThisSetRace = Race;
+				}
+			}
 		}
 
 		private void RefreshRace()

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/SubCustomisation/BodyPartCustomisations/BodyPartSpriteAndColour.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/SubCustomisation/BodyPartCustomisations/BodyPartSpriteAndColour.cs
@@ -30,7 +30,7 @@ namespace UI.CharacterCreator
 		private IEnumerator Start()
 		{
 			yield return new WaitForEndOfFrame();
-			if (characterCustomization.ThisSetRace.Base.BodyPartsThatShareTheSkinTone.Contains(RelatedBodyPart.name))
+			if (characterCustomization.ThisSetRace.Base.BodyPartsThatShareTheSkinTone.Contains(RelatedBodyPart))
 			{
 				SelectionColourImage.gameObject.SetActive(false);
 			}
@@ -156,7 +156,7 @@ namespace UI.CharacterCreator
 
 		private void CheckSkinToneShare()
 		{
-			if (characterCustomization.ThisSetRace.Base.BodyPartsThatShareTheSkinTone.Contains(RelatedBodyPart.name))
+			if (characterCustomization.ThisSetRace.Base.BodyPartsThatShareTheSkinTone.Contains(RelatedBodyPart))
 			{
 				ColorUtility.TryParseHtmlString(characterCustomization.CurrentCharacter.SkinTone, out BodyPartColour);
 				SelectionColourImage.gameObject.SetActive(false);

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/SubCustomisation/BodyPartCustomisations/BodyPartSpriteAndColour.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/SubCustomisation/BodyPartCustomisations/BodyPartSpriteAndColour.cs
@@ -27,6 +27,19 @@ namespace UI.CharacterCreator
 			}
 		}
 
+		private IEnumerator Start()
+		{
+			yield return new WaitForEndOfFrame();
+			if (characterCustomization.ThisSetRace.Base.BodyPartsThatShareTheSkinTone.Contains(RelatedBodyPart.name))
+			{
+				SelectionColourImage.gameObject.SetActive(false);
+			}
+			else
+			{
+				SelectionColourImage.gameObject.SetActive(true);
+			}
+		}
+
 		public override void Deserialise(string InData)
 		{
 			var ColourAnd_Selected = JsonConvert.DeserializeObject<ColourAndSelected>(InData);
@@ -141,11 +154,24 @@ namespace UI.CharacterCreator
 			//Refresh();
 		}
 
+		private void CheckSkinToneShare()
+		{
+			if (characterCustomization.ThisSetRace.Base.BodyPartsThatShareTheSkinTone.Contains(RelatedBodyPart.name))
+			{
+				ColorUtility.TryParseHtmlString(characterCustomization.CurrentCharacter.SkinTone, out BodyPartColour);
+				SelectionColourImage.gameObject.SetActive(false);
+			}
+			else
+			{
+				SelectionColourImage.color = BodyPartColour;
+			}
+		}
+
 		public override void Refresh()
 		{
 			//Just the first one for now
 			RelatedRelatedPreviewSprites[0].SpriteHandler.SetColor(BodyPartColour);
-			SelectionColourImage.color = BodyPartColour;
+			CheckSkinToneShare();
 
 			if (Dropdown.value == 0)
 			{

--- a/UnityProject/Assets/Textures/mobs/races/Felinid/overly/overly_m_waggingtail_cat.asset
+++ b/UnityProject/Assets/Textures/mobs/races/Felinid/overly/overly_m_waggingtail_cat.asset
@@ -59,3 +59,4 @@ MonoBehaviour:
       secondDelay: 0.1
   IsPalette: 0
   setID: 14353
+  DisplayName: Wagging Tail

--- a/UnityProject/Assets/Textures/mobs/races/lizard/overly/AnimatedTail/overly_m_waggingtail_dtiger.asset
+++ b/UnityProject/Assets/Textures/mobs/races/lizard/overly/AnimatedTail/overly_m_waggingtail_dtiger.asset
@@ -91,3 +91,4 @@ MonoBehaviour:
       secondDelay: 0.1
   IsPalette: 0
   setID: 14564
+  DisplayName: Tiger

--- a/UnityProject/Assets/Textures/mobs/races/lizard/overly/AnimatedTail/overly_m_waggingtail_ltiger.asset
+++ b/UnityProject/Assets/Textures/mobs/races/lizard/overly/AnimatedTail/overly_m_waggingtail_ltiger.asset
@@ -91,3 +91,4 @@ MonoBehaviour:
       secondDelay: 0.1
   IsPalette: 0
   setID: 14566
+  DisplayName: Tiger Thorns

--- a/UnityProject/Assets/Textures/mobs/races/lizard/overly/AnimatedTail/overly_m_waggingtail_smooth.asset
+++ b/UnityProject/Assets/Textures/mobs/races/lizard/overly/AnimatedTail/overly_m_waggingtail_smooth.asset
@@ -91,3 +91,4 @@ MonoBehaviour:
       secondDelay: 0.1
   IsPalette: 0
   setID: 14568
+  DisplayName: Wagging Smooth

--- a/UnityProject/Assets/Textures/mobs/races/lizard/overly/AnimatedTail/overly_m_waggingtail_spikes.asset
+++ b/UnityProject/Assets/Textures/mobs/races/lizard/overly/AnimatedTail/overly_m_waggingtail_spikes.asset
@@ -91,3 +91,4 @@ MonoBehaviour:
       secondDelay: 0.1
   IsPalette: 0
   setID: 14570
+  DisplayName: Wagging Spikes

--- a/UnityProject/Assets/Textures/mobs/races/lizard/overly/Horns/overly_m_horns_angler_ADJ.asset
+++ b/UnityProject/Assets/Textures/mobs/races/lizard/overly/Horns/overly_m_horns_angler_ADJ.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
       secondDelay: 0
   IsPalette: 0
   setID: 14527
+  DisplayName: Angler

--- a/UnityProject/Assets/Textures/mobs/races/lizard/overly/Horns/overly_m_horns_curled_ADJ.asset
+++ b/UnityProject/Assets/Textures/mobs/races/lizard/overly/Horns/overly_m_horns_curled_ADJ.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
       secondDelay: 0
   IsPalette: 0
   setID: 14528
+  DisplayName: Curled

--- a/UnityProject/Assets/Textures/mobs/races/lizard/overly/Horns/overly_m_horns_ram_ADJ.asset
+++ b/UnityProject/Assets/Textures/mobs/races/lizard/overly/Horns/overly_m_horns_ram_ADJ.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
       secondDelay: 0
   IsPalette: 0
   setID: 14529
+  DisplayName: Ram

--- a/UnityProject/Assets/Textures/mobs/races/lizard/overly/Horns/overly_m_horns_short_ADJ.asset
+++ b/UnityProject/Assets/Textures/mobs/races/lizard/overly/Horns/overly_m_horns_short_ADJ.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
       secondDelay: 0
   IsPalette: 0
   setID: 14530
+  DisplayName: Short

--- a/UnityProject/Assets/Textures/mobs/races/lizard/overly/Horns/overly_m_horns_simple_ADJ.asset
+++ b/UnityProject/Assets/Textures/mobs/races/lizard/overly/Horns/overly_m_horns_simple_ADJ.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
       secondDelay: 0
   IsPalette: 0
   setID: 14531
+  DisplayName: Simple

--- a/UnityProject/Assets/Textures/mobs/races/lizard/overly/Spikes/overly_m_spines_aqua_ADJ.asset
+++ b/UnityProject/Assets/Textures/mobs/races/lizard/overly/Spikes/overly_m_spines_aqua_ADJ.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
       secondDelay: 0
   IsPalette: 0
   setID: 14538
+  DisplayName: Aqua

--- a/UnityProject/Assets/Textures/mobs/races/lizard/overly/Spikes/overly_m_spines_aqua_BEHIND.asset
+++ b/UnityProject/Assets/Textures/mobs/races/lizard/overly/Spikes/overly_m_spines_aqua_BEHIND.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
       secondDelay: 0
   IsPalette: 0
   setID: 14539
+  DisplayName: Aqua Back

--- a/UnityProject/Assets/Textures/mobs/races/lizard/overly/Spikes/overly_m_spines_long_ADJ.asset
+++ b/UnityProject/Assets/Textures/mobs/races/lizard/overly/Spikes/overly_m_spines_long_ADJ.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
       secondDelay: 0
   IsPalette: 0
   setID: 14540
+  DisplayName: Long

--- a/UnityProject/Assets/Textures/mobs/races/lizard/overly/Spikes/overly_m_spines_long_BEHIND.asset
+++ b/UnityProject/Assets/Textures/mobs/races/lizard/overly/Spikes/overly_m_spines_long_BEHIND.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
       secondDelay: 0
   IsPalette: 0
   setID: 14541
+  DisplayName: Long Behind

--- a/UnityProject/Assets/Textures/mobs/races/lizard/overly/Spikes/overly_m_spines_longmeme_ADJ.asset
+++ b/UnityProject/Assets/Textures/mobs/races/lizard/overly/Spikes/overly_m_spines_longmeme_ADJ.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
       secondDelay: 0
   IsPalette: 0
   setID: 14542
+  DisplayName: Long Thorns

--- a/UnityProject/Assets/Textures/mobs/races/lizard/overly/Spikes/overly_m_spines_longmeme_BEHIND.asset
+++ b/UnityProject/Assets/Textures/mobs/races/lizard/overly/Spikes/overly_m_spines_longmeme_BEHIND.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
       secondDelay: 0
   IsPalette: 0
   setID: 14543
+  DisplayName: Long Thorns Behind

--- a/UnityProject/Assets/Textures/mobs/races/lizard/overly/Spikes/overly_m_spines_short_ADJ.asset
+++ b/UnityProject/Assets/Textures/mobs/races/lizard/overly/Spikes/overly_m_spines_short_ADJ.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
       secondDelay: 0
   IsPalette: 0
   setID: 14544
+  DisplayName: Short

--- a/UnityProject/Assets/Textures/mobs/races/lizard/overly/Spikes/overly_m_spines_shortmeme_ADJ.asset
+++ b/UnityProject/Assets/Textures/mobs/races/lizard/overly/Spikes/overly_m_spines_shortmeme_ADJ.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
       secondDelay: 0
   IsPalette: 0
   setID: 14545
+  DisplayName: Short Thorns

--- a/UnityProject/Assets/Textures/mobs/races/lizard/overly/Spikes/overly_m_spines_shortmeme_BEHIND.asset
+++ b/UnityProject/Assets/Textures/mobs/races/lizard/overly/Spikes/overly_m_spines_shortmeme_BEHIND.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
       secondDelay: 0
   IsPalette: 0
   setID: 14546
+  DisplayName: Short Thorns Behind

--- a/UnityProject/Assets/Textures/mobs/races/lizard/overly/Tail/overly_m_tail_dtiger.asset
+++ b/UnityProject/Assets/Textures/mobs/races/lizard/overly/Tail/overly_m_tail_dtiger.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
       secondDelay: 0
   IsPalette: 0
   setID: 14547
+  DisplayName: Common

--- a/UnityProject/Assets/Textures/mobs/races/lizard/overly/Tail/overly_m_tail_ltiger.asset
+++ b/UnityProject/Assets/Textures/mobs/races/lizard/overly/Tail/overly_m_tail_ltiger.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
       secondDelay: 0
   IsPalette: 0
   setID: 14549
+  DisplayName: Thicc

--- a/UnityProject/Assets/Textures/mobs/races/lizard/overly/Tail/overly_m_tail_smooth.asset
+++ b/UnityProject/Assets/Textures/mobs/races/lizard/overly/Tail/overly_m_tail_smooth.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
       secondDelay: 0
   IsPalette: 0
   setID: 14551
+  DisplayName: Smooth

--- a/UnityProject/Assets/Textures/mobs/races/lizard/overly/Tail/overly_m_tail_spikes.asset
+++ b/UnityProject/Assets/Textures/mobs/races/lizard/overly/Tail/overly_m_tail_spikes.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
       secondDelay: 0
   IsPalette: 0
   setID: 14553
+  DisplayName: Spikes


### PR DESCRIPTION
### Purpose
Part of this #6276
Adds the ability to allow races to have some of their limbs share colors with their skintones.

### Notes:
The other body parts are intentional for lizards because I think they look great with matching colors.

### Changelog:
CL: Lizards' tails will now share colors with their skintones.
CL: Lizard body parts now have display names.