### PR TITLE
Made radiation collectors use wrenchable script

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Electricity/RadiationCollector.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Electricity/RadiationCollector.prefab
@@ -24,6 +24,7 @@ GameObject:
   - component: {fileID: 5933879109768817857}
   - component: {fileID: 7688260226702700199}
   - component: {fileID: -6790315723496725363}
+  - component: {fileID: 6904090263313110087}
   m_Layer: 11
   m_Name: RadiationCollector
   m_TagString: Untagged
@@ -89,8 +90,9 @@ MonoBehaviour:
   matrixDebugLogging: 0
   objectType: 1
   AtmosPassable: 1
-  Passable: 0
   ReachableThrough: 1
+  initialPassable: 0
+  initialCrawlPassable: 0
   passableExclusionsToThis: []
 --- !u!114 &114703946515217786
 MonoBehaviour:
@@ -162,7 +164,6 @@ MonoBehaviour:
   WireEndB: 9
   WireEndA: 0
   ListCanConnectTo: 0b0000000800000001000000
-  SelfDestruct: 0
   Reactions:
   - ConnectingDevice: 11
     DirectionReaction: 1
@@ -228,6 +229,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
   ignoreExtraRotation: []
+  RotateParent: {fileID: 0}
 --- !u!114 &3912874886522507892
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -240,9 +242,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  isDirty: 0
+  isDirty: 1
   sceneId: 0
   serverOnly: 0
+  visible: 0
   m_AssetId: 
   hasSpawned: 0
 --- !u!114 &1999094162665485661
@@ -259,13 +262,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   isMeleeable: 1
   butcherTime: 2
-  butcherSound:
-    SetLoadSetting: 0
-    AssetAddress: null
-    AssetReference:
-      m_AssetGUID: 
-      m_SubObjectName: 
-      m_SubObjectType: 
+  butcherSound: 
 --- !u!114 &4997349939610282033
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -311,6 +308,7 @@ MonoBehaviour:
     LightningDamageProof: 0
   HeatResistance: 100
   ExplosionsDamage: 100
+  doDamageMessage: 1
 --- !u!114 &1773004346421643381
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -409,6 +407,27 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+--- !u!114 &6904090263313110087
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1575520830166772}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 48487dad7f2bc0541964880f6187c474, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  isSecuredStateExaminable: 1
+  isExposedFloorPlatingRequired: 0
+  secondsToSecure: 3
+  secondsToUnsecure: 3
+  lockSpriteDirection: 0
+  blockAnchorChange: 0
+  blockMessage: 
 --- !u!1 &1744594665423798
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Objects/Engineering/RadiationCollector.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/RadiationCollector.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using UnityEngine;
 using Systems.Electricity.NodeModules;
+using Objects.Construction;
 
 namespace Objects.Engineering
 {
@@ -8,11 +9,10 @@ namespace Objects.Engineering
 	{
 		private ElectricalNodeControl electricalNodeControl;
 		private ModuleSupplyingDevice moduleSupplyingDevice;
-		private PushPull pushPull;
+		private WrenchSecurable wrenchSecurable;
 		private RegisterTile registerTile;
 
 		private bool isOn;
-		private bool isWrenched;
 		private GameObject slotObject;
 
 		[SerializeField]
@@ -37,7 +37,7 @@ namespace Objects.Engineering
 		{
 			electricalNodeControl = GetComponent<ElectricalNodeControl>();
 			moduleSupplyingDevice = GetComponent<ModuleSupplyingDevice>();
-			pushPull = GetComponent<PushPull>();
+			wrenchSecurable = GetComponent<WrenchSecurable>();
 			registerTile = GetComponent<RegisterTile>();
 		}
 
@@ -57,8 +57,7 @@ namespace Objects.Engineering
 
 			if (startSetUp)
 			{
-				isWrenched = true;
-				pushPull.ServerSetPushable(false);
+				wrenchSecurable.ServerSetPushable(false);
 			}
 		}
 
@@ -92,7 +91,7 @@ namespace Objects.Engineering
 		{
 			if (DefaultWillInteract.Default(interaction, side) == false) return false;
 
-			if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Wrench)) return true;
+			if (interaction.TargetObject != gameObject) return false;
 
 			if (interaction.HandObject == null) return true;
 
@@ -103,58 +102,9 @@ namespace Objects.Engineering
 
 		public void ServerPerformInteraction(HandApply interaction)
 		{
-			if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Wrench))
-			{
-				TryWrench(interaction);
-			}
-			else if (interaction.HandObject == null)
+			if (interaction.HandObject == null)
 			{
 				SupplyToggle(interaction);
-			}
-		}
-
-		private void TryWrench(HandApply interaction)
-		{
-			if (isOn)
-			{
-				Chat.AddExamineMsgFromServer(interaction.Performer, "Turn off the collector first");
-				return;
-			}
-
-			if (isWrenched)
-			{
-				//unwrench
-				ToolUtils.ServerUseToolWithActionMessages(interaction, 1,
-					"You start to wrench the radiation collector...",
-					$"{interaction.Performer.ExpensiveName()} starts to wrench the radiation collector...",
-					"You wrench the radiation collector off the floor.",
-					$"{interaction.Performer.ExpensiveName()} wrenches the radiation collector off the floor.",
-					() =>
-					{
-						isWrenched = false;
-						pushPull.ServerSetPushable(true);
-						ChangePowerState(false);
-					});
-			}
-			else
-			{
-				if (!registerTile.Matrix.MetaTileMap.HasTile(registerTile.WorldPositionServer, LayerType.Base))
-				{
-					Chat.AddExamineMsgFromServer(interaction.Performer, "Radiation collector needs to be on a base floor");
-					return;
-				}
-
-				//wrench
-				ToolUtils.ServerUseToolWithActionMessages(interaction, 1,
-					"You start to wrench the radiation collector...",
-					$"{interaction.Performer.ExpensiveName()} starts to wrench the radiation collector...",
-					"You wrench the radiation collector onto the floor.",
-					$"{interaction.Performer.ExpensiveName()} wrenches the radiation collector onto the floor.",
-					() =>
-					{
-						isWrenched = true;
-						pushPull.ServerSetPushable(false);
-					});
 			}
 		}
 
@@ -167,7 +117,7 @@ namespace Objects.Engineering
 				Chat.AddActionMsgToChat(interaction.Performer, "You turn off the radiation collector",
 					$"{interaction.Performer.ExpensiveName()} turns off the radiation collector");
 			}
-			else if (isWrenched)
+			else if (wrenchSecurable.IsAnchored)
 			{
 				ChangePowerState(true);
 				mainSpriteHandler.AnimateOnce(1);


### PR DESCRIPTION
### Purpose
Fixes #6350 and gets rid of duplicate wrenching code.

### Notes:
Radiation collectors now use the WrenchSecure script. On Pogstation the Worldposition is off from the actual station by a small amount. When wrenching the radiation collectors using their own wrenching code, they would test the tile one up and to the right instead of the tile that they were actually on. By swapping it out for the WrenchSecure script it not only fixes the bug but cleans up code.

I also fixed a point in PogStation where two radiation collectors were spawned on top of each other.

### Changelog:
CL: Cleaned up radiation collector script
