### PR TITLE
Scene load sound error spam fix

### DIFF
--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/GenericHostileAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/GenericHostileAI.cs
@@ -64,7 +64,6 @@ namespace Systems.MobAIs
 			simpleAnimal = GetComponent<SimpleAnimal>();
 
 			if(CustomNetworkManager.IsServer == false) return;
-			_ = PlayRandomSound();
 		}
 
 		protected override void AIStartServer()
@@ -332,6 +331,7 @@ namespace Systems.MobAIs
 			{
 				simpleAnimal.SetDeadState(false);
 			}
+			_ = PlayRandomSound();
 		}
 
 		public override void OnDespawnServer(DespawnInfo info)

--- a/UnityProject/Assets/Scripts/Objects/Engineering/PowerGenerator.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/PowerGenerator.cs
@@ -10,7 +10,7 @@ using Objects.Construction;
 
 namespace Objects.Engineering
 {
-	public class PowerGenerator : NetworkBehaviour, ICheckedInteractable<HandApply>, INodeControl, IExaminable
+	public class PowerGenerator : NetworkBehaviour, ICheckedInteractable<HandApply>, INodeControl, IExaminable, IServerSpawn
 	{
 		[Tooltip("Whether this generator should start running when spawned.")]
 		[SerializeField]
@@ -58,7 +58,7 @@ namespace Objects.Engineering
 			electricalNodeControl = GetComponent<ElectricalNodeControl>();
 		}
 
-		public override void OnStartServer()
+		public void OnSpawnServer(SpawnInfo info)
 		{
 			var itemStorage = GetComponent<ItemStorage>();
 			itemSlot = itemStorage.GetIndexedItemSlot(0);


### PR DESCRIPTION
### Purpose
Fixes the error spam at scene load from xenos and generators trying to play sounds before they were initialized.

### Notes:
just moved the sound to OnSpawnServer()