### PR TITLE
Fixes mobs moving before initializations are finished

### DIFF
--- a/UnityProject/Assets/Scripts/NPC/AI/Friendly/CatAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Friendly/CatAI.cs
@@ -25,16 +25,11 @@ namespace Systems.MobAIs
 
 		protected override void Awake()
 		{
-			base.Awake();
-			ResetBehaviours();
-		}
-
-		public override void OnEnable()
-		{
-			base.OnEnable();
 			mobMask = LayerMask.GetMask( "NPC");
 			coneOfSight = GetComponent<ConeOfSight>();
 			mobAttack = GetComponent<MobMeleeAttack>();
+			base.Awake();
+			ResetBehaviours();
 		}
 
 		protected override void ResetBehaviours()

--- a/UnityProject/Assets/Scripts/NPC/AI/Friendly/ChickenAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Friendly/ChickenAI.cs
@@ -35,7 +35,6 @@ namespace Systems.MobAIs
 		{
 			base.OnSpawnMob();
 			currentLaidEggs = 0;
-			BeginExploring();
 		}
 
 		protected override void DoRandomAction()

--- a/UnityProject/Assets/Scripts/NPC/AI/Friendly/CorgiAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Friendly/CorgiAI.cs
@@ -31,16 +31,11 @@ namespace Systems.MobAIs
 
 		protected override void Awake()
 		{
+			mobMask = LayerMask.GetMask( "NPC");
+			coneOfSight = GetComponent<ConeOfSight>();
 			base.Awake();
 			dogName = mobName.ToLower();
 			ResetBehaviours();
-		}
-
-		public override void OnEnable()
-		{
-			base.OnEnable();
-			mobMask = LayerMask.GetMask( "NPC");
-			coneOfSight = GetComponent<ConeOfSight>();
 		}
 
 		private void SingleBark(GameObject barked = null)

--- a/UnityProject/Assets/Scripts/NPC/AI/Friendly/GenericFriendlyAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Friendly/GenericFriendlyAI.cs
@@ -23,7 +23,6 @@ namespace Systems.MobAIs
 		{
 			base.Awake();
 			simpleAnimal = GetComponent<SimpleAnimal>();
-			BeginExploring();
 		}
 
 		protected override void UpdateMe()
@@ -90,6 +89,7 @@ namespace Systems.MobAIs
 			{
 				simpleAnimal.SetDeadState(false);
 			}
+			BeginExploring();
 		}
 
 		protected override void OnAttackReceived(GameObject damagedBy = null)

--- a/UnityProject/Assets/Scripts/NPC/AI/Friendly/MouseAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Friendly/MouseAI.cs
@@ -115,10 +115,6 @@ namespace Systems.MobAIs
 			Squeak();
 		}
 
-		protected override void OnSpawnMob()
-		{
-			base.OnSpawnMob();
-			BeginExploring();
-		}
+
 	}
 }

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHuggerAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHuggerAI.cs
@@ -14,10 +14,10 @@ namespace Systems.MobAIs
 		//private MobMeleeAction mobMeleeAction;
 		private FaceHugAction faceHugAction;
 
-		public override void OnEnable()
+		protected override void Awake()
 		{
-			base.OnEnable();
 			faceHugAction = gameObject.GetComponent<FaceHugAction>();
+			base.Awake();
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/GenericHostileAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/GenericHostileAI.cs
@@ -54,16 +54,14 @@ namespace Systems.MobAIs
 		protected int fleeChance = 30;
 		protected int attackLastAttackerChance = 80;
 
-		public override void OnEnable()
+		protected override void Awake()
 		{
-			base.OnEnable();
 			hitMask = LayerMask.GetMask( "Players");
 			playersLayer = LayerMask.NameToLayer("Players");
 			mobMeleeAction = GetComponent<MobMeleeAction>();
 			coneOfSight = GetComponent<ConeOfSight>();
 			simpleAnimal = GetComponent<SimpleAnimal>();
-
-			if(CustomNetworkManager.IsServer == false) return;
+			base.Awake();
 		}
 
 		protected override void AIStartServer()

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/GenericHostileAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/GenericHostileAI.cs
@@ -64,7 +64,6 @@ namespace Systems.MobAIs
 			simpleAnimal = GetComponent<SimpleAnimal>();
 
 			if(CustomNetworkManager.IsServer == false) return;
-			_ = PlayRandomSound();
 		}
 
 		protected override void AIStartServer()
@@ -332,6 +331,7 @@ namespace Systems.MobAIs
 			{
 				simpleAnimal.SetDeadState(false);
 			}
+			_ = PlayRandomSound();
 		}
 
 		public override void OnDespawnServer(DespawnInfo info)

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/LarvaeAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/LarvaeAI.cs
@@ -16,9 +16,8 @@ namespace Systems.MobAIs
 
 		protected override void Awake()
 		{
-			base.Awake();
 			simpleAnimal = GetComponent<SimpleAnimal>();
-			BeginExploring();
+			base.Awake();
 		}
 
 		protected override void DoRandomAction()

--- a/UnityProject/Assets/Scripts/NPC/AI/MobAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobAI.cs
@@ -10,7 +10,7 @@ namespace Systems.MobAIs
 	[RequireComponent(typeof(MobFollow))]
 	[RequireComponent(typeof(MobExplore))]
 	[RequireComponent(typeof(MobFlee))]
-	public class MobAI : MonoBehaviour, IServerDespawn
+	public class MobAI : MonoBehaviour, IServerLifecycle
 	{
 		public string mobName;
 		[Tooltip("When the mob is unconscious, how much should the sprite obj " +
@@ -74,29 +74,21 @@ namespace Systems.MobAIs
 			uprightSprites = GetComponent<UprightSprites>();
 		}
 
-		public virtual void OnEnable()
+		public void OnSpawnServer(SpawnInfo info)
 		{
-			//only needed for starting via a map scene through the editor:
-			if (CustomNetworkManager.Instance == null) return;
-
-			if (CustomNetworkManager.Instance._isServer)
-			{
-				UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
-				UpdateManager.Add(PeriodicUpdate, 1f);
-				health.applyDamageEvent += AttackReceivedCoolDown;
-				isServer = true;
-				AIStartServer();
-			}
+			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
+			UpdateManager.Add(PeriodicUpdate, 1f);
+			health.applyDamageEvent += AttackReceivedCoolDown;
+			isServer = true;
+			AIStartServer();
 		}
 
-		public void OnDisable()
+		public virtual void OnDespawnServer(DespawnInfo info)
 		{
-			if (isServer)
-			{
-				UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);
-				UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, PeriodicUpdate);
-				health.applyDamageEvent += AttackReceivedCoolDown;
-			}
+			UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);
+			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, PeriodicUpdate);
+			health.applyDamageEvent += AttackReceivedCoolDown;
+			ResetBehaviours();
 		}
 
 		/// <summary>
@@ -468,9 +460,5 @@ namespace Systems.MobAIs
 		/// <param name="doLerpAnimation"></param>
 		public virtual void ActOnTile(Vector3Int roundToInt, Vector3 dir) { }
 
-		public virtual void OnDespawnServer(DespawnInfo info)
-		{
-			ResetBehaviours();
-		}
 	}
 }

--- a/UnityProject/Assets/Scripts/NPC/AI/MobExplore.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobExplore.cs
@@ -68,9 +68,9 @@ namespace Systems.MobAIs
 			}
 		}
 
-		public override void Start()
+		public override void OnSpawnServer(SpawnInfo info)
 		{
-			base.Start();
+			base.OnSpawnServer(info);
 			eatFoodSound = SingletonSOSounds.Instance.EatFood;
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/Engineering/PowerGenerator.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/PowerGenerator.cs
@@ -10,7 +10,7 @@ using Objects.Construction;
 
 namespace Objects.Engineering
 {
-	public class PowerGenerator : NetworkBehaviour, ICheckedInteractable<HandApply>, INodeControl, IExaminable
+	public class PowerGenerator : NetworkBehaviour, ICheckedInteractable<HandApply>, INodeControl, IExaminable, IServerSpawn
 	{
 		[Tooltip("Whether this generator should start running when spawned.")]
 		[SerializeField]
@@ -58,7 +58,7 @@ namespace Objects.Engineering
 			electricalNodeControl = GetComponent<ElectricalNodeControl>();
 		}
 
-		public override void OnStartServer()
+		public void OnSpawnServer(SpawnInfo info)
 		{
 			var itemStorage = GetComponent<ItemStorage>();
 			itemSlot = itemStorage.GetIndexedItemSlot(0);


### PR DESCRIPTION
### Purpose
Fixes the error spam at scene load from xenos and generators trying to play sounds before they were initialized.

### Notes:
Now chickens in fallstation will stop causing runtimes when bumping the botany windows before roundstart

