### PR TITLE
Fixes a tiny runtime on scene load

### DIFF
--- a/UnityProject/Assets/Prefabs/UI/AdminUI.prefab
+++ b/UnityProject/Assets/Prefabs/UI/AdminUI.prefab
@@ -3324,7 +3324,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -3652,7 +3652,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0.0000090153735}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 7}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &441894731932989149
 MonoBehaviour:
@@ -8394,9 +8394,9 @@ RectTransform:
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: -17, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &3739847912312621565
 MonoBehaviour:
@@ -10472,7 +10472,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &5569598905521721719
 RectTransform:
   m_ObjectHideFlags: 0
@@ -15123,7 +15123,7 @@ PrefabInstance:
     - target: {fileID: 1787747558030348916, guid: 0890619810adc5846b460c976db33c90,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 1787747558045631594, guid: 0890619810adc5846b460c976db33c90,
         type: 3}
@@ -15173,12 +15173,12 @@ PrefabInstance:
     - target: {fileID: 1787747559506639522, guid: 0890619810adc5846b460c976db33c90,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1787747559506639522, guid: 0890619810adc5846b460c976db33c90,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 0.8
       objectReference: {fileID: 0}
     - target: {fileID: 1911000031355105732, guid: 0890619810adc5846b460c976db33c90,
         type: 3}


### PR DESCRIPTION
### Purpose
Fixes a runtime by disabling an admin UI object so its OnEnable isn't triggered on scene load, causing a network message before mirror is ready.

