### PR TITLE
Fixes a roundload runtime with the tilemanager

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/TileManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/TileManager.cs
@@ -74,6 +74,7 @@ public class TileManager : MonoBehaviour, IInitialise
 		else
 		{
 			Destroy(this);
+			return;
 		}
 
 #if UNITY_EDITOR


### PR DESCRIPTION
### Purpose
Fixes the tilemanager continuing the initialization from Awake() if its set to be destroyed.

