### PR TITLE
Adds in some improvements and fixes to emotes

### DIFF
--- a/UnityProject/Assets/Prefabs/Chat/ChatSystem.prefab
+++ b/UnityProject/Assets/Prefabs/Chat/ChatSystem.prefab
@@ -6356,6 +6356,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 95dd82f55e7525544b644da7671f0890, type: 2}
   - {fileID: 11400000, guid: 46f3f1cab09fa684d85d1fe9f0db0b7f, type: 2}
   - {fileID: 11400000, guid: 82ba56953f6e83747a59713094e84e70, type: 2}
+  - {fileID: 11400000, guid: 7d5995929c9a86e4784da6a2cd594b55, type: 2}
 --- !u!1 &8538209952492695680
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
+++ b/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
@@ -683,6 +683,7 @@ MonoBehaviour:
   syncInterval: 0.1
   matrixDebugLogging: 0
   objectType: 2
+  networkedLean: {fileID: -8106636780342977062}
 --- !u!114 &114803877374308862
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8255,7 +8256,7 @@ SpriteRenderer:
   m_SortingLayerID: -902452607
   m_SortingLayer: 22
   m_SortingOrder: 20
-  m_Sprite: {fileID: -4549444404219585148, guid: 2adbceb9cc674484cb9a2c58b41d5493,
+  m_Sprite: {fileID: 7660122581263827943, guid: 2adbceb9cc674484cb9a2c58b41d5493,
     type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0

--- a/UnityProject/Assets/ScriptableObjects/Emotes/Backflip.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/Backflip.asset
@@ -13,6 +13,14 @@ MonoBehaviour:
   m_Name: Backflip
   m_EditorClassIdentifier: 
   emoteName: backflip
+  requiresHands: 0
+  allowEmoteWhileInCrit: 0
+  allowEmoteWhileCrawling: 0
   viewText: does a backflip!
   youText: You do a backflip, Rad!
-  emoteDefaultSounds: []
+  failText: You were unable to preform this action!
+  critViewText: attempts to move their body but fail as they groan in pain.
+  defaultSounds: []
+  maleSounds: []
+  femaleSounds: []
+  pitchRange: {x: 0.7, y: 1}

--- a/UnityProject/Assets/ScriptableObjects/Emotes/Dance.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/Dance.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   emoteName: dance
   requiresHands: 0
-  allowEmoteWhileInCrit: 1
+  allowEmoteWhileInCrit: 0
   allowEmoteWhileCrawling: 1
   viewText: dances!
   youText: You throw some sick moves!

--- a/UnityProject/Assets/ScriptableObjects/Emotes/Dance.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/Dance.asset
@@ -14,9 +14,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   emoteName: dance
   requiresHands: 0
+  allowEmoteWhileInCrit: 1
+  allowEmoteWhileCrawling: 1
   viewText: dances!
   youText: You throw some sick moves!
   failText: You were unable to preform this action!
+  critViewText: tries to cheer themselves up by dancing, but they're too weak to
+    dance and are hurt.
   defaultSounds: []
   maleSounds: []
   femaleSounds: []

--- a/UnityProject/Assets/ScriptableObjects/Emotes/Surrender.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/Surrender.asset
@@ -14,11 +14,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   emoteName: surrender
   requiresHands: 0
+  allowEmoteWhileInCrit: 0
+  allowEmoteWhileCrawling: 0
   viewText: raises their arms up as they surrender then lay down on the ground.
   youText: You've surrender! Better keep those hands above your head while you're
     laying down.
   failText: You forgot how to get down!
+  critViewText: are unable to do anything in their condition! They've surrender.
   defaultSounds: []
   maleSounds: []
   femaleSounds: []
-  audioToUse: []
+  pitchRange: {x: 0.7, y: 1}

--- a/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/clap.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/clap.asset
@@ -17,8 +17,9 @@ MonoBehaviour:
   viewText: claps!
   youText: You clap your hands together!
   failText: You do not have free hands to preform this action!
+  critViewText: claps!
+  allowEmoteWhileInCrit: 1
   defaultSounds: []
   maleSounds: []
   femaleSounds: []
   pitchRange: {x: 0.7, y: 1}
-  audioToUse: []

--- a/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/cross.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/cross.asset
@@ -17,7 +17,9 @@ MonoBehaviour:
   viewText: crosses their arms.
   youText: You cross your arms.
   failText: You cannot do this action because your arms cannot make this motion!
+  critViewText: crosses their arms.
+  allowEmoteWhileInCrit: 1
   defaultSounds: []
   maleSounds: []
   femaleSounds: []
-  audioToUse: []
+  pitchRange: {x: 0.7, y: 1}

--- a/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/drool.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/drool.asset
@@ -13,6 +13,13 @@ MonoBehaviour:
   m_Name: drool
   m_EditorClassIdentifier: 
   emoteName: drool
+  requiresHands: 0
   viewText: drools.
   youText: You drool.
-  emoteDefaultSounds: []
+  failText: You were unable to preform this action!
+  critViewText: screams in pain!
+  allowEmoteWhileInCrit: 1
+  defaultSounds: []
+  maleSounds: []
+  femaleSounds: []
+  pitchRange: {x: 0.7, y: 1}

--- a/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/frown.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/frown.asset
@@ -13,6 +13,13 @@ MonoBehaviour:
   m_Name: frown
   m_EditorClassIdentifier: 
   emoteName: frown
+  requiresHands: 0
   viewText: frowns.
   youText: You frown.
-  emoteDefaultSounds: []
+  failText: You were unable to preform this action!
+  critViewText: screams in pain!
+  allowEmoteWhileInCrit: 1
+  defaultSounds: []
+  maleSounds: []
+  femaleSounds: []
+  pitchRange: {x: 0.7, y: 1}

--- a/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/grimace.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/grimace.asset
@@ -13,6 +13,13 @@ MonoBehaviour:
   m_Name: grimace
   m_EditorClassIdentifier: 
   emoteName: grimace
+  requiresHands: 0
   viewText: grimaces.
   youText: You grimace.
-  emoteDefaultSounds: []
+  failText: You were unable to preform this action!
+  critViewText: screams in pain!
+  allowEmoteWhileInCrit: 1
+  defaultSounds: []
+  maleSounds: []
+  femaleSounds: []
+  pitchRange: {x: 0.7, y: 1}

--- a/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/jump.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/jump.asset
@@ -17,7 +17,9 @@ MonoBehaviour:
   viewText: jumps!
   youText: 1..2..3.. jump!
   failText: You cannot Jump!
+  critViewText: tries to jump! but fails and just groans in pain.
+  allowEmoteWhileInCrit: 0
   defaultSounds: []
   maleSounds: []
   femaleSounds: []
-  audioToUse: []
+  pitchRange: {x: 0.7, y: 1}

--- a/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/pout.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/pout.asset
@@ -13,6 +13,13 @@ MonoBehaviour:
   m_Name: pout
   m_EditorClassIdentifier: 
   emoteName: pout
+  requiresHands: 0
   viewText: pouts.
   youText: You pout..
-  emoteDefaultSounds: []
+  failText: You were unable to preform this action!
+  critViewText: screams in pain!
+  allowEmoteWhileInCrit: 1
+  defaultSounds: []
+  maleSounds: []
+  femaleSounds: []
+  pitchRange: {x: 0.7, y: 1}

--- a/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/shake.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/shake.asset
@@ -13,6 +13,13 @@ MonoBehaviour:
   m_Name: shake
   m_EditorClassIdentifier: 
   emoteName: shake
+  requiresHands: 0
   viewText: shakes their head.
   youText: You shake your head.
-  emoteDefaultSounds: []
+  failText: You were unable to preform this action!
+  critViewText: screams in pain!
+  allowEmoteWhileInCrit: 1
+  defaultSounds: []
+  maleSounds: []
+  femaleSounds: []
+  pitchRange: {x: 0.7, y: 1}

--- a/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/sit.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/sit.asset
@@ -13,6 +13,13 @@ MonoBehaviour:
   m_Name: sit
   m_EditorClassIdentifier: 
   emoteName: sit
+  requiresHands: 0
   viewText: sits down.
   youText: You sit down.
-  emoteDefaultSounds: []
+  failText: You were unable to preform this action!
+  critViewText: screams in pain!
+  allowEmoteWhileInCrit: 1
+  defaultSounds: []
+  maleSounds: []
+  femaleSounds: []
+  pitchRange: {x: 0.7, y: 1}

--- a/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/smile.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/smile.asset
@@ -13,6 +13,13 @@ MonoBehaviour:
   m_Name: smile
   m_EditorClassIdentifier: 
   emoteName: smile
+  requiresHands: 0
   viewText: smiles.
   youText: You let out a smile.
-  emoteDefaultSounds: []
+  failText: You were unable to preform this action!
+  critViewText: lets out a weak smile.
+  allowEmoteWhileInCrit: 0
+  defaultSounds: []
+  maleSounds: []
+  femaleSounds: []
+  pitchRange: {x: 0.7, y: 1}

--- a/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/smug.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/smug.asset
@@ -13,6 +13,13 @@ MonoBehaviour:
   m_Name: smug
   m_EditorClassIdentifier: 
   emoteName: smug
+  requiresHands: 0
   viewText: grins smugly.
   youText: Smugness has made your face punchable to some people.
-  emoteDefaultSounds: []
+  failText: You were unable to preform this action!
+  critViewText: screams in pain!
+  allowEmoteWhileInCrit: 1
+  defaultSounds: []
+  maleSounds: []
+  femaleSounds: []
+  pitchRange: {x: 0.7, y: 1}

--- a/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/snap.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/snap.asset
@@ -17,7 +17,9 @@ MonoBehaviour:
   viewText: snaps their fingers!
   youText: snap your fingers
   failText: You cannot snap any fingers!
+  critViewText: screams in pain!
+  allowEmoteWhileInCrit: 1
   defaultSounds: []
   maleSounds: []
   femaleSounds: []
-  audioToUse: []
+  pitchRange: {x: 0.7, y: 1}

--- a/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/stare.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/stare.asset
@@ -13,6 +13,13 @@ MonoBehaviour:
   m_Name: stare
   m_EditorClassIdentifier: 
   emoteName: stare
+  requiresHands: 0
   viewText: stares into nothingness.
   youText: You stare at nothing.
-  emoteDefaultSounds: []
+  failText: You were unable to preform this action!
+  critViewText: screams in pain!
+  allowEmoteWhileInCrit: 1
+  defaultSounds: []
+  maleSounds: []
+  femaleSounds: []
+  pitchRange: {x: 0.7, y: 1}

--- a/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/stretch.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/stretch.asset
@@ -13,6 +13,13 @@ MonoBehaviour:
   m_Name: stretch
   m_EditorClassIdentifier: 
   emoteName: stretch
+  requiresHands: 0
   viewText: stretches their arms.
   youText: You stretch out.
-  emoteDefaultSounds: []
+  failText: You were unable to preform this action!
+  critViewText: screams in pain!
+  allowEmoteWhileInCrit: 1
+  defaultSounds: []
+  maleSounds: []
+  femaleSounds: []
+  pitchRange: {x: 0.7, y: 1}

--- a/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/sulk.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/sulk.asset
@@ -13,6 +13,13 @@ MonoBehaviour:
   m_Name: sulk
   m_EditorClassIdentifier: 
   emoteName: sulk
+  requiresHands: 0
   viewText: sulks down sadly..
   youText: You're sulking.
-  emoteDefaultSounds: []
+  failText: You were unable to preform this action!
+  critViewText: screams in pain!
+  allowEmoteWhileInCrit: 1
+  defaultSounds: []
+  maleSounds: []
+  femaleSounds: []
+  pitchRange: {x: 0.7, y: 1}

--- a/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/surrenderSimple.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/surrenderSimple.asset
@@ -17,7 +17,9 @@ MonoBehaviour:
   viewText: surrenders as they put their hands up in the air!
   youText: Stay calm! You've put your hands up in the air and surrendered.
   failText: You were unable to preform this action!
+  critViewText: screams in pain!
+  allowEmoteWhileInCrit: 1
   defaultSounds: []
   maleSounds: []
   femaleSounds: []
-  audioToUse: []
+  pitchRange: {x: 0.7, y: 1}

--- a/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/sway.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/sway.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   viewText: sways dizzily.
   youText: You sway dizzily.
   failText: You were unable to preform this action!
+  critViewText: screams in pain!
+  allowEmoteWhileInCrit: 1
   defaultSounds: []
   maleSounds: []
   femaleSounds: []

--- a/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/tremble.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/tremble.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   viewText: trembles in fear!
   youText: Fear overcomes you.
   failText: You were unable to preform this action!
+  critViewText: screams in pain!
+  allowEmoteWhileInCrit: 1
   defaultSounds: []
   maleSounds: []
   femaleSounds: []

--- a/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/twitch.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/basicEmotes/twitch.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   viewText: twitches violently.
   youText: You twitch violently.
   failText: You were unable to preform this action!
+  critViewText: screams in pain!
+  allowEmoteWhileInCrit: 1
   defaultSounds: []
   maleSounds: []
   femaleSounds: []

--- a/UnityProject/Assets/Scripts/Player/EmoteScripts/Backflip.cs
+++ b/UnityProject/Assets/Scripts/Player/EmoteScripts/Backflip.cs
@@ -8,7 +8,7 @@ namespace Player.EmoteScripts
 	{
 		public override void Do(GameObject player)
 		{
-			if (CheckPlayerCritState(player) == false && CheckIfPlayerIsCrawling(player) == true)
+			if (CheckPlayerCritState(player) == false && CheckIfPlayerIsCrawling(player) == false)
 			{
 				var manager = player.GetComponent<PlayerEffectsManager>();
 				manager.RotatePlayer(1, 0.2f, 180, false);

--- a/UnityProject/Assets/Scripts/Player/EmoteScripts/Backflip.cs
+++ b/UnityProject/Assets/Scripts/Player/EmoteScripts/Backflip.cs
@@ -8,7 +8,7 @@ namespace Player.EmoteScripts
 	{
 		public override void Do(GameObject player)
 		{
-			if (CheckPlayerCritState(player) == false)
+			if (CheckPlayerCritState(player) == false && CheckIfPlayerIsCrawling(player) == true)
 			{
 				var manager = player.GetComponent<PlayerEffectsManager>();
 				manager.RotatePlayer(1, 0.2f, 180, false);

--- a/UnityProject/Assets/Scripts/Player/EmoteScripts/Backflip.cs
+++ b/UnityProject/Assets/Scripts/Player/EmoteScripts/Backflip.cs
@@ -8,14 +8,16 @@ namespace Player.EmoteScripts
 	{
 		public override void Do(GameObject player)
 		{
-			var manager = player.GetComponent<PlayerEffectsManager>();
-			if(manager == null)
+			if (CheckPlayerCritState(player) == false)
 			{
-				Logger.LogError("[EmoteSO/Backflip] - Could not find a rotate effect on the player!");
-				return;
+				var manager = player.GetComponent<PlayerEffectsManager>();
+				manager.RotatePlayer(1, 0.2f, 180, false);
+				base.Do(player);
 			}
-			manager.RotatePlayer(1, 0.2f, 180, false);
-			base.Do(player);
+			else
+			{
+				base.Do(player);
+			}
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Player/EmoteScripts/Dance.cs
+++ b/UnityProject/Assets/Scripts/Player/EmoteScripts/Dance.cs
@@ -9,7 +9,8 @@ namespace Player.EmoteScripts
 	{
 		public override void Do(GameObject player)
 		{
-			if(CheckPlayerCritState(player) == true)
+			Debug.Log(CheckPlayerCritState(player));
+			if (allowEmoteWhileInCrit == false && CheckPlayerCritState(player) == false)
 			{
 				//Hacky way to run a coroutine inside an SO
 				var something = player.GetComponent<PlayerScript>();
@@ -28,7 +29,7 @@ namespace Player.EmoteScripts
 
 			if (move.allowInput && !move.IsBuckled)
 			{
-				base.Do(player);
+				Chat.AddActionMsgToChat(player, $"{youText}", $"{player.ExpensiveName()} {viewText}.");
 				directional.FaceDirection(Orientation.Up);
 				yield return WaitFor.Seconds(Random.Range(0.1f, 0.5f));
 				directional.FaceDirection(Orientation.Left);

--- a/UnityProject/Assets/Scripts/Player/EmoteScripts/Dance.cs
+++ b/UnityProject/Assets/Scripts/Player/EmoteScripts/Dance.cs
@@ -9,9 +9,16 @@ namespace Player.EmoteScripts
 	{
 		public override void Do(GameObject player)
 		{
-			//Hacky way to run a coroutine inside an SO
-			var something = player.GetComponent<PlayerScript>();
-			something.StartCoroutine(PerformDance(player));
+			if(CheckPlayerCritState(player) == true)
+			{
+				//Hacky way to run a coroutine inside an SO
+				var something = player.GetComponent<PlayerScript>();
+				something.StartCoroutine(PerformDance(player));
+			}
+			else
+			{
+				base.Do(player);
+			}
 		}
 
 		private IEnumerator PerformDance(GameObject player)

--- a/UnityProject/Assets/Scripts/Player/EmoteScripts/Dance.cs
+++ b/UnityProject/Assets/Scripts/Player/EmoteScripts/Dance.cs
@@ -9,7 +9,6 @@ namespace Player.EmoteScripts
 	{
 		public override void Do(GameObject player)
 		{
-			Debug.Log(CheckPlayerCritState(player));
 			if (allowEmoteWhileInCrit == false && CheckPlayerCritState(player) == false)
 			{
 				//Hacky way to run a coroutine inside an SO

--- a/UnityProject/Assets/Scripts/Player/EmoteScripts/Surrender.cs
+++ b/UnityProject/Assets/Scripts/Player/EmoteScripts/Surrender.cs
@@ -6,15 +6,40 @@ namespace Player.EmoteScripts
 	[CreateAssetMenu(fileName = "Emote", menuName = "ScriptableObjects/RP/Emotes/Surrender")]
 	public class Surrender : EmoteSO
 	{
+		private RegisterPlayer registerPlayer;
+
 		public override void Do(GameObject player)
 		{
-			if(player.GetComponent<RegisterPlayer>() == null)
+			registerPlayer = player.GetComponent<RegisterPlayer>();
+
+			if (registerPlayer == null)
 			{
 				Logger.LogError("RegisterPlayer could not be found!");
 				Chat.AddActionMsgToChat(player, $"{failText}", "");
 				return;
 			}
-			if(CheckHandState(player) == false)
+			SurrenderLogic(player);
+		}
+
+		private void SurrenderLogic(GameObject player)
+		{
+			bool isCrawling = CheckIfPlayerIsCrawling(player);
+			if (CheckPlayerCritState(player) == false && isCrawling == false)
+			{
+				LayDown(player);
+			}
+			if(CheckPlayerCritState(player) == true)
+			{
+				FailText(player, FailType.Critical);
+			}
+			if(isCrawling == true)
+			{
+				base.Do(player);
+			}
+		}
+		private void LayDown(GameObject player)
+		{
+			if (CheckHandState(player) == false)
 			{
 				Chat.AddActionMsgToChat(player, "You surrender in defeat then lay faced down on the ground.", $"{player.ExpensiveName()} surrenders in defeat then lay faced down on the ground.");
 			}
@@ -22,7 +47,8 @@ namespace Player.EmoteScripts
 			{
 				base.Do(player);
 			}
-			player.GetComponent<RegisterPlayer>().ServerSetIsStanding(false);
+
+			registerPlayer.ServerSetIsStanding(false);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
@@ -60,7 +60,7 @@ namespace ScriptableObjects.RP
 
 		public virtual void Do(GameObject player)
 		{
-			if(allowEmoteWhileCrawling == false && CheckIfPlayerIsCrawling(player))
+			if(allowEmoteWhileCrawling == false && CheckIfPlayerIsCrawling(player) == true)
 			{
 				FailText(player, 0);
 				return;

--- a/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
@@ -58,21 +58,27 @@ namespace ScriptableObjects.RP
 		[SerializeField]
 		private Vector2 pitchRange = new Vector2(0.7f, 1f);
 
+		protected enum FailType
+		{
+			Normal,
+			Critical
+		}
+
 		public virtual void Do(GameObject player)
 		{
-			if(allowEmoteWhileCrawling == false && CheckIfPlayerIsCrawling(player) == true)
-			{
-				FailText(player, 0);
-				return;
-			}
 			if (allowEmoteWhileInCrit == false && CheckPlayerCritState(player) == true)
 			{
-				FailText(player, 1);
+				FailText(player, FailType.Critical);
+				return;
+			}
+			if (allowEmoteWhileCrawling == false && CheckIfPlayerIsCrawling(player) == true)
+			{
+				FailText(player, FailType.Normal);
 				return;
 			}
 			if (requiresHands && CheckHandState(player) == false)
 			{
-				FailText(player, 0);
+				FailText(player, FailType.Normal);
 				return;
 			}
 			else
@@ -86,15 +92,15 @@ namespace ScriptableObjects.RP
 		/// Use this instead of rewriting Chat.AddActionMsgToChat() when adding text to a failed conditon.
 		/// </summary>
 		/// <param name="player">The orignator</param>
-		/// <param name="type">0: failText, 1: critViewText</param>
-		protected void FailText(GameObject player, int type)
+		/// <param name="type">Normal : Displays failText string. Critical: Displays critViewText string.</param>
+		protected void FailText(GameObject player, FailType type)
 		{
 			switch (type)
 			{
-				case 0:
+				case FailType.Normal:
 					Chat.AddActionMsgToChat(player, $"{failText}", $"");
 					break;
-				case 1:
+				case FailType.Critical:
 					Chat.AddActionMsgToChat(player, $"{player.ExpensiveName()} {critViewText}.", $"{player.ExpensiveName()} {critViewText}.");
 					break;
 			}
@@ -157,7 +163,7 @@ namespace ScriptableObjects.RP
 		protected bool CheckPlayerCritState(GameObject player)
 		{
 			var health = player.GetComponent<LivingHealthMasterBase>();
-			if (health == null || health.IsCrit)
+			if (health == null || health.IsCrit == true || health.IsSoftCrit == true)
 			{
 				return true;
 			}

--- a/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
@@ -76,16 +76,14 @@ namespace ScriptableObjects.RP
 				FailText(player, FailType.Normal);
 				return;
 			}
-			if (requiresHands && CheckHandState(player) == false)
+			else if (requiresHands && CheckHandState(player) == false)
 			{
 				FailText(player, FailType.Normal);
 				return;
 			}
-			else
-			{
-				Chat.AddActionMsgToChat(player, $"{youText}", $"{player.ExpensiveName()} {viewText}.");
-				PlayAudio(defaultSounds, player);
-			}
+
+			Chat.AddActionMsgToChat(player, $"{youText}", $"{player.ExpensiveName()} {viewText}.");
+			PlayAudio(defaultSounds, player);
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/ScriptableObjects/RP/GenderedEmote.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/RP/GenderedEmote.cs
@@ -6,9 +6,6 @@ namespace ScriptableObjects.RP
 	[CreateAssetMenu(fileName = "Emote", menuName = "ScriptableObjects/RP/Emotes/GenderedEmote")]
 	public class GenderedEmote : EmoteSO
 	{
-		[SerializeField]
-		private string critViewText = "screams in pain!";
-
 		private string viewTextFinal;
 
 		public override void Do(GameObject player)
@@ -20,14 +17,9 @@ namespace ScriptableObjects.RP
 
 		private void HealthCheck(GameObject player)
 		{
-			var health = player.GetComponent<LivingHealthMasterBase>();
+			bool playerCondition = CheckPlayerCritState(player);
 
-			if (health == null || health.IsDead)
-			{
-				return;
-			}
-
-			viewTextFinal = health.IsCrit ? critViewText : viewText;
+			viewTextFinal = playerCondition ? critViewText : viewText;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
@@ -47,6 +47,7 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 	public PlayerScript PlayerScript => playerScript;
 	private Directional playerDirectional;
 	private UprightSprites uprightSprites;
+	[SerializeField] private Util.NetworkedLeanTween networkedLean;
 
 	/// <summary>
 	/// Returns whether this player is blocking other players from occupying the space, using the
@@ -176,11 +177,11 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 		this.isLayingDown = isDown;
 		if (isDown)
 		{
+			networkedLean.RpcRotateGameObject(new Vector3(0, 0, -90), 0.15f);
 			//uprightSprites.ExtraRotation = Quaternion.Euler(0, 0, -90);
 			//Change sprite layer
 			foreach (SpriteRenderer spriteRenderer in this.GetComponentsInChildren<SpriteRenderer>())
 			{
-				LeanTween.rotate(spriteRenderer.gameObject, new Vector3(0, 0, -90), 0.15f);
 				spriteRenderer.sortingLayerName = "Bodies";
 			}
 			playerScript.PlayerSync.SpeedServer = playerScript.playerMove.CrawlSpeed;
@@ -189,11 +190,11 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 		}
 		else
 		{
+			networkedLean.RpcRotateGameObject(new Vector3(0, 0, 0), 0.19f);
 			//uprightSprites.ExtraRotation = Quaternion.identity;
 			//back to original layer
 			foreach (SpriteRenderer spriteRenderer in this.GetComponentsInChildren<SpriteRenderer>())
 			{
-				LeanTween.rotate(spriteRenderer.gameObject, new Vector3(0, 0, 0), 0.19f);
 				spriteRenderer.sortingLayerName = "Players";
 			}
 			playerDirectional.LockDirection = false;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
@@ -176,11 +176,11 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 		this.isLayingDown = isDown;
 		if (isDown)
 		{
-			LeanTween.rotate(uprightSprites.gameObject, new Vector3(0, 0, -90), 0.15f);
 			//uprightSprites.ExtraRotation = Quaternion.Euler(0, 0, -90);
 			//Change sprite layer
 			foreach (SpriteRenderer spriteRenderer in this.GetComponentsInChildren<SpriteRenderer>())
 			{
+				LeanTween.rotate(spriteRenderer.gameObject, new Vector3(0, 0, -90), 0.15f);
 				spriteRenderer.sortingLayerName = "Bodies";
 			}
 			playerScript.PlayerSync.SpeedServer = playerScript.playerMove.CrawlSpeed;
@@ -189,11 +189,11 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 		}
 		else
 		{
-			LeanTween.rotate(uprightSprites.gameObject, new Vector3(0, 0, 0), 0.19f);
 			//uprightSprites.ExtraRotation = Quaternion.identity;
 			//back to original layer
 			foreach (SpriteRenderer spriteRenderer in this.GetComponentsInChildren<SpriteRenderer>())
 			{
+				LeanTween.rotate(spriteRenderer.gameObject, new Vector3(0, 0, 0), 0.19f);
 				spriteRenderer.sortingLayerName = "Players";
 			}
 			playerDirectional.LockDirection = false;

--- a/UnityProject/Assets/Scripts/UI/Core/ChatBubble/ActionText.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/ChatBubble/ActionText.cs
@@ -66,6 +66,7 @@ public class ActionText : MonoBehaviour
 
 	public void Update()
 	{
+		transform.rotation = Quaternion.AngleAxis(0, new Vector3(0,0,0));
 		if (DoFade)
 		{
 			timeToFade += Time.deltaTime;

--- a/UnityProject/Assets/Scripts/UI/Core/ChatBubble/ActionText.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/ChatBubble/ActionText.cs
@@ -66,7 +66,6 @@ public class ActionText : MonoBehaviour
 
 	public void Update()
 	{
-		transform.rotation = Quaternion.AngleAxis(0, new Vector3(0,0,0));
 		if (DoFade)
 		{
 			timeToFade += Time.deltaTime;


### PR DESCRIPTION
### Purpose

Part of #6276 and should two issues in fix an issue in #6195

Adds in an improvement I've suggested me and gillies a while ago to make crits check available in the base EmoteSO script + added in a check for some emotes to avoid them from doing backflips while crawling + fixes an issue where the player becomes upside down while surrendering and crawling at the same time.

### Notes:

Requires testing by other people on more than one client, pls.

### Changelog:

CL: Fixed an issue where players become upside down when surrendering.
CL: You will no longer be able to do some emotes like backflips while crawling.
CL: Critical condition texts are no longer exclusive to gendered emotes, all emotes use them now.
CL: ActionText will no longer get rotated.