### PR TITLE
Fixes editor only spawn api related runtimes 

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Lifecycle/Spawn.cs
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/Spawn.cs
@@ -54,6 +54,7 @@ public static class Spawn
 	{
 		if (objectPool == null)
 		{
+			CustomNetworkManager.Instance.SetSpawnableList();
 			//only can spawn objects that are networked
 			var spawnablePrefabs = CustomNetworkManager.Instance.spawnPrefabs
 				.Where(IsPrefab)


### PR DESCRIPTION
### Purpose
Fixes spawn behavior needing the networkmanager prefab to have the list of prefabs up to date by manually updating it, avoiding important runtimes on load.

### Notes:
This only affects the editor, the list is updated when a build is made and a build itself cannot run that code due to an `#if UNITY_EDITOR` check