### PR TITLE
Fixes UI icons staying open and crawl text

### DIFF
--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/ControlIntent.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/ControlIntent.cs
@@ -22,7 +22,8 @@ namespace UI
 		[SerializeField] private GameObject runWalkBorder = default;
 		[SerializeField] private GameObject helpWindow = default;
 		[Header("Message settings")]
-		[SerializeField] private string restMessage = "You try to lie down.";
+		[SerializeField] private string startRestMessage = "You try to lie down.";
+		[SerializeField] private string endRestMessage = "You try to stand up.";
 		[SerializeField] private string startRunningMessage = "You start running";
 		[SerializeField] private string startWalkingMessage = "You start walking";
 
@@ -55,7 +56,7 @@ namespace UI
 			Logger.Log("OnClickRest", Category.UserInput);
 			_ = SoundManager.Play(SingletonSOSounds.Instance.Click01);
 			clientResting = !clientResting;
-			Chat.AddExamineMsgToClient(restMessage);
+			Chat.AddExamineMsgToClient(clientResting ? startRestMessage : endRestMessage);
 			RequestRest.Send(clientResting);
 			// TODO: trigger rest intent
 		}

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemSlot.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemSlot.cs
@@ -256,41 +256,32 @@ namespace UI
 		{
 			PlayerScript lps = PlayerManager.LocalPlayerScript;
 			if (lps == false) return;
-
-			image.ClearAll();
-			if (amountText)
-			{
-				amountText.enabled = false;
-			}
-			if (placeholderImage)
-			{
-				placeholderImage.color = Color.white;
-			}
-
-			if (MoreInventoryImage)
-			{
-				HasSubInventory.itemStorage = null;
-				MoreInventoryImage.enabled = false;
-			}
+			ClearImage();
 		}
 
 		public void Reset()
+		{
+			ClearImage();
+			ControlTabs.CheckTabClose();
+		}
+
+		private void ClearImage()
 		{
 			image.ClearAll();
 			if (amountText)
 			{
 				amountText.enabled = false;
 			}
-			if (placeholderImage)
+			if (placeholderImage && hidden == false)
 			{
 				placeholderImage.color = Color.white;
 			}
+
 			if (MoreInventoryImage)
 			{
 				HasSubInventory.itemStorage = null;
 				MoreInventoryImage.enabled = false;
 			}
-			ControlTabs.CheckTabClose();
 		}
 
 		/// <summary>


### PR DESCRIPTION
### Purpose
Fixes #6088 and adds crawl text (One of the health rework issues).

### Notes:
In UI_ItemSlot.cs, I've moved some duplicate code into it's own function and added a test that checks if the item slot is hidden or not before displaying the placeholderImage, which caused those 'phantom icons' to appear.

### Changelog:
CL: Fixed UI icons staying open
CL: Added standing up text