### PR TITLE
MetaTileMap null fix

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
@@ -23,7 +23,7 @@ public class Matrix : MonoBehaviour
 	public List<TilemapDamage> TilemapsDamage => tilemapsDamage;
 
 	private MetaTileMap metaTileMap;
-	public MetaTileMap MetaTileMap => metaTileMap ? metaTileMap : metaTileMap = GetComponent<MetaTileMap>();
+	public MetaTileMap MetaTileMap => metaTileMap;
 
 	private TileList serverObjects;
 
@@ -89,6 +89,12 @@ public class Matrix : MonoBehaviour
 
 	private void Awake()
 	{
+		metaTileMap = GetComponent<MetaTileMap>();
+		if (metaTileMap == null)
+		{
+			Logger.LogError($"MetaTileMap was null on {gameObject.name}");
+		}
+
 		initialOffset = Vector3Int.CeilToInt(gameObject.transform.position);
 		reactionManager = GetComponent<ReactionManager>();
 		metaDataLayer = GetComponent<MetaDataLayer>();

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
@@ -562,6 +562,12 @@ public class Matrix : MonoBehaviour
 	private void OnDrawGizmos()
 	{
 		Gizmos.color = Color;
+
+		if (metaTileMap == null)
+		{
+			metaTileMap = GetComponent<MetaTileMap>();
+		}
+
 		BoundsInt bounds = MetaTileMap.GetWorldBounds();
 		DebugGizmoUtils.DrawText(gameObject.name, bounds.max, 11, 5);
 		DebugGizmoUtils.DrawRect(bounds);


### PR DESCRIPTION
Hopefully fixes this error being spammed on staging:

`NullReferenceException
  at (wrapper managed-to-native) UnityEngine.Component.GetComponentFastPath(UnityEngine.Component,System.Type,intptr)
  at UnityEngine.Component.GetComponent[T] () [0x00009] in /home/bokken/buildslave/unity/build/Runtime/Export/Scripting/Component.bindings.cs:42 
  at Matrix.get_MetaTileMap () [0x00000] in /root/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs:26 
  at Systems.Explosions.ExplosionNode.Process () [0x00030] in /root/UnityProject/Assets/Scripts/Systems/Explosions/ExplosionNode.cs:30 
  at Systems.Explosions.ExplosionManager.Step () [0x00069] in /root/UnityProject/Assets/Scripts/Systems/Explosions/ExplosionManager.cs:35 
  at UpdateManager.ProcessDelayUpdate () [0x00061] in /root/UnityProject/Assets/Scripts/Managers/UpdateManager/UpdateManager.cs:283 
  at UpdateManager.Update () [0x0009b] in /root/UnityProject/Assets/Scripts/Managers/UpdateManager/UpdateManager.cs:263 `
