### PR TITLE
Fixed UI Icons remaining after death

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ---
 
 
+* 2021/4/25: Fixes a bug that broke the character creator when creating new characters. by [MaxIsJoe](https://github.com/MaxIsJoe) in PR #[6413](https://github.com/unitystation/unitystation/pull/6413)
 * 2021/4/24: Fixed a bug where camera effects stay on even after respawning. by [MaxIsJoe](https://github.com/MaxIsJoe) in PR #[6411](https://github.com/unitystation/unitystation/pull/6411)
 * 2021/4/24: ActionText will no longer get rotated. by [MaxIsJoe](https://github.com/MaxIsJoe) in PR #[6387](https://github.com/unitystation/unitystation/pull/6387)
 * 2021/4/24: Critical condition texts are no longer exclusive to gendered emotes, all emotes use them now. by [MaxIsJoe](https://github.com/MaxIsJoe) in PR #[6387](https://github.com/unitystation/unitystation/pull/6387)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ---
 
 
+* 2021/4/24: Fixed a bug where camera effects stay on even after respawning. by [MaxIsJoe](https://github.com/MaxIsJoe) in PR #[6411](https://github.com/unitystation/unitystation/pull/6411)
 * 2021/4/24: ActionText will no longer get rotated. by [MaxIsJoe](https://github.com/MaxIsJoe) in PR #[6387](https://github.com/unitystation/unitystation/pull/6387)
 * 2021/4/24: Critical condition texts are no longer exclusive to gendered emotes, all emotes use them now. by [MaxIsJoe](https://github.com/MaxIsJoe) in PR #[6387](https://github.com/unitystation/unitystation/pull/6387)
 * 2021/4/24: You will no longer be able to do some emotes like backflips while crawling. by [MaxIsJoe](https://github.com/MaxIsJoe) in PR #[6387](https://github.com/unitystation/unitystation/pull/6387)

--- a/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/Buckled.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/Buckled.asset
@@ -12,6 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 175001bada3c3ba47945b92e3bfa2bd2, type: 3}
   m_Name: Buckled
   m_EditorClassIdentifier: 
+  actionType: 0
+  activeSpriteIndex: 1
   callOnClient: 1
   callOnServer: 0
   actionName: Buckled
@@ -21,4 +23,9 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 31baad5011b44aa45b41f8d3da30287e, type: 2}
   Backgrounds: []
   PreventBeingControlledBy: 
-  DisableOnEvent: 
+  DisableOnEvent: 0b000000
+  isAimable: 0
+  useCustomCursor: 0
+  cursorTexture: {fileID: 0}
+  cursorOffsetType: 0
+  cursorOffset: {x: 0, y: 0}

--- a/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/RestraintOverlay.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/RestraintOverlay.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
   description: You're handcuffed and can't act. If anyone drags you, you won't be
     able to move. Click the alert to free yourself.
   Sprites:
-  - {fileID: 0}
+  - {fileID: 11400000, guid: 1ba9077170f8a884aa20c72a9e781c3d, type: 2}
   Backgrounds: []
   PreventBeingControlledBy: 
   DisableOnEvent: 0b000000

--- a/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/RestraintOverlay.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/RestraintOverlay.asset
@@ -12,13 +12,20 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 175001bada3c3ba47945b92e3bfa2bd2, type: 3}
   m_Name: RestraintOverlay
   m_EditorClassIdentifier: 
+  actionType: 0
+  activeSpriteIndex: 1
   callOnClient: 1
   callOnServer: 0
   actionName: Handcuffed
   description: You're handcuffed and can't act. If anyone drags you, you won't be
     able to move. Click the alert to free yourself.
   Sprites:
-  - {fileID: 11400000, guid: 0c3c1db3702490542a12d241056cb8ed, type: 2}
+  - {fileID: 0}
   Backgrounds: []
   PreventBeingControlledBy: 
-  DisableOnEvent: 
+  DisableOnEvent: 0b000000
+  isAimable: 0
+  useCustomCursor: 0
+  cursorTexture: {fileID: 0}
+  cursorOffsetType: 0
+  cursorOffset: {x: 0, y: 0}

--- a/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/ToggleLight.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/ToggleLight.asset
@@ -12,6 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 175001bada3c3ba47945b92e3bfa2bd2, type: 3}
   m_Name: ToggleLight
   m_EditorClassIdentifier: 
+  actionType: 0
+  activeSpriteIndex: 1
   callOnClient: 1
   callOnServer: 1
   actionName: Toggle Light
@@ -19,4 +21,9 @@ MonoBehaviour:
   Sprites: []
   Backgrounds: []
   PreventBeingControlledBy: 
-  DisableOnEvent: 
+  DisableOnEvent: 0b000000
+  isAimable: 0
+  useCustomCursor: 0
+  cursorTexture: {fileID: 0}
+  cursorOffsetType: 0
+  cursorOffset: {x: 0, y: 0}

--- a/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/ToggleMagboots.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/ToggleMagboots.asset
@@ -12,6 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 175001bada3c3ba47945b92e3bfa2bd2, type: 3}
   m_Name: ToggleMagboots
   m_EditorClassIdentifier: 
+  actionType: 0
+  activeSpriteIndex: 1
   callOnClient: 1
   callOnServer: 1
   actionName: Toggle Magboots
@@ -19,4 +21,9 @@ MonoBehaviour:
   Sprites: []
   Backgrounds: []
   PreventBeingControlledBy: 
-  DisableOnEvent: 
+  DisableOnEvent: 0b000000
+  isAimable: 0
+  useCustomCursor: 0
+  cursorTexture: {fileID: 0}
+  cursorOffsetType: 0
+  cursorOffset: {x: 0, y: 0}

--- a/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/TogglePDALight.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/TogglePDALight.asset
@@ -12,6 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 175001bada3c3ba47945b92e3bfa2bd2, type: 3}
   m_Name: TogglePDALight
   m_EditorClassIdentifier: 
+  actionType: 0
+  activeSpriteIndex: 1
   callOnClient: 1
   callOnServer: 1
   actionName: Toggle PDA Light
@@ -19,4 +21,9 @@ MonoBehaviour:
   Sprites: []
   Backgrounds: []
   PreventBeingControlledBy: 
-  DisableOnEvent: 
+  DisableOnEvent: 0b000000
+  isAimable: 0
+  useCustomCursor: 0
+  cursorTexture: {fileID: 0}
+  cursorOffsetType: 0
+  cursorOffset: {x: 0, y: 0}

--- a/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/ToggleVisionGoggles.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/ToggleVisionGoggles.asset
@@ -21,7 +21,7 @@ MonoBehaviour:
   Sprites: []
   Backgrounds: []
   PreventBeingControlledBy: 
-  DisableOnEvent: 
+  DisableOnEvent: 0b000000
   isAimable: 0
   useCustomCursor: 0
   cursorTexture: {fileID: 0}

--- a/UnityProject/Assets/Scripts/Core/Camera/CameraEffectControlScript.cs
+++ b/UnityProject/Assets/Scripts/Core/Camera/CameraEffectControlScript.cs
@@ -69,5 +69,12 @@ namespace CameraEffects
 		{
 			LeanTween.scale(minimalVisibilitySprite, newSize, time);
 		}
+
+		public void EnsureAllEffectsAreDisabled()
+		{
+			drunkCamera.enabled = false;
+			glitchEffect.enabled = false;
+			nightVisionCamera.enabled = false;
+		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/TileManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/TileManager.cs
@@ -3,7 +3,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Initialisation;
+using Messages.Server;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public static class TilePaths
 {
@@ -82,6 +84,21 @@ public class TileManager : MonoBehaviour, IInitialise
 #endif
 
 		if (!initialized) StartCoroutine(LoadAllTiles());
+	}
+
+	private void OnEnable()
+	{
+		SceneManager.activeSceneChanged += OnSceneChange;
+	}
+
+	private void OnDisable()
+	{
+		SceneManager.activeSceneChanged -= OnSceneChange;
+	}
+
+	private void OnSceneChange(Scene oldScene, Scene newScene)
+	{
+		UpdateTileMessage.DelayedStuff.Clear();
 	}
 
 	[ContextMenu("Cache All Assets")]

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -212,6 +212,8 @@ namespace UI.CharacterCreator
 			PlayerCharacters.Add(character);
 			currentCharacterIndex = PlayerCharacters.Count() - 1;
 			currentCharacter = PlayerCharacters[currentCharacterIndex];
+			currentCharacter.Species = Race.Human.ToString();
+			OnRaceChange();
 			ShowCharacterCreator();
 			DoInitChecks();
 			RefreshAll();
@@ -1421,6 +1423,13 @@ namespace UI.CharacterCreator
 
 			RefreshRace();
 
+			OnSurfaceColourChange();
+		}
+
+		private void RefreshRace()
+		{
+			raceText.text = currentCharacter.Species.ToString();
+
 			foreach (var Race in RaceSOSingleton.Instance.Races)
 			{
 				if (Race.name == currentCharacter.Species)
@@ -1428,13 +1437,6 @@ namespace UI.CharacterCreator
 					ThisSetRace = Race;
 				}
 			}
-
-			OnSurfaceColourChange();
-		}
-
-		private void RefreshRace()
-		{
-			raceText.text = currentCharacter.Species.ToString();
 		}
 
 		#endregion

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_GhostOptions.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_GhostOptions.cs
@@ -71,6 +71,7 @@ namespace UI.Systems.Ghost
 		public void Respawn()
 		{
 			PlayerManager.LocalPlayerScript.playerNetworkActions.CmdRespawnPlayer(ServerData.UserID, PlayerList.Instance.AdminToken);
+			Camera.main.GetComponent<CameraEffects.CameraEffectControlScript>().EnsureAllEffectsAreDisabled();
 		}
 
 		public void ToggleAllowCloning()


### PR DESCRIPTION
### Purpose
When you died, action icons like toggling the PDA light would remain as you were a ghost, and even remain when you respawned, so I modified the scriptable object so they despawn on death. Only certain items needed this change, because other items like bags have icons that only appear when the item is in your hands and you automatically drop what you're holding when you die when you die (disabling the icon).

### Changelog:
CL: Fixes action icons not disappearing after death
