### PR TITLE
Fixes a visual bug with crawling players coming out of lockers

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
@@ -712,7 +712,6 @@ namespace Objects
 		private void CheckPlayerCrawlState(ObjectBehaviour player)
 		{
 			var regPlayer = player.GetComponent<RegisterPlayer>();
-			Debug.Log(regPlayer.IsLayingDown);
 			if (regPlayer.IsLayingDown == true)
 			{
 				regPlayer.HandleGetupAnimation(false);

--- a/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
@@ -712,7 +712,7 @@ namespace Objects
 		private void CheckPlayerCrawlState(ObjectBehaviour player)
 		{
 			var regPlayer = player.GetComponent<RegisterPlayer>();
-			if (regPlayer.IsLayingDown == true)
+			regPlayer.HandleGetupAnimation(!regPlayer.IsLayingDown)
 			{
 				regPlayer.HandleGetupAnimation(false);
 			}

--- a/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
@@ -712,7 +712,7 @@ namespace Objects
 		private void CheckPlayerCrawlState(ObjectBehaviour player)
 		{
 			var regPlayer = player.GetComponent<RegisterPlayer>();
-			regPlayer.HandleGetupAnimation(!regPlayer.IsLayingDown)
+			regPlayer.HandleGetupAnimation(!regPlayer.IsLayingDown);
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
@@ -713,13 +713,6 @@ namespace Objects
 		{
 			var regPlayer = player.GetComponent<RegisterPlayer>();
 			regPlayer.HandleGetupAnimation(!regPlayer.IsLayingDown)
-			{
-				regPlayer.HandleGetupAnimation(false);
-			}
-			else
-			{
-				regPlayer.HandleGetupAnimation(true);
-			}
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
@@ -709,6 +709,20 @@ namespace Objects
 			serverHeldItems.Clear();
 		}
 
+		private void CheckPlayerCrawlState(ObjectBehaviour player)
+		{
+			var regPlayer = player.GetComponent<RegisterPlayer>();
+			Debug.Log(regPlayer.IsLayingDown);
+			if (regPlayer.IsLayingDown == true)
+			{
+				regPlayer.HandleGetupAnimation(false);
+			}
+			else
+			{
+				regPlayer.HandleGetupAnimation(true);
+			}
+		}
+
 		/// <summary>
 		/// Adds all items currently sitting on this closet into the closet
 		/// </summary>
@@ -748,6 +762,7 @@ namespace Objects
 				player.parentContainer = null;
 				//Stop tracking closet
 				FollowCameraMessage.Send(player.gameObject, player.gameObject);
+				CheckPlayerCrawlState(player);
 			}
 			serverHeldPlayers = new List<ObjectBehaviour>();
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
@@ -175,7 +175,7 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 	{
 		EnsureInit();
 		this.isLayingDown = isDown;
-		HandleGetupAnimation(isDown);
+		HandleGetupAnimation(isDown == false);
 		if (isDown)
 		{
 			//uprightSprites.ExtraRotation = Quaternion.Euler(0, 0, -90);

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
@@ -177,7 +177,7 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 		this.isLayingDown = isDown;
 		if (isDown)
 		{
-			networkedLean.RpcRotateGameObject(new Vector3(0, 0, -90), 0.15f);
+			HandleGetupAnimation(false);
 			//uprightSprites.ExtraRotation = Quaternion.Euler(0, 0, -90);
 			//Change sprite layer
 			foreach (SpriteRenderer spriteRenderer in this.GetComponentsInChildren<SpriteRenderer>())
@@ -190,7 +190,7 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 		}
 		else
 		{
-			networkedLean.RpcRotateGameObject(new Vector3(0, 0, 0), 0.19f);
+			HandleGetupAnimation(true);
 			//uprightSprites.ExtraRotation = Quaternion.identity;
 			//back to original layer
 			foreach (SpriteRenderer spriteRenderer in this.GetComponentsInChildren<SpriteRenderer>())
@@ -199,6 +199,18 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 			}
 			playerDirectional.LockDirection = false;
 			playerScript.PlayerSync.SpeedServer = playerScript.playerMove.RunSpeed;
+		}
+	}
+
+	public void HandleGetupAnimation(bool getUp)
+	{
+		if (getUp == false && networkedLean.Target.rotation.z > -90)
+		{
+			networkedLean.RpcRotateGameObject(new Vector3(0, 0, -90), 0.15f);
+		}
+		else if (getUp == true && networkedLean.Target.rotation.z < 90)
+		{
+			networkedLean.RpcRotateGameObject(new Vector3(0, 0, 0), 0.19f);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
@@ -175,9 +175,9 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 	{
 		EnsureInit();
 		this.isLayingDown = isDown;
+		HandleGetupAnimation(isDown);
 		if (isDown)
 		{
-			HandleGetupAnimation(false);
 			//uprightSprites.ExtraRotation = Quaternion.Euler(0, 0, -90);
 			//Change sprite layer
 			foreach (SpriteRenderer spriteRenderer in this.GetComponentsInChildren<SpriteRenderer>())
@@ -190,7 +190,6 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 		}
 		else
 		{
-			HandleGetupAnimation(true);
 			//uprightSprites.ExtraRotation = Quaternion.identity;
 			//back to original layer
 			foreach (SpriteRenderer spriteRenderer in this.GetComponentsInChildren<SpriteRenderer>())


### PR DESCRIPTION
### Purpose

Title.
Part of #6276 , fixes an issue reported in #6195 

### Changelog:

CL: Fixed a bug where players appear standing up while crawling after getting out of lockers
CL: Getup and laying down animations won't trigger if the player's sprites are already rotated.
