### PR TITLE
Fixes a bug where camera effects stay on after death

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Camera/CameraEffectControlScript.cs
+++ b/UnityProject/Assets/Scripts/Core/Camera/CameraEffectControlScript.cs
@@ -69,5 +69,12 @@ namespace CameraEffects
 		{
 			LeanTween.scale(minimalVisibilitySprite, newSize, time);
 		}
+
+		public void EnsureAllEffectsAreDisabled()
+		{
+			drunkCamera.enabled = false;
+			glitchEffect.enabled = false;
+			nightVisionCamera.enabled = false;
+		}
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_GhostOptions.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_GhostOptions.cs
@@ -71,7 +71,7 @@ namespace UI.Systems.Ghost
 		public void Respawn()
 		{
 			PlayerManager.LocalPlayerScript.playerNetworkActions.CmdRespawnPlayer(ServerData.UserID, PlayerList.Instance.AdminToken);
-			PlayerManager.LocalPlayerScript.gameObject.GetComponent<CameraEffects.CameraEffectControlScript>().EnsureAllEffectsAreDisabled();
+			Camera.main.GetComponent<CameraEffects.CameraEffectControlScript>().EnsureAllEffectsAreDisabled();
 		}
 
 		public void ToggleAllowCloning()

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_GhostOptions.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_GhostOptions.cs
@@ -71,6 +71,7 @@ namespace UI.Systems.Ghost
 		public void Respawn()
 		{
 			PlayerManager.LocalPlayerScript.playerNetworkActions.CmdRespawnPlayer(ServerData.UserID, PlayerList.Instance.AdminToken);
+			PlayerManager.LocalPlayerScript.gameObject.GetComponent<CameraEffects.CameraEffectControlScript>().EnsureAllEffectsAreDisabled();
 		}
 
 		public void ToggleAllowCloning()


### PR DESCRIPTION
### Purpose

If you have a camera effect active while you're dead you keep that even when you respawn. This PR fixes this issue.

### Notes

closes #6347

### Changelog:

CL: Fixed a bug where camera effects stay on even after respawning.
