### PR TITLE
Fixes clients performing tile changes from previous rounds.

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/TileManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/TileManager.cs
@@ -3,7 +3,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Initialisation;
+using Messages.Server;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public static class TilePaths
 {
@@ -82,6 +84,21 @@ public class TileManager : MonoBehaviour, IInitialise
 #endif
 
 		if (!initialized) StartCoroutine(LoadAllTiles());
+	}
+
+	private void OnEnable()
+	{
+		SceneManager.activeSceneChanged += OnSceneChange;
+	}
+
+	private void OnDisable()
+	{
+		SceneManager.activeSceneChanged -= OnSceneChange;
+	}
+
+	private void OnSceneChange(Scene oldScene, Scene newScene)
+	{
+		UpdateTileMessage.DelayedStuff.Clear();
 	}
 
 	[ContextMenu("Cache All Assets")]


### PR DESCRIPTION

### Purpose
Fixes a client giant freeze or infinite loop.
Fixes lavaland tiles being spread across the station or other incorrect places.

### Notes:
The static list DelayedStuff contains the tile changes for lavaland. The way UpdateTileMessage works is by searching for the netID of the matrix and performing the changes there. If the player logs out before these changes happen, the list will still contain the changes and they could be performed on a random matrix with the correct netID, however it needs a fair amount of luck for this to happen.

![image](https://user-images.githubusercontent.com/701959/115971756-a888b480-a520-11eb-9888-48ce478a542b.png)
In this image there's 3 different roundstarts with the index 23 being lavaland and the index 20 being a random away mission. Due to the randomness of these numbers, lavaland tile changes could be performed in another round's asteroids, covering the station with its tiles due to the proximity.


I'm still not 100% sure that this could be the only case of lavaland tiles being spread on the station on clients since the RNG seems to high for this to happen so I'd wait before closing the respective issue

