### PR TITLE
Fixes lavaland spawning on the station for clients

### DIFF
--- a/UnityProject/Assets/Scripts/Messages/GameMessageBase.cs
+++ b/UnityProject/Assets/Scripts/Messages/GameMessageBase.cs
@@ -40,7 +40,7 @@ namespace Messages
 				NetworkObject = NetworkIdentity.spawned[id].gameObject;
 				return true;
 			}
-
+			NetworkObject = null;
 			return false;
 		}
 


### PR DESCRIPTION
### Purpose
Fixes network messages utilizing the NetworkObject from the previous similar message if said object isn't loaded in the client yet.
This fix resolves shuttles appearing on wrong spots or the station being loaded filled with lavaland ores.
Fixes #6397