### PR TITLE
Players should no longer be able to join the round before finishing loading their game.

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawn.cs
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawn.cs
@@ -235,6 +235,22 @@ public static class PlayerSpawn
 	/// <param name="body">to transfer into</param>
 	public static void ServerRejoinPlayer(JoinedViewer viewer, GameObject body)
 	{
+		RpcAwaitPlayerLoading(viewer, body);
+	}
+
+	[TargetRpc]
+	public static void RpcAwaitPlayerLoading(JoinedViewer viewer, GameObject body)
+	{
+		while(TileManager.TilesToLoad > TileManager.TilesLoaded)
+		{
+			Logger.Log($"Loading tiles.. {TileManager.TilesToLoad} / {TileManager.TilesLoaded} loaded.");
+		}
+		CmdPlayerFinishedLoading(viewer, body);
+	}
+
+	[Command]
+	public static void CmdPlayerFinishedLoading(JoinedViewer viewer, GameObject body)
+	{
 		var ps = body.GetComponent<PlayerScript>();
 		var mind = ps.mind;
 		var occupation = mind.occupation;


### PR DESCRIPTION
### Purpose
Fixes a lot of errors and possibly some other bugs that appear when players rejoin the game.
It freezes the spawn logic completely until everything is loaded. (or more accurately, it waits until all tiles are loaded because they take the longest to load and players CAN get into the game before the tiles where they are haven't even loaded yet)

### Notes:
Testing required in case we're freezing this in the wrong function.
Any other new things to wait for would also be great if someone pointed them out.

closes #5512 

### Changelog:

CL: Players will be unable to join the game until they have finished loading their game.
