### PR TITLE
Multitool text improvement, NetToggle workaround

### DIFF
--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/PipeDispenser/ColorToggle.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/PipeDispenser/ColorToggle.prefab
@@ -12,7 +12,6 @@ GameObject:
   - component: {fileID: 8727998958661407103}
   - component: {fileID: 5649171872587022298}
   - component: {fileID: 1540758683622087102}
-  - component: {fileID: 4570004714174650456}
   - component: {fileID: 5594961893074090065}
   m_Layer: 5
   m_Name: ColorToggle
@@ -124,37 +123,20 @@ MonoBehaviour:
   m_Group: {fileID: 0}
   onValueChanged:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 5594961893074090065}
+        m_TargetAssemblyTypeName: NetToggle, Assets
+        m_MethodName: ExecuteClient
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   m_IsOn: 0
---- !u!114 &4570004714174650456
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4873896949227020770}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Delegates:
-  - eventID: 4
-    callback:
-      m_PersistentCalls:
-        m_Calls:
-        - m_Target: {fileID: 5594961893074090065}
-          m_TargetAssemblyTypeName: 
-          m_MethodName: ExecuteClient
-          m_Mode: 1
-          m_Arguments:
-            m_ObjectArgument: {fileID: 0}
-            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-            m_IntArgument: 0
-            m_FloatArgument: 0
-            m_StringArgument: 
-            m_BoolArgument: 0
-          m_CallState: 2
 --- !u!114 &5594961893074090065
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -167,6 +149,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c469783ba5934436896cc7b30fe5978b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enableWorkaround: 1
   ServerMethod:
     m_PersistentCalls:
       m_Calls:

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/PipeDispenser/Toggle.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/PipeDispenser/Toggle.prefab
@@ -12,7 +12,6 @@ GameObject:
   - component: {fileID: 6144364932787196045}
   - component: {fileID: 6424047490699577042}
   - component: {fileID: 8757575389064437618}
-  - component: {fileID: 4735958661600894371}
   - component: {fileID: 8790345346895030665}
   m_Layer: 5
   m_Name: Toggle
@@ -125,37 +124,20 @@ MonoBehaviour:
   m_Group: {fileID: 0}
   onValueChanged:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 8790345346895030665}
+        m_TargetAssemblyTypeName: NetToggle, Assets
+        m_MethodName: ExecuteClient
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   m_IsOn: 0
---- !u!114 &4735958661600894371
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 211120107694494436}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Delegates:
-  - eventID: 4
-    callback:
-      m_PersistentCalls:
-        m_Calls:
-        - m_Target: {fileID: 8790345346895030665}
-          m_TargetAssemblyTypeName: 
-          m_MethodName: ExecuteClient
-          m_Mode: 1
-          m_Arguments:
-            m_ObjectArgument: {fileID: 0}
-            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-            m_IntArgument: 0
-            m_FloatArgument: 0
-            m_StringArgument: 
-            m_BoolArgument: 0
-          m_CallState: 2
 --- !u!114 &8790345346895030665
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -168,13 +150,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c469783ba5934436896cc7b30fe5978b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enableWorkaround: 1
   ServerMethod:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: 
-        m_MethodName: Btn_SetCategory
-        m_Mode: 3
+      - m_Target: {fileID: 8790345346895030665}
+        m_TargetAssemblyTypeName: NetToggle, Assets
+        m_MethodName: ExecuteClient
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabPipeDispenser.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabPipeDispenser.prefab
@@ -4516,19 +4516,9 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1540758683622087102, guid: d0176aa77d06fdb429b4f4a8b98765c6,
         type: 3}
-      propertyPath: m_IsOn
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1540758683622087102, guid: d0176aa77d06fdb429b4f4a8b98765c6,
-        type: 3}
       propertyPath: m_Group
       value: 
       objectReference: {fileID: 4356300258399364160}
-    - target: {fileID: 1540758683622087102, guid: d0176aa77d06fdb429b4f4a8b98765c6,
-        type: 3}
-      propertyPath: m_Interactable
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 1901732000548982449, guid: d0176aa77d06fdb429b4f4a8b98765c6,
         type: 3}
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -4721,12 +4711,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d0176aa77d06fdb429b4f4a8b98765c6, type: 3}
---- !u!224 &7000649770386454816 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 6967754533057542483, guid: d0176aa77d06fdb429b4f4a8b98765c6,
-    type: 3}
-  m_PrefabInstance: {fileID: 114034975687229555}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &5490008917835118626 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5594961893074090065, guid: d0176aa77d06fdb429b4f4a8b98765c6,
@@ -4739,6 +4723,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c469783ba5934436896cc7b30fe5978b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &7000649770386454816 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6967754533057542483, guid: d0176aa77d06fdb429b4f4a8b98765c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 114034975687229555}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &124671237910671362
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5201,6 +5191,11 @@ PrefabInstance:
       objectReference: {fileID: 8447441380651214098}
     - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
         type: 3}
+      propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
+        type: 3}
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 8431175497343230882}
@@ -5208,6 +5203,11 @@ PrefabInstance:
         type: 3}
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: ServerSetDispensePage
+      objectReference: {fileID: 0}
+    - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
+        type: 3}
+      propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: UI.Objects.Atmospherics.GUI_PipeDispenser, Assets
       objectReference: {fileID: 0}
     - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
         type: 3}
@@ -5361,6 +5361,11 @@ PrefabInstance:
       objectReference: {fileID: 6646684517468505173}
     - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
         type: 3}
+      propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
+        type: 3}
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 8431175497343230882}
@@ -5368,6 +5373,11 @@ PrefabInstance:
         type: 3}
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: ServerSetDispensePage
+      objectReference: {fileID: 0}
+    - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
+        type: 3}
+      propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: UI.Objects.Atmospherics.GUI_PipeDispenser, Assets
       objectReference: {fileID: 0}
     - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
         type: 3}
@@ -5526,6 +5536,11 @@ PrefabInstance:
       objectReference: {fileID: 8447441380651214098}
     - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
         type: 3}
+      propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
+        type: 3}
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 8431175497343230882}
@@ -5533,6 +5548,11 @@ PrefabInstance:
         type: 3}
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: ServerSetDispensePage
+      objectReference: {fileID: 0}
+    - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
+        type: 3}
+      propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: UI.Objects.Atmospherics.GUI_PipeDispenser, Assets
       objectReference: {fileID: 0}
     - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
         type: 3}
@@ -5556,19 +5576,9 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1540758683622087102, guid: d0176aa77d06fdb429b4f4a8b98765c6,
         type: 3}
-      propertyPath: m_IsOn
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1540758683622087102, guid: d0176aa77d06fdb429b4f4a8b98765c6,
-        type: 3}
       propertyPath: m_Group
       value: 
       objectReference: {fileID: 4356300258399364160}
-    - target: {fileID: 1540758683622087102, guid: d0176aa77d06fdb429b4f4a8b98765c6,
-        type: 3}
-      propertyPath: m_Interactable
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 1901732000548982449, guid: d0176aa77d06fdb429b4f4a8b98765c6,
         type: 3}
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -5761,12 +5771,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d0176aa77d06fdb429b4f4a8b98765c6, type: 3}
---- !u!224 &7608184806197790950 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 6967754533057542483, guid: d0176aa77d06fdb429b4f4a8b98765c6,
-    type: 3}
-  m_PrefabInstance: {fileID: 659737839091757493}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &4936666623688149476 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5594961893074090065, guid: d0176aa77d06fdb429b4f4a8b98765c6,
@@ -5779,6 +5783,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c469783ba5934436896cc7b30fe5978b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &7608184806197790950 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6967754533057542483, guid: d0176aa77d06fdb429b4f4a8b98765c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 659737839091757493}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &921012523496988886
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6095,6 +6105,11 @@ PrefabInstance:
       objectReference: {fileID: 6646684517468505173}
     - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
         type: 3}
+      propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
+        type: 3}
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 8431175497343230882}
@@ -6102,6 +6117,11 @@ PrefabInstance:
         type: 3}
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: ServerSetDispensePage
+      objectReference: {fileID: 0}
+    - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
+        type: 3}
+      propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: UI.Objects.Atmospherics.GUI_PipeDispenser, Assets
       objectReference: {fileID: 0}
     - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
         type: 3}
@@ -6582,126 +6602,6 @@ PrefabInstance:
       propertyPath: m_Group
       value: 
       objectReference: {fileID: 2702664262353378833}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.size
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[2].m_Mode
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[3].m_Mode
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 7660001179418820064}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_Target
-      value: 
-      objectReference: {fileID: 1251528350416619149}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[2].m_Target
-      value: 
-      objectReference: {fileID: 1251528350416619149}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[3].m_Target
-      value: 
-      objectReference: {fileID: 55480796237948131}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[2].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[3].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: ExecuteClient
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[3].m_MethodName
-      value: set_interactable
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_BoolArgument
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_BoolArgument
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[2].m_Arguments.m_BoolArgument
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[3].m_Arguments.m_BoolArgument
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[2].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[3].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
     - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
         type: 3}
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.size
@@ -6929,27 +6829,9 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1d0d4cec35fffac458087b5a6f61520f, type: 3}
---- !u!114 &7660001179418820064 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
-    type: 3}
-  m_PrefabInstance: {fileID: 1418738310204576873}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1251528350416619149}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c469783ba5934436896cc7b30fe5978b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!224 &1484618184549776462 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 516280798213040167, guid: 1d0d4cec35fffac458087b5a6f61520f,
-    type: 3}
-  m_PrefabInstance: {fileID: 1418738310204576873}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1251528350416619149 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 211120107694494436, guid: 1d0d4cec35fffac458087b5a6f61520f,
     type: 3}
   m_PrefabInstance: {fileID: 1418738310204576873}
   m_PrefabAsset: {fileID: 0}
@@ -7112,6 +6994,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1d0d4cec35fffac458087b5a6f61520f, type: 3}
+--- !u!224 &1372965892031502788 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 516280798213040167, guid: 1d0d4cec35fffac458087b5a6f61520f,
+    type: 3}
+  m_PrefabInstance: {fileID: 1452397216841085411}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &7915752647166761066 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
@@ -7124,12 +7012,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c469783ba5934436896cc7b30fe5978b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &1372965892031502788 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 516280798213040167, guid: 1d0d4cec35fffac458087b5a6f61520f,
-    type: 3}
-  m_PrefabInstance: {fileID: 1452397216841085411}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1455672954910919175
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7782,19 +7664,9 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1540758683622087102, guid: d0176aa77d06fdb429b4f4a8b98765c6,
         type: 3}
-      propertyPath: m_IsOn
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1540758683622087102, guid: d0176aa77d06fdb429b4f4a8b98765c6,
-        type: 3}
       propertyPath: m_Group
       value: 
       objectReference: {fileID: 4356300258399364160}
-    - target: {fileID: 1540758683622087102, guid: d0176aa77d06fdb429b4f4a8b98765c6,
-        type: 3}
-      propertyPath: m_Interactable
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 1901732000548982449, guid: d0176aa77d06fdb429b4f4a8b98765c6,
         type: 3}
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -7987,6 +7859,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d0176aa77d06fdb429b4f4a8b98765c6, type: 3}
+--- !u!224 &8582489443688330711 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6967754533057542483, guid: d0176aa77d06fdb429b4f4a8b98765c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1704981317505387652}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &6488564785302549717 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5594961893074090065, guid: d0176aa77d06fdb429b4f4a8b98765c6,
@@ -7999,12 +7877,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c469783ba5934436896cc7b30fe5978b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &8582489443688330711 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 6967754533057542483, guid: d0176aa77d06fdb429b4f4a8b98765c6,
-    type: 3}
-  m_PrefabInstance: {fileID: 1704981317505387652}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1727960414488160219
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8989,11 +8861,6 @@ PrefabInstance:
       propertyPath: m_Group
       value: 
       objectReference: {fileID: 4356300258399364160}
-    - target: {fileID: 1540758683622087102, guid: d0176aa77d06fdb429b4f4a8b98765c6,
-        type: 3}
-      propertyPath: m_Transition
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 1901732000548982449, guid: d0176aa77d06fdb429b4f4a8b98765c6,
         type: 3}
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -9333,6 +9200,11 @@ PrefabInstance:
       objectReference: {fileID: 8447441380651214098}
     - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
         type: 3}
+      propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
+        type: 3}
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 8431175497343230882}
@@ -9340,6 +9212,11 @@ PrefabInstance:
         type: 3}
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: ServerSetDispensePage
+      objectReference: {fileID: 0}
+    - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
+        type: 3}
+      propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: UI.Objects.Atmospherics.GUI_PipeDispenser, Assets
       objectReference: {fileID: 0}
     - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
         type: 3}
@@ -9685,12 +9562,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1d0d4cec35fffac458087b5a6f61520f, type: 3}
---- !u!224 &4494264750277544733 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 516280798213040167, guid: 1d0d4cec35fffac458087b5a6f61520f,
-    type: 3}
-  m_PrefabInstance: {fileID: 4140188339834561338}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &4650375466310568627 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
@@ -9703,6 +9574,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c469783ba5934436896cc7b30fe5978b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &4494264750277544733 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 516280798213040167, guid: 1d0d4cec35fffac458087b5a6f61520f,
+    type: 3}
+  m_PrefabInstance: {fileID: 4140188339834561338}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4188105539798988975
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9869,19 +9746,9 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1540758683622087102, guid: d0176aa77d06fdb429b4f4a8b98765c6,
         type: 3}
-      propertyPath: m_IsOn
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1540758683622087102, guid: d0176aa77d06fdb429b4f4a8b98765c6,
-        type: 3}
       propertyPath: m_Group
       value: 
       objectReference: {fileID: 4356300258399364160}
-    - target: {fileID: 1540758683622087102, guid: d0176aa77d06fdb429b4f4a8b98765c6,
-        type: 3}
-      propertyPath: m_Interactable
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 1901732000548982449, guid: d0176aa77d06fdb429b4f4a8b98765c6,
         type: 3}
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -10074,6 +9941,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d0176aa77d06fdb429b4f4a8b98765c6, type: 3}
+--- !u!224 &6625481817378064248 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6967754533057542483, guid: d0176aa77d06fdb429b4f4a8b98765c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 4269446844328853035}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &8567345649713219194 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5594961893074090065, guid: d0176aa77d06fdb429b4f4a8b98765c6,
@@ -10086,12 +9959,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c469783ba5934436896cc7b30fe5978b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &6625481817378064248 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 6967754533057542483, guid: d0176aa77d06fdb429b4f4a8b98765c6,
-    type: 3}
-  m_PrefabInstance: {fileID: 4269446844328853035}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5432220185864959218
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10241,6 +10108,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
         type: 3}
+      propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
+        type: 3}
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 8431175497343230882}
@@ -10248,6 +10120,11 @@ PrefabInstance:
         type: 3}
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: ServerSetCategory
+      objectReference: {fileID: 0}
+    - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
+        type: 3}
+      propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: UI.Objects.Atmospherics.GUI_PipeDispenser, Assets
       objectReference: {fileID: 0}
     - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
         type: 3}
@@ -10271,19 +10148,9 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1540758683622087102, guid: d0176aa77d06fdb429b4f4a8b98765c6,
         type: 3}
-      propertyPath: m_IsOn
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1540758683622087102, guid: d0176aa77d06fdb429b4f4a8b98765c6,
-        type: 3}
       propertyPath: m_Group
       value: 
       objectReference: {fileID: 4356300258399364160}
-    - target: {fileID: 1540758683622087102, guid: d0176aa77d06fdb429b4f4a8b98765c6,
-        type: 3}
-      propertyPath: m_Interactable
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 1901732000548982449, guid: d0176aa77d06fdb429b4f4a8b98765c6,
         type: 3}
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -10999,19 +10866,9 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1540758683622087102, guid: d0176aa77d06fdb429b4f4a8b98765c6,
         type: 3}
-      propertyPath: m_IsOn
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1540758683622087102, guid: d0176aa77d06fdb429b4f4a8b98765c6,
-        type: 3}
       propertyPath: m_Group
       value: 
       objectReference: {fileID: 4356300258399364160}
-    - target: {fileID: 1540758683622087102, guid: d0176aa77d06fdb429b4f4a8b98765c6,
-        type: 3}
-      propertyPath: m_Interactable
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 1901732000548982449, guid: d0176aa77d06fdb429b4f4a8b98765c6,
         type: 3}
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -11204,6 +11061,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d0176aa77d06fdb429b4f4a8b98765c6, type: 3}
+--- !u!224 &3708795470268663419 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6967754533057542483, guid: d0176aa77d06fdb429b4f4a8b98765c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 6037680033042153256}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &2193088308890109817 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5594961893074090065, guid: d0176aa77d06fdb429b4f4a8b98765c6,
@@ -11216,12 +11079,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c469783ba5934436896cc7b30fe5978b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &3708795470268663419 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 6967754533057542483, guid: d0176aa77d06fdb429b4f4a8b98765c6,
-    type: 3}
-  m_PrefabInstance: {fileID: 6037680033042153256}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6159547365410222824
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -11663,91 +11520,6 @@ PrefabInstance:
       propertyPath: m_Group
       value: 
       objectReference: {fileID: 2702664262353378833}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.size
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[2].m_Mode
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 2120372470650089597}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_Target
-      value: 
-      objectReference: {fileID: 8431175497343230882}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[2].m_Target
-      value: 
-      objectReference: {fileID: 55480796237948131}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[2].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: ExecuteClient
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
-      value: Bol
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
-      value: set_interactable
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_BoolArgument
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_BoolArgument
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[2].m_Arguments.m_BoolArgument
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
-    - target: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[2].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
     - target: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
         type: 3}
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.size
@@ -11906,18 +11678,6 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 7246440243873847796}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &2120372470650089597 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
-    type: 3}
-  m_PrefabInstance: {fileID: 7246440243873847796}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c469783ba5934436896cc7b30fe5978b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &7621306189581699633
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -12575,19 +12335,9 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1540758683622087102, guid: d0176aa77d06fdb429b4f4a8b98765c6,
         type: 3}
-      propertyPath: m_IsOn
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1540758683622087102, guid: d0176aa77d06fdb429b4f4a8b98765c6,
-        type: 3}
       propertyPath: m_Group
       value: 
       objectReference: {fileID: 4356300258399364160}
-    - target: {fileID: 1540758683622087102, guid: d0176aa77d06fdb429b4f4a8b98765c6,
-        type: 3}
-      propertyPath: m_Interactable
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 1901732000548982449, guid: d0176aa77d06fdb429b4f4a8b98765c6,
         type: 3}
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -13129,18 +12879,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1d0d4cec35fffac458087b5a6f61520f, type: 3}
---- !u!114 &55480796237948131 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
-    type: 3}
-  m_PrefabInstance: {fileID: 8740417154211249041}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &50005320139952664 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 8790345346895030665, guid: 1d0d4cec35fffac458087b5a6f61520f,
@@ -13151,6 +12889,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c469783ba5934436896cc7b30fe5978b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &55480796237948131 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8757575389064437618, guid: 1d0d4cec35fffac458087b5a6f61520f,
+    type: 3}
+  m_PrefabInstance: {fileID: 8740417154211249041}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!224 &9107969157678896054 stripped

--- a/UnityProject/Assets/Scripts/Core/Editor/Inspector/APCPoweredDeviceInspector.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/Inspector/APCPoweredDeviceInspector.cs
@@ -31,7 +31,7 @@ namespace CustomInspectors
 				}
 				else
 				{
-					GUILayout.Label($"Connected to APC: {device.RelatedAPC.gameObject}");
+					GUILayout.Label($"Connected to APC: {device.RelatedAPC.gameObject.name}");
 				}
 			}
 

--- a/UnityProject/Assets/Scripts/Items/Tool/Multitool/Multitool.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/Multitool/Multitool.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using Systems.Electricity;
+using System.Text;
 
 // TODO: namespace me
 public class Multitool : MonoBehaviour, ICheckedInteractable<PositionalHandApply>, IInteractable<HandActivate>
@@ -127,14 +128,15 @@ public class Multitool : MonoBehaviour, ICheckedInteractable<PositionalHandApply
 			message = "The multitool's display lights up:\n";
 		}
 
+		StringBuilder sb = new StringBuilder(message);
 		foreach (var node in electricalNodes)
 		{
-			message += node.ShowInGameDetails() + "\n";
+			sb.AppendLine(node.ShowInGameDetails());
 		}
 
 		electricalNodes.Clear();
 		ElectricalPool.PooledFPCList.Add(electricalNodes);
-		Chat.AddExamineMsgFromServer(interaction.Performer, message);
+		Chat.AddExamineMsgFromServer(interaction.Performer, sb.ToString());
 	}
 
 	public void ServerPerformInteraction(HandActivate interaction)

--- a/UnityProject/Assets/Scripts/Items/Tool/Multitool/Multitool.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/Multitool/Multitool.cs
@@ -75,8 +75,7 @@ public class Multitool : MonoBehaviour, ICheckedInteractable<PositionalHandApply
 					MultiMaster = master.MultiMaster;
 					Chat.AddExamineMsgFromServer(
 						interaction.Performer,
-						$"You add the master component {interaction.TargetObject.ExpensiveName()} " +
-						$"to the Multi-Tools buffer.");
+						$"You add the <b>{interaction.TargetObject.ExpensiveName()}</b> to the multitool's master buffer.");
 					return;
 				}
 			}
@@ -96,18 +95,17 @@ public class Multitool : MonoBehaviour, ICheckedInteractable<PositionalHandApply
 				case ISetMultitoolSlave slave:
 					slave.SetMaster(Buffer);
 					Chat.AddExamineMsgFromServer(interaction.Performer,
-						$"You set the {interaction.TargetObject.ExpensiveName()} to use the " +
-						$"{(Buffer as Component)?.gameObject.ExpensiveName()} in the buffer.");
+						$"You connect the <b>{interaction.TargetObject.ExpensiveName()}</b> " +
+						$"to the master device <b>{(Buffer as Component)?.gameObject.ExpensiveName()}</b>.");
 					return;
 				case ISetMultitoolSlaveMultiMaster slaveMultiMaster:
 					slaveMultiMaster.SetMasters(ListBuffer);
 					Chat.AddExamineMsgFromServer(interaction.Performer,
-						"You set the" + interaction.TargetObject.ExpensiveName() +
-						" to use the devices in the buffer");
+						$"You connect the <b>{interaction.TargetObject.ExpensiveName()}</b> to the master devices in the buffer.");
 					return;
 				default:
 					Chat.AddExamineMsgFromServer(interaction.Performer,
-						"This only seems to have the capability of accepting Writing to buffer");
+						"This only seems to have the capability of <b>writing</b> to the buffer.");
 					return;
 			}
 		}
@@ -121,22 +119,27 @@ public class Multitool : MonoBehaviour, ICheckedInteractable<PositionalHandApply
 		MatrixInfo matrixinfo = MatrixManager.AtPoint(worldPosInt, true);
 		var localPosInt = MatrixManager.WorldToLocalInt(worldPosInt, matrixinfo);
 		var matrix = interaction.Performer.GetComponentInParent<Matrix>();
-		var MetaDataNode = matrix.GetElectricalConnections(localPosInt);
-		string ToReturn = "The Multitool Display lights up with \n"
-		                  + "Number of electrical objects present : " + MetaDataNode.Count + "\n";
-		foreach (var D in MetaDataNode)
+		var electricalNodes = matrix.GetElectricalConnections(localPosInt);
+
+		string message = "The multitool couldn't find anything electrical here.";
+		if (electricalNodes.Count > 0)
 		{
-			ToReturn = ToReturn + D.ShowInGameDetails() + "\n";
+			message = "The multitool's display lights up:\n";
 		}
 
-		MetaDataNode.Clear();
-		ElectricalPool.PooledFPCList.Add(MetaDataNode);
-		Chat.AddExamineMsgFromServer(interaction.Performer, ToReturn);
+		foreach (var node in electricalNodes)
+		{
+			message += node.ShowInGameDetails() + "\n";
+		}
+
+		electricalNodes.Clear();
+		ElectricalPool.PooledFPCList.Add(electricalNodes);
+		Chat.AddExamineMsgFromServer(interaction.Performer, message);
 	}
 
 	public void ServerPerformInteraction(HandActivate interaction)
 	{
-		Chat.AddExamineMsgFromServer(interaction.Performer, "You Clear internal buffer");
+		Chat.AddExamineMsgFromServer(interaction.Performer, "You clear the multitool's internal buffer.");
 		ListBuffer.Clear();
 		MultiMaster = false;
 		ConfigurationBuffer = MultitoolConnectionType.Empty;
@@ -153,5 +156,6 @@ public enum MultitoolConnectionType
 	FireAlarm,
 	LightSwitch,
 	DoorButton,
-	GeneralSwitch
+	GeneralSwitch,
+	ACU,
 }

--- a/UnityProject/Assets/Scripts/Items/Tool/Multitool/Multitool.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/Multitool/Multitool.cs
@@ -156,6 +156,5 @@ public enum MultitoolConnectionType
 	FireAlarm,
 	LightSwitch,
 	DoorButton,
-	GeneralSwitch,
-	ACU,
+	GeneralSwitch
 }

--- a/UnityProject/Assets/Scripts/Systems/Electricity/FunctionsAndClasses/IntrinsicElectronicData.cs
+++ b/UnityProject/Assets/Scripts/Systems/Electricity/FunctionsAndClasses/IntrinsicElectronicData.cs
@@ -232,7 +232,7 @@ namespace Systems.Electricity
 		public string ShowInGameDetails()
 		{
 			ElectricityFunctions.WorkOutActualNumbers(this);
-			return ("Component : " + Categorytype + "\nVoltage > " + Data.ActualVoltage.ToEngineering("V") + " Current > " + Data.CurrentInWire.ToEngineering("A"));
+			return $"{Categorytype}: {Data.ActualVoltage.ToEngineering("V")}, {Data.CurrentInWire.ToEngineering("A")}";
 		}
 
 		public virtual void ShowDetails()

--- a/UnityProject/Assets/Scripts/UI/Core/Net/Elements/NetToggle.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/Net/Elements/NetToggle.cs
@@ -2,6 +2,7 @@ using System;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.UI;
+using NaughtyAttributes;
 
 /// Toggle for bool-based methods
 [RequireComponent(typeof(Toggle))]
@@ -17,6 +18,14 @@ public class NetToggle : NetUIStringElement
 		}
 	}
 
+	[SerializeField]
+	[InfoBox("If the toggle is part of a toggle group, and the toggles point to the same listeners below, " +
+			"then they will be hit multiple times (each toggle, on / off). This is often not desirable. " +
+			"A workaround is to only invoke the listener if the toggle is on, so the listener is only called once. " +
+			"Check 'Enable Workaround' to enable this behaviour. ", EInfoBoxType.Normal)]
+	// enough hours wasted on falling for the same mistake again and again... my darkest hours with that damned pipe dispenser
+	private bool enableWorkaround = false; 
+
 	public BoolEvent ServerMethod;
 	public BoolEventWithSubject ServerMethodWithSubject;
 
@@ -25,6 +34,12 @@ public class NetToggle : NetUIStringElement
 	public override void ExecuteServer(ConnectedPlayer subject) {
 		ServerMethod?.Invoke(Element.isOn);
 		ServerMethodWithSubject?.Invoke(Element.isOn, subject);
+	}
+
+	public override void ExecuteClient()
+	{
+		if (enableWorkaround && Element.group != null && Element.isOn == false) return;
+		base.ExecuteClient();
 	}
 
 	public Toggle Element {


### PR DESCRIPTION
- Improves the interaction text of the multitool.
- Adds an optional workaround for NetToggles where the toggles are assigned a group triggering listeners multiple times.
    - Updates the pipe dispenser to use this workaround.

CL: Better multitool text.

#### Test Guide

Precondition | Expectation | Result
--- | --- | ---
Use a multitool on one electrical wire, multiple wires, no wires | The multitool should output the appropriate results into the chat with the new strings, with the text being understandable |
Use a multitool to connect slave devices to a master device and then clear the buffer | The multitool should post the new messages for each action to the chat |
Use the pipe dispenser and operate the category, colour and category section toggles | The toggles should change state and the appropriate page should be activated | 

> Note: the `Test Guide` is an optional process we'd (or I'd) like to try, where the PR creator creates a bunch of relevant test cases so that others can verify the quality of the PR without necessarily having coding knowledge and without having to study the changes. It is the PRer's responsibility to ensure good test coverage, though everyone is encouraged to add more test cases in a followup comment.
>
> The test coverage doesn't need to be exhaustive; just cover the major, important things that may impact the player. The more complex the PR, the more necessary good testing is, and so this simple peer testing process will hopefully improve the quality of our game without too much overhead. This PR is pretty simple and could possibly forego testing, but serves as a good example.
>
> The tester can copy the table into a followup comment. Then for each test case, in the `Result` column, the tester will add a ✅, :x:, or ⚠️, where the first indicates a pass, the second a fail, and the warning could mean a potential issue or some other indeterminate response. Extra info can be written here, too, such as failure reproduction steps, etc.
>
> When performing a retest, you can just edit your existing table comment.
>
> It's worth noting this is not the same as a _code review_, which is a separate process. Hence the two labels `Status: Awaiting Testing` and `Status: Awaiting Review`.