### PR TITLE
Fixes the spam of errors on round restart

### DIFF
--- a/UnityProject/Assets/Scripts/Systems/Inventory/ItemStorage.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/ItemStorage.cs
@@ -105,12 +105,7 @@ public class ItemStorage : MonoBehaviour, IServerLifecycle, IServerInventoryMove
 		//reclaim the space in the slot pool.
 		ItemSlot.Free(this);
 	}
-
-	private void OnDestroy()
-	{
-		//free the slots
-		ItemSlot.Free(this);
-	}
+	
 
 	public bool ServerTrySpawnAndAdd(GameObject inGameObject)
 	{


### PR DESCRIPTION
### Purpose
Fixes item storages throwing errors when being deleted.

### Notes:
the `ItemSlot.Free(this)` was running while the networkidentity could be already been destroyed, but its irrelevant since its already ran on `OnDespawnServer()`