### PR TITLE
Players now take damage from fire

### DIFF
--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -20,7 +20,7 @@ namespace HealthV2
 	/// </Summary>
 	[RequireComponent(typeof(HealthStateController))]
 	[RequireComponent(typeof(MobSickness))]
-	public abstract class LivingHealthMasterBase : NetworkBehaviour
+	public abstract class LivingHealthMasterBase : NetworkBehaviour, IFireExposable
 	{
 		/// <summary>
 		/// Server side, each mob has a different one and never it never changes
@@ -930,6 +930,12 @@ namespace HealthV2
 		public void UpdateClientBrainStats(bool isHusk, int brainDamage)
 		{
 			//TODO: Reimplement
+		}
+
+		public void OnExposed(FireExposure exposure)
+		{
+			ChangeFireStacks(1f);
+			ApplyDamageAll(null, 1f, AttackType.Fire, DamageType.Burn, false);
 		}
 
 		/// <summary>


### PR DESCRIPTION
### Purpose
Checks the second box off #6398. Players will now take damage from fire.

### Notes:
I've realised there's bug caused by spriting that is more noticeable with this. I've added an issue to fix it.

### Changelog:
CL: Players can now be set on fire from plasma fires
