### PR TITLE
Fixes action icons not despawning after death

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/Buckled.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/Buckled.asset
@@ -12,6 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 175001bada3c3ba47945b92e3bfa2bd2, type: 3}
   m_Name: Buckled
   m_EditorClassIdentifier: 
+  actionType: 0
+  activeSpriteIndex: 1
   callOnClient: 1
   callOnServer: 0
   actionName: Buckled
@@ -21,4 +23,9 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 31baad5011b44aa45b41f8d3da30287e, type: 2}
   Backgrounds: []
   PreventBeingControlledBy: 
-  DisableOnEvent: 
+  DisableOnEvent: 0b000000
+  isAimable: 0
+  useCustomCursor: 0
+  cursorTexture: {fileID: 0}
+  cursorOffsetType: 0
+  cursorOffset: {x: 0, y: 0}

--- a/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/RestraintOverlay.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/RestraintOverlay.asset
@@ -12,13 +12,20 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 175001bada3c3ba47945b92e3bfa2bd2, type: 3}
   m_Name: RestraintOverlay
   m_EditorClassIdentifier: 
+  actionType: 0
+  activeSpriteIndex: 1
   callOnClient: 1
   callOnServer: 0
   actionName: Handcuffed
   description: You're handcuffed and can't act. If anyone drags you, you won't be
     able to move. Click the alert to free yourself.
   Sprites:
-  - {fileID: 11400000, guid: 0c3c1db3702490542a12d241056cb8ed, type: 2}
+  - {fileID: 11400000, guid: 8d93f2b2d48151b4dbd4d0cd62616d10, type: 2}
   Backgrounds: []
   PreventBeingControlledBy: 
-  DisableOnEvent: 
+  DisableOnEvent: 0b000000
+  isAimable: 0
+  useCustomCursor: 0
+  cursorTexture: {fileID: 0}
+  cursorOffsetType: 0
+  cursorOffset: {x: 0, y: 0}

--- a/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/ToggleLight.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/ToggleLight.asset
@@ -12,6 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 175001bada3c3ba47945b92e3bfa2bd2, type: 3}
   m_Name: ToggleLight
   m_EditorClassIdentifier: 
+  actionType: 0
+  activeSpriteIndex: 1
   callOnClient: 1
   callOnServer: 1
   actionName: Toggle Light
@@ -19,4 +21,9 @@ MonoBehaviour:
   Sprites: []
   Backgrounds: []
   PreventBeingControlledBy: 
-  DisableOnEvent: 
+  DisableOnEvent: 0b000000
+  isAimable: 0
+  useCustomCursor: 0
+  cursorTexture: {fileID: 0}
+  cursorOffsetType: 0
+  cursorOffset: {x: 0, y: 0}

--- a/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/ToggleMagboots.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/ToggleMagboots.asset
@@ -12,6 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 175001bada3c3ba47945b92e3bfa2bd2, type: 3}
   m_Name: ToggleMagboots
   m_EditorClassIdentifier: 
+  actionType: 0
+  activeSpriteIndex: 1
   callOnClient: 1
   callOnServer: 1
   actionName: Toggle Magboots
@@ -19,4 +21,9 @@ MonoBehaviour:
   Sprites: []
   Backgrounds: []
   PreventBeingControlledBy: 
-  DisableOnEvent: 
+  DisableOnEvent: 0b000000
+  isAimable: 0
+  useCustomCursor: 0
+  cursorTexture: {fileID: 0}
+  cursorOffsetType: 0
+  cursorOffset: {x: 0, y: 0}

--- a/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/TogglePDALight.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/TogglePDALight.asset
@@ -12,6 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 175001bada3c3ba47945b92e3bfa2bd2, type: 3}
   m_Name: TogglePDALight
   m_EditorClassIdentifier: 
+  actionType: 0
+  activeSpriteIndex: 1
   callOnClient: 1
   callOnServer: 1
   actionName: Toggle PDA Light
@@ -19,4 +21,9 @@ MonoBehaviour:
   Sprites: []
   Backgrounds: []
   PreventBeingControlledBy: 
-  DisableOnEvent: 
+  DisableOnEvent: 0b000000
+  isAimable: 0
+  useCustomCursor: 0
+  cursorTexture: {fileID: 0}
+  cursorOffsetType: 0
+  cursorOffset: {x: 0, y: 0}

--- a/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/ToggleVisionGoggles.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIActionsGraphics/ToggleVisionGoggles.asset
@@ -21,7 +21,7 @@ MonoBehaviour:
   Sprites: []
   Backgrounds: []
   PreventBeingControlledBy: 
-  DisableOnEvent: 
+  DisableOnEvent: 0b000000
   isAimable: 0
   useCustomCursor: 0
   cursorTexture: {fileID: 0}


### PR DESCRIPTION
Purpose
When you died, action icons like toggling the PDA light would remain as you were a ghost, and even remain when you respawned, so I modified the scriptable object so they despawn on death. Only certain items needed this change, because other items like bags have icons that only appear when the item is in your hands and you automatically drop what you're holding when you die when you die (disabling the icon).

Changelog:
CL: Fixed action icons not disappearing after death