### PR TITLE
Refactor AI initialisation, more flexible dead/prone states on MobSprite

### DIFF
--- a/UnityProject/Assets/Prefabs/Mobs/NPC/Resources/Friendly/NPC_GOD_Friendly.prefab
+++ b/UnityProject/Assets/Prefabs/Mobs/NPC/Resources/Friendly/NPC_GOD_Friendly.prefab
@@ -93,8 +93,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   maxHealth: 100
-  canBreathAnywhere: 0
-  cloningDamage: 0
+  canBreatheAnywhere: 1
   bloodSystem: {fileID: 0}
   brainSystem: {fileID: 0}
   respiratorySystem: {fileID: 0}
@@ -104,9 +103,6 @@ MonoBehaviour:
   - {fileID: 186469482417783052}
   allowKnifeHarvest: 0
   butcherResults: []
-  RTT: 0
-  RadiationStacks: 0
-  deadState: 0
 --- !u!114 &114555785714625820
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -154,8 +150,9 @@ MonoBehaviour:
   matrixDebugLogging: 0
   objectType: 1
   AtmosPassable: 1
-  Passable: 0
   ReachableThrough: 1
+  initialPassable: 0
+  initialCrawlPassable: 0
   passableExclusionsToThis: []
 --- !u!114 &114386898746361270
 MonoBehaviour:
@@ -187,13 +184,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   isMeleeable: 1
   butcherTime: 2
-  butcherSound:
-    SetLoadSetting: 0
-    AssetAddress: null
-    AssetReference:
-      m_AssetGUID: 
-      m_SubObjectName: 
-      m_SubObjectType: 
+  butcherSound: 
 --- !u!114 &114536369792164230
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -234,6 +225,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
   ignoreExtraRotation: []
+  RotateParent: {fileID: 0}
 --- !u!114 &114379009499332576
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -246,10 +238,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  isDirty: 0
+  isDirty: 1
   sceneId: 0
   serverOnly: 0
+  visible: 0
   m_AssetId: 
+  hasSpawned: 0
 --- !u!114 &1750259749
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -296,7 +290,12 @@ MonoBehaviour:
   spriteHandler: {fileID: 6463072077799225617}
   spriteRend: {fileID: 4890346600101626888}
   aliveSpriteIndex: 0
+  deadStateRep: 2
   deadSpriteIndex: 1
+  deadOrientation: 90
+  knockedDownStateRep: 2
+  knockedDownSpriteIndex: 1
+  knockedDownOrientation: 90
   burningPrefab: {fileID: 1558421102126524431, guid: 36094128399f8704da2ff54a58c2f4f5,
     type: 3}
   electrocutedPrefab: {fileID: 1558421102126524431, guid: 0cea8096a0de31746a1b6ef11b019ab2,
@@ -325,7 +324,7 @@ MonoBehaviour:
   performingAction: 0
   activated: 0
   tickRate: 0
-  followTarget: {fileID: 0}
+  FollowTarget: {fileID: 0}
 --- !u!114 &8093655862165673158
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -381,19 +380,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   mobName: 
-  knockedDownRotation: 90
   minTimeBetweenRandomActions: 10
   maxTimeBetweenRandomActions: 30
   doRandomActionWhenInTask: 0
   GenericSounds:
   - SetLoadSetting: 0
-    AssetAddress: 
+    AssetAddress: null
     AssetReference:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
   - SetLoadSetting: 0
-    AssetAddress: 
+    AssetAddress: null
     AssetReference:
       m_AssetGUID: 
       m_SubObjectName: 
@@ -411,6 +409,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 62cc3ef7cd9082443aaf3c255851d15a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
 --- !u!114 &5654320338845658687
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -670,7 +670,7 @@ SpriteRenderer:
   m_SortingLayerID: -229502157
   m_SortingLayer: 21
   m_SortingOrder: 11
-  m_Sprite: {fileID: 21300072, guid: 106277f633a313a4990add9de887d387, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 106277f633a313a4990add9de887d387, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0

--- a/UnityProject/Assets/Prefabs/Objects/ClosetsAndCrates/Crates/SecureCrates/PlasmaCrate.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/ClosetsAndCrates/Crates/SecureCrates/PlasmaCrate.prefab
@@ -97,12 +97,12 @@ PrefabInstance:
     - target: {fileID: 6777546918459128681, guid: e9f5c9b81c30b4742b7859c8d2b045c3,
         type: 3}
       propertyPath: initialName
-      value: A secure plasma crate.
+      value: plasma crate
       objectReference: {fileID: 0}
     - target: {fileID: 6777546918459128681, guid: e9f5c9b81c30b4742b7859c8d2b045c3,
         type: 3}
       propertyPath: initialDescription
-      value: plasma crate
+      value: A secure plasma crate.
       objectReference: {fileID: 0}
     - target: {fileID: 8717739805835431555, guid: e9f5c9b81c30b4742b7859c8d2b045c3,
         type: 3}

--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -3,14 +3,16 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Systems.Atmospherics;
-using Light2D;
-using Messages.Server.HealthMessages;
+using WebSocketSharp;
 using UnityEngine;
 using UnityEngine.Events;
-using Mirror;
 using UnityEngine.Profiling;
-using WebSocketSharp;
+using UnityEngine.Serialization;
+using Mirror;
+using Messages.Server.HealthMessages;
+using Systems.Atmospherics;
+using Light2D;
+
 
 /// <summary>
 /// The Required component for all living creatures
@@ -39,9 +41,11 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 	public float Resistance { get; } = 50;
 
 	[Tooltip("For mobs that can breath in any atmos environment")]
-	public bool canBreathAnywhere = false;
+	[FormerlySerializedAs("canBreathAnywhere")]
+	public bool canBreatheAnywhere = false;
 
 	public float OverallHealth { get; private set; } = 100;
+	[NonSerialized]
 	public float cloningDamage;
 
 	/// <summary>
@@ -86,6 +90,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 
 	public event Action OnDeathNotifyEvent;
 
+	[NonSerialized]
 	public float RTT;
 
 	public ConsciousState ConsciousState
@@ -207,7 +212,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 			respiratorySystem = gameObject.AddComponent<RespiratorySystem>();
 		}
 
-		respiratorySystem.CanBreatheAnywhere = canBreathAnywhere;
+		respiratorySystem.CanBreatheAnywhere = canBreatheAnywhere;
 
 		var tryGetHead = FindBodyPart(BodyPartType.Head);
 		if (tryGetHead != null && brainSystem == null)
@@ -553,7 +558,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 		}
 	}
 
-
+	[NonSerialized]
 	public float RadiationStacks = 0;
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Health/Living/SimpleAnimal/SimpleAnimal.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/SimpleAnimal/SimpleAnimal.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using UnityEngine;
 using Mirror;
 
@@ -10,6 +11,7 @@ namespace Systems.Mob
 		private MobSprite mobSprite;
 
 		//Syncvar hook so that new players can sync state on start
+		[NonSerialized]
 		[SyncVar(hook = nameof(SyncAliveState))]
 		public bool deadState;
 

--- a/UnityProject/Assets/Scripts/NPC/AI/Friendly/GenericFriendlyAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Friendly/GenericFriendlyAI.cs
@@ -1,12 +1,11 @@
 ﻿using System.Collections;
 using UnityEngine;
-using WebSocketSharp;
 using Systems.Mob;
 using Random = UnityEngine.Random;
 
 namespace Systems.MobAIs
 {
-	public class GenericFriendlyAI : MobAI, IServerSpawn
+	public class GenericFriendlyAI : MobAI
 	{
 		protected float timeForNextRandomAction;
 		protected float timeWaiting;
@@ -16,29 +15,30 @@ namespace Systems.MobAIs
 		protected float maxTimeBetweenRandomActions = 30f;
 		[SerializeField]
 		protected bool doRandomActionWhenInTask = false;
-		protected SimpleAnimal simpleAnimal;
 		public string MobName => mobName.Capitalize();
 
-		protected override void Awake()
-		{
-			base.Awake();
-			simpleAnimal = GetComponent<SimpleAnimal>();
-		}
+		#region Lifecycle
 
-		protected override void UpdateMe()
-		{
-			if (!MatrixManager.IsInitialized || health.IsDead || health.IsCrit || health.IsCardiacArrest) return;
-
-			base.UpdateMe();
-			MonitorExtras();
-		}
-
-
-		protected override void AIStartServer()
+		protected override void OnSpawnMob()
 		{
 			exploringStopped.AddListener(OnExploringStopped);
 			fleeingStopped.AddListener(OnFleeingStopped);
 			followingStopped.AddListener(OnFollowStopped);
+		}
+
+		protected override void OnAIStart()
+		{
+			BeginExploring();
+		}
+
+		#endregion Lifecycle
+
+		protected override void UpdateMe()
+		{
+			if (MatrixManager.IsInitialized == false || health.IsDead || health.IsCrit || health.IsCardiacArrest) return;
+
+			base.UpdateMe();
+			MonitorExtras();
 		}
 
 		protected virtual void MonitorExtras()
@@ -74,32 +74,14 @@ namespace Systems.MobAIs
 			yield return WaitFor.EndOfFrame;
 		}
 
-		protected virtual void DoRandomAction() {}
-
-		public void OnSpawnServer(SpawnInfo info)
-		{
-			OnSpawnMob();
-		}
-
-		protected virtual void OnSpawnMob()
-		{
-			mobSprite.SetToNPCLayer();
-			registerObject.RestoreAllToDefault();
-			if (simpleAnimal != null)
-			{
-				simpleAnimal.SetDeadState(false);
-			}
-			BeginExploring();
-		}
-
 		protected override void OnAttackReceived(GameObject damagedBy = null)
 		{
 			StartFleeing(damagedBy, 5f);
 		}
 
-		protected virtual void OnExploringStopped(){}
-		protected virtual void OnFleeingStopped(){}
-		protected virtual void OnFollowStopped(){}
-
+		protected virtual void OnExploringStopped() {}
+		protected virtual void OnFleeingStopped() {}
+		protected virtual void OnFollowStopped() {}
+		protected virtual void DoRandomAction() { }
 	}
 }

--- a/UnityProject/Assets/Scripts/NPC/AI/Friendly/GodAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Friendly/GodAI.cs
@@ -16,8 +16,9 @@ namespace Systems.MobAIs
 		/// </summary>
 		public int PlaySoundTime = 3;
 
-		private void Start()
+		protected override void OnAIStart()
 		{
+			base.OnAIStart();
 			PlaySound();
 		}
 

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHuggerAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHuggerAI.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace Systems.MobAIs
 {
-	public class FaceHuggerAI : GenericHostileAI, ICheckedInteractable<HandApply>, IServerSpawn
+	public class FaceHuggerAI : GenericHostileAI, ICheckedInteractable<HandApply>
 	{
 		[SerializeField]
 		[Tooltip("If true, this hugger won't be counted for the cap Queens use for lying eggs.")]
@@ -14,11 +14,25 @@ namespace Systems.MobAIs
 		//private MobMeleeAction mobMeleeAction;
 		private FaceHugAction faceHugAction;
 
+		#region Lifecycle
+
 		protected override void Awake()
 		{
 			faceHugAction = gameObject.GetComponent<FaceHugAction>();
 			base.Awake();
 		}
+
+		protected override void OnSpawnMob()
+		{
+			base.OnSpawnMob();
+			if (ignoreInQueenCount == false)
+			{
+				XenoQueenAI.AddFacehuggerToCount();
+			}
+			ResetBehaviours();
+		}
+
+		#endregion
 
 		/// <summary>
 		/// Looks around and tries to find players to target
@@ -80,17 +94,6 @@ namespace Systems.MobAIs
 			Inventory.ServerAdd(mask, handSlot, ReplacementStrategy.DropOther);
 
 			_ = Despawn.ServerSingle(gameObject);
-		}
-
-		public override void OnSpawnServer(SpawnInfo info)
-		{
-			if (ignoreInQueenCount == false)
-			{
-				XenoQueenAI.AddFacehuggerToCount();
-			}
-			base.OnSpawnServer(info);
-			ResetBehaviours();
-			BeginSearch();
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/LarvaeAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/LarvaeAI.cs
@@ -14,23 +14,30 @@ namespace Systems.MobAIs
 		[Tooltip("Reference to the  Xenomorph so we can spawn it")] [SerializeField]
 		private GameObject xenomorph = null;
 
-		protected override void Awake()
+		#region Lifecycle
+
+		protected override void OnAIStart()
 		{
-			simpleAnimal = GetComponent<SimpleAnimal>();
-			base.Awake();
+			StartFleeing(gameObject, 10f);
+			StartCoroutine(Grow());
 		}
+
+		public override void OnDespawnServer(DespawnInfo info)
+		{
+			base.OnDespawnServer(info);
+			StopAllCoroutines();
+		}
+
+		#endregion Lifecycle
 
 		protected override void DoRandomAction()
 		{
-			if(DMMath.Prob(5))
+			if (DMMath.Prob(5))
 			{
 				StartCoroutine(ChaseTail(Random.Range(1, 4)));
-				StartFleeing(gameObject, 10f);
 			}
-			else
-			{
-				StartFleeing(gameObject, 10f);
-			}
+
+			StartFleeing(gameObject, 10f);
 		}
 
 		private IEnumerator Grow()
@@ -48,19 +55,6 @@ namespace Systems.MobAIs
 		protected override void OnAttackReceived(GameObject damagedBy = null)
 		{
 			StartFleeing(damagedBy);
-		}
-
-		protected override void OnSpawnMob()
-		{
-			base.OnSpawnMob();
-			StartFleeing(gameObject, 10f);
-			StartCoroutine(Grow());
-		}
-
-		public override void OnDespawnServer(DespawnInfo info)
-		{
-			base.OnDespawnServer(info);
-			StopAllCoroutines();
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/StatueAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/StatueAI.cs
@@ -90,7 +90,7 @@ namespace Systems.MobAIs
 			}
 		}
 
-		void Freeze()
+		private void Freeze()
 		{
 			ResetBehaviours();
 			currentStatus = MobStatus.None;
@@ -104,7 +104,7 @@ namespace Systems.MobAIs
 			StartCoroutine(StatueStalk(target));
 		}
 
-		IEnumerator StatueStalk(GameObject stalked)
+		private IEnumerator StatueStalk(GameObject stalked)
 		{
 			while (!IsSomeoneLookingAtMe())
 			{
@@ -119,7 +119,7 @@ namespace Systems.MobAIs
 			yield break;
 		}
 
-		int DirToInt(Vector3 direction)
+		private int DirToInt(Vector3 direction)
 		{
 			var angleOfDir = Vector3.Angle((Vector2) direction, transform.up);
 			if (direction.x < 0f)
@@ -150,12 +150,6 @@ namespace Systems.MobAIs
 					return 2;
 
 			}
-		}
-
-		protected override void OnSpawnMob()
-		{
-			base.OnSpawnMob();
-			BeginSearch();
 		}
 
 		private readonly Dictionary<int, Orientation> orientations = new Dictionary<int, Orientation>()

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/XenoAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/XenoAI.cs
@@ -6,7 +6,8 @@ namespace Systems.MobAIs
 {
 	public class XenoAI: GenericHostileAI
 	{
-		[SerializeField][Tooltip("If true, this Xeno won't ever attempt to become Queen.")]
+		[SerializeField]
+		[Tooltip("If true, this Xeno won't ever attempt to become Queen.")]
 		private bool disableAscension = false;
 
 		[SerializeField]
@@ -19,6 +20,12 @@ namespace Systems.MobAIs
 		[HideIf(nameof(disableAscension))]
 		[Tooltip("Reference to the Queen prefab to be spawned if this xeno becomes a Queen")]
 		private GameObject queenPrefab = default;
+
+		protected override void OnAIStart()
+		{
+			base.OnAIStart();
+			TryBecomingQueen();
+		}
 
 		private void TryBecomingQueen()
 		{
@@ -46,12 +53,6 @@ namespace Systems.MobAIs
 			}
 
 			return XenoQueenAI.CurrentQueensAmt >= queenCap;
-		}
-
-		protected override void OnSpawnMob()
-		{
-			base.OnSpawnMob();
-			TryBecomingQueen();
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/XenoQueenAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/XenoQueenAI.cs
@@ -31,6 +31,27 @@ namespace Systems.MobAIs
 
 		public static int CurrentQueensAmt => currentQueensAmt;
 
+		protected override void OnSpawnMob()
+		{
+			base.OnSpawnMob();
+			AddResetHandler();
+
+			if (ignoreForQueenCount == false)
+			{
+				currentQueensAmt++;
+			}
+		}
+
+		protected override void OnAIStart()
+		{
+			base.OnAIStart();
+
+			if (fertility != 0)
+			{
+				FertilityLoop();
+			}
+		}
+
 		private bool HuggerCapReached()
 		{
 			if (huggerCap < 0)
@@ -93,24 +114,6 @@ namespace Systems.MobAIs
 
 			EventManager.AddHandler(Event.RoundStarted, ResetStaticCounters);
 			resetHandlerAdded = true;
-		}
-
-		protected override void OnSpawnMob()
-		{
-			base.OnSpawnMob();
-			AddResetHandler();
-
-			if (fertility != 0)
-			{
-				FertilityLoop();
-			}
-
-			BeginSearch();
-
-			if (ignoreForQueenCount == false)
-			{
-				currentQueensAmt ++;
-			}
 		}
 
 		protected override void HandleDeathOrUnconscious()

--- a/UnityProject/Assets/Scripts/NPC/AI/MobAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobAI.cs
@@ -13,11 +13,9 @@ namespace Systems.MobAIs
 	public class MobAI : MonoBehaviour, IServerLifecycle
 	{
 		public string mobName;
-		[Tooltip("When the mob is unconscious, how much should the sprite obj " +
-				"be rotated to indicate a knocked down or dead NPC")]
-		public float knockedDownRotation = 90f;
 
 		public event Action PettedEvent;
+		protected SimpleAnimal simpleAnimal;
 		protected MobFollow mobFollow;
 		protected MobExplore mobExplore;
 		protected MobFlee mobFlee;
@@ -61,8 +59,11 @@ namespace Systems.MobAIs
 
 		private bool isKnockedDown = false;
 
+		#region Lifecycle
+
 		protected virtual void Awake()
 		{
+			simpleAnimal = GetComponent<SimpleAnimal>();
 			mobFollow = GetComponent<MobFollow>();
 			mobExplore = GetComponent<MobExplore>();
 			mobFlee = GetComponent<MobFlee>();
@@ -76,11 +77,20 @@ namespace Systems.MobAIs
 
 		public void OnSpawnServer(SpawnInfo info)
 		{
+			mobSprite.SetToNPCLayer();
+			registerObject.RestoreAllToDefault();
+			if (simpleAnimal != null)
+			{
+				simpleAnimal.SetDeadState(false);
+			}
+
 			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 			UpdateManager.Add(PeriodicUpdate, 1f);
 			health.applyDamageEvent += AttackReceivedCoolDown;
 			isServer = true;
-			AIStartServer();
+
+			OnSpawnMob();
+			OnAIStart();
 		}
 
 		public virtual void OnDespawnServer(DespawnInfo info)
@@ -92,9 +102,18 @@ namespace Systems.MobAIs
 		}
 
 		/// <summary>
-		/// Called when the AI has come online on the server
+		/// Called after the mob is spawned, before the AI comes online
+		/// (at tne end of <see cref="OnSpawnServer(SpawnInfo)"/> and before <see cref="OnSpawnMob"/>)
 		/// </summary>
-		protected virtual void AIStartServer() { }
+		protected virtual void OnSpawnMob() { }
+
+		/// <summary>
+		/// Called when the AI has come online on the server
+		/// (at the end of <see cref="OnSpawnServer(SpawnInfo)"/> and after <see cref="OnSpawnMob"/>)
+		/// </summary>
+		protected virtual void OnAIStart() { }
+
+		#endregion
 
 		/// <summary>
 		/// Server only update loop. Make sure to call base.UpdateMe() if overriding
@@ -150,7 +169,7 @@ namespace Systems.MobAIs
 				mobSprite.SetToBodyLayer();
 
 				SoundManager.PlayNetworkedAtPos(SingletonSOSounds.Instance.Bodyfall, transform.position, sourceObj: gameObject);
-				mobSprite.SetRotationServer(knockedDownRotation);
+				mobSprite.SetToKnockedDown(true);
 			}
 		}
 
@@ -170,7 +189,7 @@ namespace Systems.MobAIs
 			}
 		}
 
-		void MonitorFollowingTime()
+		private void MonitorFollowingTime()
 		{
 			if (mobFollow.activated && followTimeMax != -1f)
 			{
@@ -182,7 +201,7 @@ namespace Systems.MobAIs
 			}
 		}
 
-		void MonitorExploreTime()
+		private void MonitorExploreTime()
 		{
 			if (mobExplore.activated && exploreTimeMax != -1f)
 			{
@@ -194,7 +213,7 @@ namespace Systems.MobAIs
 			}
 		}
 
-		void MonitorFleeingTime()
+		private void MonitorFleeingTime()
 		{
 			if (mobFlee.activated && fleeTimeMax != -1f)
 			{
@@ -293,7 +312,7 @@ namespace Systems.MobAIs
 			fleeingTime = 0f;
 		}
 
-		//Stop fleeing
+		///<summary>Stop fleeing</summary>
 		protected void StopFleeing()
 		{
 			mobFlee.Deactivate();
@@ -459,6 +478,5 @@ namespace Systems.MobAIs
 		/// <param name="dir"></param>
 		/// <param name="doLerpAnimation"></param>
 		public virtual void ActOnTile(Vector3Int roundToInt, Vector3 dir) { }
-
 	}
 }


### PR DESCRIPTION
- Refactors mob AI initialisation to make it more clear when the mob is spawned and when the AI behaviour begins.
    - Fixes various mobs with broken AI.
- Fixes the name and description texts for plasma crate being swapped.
- Enables more sprite configuration flexibility on `MobSprite`. This is to address #6427.
    - Refactors knocked down rotation to `MobSprite`.
    - Sprite state for death or being knocked down can now be represented by either a sprite index, rotation value or no change.

> Concerns: may reintroduce the issue described in #6383. Not tested.
> May be a few other sprite state bugs remaining. Inconclusive, will wait on more usage from #6427.
> `NaughtyAttributes`' `BoxGroup` and `ShowIf` don't appear to be working on `MobSprite`.
> Only `God` mob prefab has been configured to reflect the changes.