### PR TITLE
Stop, drop, and roll + Plasma fire damage tweaks

### DIFF
--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -935,7 +935,7 @@ namespace HealthV2
 		public void OnExposed(FireExposure exposure)
 		{
 			ChangeFireStacks(1f);
-			ApplyDamageAll(null, 1f, AttackType.Fire, DamageType.Burn, false);
+			ApplyDamageAll(null, 0.25f, AttackType.Fire, DamageType.Burn, false);
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -166,7 +166,7 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 	IEnumerator Roll()
 	{
 		//Can't roll if you're already rolling or have slipped
-		if (IsRolling == true || playerScript.registerTile.IsSlippingServer == true)
+		if (IsRolling || playerScript.registerTile.IsSlippingServer)
 		{
 			yield return null;
 		}
@@ -190,7 +190,7 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		{
 			//Can only roll if you're conscious and not stunned
 			if (playerScript.playerHealth.ConsciousState != ConsciousState.CONSCIOUS ||
-				playerScript.registerTile.IsSlippingServer == true)
+				playerScript.registerTile.IsSlippingServer)
 			{
 				break;
 			}

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -34,7 +34,7 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 
 	public Transform chatBubbleTarget;
 
-	public bool isRolling { get; private set; } = false;
+	public bool IsRolling { get; private set; } = false;
 
 	private void Awake()
 	{
@@ -166,12 +166,12 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 	IEnumerator Roll()
 	{
 		//Can't roll if you're already rolling or have slipped
-		if (isRolling == true || playerScript.registerTile.IsSlippingServer == true)
+		if (IsRolling == true || playerScript.registerTile.IsSlippingServer == true)
 		{
 			yield return null;
 		}
 
-		isRolling = true;
+		IsRolling = true;
 
 		// Drop the player if they aren't already, prevent them from moving until the action is complete
 		if (playerScript.registerTile.IsLayingDown == false)
@@ -220,7 +220,7 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 			playerScript.playerMove.allowInput = true;
 		}
 
-		isRolling = false;
+		IsRolling = false;
 		yield return null;
 	}
 

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -174,7 +174,7 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		isRolling = true;
 
 		// Drop the player it they aren't already, prevent them from moving until the action is complete
-		if (!playerScript.registerTile.IsLayingDown)
+		if (playerScript.registerTile.IsLayingDown == false)
 		{
 			playerScript.registerTile.ServerSetIsStanding(false);
 			SoundManager.PlayNetworkedAtPos(SingletonSOSounds.Instance.Bodyfall, transform.position, sourceObj: gameObject);
@@ -189,7 +189,8 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		while (playerScript.playerHealth.FireStacks > 0)
 		{
 			//Can only roll if you're conscious
-			if (playerScript.playerHealth.ConsciousState != ConsciousState.CONSCIOUS) {
+			if (playerScript.playerHealth.ConsciousState != ConsciousState.CONSCIOUS)
+			{
 				break;
 			}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
@@ -221,6 +221,9 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 	{
 		if (!IsLayingDown) return;
 
+		// Can't help a player up if they're rolling
+		if (playerScript.playerNetworkActions.isRolling) return;
+
 		// Check if lying down because of stun. If stunned, there is a chance helping can fail.
 		if (IsSlippingServer && Random.Range(0, 100) > HELP_CHANCE) return;
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
@@ -222,7 +222,7 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 		if (!IsLayingDown) return;
 
 		// Can't help a player up if they're rolling
-		if (playerScript.playerNetworkActions.isRolling) return;
+		if (playerScript.playerNetworkActions.IsRolling) return;
 
 		// Check if lying down because of stun. If stunned, there is a chance helping can fail.
 		if (IsSlippingServer && Random.Range(0, 100) > HELP_CHANCE) return;

--- a/UnityProject/Assets/Scripts/UI/Core/ProgressBar/StandardProgressAction.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/ProgressBar/StandardProgressAction.cs
@@ -264,7 +264,7 @@ public class StandardProgressAction : IProgressAction
 		return playerScript.playerHealth.ConsciousState == initialConsciousState &&
 		       playerScript.playerMove.IsCuffed == false &&
 		       playerScript.registerTile.IsSlippingServer == false &&
-			   playerScript.playerNetworkActions.isRolling == false &&
+			   playerScript.playerNetworkActions.IsRolling == false &&
 		       (progressActionConfig.AllowTurning ||
 		        playerScript.playerDirectional.CurrentDirection != initialDirection) &&
 		       playerScript.PlayerSync.IsMoving == false &&

--- a/UnityProject/Assets/Scripts/UI/Core/ProgressBar/StandardProgressAction.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/ProgressBar/StandardProgressAction.cs
@@ -262,11 +262,12 @@ public class StandardProgressAction : IProgressAction
 	{
 		//note: doesn't check cross matrix situations.
 		return playerScript.playerHealth.ConsciousState == initialConsciousState &&
-		       !playerScript.playerMove.IsCuffed &&
-		       !playerScript.registerTile.IsSlippingServer &&
+		       playerScript.playerMove.IsCuffed == false &&
+		       playerScript.registerTile.IsSlippingServer == false &&
+			   playerScript.playerNetworkActions.isRolling == false &&
 		       (progressActionConfig.AllowTurning ||
 		        playerScript.playerDirectional.CurrentDirection != initialDirection) &&
-		       !playerScript.PlayerSync.IsMoving &&
+		       playerScript.PlayerSync.IsMoving == false &&
 		       //make sure we're still in range
 		       Validations.IsInReachDistanceByPositions(playerScript.registerTile.WorldPositionServer,
 			       startProgressInfo.Target.TargetWorldPosition);


### PR DESCRIPTION
### Purpose
Reworked stopping, dropping, and rolling (Ticks the third box off #6398) and tweaks damage done by plasma fires to make it not too deadly.

### Notes:
A stop drop and roll works like this:

![ezgif-7-fd2a5afb4c70](https://user-images.githubusercontent.com/62051810/116661223-b29a2f80-a9c6-11eb-919a-d0077bff72a6.gif)

(Excuse the overlays, none of them seem to work at the moment)

When you click the resist button while on fire (The gif shows me clicking the drop button, but that's a recording error) you'll start a coroutine to drop and roll, reducing some fire stacks every roll until the coroutine ends or you die. After that, it'll automatically stand you up. There's also some text once you begin the roll, but I added after the gif and couldn't be bothered to re-record.

I've also tweaked the plasma fire damage so it's not ridiculous. It now does a quarter of the damage it did before, so it doesn't kill you in 3 seconds and gives people more of a chance to get away.

### Changelog:
CL: Stop, drop, and roll is now better
CL: Plasma fire damage tweaks
