### PR TITLE
Improve melee code, fix some melee issues

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Item.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Item.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 4527534762131918}
   - component: {fileID: 114341119007412586}
   - component: {fileID: 499351249353511896}
-  - component: {fileID: 114326413956932616}
   - component: {fileID: 114734890905785284}
   - component: {fileID: 114182420558184634}
   - component: {fileID: 114776788309089574}
@@ -111,27 +110,6 @@ MonoBehaviour:
     - {r: 0, g: 0, b: 0, a: 0}
     - {r: 0, g: 0, b: 0, a: 0}
     IsPaletted: 0
---- !u!114 &114326413956932616
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1011433845357754}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  isMeleeable: 0
-  butcherTime: 2
-  butcherSound:
-    SetLoadSetting: 0
-    AssetAddress: Assets/Prefabs/Effects/BladeSlice.prefab
-    AssetReference:
-      m_AssetGUID: 
-      m_SubObjectName: 
-      m_SubObjectType: 
 --- !u!114 &114734890905785284
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -146,6 +124,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  pickupAnimSpeed: 0.2
 --- !u!114 &114182420558184634
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -206,6 +185,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
   ignoreExtraRotation: []
+  RotateParent: {fileID: 0}
 --- !u!114 &114883521337486670
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -248,7 +228,10 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
+    LightningDamageProof: 0
   HeatResistance: 100
+  ExplosionsDamage: 100
+  doDamageMessage: 1
 --- !u!114 &114738972662350094
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -264,7 +247,9 @@ MonoBehaviour:
   isDirty: 0
   sceneId: 0
   serverOnly: 0
+  visible: 0
   m_AssetId: 
+  hasSpawned: 0
 --- !u!114 &1397050043076861577
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -291,6 +276,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 62cc3ef7cd9082443aaf3c255851d15a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
 --- !u!114 &1373280397285383934
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
+++ b/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
@@ -666,7 +666,31 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  KnifeTrait: {fileID: 0}
+  meleeSounds:
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/Effects/Punch1.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/Effects/Punch2.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/Effects/Punch3.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/Effects/Punch4.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
 --- !u!114 &114285504268110804
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1097,11 +1121,13 @@ MonoBehaviour:
     reagents:
       m_keys: []
       m_values: []
+    reagentKeys: []
   ReadyBloodPool:
     temperature: 0
     reagents:
       m_keys: []
       m_values: []
+    reagentKeys: []
   bloodInfo: {fileID: 11400000, guid: 5a85f8bded849a44290c34e227cd4096, type: 2}
 --- !u!114 &4232843736106124361
 MonoBehaviour:

--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using Systems.Explosions;
+using Systems.Interaction;
 using AddressableReferences;
 using DatabaseAPI;
 using UnityEngine;
@@ -22,8 +23,7 @@ using ScriptableObjects;
 [RequireComponent(typeof(CustomNetTransform))]
 [RequireComponent(typeof(RegisterTile))]
 [RequireComponent(typeof(Meleeable))]
-public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClickable, IServerSpawn, IExaminable,
-	IServerDespawn
+public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClickable, IServerSpawn, IExaminable, IServerDespawn
 {
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using Systems.Explosions;
-using Systems.Interaction;
 using AddressableReferences;
 using DatabaseAPI;
 using UnityEngine;
@@ -22,7 +21,6 @@ using ScriptableObjects;
 /// </summary>
 [RequireComponent(typeof(CustomNetTransform))]
 [RequireComponent(typeof(RegisterTile))]
-[RequireComponent(typeof(Meleeable))]
 public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClickable, IServerSpawn, IExaminable, IServerDespawn
 {
 

--- a/UnityProject/Assets/Scripts/Items/Weapons/Meleeable.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Meleeable.cs
@@ -1,144 +1,92 @@
 ﻿using System.Collections.Generic;
-using HealthV2;
 using UnityEngine;
 using Items;
 
-//Do not derive from NetworkBehaviour, this is also used on tilemap layers
-/// <summary>
-/// Allows an object or tiles to be attacked by melee.
-/// </summary>
-public class Meleeable : MonoBehaviour, IPredictedCheckedInteractable<PositionalHandApply>
+namespace Systems.Interaction
 {
-	[SerializeField] private bool isMeleeable = true;
-
-	[SerializeField] private static readonly StandardProgressActionConfig ProgressConfig
-		= new StandardProgressActionConfig(StandardProgressActionType.Restrain);
-
-	[SerializeField] private float butcherTime = 2.0f;
-
-	[SerializeField] private string butcherSound = "BladeSlice";
-
+	// Do not derive from NetworkBehaviour, this is also used on tilemap layers
 	/// <summary>
-	/// Which layers are allowed to be attacked on tiles regardless of intent
+	/// Allows an object or tiles to be attacked by melee.
 	/// </summary>
-	private static readonly HashSet<LayerType> attackableLayers = new HashSet<LayerType>(
-		new[]
-		{
+	public class Meleeable : MonoBehaviour, IPredictedCheckedInteractable<PositionalHandApply>
+	{
+		[SerializeField]
+		private bool isMeleeable = true;
+		// If it has this component, isn't it assumed to be meleeable? Is this still true for tilemaps?
+		public bool IsMeleeable => isMeleeable;
+
+		/// <summary>
+		/// Which layers are allowed to be attacked
+		/// </summary>
+		private static readonly HashSet<LayerType> attackableLayers = new HashSet<LayerType>(
+			new[]
+			{
 			LayerType.Grills,
 			LayerType.Walls,
 			LayerType.Windows
-		});
+			});
 
-	/// <summary>
-	/// Which layers are allowed to be attacked on tiles only on harm intent
-	/// </summary>
-	/// NOTE: Not allowing attacking base or floors now because it's annoying during combat when you misclick
-	// private static readonly HashSet<LayerType> harmIntentOnlyAttackableLayers = new HashSet<LayerType>(
-	// 	new[] {
-	// 		LayerType.Base,
-	// 		LayerType.Floors
-	// 	});
-	private static readonly HashSet<LayerType> harmIntentOnlyAttackableLayers = new HashSet<LayerType>();
+		private InteractableTiles interactableTiles;
 
-	private InteractableTiles interactableTiles;
-
-	private void Start()
-	{
-		interactableTiles = GetComponent<InteractableTiles>();
-	}
-
-	public bool WillInteract(PositionalHandApply interaction, NetworkSide side)
-	{
-		//are we in range
-		if (!DefaultWillInteract.Default(interaction, side)) return false;
-		//must be targeting us
-		if (interaction.TargetObject != gameObject) return false;
-		//allowed to attack due to cooldown?
-		//note: actual cooldown is started in WeaponNetworkActions melee logic on server side,
-		//clientPredictInteraction on clientside
-		if (Cooldowns.IsOn(interaction, CooldownID.Asset(CommonCooldowns.Instance.Melee, side)))
+		private void Start()
 		{
-			interaction = PositionalHandApply.Invalid;
+			interactableTiles = GetComponent<InteractableTiles>();
+		}
+
+		public bool WillInteract(PositionalHandApply interaction, NetworkSide side)
+		{
+			if (DefaultWillInteract.Default(interaction, side) == false) return false;
+			// must be targeting us
+			if (interaction.TargetObject != gameObject) return false;
+			// allowed to attack due to cooldown?
+			// note: actual cooldown is started in WeaponNetworkActions melee logic on server side,
+			// clientPredictInteraction on clientside
+			if (side == NetworkSide.Client && Cooldowns.IsOn(interaction, CooldownID.Asset(CommonCooldowns.Instance.Melee, side))) return false;
+
+			// not punching unless harm intent
+			if (interaction.HandObject == null && interaction.Intent != Intent.Harm) return false;
+
+			// if attacking tiles, only some layers are allowed to be attacked
+			if (interactableTiles != null)
+			{
+				var tileAt = interactableTiles.LayerTileAt(interaction.WorldPositionTarget, true);
+
+				// Nothing there, could be space?
+				if (tileAt == null) return false;
+
+				if (attackableLayers.Contains(tileAt.LayerType) == false) return false;
+			}
+
 			return true;
 		}
 
-		//not punching unless harm intent
-		if (interaction.HandObject == null && interaction.Intent != Intent.Harm) return false;
-
-		//if attacking tiles, only some layers are allowed to be attacked
-		if (interactableTiles != null)
+		public void ClientPredictInteraction(PositionalHandApply interaction)
 		{
-			var tileAt = interactableTiles.LayerTileAt(interaction.WorldPositionTarget, true);
-
-			//Nothing there, could be space?
-			if (tileAt == null) return false;
-
-			if (!attackableLayers.Contains(tileAt.LayerType))
-			{
-				return interaction.Intent == Intent.Harm && harmIntentOnlyAttackableLayers.Contains(tileAt.LayerType);
-			}
+			// start clientside melee cooldown so we don't try to spam melee
+			// requests to server
+			Cooldowns.TryStartClient(interaction, CommonCooldowns.Instance.Melee);
 		}
 
-		return true;
-	}
+		// no rollback logic
+		public void ServerRollbackClient(PositionalHandApply interaction) { }
 
-	public void ClientPredictInteraction(PositionalHandApply interaction)
-	{
-		//start clientside melee cooldown so we don't try to spam melee
-		//requests to server
-		Cooldowns.TryStartClient(interaction, CommonCooldowns.Instance.Melee);
-	}
-
-	//no rollback logic
-	public void ServerRollbackClient(PositionalHandApply interaction) { }
-
-	public void ServerPerformInteraction(PositionalHandApply interaction)
-	{
-		var handObject = interaction.HandObject;
-
-		bool emptyHand = interaction.HandSlot.IsEmpty;
-
-		var wna = interaction.Performer.GetComponent<WeaponNetworkActions>();
-		if (interactableTiles != null && !emptyHand)
+		public void ServerPerformInteraction(PositionalHandApply interaction)
 		{
-			//attacking tiles
-			var tileAt = interactableTiles.LayerTileAt(interaction.WorldPositionTarget, true);
-			if (tileAt == null)
+			var handObject = interaction.HandObject;
+
+			var wna = interaction.Performer.GetComponent<WeaponNetworkActions>();
+			var layerType = LayerType.None;
+			if (interactableTiles != null)
 			{
-				return;
+				// attacking tiles
+				layerType = interactableTiles.LayerTileAt(interaction.WorldPositionTarget, true).LayerType;
 			}
 
-			if (tileAt.TileType == TileType.Wall)
-			{
-				return;
-			}
-
-			wna.ServerPerformMeleeAttack(gameObject, interaction.TargetVector, BodyPartType.None, tileAt.LayerType);
+			wna.ServerPerformMeleeAttack(gameObject, interaction.TargetVector, interaction.TargetBodyPart, layerType);
 			if (Validations.HasItemTrait(handObject, CommonTraits.Instance.Breakable))
 			{
 				handObject.GetComponent<ItemBreakable>().AddDamage();
 			}
 		}
-		else
-		{
-			if (interaction.Intent == Intent.Help) return;
-			GameObject victim = interaction.TargetObject;
-			var healthComponent = victim.GetComponent<LivingHealthMasterBase>();
-
-
-			if (gameObject.GetComponent<Integrity>() && emptyHand) return;
-
-			wna.ServerPerformMeleeAttack(gameObject, interaction.TargetVector, interaction.TargetBodyPart,
-				LayerType.None);
-			if (Validations.HasItemTrait(handObject, CommonTraits.Instance.Breakable))
-			{
-				handObject.GetComponent<ItemBreakable>().AddDamage();
-			}
-		}
-	}
-
-	public bool GetMeleeable()
-	{
-		return isMeleeable;
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Weapons/Meleeable.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Meleeable.cs
@@ -13,7 +13,18 @@ namespace Systems.Interaction
 		[SerializeField]
 		private bool isMeleeable = true;
 		// If it has this component, isn't it assumed to be meleeable? Is this still true for tilemaps?
-		public bool IsMeleeable => isMeleeable;
+		public bool IsMeleeable
+		{
+			get
+			{
+				if (isMeleeable == false)
+				{
+					Logger.LogWarning($"Remove {nameof(Meleeable)} component from {this} if it isn't meleeable, " +
+						$"instead of relying on the isMeleeable field.");
+				}
+				return isMeleeable;
+			}
+		}
 
 		/// <summary>
 		/// Which layers are allowed to be attacked

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
@@ -1,37 +1,35 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using TileManagement;
+using Mirror;
 using AddressableReferences;
 using HealthV2;
 using Items;
 using Messages.Server.SoundMessages;
-using UnityEngine;
-using Utility = UnityEngine.Networking.Utility;
-using Mirror;
-using TileManagement;
-using Weapons;
-
+using Systems.Interaction;
 
 public class WeaponNetworkActions : ManagedNetworkBehaviour
 {
-	private readonly float speed = 7f;
-	float fistDamage = 5;
+	[SerializeField]
+	private List<AddressableAudioSource> meleeSounds = default;
 
-	//muzzle flash
-	private bool isFlashing;
+	private readonly float speed = 7f;
+	private readonly float fistDamage = 5;
 
 	private bool isForLerpBack;
 	private Vector3 lerpFrom;
-	public bool lerping { get; private set; } //needs to be read by Camera2DFollow
+	public bool lerping { get; private set; } // needs to be read by Camera2DFollow
 
 	private float lerpProgress;
 
-	//Lerp parameters
+	// Lerp parameters
 	private SpriteRenderer spriteRendererSource; // need renderer for shader configuration
 
 	private Vector3 lerpTo;
 	private PlayerMove playerMove;
 	private PlayerScript playerScript;
 	private GameObject spritesObj;
-	public ItemTrait KnifeTrait;
 
 	private void Start()
 	{
@@ -51,130 +49,106 @@ public class WeaponNetworkActions : ManagedNetworkBehaviour
 	/// <param name="damageZone">damage zone if attacking mob, otherwise use None</param>
 	/// <param name="layerType">layer being attacked if attacking tilemap, otherwise use None</param>
 	[Server]
-	public void ServerPerformMeleeAttack(GameObject victim, Vector2 attackDirection,
-		BodyPartType damageZone, LayerType layerType)
+	public void ServerPerformMeleeAttack(GameObject victim, Vector2 attackDirection, BodyPartType damageZone, LayerType layerType)
 	{
+		if (victim == null) return;
 		if (Cooldowns.IsOnServer(playerScript, CommonCooldowns.Instance.Melee)) return;
-		var weapon = playerScript.playerNetworkActions.GetActiveHandItem();
-
-		var tiles = victim.GetComponent<InteractableTiles>();
-		if (tiles)
+		if (playerMove.allowInput == false) return;
+		if (playerScript.IsGhost) return;
+		if (playerScript.playerHealth.serverPlayerConscious == false) return;
+		
+		if (victim.TryGetComponent<InteractableTiles>(out var tiles))
 		{
-			//validate based on position of target vector
-			if (!Validations.CanApply(playerScript, victim, NetworkSide.Server, targetVector: attackDirection)) return;
+			// validate based on position of target vector
+			if (Validations.CanApply(playerScript, victim, NetworkSide.Server, targetVector: attackDirection) == false) return;
 		}
 		else
 		{
-			//validate based on position of target object
-			if (!Validations.CanApply(playerScript, victim, NetworkSide.Server)) return;
+			// validate based on position of target object
+			if (Validations.CanApply(playerScript, victim, NetworkSide.Server) == false) return;
 		}
 
-		if (!playerMove.allowInput ||
-			playerScript.IsGhost ||
-			!victim ||
-			!playerScript.playerHealth.serverPlayerConscious
-		)
+		float damage = fistDamage;
+		DamageType damageType = DamageType.Brute;
+		AddressableAudioSource weaponSound = meleeSounds.PickRandom();
+		GameObject weapon = playerScript.playerNetworkActions.GetActiveHandItem();
+		ItemAttributesV2 weaponAttributes = weapon == null ? null : weapon.GetComponent<ItemAttributesV2>();
+
+		if (weaponAttributes != null)
 		{
-			return;
+			damage = weaponAttributes.ServerHitDamage;
+			damageType = weaponAttributes.ServerDamageType;
+			weaponSound = weaponAttributes.hitSoundSettings == SoundItemSettings.OnlyObject ? null : weaponAttributes.ServerHitSound;
 		}
 
-		var isWeapon = weapon != null;
-		ItemAttributesV2 weaponAttr = isWeapon ? weapon.GetComponent<ItemAttributesV2>() : null;
-		var damage = isWeapon ? weaponAttr.ServerHitDamage : fistDamage;
-		var damageType = isWeapon ? weaponAttr.ServerDamageType : DamageType.Brute;
-		var attackSound = isWeapon ? weaponAttr.ServerHitSound : null;
 		LayerTile attackedTile = null;
 		bool didHit = false;
-
-		ItemAttributesV2 weaponStats = null;
-		if (isWeapon)
-		{
-			weaponStats = weapon.GetComponent<ItemAttributesV2>();
-		}
-
 
 		// If Tilemap LayerType is not None then it is a tilemap being attacked
 		if (layerType != LayerType.None)
 		{
 			var tileChangeManager = victim.GetComponent<TileChangeManager>();
-			if (tileChangeManager == null) return; //Make sure its on a matrix that is destructable
+			if (tileChangeManager == null) return; // Make sure its on a matrix that is destructable
 
-			//Tilemap stuff:
-			var tileMapDamage = victim.GetComponentInChildren<MetaTileMap>().Layers[layerType].gameObject
-				.GetComponent<TilemapDamage>();
-			if (tileMapDamage != null)
-			{
-				if (isWeapon && weaponStats != null &&
-				    weaponStats.hitSoundSettings == SoundItemSettings.OnlyObject)
-				{
-					attackSound = null;
-				}
-				var worldPos = (Vector2)transform.position + attackDirection;
-				attackedTile = tileChangeManager.InteractableTiles.LayerTileAt(worldPos, true);
-				tileMapDamage.ApplyDamage((int)damage, AttackType.Melee, worldPos);
-				didHit = true;
+			// Tilemap stuff:
+			var tileMapDamage = victim.GetComponentInChildren<MetaTileMap>().Layers[layerType].gameObject.GetComponent<TilemapDamage>();
+			if (tileMapDamage == null) return;
 
-			}
+			var worldPos = (Vector2)transform.position + attackDirection;
+			attackedTile = tileChangeManager.InteractableTiles.LayerTileAt(worldPos, true);
+
+			// Tile itself is responsible for playing victim damage sound
+			tileMapDamage.ApplyDamage(damage, AttackType.Melee, worldPos);
+			didHit = true;
 		}
+		// Damaging an object
+		else if (victim.TryGetComponent<Integrity>(out var integrity) &&
+			victim.TryGetComponent<Meleeable>(out var meleeable) && meleeable.IsMeleeable)
+		{
+			if (weaponAttributes != null && weaponAttributes.hitSoundSettings != SoundItemSettings.OnlyItem)
+			{
+				AudioSourceParameters audioSourceParameters = new AudioSourceParameters(pitch: Random.Range(0.9f, 1.1f));
+				SoundManager.PlayNetworkedAtPos(integrity.soundOnHit, gameObject.WorldPosServer(), audioSourceParameters, sourceObj: gameObject);
+			}
+
+			integrity.ApplyDamage(damage, AttackType.Melee, damageType);
+			didHit = true;
+		}
+		// must be a living thing
 		else
 		{
-			//a regular object being attacked
-
-			LivingHealthMasterBase victimHealth = victim.GetComponent<LivingHealthMasterBase>();
-
-			var integrity = victim.GetComponent<Integrity>();
-			var meleeable = victim.GetComponent<Meleeable>();
-			if (integrity != null)
+			// This is based off the alien/humanoid/attack_hand punch code of TGStation's codebase.
+			// Punches have 90% chance to hit, otherwise it is a miss.
+			if (DMMath.Prob(90))
 			{
-				if (meleeable.GetMeleeable())
-				{//damaging an object
-					if(isWeapon && weaponStats != null &&
-					weaponStats.hitSoundSettings == SoundItemSettings.Both)
-					{
-						AudioSourceParameters audioSourceParameters = new AudioSourceParameters(pitch: Random.Range(0.9f, 1.1f));
-						SoundManager.PlayNetworkedAtPos(integrity.soundOnHit, gameObject.WorldPosServer(), audioSourceParameters, sourceObj: gameObject);
-					}
-					else if (isWeapon && weaponStats != null &&
-				    	     weaponStats.hitSoundSettings == SoundItemSettings.OnlyObject && integrity.soundOnHit == null)
-					{
-						AudioSourceParameters audioSourceParameters = new AudioSourceParameters(pitch: Random.Range(0.9f, 1.1f));
-						SoundManager.PlayNetworkedAtPos(integrity.soundOnHit, gameObject.WorldPosServer(), audioSourceParameters, sourceObj: gameObject);
-						attackSound = null;
-					}
-					integrity.ApplyDamage((int)damage, AttackType.Melee, damageType);
+				// The attack hit.
+				if (victim.TryGetComponent<LivingHealthMasterBase>(out var victimHealth))
+				{
+					victimHealth.ApplyDamageToBodyPart(gameObject, damage, AttackType.Melee, damageType, damageZone);
+					didHit = true;
+				}
+				else if (victim.TryGetComponent<LivingHealthBehaviour>(out var victimHealthOld))
+				{
+					victimHealthOld.ApplyDamageToBodyPart(gameObject, damage, AttackType.Melee, damageType, damageZone);
 					didHit = true;
 				}
 			}
 			else
 			{
-				//damaging a living thing
-				var rng = new System.Random();
-				// This is based off the alien/humanoid/attack_hand punch code of TGStation's codebase.
-				// Punches have 90% chance to hit, otherwise it is a miss.
-				if (isWeapon || 90 >= rng.Next(1, 100))
-				{
-					if (victimHealth == null || gameObject == null) return;
-					// The attack hit.
-					victimHealth.ApplyDamageToBodyPart(gameObject, (int)damage, AttackType.Melee, damageType, damageZone);
-					didHit = true;
-				}
-				else
-				{
-					// The punch missed.
-					string victimName = victim.Player()?.Name;
-					SoundManager.PlayNetworkedAtPos(SingletonSOSounds.Instance.PunchMiss, transform.position, sourceObj: gameObject);
-					Chat.AddCombatMsgToChat(gameObject, $"You attempted to punch {victimName} but missed!",
-						$"{gameObject.Player()?.Name} has attempted to punch {victimName}!");
-				}
+				// The punch missed.
+				string victimName = victim.ExpensiveName();
+				SoundManager.PlayNetworkedAtPos(SingletonSOSounds.Instance.PunchMiss, transform.position, sourceObj: gameObject);
+				Chat.AddCombatMsgToChat(gameObject, $"You attempted to punch {victimName} but missed!",
+					$"{gameObject.ExpensiveName()} has attempted to punch {victimName}!");
 			}
 		}
 
-		//common logic to do if we hit something
+		// common logic to do if we hit something
 		if (didHit)
 		{
-			if (attackSound != null)
+			if (weaponSound != null)
 			{
-				SoundManager.PlayNetworkedAtPos(attackSound, transform.position, sourceObj: gameObject);
+				SoundManager.PlayNetworkedAtPos(weaponSound, transform.position, sourceObj: gameObject);
 			}
 
 			if (damage > 0)
@@ -184,7 +158,6 @@ public class WeaponNetworkActions : ManagedNetworkBehaviour
 			if (victim != gameObject)
 			{
 				RpcMeleeAttackLerp(attackDirection, weapon);
-				//playerMove.allowInput = false;
 			}
 		}
 
@@ -235,7 +208,7 @@ public class WeaponNetworkActions : ManagedNetworkBehaviour
 		}
 	}
 
-	//Server lerps
+	// Server lerps
 	public override void UpdateMe()
 	{
 		if (lerping)
@@ -252,13 +225,13 @@ public class WeaponNetworkActions : ManagedNetworkBehaviour
 					{
 						if (PlayerManager.LocalPlayer == gameObject)
 						{
-							CmdRequestInputActivation(); //Ask server if you can move again after melee attack
+							CmdRequestInputActivation(); // Ask server if you can move again after melee attack
 						}
 					}
 				}
 				else
 				{
-					//To lerp back from knife attack
+					// To lerp back from knife attack
 					ResetLerp();
 					lerpTo = lerpFrom;
 					lerpFrom = spritesObj.transform.localPosition;

--- a/UnityProject/Assets/Scripts/Player/PlayerMove.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerMove.cs
@@ -128,9 +128,8 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn, IActi
 		MoveAction.MoveUp, MoveAction.MoveLeft, MoveAction.MoveDown, MoveAction.MoveRight
 	};
 
-	public Directional PlayerDirectional;
-
-	[HideInInspector] public PlayerNetworkActions pna;
+	[NonSerialized]
+	public PlayerNetworkActions pna;
 
 	[SyncVar(hook = nameof(SyncRunSpeed))] public float RunSpeed;
 	[SyncVar(hook = nameof(SyncWalkSpeed))] public float WalkSpeed;
@@ -144,6 +143,7 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn, IActi
 	private RegisterPlayer registerPlayer;
 	private Matrix matrix => registerPlayer.Matrix;
 	private PlayerScript playerScript;
+	private Directional PlayerDirectional;
 
 	private void Awake()
 	{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterDoor.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterDoor.cs
@@ -1,5 +1,5 @@
 ﻿using UnityEngine;
-
+using Systems.Interaction;
 
 	[RequireComponent(typeof(Integrity))]
 	[RequireComponent(typeof(Meleeable))]


### PR DESCRIPTION
- Improves melee code.
- Fixes melee bugs.
    - Fixes being unable to melee mobs with the old `LivingHealthBehaviour` component. Fixes #6423.
    - You can now punch windows and grilles (and walls, which may not be desirable but is harmless enough).
- Re-adds punch sounds. Fixes #6089.