### PR TITLE
Fix jukebox breaking when setting volume to 0

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Machines/Jukebox.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/Jukebox.cs
@@ -233,7 +233,7 @@ namespace Objects
 		{
 			audioSourceParameters.Volume = newVolume;
 
-			audioSourceParameters.IsMute = newVolume == 0;
+			audioSourceParameters.IsMute = newVolume <= 0;
 
 			ChangeAudioSourceParametersMessage.SendToAll(guid, audioSourceParameters);
 		}

--- a/UnityProject/Assets/Scripts/Objects/Machines/Jukebox.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/Jukebox.cs
@@ -195,7 +195,7 @@ namespace Objects
 				{
 					SoundManager.StopNetworked(guid);
 				}
-				
+
 				currentSongTrackIndex--;
 				UpdateGUI();
 
@@ -214,7 +214,7 @@ namespace Objects
 				{
 					SoundManager.StopNetworked(guid);
 				}
-				
+
 				currentSongTrackIndex++;
 				UpdateGUI();
 
@@ -233,8 +233,7 @@ namespace Objects
 		{
 			audioSourceParameters.Volume = newVolume;
 
-			if( newVolume == 0)
-				audioSourceParameters.IsMute = true;
+			audioSourceParameters.IsMute = newVolume == 0;
 
 			ChangeAudioSourceParametersMessage.SendToAll(guid, audioSourceParameters);
 		}


### PR DESCRIPTION
### Purpose

Fixes #6445. 

### Notes:

There was an issue with jukebox being permanently muted when the volume slider is brought all the way down to zero. This fixes it so that it mutes when it's at zero and unmutes when it's not zero.

### Changelog:

CL: Fix jukebox breaking when setting volume to 0.
