### PR TITLE
Enabling Physics2D for ambience colliders

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -166,7 +166,7 @@ public partial class GameManager : MonoBehaviour, IInitialise
 		ShuttleGibbingAllowed = GameConfigManager.GameConfig.ShuttleGibbingAllowed;
 		AdminOnlyHtml = GameConfigManager.GameConfig.AdminOnlyHtml;
 		Physics.autoSimulation = false;
-		Physics2D.simulationMode = SimulationMode2D.Script;
+		Physics2D.simulationMode = SimulationMode2D.Update;
 	}
 
 	private void OnEnable()

--- a/UnityProject/ProjectSettings/Physics2DSettings.asset
+++ b/UnityProject/ProjectSettings/Physics2DSettings.asset
@@ -3,8 +3,8 @@
 --- !u!19 &1
 Physics2DSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 4
-  m_Gravity: {x: 0, y: -9.81}
+  serializedVersion: 5
+  m_Gravity: {x: 0, y: 0}
   m_DefaultMaterial: {fileID: 0}
   m_VelocityIterations: 8
   m_PositionIterations: 3
@@ -38,7 +38,7 @@ Physics2DSettings:
     m_IslandSolverJointCostScale: 10
     m_IslandSolverBodiesPerJob: 50
     m_IslandSolverContactsPerJob: 50
-  m_AutoSimulation: 1
+  m_SimulationMode: 0
   m_QueriesHitTriggers: 1
   m_QueriesStartInColliders: 1
   m_CallbacksOnDisable: 1


### PR DESCRIPTION
* Physics2D simulation mode changed from script to update
* Physics2D y axis gravity changed to 0

### Purpose
Enables collision simulation, in this case so that AmbientSoundArea colliders can be checked for/from to enable/disable station ambience.

### Notes:
Performance before and after the changes were profiled and performance of rotating/piloting the main station matrix was tested. Performance difference was found to be negligible in both cases, most likely since anything that used to rely on Physics2Dsimulation was changed to a different system.
