### PR TITLE
Change cable cutting window RegisterHandler to ReplaceHandler

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
@@ -68,9 +68,12 @@ public class InteractableTiles : NetworkBehaviour, IClientInteractable<Positiona
 		tileChangeManager = GetComponent<TileChangeManager>();
 		CacheTileMaps();
 
-		// register message handler for CableCuttingMessage here because CableCuttingWindow prefab won't be loaded on server
-		// so registration cannot be inside Start or Awake method inside CableCuttingWindow
-		NetworkServer.RegisterHandler<CableCuttingWindow.CableCuttingMessage>(ServerPerformCableCuttingInteraction);
+		// Register message handler for CableCuttingMessage here because CableCuttingWindow prefab won't be loaded on server
+		// so registration cannot be inside Start or Awake method inside CableCuttingWindow. ReplaceHandler does the same
+		// thing as RegisterHandler, except RegisterHandler warns about conflicting ID types. See Mirror's documentation or
+		// Mirror's implementation of these methods in NetworkServer.cs.
+		// TODO: This is somehow called multiple times. Document how this happens.
+		NetworkServer.ReplaceHandler<CableCuttingWindow.CableCuttingMessage>(ServerPerformCableCuttingInteraction);
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
@@ -72,7 +72,8 @@ public class InteractableTiles : NetworkBehaviour, IClientInteractable<Positiona
 		// so registration cannot be inside Start or Awake method inside CableCuttingWindow. ReplaceHandler does the same
 		// thing as RegisterHandler, except RegisterHandler warns about conflicting ID types. See Mirror's documentation or
 		// Mirror's implementation of these methods in NetworkServer.cs.
-		// TODO: This is somehow called multiple times. Document how this happens.
+		// TODO: This is somehow called multiple times. Not sure why. Figure out if it's an issue and document why this
+		//       happens.
 		NetworkServer.ReplaceHandler<CableCuttingWindow.CableCuttingMessage>(ServerPerformCableCuttingInteraction);
 	}
 


### PR DESCRIPTION
### Purpose

Fixes #6450
Progress on #2526

### Notes:

There was an issue with Mirror flooding the console with warning messages about the use of `RegisterHandler()` (see issue #6450 for details). After digging a little more, I found that the implementation for `RegisterHandler()` and `ReplaceHandler()` is pretty much the same, with the difference being that `RegisterHandler()` warns about conflicting `msgType` ID.

This is `RegisterHandler()` implementation.

```cs
int msgType = MessagePacking.GetId<T>();
if (handlers.ContainsKey(msgType))
{
    Debug.LogWarning($"NetworkServer.RegisterHandler replacing handler for {typeof(T).FullName}, id={msgType}. If replacement is intentional, use ReplaceHandler instead to avoid this warning.");
}
handlers[msgType] = MessagePacking.WrapHandler(handler, requireAuthentication);
```

And this is `ReplaceHandler()`'s implementation.

```cs
int msgType = MessagePacking.GetId<T>();
handlers[msgType] = MessagePacking.WrapHandler(handler, requireAuthentication);
```

So, my conclusion is that we can use `ReplaceHandler()` without any differences, and my testing shows same behavior. I did add a TODO for someone with more expertise to comment on why this is called multiple times. Other than that, it should cut down the number warnings thrown out.