### PR TITLE
Fixes the mob error spam after a round ends

### DIFF
--- a/UnityProject/Assets/Scripts/NPC/AI/MobAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobAI.cs
@@ -95,10 +95,14 @@ namespace Systems.MobAIs
 
 		public virtual void OnDespawnServer(DespawnInfo info)
 		{
-			UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);
-			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, PeriodicUpdate);
 			health.applyDamageEvent += AttackReceivedCoolDown;
 			ResetBehaviours();
+		}
+
+		public void OnDisable()
+		{
+			UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);
+			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, PeriodicUpdate);
 		}
 
 		/// <summary>


### PR DESCRIPTION
### Purpose
Fixes mobs still being in the UpdateManager list after being deleted.
Apparently OnDespawnServer() isnt called when the round ends, who knew?
