### PR TITLE
Hotfixes half of the memory leaks inbetween rounds

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -11,7 +11,7 @@ using Objects.Construction;
 /// </summary>
 public class MetaDataLayer : MonoBehaviour
 {
-	private MetaDataDictionary nodes = new MetaDataDictionary();
+	private SerializableDictionary<Vector3Int, MetaDataNode> nodes = new SerializableDictionary<Vector3Int, MetaDataNode>();
 
 	private SubsystemManager subsystemManager;
 	private ReactionManager reactionManager;
@@ -22,6 +22,11 @@ public class MetaDataLayer : MonoBehaviour
 		subsystemManager = GetComponentInParent<SubsystemManager>();
 		reactionManager = GetComponentInParent<ReactionManager>();
 		matrix = GetComponent<Matrix>();
+	}
+
+	private void OnDestroy()
+	{
+		nodes.Clear();
 	}
 
 	public MetaDataNode Get(Vector3Int localPosition, bool createIfNotExists = true)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -26,6 +26,7 @@ public class MetaDataLayer : MonoBehaviour
 
 	private void OnDestroy()
 	{
+		//In the case of the matrix remaining in memory after the round ends, this will ensure the MetaDataNodes are GC
 		nodes.Clear();
 	}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Utils/SerializableDictionaries.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Utils/SerializableDictionaries.cs
@@ -19,11 +19,6 @@ public class EventDictionary : GridDictionary<UnityEvent>
 }
 
 [Serializable]
-public class MetaDataDictionary : SerializableDictionary<Vector3Int, MetaDataNode>
-{
-}
-
-[Serializable]
 public class PassableDictionary : SerializableDictionary<CollisionType, bool>
 {
 }


### PR DESCRIPTION
### Purpose
Hotfixes MetaDataNodes persisting through rounds, removing half of the memory leaks.
The main issue persists and this hotfix arguably can be removed in the future after the game's matrixes and its contents properly gc.

### Notes
This does not fix the original issue, its only a patch