### PR TITLE
Fix cable cutting window, cable duplication, and cable construction costs

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Engineering/CableCoil.cs
+++ b/UnityProject/Assets/Scripts/Items/Engineering/CableCoil.cs
@@ -69,7 +69,6 @@ namespace Objects.Electrical
 		/// this proceeds to add the new cable to the electrical pool and
 		/// builds the cable.
 		/// </summary>
-		/// <param name="interaction"></param>
 		public void ServerPerformInteraction(ConnectionApply interaction)
 		{
 			CableCoil cableCoil = interaction.HandObject.GetComponent<CableCoil>();
@@ -159,7 +158,7 @@ namespace Objects.Electrical
 
 		/// <summary>
 		/// Checks if the connection ends are legal. In this case, high-voltage
-		/// cables cannot cannot diagonally and no connections are illegal. All
+		/// cables cannot connect diagonally and no connections are illegal. All
 		/// other connections are legal.
 		/// </summary>
 		/// <param name="wireEndA">The first connection we're building from.</param>
@@ -207,7 +206,7 @@ namespace Objects.Electrical
 		/// Finds overlapping wires and combines them to create a new
 		/// connection.
 		/// </summary>
-		/// <param name="position">Position of the cell we're building thecable at.</param>
+		/// <param name="position">Position of the cell we're building the cable at.</param>
 		/// <param name="wireEndA">The first connection we're building from.</param>
 		/// <param name="wireEndB">The second connection we're building to.</param>
 		/// <param name="interaction">Object to allow us to interact with the server.</param>
@@ -215,7 +214,7 @@ namespace Objects.Electrical
 			ConnectionApply interaction)
 		{
 			// If the wire ends are overlapping...
-			if (wireEndA == Connection.Overlap | wireEndB == Connection.Overlap)
+			if (wireEndA == Connection.Overlap || wireEndB == Connection.Overlap)
 			{
 				// Stores boolean representing whether or not wireEndA is an
 				// overlap.
@@ -301,7 +300,6 @@ namespace Objects.Electrical
 		/// <param name="eConn">Electrical connection we're replacing.</param>
 		/// <param name="wireEndA">Connection direction of one end.</param>
 		/// <param name="wireEndB">Connection direction of the other end.</param>
-		/// <param name="interaction"></param>
 		private void ReplaceEConn(Vector3 position, IntrinsicElectronicData eConn, Connection wireEndA,
 			Connection wireEndB, ConnectionApply interaction)
 		{

--- a/UnityProject/Assets/Scripts/Items/Engineering/CableCoil.cs
+++ b/UnityProject/Assets/Scripts/Items/Engineering/CableCoil.cs
@@ -168,13 +168,9 @@ namespace Objects.Electrical
 					isA = false;
 				}
 
-				List<IntrinsicElectronicData> Econns = new List<IntrinsicElectronicData>();
-				var IEnumerableEconns = interaction.Performer.GetComponentInParent<Matrix>()
-					.GetElectricalConnections(position.RoundToInt());
-				foreach (var T in IEnumerableEconns)
-				{
-					Econns.Add(T);
-				}
+				List<IntrinsicElectronicData> IEnumerableEconns =
+					interaction.Performer.GetComponentInParent<Matrix>().GetElectricalConnections(position.RoundToInt());
+				List<IntrinsicElectronicData> Econns = new List<IntrinsicElectronicData>(IEnumerableEconns);
 
 				IEnumerableEconns.Clear();
 				ElectricalPool.PooledFPCList.Add(IEnumerableEconns);

--- a/UnityProject/Assets/Scripts/Items/Engineering/CableCoil.cs
+++ b/UnityProject/Assets/Scripts/Items/Engineering/CableCoil.cs
@@ -310,7 +310,7 @@ namespace Objects.Electrical
 			// connection.
 			int oldTileCost = 0;
 
-			// Get the cost of the old tile. Thend estroy the current
+			// Get the cost of the old tile. Then destroy the current
 			// electrical connection only if we were given a connection.
 			if (eConn != null)
 			{

--- a/UnityProject/Assets/Scripts/Items/Engineering/CableCoil.cs
+++ b/UnityProject/Assets/Scripts/Items/Engineering/CableCoil.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using Mirror;
 using UnityEngine;
@@ -141,23 +141,38 @@ namespace Objects.Electrical
 
 					econs.Clear();
 					ElectricalPool.PooledFPCList.Add(econs);
+					// Builds the cable using the position and connections.
 					BuildCable(localPosInt, interaction.Performer.transform.parent, WireEndA, WireEndB, interaction);
+					// Consume a cable from the hand.
+					// TODO: We sometimes need to consume more than one cable coil.
+					//       Either we cut one joint at a time, or retrieve the number of
+					//       cables.
 					Inventory.ServerConsume(interaction.HandSlot, 1);
 				}
 			}
 		}
 
-		private void BuildCable(Vector3 position, Transform parent, Connection WireEndA, Connection WireEndB, ConnectionApply interaction)
+		private void BuildCable(Vector3 position, Transform parent, Connection WireEndA, Connection WireEndB,
+			ConnectionApply interaction)
 		{
 			ElectricalManager.Instance.electricalSync.StructureChange = true;
 			FindOverlapsAndCombine(position, WireEndA, WireEndB, interaction);
 		}
 
+		/// <summary>
+		/// TODO: Document this.
+		/// </summary>
+		/// <param name="position"></param>
+		/// <param name="WireEndA"></param>
+		/// <param name="WireEndB"></param>
+		/// <param name="interaction"></param>
 		public void FindOverlapsAndCombine(Vector3 position, Connection WireEndA, Connection WireEndB,
 			ConnectionApply interaction)
 		{
+			// If the wire ends are overlapping...
 			if (WireEndA == Connection.Overlap | WireEndB == Connection.Overlap)
 			{
+				// TODO: What is this...? Needs more documentation.
 				bool isA;
 				if (WireEndA == Connection.Overlap)
 				{
@@ -172,16 +187,23 @@ namespace Objects.Electrical
 					interaction.Performer.GetComponentInParent<Matrix>().GetElectricalConnections(position.RoundToInt());
 				List<IntrinsicElectronicData> Econns = new List<IntrinsicElectronicData>(IEnumerableEconns);
 
+				// TODO: What does this do? By this, we're removing all elements from
+				//       the list, but then adding this empty, but with-capacity list
+				//       to this.
 				IEnumerableEconns.Clear();
 				ElectricalPool.PooledFPCList.Add(IEnumerableEconns);
 
+				// First, make sure we actually found electrical connections.
 				if (Econns != null)
 				{
 					// Now, we loop through each electrical connection.
 					for (int i = 0; i < Econns.Count; i++)
 					{
+						// If the power type of the current cable matches the the
+						// connection's category...
 						if (powerTypeCategory == Econns[i].Categorytype)
 						{
+							// If the end of the wire is overlapping...
 							if (Econns[i].WireEndA == Connection.Overlap)
 							{
 								if (isA)
@@ -192,10 +214,15 @@ namespace Objects.Electrical
 								{
 									WireEndB = Econns[i].WireEndB;
 								}
+
+								// Destroy the current electrical connection.
 								Econns[i].DestroyThisPlease();
-								var tile = ElectricityFunctions.RetrieveElectricalTile(WireEndA, WireEndB,
+								// Get the electrical cable tile with the wire connection direction.
+								ElectricalCableTile tile = ElectricityFunctions.RetrieveElectricalTile(WireEndA, WireEndB,
 									powerTypeCategory);
-								interaction.Performer.GetComponentInParent<Matrix>().AddElectricalNode(position.RoundToInt(), tile, true);
+								// Then, add an electrical node at the tile.
+								interaction.Performer.GetComponentInParent<Matrix>()
+									.AddElectricalNode(position.RoundToInt(), tile, true);
 
 								return;
 							}
@@ -209,10 +236,12 @@ namespace Objects.Electrical
 								{
 									WireEndB = Econns[i].WireEndA;
 								}
+
 								Econns[i].DestroyThisPlease();
-								var tile = ElectricityFunctions.RetrieveElectricalTile(WireEndA, WireEndB,
+								ElectricalCableTile tile = ElectricityFunctions.RetrieveElectricalTile(WireEndA, WireEndB,
 									powerTypeCategory);
-								interaction.Performer.GetComponentInParent<Matrix>().AddElectricalNode(position.RoundToInt(), tile, true);
+								interaction.Performer.GetComponentInParent<Matrix>()
+									.AddElectricalNode(position.RoundToInt(), tile, true);
 
 								return;
 							}

--- a/UnityProject/Assets/Scripts/Items/Engineering/CableCoil.cs
+++ b/UnityProject/Assets/Scripts/Items/Engineering/CableCoil.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using Mirror;
 using UnityEngine;
@@ -178,10 +178,11 @@ namespace Objects.Electrical
 
 				IEnumerableEconns.Clear();
 				ElectricalPool.PooledFPCList.Add(IEnumerableEconns);
-				int i = 0;
+
 				if (Econns != null)
 				{
-					while (!(i >= Econns.Count))
+					// Now, we loop through each electrical connection.
+					for (int i = 0; i < Econns.Count; i++)
 					{
 						if (powerTypeCategory == Econns[i].Categorytype)
 						{
@@ -220,8 +221,6 @@ namespace Objects.Electrical
 								return;
 							}
 						}
-
-						i++;
 					}
 				}
 			}

--- a/UnityProject/Assets/Scripts/Systems/Electricity/ConnectionMap.cs
+++ b/UnityProject/Assets/Scripts/Systems/Electricity/ConnectionMap.cs
@@ -210,6 +210,11 @@ public static class ConnectionMap
 
 }
 
+/// <summary>
+/// Enum that describes the type of connection a tile is currently taking on.
+/// This is especially useful for things such as electrical cables that has
+/// lots of different kinds of connection.
+/// </summary>
 public enum Connection
 {
 	NA,

--- a/UnityProject/Assets/Scripts/Systems/Electricity/Electrical processes/ElectricalPool.cs
+++ b/UnityProject/Assets/Scripts/Systems/Electricity/Electrical processes/ElectricalPool.cs
@@ -16,7 +16,9 @@ namespace Systems.Electricity
 		//WrapCurrent
 		public static List<WrapCurrent> PooledWrapCurrent = new List<WrapCurrent>();
 
-		//Find possible connections
+		/// <summary>
+		/// Find possible connections (FPC). List of electrical connections.
+		/// </summary>
 		public static List<List<IntrinsicElectronicData>> PooledFPCList = new List<List<IntrinsicElectronicData>>();
 
 		//ElectronicSupplyData

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
@@ -195,7 +195,6 @@ public class InteractableTiles : NetworkBehaviour, IClientInteractable<Positiona
 	/// tile is encountered, we open the cable cutting window.
 	/// </summary>
 	/// <param name="interaction">Position of interaction with a hand</param>
-	/// <returns></returns>
 	public bool Interact(PositionalHandApply interaction)
 	{
 		// translate to the tile interaction system

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
@@ -188,33 +188,53 @@ public class InteractableTiles : NetworkBehaviour, IClientInteractable<Positiona
 		return msg;
 	}
 
+	/// <summary>
+	/// Interaction callback to attempt to interact with tiles using a HandApply
+	/// interaction. We check for both basic tiles and under floor tiles and
+	/// attempt to apply its interaction. In the event that an electric cable
+	/// tile is encountered, we open the cable cutting window.
+	/// </summary>
+	/// <param name="interaction">Position of interaction with a hand</param>
+	/// <returns></returns>
 	public bool Interact(PositionalHandApply interaction)
 	{
 		// translate to the tile interaction system
 		Vector3Int localPosition = WorldToCell(interaction.WorldPositionTarget);
 		// pass the interaction down to the basic tile
 		LayerTile tile = LayerTileAt(interaction.WorldPositionTarget, true);
+
+		// If the tile we're looking at is a basic tile...
 		if (tile is BasicTile basicTile)
 		{
-			// The underfloor layer can be composed of multiple tiles, iterate over them until interaction is found.
+			// If the the tile is something that's supposed to be underneath floors...
 			if (basicTile.LayerType == LayerType.Underfloor)
 			{
-				// if pointing at electrical cable tile and player holds Wirecutter in hand
-				if (basicTile is ElectricalCableTile &&
-					Validations.HasItemTrait(UIManager.Hands.CurrentSlot.ItemObject, CommonTraits.Instance.Wirecutter))
+				// Then we loop through each under floor layer in the matrix until we
+				// can find an interaction.
+				foreach (BasicTile underFloorTile in matrix.UnderFloorLayer.GetAllTilesByType<BasicTile>(localPosition))
 				{
-					// open cable cutting ui window instead of cutting cable
-					EnableCableCuttingWindow();
-					// return false to not cut the cable
-					return false;
-				}
+					// If pointing at electrical cable tile and player is holding
+					// Wirecutter in hand, we enable the cutting window and return false
+					// to indicate that we will not be interacting with anything... yet.
+					// TODO: Check how many cables we have first. Only open the cable
+					//       cutting window when the number of cables exceeds 2.
+					if (underFloorTile is ElectricalCableTile &&
+						Validations.HasItemTrait(UIManager.Hands.CurrentSlot.ItemObject, CommonTraits.Instance.Wirecutter))
+					{
+						// open cable cutting ui window instead of cutting cable
+						EnableCableCuttingWindow();
+						// return false to not cut the cable
+						return false;
+					}
+					// Else, we attempt to interact with the tile with whatever is in our
+					// at the target.
+					else
+					{
+						var underFloorApply = new TileApply(interaction.Performer, interaction.UsedObject, interaction.Intent,
+							(Vector2Int) localPosition, this, underFloorTile, interaction.HandSlot, interaction.TargetVector);
 
-				foreach (var underFloorTile in matrix.UnderFloorLayer.GetAllTilesByType<BasicTile>(localPosition))
-				{
-					var underFloorApply = new TileApply(interaction.Performer, interaction.UsedObject, interaction.Intent,
-						(Vector2Int) localPosition, this, underFloorTile, interaction.HandSlot, interaction.TargetVector);
-
-					if (TryInteractWithTile(underFloorApply)) return true;
+						if (TryInteractWithTile(underFloorApply)) return true;
+					}
 				}
 			}
 			else

--- a/UnityProject/Assets/Scripts/UI/Objects/Engineering/Cable/LoadCableCuttingWindow.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Engineering/Cable/LoadCableCuttingWindow.cs
@@ -16,7 +16,7 @@ public class LoadCableCuttingWindow : MonoBehaviour
 	/// Reference to cableCuttingWindow - instead of loading from resources every time, just enable and disable GameObject
 	/// </summary>
 	[SerializeField]
-	private CableCuttingWindow cableCuttingWindowPrefab;
+	private GameObject cableCuttingWindowPrefab;
 
 	/// <summary>
 	/// Reference to cableCuttingWindow - instead of loading from resources every time, just enable and disable GameObject
@@ -103,6 +103,9 @@ public class LoadCableCuttingWindow : MonoBehaviour
 		// else, load window from resources, store reference and initialize
 		else
 		{
+			// only load from resources if the prefab is null
+			if (cableCuttingWindowPrefab == null)
+				cableCuttingWindowPrefab = Resources.Load<GameObject>(PATH_TO_WINDOW_PREFAB);
 			cableCuttingWindow = Instantiate(cableCuttingWindowPrefab).GetComponentInChildren<CableCuttingWindow>();
 			cableCuttingWindow.InitializeCableCuttingWindow(matrix, cellPosition, mousePosition);
 		}

--- a/UnityProject/Assets/Textures/under floors/Power_Cond/Resources/CableCuttingWindow.prefab
+++ b/UnityProject/Assets/Textures/under floors/Power_Cond/Resources/CableCuttingWindow.prefab
@@ -63,6 +63,8 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0.392}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -95,7 +97,7 @@ MonoBehaviour:
   m_Elasticity: 0.1
   m_Inertia: 1
   m_DecelerationRate: 0.135
-  m_ScrollSensitivity: 1
+  m_ScrollSensitivity: 64
   m_Viewport: {fileID: 5361941834854776440}
   m_HorizontalScrollbar: {fileID: 0}
   m_VerticalScrollbar: {fileID: 4338660327651572119}
@@ -166,6 +168,8 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -241,6 +245,8 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -359,7 +365,7 @@ Canvas:
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 0
+  m_AdditionalShaderChannelsFlag: 25
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
@@ -461,13 +467,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.4716981, g: 0, b: 0, a: 1}
+  m_Color: {r: 1, g: 0.1254902, b: 0.1254902, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
+  m_Sprite: {fileID: 21300016, guid: 456b3993efaf4018ab1d98293d1d592b, type: 3}
+  m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -520,6 +528,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 3476793409770523465}
+        m_TargetAssemblyTypeName: 
         m_MethodName: SetActive
         m_Mode: 6
         m_Arguments:
@@ -564,6 +573,7 @@ RectTransform:
   m_Children:
   - {fileID: 3476793409381657972}
   - {fileID: 4244848080837423669}
+  - {fileID: 8475443422331581147}
   m_Father: {fileID: 2475787968045008862}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -587,8 +597,6 @@ MonoBehaviour:
   scrollViewLayoutGroup: {fileID: 4969011835112505957}
   cableCellUIPrefab: {fileID: 2529095858165874135, guid: 3bd6f0b920f44ab49a1551d463535914,
     type: 3}
-  performerStartActionMessage: 
-  othersStartActionMessage: 
   HIGH_VOLTAGE_CABLE_PATH: power_cond_high
   STANDARD_CABLE_PATH: power_cond_red
   LOW_VOLTAGE_CABLE_PATH: power_cond_low
@@ -613,8 +621,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0.0742504, g: 0.06643778, b: 0.07815671, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -660,6 +670,7 @@ MonoBehaviour:
       m_PersistentCalls:
         m_Calls:
         - m_Target: {fileID: 6412485437036430925}
+          m_TargetAssemblyTypeName: 
           m_MethodName: OnDrag
           m_Mode: 1
           m_Arguments:
@@ -675,6 +686,7 @@ MonoBehaviour:
       m_PersistentCalls:
         m_Calls:
         - m_Target: {fileID: 6412485437036430925}
+          m_TargetAssemblyTypeName: 
           m_MethodName: BeginDrag
           m_Mode: 1
           m_Arguments:
@@ -709,7 +721,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3595321167920129602}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
@@ -717,9 +729,9 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.000030517578}
-  m_SizeDelta: {x: 0, y: 300}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 343, y: 320}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &4969011835112505957
 MonoBehaviour:
@@ -734,17 +746,151 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Padding:
-    m_Left: 0
-    m_Right: 0
-    m_Top: 0
-    m_Bottom: 10
+    m_Left: 4
+    m_Right: 4
+    m_Top: 4
+    m_Bottom: 4
   m_ChildAlignment: 1
   m_StartCorner: 0
   m_StartAxis: 0
   m_CellSize: {x: 340, y: 80}
-  m_Spacing: {x: 0, y: 10}
+  m_Spacing: {x: 4, y: 8}
   m_Constraint: 0
   m_ConstraintCount: 2
+--- !u!1 &5629678375239051376
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8475443422331581147}
+  - component: {fileID: 1008829791591824641}
+  - component: {fileID: 3865118709886205176}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8475443422331581147
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5629678375239051376}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3476793409770523466}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -20.64, y: 134.87}
+  m_SizeDelta: {x: 292.1291, y: 38.49716}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1008829791591824641
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5629678375239051376}
+  m_CullTransparentMesh: 0
+--- !u!114 &3865118709886205176
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5629678375239051376}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Cut Cables
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 32
+  m_fontSizeBase: 32
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 1
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &7986335787242283205
 GameObject:
   m_ObjectHideFlags: 0
@@ -805,8 +951,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0.2509804, g: 0.2509804, b: 0.2509804, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -863,7 +1011,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 4592361383559387912}
   m_Direction: 2
   m_Value: 1
-  m_Size: 0.9
+  m_Size: 0.84375
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:


### PR DESCRIPTION
### Purpose

Fixes a whole lot dealing with the cable cutting window, the amount of cable coils consumed, and duplication issue.

Fixes #6458.
FIxes #6460.
Fixes #6469.

### Notes:

`cableCuttingWindowPrefab` was never assigned, which causes the `Instantiate()` call to raise an `ArgumentException`. This in turn breaks the cable cutting window from popping up, and ultimately results in the user being unable to cut electrical cables. Simply enough, the solution is to just load the resource. We ideally only want to do it once (hence the `null` check).

After fixing the cable cutting window, I noticed that cables are immediately cut without the cable cutting window popping up if build cables on a cell with other non-electrical wire tiles, such as pipes. It only checks the first tile. I fixed it so that we search all tiles in cell at a given position before determining whether or not to open the cable cutting window.

I then fixed the cable duplication issue and did some basic arithmetic to make sure that we only consume the difference needed to build over overlapping cables.

There are some other behaviors I want to work on, but since we're in a feature freeze, I'll hold it off for now.

### Changelog:

CL [Fix]: Fixed issue of not being able to cut electrical cables.
CL [Fix]: Fixed cable coil duplication and consumed amount.
CL [Fix]: Fixed cable cutting window not showing when cutting cables on cells with non-electrical tiles.
