### PR TITLE
Custom Net Transform Packet Optimisations

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Kitchen/FoodProcessor.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Kitchen/FoodProcessor.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 4000011070416052}
   - component: {fileID: 212000012478038690}
   - component: {fileID: 5324205694381129883}
-  - component: {fileID: 5862916945457128248}
   m_Layer: 0
   m_Name: Sprite
   m_TagString: Untagged
@@ -106,24 +105,6 @@ MonoBehaviour:
   variantIndex: 0
   palette: []
   Sprites: []
---- !u!114 &5862916945457128248
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000010721452394}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  isDirty: 0
-  sceneId: 0
-  serverOnly: 0
-  visible: 0
-  m_AssetId: 
-  hasSpawned: 0
 --- !u!1 &1000014212709224
 GameObject:
   m_ObjectHideFlags: 0
@@ -215,8 +196,9 @@ MonoBehaviour:
   matrixDebugLogging: 0
   objectType: 1
   AtmosPassable: 1
-  Passable: 0
   ReachableThrough: 1
+  initialPassable: 0
+  initialCrawlPassable: 0
   passableExclusionsToThis: []
 --- !u!114 &114579017526306362
 MonoBehaviour:
@@ -246,8 +228,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isMeleeable: 1
-  butcherTime: 2
-  butcherSound: 
 --- !u!114 &114081303556081810
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -322,7 +302,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  isDirty: 0
+  isDirty: 1
   sceneId: 0
   serverOnly: 0
   visible: 0
@@ -405,6 +385,7 @@ MonoBehaviour:
   itemStorageCapacity: {fileID: 11400000, guid: 51557be05ba9141e7849ea1c1c3ed19d,
     type: 2}
   itemStoragePopulator: {fileID: 0}
+  dropItemsOnDespawn: 0
   UesAddlistPopulater: 0
   Populater:
     MergeMode: 0
@@ -565,7 +546,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  originalPosition: {x: 0, y: 0, z: 0}
   axisMode: 0
   animType: 0
   spriteReference: {fileID: 4000011070416052}
@@ -584,6 +564,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0
-  isAnim: 0
-  target: {fileID: 4000011070416052}
-  animType: 0
+  Target: {fileID: 0}

--- a/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
@@ -52,6 +52,9 @@ namespace AdminCommands
 			var admin = PlayerList.Instance.GetAdmin(adminId, adminToken);
 			if (admin == null)
 			{
+				var player = PlayerList.Instance.GetByUserID(adminId);
+				Logger.LogError($"Failed Admin check with id: {adminId}, associated player with that id (null if not valid id): {player?.Username}," +
+				                $"Possible hacked client", Category.Exploits);
 				return false;
 			}
 


### PR DESCRIPTION
-Sync's the clientState Transform struct as individual sync vars instead of the whole struct as the whole struct was sent even if one one value was changed.

-Adds log to failed admin check

-Fixes cant spawn error for food processor sprite as it had a net identity where it shouldnt

Has been built tested with headless and two joining clients throwing items and pushing stuff around