### PR TITLE
Fixes welders turning air into space

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
@@ -90,6 +90,18 @@ public class RegisterTile : NetworkBehaviour, IServerDespawn
 					OnRotate(new MatrixRotationInfo(matrix.MatrixMove, matrix.MatrixMove.FacingOffsetFromInitial,
 						NetworkSide.Client, RotationEvent.Register));
 				}
+
+				if (isServer && TryGetComponent<ItemStorage>(out var itemStorage))
+				{
+					foreach (var itemSlot in itemStorage.GetItemSlots())
+					{
+						if (itemSlot.Item)
+						{
+							var itemSlotRegisterItem = itemSlot.Item.GetComponent<RegisterItem>();
+							itemSlotRegisterItem.matrix = matrix;
+						}
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Purpose
Fixes items inside storages not changing its matrix when the storage itself does.

The welder (or any firesource) was using its original matrix's ReactionManager, reaching for empty spots resulting in space atmos.