### PR TITLE
Issue 4292 fix

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Chat/ChatUI.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/ChatUI.cs
@@ -347,7 +347,7 @@ public class ChatUI : MonoBehaviour
 
 	private void PlayerSendChat(string sendMessage)
 	{
-		sendMessage = sendMessage.Replace("\n", " ").Replace("\r", " ");
+		sendMessage = sendMessage.Replace("\n", " ").Replace("\r", " ");  // We don't want users to spam chat vertically
 		if(selectedVoiceLevel == -1)
 			sendMessage = "#" + sendMessage;
 		if(selectedVoiceLevel == 1)

--- a/UnityProject/Assets/Scripts/Core/Chat/ChatUI.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/ChatUI.cs
@@ -347,6 +347,7 @@ public class ChatUI : MonoBehaviour
 
 	private void PlayerSendChat(string sendMessage)
 	{
+		sendMessage = sendMessage.Replace("\n", " ").Replace("\r", " ");
 		if(selectedVoiceLevel == -1)
 			sendMessage = "#" + sendMessage;
 		if(selectedVoiceLevel == 1)

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -1169,7 +1169,7 @@ namespace UI.CharacterCreator
 
 		private string TruncateName(string proposedName)
 		{
-			proposedName = TI.ToTitleCase(proposedName.ToLower());
+			proposedName = textInfo.ToTitleCase(proposedName.ToLower());
 			if (proposedName.Length >= CharacterSettings.MAX_NAME_LENGTH)
 			{
 				return proposedName.Substring(0, CharacterSettings.MAX_NAME_LENGTH);

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -10,6 +10,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.Networking;
 using NaughtyAttributes;
+using System.Globalization;
 
 namespace UI.CharacterCreator
 {
@@ -118,6 +119,8 @@ namespace UI.CharacterCreator
 
 		private CharacterSettings lastSettings;
 		private int currentCharacterIndex = 0;
+
+		private TextInfo TI = new CultureInfo("en-US", false).TextInfo;
 
 		#region Lifecycle
 
@@ -1166,7 +1169,7 @@ namespace UI.CharacterCreator
 
 		private string TruncateName(string proposedName)
 		{
-			proposedName = System.Threading.Thread.CurrentThread.CurrentCulture.TextInfo.ToTitleCase(proposedName.ToLower());
+			proposedName = TI.ToTitleCase(proposedName.ToLower());
 			if (proposedName.Length >= CharacterSettings.MAX_NAME_LENGTH)
 			{
 				return proposedName.Substring(0, CharacterSettings.MAX_NAME_LENGTH);

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -120,7 +120,7 @@ namespace UI.CharacterCreator
 		private CharacterSettings lastSettings;
 		private int currentCharacterIndex = 0;
 
-		private TextInfo TI = new CultureInfo("en-US", false).TextInfo;
+		private TextInfo textInfo = CultureInfo.CurrentCulture.TextInfo;
 
 		#region Lifecycle
 

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -1097,6 +1097,7 @@ namespace UI.CharacterCreator
 			DisplayErrorText("");
 			try
 			{
+				currentCharacter.Name = TruncateName(currentCharacter.Name);
 				currentCharacter.ValidateSettings();
 			}
 			catch (InvalidOperationException e)
@@ -1165,6 +1166,7 @@ namespace UI.CharacterCreator
 
 		private string TruncateName(string proposedName)
 		{
+			proposedName = System.Threading.Thread.CurrentThread.CurrentCulture.TextInfo.ToTitleCase(proposedName.ToLower());
 			if (proposedName.Length >= CharacterSettings.MAX_NAME_LENGTH)
 			{
 				return proposedName.Substring(0, CharacterSettings.MAX_NAME_LENGTH);


### PR DESCRIPTION
### Purpose
Prevents users from setting all caps names, and prevents users from spamming chat and chat bubbles vertically.
Fixes issue #4292.

### Changelog:
CL: Users can no longer set all caps character names
CL: Newlines and return characters are removed from chat messages so chat isn't spammed vertically
