### PR TITLE
Overlay fixes

### DIFF
--- a/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
+++ b/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
@@ -150,6 +150,7 @@ Transform:
   m_Children:
   - {fileID: 4892080207053079231}
   - {fileID: 8122509100923692975}
+  - {fileID: 6973244498870489173}
   m_Father: {fileID: 4102488425209486}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -563,6 +564,7 @@ MonoBehaviour:
   CustomisationSprites: {fileID: 975496025995574624}
   InternalNetIDs: 
   RootBodyPartsLoaded: 0
+  OverlaySprites: {fileID: 9164488584065593561}
 --- !u!114 &114413669770135258
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -629,8 +631,6 @@ MonoBehaviour:
   IsTrapped: 0
   actionData: {fileID: 11400000, guid: 967a13d2ea206e9448f6c6e2af11a3cf, type: 2}
   moveList: 05000000060000000700000008000000
-  PlayerDirectional: {fileID: 0}
-  pna: {fileID: 0}
   RunSpeed: 6
   WalkSpeed: 3
   CrawlSpeed: 0.8
@@ -808,8 +808,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isMeleeable: 1
-  butcherTime: 2
-  butcherSound: 
 --- !u!114 &6017414943583453005
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8282,7 +8280,7 @@ SpriteRenderer:
   m_SortingLayerID: -902452607
   m_SortingLayer: 22
   m_SortingOrder: 20
-  m_Sprite: {fileID: 7660122581263827943, guid: 2adbceb9cc674484cb9a2c58b41d5493,
+  m_Sprite: {fileID: -4549444404219585148, guid: 2adbceb9cc674484cb9a2c58b41d5493,
     type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -8874,6 +8872,36 @@ Transform:
   m_Father: {fileID: 4962232741225816}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &9164488584065593561
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6973244498870489173}
+  m_Layer: 8
+  m_Name: OverlaySprites
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6973244498870489173
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9164488584065593561}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4962232741225816}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &4300145449095171559
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8953,12 +8981,6 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 4300145449095171559}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &4304794156734570639 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4676201352523112, guid: e2b1333de46384f95876864de1911fff,
-    type: 3}
-  m_PrefabInstance: {fileID: 4300145449095171559}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &4196149980577959187 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 114445607401685236, guid: e2b1333de46384f95876864de1911fff,
@@ -8971,3 +8993,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 61930e16e81db5c43a4ecc22422a0953, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!4 &4304794156734570639 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4676201352523112, guid: e2b1333de46384f95876864de1911fff,
+    type: 3}
+  m_PrefabInstance: {fileID: 4300145449095171559}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
@@ -91,7 +91,8 @@ public class PlayerSprites : MonoBehaviour
 
 	public bool RootBodyPartsLoaded = false;
 
-	public GameObject OverlaySprites;
+	[SerializeField]
+	private GameObject OverlaySprites;
 
 	protected void Awake()
 	{

--- a/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
@@ -91,6 +91,8 @@ public class PlayerSprites : MonoBehaviour
 
 	public bool RootBodyPartsLoaded = false;
 
+	public GameObject OverlaySprites;
+
 	protected void Awake()
 	{
 		directional = GetComponent<Directional>();
@@ -127,7 +129,7 @@ public class PlayerSprites : MonoBehaviour
 		if (engulfedBurningOverlay == null)
 		{
 			engulfedBurningOverlay =
-				Instantiate(engulfedBurningPrefab, transform).GetComponent<PlayerDirectionalOverlay>();
+				Instantiate(engulfedBurningPrefab, OverlaySprites.transform).GetComponent<PlayerDirectionalOverlay>();
 			engulfedBurningOverlay.enabled = true;
 			engulfedBurningOverlay.StopOverlay();
 		}
@@ -135,14 +137,14 @@ public class PlayerSprites : MonoBehaviour
 		if (partialBurningOverlay == null)
 		{
 			partialBurningOverlay =
-				Instantiate(partialBurningPrefab, transform).GetComponent<PlayerDirectionalOverlay>();
+				Instantiate(partialBurningPrefab, OverlaySprites.transform).GetComponent<PlayerDirectionalOverlay>();
 			partialBurningOverlay.enabled = true;
 			partialBurningOverlay.StopOverlay();
 		}
 
 		if (electrocutedOverlay == null)
 		{
-			electrocutedOverlay = Instantiate(electrocutedPrefab, transform).GetComponent<PlayerDirectionalOverlay>();
+			electrocutedOverlay = Instantiate(electrocutedPrefab, OverlaySprites.transform).GetComponent<PlayerDirectionalOverlay>();
 			electrocutedOverlay.enabled = true;
 			electrocutedOverlay.StopOverlay();
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
@@ -42,6 +42,8 @@ namespace TileManagement
 		public Layer[] LayersValues { get; private set; }
 		public ObjectLayer ObjectLayer { get; private set; }
 
+		//Determines the maximum amount of overlays allowed on a tile
+		private const int OVERLAY_LIMIT = 20;
 
 		public List<Layer> ffLayersValues;
 
@@ -905,15 +907,15 @@ namespace TileManagement
 			}
 
 			TileLocation tileLocation = null;
-			position.z = 1;
+			position.z = 0;
 
 			if (Layers.TryGetValue(layerType, out var layer))
 			{
-				//Only check 20 as its unlikely to ever have more than 20 overlays
+				//Go through overlays under the overlay limit. The first overlay checked will be at z = 1.
 				var count = 0;
-				while (count < 20)
+				while (count < OVERLAY_LIMIT)
 				{
-					position.z += count;
+					position.z++;
 
 					lock (PresentTiles)
 					{
@@ -954,15 +956,15 @@ namespace TileManagement
 
 			TileLocation tileLocation = null;
 			OverlayTile overlayTile = null;
-			position.z = 1;
+			position.z = 0;
 
 			if (Layers.TryGetValue(layerType, out var layer))
 			{
-				//Only check 20 as its unlikely to ever have more than 20 overlays
+				//Go through overlays under the overlay limit. The first overlay checked will be at z = 1.
 				var count = 0;
-				while (count < 20)
+				while (count < OVERLAY_LIMIT)
 				{
-					position.z += count;
+					position.z++;
 
 					lock (PresentTiles)
 					{
@@ -1008,15 +1010,15 @@ namespace TileManagement
 			TileLocation tileLocation = null;
 			OverlayTile overlayTile = null;
 			List<Vector3Int> pos = new List<Vector3Int>();
-			position.z = 1;
+			position.z = 0;
 
 			if (Layers.TryGetValue(layerType, out var layer))
 			{
-				//Only check 20 as its unlikely to ever have more than 20 overlays
+				//Go through overlays under the overlay limit. The first overlay checked will be at z = 1.
 				var count = 0;
-				while (count < 20)
+				while (count < OVERLAY_LIMIT)
 				{
-					position.z += count;
+					position.z++;
 
 					lock (PresentTiles)
 					{
@@ -1062,15 +1064,15 @@ namespace TileManagement
 			TileLocation tileLocation = null;
 			OverlayTile overlayTile = null;
 			List<Vector3Int> pos = new List<Vector3Int>();
-			position.z = 1;
+			position.z = 0;
 
 			if (Layers.TryGetValue(layerType, out var layer))
 			{
-				//Only check 20 as its unlikely to ever have more than 20 overlays
+				//Go through overlays under the overlay limit. The first overlay checked will be at z = 1.
 				var count = 0;
-				while (count < 20)
+				while (count < OVERLAY_LIMIT)
 				{
-					position.z += count;
+					position.z++;
 
 					lock (PresentTiles)
 					{
@@ -1116,15 +1118,15 @@ namespace TileManagement
 			TileLocation tileLocation = null;
 			OverlayTile overlayTile = null;
 			List<OverlayTile> overlayTiles = new List<OverlayTile>();
-			position.z = 1;
+			position.z = 0;
 
 			if (Layers.TryGetValue(layerType, out var layer))
 			{
-				//Only check 20 as its unlikely to ever have more than 20 overlays
+				//Go through overlays under the overlay limit. The first overlay checked will be at z = 1.
 				var count = 0;
-				while (count < 20)
+				while (count < OVERLAY_LIMIT)
 				{
-					position.z += count;
+					position.z++;
 
 					lock (PresentTiles)
 					{
@@ -1165,15 +1167,15 @@ namespace TileManagement
 
 			TileLocation tileLocation = null;
 			OverlayTile overlayTile = null;
-			position.z = 1;
+			position.z = 0;
 
 			if (Layers.TryGetValue(layerType, out var layer))
 			{
-				//Only check 20 as its unlikely to ever have more than 20 overlays
+				//Go through overlays under the overlay limit. The first overlay checked will be at z = 1.
 				var count = 0;
-				while (count < 20)
+				while (count < OVERLAY_LIMIT)
 				{
-					position.z += count;
+					position.z++;
 
 					lock (PresentTiles)
 					{
@@ -1184,7 +1186,7 @@ namespace TileManagement
 					{
 						overlayTile = tileLocation.Tile as OverlayTile;
 
-						if (overlayTile != null && overlayTile == overlayTileWanted)
+						if (overlayTile != null && overlayTile.Equals(overlayTileWanted))
 						{
 							return true;
 						}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
@@ -907,7 +907,7 @@ namespace TileManagement
 			}
 
 			TileLocation tileLocation = null;
-			position.z = 0;
+			position.z = 1;
 
 			if (Layers.TryGetValue(layerType, out var layer))
 			{
@@ -915,8 +915,6 @@ namespace TileManagement
 				var count = 0;
 				while (count < OVERLAY_LIMIT)
 				{
-					position.z++;
-
 					lock (PresentTiles)
 					{
 						PresentTiles[layer].TryGetValue(position, out tileLocation);
@@ -928,6 +926,7 @@ namespace TileManagement
 						return position;
 					}
 
+					position.z++;
 					count++;
 				}
 			}
@@ -956,7 +955,7 @@ namespace TileManagement
 
 			TileLocation tileLocation = null;
 			OverlayTile overlayTile = null;
-			position.z = 0;
+			position.z = 1;
 
 			if (Layers.TryGetValue(layerType, out var layer))
 			{
@@ -964,8 +963,6 @@ namespace TileManagement
 				var count = 0;
 				while (count < OVERLAY_LIMIT)
 				{
-					position.z++;
-
 					lock (PresentTiles)
 					{
 						PresentTiles[layer].TryGetValue(position, out tileLocation);
@@ -981,6 +978,7 @@ namespace TileManagement
 						}
 					}
 
+					position.z++;
 					count++;
 				}
 			}
@@ -1010,7 +1008,7 @@ namespace TileManagement
 			TileLocation tileLocation = null;
 			OverlayTile overlayTile = null;
 			List<Vector3Int> pos = new List<Vector3Int>();
-			position.z = 0;
+			position.z = 1;
 
 			if (Layers.TryGetValue(layerType, out var layer))
 			{
@@ -1018,8 +1016,6 @@ namespace TileManagement
 				var count = 0;
 				while (count < OVERLAY_LIMIT)
 				{
-					position.z++;
-
 					lock (PresentTiles)
 					{
 						PresentTiles[layer].TryGetValue(position, out tileLocation);
@@ -1035,6 +1031,7 @@ namespace TileManagement
 						}
 					}
 
+					position.z++;
 					count++;
 				}
 			}
@@ -1064,7 +1061,7 @@ namespace TileManagement
 			TileLocation tileLocation = null;
 			OverlayTile overlayTile = null;
 			List<Vector3Int> pos = new List<Vector3Int>();
-			position.z = 0;
+			position.z = 1;
 
 			if (Layers.TryGetValue(layerType, out var layer))
 			{
@@ -1072,8 +1069,6 @@ namespace TileManagement
 				var count = 0;
 				while (count < OVERLAY_LIMIT)
 				{
-					position.z++;
-
 					lock (PresentTiles)
 					{
 						PresentTiles[layer].TryGetValue(position, out tileLocation);
@@ -1089,6 +1084,7 @@ namespace TileManagement
 						}
 					}
 
+					position.z++;
 					count++;
 				}
 			}
@@ -1118,7 +1114,7 @@ namespace TileManagement
 			TileLocation tileLocation = null;
 			OverlayTile overlayTile = null;
 			List<OverlayTile> overlayTiles = new List<OverlayTile>();
-			position.z = 0;
+			position.z = 1;
 
 			if (Layers.TryGetValue(layerType, out var layer))
 			{
@@ -1126,8 +1122,6 @@ namespace TileManagement
 				var count = 0;
 				while (count < OVERLAY_LIMIT)
 				{
-					position.z++;
-
 					lock (PresentTiles)
 					{
 						PresentTiles[layer].TryGetValue(position, out tileLocation);
@@ -1143,6 +1137,7 @@ namespace TileManagement
 						}
 					}
 
+					position.z++;
 					count++;
 				}
 			}
@@ -1167,7 +1162,7 @@ namespace TileManagement
 
 			TileLocation tileLocation = null;
 			OverlayTile overlayTile = null;
-			position.z = 0;
+			position.z = 1;
 
 			if (Layers.TryGetValue(layerType, out var layer))
 			{
@@ -1175,8 +1170,6 @@ namespace TileManagement
 				var count = 0;
 				while (count < OVERLAY_LIMIT)
 				{
-					position.z++;
-
 					lock (PresentTiles)
 					{
 						PresentTiles[layer].TryGetValue(position, out tileLocation);
@@ -1192,6 +1185,7 @@ namespace TileManagement
 						}
 					}
 
+					position.z++;
 					count++;
 				}
 			}

--- a/UnityProject/Assets/Scripts/Tilemaps/Tiles/OverlayTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Tiles/OverlayTile.cs
@@ -35,4 +35,18 @@ public class OverlayTile : LayerTile
 	private TileChangeManager.OverlayType overlayType = TileChangeManager.OverlayType.None;
 
 	public TileChangeManager.OverlayType OverlayType => overlayType;
+
+	public override bool Equals(object other)
+	{
+		if (other != null && this.GetType().Equals(other.GetType()))
+		{
+			OverlayTile comparedOverlay = (OverlayTile)other;
+			return (overlayName == comparedOverlay.overlayName)
+				&& (PreviewSprite == comparedOverlay.PreviewSprite)
+				&& (overlayType == comparedOverlay.OverlayType)
+				&& (isCleanable == comparedOverlay.isCleanable)
+				&& (isGraffiti == comparedOverlay.isGraffiti);
+		}
+		return false;
+	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Utils/TileList.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Utils/TileList.cs
@@ -159,7 +159,7 @@ public class TileList
 		}
 
 		lockedPosition = localPosition;
-		foreach (var registerTile in Get(localPosition))
+		foreach (var registerTile in Get((Vector3Int)lockedPosition))
 		{
 			action.Invoke(registerTile);
 		}


### PR DESCRIPTION
### Purpose
This PR fixes bugs that I noticed while looking at plasma fires, like player overlays, tile overlays, and Unity throwing modified collection errors in TileList.cs.

### Explanation:
<img width="239" alt="Screenshot 2021-05-09 194229" src="https://user-images.githubusercontent.com/62051810/117570958-1cb97f80-b0ff-11eb-9200-83196347cc3d.png">
Overlays are now stored under the sprite gameobject in players, so they rotate whenever the player body rotates. This fixes #6429.

Tile overlays like windows smashing were added too many times because the system was not checking if an overlay was already added correctly. I overwrote the .Equals() function so they can compare in a more functional way.

Tile overlays now have a const which determines the maximum overlays allowed per tile, and some weird code has been cleaned up. Previously, the z position of overlays was increased in this order: 1, 2, 4, 7, 11. Now, they'll increase in a normal ascending order (1, 2, 3, etc).

### Changelog:
CL: Fixed fire and electrocution overlay not matching the player's rotation
CL: Fixed tiles having too many overlays
