### PR TITLE
Fixes a case of clients seeing other players as floating skulls

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandler.cs
+++ b/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandler.cs
@@ -576,6 +576,15 @@ public class SpriteHandler : MonoBehaviour
 		TryInit();
 	}
 
+	private void OnDestroy()
+	{
+		if (SpriteHandlerManager.Instance)
+		{
+			SpriteHandlerManager.Instance.QueueChanges.Remove(this);
+			SpriteHandlerManager.Instance.NewClientChanges.Remove(this);
+		}
+	}
+
 	private void SetImageColor(Color value)
 	{
 		if (spriteRenderer != null)

--- a/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandlerManager.cs
+++ b/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandlerManager.cs
@@ -1,31 +1,16 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data.Common;
 using Messages.Client.SpriteMessages;
 using Messages.Server.SpritesMessages;
 using Mirror;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class SpriteHandlerManager : NetworkBehaviour
 {
-	//public static int AvailableID = 1;
-
 	private static SpriteHandlerManager spriteHandlerManager;
-	public static SpriteHandlerManager Instance
-	{
-		get
-		{
-			if (!spriteHandlerManager)
-			{
-				spriteHandlerManager = FindObjectOfType<SpriteHandlerManager>();
-			}
-
-			return spriteHandlerManager;
-		}
-	}
-
-
+	public static SpriteHandlerManager Instance => spriteHandlerManager;
 
 	public Dictionary<NetworkIdentity, Dictionary<string, SpriteHandler>> PresentSprites =
 		new Dictionary<NetworkIdentity, Dictionary<string, SpriteHandler>>();
@@ -34,8 +19,34 @@ public class SpriteHandlerManager : NetworkBehaviour
 
 	public Dictionary<SpriteHandler, SpriteChange> NewClientChanges = new Dictionary<SpriteHandler, SpriteChange>();
 
+	private void Awake()
+	{
+		if (spriteHandlerManager == null)
+		{
+			spriteHandlerManager = this;
+		}
+		else
+		{
+			Destroy(this);
+		}
+	}
 
+	private void OnEnable()
+	{
+		SceneManager.activeSceneChanged += OnRoundRestart;
+	}
 
+	private void OnDisable()
+	{
+		SceneManager.activeSceneChanged -= OnRoundRestart;
+	}
+
+	void OnRoundRestart(Scene oldScene, Scene newScene)
+	{
+		QueueChanges.Clear();
+		NewClientChanges.Clear();
+		PresentSprites.Clear();
+	}
 
 	public static void UnRegisterHandler(NetworkIdentity networkIdentity, SpriteHandler spriteHandler)
 	{
@@ -83,18 +94,6 @@ public class SpriteHandlerManager : NetworkBehaviour
 		}
 
 		Instance.PresentSprites[networkIdentity][spriteHandler.name] = spriteHandler;
-	}
-
-
-	// Start is called before the first frame update
-	void Start()
-	{
-		//AvailableID = 1;
-		//foreach (var Product in SpriteCatalogue.Instance.Catalogue)
-		//{
-			//Product.ID = AvailableID;
-			//AvailableID++;
-		//}
 	}
 
 	public void UpdateNewPlayer(NetworkConnection requestedBy)


### PR DESCRIPTION
### Purpose
Stops the server from sending sprite updates from objects that no longer exist, making clients constantly search for them.
Fixes a runtime in the server sprite update sending message, preventing clients who logged in from receiving an important chunk of these updates, resulting in players seeing others as floating skulls.

### Notes:
the list NewClientChanges could contain SpriteHandlers from objects who were deleted
I introduced this bug on my last pr and staging didn't update yet, but I understand that floating skulls were present before I started my work on SpriteUpdateMessage, so there's a chance that the problem persists and that I'm just fixing a bug nobdoy has experienced yet.
