### PR TITLE
Fixes SM Shield Overlay and Locker Space Sound

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Electricity/Engines/SuperMatterEngine/SuperMatter.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Electricity/Engines/SuperMatterEngine/SuperMatter.prefab
@@ -26,8 +26,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6110762193567610245}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.028, y: 0.0271, z: 0}
-  m_LocalScale: {x: 1.0569181, y: 1.5342727, z: 1}
+  m_LocalPosition: {x: 0.028, y: 0.264, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 6976381843524439032}
   m_RootOrder: 2
@@ -405,6 +405,16 @@ PrefabInstance:
     - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3558259718671294003, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 3558259718671294003, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5212070883374448474, guid: b06b702714bab49b9ad949eab1ca4534,

--- a/UnityProject/Assets/Prefabs/Objects/Electricity/Engines/SuperMatterEngine/SuperMatterShard.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Electricity/Engines/SuperMatterEngine/SuperMatterShard.prefab
@@ -96,5 +96,20 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: d7c69fc46a8ff9345b55821c4e771efa,
         type: 3}
+    - target: {fileID: 8510946580789324972, guid: a2f7e3ea5d1b72341939c4aeb0895b36,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 8510946580789324972, guid: a2f7e3ea5d1b72341939c4aeb0895b36,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 8510946580789324972, guid: a2f7e3ea5d1b72341939c4aeb0895b36,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.07
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a2f7e3ea5d1b72341939c4aeb0895b36, type: 3}

--- a/UnityProject/Assets/Scripts/Core/Sound/AmbientSoundArea.cs
+++ b/UnityProject/Assets/Scripts/Core/Sound/AmbientSoundArea.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using AddressableReferences;
 using Audio.Containers;
@@ -29,6 +30,16 @@ public class AmbientSoundArea : MonoBehaviour
 	{
 		if (player == null) return;
 		if (player != PlayerManager.LocalPlayer) return;
+
+		// Dont change sound when sent to hidden pos, e.g in locker
+		// TODO entering sound still plays when exiting locker, but this at least stops space sound
+		if (player.TryGetComponent<PlayerSync>(out var playerSync))
+		{
+			if (playerSync.TrustedPosition == TransformState.HiddenPos)
+			{
+				return;
+			}
+		}
 
 		if (isEntering)
 		{


### PR DESCRIPTION
CL: Resizes the shield and moves the SM sprites to better fix the tile

CL: Fixes space sound playing when going to hidden pos

-Sound change will still happen when exiting hidden pos though
