### PR TITLE
Possible fix for unending plasma fires

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Utils/TileList.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Utils/TileList.cs
@@ -159,7 +159,14 @@ public class TileList
 		}
 
 		lockedPosition = localPosition;
+		List<RegisterTile> registerTiles = new List<RegisterTile>();
 		foreach (var registerTile in Get((Vector3Int)lockedPosition))
+		{
+			registerTiles.Add(registerTile);
+		}
+
+		//To prevent modifying collection while in the loop
+		foreach (RegisterTile registerTile in registerTiles)
 		{
 			action.Invoke(registerTile);
 		}


### PR DESCRIPTION
### Purpose
Removes a InvalidOperationExemption error that occurred when plasma fires were around. This seems stop the unending plasma fires that could be started using my process in #6398, although I think we should wait to see if any more come up before settling this bounty.

### Notes:
Got a pretty bad cold on Friday, so I was gone for a bit. Sorry about that.

### Changelog:
CL: Possible fix for eternal fires
