### PR TITLE
RCS fixes

### DIFF
--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
@@ -130,7 +130,7 @@ public partial class PlayerSync
 
 				}
 				//can only move freely if we are grounded or adjacent to another player
-				else if (CanMoveFreely(isGrounded, clientBump))
+				else if (CanMoveFreely(isGrounded, clientBump) && playerScript.playerMove.IsBuckled == false)
 				{
 					//move freely
 					pendingActions.Enqueue(action);

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -491,22 +491,22 @@ public partial class PlayerSync
 	[Server]
 	private PlayerState NextStateServer(PlayerState state, PlayerAction action)
 	{
-		//movement not allowed when buckled
-		if (playerMove.IsBuckled)
-		{
-			Logger.LogWarning($"Ignored {action}: player is bucked, rolling back!", Category.Movement);
-			RollbackPosition();
-			return state;
-		}
-
 		// if player is in RCS mode and MatrixMove is not null
-		if(playerScript.RcsMode && playerScript.RcsMatrixMove)
+		if (playerScript.RcsMode && playerScript.RcsMatrixMove)
 		{
 			Vector2Int dir = action.Direction();
 			// try to move shuttle on server side
 			playerScript.RcsMatrixMove.RcsMoveServer(Orientation.From(dir));
 
 			// don't move player while in RCS mode so return state without any changes
+			return state;
+		}
+
+		//movement not allowed when buckled
+		if (playerMove.IsBuckled)
+		{
+			Logger.LogWarning($"Ignored {action}: player is bucked, rolling back!", Category.Movement);
+			RollbackPosition();
 			return state;
 		}
 

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.cs
@@ -645,7 +645,7 @@ public partial class PlayerSync : NetworkBehaviour, IPushable, IPlayerControllab
 		{
 			bool beingDraggedWithCuffs = playerMove.IsCuffed && playerScript.pushPull.IsBeingPulledClient;
 
-			if (playerMove.allowInput && !playerMove.IsBuckled && !beingDraggedWithCuffs && !UIManager.IsInputFocus)
+			if (playerMove.allowInput && !beingDraggedWithCuffs && !UIManager.IsInputFocus)
 			{
 				StartCoroutine(DoProcess(moveActions));
 			}


### PR DESCRIPTION
### Purpose
Fixes issue #5232. Player movements weren't being registered while buckled even though the processing of those movements somewhat handled that, so RCS didn't trigger.

### Changelog:
CL: You can now use RCS while buckled to a chair
