### PR TITLE
Fixes handcuffs and other items from being uninteractable.

### DIFF
--- a/UnityProject/Assets/Scripts/Messages/Server/UpdateItemSlotMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/UpdateItemSlotMessage.cs
@@ -38,19 +38,11 @@ namespace Messages.Server
 					slot = ItemSlot.GetIndexed(NetworkObjects[0].GetComponent<ItemStorage>(), msg.SlotIndex);
 				}
 
-				var previouslyInSlot = slot.ItemObject;
-				var pickupable = msg.Item == NetId.Invalid ? null : NetworkObjects[1].GetComponent<Pickupable>();
-				slot.ClientUpdate(pickupable);
-
-
-				if (previouslyInSlot != null)
+				if (slot.ItemObject)
 				{
-					if (pickupable != null)
-					{
-						//was removed from slot
-						pickupable._SetItemSlot(null);
-					}
-
+					var previouslyInSlot = slot.ItemObject.GetComponent<Pickupable>();
+					//was removed from slot
+					previouslyInSlot._SetItemSlot(null);
 					var moveInfo = ClientInventoryMove.OfType(ClientInventoryMoveType.Removed);
 					var hooks = previouslyInSlot.GetComponents<IClientInventoryMove>();
 					foreach (var hook in hooks)
@@ -59,6 +51,8 @@ namespace Messages.Server
 					}
 				}
 
+				var pickupable = msg.Item == NetId.Invalid ? null : NetworkObjects[1].GetComponent<Pickupable>();
+				slot.ClientUpdate(pickupable);
 				if (pickupable != null)
 				{
 					//was added to slot


### PR DESCRIPTION
### Purpose
Fixes handcuffs and other items from being interactable.

If the clients received an update of removal from an itemslot that they were observing (even theirs), they would never set the pickupeable itemslot to null.
Because they believed the pickupeables had an itemslot, they would refuse to interact with it. 
It didnt happen when they were the ones dropping the object because the WillInteract() just believed that it was in their own inventory and returned true.