### PR TITLE
Block Spectator Revive

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
@@ -183,7 +183,7 @@ public class Lungs : BodyPartModification
 			RelatedPart.HealthMaster.HealthStateController.SetSuffocating(true);
 			if (Random.value < 0.2)
 			{
-				Chat.AddActionMsgToChat(gameObject, "You gasp for breath", $"{RelatedPart.HealthMaster.gameObject.ExpensiveName()} gasps");
+				Chat.AddActionMsgToChat(RelatedPart.HealthMaster.gameObject, "You gasp for breath", $"{RelatedPart.HealthMaster.gameObject.ExpensiveName()} gasps");
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
@@ -47,7 +47,14 @@ namespace AdminCommands
 			}
 		}
 
-		public static bool IsAdmin(string adminId, string adminToken)
+		/// <summary>
+		/// Checks whether the adminId and adminToken are valid
+		/// </summary>
+		/// <param name="adminId"></param>
+		/// <param name="adminToken"></param>
+		/// <param name="sender">The client which sends the command, this is populated by mirror so doesnt need to be manually
+		/// put in the parameters when calling the commands</param>
+		public static bool IsAdmin(string adminId, string adminToken, NetworkConnectionToClient sender)
 		{
 			var admin = PlayerList.Instance.GetAdmin(adminId, adminToken);
 			if (admin == null)
@@ -55,9 +62,10 @@ namespace AdminCommands
 				var player = PlayerList.Instance.GetByUserID(adminId);
 				var message =
 					$"Failed Admin check with id: {adminId}, associated player with that id (null if not valid id): {player?.Username}," +
-					$"Possible hacked client";
+					$"Possible hacked client with ip address: {sender?.address}, netIdentity object name: {sender?.identity.OrNull()?.name}]";
 				Logger.LogError(message, Category.Exploits);
 				LogAdminAction(message);
+
 				return false;
 			}
 
@@ -67,9 +75,9 @@ namespace AdminCommands
 		#region GamemodePage
 
 		[Command(requiresAuthority = false)]
-		public void CmdToggleOOCMute(string adminId, string adminToken)
+		public void CmdToggleOOCMute(string adminId, string adminToken, NetworkConnectionToClient sender = null)
 		{
-			if (IsAdmin(adminId, adminToken) == false) return;
+			if (IsAdmin(adminId, adminToken, sender) == false) return;
 
 			Chat.Instance.OOCMute = !Chat.Instance.OOCMute;
 
@@ -88,9 +96,9 @@ namespace AdminCommands
 		[Command(requiresAuthority = false)]
 		public void CmdTriggerGameEvent(string adminId, string adminToken, int eventIndex, bool isFake,
 			bool announceEvent,
-			InGameEventType eventType, string serializedEventParameters)
+			InGameEventType eventType, string serializedEventParameters, NetworkConnectionToClient sender = null)
 		{
-			if (IsAdmin(adminId, adminToken) == false) return;
+			if (IsAdmin(adminId, adminToken, sender) == false) return;
 
 			InGameEventsManager.Instance.TriggerSpecificEvent(eventIndex, eventType, isFake,
 				PlayerList.Instance.GetByUserID(adminId).Username, announceEvent, serializedEventParameters);
@@ -101,9 +109,9 @@ namespace AdminCommands
 		#region RoundPage
 
 		[Command(requiresAuthority = false)]
-		public void CmdStartRound(string adminId, string adminToken)
+		public void CmdStartRound(string adminId, string adminToken, NetworkConnectionToClient sender = null)
 		{
-			if (IsAdmin(adminId, adminToken) == false) return;
+			if (IsAdmin(adminId, adminToken, sender) == false) return;
 
 			if (GameManager.Instance.CurrentRoundState == RoundState.PreRound && GameManager.Instance.waitForStart)
 			{
@@ -116,9 +124,9 @@ namespace AdminCommands
 		}
 
 		[Command(requiresAuthority = false)]
-		public void CmdEndRound(string adminId, string adminToken)
+		public void CmdEndRound(string adminId, string adminToken, NetworkConnectionToClient sender = null)
 		{
-			if (IsAdmin(adminId, adminToken) == false) return;
+			if (IsAdmin(adminId, adminToken, sender) == false) return;
 			if (GameManager.Instance.CurrentRoundState == RoundState.Started)
 			{
 				GameManager.Instance.RoundEndTime = 5; // Quick round end when triggered by admin.
@@ -131,9 +139,9 @@ namespace AdminCommands
 		}
 
 		[Command(requiresAuthority = false)]
-		public void CmdChangeNextMap(string adminId, string adminToken, string nextMap)
+		public void CmdChangeNextMap(string adminId, string adminToken, string nextMap, NetworkConnectionToClient sender = null)
 		{
-			if (IsAdmin(adminId, adminToken) == false) return;
+			if (IsAdmin(adminId, adminToken, sender) == false) return;
 
 			if (SubSceneManager.AdminForcedMainStation == nextMap) return;
 
@@ -143,9 +151,9 @@ namespace AdminCommands
 		}
 
 		[Command(requiresAuthority = false)]
-		public void CmdChangeAwaySite(string adminId, string adminToken, string nextAwaySite)
+		public void CmdChangeAwaySite(string adminId, string adminToken, string nextAwaySite, NetworkConnectionToClient sender = null)
 		{
-			if (IsAdmin(adminId, adminToken) == false) return;
+			if (IsAdmin(adminId, adminToken, sender) == false) return;
 
 			if (SubSceneManager.AdminForcedAwaySite == nextAwaySite) return;
 
@@ -155,9 +163,9 @@ namespace AdminCommands
 		}
 
 		[Command(requiresAuthority = false)]
-		public void CmdChangeAlertLevel(string adminId, string adminToken, CentComm.AlertLevel alertLevel)
+		public void CmdChangeAlertLevel(string adminId, string adminToken, CentComm.AlertLevel alertLevel , NetworkConnectionToClient sender = null)
 		{
-			if (IsAdmin(adminId, adminToken) == false) return;
+			if (IsAdmin(adminId, adminToken, sender) == false) return;
 
 			var currentLevel = GameManager.Instance.CentComm.CurrentAlertLevel;
 
@@ -173,9 +181,9 @@ namespace AdminCommands
 		#region CentCom
 
 		[Command(requiresAuthority = false)]
-		public void CmdCallShuttle(string adminId, string adminToken, string text)
+		public void CmdCallShuttle(string adminId, string adminToken, string text, NetworkConnectionToClient sender = null)
 		{
-			if (IsAdmin(adminId, adminToken) == false) return;
+			if (IsAdmin(adminId, adminToken, sender) == false) return;
 
 			var shuttle = GameManager.Instance.PrimaryEscapeShuttle;
 
@@ -191,9 +199,9 @@ namespace AdminCommands
 		}
 
 		[Command(requiresAuthority = false)]
-		public void CmdRecallShuttle(string adminId, string adminToken, string text)
+		public void CmdRecallShuttle(string adminId, string adminToken, string text, NetworkConnectionToClient sender = null)
 		{
-			if (IsAdmin(adminId, adminToken) == false) return;
+			if (IsAdmin(adminId, adminToken, sender) == false) return;
 
 			var success = GameManager.Instance.PrimaryEscapeShuttle.RecallShuttle(out var result, true);
 
@@ -205,9 +213,9 @@ namespace AdminCommands
 		}
 
 		[Command(requiresAuthority = false)]
-		public void CmdSendCentCommAnnouncement(string adminId, string adminToken, string text)
+		public void CmdSendCentCommAnnouncement(string adminId, string adminToken, string text, NetworkConnectionToClient sender = null)
 		{
-			if (IsAdmin(adminId, adminToken) == false) return;
+			if (IsAdmin(adminId, adminToken, sender) == false) return;
 
 			CentComm.MakeAnnouncement(ChatTemplates.CentcomAnnounce, text, CentComm.UpdateSound.Notice);
 
@@ -215,9 +223,9 @@ namespace AdminCommands
 		}
 
 		[Command(requiresAuthority = false)]
-		public void CmdSendCentCommReport(string adminId, string adminToken, string text)
+		public void CmdSendCentCommReport(string adminId, string adminToken, string text, NetworkConnectionToClient sender = null)
 		{
-			if (IsAdmin(adminId, adminToken) == false) return;
+			if (IsAdmin(adminId, adminToken, sender) == false) return;
 
 			GameManager.Instance.CentComm.MakeCommandReport(text, CentComm.UpdateSound.Notice);
 
@@ -225,9 +233,9 @@ namespace AdminCommands
 		}
 
 		[Command(requiresAuthority = false)]
-		public void CmdSendBlockShuttleCall(string adminId, string adminToken, bool toggleBool)
+		public void CmdSendBlockShuttleCall(string adminId, string adminToken, bool toggleBool, NetworkConnectionToClient sender = null)
 		{
-			if (IsAdmin(adminId, adminToken) == false) return;
+			if (IsAdmin(adminId, adminToken, sender) == false) return;
 
 			var shuttle = GameManager.Instance.PrimaryEscapeShuttle;
 
@@ -239,9 +247,9 @@ namespace AdminCommands
 		}
 
 		[Command(requiresAuthority = false)]
-		public void CmdSendBlockShuttleRecall(string adminId, string adminToken, bool toggleBool)
+		public void CmdSendBlockShuttleRecall(string adminId, string adminToken, bool toggleBool, NetworkConnectionToClient sender = null)
 		{
-			if (IsAdmin(adminId, adminToken) == false) return;
+			if (IsAdmin(adminId, adminToken, sender) == false) return;
 
 			var shuttle = GameManager.Instance.PrimaryEscapeShuttle;
 
@@ -253,9 +261,9 @@ namespace AdminCommands
 		}
 
 		[Command(requiresAuthority = false)]
-		public void CmdCreateDeathSquad(string adminId, string adminToken)
+		public void CmdCreateDeathSquad(string adminId, string adminToken, NetworkConnectionToClient sender = null)
 		{
-			if (IsAdmin(adminId, adminToken) == false) return;
+			if (IsAdmin(adminId, adminToken, sender) == false) return;
 
 			Systems.GhostRoles.GhostRoleManager.Instance.ServerCreateRole(deathsquadRole);
 
@@ -272,11 +280,11 @@ namespace AdminCommands
 		/// <param name="adminId">Id of the admin performing the action</param>
 		/// <param name="adminToken">Token that proves the admin privileges</param>
 		/// <param name="userToSmite">User Id of the user to smite</param>
+		/// <param name="sender"></param>
 		[Command(requiresAuthority = false)]
-		public void CmdSmitePlayer(string adminId, string adminToken, string userToSmite)
+		public void CmdSmitePlayer(string adminId, string adminToken, string userToSmite, NetworkConnectionToClient sender = null)
 		{
-			GameObject admin = PlayerList.Instance.GetAdmin(adminId, adminToken);
-			if (admin == null) return;
+			if (IsAdmin(adminId, adminToken, sender) == false) return;
 
 			var players = PlayerList.Instance.GetAllByUserID(userToSmite);
 			if (players.Count != 0)
@@ -300,12 +308,12 @@ namespace AdminCommands
 		/// </summary>
 		/// <param name="adminId"></param>
 		/// <param name="adminToken"></param>
-		/// <param name="userToSmite"></param>
+		/// <param name="userToHeal"></param>
+		/// <param name="sender"></param>
 		[Command(requiresAuthority = false)]
-		public void CmdHealUpPlayer(string adminId, string adminToken, string userToHeal)
+		public void CmdHealUpPlayer(string adminId, string adminToken, string userToHeal, NetworkConnectionToClient sender = null)
 		{
-			GameObject admin = PlayerList.Instance.GetAdmin(adminId, adminToken);
-			if (admin == null) return;
+			if (IsAdmin(adminId, adminToken, sender) == false) return;
 
 			var players = PlayerList.Instance.GetAllByUserID(userToHeal);
 			if (players.Count != 0)
@@ -331,9 +339,9 @@ namespace AdminCommands
 		#region Sound
 
 		[Command(requiresAuthority = false)]
-		public void CmdPlaySound(string adminId, string adminToken, string index)
+		public void CmdPlaySound(string adminId, string adminToken, string index, NetworkConnectionToClient sender = null)
 		{
-			if (IsAdmin(adminId, adminToken) == false) return;
+			if (IsAdmin(adminId, adminToken, sender) == false) return;
 
 			var players = PlayerList.Instance.InGamePlayers;
 
@@ -353,25 +361,25 @@ namespace AdminCommands
 		#region Profiling
 
 		[Command(requiresAuthority = false)]
-		public void CmdStartProfile(string adminId, string adminToken, int frameCount)
+		public void CmdStartProfile(string adminId, string adminToken, int frameCount, NetworkConnectionToClient sender = null)
 		{
-			if (IsAdmin(adminId, adminToken) == false) return;
+			if (IsAdmin(adminId, adminToken, sender) == false) return;
 
 			ProfileManager.Instance.StartProfile(frameCount);
 		}
 
 		[Command(requiresAuthority = false)]
-		public void CmdRequestProfiles(string adminId, string adminToken)
+		public void CmdRequestProfiles(string adminId, string adminToken, NetworkConnectionToClient sender = null)
 		{
-			if (IsAdmin(adminId, adminToken) == false) return;
+			if (IsAdmin(adminId, adminToken, sender) == false) return;
 			var admin = PlayerList.Instance.GetAdmin(adminId, adminToken);
 			ProfileMessage.Send(admin);
 		}
 
 		[Command(requiresAuthority = false)]
-		public void CmdDeleteProfile(string adminId, string adminToken, string profileName)
+		public void CmdDeleteProfile(string adminId, string adminToken, string profileName, NetworkConnectionToClient sender = null)
 		{
-			if (IsAdmin(adminId, adminToken) == false) return;
+			if (IsAdmin(adminId, adminToken, sender) == false) return;
 			if (ProfileManager.runningProfile || ProfileManager.runningMemoryProfile) return;
 
 			string path = Directory.GetCurrentDirectory() + "/Profiles/" + profileName;
@@ -384,9 +392,9 @@ namespace AdminCommands
 		}
 
 		[Command(requiresAuthority = false)]
-		public void CmdStartMemoryProfile(string adminId, string adminToken, bool full)
+		public void CmdStartMemoryProfile(string adminId, string adminToken, bool full, NetworkConnectionToClient sender = null)
 		{
-			if (IsAdmin(adminId, adminToken) == false) return;
+			if (IsAdmin(adminId, adminToken, sender) == false) return;
 
 			ProfileManager.Instance.RunMemoryProfile(full);
 		}
@@ -396,9 +404,9 @@ namespace AdminCommands
 		#region Inventory
 
 		[Command(requiresAuthority = false)]
-		public void CmdAdminGhostDropItem(string adminId, string adminToken)
+		public void CmdAdminGhostDropItem(string adminId, string adminToken, NetworkConnectionToClient sender = null)
 		{
-			if (IsAdmin(adminId, adminToken) == false) return;
+			if (IsAdmin(adminId, adminToken, sender) == false) return;
 
 			var admin = PlayerList.Instance.GetAdmin(adminId, adminToken);
 			var connectedPlayer = admin.Player();
@@ -409,9 +417,9 @@ namespace AdminCommands
 
 
 		[Command(requiresAuthority = false)]
-		public void CmdAdminGhostSmashItem(string adminId, string adminToken)
+		public void CmdAdminGhostSmashItem(string adminId, string adminToken, NetworkConnectionToClient sender = null)
 		{
-			if (IsAdmin(adminId, adminToken) == false) return;
+			if (IsAdmin(adminId, adminToken, sender) == false) return;
 
 			var admin = PlayerList.Instance.GetAdmin(adminId, adminToken);
 			var connectedPlayer = admin.Player();

--- a/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
@@ -53,8 +53,11 @@ namespace AdminCommands
 			if (admin == null)
 			{
 				var player = PlayerList.Instance.GetByUserID(adminId);
-				Logger.LogError($"Failed Admin check with id: {adminId}, associated player with that id (null if not valid id): {player?.Username}," +
-				                $"Possible hacked client", Category.Exploits);
+				var message =
+					$"Failed Admin check with id: {adminId}, associated player with that id (null if not valid id): {player?.Username}," +
+					$"Possible hacked client";
+				Logger.LogError(message, Category.Exploits);
+				LogAdminAction(message);
 				return false;
 			}
 

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -560,10 +560,10 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 			}
 		}
 
-		//Can be null if respawning spectator ghost as they didnt have an occupation set before so give assistant just in case
+		//Can be null if respawning spectator ghost as they dont have an occupation
 		if (playerScript.mind.occupation == null)
 		{
-			playerScript.mind.occupation = OccupationList.Instance.Get(JobType.ASSISTANT);
+			return;
 		}
 
 		PlayerSpawn.ServerRespawnPlayer(playerScript.mind);

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -560,6 +560,12 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 			}
 		}
 
+		//Can be null if respawning spectator ghost as they didnt have an occupation set before so give assistant just in case
+		if (playerScript.mind.occupation == null)
+		{
+			playerScript.mind.occupation = OccupationList.Instance.Get(JobType.ASSISTANT);
+		}
+
 		PlayerSpawn.ServerRespawnPlayer(playerScript.mind);
 	}
 

--- a/UnityProject/Assets/Scripts/Shuttles/MatrixMove.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/MatrixMove.cs
@@ -353,9 +353,9 @@ public class MatrixMove : ManagedBehaviour
 		networkedMatrix.MatrixSync.SyncInitialPosition(oldPos, initialPos);
 	}
 
-	public void SyncPivot(Vector3 oldPivot, Vector3 pivot)
+	private void SyncPivot(Vector3 oldPivot, Vector3 pivot)
 	{
-
+		networkedMatrix.MatrixSync.SyncPivot(oldPivot, pivot);
 	}
 
 	/// <summary>


### PR DESCRIPTION
Fixes #6592

-Also send admin check fail to the webhook

-Fix pivot sync

-Fix gasp message

-Mirror fills the `NetworkConnectionToClient sender = null` parameter on commands so you dont need to fill them manually