### PR TITLE
Admin healing will now revive dead players instead of healing dead bodies.

### DIFF
--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -860,7 +860,6 @@ namespace HealthV2
 			Extinguish(); //Remove any fire on them.
 			ResetDamageAll(); //Bring their entire body parts that are on them in good shape.
 			healthStateController.SetOverallHealth(maxHealth); //Set the player's overall health to their race's maxHealth.
-			healthStateController.SetConsciousState(ConsciousState.CONSCIOUS); //They're allliiivveee!
 			foreach (var BodyPart in ImplantList) //Restart their heart.
 			{
 				foreach (var bodyPartModification in BodyPart.BodyPartModifications)
@@ -874,6 +873,7 @@ namespace HealthV2
 					}
 				}
 			}
+			CalculateOverallHealth(); //This makes the player alive and concision.
 			player.playerMove.allowInput = true; //Let them interact with the world again.
 		}
 

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -861,19 +861,7 @@ namespace HealthV2
 			ResetDamageAll(); //Bring their entire body parts that are on them in good shape.
 			healthStateController.SetOverallHealth(maxHealth); //Set the player's overall health to their race's maxHealth.
 			healthStateController.SetConsciousState(ConsciousState.CONSCIOUS); //They're allliiivveee!
-			foreach (var BodyPart in ImplantList) //Restart their heart.
-			{
-				foreach (var bodyPartModification in BodyPart.BodyPartModifications)
-				{
-					if (bodyPartModification is Heart heart)
-					{
-						heart.HeartAttack = false;
-						heart.CanTriggerHeartAttack = false;
-						heart.CurrentPulse = 100;
-						heart.DoHeartBeat(this);
-					}
-				}
-			}
+			CalculateOverallHealth(); //Restart the heart.
 			player.playerMove.allowInput = true; //Let them interact with the world again.
 		}
 

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -861,7 +861,19 @@ namespace HealthV2
 			ResetDamageAll(); //Bring their entire body parts that are on them in good shape.
 			healthStateController.SetOverallHealth(maxHealth); //Set the player's overall health to their race's maxHealth.
 			healthStateController.SetConsciousState(ConsciousState.CONSCIOUS); //They're allliiivveee!
-			CalculateOverallHealth(); //Restart the heart.
+			foreach (var BodyPart in ImplantList) //Restart their heart.
+			{
+				foreach (var bodyPartModification in BodyPart.BodyPartModifications)
+				{
+					if (bodyPartModification is Heart heart)
+					{
+						heart.HeartAttack = false;
+						heart.CanTriggerHeartAttack = false;
+						heart.CurrentPulse = 100;
+						heart.DoHeartBeat(this);
+					}
+				}
+			}
 			player.playerMove.allowInput = true; //Let them interact with the world again.
 		}
 

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -859,7 +859,7 @@ namespace HealthV2
 		{
 			Extinguish(); //Remove any fire on them.
 			ResetDamageAll(); //Bring their entire body parts that are on them in good shape.
-			healthStateController.SetOverallHealth(maxHealth); //Set the player's overhealth to their race's maxHealth.
+			healthStateController.SetOverallHealth(maxHealth); //Set the player's overall health to their race's maxHealth.
 			healthStateController.SetConsciousState(ConsciousState.CONSCIOUS); //They're allliiivveee!
 			foreach (var BodyPart in ImplantList) //Restart their heart.
 			{

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -849,6 +849,32 @@ namespace HealthV2
 			{
 				bodyPart.ResetDamage();
 			}
+			
+		}
+
+		/// <summary>
+		/// Revives a dead player to full health.
+		/// </summary>
+		public void RevivePlayerToFullHealth(PlayerScript player)
+		{
+			Extinguish(); //Remove any fire on them.
+			ResetDamageAll(); //Bring their entire body parts that are on them in good shape.
+			healthStateController.SetOverallHealth(maxHealth); //Set the player's overhealth to their race's maxHealth.
+			healthStateController.SetConsciousState(ConsciousState.CONSCIOUS); //They're allliiivveee!
+			foreach (var BodyPart in ImplantList) //Restart their heart.
+			{
+				foreach (var bodyPartModification in BodyPart.BodyPartModifications)
+				{
+					if (bodyPartModification is Heart heart)
+					{
+						heart.HeartAttack = false;
+						heart.CanTriggerHeartAttack = false;
+						heart.CurrentPulse = 100;
+						heart.DoHeartBeat(this);
+					}
+				}
+			}
+			player.playerMove.allowInput = true; //Let them interact with the world again.
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
@@ -309,16 +309,45 @@ namespace AdminCommands
 			{
 				foreach (ConnectedPlayer player in players)
 				{
-					string message =
-						$"{PlayerList.Instance.GetByUserID(adminId).Username}: Healed up Username: {player.Username} ({player.Name})";
+					//get player stuff.
+					PlayerScript playerScript = player.Script;
+					Mind playerMind = playerScript.mind;
+					var playerBody = playerMind.body;
+					HealthV2.PlayerHealthV2 health = playerBody.playerHealth;
+					string message = "";
+
+					//Does this player have a body that can be healed?
+					if(playerBody != null)
+					{
+						if(health.IsDead == false) //If player is not dead; simply heal all his damage and that's all.
+						{
+							health.ResetDamageAll();
+							playerScript.registerTile.ServerStandUp();
+						}
+						else //If not, start reviving the player.
+						{
+							//(Max): Because Mirror authority does not allow us to call functions from PlayerSpawn in [Command(requiresAuthority = false)]
+							//(Max): We have to avoid forcing the player ghost back into his body for now until we find a work around.
+							//If the player is a ghost --force them into their body-- tell admins to tell the player to return back to their body to revive them.
+							if(playerScript.IsGhost)
+							{
+								message = $"{PlayerList.Instance.GetByUserID(adminId).Username}: Attempted healing {player.Username} but their ghost is outside of their body!";
+								Logger.Log(message, Category.Admin);
+								LogAdminAction(message);
+								return;
+							}
+							health.RevivePlayerToFullHealth(playerScript);
+							playerScript.registerTile.ServerStandUp();
+						}
+						message = $"{PlayerList.Instance.GetByUserID(adminId).Username}: Healed up Username: {player.Username} ({player.Name})";
+					}
+					else
+					{
+						message = $"{PlayerList.Instance.GetByUserID(adminId).Username}: Attempted healing {player.Username} but they had no body!";
+					}
+					//Log what we did.
 					Logger.Log(message, Category.Admin);
-
 					LogAdminAction(message);
-
-					var playerScript = player.Script;
-					var health = playerScript.playerHealth;
-					health.ResetDamageAll();
-					playerScript.registerTile.ServerStandUp();
 				}
 			}
 		}


### PR DESCRIPTION
### Purpose
fixes #6595

### Changelog:
CL: [Improvement] - Admins now can now revive dead players instead of forcing their character to respawn.
CL: [Fix] - Admins no longer can heal dead bodies.
