### PR TITLE
Fix QuickBuild issues

### DIFF
--- a/UnityProject/ProjectSettings/ProjectSettings.asset
+++ b/UnityProject/ProjectSettings/ProjectSettings.asset
@@ -807,8 +807,10 @@ PlayerSettings:
   ps4IncludedModules: []
   ps4attribVROutputEnabled: 0
   monoEnv: 
-  splashScreenBackgroundSourceLandscape: {fileID: 0}
-  splashScreenBackgroundSourcePortrait: {fileID: 0}
+  splashScreenBackgroundSourceLandscape: {fileID: 21300000, guid: e9d98527a73c4d738627a7bb161dda59,
+    type: 3}
+  splashScreenBackgroundSourcePortrait: {fileID: 21300000, guid: f4afa1ebb67f14660bc72e5a9ad8c17f,
+    type: 3}
   blurSplashScreenBackground: 1
   spritePackerPolicy: DefaultPackerPolicy
   webGLMemorySize: 512


### PR DESCRIPTION
- Adds a background to Unity splash screen. Looks neat.
- Fixes some issues with QuickBuild, small improvements.

> Doesn't actually fix the build being broken... still looking for the problem.