### PR TITLE
Better possible fixes for plasma fires

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Utils/TileList.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Utils/TileList.cs
@@ -150,7 +150,7 @@ public class TileList
 	/// <returns></returns>
 	public void ForEachSafe(IRegisterTileAction action, Vector3Int localPosition)
 	{
-		if (lockedPosition != null && lockedPosition != localPosition)
+		if (lockedPosition != null)
 		{
 			Logger.LogErrorFormat("Tried to lock tile at position {0} while position {1} is currently locked." +
 			                      " TileList only supports locking one position at a time. Please add this locking capability" +


### PR DESCRIPTION
### Purpose
I realised the fix I had for plasma fires before was a pretty bad way for going about it, so I've done a new method to reduce some red unity errors that may be causing immortal plasma fires.

### Explanation:
An InvalidOperationError was being called because the lighting thread tried to create sparks which could light fires. This could overlap with the ForEachSafe function in TileList.cs, meaning two of the same function on the same object would try to be called at the same time. I've fixed this by changing the requirements for the ForEachSafe function to break, from `lockedposition != null && lockedposition != localposition` to `lockedposition != null`. I don't see why the `localposition` was checked as well, because even if it was the same as `lockedposition` the variable would still be changed, causing the InvalidOperationError. However, from my testing it hasn't broken anything.

Because of that, I've also had to lock the hotspotsToAdd and hotspotsToRemove during updates since other threads can now edit them while the update is running without an error being thrown and the code breaking.

### Notes:
I've realised my way of reproducing the immortal plasma fires doesn't work, and it was probably a fluke of the bug that caused me to think that spot was special. It seems the only way to find out if these fires are fixed is to wait and see if the bug occurs again. From my testing though, I haven't seen it reappear.

### Changelog:
CL: Fixes a possible cause of neverending plasma fires
