### PR TITLE
Adds in dismembering players + No more alive headless players

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/AncientHelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/AncientHelmet.prefab
@@ -11,14 +11,12 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: dc54ab84b7429a549b14160fb4f285e7,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 3568482238077595727, guid: d3d950d792abb79fba51d3166022f581,
         type: 3}
       propertyPath: currentClothData
       value: 
-      objectReference: {fileID: 11400000, guid: dc54ab84b7429a549b14160fb4f285e7,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 3568482238077595727, guid: d3d950d792abb79fba51d3166022f581,
         type: 3}
       propertyPath: allClothingData.Array.size
@@ -36,6 +34,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: e9d704e271b82514fb53467658da6c67,
         type: 2}
+    - target: {fileID: 5936454131396164911, guid: d3d950d792abb79fba51d3166022f581,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.7
+      objectReference: {fileID: 0}
     - target: {fileID: 7524605284256423550, guid: d3d950d792abb79fba51d3166022f581,
         type: 3}
       propertyPath: m_AssetId

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/BulletproofHelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/BulletproofHelmet.prefab
@@ -184,6 +184,16 @@ PrefabInstance:
       propertyPath: armoredBodyParts.Array.data[1].armoringBodyPartType
       value: 7
       objectReference: {fileID: 0}
+    - target: {fileID: 2727688219082199354, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2727688219082199354, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[1].armor.DismembermentProtectionChance
+      value: 0.5
+      objectReference: {fileID: 0}
     - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: clothData

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/CrusaderHelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/CrusaderHelmet.prefab
@@ -174,6 +174,11 @@ PrefabInstance:
       propertyPath: armoredBodyParts.Array.data[0].armor.Energy
       value: -30
       objectReference: {fileID: 0}
+    - target: {fileID: 2727688219082199354, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.75
+      objectReference: {fileID: 0}
     - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: clothData

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/Hardhats/AtmosphericTechniciansFirefightingHelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/Hardhats/AtmosphericTechniciansFirefightingHelmet.prefab
@@ -23,14 +23,12 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: 65ae818a9be0e65469a73890dd84a1c4,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 3568482238077595727, guid: 64e430f828cfc465ea88b8d6e6fecda4,
         type: 3}
       propertyPath: currentClothData
       value: 
-      objectReference: {fileID: 11400000, guid: 65ae818a9be0e65469a73890dd84a1c4,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 3568482238077595727, guid: 64e430f828cfc465ea88b8d6e6fecda4,
         type: 3}
       propertyPath: hideClothingFlags
@@ -80,6 +78,11 @@ PrefabInstance:
         type: 3}
       propertyPath: bodyPartsCovered
       value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 5936454131396164911, guid: 64e430f828cfc465ea88b8d6e6fecda4,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 7521929656741835326, guid: 64e430f828cfc465ea88b8d6e6fecda4,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/RiotHelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/RiotHelmet.prefab
@@ -193,6 +193,11 @@ PrefabInstance:
       propertyPath: armoredBodyParts.Array.data[2].armoringBodyPartType
       value: 8
       objectReference: {fileID: 0}
+    - target: {fileID: 2727688219082199354, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[1].armor.DismembermentProtectionChance
+      value: 0.1
+      objectReference: {fileID: 0}
     - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: clothData

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/EVAHelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/EVAHelmet.prefab
@@ -17,14 +17,12 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: f7547e1a886c3b844be84a4e62c738e4,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 4548501816867735510, guid: 5269bbb43ef5a0b40a2676310664d6c6,
         type: 3}
       propertyPath: currentClothData
       value: 
-      objectReference: {fileID: 11400000, guid: f7547e1a886c3b844be84a4e62c738e4,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 4548501816867735510, guid: 5269bbb43ef5a0b40a2676310664d6c6,
         type: 3}
       propertyPath: allClothingData.Array.size
@@ -36,6 +34,21 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: bf62a22f9b69f8140b40cf65e1e8abfa,
         type: 2}
+    - target: {fileID: 6699324801598458550, guid: 5269bbb43ef5a0b40a2676310664d6c6,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.65
+      objectReference: {fileID: 0}
+    - target: {fileID: 6699324801598458550, guid: 5269bbb43ef5a0b40a2676310664d6c6,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[1].armor.DismembermentProtectionChance
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 6699324801598458550, guid: 5269bbb43ef5a0b40a2676310664d6c6,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[2].armor.DismembermentProtectionChance
+      value: 0.8
+      objectReference: {fileID: 0}
     - target: {fileID: 7029879816411904817, guid: 5269bbb43ef5a0b40a2676310664d6c6,
         type: 3}
       propertyPath: initialName

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/HardsuitHelmets/ERTHelmets/PRTHelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/HardsuitHelmets/ERTHelmets/PRTHelmet.prefab
@@ -11,14 +11,12 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: 4d797a041601d264aa974a54e67cd2d7,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 226526901835897784, guid: 4870238ed625c0e45839e280fab63823,
         type: 3}
       propertyPath: currentClothData
       value: 
-      objectReference: {fileID: 11400000, guid: 4d797a041601d264aa974a54e67cd2d7,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 226526901835897784, guid: 4870238ed625c0e45839e280fab63823,
         type: 3}
       propertyPath: allClothingData.Array.data[0]
@@ -129,6 +127,16 @@ PrefabInstance:
         type: 3}
       propertyPath: initialDescription
       value: A helmet worn by those who deal with paranormal threats for a living.
+      objectReference: {fileID: 0}
+    - target: {fileID: 6972565221476718296, guid: 4870238ed625c0e45839e280fab63823,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[1].armor.DismembermentProtectionChance
+      value: 0.67
+      objectReference: {fileID: 0}
+    - target: {fileID: 6972565221476718296, guid: 4870238ed625c0e45839e280fab63823,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[2].armor.DismembermentProtectionChance
+      value: 0.67
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 6746541494595479454, guid: 4870238ed625c0e45839e280fab63823, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/HardsuitHelmets/EliteSyndicateHardsuitHelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/HardsuitHelmets/EliteSyndicateHardsuitHelmet.prefab
@@ -102,6 +102,21 @@ PrefabInstance:
       propertyPath: armoredBodyParts.Array.data[0].armor.Energy
       value: 70
       objectReference: {fileID: 0}
+    - target: {fileID: 4646148038149176953, guid: b05f31cc06e66ee43a22ce2771dba99d,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 4646148038149176953, guid: b05f31cc06e66ee43a22ce2771dba99d,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[1].armor.DismembermentProtectionChance
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4646148038149176953, guid: b05f31cc06e66ee43a22ce2771dba99d,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[2].armor.DismembermentProtectionChance
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 7357085494083097413, guid: b05f31cc06e66ee43a22ce2771dba99d,
         type: 3}
       propertyPath: Color.b

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/HardsuitHelmets/EngineeringHardsuitHelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/HardsuitHelmets/EngineeringHardsuitHelmet.prefab
@@ -7,6 +7,16 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1958420083617270434, guid: c60440956ff96af4b84ba3e95e41c3e0,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[1].armor.DismembermentProtectionChance
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1958420083617270434, guid: c60440956ff96af4b84ba3e95e41c3e0,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[2].armor.DismembermentProtectionChance
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 2352077745602750771, guid: c60440956ff96af4b84ba3e95e41c3e0,
         type: 3}
       propertyPath: m_RootOrder
@@ -152,14 +162,12 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: c5389b81c367a404aa5fc69096b6f967,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 8704044746233661378, guid: c60440956ff96af4b84ba3e95e41c3e0,
         type: 3}
       propertyPath: currentClothData
       value: 
-      objectReference: {fileID: 11400000, guid: c5389b81c367a404aa5fc69096b6f967,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 8704044746233661378, guid: c60440956ff96af4b84ba3e95e41c3e0,
         type: 3}
       propertyPath: allClothingData.Array.size

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/HardsuitHelmets/SyndicateHardsuitHelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/HardsuitHelmets/SyndicateHardsuitHelmet.prefab
@@ -37,6 +37,16 @@ PrefabInstance:
       propertyPath: armoredBodyParts.Array.data[0].armor.Energy
       value: 40
       objectReference: {fileID: 0}
+    - target: {fileID: 1958420083617270434, guid: c60440956ff96af4b84ba3e95e41c3e0,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[1].armor.DismembermentProtectionChance
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1958420083617270434, guid: c60440956ff96af4b84ba3e95e41c3e0,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[2].armor.DismembermentProtectionChance
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1967846948629829625, guid: c60440956ff96af4b84ba3e95e41c3e0,
         type: 3}
       propertyPath: Colour.b

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/HardsuitHelmets/_HardsuitHelmetBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/HardsuitHelmets/_HardsuitHelmetBase.prefab
@@ -292,6 +292,11 @@ PrefabInstance:
       propertyPath: armoredBodyParts.Array.data[2].armor.Bullet
       value: 10
       objectReference: {fileID: 0}
+    - target: {fileID: 6699324801598458550, guid: 5269bbb43ef5a0b40a2676310664d6c6,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.55
+      objectReference: {fileID: 0}
     - target: {fileID: 7029879816411904817, guid: 5269bbb43ef5a0b40a2676310664d6c6,
         type: 3}
       propertyPath: initialName

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/PlasmaEnvirosuitHelmets/AtmosphericsEnvirohelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/PlasmaEnvirosuitHelmets/AtmosphericsEnvirohelmet.prefab
@@ -7,6 +7,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 346633510809408503, guid: fb326cff61a55704ca244f0116325115,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.23
+      objectReference: {fileID: 0}
     - target: {fileID: 4159236212715709040, guid: fb326cff61a55704ca244f0116325115,
         type: 3}
       propertyPath: initialName
@@ -93,14 +98,12 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: c8e0a7d44222b4b49b3231007f1ddb1d,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 7433247755527118487, guid: fb326cff61a55704ca244f0116325115,
         type: 3}
       propertyPath: currentClothData
       value: 
-      objectReference: {fileID: 11400000, guid: c8e0a7d44222b4b49b3231007f1ddb1d,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 7433247755527118487, guid: fb326cff61a55704ca244f0116325115,
         type: 3}
       propertyPath: allClothingData.Array.size

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/PlasmaEnvirosuitHelmets/BotanyEnvirohelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/PlasmaEnvirosuitHelmets/BotanyEnvirohelmet.prefab
@@ -90,18 +90,31 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 72b779d387f35014ba03cbd3ec4a8a9a,
         type: 3}
+    - target: {fileID: 3980457662688195350, guid: 2c46f309a45d8714f9c5db5361e854e6,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 3980457662688195350, guid: 2c46f309a45d8714f9c5db5361e854e6,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[1].armor.DismembermentProtectionChance
+      value: 0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 3980457662688195350, guid: 2c46f309a45d8714f9c5db5361e854e6,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[2].armor.DismembermentProtectionChance
+      value: 0.1
+      objectReference: {fileID: 0}
     - target: {fileID: 6114237942327262838, guid: 2c46f309a45d8714f9c5db5361e854e6,
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: 5df9ba9914e64304cb3d0b7665c3b792,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 6114237942327262838, guid: 2c46f309a45d8714f9c5db5361e854e6,
         type: 3}
       propertyPath: currentClothData
       value: 
-      objectReference: {fileID: 11400000, guid: 5df9ba9914e64304cb3d0b7665c3b792,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 6114237942327262838, guid: 2c46f309a45d8714f9c5db5361e854e6,
         type: 3}
       propertyPath: allClothingData.Array.size

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/PlasmaEnvirosuitHelmets/ClownEnvirohelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/PlasmaEnvirosuitHelmets/ClownEnvirohelmet.prefab
@@ -88,18 +88,26 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 8143a63083f20a64b998dab7818d0a49,
         type: 3}
+    - target: {fileID: 3980457662688195350, guid: 2c46f309a45d8714f9c5db5361e854e6,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 3980457662688195350, guid: 2c46f309a45d8714f9c5db5361e854e6,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[2].armor.DismembermentProtectionChance
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6114237942327262838, guid: 2c46f309a45d8714f9c5db5361e854e6,
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: ed28a867477c18b41bfdc0c2b104bcb3,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 6114237942327262838, guid: 2c46f309a45d8714f9c5db5361e854e6,
         type: 3}
       propertyPath: currentClothData
       value: 
-      objectReference: {fileID: 11400000, guid: ed28a867477c18b41bfdc0c2b104bcb3,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 6114237942327262838, guid: 2c46f309a45d8714f9c5db5361e854e6,
         type: 3}
       propertyPath: allClothingData.Array.size

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/PlasmaEnvirosuitHelmets/ScienceEnvirohelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/PlasmaEnvirosuitHelmets/ScienceEnvirohelmet.prefab
@@ -88,18 +88,31 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: d7a57704f4173c84daae492b9c3ef689,
         type: 3}
+    - target: {fileID: 3980457662688195350, guid: 2c46f309a45d8714f9c5db5361e854e6,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3980457662688195350, guid: 2c46f309a45d8714f9c5db5361e854e6,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[1].armor.DismembermentProtectionChance
+      value: 0.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3980457662688195350, guid: 2c46f309a45d8714f9c5db5361e854e6,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[2].armor.DismembermentProtectionChance
+      value: 0.9
+      objectReference: {fileID: 0}
     - target: {fileID: 6114237942327262838, guid: 2c46f309a45d8714f9c5db5361e854e6,
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: 7f36dd18648bd4d48932b3008021520d,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 6114237942327262838, guid: 2c46f309a45d8714f9c5db5361e854e6,
         type: 3}
       propertyPath: currentClothData
       value: 
-      objectReference: {fileID: 11400000, guid: 7f36dd18648bd4d48932b3008021520d,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 6114237942327262838, guid: 2c46f309a45d8714f9c5db5361e854e6,
         type: 3}
       propertyPath: allClothingData.Array.data[0]

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/SyndicateSpaceHelmets/BlackAndBlueSpaceHelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/SyndicateSpaceHelmets/BlackAndBlueSpaceHelmet.prefab
@@ -7,6 +7,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1971380573346755037, guid: 41dbf3c1a7494294ba8fce1471396d5c,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.35
+      objectReference: {fileID: 0}
     - target: {fileID: 2360366142296125240, guid: 41dbf3c1a7494294ba8fce1471396d5c,
         type: 3}
       propertyPath: m_Name
@@ -93,14 +98,12 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: 268bc9bb32f2875489ba2701e2bec6d7,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 8699984762159447229, guid: 41dbf3c1a7494294ba8fce1471396d5c,
         type: 3}
       propertyPath: currentClothData
       value: 
-      objectReference: {fileID: 11400000, guid: 268bc9bb32f2875489ba2701e2bec6d7,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 8699984762159447229, guid: 41dbf3c1a7494294ba8fce1471396d5c,
         type: 3}
       propertyPath: allClothingData.Array.size

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/SyndicateSpaceHelmets/BlackAndGreenSpaceHelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/SyndicateSpaceHelmets/BlackAndGreenSpaceHelmet.prefab
@@ -7,6 +7,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1971380573346755037, guid: 41dbf3c1a7494294ba8fce1471396d5c,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.35
+      objectReference: {fileID: 0}
     - target: {fileID: 2360366142296125240, guid: 41dbf3c1a7494294ba8fce1471396d5c,
         type: 3}
       propertyPath: m_Name
@@ -93,14 +98,12 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: 96f1db777cd5e8848a6388cea5600229,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 8699984762159447229, guid: 41dbf3c1a7494294ba8fce1471396d5c,
         type: 3}
       propertyPath: currentClothData
       value: 
-      objectReference: {fileID: 11400000, guid: 96f1db777cd5e8848a6388cea5600229,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 8699984762159447229, guid: 41dbf3c1a7494294ba8fce1471396d5c,
         type: 3}
       propertyPath: allClothingData.Array.size

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/SyndicateSpaceHelmets/BlackAndOrangeSpaceHelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/SyndicateSpaceHelmets/BlackAndOrangeSpaceHelmet.prefab
@@ -7,6 +7,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1971380573346755037, guid: 41dbf3c1a7494294ba8fce1471396d5c,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.35
+      objectReference: {fileID: 0}
     - target: {fileID: 2360366142296125240, guid: 41dbf3c1a7494294ba8fce1471396d5c,
         type: 3}
       propertyPath: m_Name
@@ -93,14 +98,12 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: 383410323856d854a9d6a527d3b13825,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 8699984762159447229, guid: 41dbf3c1a7494294ba8fce1471396d5c,
         type: 3}
       propertyPath: currentClothData
       value: 
-      objectReference: {fileID: 11400000, guid: 383410323856d854a9d6a527d3b13825,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 8699984762159447229, guid: 41dbf3c1a7494294ba8fce1471396d5c,
         type: 3}
       propertyPath: allClothingData.Array.size

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/SyndicateSpaceHelmets/BlackAndRedSpaceHelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/SyndicateSpaceHelmets/BlackAndRedSpaceHelmet.prefab
@@ -7,6 +7,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1971380573346755037, guid: 41dbf3c1a7494294ba8fce1471396d5c,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.35
+      objectReference: {fileID: 0}
     - target: {fileID: 2360366142296125240, guid: 41dbf3c1a7494294ba8fce1471396d5c,
         type: 3}
       propertyPath: m_Name
@@ -93,14 +98,12 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: 30be4b7204d00604fafc6aabad0ca768,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 8699984762159447229, guid: 41dbf3c1a7494294ba8fce1471396d5c,
         type: 3}
       propertyPath: currentClothData
       value: 
-      objectReference: {fileID: 11400000, guid: 30be4b7204d00604fafc6aabad0ca768,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 8699984762159447229, guid: 41dbf3c1a7494294ba8fce1471396d5c,
         type: 3}
       propertyPath: allClothingData.Array.size

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/SyndicateSpaceHelmets/BlackEngineeringSpaceHelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/SyndicateSpaceHelmets/BlackEngineeringSpaceHelmet.prefab
@@ -7,6 +7,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1971380573346755037, guid: 41dbf3c1a7494294ba8fce1471396d5c,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.35
+      objectReference: {fileID: 0}
     - target: {fileID: 2360366142296125240, guid: 41dbf3c1a7494294ba8fce1471396d5c,
         type: 3}
       propertyPath: m_Name
@@ -93,14 +98,12 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: d0f70643c33eda0469a1b0430ebbb1f3,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 8699984762159447229, guid: 41dbf3c1a7494294ba8fce1471396d5c,
         type: 3}
       propertyPath: currentClothData
       value: 
-      objectReference: {fileID: 11400000, guid: d0f70643c33eda0469a1b0430ebbb1f3,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 8699984762159447229, guid: 41dbf3c1a7494294ba8fce1471396d5c,
         type: 3}
       propertyPath: allClothingData.Array.size

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/SyndicateSpaceHelmets/BlackMedicalSpaceHelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/SyndicateSpaceHelmets/BlackMedicalSpaceHelmet.prefab
@@ -7,6 +7,21 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1971380573346755037, guid: 41dbf3c1a7494294ba8fce1471396d5c,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 1971380573346755037, guid: 41dbf3c1a7494294ba8fce1471396d5c,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[1].armor.DismembermentProtectionChance
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 1971380573346755037, guid: 41dbf3c1a7494294ba8fce1471396d5c,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[2].armor.DismembermentProtectionChance
+      value: 0.35
+      objectReference: {fileID: 0}
     - target: {fileID: 2360366142296125240, guid: 41dbf3c1a7494294ba8fce1471396d5c,
         type: 3}
       propertyPath: m_Name
@@ -93,14 +108,12 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: 40c2b7e34cc4c664397a0cecff29df78,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 8699984762159447229, guid: 41dbf3c1a7494294ba8fce1471396d5c,
         type: 3}
       propertyPath: currentClothData
       value: 
-      objectReference: {fileID: 11400000, guid: 40c2b7e34cc4c664397a0cecff29df78,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 8699984762159447229, guid: 41dbf3c1a7494294ba8fce1471396d5c,
         type: 3}
       propertyPath: allClothingData.Array.size

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/SyndicateSpaceHelmets/BlackSpaceHelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/SyndicateSpaceHelmets/BlackSpaceHelmet.prefab
@@ -7,6 +7,21 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 599451640780905422, guid: 14560ef46420dc74987b83e71df1181b,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 599451640780905422, guid: 14560ef46420dc74987b83e71df1181b,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[1].armor.DismembermentProtectionChance
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 599451640780905422, guid: 14560ef46420dc74987b83e71df1181b,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[2].armor.DismembermentProtectionChance
+      value: 0.35
+      objectReference: {fileID: 0}
     - target: {fileID: 3547199489808496247, guid: 14560ef46420dc74987b83e71df1181b,
         type: 3}
       propertyPath: m_Sprite
@@ -93,14 +108,12 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: 7ac78ef1ad9aef7428213d3738243cd4,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 7761637519219103406, guid: 14560ef46420dc74987b83e71df1181b,
         type: 3}
       propertyPath: currentClothData
       value: 
-      objectReference: {fileID: 11400000, guid: 7ac78ef1ad9aef7428213d3738243cd4,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 7761637519219103406, guid: 14560ef46420dc74987b83e71df1181b,
         type: 3}
       propertyPath: allClothingData.Array.size

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/SyndicateSpaceHelmets/BlueSpaceHelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/SyndicateSpaceHelmets/BlueSpaceHelmet.prefab
@@ -7,6 +7,21 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 599451640780905422, guid: 14560ef46420dc74987b83e71df1181b,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 599451640780905422, guid: 14560ef46420dc74987b83e71df1181b,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[1].armor.DismembermentProtectionChance
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 599451640780905422, guid: 14560ef46420dc74987b83e71df1181b,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[2].armor.DismembermentProtectionChance
+      value: 0.35
+      objectReference: {fileID: 0}
     - target: {fileID: 3547199489808496247, guid: 14560ef46420dc74987b83e71df1181b,
         type: 3}
       propertyPath: m_Sprite
@@ -93,14 +108,12 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: 59c1907771967214f80dcfe1cca9d981,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 7761637519219103406, guid: 14560ef46420dc74987b83e71df1181b,
         type: 3}
       propertyPath: currentClothData
       value: 
-      objectReference: {fileID: 11400000, guid: 59c1907771967214f80dcfe1cca9d981,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 7761637519219103406, guid: 14560ef46420dc74987b83e71df1181b,
         type: 3}
       propertyPath: allClothingData.Array.size

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/SyndicateSpaceHelmets/RedSpaceHelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/SyndicateSpaceHelmets/RedSpaceHelmet.prefab
@@ -79,6 +79,11 @@ PrefabInstance:
       propertyPath: armoredBodyParts.Array.data[2].armor.Bullet
       value: 10
       objectReference: {fileID: 0}
+    - target: {fileID: 6699324801598458550, guid: 5269bbb43ef5a0b40a2676310664d6c6,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[1].armor.DismembermentProtectionChance
+      value: 0.2
+      objectReference: {fileID: 0}
     - target: {fileID: 7029879816411904817, guid: 5269bbb43ef5a0b40a2676310664d6c6,
         type: 3}
       propertyPath: initialName

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/Armor/ArmorVests/ArmorVest.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/Armor/ArmorVests/ArmorVest.prefab
@@ -7,6 +7,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 855803449108065293, guid: e606c25f8104ffa4e94b68151182a216,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.25
+      objectReference: {fileID: 0}
     - target: {fileID: 3495234765619245072, guid: e606c25f8104ffa4e94b68151182a216,
         type: 3}
       propertyPath: initialName
@@ -99,14 +104,12 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: d37e937b0cad62e45b321201c7c2fdd5,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 7931175119129480439, guid: e606c25f8104ffa4e94b68151182a216,
         type: 3}
       propertyPath: currentClothData
       value: 
-      objectReference: {fileID: 11400000, guid: d37e937b0cad62e45b321201c7c2fdd5,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 7931175119129480439, guid: e606c25f8104ffa4e94b68151182a216,
         type: 3}
       propertyPath: allClothingData.Array.size

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/Armor/ArmorVests/ArmorVestLarge.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/Armor/ArmorVests/ArmorVestLarge.prefab
@@ -11,14 +11,12 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: de9925f421dae6a469b53c90513cbe2e,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 2603394941573166480, guid: 900572ab8ed9030429b12eaa3974a43f,
         type: 3}
       propertyPath: currentClothData
       value: 
-      objectReference: {fileID: 11400000, guid: de9925f421dae6a469b53c90513cbe2e,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 2603394941573166480, guid: 900572ab8ed9030429b12eaa3974a43f,
         type: 3}
       propertyPath: allClothingData.Array.data[0]
@@ -31,6 +29,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 29dcb683ebefa76478cb9f3efd056bcc,
         type: 2}
+    - target: {fileID: 4742361789441152362, guid: 900572ab8ed9030429b12eaa3974a43f,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.3
+      objectReference: {fileID: 0}
     - target: {fileID: 8841056279837395319, guid: 900572ab8ed9030429b12eaa3974a43f,
         type: 3}
       propertyPath: initialName

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/Armor/ArmoredGreatcoat.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/Armor/ArmoredGreatcoat.prefab
@@ -12,6 +12,11 @@ PrefabInstance:
       propertyPath: bodyPartsCovered
       value: 1008
       objectReference: {fileID: 0}
+    - target: {fileID: 855803449108065293, guid: e606c25f8104ffa4e94b68151182a216,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.15
+      objectReference: {fileID: 0}
     - target: {fileID: 3495234765619245072, guid: e606c25f8104ffa4e94b68151182a216,
         type: 3}
       propertyPath: initialName
@@ -114,14 +119,12 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: 21ce4585ec041a742a84f8f744c190fb,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 7931175119129480439, guid: e606c25f8104ffa4e94b68151182a216,
         type: 3}
       propertyPath: currentClothData
       value: 
-      objectReference: {fileID: 11400000, guid: 21ce4585ec041a742a84f8f744c190fb,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 7931175119129480439, guid: e606c25f8104ffa4e94b68151182a216,
         type: 3}
       propertyPath: allClothingData.Array.size

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/Armor/BoneArmor.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/Armor/BoneArmor.prefab
@@ -87,6 +87,11 @@ PrefabInstance:
       propertyPath: armoredBodyParts.Array.data[2].armoringBodyPartType
       value: 3
       objectReference: {fileID: 0}
+    - target: {fileID: 855803449108065293, guid: e606c25f8104ffa4e94b68151182a216,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.25
+      objectReference: {fileID: 0}
     - target: {fileID: 3495234765619245072, guid: e606c25f8104ffa4e94b68151182a216,
         type: 3}
       propertyPath: initialName

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/CrusaderArmor.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/CrusaderArmor.prefab
@@ -291,5 +291,10 @@ PrefabInstance:
       propertyPath: armoredBodyParts.Array.data[5].armoringBodyPartType
       value: 2
       objectReference: {fileID: 0}
+    - target: {fileID: 8215174308799955191, guid: de234d793cfd842599c9c8726207f217,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.3
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: de234d793cfd842599c9c8726207f217, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/SpaceSuits/Hardsuits/AtmosphericsHardsuit.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/SpaceSuits/Hardsuits/AtmosphericsHardsuit.prefab
@@ -387,6 +387,11 @@ PrefabInstance:
       propertyPath: armoredBodyParts.Array.data[9].armoringBodyPartType
       value: 12
       objectReference: {fileID: 0}
+    - target: {fileID: 4440411610366646283, guid: 42314b61cae71bf43b6dacdb1b81fc2e,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.5
+      objectReference: {fileID: 0}
     - target: {fileID: 6149096178508402931, guid: 42314b61cae71bf43b6dacdb1b81fc2e,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/SpaceSuits/Hardsuits/CaptainsSWATSuit.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/SpaceSuits/Hardsuits/CaptainsSWATSuit.prefab
@@ -11,14 +11,12 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: 3feeff27729ce7f429ecaa57c2872732,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 3696664957502459903, guid: 91aad833277815d498e0686d9fc85bed,
         type: 3}
       propertyPath: currentClothData
       value: 
-      objectReference: {fileID: 11400000, guid: 3feeff27729ce7f429ecaa57c2872732,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 3696664957502459903, guid: 91aad833277815d498e0686d9fc85bed,
         type: 3}
       propertyPath: allClothingData.Array.size
@@ -36,6 +34,56 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: a2ebe07ec886a4e4ea6c709dd097ed72,
         type: 2}
+    - target: {fileID: 6249989393794428677, guid: 91aad833277815d498e0686d9fc85bed,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 6249989393794428677, guid: 91aad833277815d498e0686d9fc85bed,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[1].armor.DismembermentProtectionChance
+      value: 0.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 6249989393794428677, guid: 91aad833277815d498e0686d9fc85bed,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[2].armor.DismembermentProtectionChance
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 6249989393794428677, guid: 91aad833277815d498e0686d9fc85bed,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[3].armor.DismembermentProtectionChance
+      value: 0.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 6249989393794428677, guid: 91aad833277815d498e0686d9fc85bed,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[4].armor.DismembermentProtectionChance
+      value: 0.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 6249989393794428677, guid: 91aad833277815d498e0686d9fc85bed,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[5].armor.DismembermentProtectionChance
+      value: 0.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 6249989393794428677, guid: 91aad833277815d498e0686d9fc85bed,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[6].armor.DismembermentProtectionChance
+      value: 0.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 6249989393794428677, guid: 91aad833277815d498e0686d9fc85bed,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[7].armor.DismembermentProtectionChance
+      value: 0.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 6249989393794428677, guid: 91aad833277815d498e0686d9fc85bed,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[8].armor.DismembermentProtectionChance
+      value: 0.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 6249989393794428677, guid: 91aad833277815d498e0686d9fc85bed,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[9].armor.DismembermentProtectionChance
+      value: 0.8
+      objectReference: {fileID: 0}
     - target: {fileID: 7620651485336760102, guid: 91aad833277815d498e0686d9fc85bed,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/SpaceSuits/Hardsuits/NarSienHardenedArmor.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/SpaceSuits/Hardsuits/NarSienHardenedArmor.prefab
@@ -60,6 +60,11 @@ PrefabInstance:
       propertyPath: armoredBodyParts.Array.data[0].armor.Energy
       value: 25
       objectReference: {fileID: 0}
+    - target: {fileID: 4992377332610353592, guid: 5da2eb22d55c9c045bd7c22925c9b948,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.23
+      objectReference: {fileID: 0}
     - target: {fileID: 8702110326122445511, guid: 5da2eb22d55c9c045bd7c22925c9b948,
         type: 3}
       propertyPath: m_Name

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/SpaceSuits/Hardsuits/SyndicateHardsuit.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/SpaceSuits/Hardsuits/SyndicateHardsuit.prefab
@@ -11,14 +11,12 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: 96b702926e8fa6348a8964fd996b1761,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 2357952952862320962, guid: 5da2eb22d55c9c045bd7c22925c9b948,
         type: 3}
       propertyPath: currentClothData
       value: 
-      objectReference: {fileID: 11400000, guid: 96b702926e8fa6348a8964fd996b1761,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 2357952952862320962, guid: 5da2eb22d55c9c045bd7c22925c9b948,
         type: 3}
       propertyPath: allClothingData.Array.size
@@ -51,6 +49,46 @@ PrefabInstance:
         type: 3}
       propertyPath: walkingSpeedDebuff
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4992377332610353592, guid: 5da2eb22d55c9c045bd7c22925c9b948,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4992377332610353592, guid: 5da2eb22d55c9c045bd7c22925c9b948,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[1].armor.DismembermentProtectionChance
+      value: 0.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4992377332610353592, guid: 5da2eb22d55c9c045bd7c22925c9b948,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[2].armor.DismembermentProtectionChance
+      value: 0.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4992377332610353592, guid: 5da2eb22d55c9c045bd7c22925c9b948,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[3].armor.DismembermentProtectionChance
+      value: 0.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4992377332610353592, guid: 5da2eb22d55c9c045bd7c22925c9b948,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[4].armor.DismembermentProtectionChance
+      value: 0.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4992377332610353592, guid: 5da2eb22d55c9c045bd7c22925c9b948,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[5].armor.DismembermentProtectionChance
+      value: 0.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4992377332610353592, guid: 5da2eb22d55c9c045bd7c22925c9b948,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[6].armor.DismembermentProtectionChance
+      value: 0.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4992377332610353592, guid: 5da2eb22d55c9c045bd7c22925c9b948,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[8].armor.DismembermentProtectionChance
+      value: 0.7
       objectReference: {fileID: 0}
     - target: {fileID: 8702110326122445511, guid: 5da2eb22d55c9c045bd7c22925c9b948,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/StudentRobeArmor.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/StudentRobeArmor.prefab
@@ -12,6 +12,11 @@ PrefabInstance:
       propertyPath: bodyPartsCovered
       value: 112
       objectReference: {fileID: 0}
+    - target: {fileID: 1973002661359593264, guid: 548b2e942a9ec6d69af3374e3be7dd50,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
+      value: 0.1
+      objectReference: {fileID: 0}
     - target: {fileID: 2909197017712554513, guid: 548b2e942a9ec6d69af3374e3be7dd50,
         type: 3}
       propertyPath: m_AssetId
@@ -97,14 +102,12 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: 07ee11881cad43d40b730ef7217b3ead,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 8193882076658244640, guid: 548b2e942a9ec6d69af3374e3be7dd50,
         type: 3}
       propertyPath: currentClothData
       value: 
-      objectReference: {fileID: 11400000, guid: 07ee11881cad43d40b730ef7217b3ead,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 8193882076658244640, guid: 548b2e942a9ec6d69af3374e3be7dd50,
         type: 3}
       propertyPath: hideClothingFlags

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/Brain.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/Brain.prefab
@@ -157,6 +157,11 @@ PrefabInstance:
       propertyPath: initialDescription
       value: Not so intelligent now, ay?
       objectReference: {fileID: 0}
+    - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
+      propertyPath: DeathOnRemoval
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: 35ef0ee8523cfc342bc863c12a3ac07c, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanHead.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanHead.prefab
@@ -70,8 +70,18 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 1673759363237950006, guid: e241039a7933eb347bd1a9bb67a9078a,
         type: 3}
+      propertyPath: DeathOnRemoval
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1673759363237950006, guid: e241039a7933eb347bd1a9bb67a9078a,
+        type: 3}
       propertyPath: bloodThroughput
       value: 0.015
+      objectReference: {fileID: 0}
+    - target: {fileID: 1673759363237950006, guid: e241039a7933eb347bd1a9bb67a9078a,
+        type: 3}
+      propertyPath: GibsOnSeverityLevel
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 1673759363237950006, guid: e241039a7933eb347bd1a9bb67a9078a,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanLeftArm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanLeftArm.prefab
@@ -131,6 +131,16 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6313817628243374210, guid: ba9a875c31908af4ab3749cd127a2edb,
         type: 3}
+      propertyPath: DamageThreshold
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 6313817628243374210, guid: ba9a875c31908af4ab3749cd127a2edb,
+        type: 3}
+      propertyPath: GibsOnSeverityLevel
+      value: 125
+      objectReference: {fileID: 0}
+    - target: {fileID: 6313817628243374210, guid: ba9a875c31908af4ab3749cd127a2edb,
+        type: 3}
       propertyPath: BodyTypesSprites.SpriteOrder.Orders.Array.data[2]
       value: 2
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightArm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightArm.prefab
@@ -254,6 +254,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
         type: 3}
+      propertyPath: GibsOnSeverityLevel
+      value: 125
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
+        type: 3}
       propertyPath: BodyTypesSprites.BodyTypes.Array.size
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanTorso.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanTorso.prefab
@@ -81,6 +81,11 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 1673759363237950006, guid: e241039a7933eb347bd1a9bb67a9078a,
         type: 3}
+      propertyPath: DeathOnRemoval
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1673759363237950006, guid: e241039a7933eb347bd1a9bb67a9078a,
+        type: 3}
       propertyPath: bloodThroughput
       value: 0.015
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Scripts/Health/Objects/Armor.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Armor.cs
@@ -25,6 +25,8 @@ public class Armor
 	[Range(-100,100)] public float Magic;
 	[Range(-100,100)] public float Bio;
 
+	[Range(0f,1f)] public float DismembermentProtectionChance;
+
 	/// <summary>
 	/// Calculates how much damage would be done based on armor resistance and armor penetration.
 	/// </summary>

--- a/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPart.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPart.cs
@@ -15,7 +15,7 @@ namespace HealthV2
 	public partial class BodyPart : MonoBehaviour, IBodyPartDropDownOrgans
 	{
 		[SerializeField]
-		[Tooltip("The Heath Master associated with this part, will find from parents if not set in editor")]
+		[Tooltip("The Health Master associated with this part, will find from parents if not set in editor")]
 		protected LivingHealthMasterBase healthMaster = null;
 
 		public LivingHealthMasterBase HealthMaster
@@ -124,6 +124,9 @@ namespace HealthV2
 		/// </summary>
 		[Tooltip("Is the body part on the surface?")]
 		public bool IsSurface = false;
+
+		[Tooltip("Does the player die when this part gets removed from their body?")]
+		public bool DeathOnRemoval = false;
 
 		/// <summary>
 		/// Flag to hide clothing on this body part
@@ -285,6 +288,10 @@ namespace HealthV2
 		/// </summary>
 		public virtual void RemoveFromBodyThis()
 		{
+			if(DeathOnRemoval)
+			{
+				healthMaster.Death();
+			}
 			var parent = this.GetParent();
 			if (parent != null)
 			{

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
@@ -74,7 +74,7 @@ namespace HealthV2
 		/// <summary>
 		public float DamageThreshold = 18f;
 		public DamageSeverity GibsOnSeverityLevel = DamageSeverity.Max;
-		public float GibChance = 0.25f;
+		public float GibChance = 0.15f;
 
 		/// <summary>
 		/// Toxin damage taken
@@ -404,8 +404,10 @@ namespace HealthV2
 		{
 			float chance = UnityEngine.Random.RandomRange(0.0f, 1.0f);
 			float armorChanceModifer = GibChance + SelfArmor.DismembermentProtectionChance;
+			if(Severity == DamageSeverity.Max){armorChanceModifer -= 0.25f;} //Make it more likely that the bodypart can be gibbed in it's worst condition.
 			if(chance >= armorChanceModifer)
 			{
+				Chat.AddActionMsgToChat(PlayerManager.PlayerScript.gameObject, $"Your {this.name} flies off from your body.", $"{PlayerManager.PlayerScript.gameObject}'s {this.name} has been cut off from their body!");
 				RemoveFromBodyThis();
 			}
 		}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
@@ -267,12 +267,18 @@ namespace HealthV2
 				}
 			}
 
-			if(attackType == AttackType.Melee || attackType == AttackType.Laser 
-			|| attackType == AttackType.Bomb || attackType == AttackType.Energy)
+			if(attackType == AttackType.Melee || attackType == AttackType.Laser || attackType == AttackType.Energy)
 			{
 				if(damageToLimb >= DamageThreshold)
 				{
 					CheckBodyPartIntigrity();
+				}
+			}
+			if(attackType == AttackType.Bomb)
+			{
+				if(damageToLimb >= DamageThreshold)
+				{
+					GibBodyPartWithChance();
 				}
 			}
 		}
@@ -389,7 +395,7 @@ namespace HealthV2
 		/// <summary>
 		/// Checks if the bodypart is damaged to a point where it can be gibbed from the body
 		/// </summary>
-		public void CheckBodyPartIntigrity()
+		protected void CheckBodyPartIntigrity()
 		{
 			if(Severity >= GibsOnSeverityLevel)
 			{

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
@@ -70,6 +70,13 @@ namespace HealthV2
 		public DamageSeverity Severity = DamageSeverity.LightModerate;
 
 		/// <summary>
+		/// How much damage can this body part last before it breaks/gibs
+		/// <summary>
+		public float DamageThreshold = 18f;
+		public DamageSeverity GibsOnSeverityLevel = DamageSeverity.Max;
+		public float GibChance = 0.25f;
+
+		/// <summary>
 		/// Toxin damage taken
 		/// </summary>
 		public float Toxin => Damages[(int) DamageType.Tox];
@@ -259,6 +266,15 @@ namespace HealthV2
 					}
 				}
 			}
+
+			if(attackType == AttackType.Melee || attackType == AttackType.Laser 
+			|| attackType == AttackType.Bomb || attackType == AttackType.Energy)
+			{
+				if(damageToLimb >= DamageThreshold)
+				{
+					CheckBodyPartIntigrity();
+				}
+			}
 		}
 
 
@@ -367,6 +383,30 @@ namespace HealthV2
 			if (oldSeverity != Severity && healthMaster != null)
 			{
 				UpdateIcons();
+			}
+		}
+
+		/// <summary>
+		/// Checks if the bodypart is damaged to a point where it can be gibbed from the body
+		/// </summary>
+		public void CheckBodyPartIntigrity()
+		{
+			if(Severity >= GibsOnSeverityLevel)
+			{
+				GibBodyPartWithChance();
+			}
+		}
+
+		/// <summary>
+		/// Checks if the player is lucky enough and is wearing enough protective armor to avoid getting his bodypart removed.
+		/// </summary>
+		public void GibBodyPartWithChance()
+		{
+			float chance = UnityEngine.Random.RandomRange(0.0f, 1.0f);
+			float armorChanceModifer = GibChance + SelfArmor.DismembermentProtectionChance;
+			if(chance >= armorChanceModifer)
+			{
+				RemoveFromBodyThis();
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
@@ -407,7 +407,6 @@ namespace HealthV2
 			if(Severity == DamageSeverity.Max){armorChanceModifer -= 0.25f;} //Make it more likely that the bodypart can be gibbed in it's worst condition.
 			if(chance >= armorChanceModifer)
 			{
-				Chat.AddActionMsgToChat(PlayerManager.PlayerScript.gameObject, $"Your {this.name} flies off from your body.", $"{PlayerManager.PlayerScript.gameObject}'s {this.name} has been cut off from their body!");
 				RemoveFromBodyThis();
 			}
 		}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
@@ -278,7 +278,7 @@ namespace HealthV2
 			{
 				if(damageToLimb >= DamageThreshold)
 				{
-					GibBodyPartWithChance();
+					DismemberBodyPartWithChance();
 				}
 			}
 		}
@@ -399,14 +399,14 @@ namespace HealthV2
 		{
 			if(Severity >= GibsOnSeverityLevel)
 			{
-				GibBodyPartWithChance();
+				DismemberBodyPartWithChance();
 			}
 		}
 
 		/// <summary>
 		/// Checks if the player is lucky enough and is wearing enough protective armor to avoid getting his bodypart removed.
 		/// </summary>
-		public void GibBodyPartWithChance()
+		public void DismemberBodyPartWithChance()
 		{
 			float chance = UnityEngine.Random.RandomRange(0.0f, 1.0f);
 			float armorChanceModifer = GibChance + SelfArmor.DismembermentProtectionChance;

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -900,6 +900,7 @@ namespace HealthV2
 		///</Summary>
 		public virtual void Death()
 		{
+			PlayerManager.PlayerScript.playerMove.allowInput = false;
 			SetConsciousState(ConsciousState.DEAD);
 			OnDeathActions();
 			UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);


### PR DESCRIPTION
### Purpose
Part of #6270

Adds in the ability to dismember players using weapons, bomb explosions and more while giving armor a way to soften the chance of dismembering a player. The idea of my approach is that the system is flexible enough to allow for anything to dismember the player as long as the damage is great enough for it to dismember them.
Also kills off the player when they're missing a brain, head or torso.

### Notes:
ticks one box off #6195 

catpeople, moths and lizards currently share the same values humans. This will be changed later after some tests on staging.
Only the most common and popular armor have armor values right now, the rest don't until we get some tests going.

### What's left?
In the next few PRs i'll add in the ability for players to bleed to death after they have lose a limb + tweak and add more armor values to balance this new addition to the game + the ability for limbs to simply alt F4 when then they receive enough damage for them to completely get wiped off the game.

### Changelog:
CL: [New] - Players can now be dismembered by other players and explosives.
CL: [Fix] - Players can no longer walk around headless or without a brain or torso and stay alive.