### PR TITLE
Fix NetTabs Not displaying

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/NetTabs.asset
+++ b/UnityProject/Assets/ScriptableObjects/NetTabs.asset
@@ -13,7 +13,6 @@ MonoBehaviour:
   m_Name: NetTabs
   m_EditorClassIdentifier: 
   gameObjects:
-  - {fileID: 1502172408805726, guid: 4ae3b354acd8e1149b3f5ce8b1e6717b, type: 3}
   - {fileID: 1871118659464886, guid: 142960eefb1ce0e468476139f2a34205, type: 3}
   - {fileID: 4811654813790555330, guid: 371cd598282470547aa3a80df9341a42, type: 3}
   - {fileID: 1576420294694384, guid: ba3496ca0f4fe6d4abf02da914737e7f, type: 3}


### PR DESCRIPTION
#6603 was almost on the right track
Missing file reference in NetTabs SO was simply moved to the top of the SO's list in #6603
This PR removes the missing file reference entirely

CL: [Fix] Most if not all current NetTabs should now pop up again