### PR TITLE
Spill reagents

### DIFF
--- a/UnityProject/Assets/Prefabs/Decal/Resources/PowderSplat.prefab
+++ b/UnityProject/Assets/Prefabs/Decal/Resources/PowderSplat.prefab
@@ -18,7 +18,7 @@ GameObject:
   - component: {fileID: 5743653973661802587}
   - component: {fileID: 5430220527865361548}
   m_Layer: 0
-  m_Name: ChemSplat
+  m_Name: PowderSplat
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -73,7 +73,7 @@ MonoBehaviour:
   CanDryUp: 0
   color: {r: 0, g: 0, b: 0, a: 0}
   PossibleSprites:
-  - {fileID: 21300000, guid: a6f07a86b2391dc4c9df37f6d794eb0c, type: 3}
+  - {fileID: 21300000, guid: 6fe052b4495d1984094aa7a5e650fc63, type: 3}
 --- !u!114 &3880655971207283369
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -188,7 +188,7 @@ MonoBehaviour:
   possibleTransferAmounts: []
   transferAmount: 2
   maxCapacity: 1000
-  reactionSet: {fileID: 11400000, guid: 2d5f766d9268838aa8d819bee2a442a7, type: 2}
+  reactionSet: {fileID: 0}
   AdditionalReactions: []
   canPourOut: 0
   initialReagentMix:
@@ -270,7 +270,7 @@ SpriteRenderer:
   m_SortingLayerID: 322132419
   m_SortingLayer: 2
   m_SortingOrder: 30
-  m_Sprite: {fileID: 21300000, guid: a6f07a86b2391dc4c9df37f6d794eb0c, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 6fe052b4495d1984094aa7a5e650fc63, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0

--- a/UnityProject/Assets/Prefabs/Decal/Resources/PowderSplat.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Decal/Resources/PowderSplat.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c5afef275fe9a5d4ea1534cfc6921b05
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Items/Food/Drinks/MugDutchHotCoco.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Drinks/MugDutchHotCoco.prefab
@@ -19,6 +19,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5262053233861054308, guid: a3c2eebd1ee083c4f873a4e8475bae26,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5262053233861054308, guid: a3c2eebd1ee083c4f873a4e8475bae26,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -34,6 +39,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5262053233861054308, guid: a3c2eebd1ee083c4f873a4e8475bae26,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5262053233861054308, guid: a3c2eebd1ee083c4f873a4e8475bae26,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -46,16 +56,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5262053233861054308, guid: a3c2eebd1ee083c4f873a4e8475bae26,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5262053233861054308, guid: a3c2eebd1ee083c4f873a4e8475bae26,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5262053233861054308, guid: a3c2eebd1ee083c4f873a4e8475bae26,
         type: 3}
@@ -79,45 +79,56 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5762506483007905138, guid: a3c2eebd1ee083c4f873a4e8475bae26,
         type: 3}
-      propertyPath: initialDescription
-      value: Made in Space South America.
+      propertyPath: initialName
+      value: Dutch hot coco
       objectReference: {fileID: 0}
     - target: {fileID: 5762506483007905138, guid: a3c2eebd1ee083c4f873a4e8475bae26,
         type: 3}
-      propertyPath: initialName
-      value: Dutch hot coco
+      propertyPath: initialDescription
+      value: Made in Space South America.
       objectReference: {fileID: 0}
     - target: {fileID: 6358828029291461304, guid: a3c2eebd1ee083c4f873a4e8475bae26,
         type: 3}
       propertyPath: initialReagentMix.reagents.m_keys.Array.size
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 6358828029291461304, guid: a3c2eebd1ee083c4f873a4e8475bae26,
         type: 3}
       propertyPath: initialReagentMix.reagents.m_values.Array.size
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 6358828029291461304, guid: a3c2eebd1ee083c4f873a4e8475bae26,
         type: 3}
       propertyPath: initialReagentMix.reagents.m_keys.Array.data[0]
       value: 
-      objectReference: {fileID: 11400000, guid: f7d2e4cdb6fe85456b9ac4626bd0baea,
-        type: 2}
-    - target: {fileID: 6358828029291461304, guid: a3c2eebd1ee083c4f873a4e8475bae26,
-        type: 3}
-      propertyPath: initialReagentMix.reagents.m_values.Array.data[0]
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 6358828029291461304, guid: a3c2eebd1ee083c4f873a4e8475bae26,
-        type: 3}
-      propertyPath: initialReagentMix.reagents.m_keys.Array.data[1]
-      value: 
       objectReference: {fileID: 11400000, guid: 911271db97b77da51889f97d6688a103,
         type: 2}
     - target: {fileID: 6358828029291461304, guid: a3c2eebd1ee083c4f873a4e8475bae26,
         type: 3}
-      propertyPath: initialReagentMix.reagents.m_values.Array.data[1]
+      propertyPath: initialReagentMix.reagents.m_keys.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: f7d2e4cdb6fe85456b9ac4626bd0baea,
+        type: 2}
+    - target: {fileID: 6358828029291461304, guid: a3c2eebd1ee083c4f873a4e8475bae26,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_keys.Array.data[2]
+      value: 
+      objectReference: {fileID: 11400000, guid: 5b5f8bbc79979ff58b9cbaa4a2a95eaf,
+        type: 2}
+    - target: {fileID: 6358828029291461304, guid: a3c2eebd1ee083c4f873a4e8475bae26,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_values.Array.data[0]
       value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6358828029291461304, guid: a3c2eebd1ee083c4f873a4e8475bae26,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_values.Array.data[1]
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 6358828029291461304, guid: a3c2eebd1ee083c4f873a4e8475bae26,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_values.Array.data[2]
+      value: 30
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a3c2eebd1ee083c4f873a4e8475bae26, type: 3}

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/NetworkManager.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/NetworkManager.prefab
@@ -71,6 +71,7 @@ MonoBehaviour:
   - {fileID: 1069497300762596, guid: 5a1312c2657fb8844b037a6afcdd0f3d, type: 3}
   - {fileID: 1069497300762596, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
   - {fileID: 1069497300762596, guid: af12b9fd93dd4d443b4bfeb93cff5dfc, type: 3}
+  - {fileID: 3880655971207283372, guid: c5afef275fe9a5d4ea1534cfc6921b05, type: 3}
   - {fileID: 1069497300762596, guid: 07ae9a1b034f5124498e550fffcea7e8, type: 3}
   - {fileID: 1069497300762596, guid: 5db3183353b72014cbe89d0622f0b732, type: 3}
   - {fileID: 3880655971207283372, guid: a603f2cdab70dcf4b97b8fabaadf8262, type: 3}
@@ -4771,6 +4772,7 @@ MonoBehaviour:
   - {fileID: 1069497300762596, guid: 5a1312c2657fb8844b037a6afcdd0f3d, type: 3}
   - {fileID: 1069497300762596, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
   - {fileID: 1069497300762596, guid: af12b9fd93dd4d443b4bfeb93cff5dfc, type: 3}
+  - {fileID: 3880655971207283372, guid: c5afef275fe9a5d4ea1534cfc6921b05, type: 3}
   - {fileID: 1069497300762596, guid: 07ae9a1b034f5124498e550fffcea7e8, type: 3}
   - {fileID: 1069497300762596, guid: 5db3183353b72014cbe89d0622f0b732, type: 3}
   - {fileID: 3880655971207283372, guid: a603f2cdab70dcf4b97b8fabaadf8262, type: 3}

--- a/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.Examine.cs
+++ b/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.Examine.cs
@@ -10,7 +10,8 @@ namespace Chemistry.Components
 		public enum ExamineAmountMode
 		{
 			APROXIMATE_AMOUNT, // player only can see that container is empty, half-empty or full
-			EXACT_AMOUNT // player can see exact reagent mix ammount in units
+			EXACT_AMOUNT, // player can see exact reagent mix ammount in units
+			UNKNOWN_AMOUNT //player has no idea how much could be in there or doesnt have a container
 		}
 
 		public enum ExamineContentMode
@@ -21,7 +22,7 @@ namespace Chemistry.Components
 		}
 
 		[Header("Examine settings")]
-		[Tooltip("Generate automatic examine message about contauner content?")]
+		[Tooltip("Generate automatic examine message about container content?")]
 		public bool UseStandardExamine = true;
 		public ExamineAmountMode ExamineAmount = ExamineAmountMode.APROXIMATE_AMOUNT;
 		public ExamineContentMode ExamineContent = ExamineContentMode.NONE;
@@ -72,6 +73,19 @@ namespace Chemistry.Components
 				{
 					return $"It's {fillDesc}. It contains {units} units, mostly of {name}.";
 				}
+			}
+			else if (ExamineAmount == ExamineAmountMode.UNKNOWN_AMOUNT)
+			{
+				var output = $"";
+
+				if(stateDesc == "powder")
+				{
+					output = $"It's a pile of {colorDesc} {stateDesc}";
+				} else
+				{
+					output = $"It's a pool of {colorDesc} {stateDesc}";
+				}
+				return output;
 			}
 
 			return null;

--- a/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.Examine.cs
+++ b/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.Examine.cs
@@ -76,18 +76,14 @@ namespace Chemistry.Components
 			}
 			else if (ExamineAmount == ExamineAmountMode.UNKNOWN_AMOUNT)
 			{
-				var output = $"";
+				var output = $"It's a pool of {colorDesc} {stateDesc}";
 
-				if(stateDesc == "powder")
+				if (stateDesc == "powder")
 				{
 					output = $"It's a pile of {colorDesc} {stateDesc}";
-				} else
-				{
-					output = $"It's a pool of {colorDesc} {stateDesc}";
 				}
 				return output;
 			}
-
 			return null;
 		}
 	}

--- a/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs
+++ b/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs
@@ -39,6 +39,9 @@ namespace Chemistry.Components
 		[Tooltip("If its unique container and can't be bothered to make SO")]
 		public List<Reaction> AdditionalReactions = new List<Reaction>();
 
+		[Tooltip("Can you empty out its contents?")]
+		public bool canPourOut = true;
+
 		[Tooltip("Initial mix of reagent inside container")]
 		[FormerlySerializedAs("reagentMix")]
 		[SerializeField] private ReagentMix initialReagentMix = new ReagentMix();
@@ -49,6 +52,7 @@ namespace Chemistry.Components
 		private RegisterTile registerTile;
 		private CustomNetTransform customNetTransform;
 		private Integrity integrity;
+
 
 		public bool ContentsSet = false;
 
@@ -404,7 +408,7 @@ namespace Chemistry.Components
 			var result = RightClickableResult.Create();
 			result.AddElement("Contents", OnExamineContentsClicked);
 			//Pour / add can only be done if in reach
-			if (WillInteract(ContextMenuApply.ByLocalPlayer(gameObject, "PourOut"), NetworkSide.Client))
+			if (WillInteract(ContextMenuApply.ByLocalPlayer(gameObject, "PourOut"), NetworkSide.Client) && canPourOut)
 			{
 				result.AddElement("PourOut", OnPourOutClicked);
 			}
@@ -451,11 +455,21 @@ namespace Chemistry.Components
 				Chat.AddExamineMsgToClient($"The {gameObject.ExpensiveName()} is empty.");
 				return;
 			}
-
-			foreach (var reagent in CurrentReagentMix.reagents.m_dict)
+			//We cant use the container game object to manage this, do it ourselves.
+			if(this.ExamineAmount == ExamineAmountMode.UNKNOWN_AMOUNT)
 			{
-				Chat.AddExamineMsgToClient($"The {gameObject.ExpensiveName()} contains {reagent.Value} {reagent.Key}.");
+				//TODO: Cleanup the logic between looking at things in containters and things with no container/item attributes
+				Chat.AddExamineMsgToClient(this.Examine());
 			}
+			else
+			{
+				foreach (var reagent in CurrentReagentMix.reagents.m_dict)
+				{
+					Chat.AddExamineMsgToClient($"The {gameObject.ExpensiveName()} contains {reagent.Value} {reagent.Key}.");
+				}
+			}
+
+			
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs
+++ b/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs
@@ -468,8 +468,6 @@ namespace Chemistry.Components
 					Chat.AddExamineMsgToClient($"The {gameObject.ExpensiveName()} contains {reagent.Value} {reagent.Key}.");
 				}
 			}
-
-			
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/Core/Factories/EffectsFactory.cs
+++ b/UnityProject/Assets/Scripts/Core/Factories/EffectsFactory.cs
@@ -1,6 +1,8 @@
 ﻿using System.Linq;
 using UnityEngine;
 using Objects.Construction;
+using Chemistry;
+using Chemistry.Components;
 
 public static class EffectsFactory
 {
@@ -9,10 +11,12 @@ public static class EffectsFactory
 	private static GameObject largeBloodTile;
 	private static GameObject waterTile;
 	private static GameObject chemTile;
+	private static GameObject powderTile;
 
 	private static GameObject smallXenoBloodTile;
 	private static GameObject medXenoBloodTile;
 	private static GameObject largeXenoBloodTile;
+
 
 	private static void EnsureInit()
 	{
@@ -24,6 +28,7 @@ public static class EffectsFactory
 			largeBloodTile = CustomNetworkManager.Instance.GetSpawnablePrefabFromName("LargeBloodSplat");
 			waterTile = CustomNetworkManager.Instance.GetSpawnablePrefabFromName("WaterSplat");
 			chemTile = CustomNetworkManager.Instance.GetSpawnablePrefabFromName("ChemSplat");
+			powderTile = CustomNetworkManager.Instance.GetSpawnablePrefabFromName("PowderSplat");
 			smallXenoBloodTile = CustomNetworkManager.Instance.GetSpawnablePrefabFromName("SmallXenoBloodSplat");
 			medXenoBloodTile = CustomNetworkManager.Instance.GetSpawnablePrefabFromName("MedXenoBloodSplat");
 			largeXenoBloodTile = CustomNetworkManager.Instance.GetSpawnablePrefabFromName("LargeXenoBloodSplat");
@@ -82,8 +87,15 @@ public static class EffectsFactory
 			var matrix = MatrixManager.AtPoint(Vector3Int.RoundToInt(worldPos), true);
 			if (matrix.Matrix.Get<FloorDecal>(worldPos.ToLocalInt(matrix.Matrix), true).Count() == 0)
 			{
-				Spawn.ServerPrefab(chosenTile, worldPos,
-								   matrix.Objects);
+
+				var bloodTileInst = Spawn.ServerPrefab(chosenTile, worldPos, matrix.Objects);
+				var bloodTileGO = bloodTileInst.GameObject;
+				var tileReagents = bloodTileGO.GetComponent<ReagentContainer>();
+				/*if (reagents != null)
+				{
+					tileReagents.Add(reagents);
+				}*/
+
 			}
 		}
 	}
@@ -103,19 +115,47 @@ public static class EffectsFactory
 		Spawn.ServerPrefab(waterTile, worldPos,	MatrixManager.AtPoint(worldPos, true).Objects, Quaternion.identity);
 	}
 
-	public static void ChemSplat(Vector3Int worldPos, Color color)
+	public static void ChemSplat(Vector3Int worldPos, Color color, ReagentMix reagents)
 	{
 		EnsureInit();
 		var chemTileInst = Spawn.ServerPrefab(chemTile, worldPos, MatrixManager.AtPoint(worldPos, true).Objects, Quaternion.identity);
 		if (chemTileInst.Successful)
 		{
 			var chemTileGO = chemTileInst.GameObject;
+			var tileReagents = chemTileGO.GetComponent<ReagentContainer>();
 			if (chemTileGO)
 			{
 				var decal = chemTileGO.GetComponent<FloorDecal>();
 				if (decal)
 				{
 					decal.color = color;
+				}
+				if (reagents != null)
+				{
+					tileReagents.Add(reagents);
+				}
+			}
+		}
+	}
+
+	public static void PowderSplat(Vector3Int worldPos, Color color, ReagentMix reagents)
+	{
+		EnsureInit();
+		var powderTileInst = Spawn.ServerPrefab(powderTile, worldPos, MatrixManager.AtPoint(worldPos, true).Objects, Quaternion.identity);
+		if (powderTileInst.Successful)
+		{
+			var powderTileGO = powderTileInst.GameObject;
+			var tileReagents = powderTileGO.GetComponent<ReagentContainer>();
+			if (powderTileGO)
+			{
+				var decal = powderTileGO.GetComponent<FloorDecal>();
+				if (decal)
+				{
+					decal.color = color;
+				}
+				if (reagents != null)
+				{
+					tileReagents.Add(reagents);
 				}
 			}
 		}

--- a/UnityProject/Assets/Scripts/Core/Factories/EffectsFactory.cs
+++ b/UnityProject/Assets/Scripts/Core/Factories/EffectsFactory.cs
@@ -87,15 +87,8 @@ public static class EffectsFactory
 			var matrix = MatrixManager.AtPoint(Vector3Int.RoundToInt(worldPos), true);
 			if (matrix.Matrix.Get<FloorDecal>(worldPos.ToLocalInt(matrix.Matrix), true).Count() == 0)
 			{
-
-				var bloodTileInst = Spawn.ServerPrefab(chosenTile, worldPos, matrix.Objects);
-				var bloodTileGO = bloodTileInst.GameObject;
-				var tileReagents = bloodTileGO.GetComponent<ReagentContainer>();
-				/*if (reagents != null)
-				{
-					tileReagents.Add(reagents);
-				}*/
-
+				Spawn.ServerPrefab(chosenTile, worldPos, matrix.Objects);
+				//TODO: Need to add blood reagents
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/InteractionUtils.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/InteractionUtils.cs
@@ -94,7 +94,7 @@ public static class InteractionUtils
 		wasClientInteractable = false;
 		//interactions targeting an object at hiddenpos are NEVER allowed (except for inventory actions,
 		//since they can target an object in inventory which means its at hiddenpos)
-		if (!(interaction is InventoryApply) && interaction is TargetedInteraction targetedInteraction)
+		if (!(interaction is InventoryApply) && interaction is TargetedInteraction targetedInteraction && !(interaction is ContextMenuApply))
 		{
 			if (targetedInteraction.TargetObject != null &&
 			    targetedInteraction.TargetObject.IsAtHiddenPos())

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Chemistry;
+using Chemistry.Components;
 using Doors;
 using TileManagement;
 using UnityEngine;

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Chemistry;
-using Chemistry.Components;
 using Doors;
 using TileManagement;
 using UnityEngine;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -104,7 +104,7 @@ public class MetaDataLayer : MonoBehaviour
 	/// </summary>
 	public void ReagentReact(ReagentMix reagents, Vector3Int worldPosInt, Vector3Int localPosInt)
 	{
-		//if (MatrixManager.IsTotallyImpassable(worldPosInt, true)) return;
+		if (MatrixManager.IsTotallyImpassable(worldPosInt, true)) return;
 
 		bool didSplat = false;
 

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemSlot.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemSlot.cs
@@ -363,7 +363,7 @@ namespace UI
 				if (InteractionUtils.ClientCheckAndTrigger(targetInteractables, combine) != null) return true;
 			}
 
-			return false;
+			return true;
 		}
 
 		[ContextMenu("Debug Slot")]

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemSlot.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemSlot.cs
@@ -363,7 +363,7 @@ namespace UI
 				if (InteractionUtils.ClientCheckAndTrigger(targetInteractables, combine) != null) return true;
 			}
 
-			return true;
+			return false;
 		}
 
 		[ContextMenu("Debug Slot")]


### PR DESCRIPTION
### Purpose
Whiles working on health we realized we need a way to pour reagents on the ground when bleeding.  This PR will make it so reagents are now placed on the ground in a pile or pool using the ChemSplat prefab as well as enhance ReagentContainers to handle undefined sizes of reagent.  This also fixes a empty contents bug that wouldn't allow emptying of reagent containers.

This PR does not close any issues directly but will help the following issues. 
Could help with #5311 (need to update prefabs to toggle off CanPour Bool on the reagent container) 
Will help #6400 
Will help #6156 (adding two reagents ontop of each other react now in this PR) 

### Notes:
This is a second attempt to PR, first one was too far behind upstream.
This is a prolog to having blood bleed real reagents, first focused on chemicals.  This currently does not touch blood but will after this PR is merged. 

### Changelog:

CL: [New] - Reagents can be poured and mixed with other reagents on the floor.
CL: [Improvement] - Reagents now show if they are a Gas, Powder or Liquid using there appropriate sprites.
CL: [Improvement] Liquid reagents will now make the floor slippery for a short time (same as water). 
CL: [Fix] - Fixed a bug where the player couldn't empty a reagent container in there hand

Developer Changes: 
- ReagentContainters now have a "Unknown" size for use with piles and pools of reagents
- ReagentContainers can now toggle if they can have there contents poured out (again for large bodies of reagents)
- ReagentContainer.Examine has a new examine output for examining a reagent with an Unknown qty (useful for reagents without a GO container like a beer glass) 
- EffectsFactory now also has a PowderSplat function for use when a reagent is more powder than liquid.
- MetaDataLayer now will try to combine reagents if placed over one another.
- fixed Dutch Hot Coca to have milk  so your not drinking powder.