### PR TITLE
makes it so on to spawn, register tiles remove themselves from locations hopefully fixing the null reference bug?

### DIFF
--- a/UnityProject/Assets/Mirror/Editor/NetworkScenePostProcess.cs
+++ b/UnityProject/Assets/Mirror/Editor/NetworkScenePostProcess.cs
@@ -61,11 +61,11 @@ namespace Mirror
                         // * if an unopened scene needs resaving
                         // show a proper error message in both cases so the user
                         // knows what to do.
-                        string path = identity.gameObject.scene.path;
+	                    string path = identity.gameObject.scene.path;
                         if (string.IsNullOrWhiteSpace(path))
-                            Debug.LogError($"{identity.name} is currently open in Prefab Edit Mode. Please open the actual scene before launching Mirror.");
+                            Debug.LogWarning($"{identity.name} is currently open in Prefab Edit Mode. Please open the actual scene before launching Mirror.");
                         else
-                            Debug.LogError($"Scene {path} needs to be opened and resaved, because the scene object {identity.name} has no valid sceneId yet.");
+                            Debug.LogWarning($"Scene {path} needs to be opened and resaved, because the scene object {identity.name} has no valid sceneId yet.");
 
                         // either way we shouldn't continue. nothing good will
                         // happen when trying to launch with invalid sceneIds.

--- a/UnityProject/Assets/Mirror/Editor/NetworkScenePostProcess.cs
+++ b/UnityProject/Assets/Mirror/Editor/NetworkScenePostProcess.cs
@@ -63,8 +63,12 @@ namespace Mirror
                         // knows what to do.
 	                    string path = identity.gameObject.scene.path;
                         if (string.IsNullOrWhiteSpace(path))
+	                        ///UNITYSTATION CODE///
+	                        /// Replaced with warning, Used to be error, Used to cause Builds to Cancel with enough errors
                             Debug.LogWarning($"{identity.name} is currently open in Prefab Edit Mode. Please open the actual scene before launching Mirror.");
                         else
+	                        ///UNITYSTATION CODE///
+	                        /// Replaced with warning, Used to be error, Used to cause Builds to Cancel with enough errors
                             Debug.LogWarning($"Scene {path} needs to be opened and resaved, because the scene object {identity.name} has no valid sceneId yet.");
 
                         // either way we shouldn't continue. nothing good will

--- a/UnityProject/Assets/Mirror/Runtime/ClientScene.cs
+++ b/UnityProject/Assets/Mirror/Runtime/ClientScene.cs
@@ -950,10 +950,11 @@ namespace Mirror
                 // scene object.. disable it in scene instead of destroying
                 else
                 {
-                    localObject.gameObject.SetActive(false);
-                    spawnableObjects[localObject.sceneId] = localObject;
+	                Object.Destroy(localObject.gameObject);
+                    // localObject.gameObject.SetActive(false);
+                    // spawnableObjects[localObject.sceneId] = localObject;
                     // reset for scene objects
-                    localObject.Reset();
+                    // localObject.Reset();
                 }
 
                 // remove from dictionary no matter how it is unspawned

--- a/UnityProject/Assets/Mirror/Runtime/ClientScene.cs
+++ b/UnityProject/Assets/Mirror/Runtime/ClientScene.cs
@@ -950,7 +950,14 @@ namespace Mirror
                 // scene object.. disable it in scene instead of destroying
                 else
                 {
+	                ///Added
 	                Object.Destroy(localObject.gameObject);
+	                ///UNITYSTATION CODE///
+	                /// why because for some reason mirror wants to treat seen objects as special
+	                /// and it's more consistent to just destroy so don't get Inconsistent behaviour
+	                /// between something that spawned in and something that was put in the scene
+	                /// Original code below
+
                     // localObject.gameObject.SetActive(false);
                     // spawnableObjects[localObject.sceneId] = localObject;
                     // reset for scene objects

--- a/UnityProject/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/UnityProject/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -548,6 +548,8 @@ namespace Mirror
                 // => throw an exception to cancel the build and let the user
                 //    know how to fix it!
                  if (BuildPipeline.isBuildingPlayer)
+	                 ///UNITYSTATION CODE///
+	                 /// Replaced with warning, It used to stop build
                      Debug.LogWarning("Scene " + gameObject.scene.path + " needs to be opened and resaved before building, because the scene object " + name + " has no valid sceneId yet.");
 
                 // if we generate the sceneId then we MUST be sure to set dirty

--- a/UnityProject/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/UnityProject/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -547,8 +547,8 @@ namespace Mirror
                 //    permanent
                 // => throw an exception to cancel the build and let the user
                 //    know how to fix it!
-                if (BuildPipeline.isBuildingPlayer)
-                    throw new InvalidOperationException("Scene " + gameObject.scene.path + " needs to be opened and resaved before building, because the scene object " + name + " has no valid sceneId yet.");
+                 if (BuildPipeline.isBuildingPlayer)
+                     Debug.LogWarning("Scene " + gameObject.scene.path + " needs to be opened and resaved before building, because the scene object " + name + " has no valid sceneId yet.");
 
                 // if we generate the sceneId then we MUST be sure to set dirty
                 // in order to save the scene object properly. otherwise it

--- a/UnityProject/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/UnityProject/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -350,6 +350,15 @@ namespace Mirror
                     return;
                 }
 
+                // old not empty
+                if (!string.IsNullOrEmpty(oldAssetIdSrting))
+                {
+	                return;
+	                //Would be nice to have the reason why it complains if it's set wrong
+	                //Debug.LogError($"Can not Set AssetId on NetworkIdentity '{name}' because it already had an assetId, current assetId '{oldAssetIdSrting}', attempted new assetId '{newAssetIdString}'");
+                }
+
+
                 // old is empty
                 m_AssetId = newAssetIdString;
 

--- a/UnityProject/Assets/Scripts/Health/Objects/Armor.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Armor.cs
@@ -47,7 +47,7 @@ public class Armor
 	/// <param name="attackType">Type of attack</param>
 	/// <param name="armorPenetration">How well the attack will break through different types of armor</param>
 	/// <returns>New damage after applying protection values</returns>
-	public float getForce(float damage, AttackType attackType, float armorPenetration = 0)
+	public float GetForce(float damage, AttackType attackType, float armorPenetration = 0)
 	{
 		return damage / GetRatingValue(attackType, armorPenetration);
 	}

--- a/UnityProject/Assets/Scripts/Health/Objects/Armor.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Armor.cs
@@ -39,6 +39,19 @@ public class Armor
 		return damage * GetRatingValue(attackType, armorPenetration);
 	}
 
+
+	/// <summary>
+	/// From the damage done, calculates how much force was put into it
+	/// </summary>
+	/// <param name="damage">Base damage</param>
+	/// <param name="attackType">Type of attack</param>
+	/// <param name="armorPenetration">How well the attack will break through different types of armor</param>
+	/// <returns>New damage after applying protection values</returns>
+	public float GetForce(float damage, AttackType attackType, float armorPenetration = 0)
+	{
+		return damage / GetRatingValue(attackType, armorPenetration);
+	}
+
 	/// <summary>
 	/// Get the proportion of damage that will be dealt through this armor
 	/// depending on the armor penetration of the attack.

--- a/UnityProject/Assets/Scripts/Health/Objects/Armor.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Armor.cs
@@ -47,7 +47,7 @@ public class Armor
 	/// <param name="attackType">Type of attack</param>
 	/// <param name="armorPenetration">How well the attack will break through different types of armor</param>
 	/// <returns>New damage after applying protection values</returns>
-	public float GetForce(float damage, AttackType attackType, float armorPenetration = 0)
+	public float getForce(float damage, AttackType attackType, float armorPenetration = 0)
 	{
 		return damage / GetRatingValue(attackType, armorPenetration);
 	}

--- a/UnityProject/Assets/Scripts/Objects/Furniture/TableBuilding.cs
+++ b/UnityProject/Assets/Scripts/Objects/Furniture/TableBuilding.cs
@@ -49,6 +49,8 @@ namespace Objects.Construction
 			//only care about interactions targeting us
 			if (interaction.TargetObject != gameObject) return false;
 
+			if (interaction.HandObject == null) return false;
+
 			if (interaction.HandObject.GetComponent<Stackable>().Amount < 2) return false;
 
 			//only try to interact if the user has a wrench, screwdriver in their hand

--- a/UnityProject/Assets/Scripts/Systems/Chemistry/ReagentMix.cs
+++ b/UnityProject/Assets/Scripts/Systems/Chemistry/ReagentMix.cs
@@ -323,7 +323,7 @@ namespace Chemistry
 
 			lock (reagents)
 			{
-				foreach (var key in reagents.m_dict.Keys)
+				foreach (var key in reagents.m_dict.Keys.ToArray())
 				{
 					reagents.m_dict[key] *= multiplier;
 				}
@@ -349,7 +349,7 @@ namespace Chemistry
 
 			lock (reagents)
 			{
-				foreach (var key in reagents.m_dict.Keys)
+				foreach (var key in reagents.m_dict.Keys.ToArray())
 				{
 					reagents.m_dict[key] /= Divider;
 				}

--- a/UnityProject/Assets/Scripts/Systems/Explosions/ExplosionNode.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/ExplosionNode.cs
@@ -35,11 +35,7 @@ namespace Systems.Explosions
 			}
 
 			EnergyExpended = metaTileMap.ApplyDamage(v3int, Damagedealt,
-			MatrixManager.LocalToWorldInt(v3int, matrix.MatrixInfo), AttackType.Bomb) * 0.375f;
-
-			// Prevents a perpetual motion explosion
-			if(EnergyExpended <= 0.375f)
-				EnergyExpended = 0.375f;
+			MatrixManager.LocalToWorldInt(v3int, matrix.MatrixInfo), AttackType.Bomb);
 
 			if (Damagedealt > 100)
 			{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
@@ -305,6 +305,12 @@ public class RegisterTile : NetworkBehaviour, IServerDespawn
 
 	public virtual void OnDespawnServer(DespawnInfo info)
 	{
+		if (objectLayer)
+		{
+			objectLayer.ServerObjects.Remove(LocalPositionServer, this);
+			objectLayer.ClientObjects.Remove(LocalPositionClient, this);
+		}
+
 		//cancel all relationships
 		if (sameMatrixRelationships != null)
 		{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
@@ -398,8 +398,8 @@ public class RegisterTile : NetworkBehaviour, IServerDespawn
 		objectLayer?.ClientObjects.Remove(LocalPositionClient, this);
 		objectLayer?.ServerObjects.Remove(LocalPositionServer, this);
 
-		LocalPositionClient = Vector3Int.zero;
-		LocalPositionServer = Vector3Int.zero;
+		LocalPositionClient = TransformState.HiddenPos;
+		LocalPositionServer = TransformState.HiddenPos;
 
 		objectLayer = networkedMatrix.GetComponentInChildren<ObjectLayer>();
 		transform.SetParent(objectLayer.transform, true);
@@ -451,6 +451,8 @@ public class RegisterTile : NetworkBehaviour, IServerDespawn
 			              transform.parent.GetComponentInParent<ObjectLayer>();
 			Matrix = transform.parent.GetComponentInParent<Matrix>();
 
+			LocalPositionServer = TransformState.HiddenPos;
+			LocalPositionClient = TransformState.HiddenPos;
 
 			LocalPositionServer = Vector3Int.RoundToInt(transform.localPosition);
 			LocalPositionClient = Vector3Int.RoundToInt(transform.localPosition);

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
@@ -77,7 +77,7 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 	private float AddDamage(float Energy, AttackType attackType, MetaDataNode data,
 		BasicTile basicTile, Vector3 worldPosition)
 	{
-		float EnergyAbsorbed = 0;
+		float energyAbsorbed = 0;
 		if (basicTile.indestructible || Energy < basicTile.damageDeflection)
 		{
 			if (attackType == AttackType.Bomb && basicTile.ExplosionImpassable == false)
@@ -88,11 +88,11 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 			{
 				if (attackType == AttackType.Bomb)
 				{
-					return EnergyAbsorbed*  0.85f;
+					return energyAbsorbed * 0.85f;
 				}
 				else
 				{
-					return EnergyAbsorbed;
+					return energyAbsorbed;
 				}
 			}
 		}
@@ -111,7 +111,7 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 
 		if (totalDamageTaken >= basicTile.MaxHealth)
 		{
-			float ExcessEnergy = basicTile.Armor.getForce( totalDamageTaken - basicTile.MaxHealth, attackType);
+			float excessEnergy = basicTile.Armor.GetForce( totalDamageTaken - basicTile.MaxHealth, attackType);
 			if (basicTile.SoundOnDestroy.Count > 0)
 			{
 				SoundManager.PlayNetworkedAtPos(basicTile.SoundOnDestroy.RandomElement(), worldPosition);
@@ -141,19 +141,19 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 
 				var overFlowProtection = 0;
 
-				while (ExcessEnergy > 0 && tile != null)
+				while (excessEnergy > 0 && tile != null)
 				{
 					overFlowProtection++;
 
-					if (tile.MaxHealth <= ExcessEnergy)
+					if (tile.MaxHealth <= excessEnergy)
 					{
-						ExcessEnergy -= tile.MaxHealth;
+						excessEnergy -= tile.MaxHealth;
 						tile = tile.ToTileWhenDestroyed as BasicTile;
 					}
 					else
 					{
 						//Atm we just set remaining damage to 0, instead of absorbing it for the new tile
-						ExcessEnergy = 0;
+						excessEnergy = 0;
 						tileChangeManager.UpdateTile(data.Position, tile);
 						break;
 					}
@@ -165,7 +165,7 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 					}
 				}
 
-				EnergyAbsorbed = Energy - ExcessEnergy;
+				energyAbsorbed = Energy - excessEnergy;
 			}
 
 			if (basicTile.SpawnOnDestroy != null)
@@ -190,7 +190,7 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 			}
 
 			//All the damage was absorbed, none left to return for next layer
-			EnergyAbsorbed = Energy;
+			energyAbsorbed = Energy;
 		}
 
 		if (basicTile.MaxHealth < basicTile.MaxHealth - totalDamageTaken)
@@ -200,17 +200,17 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 
 		if (attackType == AttackType.Bomb && basicTile.ExplosionImpassable == false)
 		{
-			return EnergyAbsorbed  * 0.375f;
+			return energyAbsorbed  * 0.375f;
 		}
 		else
 		{
 			if (attackType == AttackType.Bomb)
 			{
-				return EnergyAbsorbed*  0.85f;
+				return energyAbsorbed*  0.85f;
 			}
 			else
 			{
-				return EnergyAbsorbed;
+				return energyAbsorbed;
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
@@ -111,7 +111,7 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 
 		if (totalDamageTaken >= basicTile.MaxHealth)
 		{
-			float ExcessEnergy = basicTile.Armor.GetForce( totalDamageTaken - basicTile.MaxHealth, attackType);
+			float ExcessEnergy = basicTile.Armor.getForce( totalDamageTaken - basicTile.MaxHealth, attackType);
 			if (basicTile.SoundOnDestroy.Count > 0)
 			{
 				SoundManager.PlayNetworkedAtPos(basicTile.SoundOnDestroy.RandomElement(), worldPosition);

--- a/UnityProject/Assets/Scripts/Tilemaps/Tiles/BasicTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Tiles/BasicTile.cs
@@ -53,6 +53,9 @@ public abstract class BasicTile : LayerTile
 	[Tooltip("Can this tile be damaged at all?")]
 	public bool indestructible;
 
+	[Tooltip("Do explosions have to completely destroy the tile before passing it, Otherwise explosion extends all its energy on the wall")]
+	public bool ExplosionImpassable;
+
 	[Tooltip("What things are allowed to pass through this even if it is not passable?")]
 	[FormerlySerializedAs("PassableException")]
 	[SerializeField]

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/AdminWall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/AdminWall.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 1
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0
@@ -57,6 +60,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Bananium Ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Bananium Ore.asset
@@ -27,6 +27,7 @@ MonoBehaviour:
   RadiationPassability: 1
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +44,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 315512072097039032, guid: 7f36d623d91cac64cb72c7fe44cc9d72,
     type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/BlueSpace Ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/BlueSpace Ore.asset
@@ -27,6 +27,7 @@ MonoBehaviour:
   RadiationPassability: 1
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +44,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 6211075373097523109, guid: ec5fbdce8af90e84ead236f0e04aa67a,
     type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Diamond ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Diamond ore.asset
@@ -27,6 +27,7 @@ MonoBehaviour:
   RadiationPassability: 1
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +44,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 3847547868569572698, guid: 329682eedacc925409e4d48e76912be0,
     type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Gold Ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Gold Ore.asset
@@ -27,6 +27,7 @@ MonoBehaviour:
   RadiationPassability: 1
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +44,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 2983437147595714925, guid: 8ea4bb3d70e3ed14391cd7eee704747f,
     type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Iron Ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Iron Ore.asset
@@ -27,6 +27,7 @@ MonoBehaviour:
   RadiationPassability: 1
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +44,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 8086189346554243681, guid: 30c1980ca0250624a893b6e4f398f2a9,
     type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Plasma Ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Plasma Ore.asset
@@ -27,6 +27,7 @@ MonoBehaviour:
   RadiationPassability: 1
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +44,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 8949931981533366558, guid: 5de3487372396e34e839c297ece28ef0,
     type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Silver Ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Silver Ore.asset
@@ -27,6 +27,7 @@ MonoBehaviour:
   RadiationPassability: 1
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +44,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 6375000470135993727, guid: 81e1dcfb97892054295d23cfd69c5542,
     type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Titanium Ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Titanium Ore.asset
@@ -27,6 +27,7 @@ MonoBehaviour:
   RadiationPassability: 1
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +44,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 6447095856050897818, guid: db34b9991c6517848999bc6bfe8ba25d,
     type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Uranium Ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Uranium Ore.asset
@@ -27,6 +27,7 @@ MonoBehaviour:
   RadiationPassability: 1
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +44,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 7525139179178726709, guid: 6d0e5d5bc9d6eeb4bac0fcf68fc738b8,
     type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallAnchorBolts.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallAnchorBolts.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.15
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: e7dbaec31525647378209f60c5769d78, type: 2}
   - {fileID: 11400000, guid: a98a88e95993e4baa9b8a1ac0581371f, type: 2}
@@ -60,4 +63,5 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   sprite: {fileID: 21300000, guid: 44e56b599ea826c4092688924b1598b1, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallCover.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallCover.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.15
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 755e9178883ca42078adcafed89a098e, type: 2}
   - {fileID: 11400000, guid: 35adc0f539c6c4c93af01c6244984d8e, type: 2}
@@ -60,4 +63,5 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   sprite: {fileID: 21300000, guid: e1cd0f3d3708b2e47be980e0ea6fca78, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallCutCover.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallCutCover.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.15
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 80fa3856a932643f38b929bd7e371344, type: 2}
   - {fileID: 11400000, guid: af5d9791dd6ca4ba2a75443eae419653, type: 2}
@@ -60,4 +63,5 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   sprite: {fileID: 21300000, guid: 9785839f4bb4c984ea2a4f0c03bf483a, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/ReinforcedWall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/ReinforcedWall.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.15
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: df2824a08f89f459e90d745b5e8e07a2, type: 2}
   spawnOnDeconstruct: {fileID: 0}
@@ -59,6 +62,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/Wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/Wall.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 90
+    DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: bb76dc79372e14705abf68e3caa3e0f9, type: 2}
   spawnOnDeconstruct: {fileID: 0}
@@ -58,6 +61,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/abductor_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/abductor_wall.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
@@ -57,6 +60,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/bananium_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/bananium_wall.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
@@ -57,6 +60,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/blank_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/blank_wall.asset
@@ -23,9 +23,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -42,6 +44,7 @@ MonoBehaviour:
     Acid: 100
     Magic: 100
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0
@@ -56,6 +59,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 4
   connectType: 2
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/clockwork_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/clockwork_wall.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
@@ -57,6 +60,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/cult_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/cult_wall.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
@@ -57,6 +60,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/diamond_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/diamond_wall.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
@@ -57,6 +60,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/false_open.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/false_open.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 1
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: bb76dc79372e14705abf68e3caa3e0f9, type: 2}
   spawnOnDeconstruct: {fileID: 0}
@@ -58,6 +61,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/gold_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/gold_wall.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
@@ -57,6 +60,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/hierophant_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/hierophant_wall.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
@@ -57,6 +60,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/iron_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/iron_wall.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
@@ -57,6 +60,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/plasma_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/plasma_wall.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
@@ -57,6 +60,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/plastitanium_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/plastitanium_wall.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
@@ -57,6 +60,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/plastitanium_wall_corner.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/plastitanium_wall_corner.asset
@@ -23,9 +23,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -42,6 +44,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
@@ -56,6 +59,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/pod_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/pod_wall.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
@@ -57,6 +60,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/resin_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/resin_wall.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
@@ -57,6 +60,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/rock_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/rock_wall.asset
@@ -23,9 +23,11 @@ MonoBehaviour:
   SpawnWithNoAir: 1
   passable: 0
   mineable: 1
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -42,6 +44,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0
@@ -56,6 +59,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/rusty_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/rusty_wall.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 100
+    DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: bb76dc79372e14705abf68e3caa3e0f9, type: 2}
   spawnOnDeconstruct: {fileID: 0}
@@ -58,6 +61,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/sandstone_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/sandstone_wall.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 90
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
@@ -57,6 +60,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/shuttle_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/shuttle_wall.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 1
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 90
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
@@ -57,6 +60,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/shuttle_wall_corner.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/shuttle_wall_corner.asset
@@ -23,9 +23,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 1
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -42,6 +44,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 90
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
@@ -56,6 +59,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/silver_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/silver_wall.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 90
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
@@ -57,6 +60,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/smooth_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/smooth_wall.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 90
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
@@ -57,6 +60,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/snow_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/snow_wall.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 90
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
@@ -57,6 +60,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/survival_pod_walls.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/survival_pod_walls.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 90
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
@@ -57,6 +60,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/uranium_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/uranium_wall.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 90
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
@@ -57,6 +60,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/wood_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/wood_wall.asset
@@ -24,9 +24,11 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 0
   mineable: 0
+  miningTime: 5
   RadiationPassability: 0.35
   doesReflectBullet: 0
   indestructible: 0
+  ExplosionImpassable: 1
   passableException:
     m_keys: 
     m_values: 
@@ -43,6 +45,7 @@ MonoBehaviour:
     Acid: 90
     Magic: 0
     Bio: 90
+    DismembermentProtectionChance: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
@@ -57,6 +60,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  SoundOnDestroy: []
   connectCategory: 0
   connectType: 1
   spriteSheet:


### PR DESCRIPTION
don't worry the changes have already been merged showing them for some reason though they've already been merged,
also improved explosion code a bit

fixes NRE with table interactions while it's under construction if you don't have anything in your hand
so, mirror with  objects that were in the scene when it was safe when server requests to destroy them it just hides them instead resulting in inconsistent destruction path , (if it were responding then it gets destroyed normally if it was there already it would gethidden) so, I've made it so it destroys even if it was a scene object and tested with a few round restarts with editor hosting and build as client

also removes the annoying " scene needing to be received" thing that stops builds from proceeding,
 for testing purposes becauseit's particularly annoying when it gets half way through a build and stops
