### PR TITLE
New floor clean logic + Tile reagent splat paint code cleanup

### DIFF
--- a/UnityProject/Assets/Prefabs/Decal/Resources/ChemSplat.prefab
+++ b/UnityProject/Assets/Prefabs/Decal/Resources/ChemSplat.prefab
@@ -90,6 +90,7 @@ MonoBehaviour:
   syncInterval: 0.1
   matrixDebugLogging: 0
   objectType: 1
+  CurrentsortingGroup: {fileID: 0}
 --- !u!114 &3880655971207283370
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Decal/Resources/WaterSplat.prefab
+++ b/UnityProject/Assets/Prefabs/Decal/Resources/WaterSplat.prefab
@@ -52,6 +52,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  snapToGridOnStart: 1
   IsFixedMatrix: 0
 --- !u!114 &1171502632885236370
 MonoBehaviour:
@@ -95,6 +96,7 @@ MonoBehaviour:
   syncInterval: 0.1
   matrixDebugLogging: 0
   objectType: 1
+  CurrentsortingGroup: {fileID: 0}
 --- !u!114 &3880655971207283370
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -112,7 +114,13 @@ MonoBehaviour:
   registerTile: {fileID: 0}
   floorDecal: {fileID: 0}
   isInitiallyNotPushable: 1
-  pushPullSound: 
+  pushPullSound:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   soundDelayTime: 0
   soundMinimumPitchVariance: 1
   soundMaximumPitchVariance: 1
@@ -133,6 +141,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
   ignoreExtraRotation: []
+  RotateParent: {fileID: 0}
 --- !u!114 &6905794213313038048
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -148,7 +157,9 @@ MonoBehaviour:
   isDirty: 0
   sceneId: 0
   serverOnly: 0
+  visible: 0
   m_AssetId: 
+  hasSpawned: 0
 --- !u!114 &-8250776762379421101
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -163,7 +174,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  forceHidden: 0
 --- !u!1 &3880655971395685414
 GameObject:
   m_ObjectHideFlags: 0
@@ -210,6 +220,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:

--- a/UnityProject/Assets/Prefabs/Items/Food/Drinks/MugDutchHotCoco.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Drinks/MugDutchHotCoco.prefab
@@ -12,6 +12,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 5224528153624499084, guid: a3c2eebd1ee083c4f873a4e8475bae26,
+        type: 3}
+      propertyPath: CurrentsortingGroup
+      value: 
+      objectReference: {fileID: 7996204198541009528}
     - target: {fileID: 5228294035572171748, guid: a3c2eebd1ee083c4f873a4e8475bae26,
         type: 3}
       propertyPath: Resistances.FreezeProof
@@ -90,24 +95,24 @@ PrefabInstance:
     - target: {fileID: 6358828029291461304, guid: a3c2eebd1ee083c4f873a4e8475bae26,
         type: 3}
       propertyPath: initialReagentMix.reagents.m_keys.Array.size
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6358828029291461304, guid: a3c2eebd1ee083c4f873a4e8475bae26,
         type: 3}
       propertyPath: initialReagentMix.reagents.m_values.Array.size
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6358828029291461304, guid: a3c2eebd1ee083c4f873a4e8475bae26,
         type: 3}
       propertyPath: initialReagentMix.reagents.m_keys.Array.data[0]
       value: 
-      objectReference: {fileID: 11400000, guid: 911271db97b77da51889f97d6688a103,
+      objectReference: {fileID: 11400000, guid: f7d2e4cdb6fe85456b9ac4626bd0baea,
         type: 2}
     - target: {fileID: 6358828029291461304, guid: a3c2eebd1ee083c4f873a4e8475bae26,
         type: 3}
       propertyPath: initialReagentMix.reagents.m_keys.Array.data[1]
       value: 
-      objectReference: {fileID: 11400000, guid: f7d2e4cdb6fe85456b9ac4626bd0baea,
+      objectReference: {fileID: 11400000, guid: 5b5f8bbc79979ff58b9cbaa4a2a95eaf,
         type: 2}
     - target: {fileID: 6358828029291461304, guid: a3c2eebd1ee083c4f873a4e8475bae26,
         type: 3}
@@ -118,12 +123,12 @@ PrefabInstance:
     - target: {fileID: 6358828029291461304, guid: a3c2eebd1ee083c4f873a4e8475bae26,
         type: 3}
       propertyPath: initialReagentMix.reagents.m_values.Array.data[0]
-      value: 5
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 6358828029291461304, guid: a3c2eebd1ee083c4f873a4e8475bae26,
         type: 3}
       propertyPath: initialReagentMix.reagents.m_values.Array.data[1]
-      value: 15
+      value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 6358828029291461304, guid: a3c2eebd1ee083c4f873a4e8475bae26,
         type: 3}
@@ -132,3 +137,9 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a3c2eebd1ee083c4f873a4e8475bae26, type: 3}
+--- !u!210 &7996204198541009528 stripped
+SortingGroup:
+  m_CorrespondingSourceObject: {fileID: 2135095128480167006, guid: a3c2eebd1ee083c4f873a4e8475bae26,
+    type: 3}
+  m_PrefabInstance: {fileID: 8311772372205835814}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Other/Oxygen.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Other/Oxygen.asset
@@ -14,5 +14,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   displayName: Oxygen
   description: A colorless, odorless gas. Grows on trees but is still pretty valuable.
-  color: {r: 0.5019608, g: 0.5019608, b: 0.5019608, a: 1}
+  color: {r: 0.7607844, g: 0.7607844, b: 0.7607844, a: 0}
   state: 2
+  heatDensity: 5

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Other/SpaceCleaner.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Other/SpaceCleaner.asset
@@ -15,4 +15,5 @@ MonoBehaviour:
   displayName: Space cleaner
   description: A compound used to clean things. Now with 50% more sodium hypochlorite!
   color: {r: 0.64705884, g: 0.9411765, b: 0.93333334, a: 1}
-  state: 0
+  state: 1
+  heatDensity: 5

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Other/Water.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Other/Water.asset
@@ -15,5 +15,6 @@ MonoBehaviour:
   displayName: Water
   description: An ubiquitous chemical substance that is composed of hydrogen and
     oxygen.
-  color: {r: 0.5577163, g: 0.77330136, b: 0.7830189, a: 0.11372549}
+  color: {r: 0.75956744, g: 0.9428339, b: 0.9528302, a: 0.23529412}
   state: 1
+  heatDensity: 5

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Other/WeldingFuel.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Other/WeldingFuel.asset
@@ -14,5 +14,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   displayName: Welding fuel
   description: Required for welders. Flammable.
-  color: {r: 0.4, g: 0, b: 0, a: 1}
-  state: 0
+  color: {r: 0.9245283, g: 0.44891587, b: 0.047970813, a: 1}
+  state: 1
+  heatDensity: 5

--- a/UnityProject/Assets/ScriptableObjects/Health/BloodTypes/HumanBlood.asset
+++ b/UnityProject/Assets/ScriptableObjects/Health/BloodTypes/HumanBlood.asset
@@ -12,8 +12,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8f64d4f5b1b1d304bb037fa918fad45f, type: 3}
   m_Name: HumanBlood
   m_EditorClassIdentifier: 
-  Blood: {fileID: 11400000, guid: eea05337a284c407e926bf3110b00916, type: 2}
+  displayName: Red Blood Cells
+  description: 'The man goo that makes humans choo choo '
+  color: {r: 0.8773585, g: 0, b: 0, a: 0}
+  state: 1
+  heatDensity: 5
   CirculatedReagent: {fileID: 11400000, guid: 72991f100b5704f5fb63c9629fcdeb6c, type: 2}
-  Color: {r: 0.6698113, g: 0.015797434, b: 0.015797434, a: 1}
+  Type: 0
   BloodCapacityOf: 0.2
   BloodGasCapability: 0.0005

--- a/UnityProject/Assets/Scripts/Items/Tool/Mop.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/Mop.cs
@@ -57,7 +57,25 @@ public class Mop : MonoBehaviour, ICheckedInteractable<PositionalHandApply>, IEx
 		//do the mopping
 		void CompleteProgress()
 		{
-			CleanTile(interaction.WorldPositionTarget);
+			Vector3Int worldPos = interaction.WorldPositionTarget.RoundToInt();
+			MatrixInfo matrixInfo = MatrixManager.AtPoint(worldPos, true);
+			Vector3Int localPos = MatrixManager.WorldToLocalInt(worldPos, matrixInfo);
+			if (reagentContainer)
+			{
+				if (reagentContainer.MajorMixReagent.name == "Water")
+				{
+					matrixInfo.MetaDataLayer.Clean(worldPos, localPos, true);
+				}
+				else if (reagentContainer.MajorMixReagent.name == "SpaceCleaner")
+				{
+					matrixInfo.MetaDataLayer.Clean(worldPos, localPos, false);
+				}
+				else
+				{
+					MatrixManager.ReagentReact(reagentContainer.TakeReagents(reagentsPerUse), worldPos);
+				}
+			}
+			
 			Chat.AddExamineMsg(interaction.Performer, "You finish mopping.");
 		}
 
@@ -72,12 +90,7 @@ public class Mop : MonoBehaviour, ICheckedInteractable<PositionalHandApply>, IEx
 				$"{interaction.Performer.name} begins to clean the floor with the {gameObject.ExpensiveName()}.");
 		}
 	}
-
-	public void CleanTile(Vector3 worldPos)
-	{
-		MatrixManager.ReagentReact(reagentContainer.TakeReagents(reagentsPerUse), worldPos.CutToInt());
-	}
-
+	
 	public string Examine(Vector3 worldPos = default)
 	{
 		string msg = null;

--- a/UnityProject/Assets/Scripts/Items/Tool/SpaceCleaner.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/SpaceCleaner.cs
@@ -70,7 +70,23 @@ public class SpaceCleaner : NetworkBehaviour, ICheckedInteractable<AimApply>
 
 	void SprayTile(Vector3Int worldPos)
 	{
-		reagentContainer.Spill(worldPos, reagentsPerUse);
+		MatrixInfo matrixInfo = MatrixManager.AtPoint(worldPos, true);
+		Vector3Int localPos = MatrixManager.WorldToLocalInt(worldPos, matrixInfo);
+		if (reagentContainer != null && reagentContainer.ReagentMixTotal > 0.1)
+		{
+			if (reagentContainer.MajorMixReagent.name == "SpaceCleaner")
+			{
+				matrixInfo.MetaDataLayer.Clean(worldPos, localPos, false);
+			}
+			else if (reagentContainer.MajorMixReagent.name == "Water")
+			{
+				matrixInfo.MetaDataLayer.Clean(worldPos, localPos, true);
+			}
+			else
+			{
+				MatrixManager.ReagentReact(reagentContainer.TakeReagents(reagentsPerUse), worldPos);
+			}
+		}
 	}
 	private List<Vector3Int> CheckPassableTiles(Vector2 startPos, Vector2 targetPos)
 	{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -183,7 +183,7 @@ public class MetaDataLayer : MonoBehaviour
 			}
 			case "liquid":
 			{
-				MakeSlipperyAt(localPosInt, true);
+				MakeSlipperyAt(localPosInt);
 				EffectsFactory.ChemSplat(worldPosInt, splatColor, reagents);
 				break;
 			}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -111,99 +111,89 @@ public class MetaDataLayer : MonoBehaviour
 		//Find all reagents on this tile (including current reagent) 
 		var reagentContainersList = MatrixManager.GetAt<ReagentContainer>(worldPosInt, true);
 
-		bool landedOnReagents = false;
-
-		if(reagentContainersList.Count > 0)
+		//If there is more than one Reagent Container, loop through them
+		foreach (ReagentContainer chem in reagentContainersList)
 		{
-			//If there is more than one Reagent Container, loop through them
-			foreach (ReagentContainer chem in reagentContainersList)
+			//If the reagent tile is a pool/puddle/splat
+			if (chem.ExamineAmount == ReagentContainer.ExamineAmountMode.UNKNOWN_AMOUNT)
 			{
-				//If the reagent tile is a pool/puddle/splat
-				if(chem.ExamineAmount == ReagentContainer.ExamineAmountMode.UNKNOWN_AMOUNT)
-				{
-					reagents.Add(chem.CurrentReagentMix);
-				}
-				//TODO: could allow you to add this to other container types like beakers but would need some balance and perhaps knocking over the beaker
-				
+				reagents.Add(chem.CurrentReagentMix);
 			}
-			landedOnReagents = true;
+			//TODO: could allow you to add this to other container types like beakers but would need some balance and perhaps knocking over the beaker
 		}
-	
-		foreach (var reagent in reagents.reagents.m_dict)
+
+
+		if(reagents.reagents != null && reagents.Total > 1)
 		{
-			if (reagent.Value < 1)
+			foreach (var reagent in reagents.reagents.m_dict)
 			{
-				continue;
-			}
-
-			switch (reagent.Key.name)
-			{
-				case "Water":
+				if (reagent.Value < 1)
 				{
-					matrix.ReactionManager.ExtinguishHotspot(localPosInt);
-
-					foreach (var livingHealthBehaviour in matrix.Get<LivingHealthMasterBase>(localPosInt, true))
-					{
-						livingHealthBehaviour.Extinguish();
-					}
-
-					Clean(worldPosInt, localPosInt, true);
-					break;
+					continue;
 				}
-				case "SpaceCleaner":
-					Clean(worldPosInt, localPosInt, false);
-					break;
-				case "SpaceLube":
+
+				switch (reagent.Key.name)
 				{
-					// ( ͡° ͜ʖ ͡°)
-					if (Get(localPosInt).IsSlippery == false)
-					{
-						EffectsFactory.WaterSplat(worldPosInt);
-						MakeSlipperyAt(localPosInt, false);
-					}
+					case "Water":
+						{
+							matrix.ReactionManager.ExtinguishHotspot(localPosInt);
+							foreach (var livingHealthBehaviour in matrix.Get<LivingHealthMasterBase>(localPosInt, true))
+							{
+								livingHealthBehaviour.Extinguish();
+							}
+							Paintsplat(worldPosInt, localPosInt, reagents.MixColor, reagents);
+							break;
+						}
+					case "SpaceCleaner":
+						Clean(worldPosInt, localPosInt, false);
+						break;
+					case "SpaceLube":
+						{
+							// ( ͡° ͜ʖ ͡°)
+							if (Get(localPosInt).IsSlippery == false)
+							{
+								EffectsFactory.WaterSplat(worldPosInt);
+								MakeSlipperyAt(localPosInt, false);
+							}
 
-					break;
-				}
-				default:
-				{
-					var stateDesc = ChemistryUtils.GetMixStateDescription(reagents);
-					
-					if (didSplat == false && landedOnReagents == false)
-					{
-
-						if(stateDesc == "powder")
-						{
-							EffectsFactory.PowderSplat(worldPosInt, reagents.MixColor, reagents);
+							break;
 						}
-						else
+					default:
 						{
-							MakeSlipperyAt(localPosInt, false);
-							EffectsFactory.ChemSplat(worldPosInt, reagents.MixColor, reagents);
+							if (didSplat == false)
+							{
+								Clean(worldPosInt, localPosInt, false);
+								Paintsplat(worldPosInt, localPosInt, reagents.MixColor, reagents);
+							}
+							didSplat = true;
+							break;
 						}
-					}
-					else
-					{
-						//There is already a reagent here, clear its tile like you washed it and place a new effect over it (already has new reagents added)
-
-						if (stateDesc == "powder")
-						{
-							Clean(worldPosInt, localPosInt, Get(localPosInt).IsSlippery);
-							//TODO: Power should not clean but overlap... Clean because we want to move the existing reagent
-							EffectsFactory.PowderSplat(worldPosInt, reagents.MixColor, reagents);
-						}
-						else
-						{
-							Clean(worldPosInt, localPosInt, true);
-							EffectsFactory.ChemSplat(worldPosInt, reagents.MixColor, reagents);
-						}
-					}
-					didSplat = true;
-					break;
 				}
 			}
 		}
 	}
-
+	public void Paintsplat(Vector3Int worldPosInt, Vector3Int localPosInt, Color splatColor, ReagentMix reagents)
+	{
+		switch (ChemistryUtils.GetMixStateDescription(reagents))
+		{
+			case "powder":
+			{
+				EffectsFactory.PowderSplat(worldPosInt, splatColor, reagents);
+				break;
+			}
+			case "liquid":
+			{
+				MakeSlipperyAt(localPosInt, true);
+				EffectsFactory.ChemSplat(worldPosInt, splatColor, reagents);
+				break;
+			}
+			default:
+			{
+				EffectsFactory.ChemSplat(worldPosInt, splatColor, reagents);
+				break;
+			}
+		}
+	}
 	public void Clean(Vector3Int worldPosInt, Vector3Int localPosInt, bool makeSlippery)
 	{
 		Get(localPosInt).IsSlippery = false;


### PR DESCRIPTION
Now we don't just dump a mop or space cleaner reagents on the tile but judge if the contents are suited for cleaning and directly call the clean tile function inside the cleaning tool.

Centralized ChemSplat paint logic to a single function.

Fixed a NRE that could occur if ChemSprayer has too little reagents.

Touched up some reagents states and colors.

Oh and hot coca no longer makes floor chocolate bars.


### Changelog:
[Fix] #6667
