### PR TITLE
Fixes admin windows not disabling character input

### DIFF
--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/AdminSearchBar.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/AdminSearchBar.cs
@@ -12,29 +12,6 @@ public class AdminSearchBar : MonoBehaviour
 		Searchtext = GetComponent<InputField>();
 	}
 
-	void Update()
-	{
-		if (Searchtext.isFocused)
-		{
-			InputFocus();
-		}
-		else if (!Searchtext.isFocused)
-		{
-			InputUnfocus();
-		}
-	}
-
-	private void InputFocus()
-	{
-		//disable keyboard commands while input is focused
-		UIManager.IsInputFocus = true;
-	}
-	private void InputUnfocus()
-	{
-		//disable keyboard commands while input is focused
-		UIManager.IsInputFocus = false;
-	}
-
 	public InputField SearchText()
 	{
 		return Searchtext;


### PR DESCRIPTION
### Purpose
Fixes admin windows sometimes not disabling character keyboard input when using text fields.
Fixes #5303

### Notes:
The search input field was enabling character input on each frame if that specific input field wasn't being used. The search box already uses our InputFieldFocus so that's handled already.