### PR TITLE
disables skin tone validation

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawn.cs
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawn.cs
@@ -57,11 +57,14 @@ public static class PlayerSpawn
 		var isOk = true;
 		var message = "";
 
+		//Disable this until we fix skin tone checks.
+		/*
 		if(ServerValidations.HasIllegalSkinTone(request.CharacterSettings))
 		{
 			message += " Invalid player skin tone.";
 			isOk = false;
 		}
+		*/
 
 		if(ServerValidations.HasIllegalCharacterName(request.CharacterSettings.Name))
 		{


### PR DESCRIPTION
quick PR to fix an issue where people keep getting kicked for playing dark skinned characters.
This comments out code until we figure out why it isn't working then fix it.