### PR TITLE
Fixes uplink bought items being at hiddenpos if not assigned an inventory slot

### DIFF
--- a/UnityProject/Assets/Scripts/Items/PDA/PDALogic.cs
+++ b/UnityProject/Assets/Scripts/Items/PDA/PDALogic.cs
@@ -436,7 +436,7 @@ namespace Items.PDA
 
 			if (cost > UplinkTC) return;
 
-			var result = Spawn.ServerPrefab(objectRequested);
+			var result = Spawn.ServerPrefab(objectRequested,GetComponent<Pickupable>().ItemSlot.Player.WorldPosition);
 			if (result.Successful)
 			{
 				UplinkTC -= cost;


### PR DESCRIPTION
Fixes #6761

CL: **[Fix]** Items bought in PDA uplink that can't find an ideal slot to go to will now spawn on the ground.
