### PR TITLE
Fixes pickaxes and other interactions on tiles not outside the station

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Input System/BlobMouseInputController.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/BlobMouseInputController.cs
@@ -47,7 +47,7 @@ public class BlobMouseInputController : MouseInputController
 			if (KeyboardInputManager.IsControlPressed())
 			{
 				//Place strong blob / reflective if strong blob already
-				blobPlayer.CmdTryPlaceStrongReflective(Camera.main.ScreenToWorldPoint(CommonInput.mousePosition).RoundToInt());
+				blobPlayer.CmdTryPlaceStrongReflective(MouseUtils.MouseToWorldPos().RoundToInt());
 				return;
 			}
 
@@ -61,11 +61,11 @@ public class BlobMouseInputController : MouseInputController
 			if (KeyboardInputManager.IsAltPressed())
 			{
 				//Remove blob
-				blobPlayer.CmdRemoveBlob(Camera.main.ScreenToWorldPoint(CommonInput.mousePosition).RoundToInt());
+				blobPlayer.CmdRemoveBlob(MouseUtils.MouseToWorldPos().RoundToInt());
 				return;
 			}
 
-			blobPlayer.CmdTryPlaceBlobOrAttack(Camera.main.ScreenToWorldPoint(CommonInput.mousePosition).RoundToInt());
+			blobPlayer.CmdTryPlaceBlobOrAttack(MouseUtils.MouseToWorldPos().RoundToInt());
 		}
 		else
 		{
@@ -82,22 +82,22 @@ public class BlobMouseInputController : MouseInputController
 			switch (blobConstructs)
 			{
 				case BlobConstructs.Core:
-					blobPlayer.CmdMoveCore(Camera.main.ScreenToWorldPoint(CommonInput.mousePosition).RoundToInt());
+					blobPlayer.CmdMoveCore(MouseUtils.MouseToWorldPos().RoundToInt());
 					break;
 				case BlobConstructs.Node:
-					blobPlayer.CmdTryPlaceOther(Camera.main.ScreenToWorldPoint(CommonInput.mousePosition).RoundToInt(), BlobConstructs.Node);
+					blobPlayer.CmdTryPlaceOther(MouseUtils.MouseToWorldPos().RoundToInt(), BlobConstructs.Node);
 					break;
 				case BlobConstructs.Factory:
-					blobPlayer.CmdTryPlaceOther(Camera.main.ScreenToWorldPoint(CommonInput.mousePosition).RoundToInt(), BlobConstructs.Factory);
+					blobPlayer.CmdTryPlaceOther(MouseUtils.MouseToWorldPos().RoundToInt(), BlobConstructs.Factory);
 					break;
 				case BlobConstructs.Resource:
-					blobPlayer.CmdTryPlaceOther(Camera.main.ScreenToWorldPoint(CommonInput.mousePosition).RoundToInt(), BlobConstructs.Resource);
+					blobPlayer.CmdTryPlaceOther(MouseUtils.MouseToWorldPos().RoundToInt(), BlobConstructs.Resource);
 					break;
 				case BlobConstructs.Strong:
-					blobPlayer.CmdTryPlaceStrongReflective(Camera.main.ScreenToWorldPoint(CommonInput.mousePosition).RoundToInt());
+					blobPlayer.CmdTryPlaceStrongReflective(MouseUtils.MouseToWorldPos().RoundToInt());
 					break;
 				case BlobConstructs.Reflective:
-					blobPlayer.CmdTryPlaceStrongReflective(Camera.main.ScreenToWorldPoint(CommonInput.mousePosition).RoundToInt());
+					blobPlayer.CmdTryPlaceStrongReflective(MouseUtils.MouseToWorldPos().RoundToInt());
 					break;
 				default:
 					Logger.LogError("Switch has no correct case for blob click!", Category.Blob);

--- a/UnityProject/Assets/Scripts/Core/Input System/CablePlacementVisualisation.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/CablePlacementVisualisation.cs
@@ -84,7 +84,7 @@ public class CablePlacementVisualisation : MonoBehaviour
 		if (!cablePlacementVisualisation.activeSelf) return;
 
 		// get releative mouse position
-		Vector2 releativeMousePosition = Camera.main.ScreenToWorldPoint(CommonInput.mousePosition) - cablePlacementVisualisation.transform.position;
+		Vector2 releativeMousePosition = MouseUtils.MouseToWorldPos() - cablePlacementVisualisation.transform.position;
 		// get nearest point
 		int x = Mathf.RoundToInt(releativeMousePosition.x * 2);
 		int y = 2 - Mathf.RoundToInt(releativeMousePosition.y * 2);
@@ -266,46 +266,34 @@ public class CablePlacementVisualisation : MonoBehaviour
 		if (!UIManager.IsMouseInteractionDisabled && UIManager.Hands.CurrentSlot != null)
 		{
 			// get mouse position
-			Vector3 mousePosition = Camera.main.ScreenToWorldPoint(CommonInput.mousePosition);
-			// round mouse position
-			Vector3Int roundedMousePosition = Vector3Int.RoundToInt(mousePosition);
+			var mousePosition = MouseUtils.MouseToWorldPos().RoundToInt();
 
 			// if distance is greater than interaction distance
-			if (Vector2.Distance(transform.position, (Vector3)roundedMousePosition) > PlayerScript.interactionDistance)
+			if (Vector2.Distance(transform.position, (Vector3)mousePosition) > PlayerScript.interactionDistance)
 			{
 				DisableVisualisation();
 				return;
 			}
 
 			// if position has changed and player has cable in hand
-			if (roundedMousePosition != lastMouseWordlPositionInt
-				&& Validations.HasItemTrait(UIManager.Hands.CurrentSlot.ItemObject, CommonTraits.Instance.Cable))
+			if (mousePosition != lastMouseWordlPositionInt
+			    && Validations.HasItemTrait(UIManager.Hands.CurrentSlot.ItemObject, CommonTraits.Instance.Cable))
 			{
-				lastMouseWordlPositionInt = roundedMousePosition;
+				lastMouseWordlPositionInt = mousePosition;
 
-				// get metaTileMap and top tile
-				// MetaTileMap metaTileMap = MatrixManager.AtPoint(roundedMousePosition, false).MetaTileMap;
-				// LayerTile topTile = metaTileMap.GetTile(metaTileMap.WorldToCell(mousePosition), true);
-				// *code above works only on Station matrix
-				// TODO: replace GetComponent solution with some built-in method?
+				var metaTileMap = MatrixManager.AtPoint(mousePosition, false).MetaTileMap;
+				var topTile = metaTileMap.GetTile(metaTileMap.WorldToCell(mousePosition), true);
 
-				var hit = MouseUtils.GetOrderedObjectsUnderMouse().FirstOrDefault();
-				MetaTileMap metaTileMap = hit.GetComponentInChildren<MetaTileMap>();
-				if (metaTileMap)
+				if (topTile && (topTile.LayerType == LayerType.Base || topTile.LayerType == LayerType.Underfloor))
 				{
-					LayerTile topTile = metaTileMap.GetTile(metaTileMap.WorldToCell(roundedMousePosition), true);
-					if (topTile && (topTile.LayerType == LayerType.Base || topTile.LayerType == LayerType.Underfloor))
-					{
-						// move cable placement visualisation to rounded mouse position and enable it
-						cablePlacementVisualisation.transform.position = roundedMousePosition - new Vector3(0.5f, 0.5f, 0); ;
-						cablePlacementVisualisation.SetActive(true);
-					}
-					// disable visualisation if active
-					else
-						DisableVisualisation();
+					// move cable placement visualisation to rounded mouse position and enable it
+					cablePlacementVisualisation.transform.position = mousePosition - new Vector3(0.5f, 0.5f, 0); ;
+					cablePlacementVisualisation.SetActive(true);
 				}
+				// disable visualisation if active
 				else
 					DisableVisualisation();
+
 			}
 		}
 		else

--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Interactions/AimApply.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Interactions/AimApply.cs
@@ -75,7 +75,7 @@ public class AimApply : Interaction
 			PLAYER_LAYER_MASK = LayerMask.GetMask("Players");
 		}
 
-		var targetVector = (Vector2) Camera.main.ScreenToWorldPoint(CommonInput.mousePosition) -
+		var targetVector = (Vector2) MouseUtils.MouseToWorldPos() -
 		                   (Vector2) PlayerManager.LocalPlayer.transform.position;
 		//check for self aim if target vector is sufficiently small so we can avoid raycast
 		var selfAim = false;

--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Interactions/ConnectionApply.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Interactions/ConnectionApply.cs
@@ -42,7 +42,7 @@ public class ConnectionApply : TargetedInteraction
 	public Connection WireEndB => connectionPointB;
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	/// <param name="performer">The gameobject of the player performing the drop interaction</param>
 	/// <param name="handObject">Object in the player's active hand. Null if player's hand is empty.</param>
@@ -73,8 +73,7 @@ public class ConnectionApply : TargetedInteraction
 	{
 		if (PlayerManager.LocalPlayerScript.IsGhost) return Invalid;
 
-		var targetVec = targetVector ?? Camera.main.ScreenToWorldPoint(CommonInput.mousePosition) -
-						PlayerManager.LocalPlayer.transform.position;
+		var targetVec = targetVector ?? MouseUtils.MouseToWorldPos() - PlayerManager.LocalPlayer.transform.position;
 
 		return new ConnectionApply(
 			PlayerManager.LocalPlayer,

--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Interactions/PositionalHandApply.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Interactions/PositionalHandApply.cs
@@ -62,8 +62,7 @@ public class PositionalHandApply : BodyPartTargetedInteraction
 		{
 			return Invalid;
 		}
-		var targetVec = targetVector ?? Camera.main.ScreenToWorldPoint(CommonInput.mousePosition) -
-		                PlayerManager.LocalPlayer.transform.position;
+		var targetVec = targetVector ?? MouseUtils.MouseToWorldPos() - PlayerManager.LocalPlayer.transform.position;
 		return new PositionalHandApply(PlayerManager.LocalPlayer,
 			UIManager.Hands.CurrentSlot.ItemObject,
 			targetObject,

--- a/UnityProject/Assets/Scripts/Core/Input System/MouseInputController.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/MouseInputController.cs
@@ -358,10 +358,8 @@ public class MouseInputController : MonoBehaviour
 			}
 
 			// check empty space positional hand apply
-			var posHandApply = PositionalHandApply.ByLocalPlayer(MatrixManager
-				.AtPoint(
-					(Camera.main.ScreenToWorldPoint(CommonInput.mousePosition) -
-					 PlayerManager.LocalPlayer.transform.position).RoundToInt(), false).GameObject.transform.parent.gameObject);
+			var mousePos = MouseUtils.MouseToWorldPos().RoundToInt();
+			var posHandApply = PositionalHandApply.ByLocalPlayer(MatrixManager.AtPoint(mousePos, false).GameObject.transform.parent.gameObject);
 			if (posHandApply.HandObject != null)
 			{
 				var handAppliables = posHandApply.HandObject.GetComponents<IBaseInteractable<PositionalHandApply>>()

--- a/UnityProject/Assets/Scripts/Core/Input System/MouseUtils.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/MouseUtils.cs
@@ -30,6 +30,17 @@ public static class MouseUtils
 	}
 
 	/// <summary>
+	/// orthographic cameras print their z position when using ScreenToWorldPoint()
+	/// this function is meant to set that to 0 which is the usual position of objects and tiles
+	/// </summary>
+	public static Vector3 MouseToWorldPos()
+	{
+		var worldPos = Camera.main.ScreenToWorldPoint(CommonInput.mousePosition).RoundToInt();
+		worldPos.z = 0;
+		return worldPos;
+	}
+
+	/// <summary>
 	/// Gets the game objects under the given world position, ordered so that highest item comes first.
 	///
 	/// The top-level matrix gameobject (the one with InteractableTiles) at this point is included at the end (if any of its tilemap gameobjects were at this point)
@@ -45,7 +56,6 @@ public static class MouseUtils
 	public static IEnumerable<GameObject> GetOrderedObjectsAtPoint(Vector3 worldPoint, LayerMask? layerMask = null,
 		Func<GameObject, bool> gameObjectFilter = null)
 	{
-		worldPoint.z = 0;
 		var matrix = MatrixManager.AtPoint(Vector3Int.RoundToInt(worldPoint), CustomNetworkManager.Instance._isServer)
 			.Matrix;
 		if (!matrix)
@@ -128,7 +138,7 @@ public static class MouseUtils
 	public static IEnumerable<GameObject> GetOrderedObjectsUnderMouse(LayerMask? layerMask = null,
 		Func<GameObject, bool> gameObjectFilter = null)
 	{
-		return GetOrderedObjectsAtPoint(Camera.main.ScreenToWorldPoint(CommonInput.mousePosition), layerMask,
+		return GetOrderedObjectsAtPoint(MouseToWorldPos(), layerMask,
 			gameObjectFilter);
 	}
 

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobPlayer.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobPlayer.cs
@@ -567,8 +567,6 @@ namespace Blob
 		[Command]
 		public void CmdTryPlaceBlobOrAttack(Vector3Int worldPos)
 		{
-			worldPos.z = 0;
-
 			//Whether player can click anywhere, or if when they click it treats it as if they clicked the tile they're
 			//standing on (or around since validation checks adjacent)
 			if (!clickCoords)
@@ -943,8 +941,6 @@ namespace Blob
 		[Command]
 		public void CmdTryPlaceStrongReflective(Vector3Int worldPos)
 		{
-			worldPos.z = 0;
-
 			if (!ValidateAction(worldPos)) return;
 
 			if (blobTiles.TryGetValue(worldPos, out var blob) && blob != null)
@@ -999,8 +995,6 @@ namespace Blob
 		[Command]
 		public void CmdTryPlaceOther(Vector3Int worldPos, BlobConstructs blobConstructs)
 		{
-			worldPos.z = 0;
-
 			if (!ValidateAction(worldPos)) return;
 
 			if (MatrixManager.IsSpaceAt(worldPos, true))
@@ -1124,8 +1118,6 @@ namespace Blob
 		[Command]
 		public void CmdRemoveBlob(Vector3Int worldPos)
 		{
-			worldPos.z = 0;
-
 			InternalRemoveBlob(worldPos);
 		}
 
@@ -1290,8 +1282,6 @@ namespace Blob
 		[Command]
 		public void CmdMoveCore(Vector3Int worldPos)
 		{
-			worldPos.z = 0;
-
 			if (blobTiles.TryGetValue(worldPos, out var blob) && blob != null)
 			{
 				SwitchCore(blob);

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
@@ -444,7 +444,7 @@ public class InteractableTiles : MonoBehaviour, IClientInteractable<PositionalHa
 		var wallMount = CheckWallMountOverlay();
 		if (wallMount)
 		{
-			Vector2 cameraPos = Camera.main.ScreenToWorldPoint(CommonInput.mousePosition);
+			Vector2 cameraPos = MouseUtils.MouseToWorldPos();
 			var tilePos = cameraPos.RoundToInt();
 			OrientationEnum orientation = OrientationEnum.Down;
 			Vector3Int PlaceDirection = PlayerManager.LocalPlayerScript.WorldPos - tilePos;

--- a/UnityProject/Assets/Scripts/UI/Core/RightClick/RightClickManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/RightClick/RightClickManager.cs
@@ -185,8 +185,7 @@ public class RightClickManager : MonoBehaviour
 			return null;
 		}
 
-		var position = Camera.main.ScreenToWorldPoint(mousePosition);
-		position.z = 0f;
+		var position = MouseUtils.MouseToWorldPos();
 		var objects = UITileList.GetItemsAtPosition(position);
 
 		//special case, remove wallmounts that are transparent

--- a/UnityProject/Assets/Scripts/UI/Objects/Engineering/Cable/LoadCableCuttingWindow.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Engineering/Cable/LoadCableCuttingWindow.cs
@@ -78,7 +78,7 @@ public class LoadCableCuttingWindow : MonoBehaviour
 	public void OpenCableCuttingWindow()
 	{
 		// get mouse position
-		Vector3 mousePosition = Camera.main.ScreenToWorldPoint(CommonInput.mousePosition);
+		Vector3 mousePosition = MouseUtils.MouseToWorldPos();
 		// round mouse position
 		Vector3Int roundedMousePosition = Vector3Int.RoundToInt(mousePosition);
 		targetWorldPosition = roundedMousePosition;

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/DevSpawnerListItemController.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/DevSpawnerListItemController.cs
@@ -70,7 +70,7 @@ public class DevSpawnerListItemController : MonoBehaviour
 	{
 		if (selectedItem == this)
 		{
-			cursorObject.transform.position = Camera.main.ScreenToWorldPoint(CommonInput.mousePosition);
+			cursorObject.transform.position = MouseUtils.MouseToWorldPos();
 			if (CommonInput.GetMouseButtonDown(0))
 			{
 				//Ignore spawn if pointer is hovering over GUI
@@ -181,7 +181,6 @@ public class DevSpawnerListItemController : MonoBehaviour
 	private void TrySpawn()
 	{
 		Vector3Int position = cursorObject.transform.position.RoundToInt();
-		position.z = 0;
 
 		if (CustomNetworkManager.IsServer)
 		{

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/GUI_DevCloner.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/GUI_DevCloner.cs
@@ -190,11 +190,10 @@ public class GUI_DevCloner : MonoBehaviour
 		}
 		else if (state == State.DRAWING)
 		{
-			cursorObject.transform.position = Camera.main.ScreenToWorldPoint(CommonInput.mousePosition);
+			cursorObject.transform.position = MouseUtils.MouseToWorldPos();
 			if (CommonInput.GetMouseButtonDown(0))
 			{
 				Vector3Int position = cursorObject.transform.position.RoundToInt();
-				position.z = 0;
 				if (MatrixManager.IsPassableAtAllMatricesOneTile(position, false))
 				{
 					if (CustomNetworkManager.IsServer)

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/GUI_DevSelectVVTile.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/GUI_DevSelectVVTile.cs
@@ -103,7 +103,7 @@ public class GUI_DevSelectVVTile : MonoBehaviour
 			}
 			if (CommonInput.GetMouseButtonDown(0))
 			{
-				RequestToViewObjectsAtTile.Send(Camera.main.ScreenToWorldPoint(CommonInput.mousePosition),
+				RequestToViewObjectsAtTile.Send(MouseUtils.MouseToWorldPos(),
 					ServerData.UserID, PlayerList.Instance.AdminToken);
 				OnEscape();
 			}

--- a/UnityProject/Assets/Scripts/Variable Viewer/BookViewer/VariableViewer.cs
+++ b/UnityProject/Assets/Scripts/Variable Viewer/BookViewer/VariableViewer.cs
@@ -19,7 +19,6 @@ public static class VariableViewer
 {
 	public static void ProcessTile(Vector3 Location, GameObject WhoBy)
 	{
-		Location.z = 0f;
 		Vector3Int worldPosInt = Location.To2Int().To3Int();
 		Matrix matrix = MatrixManager.AtPoint(worldPosInt, true).Matrix;
 


### PR DESCRIPTION
### Purpose
Fixes pickaxes and other interactions on tiles not working in non-station matrixes.
Adds a MouseToWorld() function to MouseUtils that returns the world position of the mouse location making sure that Z is set to 0 to be able to use it on MetaTileMap systems.
Replaces all parts in the project that manually set their Z mousepos to 0 to make them use this new function.

### Notes
When clicking on an asteroid tile, the position used had the camera Z's -1. Due to this, the matrix returned was the station as it's the default when nothing can be found. When checking if the station's matrix has a mineable wall at the position clicked, there was nothing and it failed.