### PR TITLE
Adds in burn damage, Ashing and a small upgrade to advanced health scanners.

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Implants/HumanLimb.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/HumanLimb.prefab
@@ -25,6 +25,12 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1340275603506720484, guid: e241039a7933eb347bd1a9bb67a9078a,
+        type: 3}
+      propertyPath: ashPrefab
+      value: 
+      objectReference: {fileID: 2957035178188790827, guid: 9ac6968a3f3ed54428662c9aae5a4b32,
+        type: 3}
     - target: {fileID: 1673759363237950006, guid: e241039a7933eb347bd1a9bb67a9078a,
         type: 3}
       propertyPath: BodyPartItemSprite

--- a/UnityProject/Assets/Prefabs/Items/Implants/Implant.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Implant.prefab
@@ -26,12 +26,16 @@ MonoBehaviour:
   RelatedPresentSprites: []
   SpritePrefab: {fileID: 8495837738996047739, guid: 7f846789e62ac004499611e9c1417efa,
     type: 3}
+  BodyPartItemSprite: {fileID: 0}
+  BodyPartItemInheritsSkinColor: 0
   BodySpriteSet: 0
   LobbyCustomisation: {fileID: 0}
   optionalOrgans: []
   OptionalReplacementOrgan: []
   IsSurface: 0
+  DeathOnRemoval: 0
   ClothingHide: 0
+  Tone: {r: 1, g: 1, b: 1, a: 1}
   efficiency: 1
   TotalModified: 1
   SurgeryProcedureBase: []
@@ -58,6 +62,7 @@ MonoBehaviour:
     Acid: 0
     Magic: 0
     Bio: 0
+    DismembermentProtectionChance: 0
   SubOrganBodyPartArmour:
     Melee: 100
     Bullet: 90
@@ -69,11 +74,25 @@ MonoBehaviour:
     Acid: 100
     Magic: 100
     Bio: 0
+    DismembermentProtectionChance: 0
   SubOrganDamageIncreasePoint: 50
   DamageContributesToOverallHealth: 1
   DamageEfficiencyMultiplier: 1
   maxHealth: 100
   Severity: 50
+  DamageThreshold: 18
+  GibsOnSeverityLevel: 150
+  GibChance: 0.15
+  BodyPartStorageContentsSpillOutOnCutSize: 3
+  BodyPartSlashLogicOnCutSize: 1
+  BodyPartDisembowelLogicOnCutSize: 2
+  spillChanceWhenCutPresent: 0.5
+  CanBleedInternally: 0
+  CanBleedExternally: 0
+  MinMaxInternalBleedingValues: {x: 5, y: 20}
+  maximumInternalBleedDamage: 100
+  bodyPartColorWhenCharred: {r: 0, g: 0, b: 0, a: 1}
+  bodyPartAshesAboveThisDamage: 125
 --- !u!114 &2719098251223779414
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -97,6 +116,8 @@ MonoBehaviour:
   Populater:
     MergeMode: 0
     Contents: []
+  ashPrefab: {fileID: 2957035178188790827, guid: 9ac6968a3f3ed54428662c9aae5a4b32,
+    type: 3}
 --- !u!114 &8113072997116454967
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -120,6 +141,7 @@ MonoBehaviour:
   maxCapacity: 0.5
   reactionSet: {fileID: 11400000, guid: 9635f48a9fe17f742aee13832a4ed6c2, type: 2}
   AdditionalReactions: []
+  canPourOut: 1
   initialReagentMix:
     temperature: 273.15
     reagents:

--- a/UnityProject/Assets/Prefabs/Items/Implants/Lizard/Frills.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Lizard/Frills.prefab
@@ -127,6 +127,11 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 145
+      objectReference: {fileID: 0}
+    - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
       propertyPath: BodyPartItemInheritsSkinColor
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Lizard/Hornes.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Lizard/Hornes.prefab
@@ -122,6 +122,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 145
+      objectReference: {fileID: 0}
+    - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
       propertyPath: BodyTypesSprites.BodyTypes.Array.size
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Lizard/HumanChest Variant 2.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Lizard/HumanChest Variant 2.prefab
@@ -35,6 +35,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5445495118236055813, guid: cc032f91cda505e44b066c36db32760d,
         type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 145
+      objectReference: {fileID: 0}
+    - target: {fileID: 5445495118236055813, guid: cc032f91cda505e44b066c36db32760d,
+        type: 3}
       propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[0]
       value: 
       objectReference: {fileID: 11400000, guid: 66791af9bc1d52a4dbf346d6aa386d1e,

--- a/UnityProject/Assets/Prefabs/Items/Implants/Lizard/HumanHead Variant 2.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Lizard/HumanHead Variant 2.prefab
@@ -20,6 +20,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6597352703958914049, guid: 78253771c2047f94c9ae40161a6be7ee,
         type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 145
+      objectReference: {fileID: 0}
+    - target: {fileID: 6597352703958914049, guid: 78253771c2047f94c9ae40161a6be7ee,
+        type: 3}
       propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[0]
       value: 
       objectReference: {fileID: 11400000, guid: 93cc56c549d8bcd48990dd32f3295b61,

--- a/UnityProject/Assets/Prefabs/Items/Implants/Lizard/HumanLeftArm Variant 2.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Lizard/HumanLeftArm Variant 2.prefab
@@ -95,6 +95,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2934630090728222927, guid: 719377fefb0114b448fc6ca9f7a5a6df,
         type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 145
+      objectReference: {fileID: 0}
+    - target: {fileID: 2934630090728222927, guid: 719377fefb0114b448fc6ca9f7a5a6df,
+        type: 3}
       propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[0]
       value: 
       objectReference: {fileID: 11400000, guid: 2371767b78363464c902953217c61d3f,

--- a/UnityProject/Assets/Prefabs/Items/Implants/Lizard/HumanLeftLeg Variant 2.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Lizard/HumanLeftLeg Variant 2.prefab
@@ -14,6 +14,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1544594378003915950, guid: 2e6f2ff9beb985749940d242877d84f0,
         type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 145
+      objectReference: {fileID: 0}
+    - target: {fileID: 1544594378003915950, guid: 2e6f2ff9beb985749940d242877d84f0,
+        type: 3}
       propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[0]
       value: 
       objectReference: {fileID: 11400000, guid: 8cda47cca77fdd844aff26e911f13f31,

--- a/UnityProject/Assets/Prefabs/Items/Implants/Lizard/HumanRightArm Variant 2.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Lizard/HumanRightArm Variant 2.prefab
@@ -32,6 +32,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6313817628243374210, guid: ba9a875c31908af4ab3749cd127a2edb,
         type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 145
+      objectReference: {fileID: 0}
+    - target: {fileID: 6313817628243374210, guid: ba9a875c31908af4ab3749cd127a2edb,
+        type: 3}
       propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[0]
       value: 
       objectReference: {fileID: 11400000, guid: aa188067080aaec42946935a7411dc5c,

--- a/UnityProject/Assets/Prefabs/Items/Implants/Lizard/HumanRightLeg Variant 2.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Lizard/HumanRightLeg Variant 2.prefab
@@ -107,6 +107,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
         type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 145
+      objectReference: {fileID: 0}
+    - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
+        type: 3}
       propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[0]
       value: 
       objectReference: {fileID: 11400000, guid: 1eea53d9d708d2841a280bbc4075f7c4,

--- a/UnityProject/Assets/Prefabs/Items/Implants/Lizard/LizardSnout.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Lizard/LizardSnout.prefab
@@ -117,6 +117,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 145
+      objectReference: {fileID: 0}
+    - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
       propertyPath: BodyTypesSprites.BodyTypes.Array.size
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Lizard/LizardTail.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Lizard/LizardTail.prefab
@@ -20,6 +20,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4990853901509658031, guid: b87ebcdea6fb0dd49b0fbcf1b308c159,
         type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 145
+      objectReference: {fileID: 0}
+    - target: {fileID: 4990853901509658031, guid: b87ebcdea6fb0dd49b0fbcf1b308c159,
+        type: 3}
       propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[0]
       value: 
       objectReference: {fileID: 11400000, guid: e7262018d6d537a428d9e7f88f362630,

--- a/UnityProject/Assets/Prefabs/Items/Implants/Lizard/Spikes.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Lizard/Spikes.prefab
@@ -117,6 +117,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 145
+      objectReference: {fileID: 0}
+    - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
       propertyPath: BodyPartItemInheritsSkinColor
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothAntennae.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothAntennae.prefab
@@ -15,6 +15,11 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 2282787501680206576, guid: 2cdfee5611d505240ab3835c94a38fa8,
         type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 2282787501680206576, guid: 2cdfee5611d505240ab3835c94a38fa8,
+        type: 3}
       propertyPath: BodyTypesSprites.BodyTypes.Array.size
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothChest.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothChest.prefab
@@ -40,6 +40,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5445495118236055813, guid: cc032f91cda505e44b066c36db32760d,
         type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 5445495118236055813, guid: cc032f91cda505e44b066c36db32760d,
+        type: 3}
       propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[0]
       value: 
       objectReference: {fileID: 11400000, guid: 53baadb2a9c8cb84e9f7e46149768d7b,

--- a/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothHead.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothHead.prefab
@@ -20,6 +20,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6597352703958914049, guid: 78253771c2047f94c9ae40161a6be7ee,
         type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 6597352703958914049, guid: 78253771c2047f94c9ae40161a6be7ee,
+        type: 3}
       propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[0]
       value: 
       objectReference: {fileID: 11400000, guid: 54f907947611e464097072d8f8a17b94,

--- a/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothLeftArm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothLeftArm.prefab
@@ -100,6 +100,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2934630090728222927, guid: 719377fefb0114b448fc6ca9f7a5a6df,
         type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 2934630090728222927, guid: 719377fefb0114b448fc6ca9f7a5a6df,
+        type: 3}
       propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[0]
       value: 
       objectReference: {fileID: 11400000, guid: 7b6257530324e1c40b6fe34a0f8f1957,

--- a/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothLeftLeg.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothLeftLeg.prefab
@@ -14,6 +14,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1544594378003915950, guid: 2e6f2ff9beb985749940d242877d84f0,
         type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 1544594378003915950, guid: 2e6f2ff9beb985749940d242877d84f0,
+        type: 3}
       propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[0]
       value: 
       objectReference: {fileID: 11400000, guid: c9191e040f023ed4fb5eb384a338f1b1,

--- a/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothMarkings.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothMarkings.prefab
@@ -83,5 +83,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 7311007552350428261, guid: 1cdb6616b987ef0489edf7a59858a221,
         type: 3}
+    - target: {fileID: 2378934203328871246, guid: 1ce21cfcc54d23d42825f0d4a9b15d49,
+        type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 100
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1ce21cfcc54d23d42825f0d4a9b15d49, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothRightArm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothRightArm.prefab
@@ -32,6 +32,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6313817628243374210, guid: ba9a875c31908af4ab3749cd127a2edb,
         type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 6313817628243374210, guid: ba9a875c31908af4ab3749cd127a2edb,
+        type: 3}
       propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[0]
       value: 
       objectReference: {fileID: 11400000, guid: 7897d6389c487ff4da3c05718d54bae2,

--- a/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothRightLeg.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothRightLeg.prefab
@@ -107,6 +107,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
         type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
+        type: 3}
       propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[0]
       value: 
       objectReference: {fileID: 11400000, guid: db13675458d4d8f4b976bae15bab15c5,

--- a/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothWings.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothWings.prefab
@@ -26,6 +26,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5688082005075186663, guid: d243d9aff97ede04581d82563a576f0c,
         type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 5688082005075186663, guid: d243d9aff97ede04581d82563a576f0c,
+        type: 3}
       propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[0]
       value: 
       objectReference: {fileID: 11400000, guid: 1b5f00f4d05e87e4490435ab9702e11d,

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/Bones.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/Bones.prefab
@@ -123,6 +123,11 @@ PrefabInstance:
       propertyPath: BodyPartType
       value: -1
       objectReference: {fileID: 0}
+    - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
+      propertyPath: BodyPartReadableName
+      value: Bone
+      objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: -4791504671035111961, guid: 35ef0ee8523cfc342bc863c12a3ac07c, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 35ef0ee8523cfc342bc863c12a3ac07c, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/Brain.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/Brain.prefab
@@ -169,6 +169,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
+      propertyPath: BodyPartReadableName
+      value: Brain
+      objectReference: {fileID: 0}
+    - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
       propertyPath: MinMaxInternalBleedingValues.x
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/Ears.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/Ears.prefab
@@ -112,6 +112,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
+      propertyPath: BodyPartReadableName
+      value: Ears
+      objectReference: {fileID: 0}
+    - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
       propertyPath: MinMaxInternalBleedingValues.x
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/Eyes.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/Eyes.prefab
@@ -128,6 +128,11 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
+      propertyPath: BodyPartReadableName
+      value: Eyes
+      objectReference: {fileID: 0}
+    - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
       propertyPath: NutrimentConsumption
       value: 0.002
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/Facial Hair.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/Facial Hair.prefab
@@ -36,6 +36,11 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 1723238164438836345, guid: 6c6b9b73c0bb8d14c9329b24820e0a9a,
         type: 3}
+      propertyPath: BodyPartReadableName
+      value: Facial Hair
+      objectReference: {fileID: 0}
+    - target: {fileID: 1723238164438836345, guid: 6c6b9b73c0bb8d14c9329b24820e0a9a,
+        type: 3}
       propertyPath: isBloodReagentConsumed
       value: 0
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/Hair.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/Hair.prefab
@@ -133,6 +133,11 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
+      propertyPath: BodyPartReadableName
+      value: Hair
+      objectReference: {fileID: 0}
+    - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
       propertyPath: isBloodReagentConsumed
       value: 0
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/Human Heart.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/Human Heart.prefab
@@ -145,6 +145,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
+      propertyPath: BodyPartReadableName
+      value: Heart
+      objectReference: {fileID: 0}
+    - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
       propertyPath: MinMaxInternalBleedingValues.x
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/Human Lungs.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/Human Lungs.prefab
@@ -143,6 +143,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
+      propertyPath: BodyPartReadableName
+      value: Lungs
+      objectReference: {fileID: 0}
+    - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
       propertyPath: maximumInternalBleedDamage
       value: 165
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/Human Stomach.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/Human Stomach.prefab
@@ -40,6 +40,7 @@ MonoBehaviour:
   maxCapacity: 100
   reactionSet: {fileID: 0}
   AdditionalReactions: []
+  canPourOut: 1
   initialReagentMix:
     temperature: 273.15
     reagents:
@@ -161,6 +162,11 @@ PrefabInstance:
         type: 3}
       propertyPath: CanBleedInternally
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
+      propertyPath: BodyPartReadableName
+      value: Stomach
       objectReference: {fileID: 0}
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanFat.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanFat.prefab
@@ -135,6 +135,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
+      propertyPath: BodyPartReadableName
+      value: Fat
+      objectReference: {fileID: 0}
+    - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
       propertyPath: MinMaxInternalBleedingValues.x
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanHead.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanHead.prefab
@@ -85,6 +85,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1673759363237950006, guid: e241039a7933eb347bd1a9bb67a9078a,
         type: 3}
+      propertyPath: BodyPartReadableName
+      value: Head
+      objectReference: {fileID: 0}
+    - target: {fileID: 1673759363237950006, guid: e241039a7933eb347bd1a9bb67a9078a,
+        type: 3}
       propertyPath: maleSprite.Array.size
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanLeftArm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanLeftArm.prefab
@@ -1,21 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-1360619806965098635
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1766215212362074963}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d3a4d93919206aa40bad0e7a3e0bb835, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  LivingHealthMasterBase: {fileID: 0}
-  InitiateSurgeryItemTraits: []
 --- !u!1001 &9162231676926722125
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -288,9 +272,3 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: ba9a875c31908af4ab3749cd127a2edb, type: 3}
---- !u!1 &1766215212362074963 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7468114191605762846, guid: ba9a875c31908af4ab3749cd127a2edb,
-    type: 3}
-  m_PrefabInstance: {fileID: 9162231676926722125}
-  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanLeftArm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanLeftArm.prefab
@@ -1,5 +1,21 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-1360619806965098635
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1766215212362074963}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d3a4d93919206aa40bad0e7a3e0bb835, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  LivingHealthMasterBase: {fileID: 0}
+  InitiateSurgeryItemTraits: []
 --- !u!1001 &9162231676926722125
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -269,5 +285,12 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: ba9a875c31908af4ab3749cd127a2edb, type: 3}
+--- !u!1 &1766215212362074963 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7468114191605762846, guid: ba9a875c31908af4ab3749cd127a2edb,
+    type: 3}
+  m_PrefabInstance: {fileID: 9162231676926722125}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanLeftLeg.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanLeftLeg.prefab
@@ -1,21 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-5590053673681855753
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2689983249500970802}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d3a4d93919206aa40bad0e7a3e0bb835, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  LivingHealthMasterBase: {fileID: 0}
-  InitiateSurgeryItemTraits: []
 --- !u!1001 &9185682862828390235
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -255,9 +239,3 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: 51326f2264a075148a8aaa6bf95604c7, type: 3}
---- !u!1 &2689983249500970802 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 6498312071342856297, guid: 51326f2264a075148a8aaa6bf95604c7,
-    type: 3}
-  m_PrefabInstance: {fileID: 9185682862828390235}
-  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanLeftLeg.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanLeftLeg.prefab
@@ -208,7 +208,7 @@ PrefabInstance:
     - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
         type: 3}
       propertyPath: bodyPartAshesAboveThisDamage
-      value: 10
+      value: 125
       objectReference: {fileID: 0}
     - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanLeftLeg.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanLeftLeg.prefab
@@ -1,5 +1,21 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-5590053673681855753
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2689983249500970802}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d3a4d93919206aa40bad0e7a3e0bb835, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  LivingHealthMasterBase: {fileID: 0}
+  InitiateSurgeryItemTraits: []
 --- !u!1001 &9185682862828390235
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -166,6 +182,36 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
         type: 3}
+      propertyPath: bodyPartColorWhenCharred.a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.b
+      value: 0.00591848
+      objectReference: {fileID: 0}
+    - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.g
+      value: 0.00591848
+      objectReference: {fileID: 0}
+    - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.r
+      value: 0.1792453
+      objectReference: {fileID: 0}
+    - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
+        type: 3}
+      propertyPath: SubOrganBodyPartArmour.Fire
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
+        type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
+        type: 3}
       propertyPath: MinMaxInternalBleedingValues.x
       value: 1
       objectReference: {fileID: 0}
@@ -200,5 +246,18 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 017d1b29096f3444ca19a41866459176,
         type: 2}
-    m_RemovedComponents: []
+    - target: {fileID: 8049734946158378791, guid: 51326f2264a075148a8aaa6bf95604c7,
+        type: 3}
+      propertyPath: ashPrefab
+      value: 
+      objectReference: {fileID: 2957035178188790827, guid: 9ac6968a3f3ed54428662c9aae5a4b32,
+        type: 3}
+    m_RemovedComponents:
+    - {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: 51326f2264a075148a8aaa6bf95604c7, type: 3}
+--- !u!1 &2689983249500970802 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6498312071342856297, guid: 51326f2264a075148a8aaa6bf95604c7,
+    type: 3}
+  m_PrefabInstance: {fileID: 9185682862828390235}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightArm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightArm.prefab
@@ -296,7 +296,7 @@ PrefabInstance:
     - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
         type: 3}
       propertyPath: bodyPartAshesAboveThisDamage
-      value: 10
+      value: 125
       objectReference: {fileID: 0}
     - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightArm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightArm.prefab
@@ -270,6 +270,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
         type: 3}
+      propertyPath: BodyPartReadableName
+      value: Arm
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
+        type: 3}
       propertyPath: bodyPartColorWhenCharred.a
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightArm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightArm.prefab
@@ -242,6 +242,12 @@ PrefabInstance:
       propertyPath: m_WasSpriteAssigned
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 6999556221578282813, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
+        type: 3}
+      propertyPath: ashPrefab
+      value: 
+      objectReference: {fileID: 2957035178188790827, guid: 9ac6968a3f3ed54428662c9aae5a4b32,
+        type: 3}
     - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
         type: 3}
       propertyPath: IsSurface
@@ -261,6 +267,36 @@ PrefabInstance:
         type: 3}
       propertyPath: GibsOnSeverityLevel
       value: 125
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.b
+      value: 0.00591848
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.g
+      value: 0.00591848
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.r
+      value: 0.1792453
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
+        type: 3}
+      propertyPath: SubOrganBodyPartArmour.Fire
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
+        type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightLeg.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightLeg.prefab
@@ -239,6 +239,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
         type: 3}
+      propertyPath: BodyPartReadableName
+      value: Leg
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
+        type: 3}
       propertyPath: bodyPartColorWhenCharred.a
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightLeg.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightLeg.prefab
@@ -265,7 +265,7 @@ PrefabInstance:
     - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
         type: 3}
       propertyPath: bodyPartAshesAboveThisDamage
-      value: 10
+      value: 125
       objectReference: {fileID: 0}
     - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightLeg.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightLeg.prefab
@@ -216,6 +216,12 @@ PrefabInstance:
       propertyPath: m_WasSpriteAssigned
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 6999556221578282813, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
+        type: 3}
+      propertyPath: ashPrefab
+      value: 
+      objectReference: {fileID: 2957035178188790827, guid: 9ac6968a3f3ed54428662c9aae5a4b32,
+        type: 3}
     - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
         type: 3}
       propertyPath: IsSurface
@@ -230,6 +236,36 @@ PrefabInstance:
         type: 3}
       propertyPath: CanBleedExternally
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.b
+      value: 0.00591848
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.g
+      value: 0.00591848
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.r
+      value: 0.1792453
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
+        type: 3}
+      propertyPath: SubOrganBodyPartArmour.Fire
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
+        type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanTorso.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanTorso.prefab
@@ -9,6 +9,12 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1340275603506720484, guid: e241039a7933eb347bd1a9bb67a9078a,
         type: 3}
+      propertyPath: ashPrefab
+      value: 
+      objectReference: {fileID: 2957035178188790827, guid: 9ac6968a3f3ed54428662c9aae5a4b32,
+        type: 3}
+    - target: {fileID: 1340275603506720484, guid: e241039a7933eb347bd1a9bb67a9078a,
+        type: 3}
       propertyPath: UesAddlistPopulater
       value: 1
       objectReference: {fileID: 0}
@@ -122,6 +128,26 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1673759363237950006, guid: e241039a7933eb347bd1a9bb67a9078a,
         type: 3}
+      propertyPath: bodyPartColorWhenCharred.a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1673759363237950006, guid: e241039a7933eb347bd1a9bb67a9078a,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.b
+      value: 0.00591848
+      objectReference: {fileID: 0}
+    - target: {fileID: 1673759363237950006, guid: e241039a7933eb347bd1a9bb67a9078a,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.g
+      value: 0.00591848
+      objectReference: {fileID: 0}
+    - target: {fileID: 1673759363237950006, guid: e241039a7933eb347bd1a9bb67a9078a,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.r
+      value: 0.1792453
+      objectReference: {fileID: 0}
+    - target: {fileID: 1673759363237950006, guid: e241039a7933eb347bd1a9bb67a9078a,
+        type: 3}
       propertyPath: femaleSprite.Array.data[0]
       value: 
       objectReference: {fileID: 11400000, guid: ccfebde2cc0de824b80261ac774928d7,
@@ -130,6 +156,16 @@ PrefabInstance:
         type: 3}
       propertyPath: OpenSurgerySteps.Array.size
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1673759363237950006, guid: e241039a7933eb347bd1a9bb67a9078a,
+        type: 3}
+      propertyPath: SubOrganBodyPartArmour.Fire
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1673759363237950006, guid: e241039a7933eb347bd1a9bb67a9078a,
+        type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 1673759363237950006, guid: e241039a7933eb347bd1a9bb67a9078a,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanTorso.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanTorso.prefab
@@ -107,6 +107,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1673759363237950006, guid: e241039a7933eb347bd1a9bb67a9078a,
         type: 3}
+      propertyPath: BodyPartReadableName
+      value: Torso
+      objectReference: {fileID: 0}
+    - target: {fileID: 1673759363237950006, guid: e241039a7933eb347bd1a9bb67a9078a,
+        type: 3}
       propertyPath: maleSprite.Array.size
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanTorso.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanTorso.prefab
@@ -165,7 +165,7 @@ PrefabInstance:
     - target: {fileID: 1673759363237950006, guid: e241039a7933eb347bd1a9bb67a9078a,
         type: 3}
       propertyPath: bodyPartAshesAboveThisDamage
-      value: 10
+      value: 125
       objectReference: {fileID: 0}
     - target: {fileID: 1673759363237950006, guid: e241039a7933eb347bd1a9bb67a9078a,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/Kidneys.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/Kidneys.prefab
@@ -129,6 +129,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
+      propertyPath: BodyPartReadableName
+      value: Kidneys
+      objectReference: {fileID: 0}
+    - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
       propertyPath: MinMaxInternalBleedingValues.x
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/Liver.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/Liver.prefab
@@ -127,6 +127,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
+      propertyPath: BodyPartReadableName
+      value: Liver
+      objectReference: {fileID: 0}
+    - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
       propertyPath: MinMaxInternalBleedingValues.x
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/Organ.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/Organ.prefab
@@ -138,6 +138,12 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 3a60d21cb4e18b14ba0387530f2dccd5,
         type: 2}
+    - target: {fileID: 2719098251223779414, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: ashPrefab
+      value: 
+      objectReference: {fileID: 2957035178188790827, guid: 9ac6968a3f3ed54428662c9aae5a4b32,
+        type: 3}
     - target: {fileID: 8113072997116454967, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
       propertyPath: maxCapacity

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/_TailBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/_TailBase.prefab
@@ -15,6 +15,11 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 2282787501680206576, guid: 2cdfee5611d505240ab3835c94a38fa8,
         type: 3}
+      propertyPath: BodyPartReadableName
+      value: Tail
+      objectReference: {fileID: 0}
+    - target: {fileID: 2282787501680206576, guid: 2cdfee5611d505240ab3835c94a38fa8,
+        type: 3}
       propertyPath: BodyTypesSprites.BodyTypes.Array.size
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanChest Variant 1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanChest Variant 1.prefab
@@ -25,6 +25,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5445495118236055813, guid: cc032f91cda505e44b066c36db32760d,
         type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5445495118236055813, guid: cc032f91cda505e44b066c36db32760d,
+        type: 3}
       propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[0]
       value: 
       objectReference: {fileID: 11400000, guid: 53baadb2a9c8cb84e9f7e46149768d7b,

--- a/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanChest Variant 1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanChest Variant 1.prefab
@@ -26,7 +26,7 @@ PrefabInstance:
     - target: {fileID: 5445495118236055813, guid: cc032f91cda505e44b066c36db32760d,
         type: 3}
       propertyPath: bodyPartAshesAboveThisDamage
-      value: 10
+      value: 125
       objectReference: {fileID: 0}
     - target: {fileID: 5445495118236055813, guid: cc032f91cda505e44b066c36db32760d,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanHead Variant 1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanHead Variant 1.prefab
@@ -20,6 +20,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6597352703958914049, guid: 78253771c2047f94c9ae40161a6be7ee,
         type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6597352703958914049, guid: 78253771c2047f94c9ae40161a6be7ee,
+        type: 3}
       propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[0]
       value: 
       objectReference: {fileID: 11400000, guid: 54f907947611e464097072d8f8a17b94,
@@ -36,6 +41,12 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 01d04197cc9bcc24ba9f0d382c63e4af,
         type: 2}
+    - target: {fileID: 6786220533655849171, guid: 78253771c2047f94c9ae40161a6be7ee,
+        type: 3}
+      propertyPath: ashPrefab
+      value: 
+      objectReference: {fileID: 2957035178188790827, guid: 9ac6968a3f3ed54428662c9aae5a4b32,
+        type: 3}
     - target: {fileID: 6786220533655849171, guid: 78253771c2047f94c9ae40161a6be7ee,
         type: 3}
       propertyPath: Populater.Contents.Array.size

--- a/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanHead Variant 1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanHead Variant 1.prefab
@@ -21,7 +21,7 @@ PrefabInstance:
     - target: {fileID: 6597352703958914049, guid: 78253771c2047f94c9ae40161a6be7ee,
         type: 3}
       propertyPath: bodyPartAshesAboveThisDamage
-      value: 10
+      value: 125
       objectReference: {fileID: 0}
     - target: {fileID: 6597352703958914049, guid: 78253771c2047f94c9ae40161a6be7ee,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanLeftArm Variant 1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanLeftArm Variant 1.prefab
@@ -121,5 +121,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 0723fa5ca6e0e044989622682154ea0a,
         type: 2}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: -1360619806965098635, guid: 719377fefb0114b448fc6ca9f7a5a6df, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 719377fefb0114b448fc6ca9f7a5a6df, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanLeftArm Variant 1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanLeftArm Variant 1.prefab
@@ -83,6 +83,26 @@ PrefabInstance:
       propertyPath: CanBleedExternally
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 2934630090728222927, guid: 719377fefb0114b448fc6ca9f7a5a6df,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.b
+      value: 0.08859915
+      objectReference: {fileID: 0}
+    - target: {fileID: 2934630090728222927, guid: 719377fefb0114b448fc6ca9f7a5a6df,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.g
+      value: 0.08859915
+      objectReference: {fileID: 0}
+    - target: {fileID: 2934630090728222927, guid: 719377fefb0114b448fc6ca9f7a5a6df,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.r
+      value: 0.103773594
+      objectReference: {fileID: 0}
+    - target: {fileID: 2934630090728222927, guid: 719377fefb0114b448fc6ca9f7a5a6df,
+        type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 5603819714738991316, guid: 719377fefb0114b448fc6ca9f7a5a6df,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanLeftArm Variant 1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanLeftArm Variant 1.prefab
@@ -101,7 +101,7 @@ PrefabInstance:
     - target: {fileID: 2934630090728222927, guid: 719377fefb0114b448fc6ca9f7a5a6df,
         type: 3}
       propertyPath: bodyPartAshesAboveThisDamage
-      value: 10
+      value: 125
       objectReference: {fileID: 0}
     - target: {fileID: 5603819714738991316, guid: 719377fefb0114b448fc6ca9f7a5a6df,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanLeftLeg Variant 1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanLeftLeg Variant 1.prefab
@@ -12,6 +12,26 @@ PrefabInstance:
       propertyPath: CanBleedExternally
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 1544594378003915950, guid: 2e6f2ff9beb985749940d242877d84f0,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.b
+      value: 0.08859915
+      objectReference: {fileID: 0}
+    - target: {fileID: 1544594378003915950, guid: 2e6f2ff9beb985749940d242877d84f0,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.g
+      value: 0.08859915
+      objectReference: {fileID: 0}
+    - target: {fileID: 1544594378003915950, guid: 2e6f2ff9beb985749940d242877d84f0,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.r
+      value: 0.103773594
+      objectReference: {fileID: 0}
+    - target: {fileID: 1544594378003915950, guid: 2e6f2ff9beb985749940d242877d84f0,
+        type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 2648266232423228038, guid: 2e6f2ff9beb985749940d242877d84f0,
         type: 3}
       propertyPath: m_AssetId

--- a/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanLeftLeg Variant 1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanLeftLeg Variant 1.prefab
@@ -30,7 +30,7 @@ PrefabInstance:
     - target: {fileID: 1544594378003915950, guid: 2e6f2ff9beb985749940d242877d84f0,
         type: 3}
       propertyPath: bodyPartAshesAboveThisDamage
-      value: 10
+      value: 125
       objectReference: {fileID: 0}
     - target: {fileID: 2648266232423228038, guid: 2e6f2ff9beb985749940d242877d84f0,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanRightArm Variant 1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanRightArm Variant 1.prefab
@@ -48,7 +48,7 @@ PrefabInstance:
     - target: {fileID: 6313817628243374210, guid: ba9a875c31908af4ab3749cd127a2edb,
         type: 3}
       propertyPath: bodyPartAshesAboveThisDamage
-      value: 10
+      value: 125
       objectReference: {fileID: 0}
     - target: {fileID: 7301997280600668226, guid: ba9a875c31908af4ab3749cd127a2edb,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanRightArm Variant 1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanRightArm Variant 1.prefab
@@ -30,6 +30,26 @@ PrefabInstance:
       propertyPath: CanBleedExternally
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 6313817628243374210, guid: ba9a875c31908af4ab3749cd127a2edb,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.b
+      value: 0.08859915
+      objectReference: {fileID: 0}
+    - target: {fileID: 6313817628243374210, guid: ba9a875c31908af4ab3749cd127a2edb,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.g
+      value: 0.08859915
+      objectReference: {fileID: 0}
+    - target: {fileID: 6313817628243374210, guid: ba9a875c31908af4ab3749cd127a2edb,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.r
+      value: 0.103773594
+      objectReference: {fileID: 0}
+    - target: {fileID: 6313817628243374210, guid: ba9a875c31908af4ab3749cd127a2edb,
+        type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 7301997280600668226, guid: ba9a875c31908af4ab3749cd127a2edb,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanRightLeg Variant 1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanRightLeg Variant 1.prefab
@@ -95,5 +95,25 @@ PrefabInstance:
       propertyPath: CanBleedExternally
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.b
+      value: 0.08859915
+      objectReference: {fileID: 0}
+    - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.g
+      value: 0.08859915
+      objectReference: {fileID: 0}
+    - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
+        type: 3}
+      propertyPath: bodyPartColorWhenCharred.r
+      value: 0.103773594
+      objectReference: {fileID: 0}
+    - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
+        type: 3}
+      propertyPath: bodyPartAshesAboveThisDamage
+      value: 10
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 51326f2264a075148a8aaa6bf95604c7, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanRightLeg Variant 1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanRightLeg Variant 1.prefab
@@ -113,7 +113,7 @@ PrefabInstance:
     - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
         type: 3}
       propertyPath: bodyPartAshesAboveThisDamage
-      value: 10
+      value: 125
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 51326f2264a075148a8aaa6bf95604c7, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Other/NuclearDisk.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/NuclearDisk.prefab
@@ -79,6 +79,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 114883521337486670, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
+      propertyPath: CannotBeAshed
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114883521337486670, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
       propertyPath: Resistances.Indestructable
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Other/NuclearDisk.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/NuclearDisk.prefab
@@ -120,6 +120,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
+      propertyPath: cannotBeAshed
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
       propertyPath: initialDescription
       value: Get access to the nuke.
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Other/NuclearDiskPinpointer.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/NuclearDiskPinpointer.prefab
@@ -238,6 +238,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
+      propertyPath: cannotBeAshed
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
       propertyPath: initialDescription
       value: Shows disk coordinates
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Other/ObjectiveDataDisk-Crash.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/ObjectiveDataDisk-Crash.prefab
@@ -180,6 +180,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 114883521337486670, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
+      propertyPath: CannotBeAshed
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114883521337486670, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
       propertyPath: Resistances.Indestructable
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Other/ObjectiveDataDisk-Crash.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/ObjectiveDataDisk-Crash.prefab
@@ -241,6 +241,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
+      propertyPath: cannotBeAshed
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
       propertyPath: exportMessage
       value: Congratulations, Gateway Mission successful.
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Other/ObjectiveDataDisk-MegaFauna.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/ObjectiveDataDisk-MegaFauna.prefab
@@ -226,6 +226,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 114883521337486670, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
+      propertyPath: CannotBeAshed
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114883521337486670, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
       propertyPath: Resistances.Indestructable
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Other/ObjectiveDataDisk-MegaFauna.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/ObjectiveDataDisk-MegaFauna.prefab
@@ -287,6 +287,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
+      propertyPath: cannotBeAshed
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
       propertyPath: exportMessage
       value: Congratulations, Gateway Mission successful.
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Other/ObjectiveDataDisk-Queen.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/ObjectiveDataDisk-Queen.prefab
@@ -172,6 +172,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 114883521337486670, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
+      propertyPath: CannotBeAshed
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114883521337486670, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
       propertyPath: Resistances.Indestructable
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Other/ObjectiveDataDisk-Queen.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/ObjectiveDataDisk-Queen.prefab
@@ -233,6 +233,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
+      propertyPath: cannotBeAshed
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
       propertyPath: exportMessage
       value: Congratulations, Gateway Mission successful.
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ChaplainEnergySwordLight.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ChaplainEnergySwordLight.prefab
@@ -15,6 +15,11 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 5869444691453870322, guid: 9c123336301845541830989cb9e3d606,
         type: 3}
+      propertyPath: burnDamage
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869444691453870322, guid: 9c123336301845541830989cb9e3d606,
+        type: 3}
       propertyPath: initialName
       value: light energy sword
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Resources/Scalpel.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Resources/Scalpel.prefab
@@ -20,6 +20,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5847001516606818509, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5847001516606818509, guid: 93af1c166793efb498012ddc7370f8ec,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -35,6 +40,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5847001516606818509, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5847001516606818509, guid: 93af1c166793efb498012ddc7370f8ec,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -47,16 +57,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5847001516606818509, guid: 93af1c166793efb498012ddc7370f8ec,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5847001516606818509, guid: 93af1c166793efb498012ddc7370f8ec,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5847001516606818509, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}
@@ -91,23 +91,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}
-      propertyPath: initialTraits.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
-        type: 3}
-      propertyPath: initialName
-      value: Scalpel
-      objectReference: {fileID: 0}
-    - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
-        type: 3}
-      propertyPath: initialDescription
-      value: A specialist Surgery knife, hellish sharp
-      objectReference: {fileID: 0}
-    - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
-        type: 3}
-      propertyPath: initialSize
-      value: 0
+      propertyPath: hitSound
+      value: BladeSlice
       objectReference: {fileID: 0}
     - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}
@@ -116,7 +101,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}
-      propertyPath: throwDamage
+      propertyPath: throwRange
       value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
@@ -126,13 +111,38 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}
-      propertyPath: throwRange
+      propertyPath: initialName
+      value: Scalpel
+      objectReference: {fileID: 0}
+    - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
+        type: 3}
+      propertyPath: initialSize
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
+        type: 3}
+      propertyPath: throwDamage
       value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}
-      propertyPath: hitSound
-      value: BladeSlice
+      propertyPath: initialDescription
+      value: A specialist Surgery knife, hellish sharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
+        type: 3}
+      propertyPath: hitSound.AssetAddress
+      value: Assets/Prefabs/Effects/BladeSlice.prefab
+      objectReference: {fileID: 0}
+    - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
+        type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
+        type: 3}
+      propertyPath: CanBeUsedOnSelfOnHelpIntent
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}
@@ -140,10 +150,5 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 30127bfedd67541a3afa2a5582daa98c,
         type: 2}
-    - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
-        type: 3}
-      propertyPath: hitSound.AssetAddress
-      value: Assets/Prefabs/Effects/BladeSlice.prefab
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 93af1c166793efb498012ddc7370f8ec, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Resources/SupermatterScalpel.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Resources/SupermatterScalpel.prefab
@@ -96,6 +96,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: f7a04efe5e6bebf44856e6d70b991929,
         type: 3}
+      propertyPath: CanBeUsedOnSelfOnHelpIntent
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7858931176587863443, guid: f7a04efe5e6bebf44856e6d70b991929,
+        type: 3}
       propertyPath: initialTraits.Array.data[0]
       value: 
       objectReference: {fileID: 11400000, guid: 635f2dad6ee0ce749a89253fd4a13f8f,

--- a/UnityProject/Assets/Prefabs/Objects/LiquidPipes/DepreciatedScrubber.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/LiquidPipes/DepreciatedScrubber.prefab
@@ -187,7 +187,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300096, guid: ab114164e53d9954dac5b33964df4cf3,
+      objectReference: {fileID: 21300032, guid: ab114164e53d9954dac5b33964df4cf3,
         type: 3}
     - target: {fileID: 4116897424394887774, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
+++ b/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
@@ -967,6 +967,7 @@ MonoBehaviour:
   Populater:
     MergeMode: 0
     Contents: []
+  ashPrefab: {fileID: 0}
 --- !u!114 &4171332437423579703
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7975,6 +7976,8 @@ MonoBehaviour:
   Populater:
     MergeMode: 0
     Contents: []
+  ashPrefab: {fileID: 2957035178188790827, guid: 9ac6968a3f3ed54428662c9aae5a4b32,
+    type: 3}
 --- !u!114 &1623862359695953465
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8089,6 +8092,8 @@ MonoBehaviour:
   Populater:
     MergeMode: 0
     Contents: []
+  ashPrefab: {fileID: 2957035178188790827, guid: 9ac6968a3f3ed54428662c9aae5a4b32,
+    type: 3}
 --- !u!114 &167948671899965558
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8234,6 +8239,8 @@ MonoBehaviour:
   Populater:
     MergeMode: 0
     Contents: []
+  ashPrefab: {fileID: 2957035178188790827, guid: 9ac6968a3f3ed54428662c9aae5a4b32,
+    type: 3}
 --- !u!114 &3893195702280130298
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8338,7 +8345,7 @@ SpriteRenderer:
   m_SortingLayerID: -902452607
   m_SortingLayer: 22
   m_SortingOrder: 20
-  m_Sprite: {fileID: 7660122581263827943, guid: 2adbceb9cc674484cb9a2c58b41d5493,
+  m_Sprite: {fileID: -4549444404219585148, guid: 2adbceb9cc674484cb9a2c58b41d5493,
     type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -8581,6 +8588,8 @@ MonoBehaviour:
   Populater:
     MergeMode: 0
     Contents: []
+  ashPrefab: {fileID: 2957035178188790827, guid: 9ac6968a3f3ed54428662c9aae5a4b32,
+    type: 3}
 --- !u!114 &359018724164210273
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8802,6 +8811,8 @@ MonoBehaviour:
   Populater:
     MergeMode: 0
     Contents: []
+  ashPrefab: {fileID: 2957035178188790827, guid: 9ac6968a3f3ed54428662c9aae5a4b32,
+    type: 3}
 --- !u!114 &1044408257225912275
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8916,6 +8927,8 @@ MonoBehaviour:
   Populater:
     MergeMode: 0
     Contents: []
+  ashPrefab: {fileID: 2957035178188790827, guid: 9ac6968a3f3ed54428662c9aae5a4b32,
+    type: 3}
 --- !u!114 &2073203771905383012
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -122,6 +122,8 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 
 	public float Resistance => pushable == null ? integrity : integrity * ((int)pushable.Size / 10f);
 
+	public bool CannotBeAshed = false;
+
 	private void Awake()
 	{
 		EnsureInit();

--- a/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPart.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPart.cs
@@ -140,6 +140,9 @@ namespace HealthV2
 		[Tooltip("Should clothing be hidden on this?")]
 		public ClothingHideFlags ClothingHide;
 
+		/// <summary>
+		/// What is this BodyPart's sprite's tone if it shared a skin tone with the player?
+		/// </summary>
 		[HideInInspector] public Color Tone = Color.white;
 
 		[System.NonSerialized]
@@ -303,7 +306,7 @@ namespace HealthV2
 		public virtual void RemoveFromBodyThis()
 		{
 			BodyPartRemovalChecks();
-			var parent = this.GetParent();
+			RootBodyPartContainer parent = this.GetParent();
 			if (parent != null)
 			{
 				parent.RemoveSpecifiedFromThis(this.gameObject);

--- a/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPart.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPart.cs
@@ -317,11 +317,15 @@ namespace HealthV2
 		private void BodyPartRemovalChecks()
 		{
 			//Checks if the body part is not an internal organ and if that part shares a skin tone.
-			if(IsSurface && BodyPartItemInheritsSkinColor)
+			if(IsSurface && BodyPartItemInheritsSkinColor && currentBurnDamageLevel != BurnDamageLevels.CHARRED)
 			{
 				CharacterSettings settings = HealthMaster.gameObject.Player().Script.characterSettings;
 				ColorUtility.TryParseHtmlString(settings.SkinTone, out Tone);
 				BodyPartItemSprite.SetColor(Tone);
+			}
+			if(currentBurnDamageLevel == BurnDamageLevels.CHARRED)
+			{
+				BodyPartItemSprite.SetColor(bodyPartColorWhenCharred);
 			}
 			//Fixes an error where externally bleeding body parts would continue to try bleeding even after their removal.
 			if(IsBleedingExternally)

--- a/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/RootBodyPartContainer.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/RootBodyPartContainer.cs
@@ -382,24 +382,32 @@ namespace HealthV2
 		}
 
 		/// <summary>
-		/// Applies slash damage to limbs inside of this container. Armor chance is handled inside of ApplyCutSizeLogic();
+		/// Applies slash damage to limbs inside of this container. Armor chance is handled inside of ApplyTraumaDamage();
 		/// </summary>
 		public void TakeSlashDamage(float damage)
 		{
 			foreach (var limb in ContainsLimbs)
 			{
-				limb.ApplyCutSizeLogic(damage);
+				limb.ApplyTraumaDamage(damage);
 			}
 		}
 
 		/// <summary>
-		/// Applies pierce damage to limbs inside of this container. Armor chance is handled inside of ApplyCutSizeLogic();
+		/// Applies pierce damage to limbs inside of this container. Armor chance is handled inside of ApplyTraumaDamage();
 		/// </summary>
 		public void TakePierceDamage(float damage)
 		{
 			foreach (var ContainsLimb in ContainsLimbs)
 			{
-				ContainsLimb.ApplyCutSizeLogic(damage, BodyPart.TramuticDamageTypes.PIERCE);
+				ContainsLimb.ApplyTraumaDamage(damage, BodyPart.TramuticDamageTypes.PIERCE);
+			}
+		}
+
+		public void TakeBurnDamage(float damage)
+		{
+			foreach (var ContainsLimb in ContainsLimbs)
+			{
+				ContainsLimb.ApplyTraumaDamage(damage, BodyPart.TramuticDamageTypes.BURN);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/HealthV2/Living/CirculatorySystem/CirculatorySystemBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/CirculatorySystem/CirculatorySystemBase.cs
@@ -52,7 +52,7 @@ namespace HealthV2
 		public void Bleed(float amount)
 		{
 			ReadyBloodPool.Take(amount);
-			if(amount > 12)
+			if(amount > 8)
 			{
 				EffectsFactory.BloodSplat(healthMaster.gameObject.RegisterTile().WorldPositionServer, BloodSplatSize.medium, BloodSplatType.red);
 			}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
@@ -400,6 +400,10 @@ namespace HealthV2
 					DismemberBodyPartWithChance();
 				}
 			}
+			if(attackType == AttackType.Fire)
+			{
+				TakeBurnDamage(damage);
+			}
 		}
 
 
@@ -637,13 +641,17 @@ namespace HealthV2
 			}
 		}
 
+		/// <summary>
+		/// The logic executed for when a body part is externally bleeding.
+		/// checks if bleeding stops on it's own over time.
+		/// </summary>
 		public IEnumerator ExternalBleedingLogic()
 		{
-			bool willCloseOnItsOwn = false;
 			if(isBleedingExternally)
 			{
 				yield break;
 			}
+			bool willCloseOnItsOwn = false;
 			isBleedingExternally = true;
 			StartCoroutine(Bleedout());
 			CheckCutSize();
@@ -733,6 +741,9 @@ namespace HealthV2
 			}
 		}
 
+		/// <summary>
+		/// Checks and sets what damage level this body part is on, once it becomes charred; the game displays it being charred.
+		/// </summary>
 		private void CheckBurnDamageLevels()
 		{
 			if (currentBurnDamage <= 0)
@@ -749,10 +760,25 @@ namespace HealthV2
 			}
 			if (currentBurnDamage >= 95)
 			{
+				if(currentBurnDamageLevel != BurnDamageLevels.CHARRED) //So we can do this once.
+				{
+					var spritesList = Root.ImplantBaseSpritesDictionary.Values;
+					foreach (var sprites in spritesList)
+					{
+						foreach(var sprite in sprites)
+						{
+							sprite.baseSpriteHandler.SetColor(bodyPartColorWhenCharred);
+						}
+					}
+				}
 				currentBurnDamageLevel = BurnDamageLevels.CHARRED;
 			}
 		}
 
+		/// <summary>
+		/// Returns current burn damage
+		/// </summary>
+		/// <returns>currentBurnDamage</returns>
 		public float GetCurrentBurnDamage()
 		{
 			return currentBurnDamage;

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
@@ -138,7 +138,7 @@ namespace HealthV2
 		private float currentPierceDamage   = 0;
 		private float currentBurnDamage     = 0;
 
-		[SerializeField] private float bodyPartAshesAboveThisDamage = 10;
+		[SerializeField] private float bodyPartAshesAboveThisDamage = 125;
 		public float BodyPartAshesAboveThisDamage => bodyPartAshesAboveThisDamage;
 
 		private PierceDamageLevel currentPierceDamageLevel = PierceDamageLevel.NONE;

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
@@ -131,11 +131,16 @@ namespace HealthV2
 
 		private float currentInternalBleedingDamage = 0;
 
+		[SerializeField]
+		private Color bodyPartColorWhenCharred = Color.black;
+
 		private float currentSlashCutDamage = 0;
-		private float currentPierceDamage = 0;
+		private float currentPierceDamage   = 0;
+		private float currentBurnDamage     = 0;
 
 		private PierceDamageLevel currentPierceDamageLevel = PierceDamageLevel.NONE;
 		private SlashDamageLevel currentSlashDamageLevel = SlashDamageLevel.NONE;
+		private BurnDamageLevels currentBurnDamageLevel = BurnDamageLevels.NONE;
 
 		/// <summary>
 		/// Toxin damage taken
@@ -707,6 +712,35 @@ namespace HealthV2
 			if(chance >= armorChanceModifer)
 			{
 				RemoveFromBodyThis();
+			}
+		}
+
+		private void TakeBurnDamage(float burnDamage)
+		{
+			if(SelfArmor.Fire < burnDamage)
+			{
+				currentBurnDamage += burnDamage;
+				CheckBurnDamageLevels();
+			}
+		}
+
+		private void CheckBurnDamageLevels()
+		{
+			if (currentBurnDamage <= 0)
+			{
+				currentBurnDamageLevel = BurnDamageLevels.NONE;
+			}
+			if (currentBurnDamage >= 25)
+			{
+				currentBurnDamageLevel = BurnDamageLevels.MINOR;
+			}
+			if (currentBurnDamage >= 50)
+			{
+				currentBurnDamageLevel = BurnDamageLevels.MAJOR;
+			}
+			if (currentBurnDamage >= 95)
+			{
+				currentBurnDamageLevel = BurnDamageLevels.CHARRED;
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
@@ -803,7 +803,7 @@ namespace HealthV2
 					{
 						if (item.ItemAttributes.CannotBeAshed)
 						{
-							Inventory.ServerDespawn(item);
+							Inventory.ServerDrop(item);
 						}
 					}
 					var organ = item.ItemObject?.GetComponent<BodyPart>();

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
@@ -758,7 +758,7 @@ namespace HealthV2
 			{
 				currentBurnDamageLevel = BurnDamageLevels.MAJOR;
 			}
-			if (currentBurnDamage >= 95)
+			if (currentBurnDamage >= 75)
 			{
 				if(currentBurnDamageLevel != BurnDamageLevels.CHARRED) //So we can do this once.
 				{
@@ -772,6 +772,41 @@ namespace HealthV2
 					}
 				}
 				currentBurnDamageLevel = BurnDamageLevels.CHARRED;
+				AshBodyPart();
+			}
+		}
+
+		private void AshBodyPart()
+		{
+			if(currentBurnDamageLevel == BurnDamageLevels.CHARRED && currentBurnDamage > bodyPartAshesAboveThisDamage)
+			{
+				IEnumerable<ItemSlot> internalItemList = Storage.GetItemSlots();
+				IEnumerable<ItemSlot> PlayerItemList = healthMaster.PlayerScriptOwner.ItemStorage.GetItemSlots();
+				foreach(ItemSlot item in internalItemList)
+				{
+					if(item.ItemAttributes != null) //Incase this is an empty slot
+					{
+						if (item.ItemAttributes.CannotBeAshed)
+						{
+							Inventory.ServerDespawn(item);
+						}
+					}
+				}
+				if(PlayerItemList != null) //In case this is not a player
+				{
+					foreach (ItemSlot item in PlayerItemList)
+					{
+						if (item.ItemAttributes != null)
+						{
+							if (item.ItemAttributes.CannotBeAshed)
+							{
+								Inventory.ServerDespawn(item);
+							}
+						}
+					}
+				}
+				_ = Spawn.ServerPrefab(Storage.AshPrefab, HealthMaster.gameObject.RegisterTile().WorldPosition);
+				_ = Despawn.ServerSingle(this.gameObject);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
@@ -689,7 +689,7 @@ namespace HealthV2
 			while(isBleedingExternally)
 			{
 				yield return WaitFor.Seconds(4f);
-				if(healthMaster != null || healthMaster.CirculatorySystem != null) //This is to prevent rare moments where body parts still attempt to bleed when they no longer should.
+				if(Root.ContainsLimbs.Contains(this) != false) //This is to prevent rare moments where body parts still attempt to bleed when they no longer should.
 				{
 					healthMaster.CirculatorySystem.Bleed(UnityEngine.Random.Range(MinMaxInternalBleedingValues.x, MinMaxInternalBleedingValues.y));
 				}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
@@ -799,9 +799,10 @@ namespace HealthV2
 				IEnumerable<ItemSlot> PlayerItemList = healthMaster.PlayerScriptOwner.ItemStorage.GetItemSlots();
 				foreach(ItemSlot item in internalItemList)
 				{
-					if(item.ItemAttributes != null) //Incase this is an empty slot
+					Integrity itemObject = item.ItemObject.GetComponent<Integrity>();
+					if(itemObject != null) //Incase this is an empty slot
 					{
-						if (item.ItemAttributes.CannotBeAshed)
+						if (itemObject.CannotBeAshed || itemObject.Resistances.Indestructable)
 						{
 							Inventory.ServerDrop(item);
 						}
@@ -819,9 +820,10 @@ namespace HealthV2
 				{
 					foreach (ItemSlot item in PlayerItemList)
 					{
-						if (item.ItemAttributes != null)
+						Integrity itemObject = item.ItemObject.GetComponent<Integrity>();
+						if (itemObject != null)
 						{
-							if (item.ItemAttributes.CannotBeAshed)
+							if (itemObject.CannotBeAshed || itemObject.Resistances.Indestructable)
 							{
 								Inventory.ServerDrop(item);
 							}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamageDiscriptors.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamageDiscriptors.cs
@@ -1,0 +1,111 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+
+namespace HealthV2
+{
+	public partial class BodyPart
+	{
+		[Header("Damage Descriptions")]
+		public string BodyPartReadableName    = "[Default Part Name]";
+		private string burnDamageDescOnNone   = "{readableName} suffers no burns.";
+		private string burnDamageDescOnMINOR  = "{readableName} suffers Second Degree Burns.";
+		private string burnDamageDescOnMAJOR  = "{readableName} suffers Third Degree Burns.";
+		private string burnDamageDescOnCHARRED= "{readableName} suffers Catastrophic Burns! They're charred beyond recognation!";
+		private string slashDamageDescOnNone  = "{readableName} has no large enough wounds to concern about.";
+		private string slashDamageDescOnSMALL = "{readableName} suffers from Rough Abrasion.";
+		private string slashDamageDescOnMEDIUM= "{readableName} suffers from Open Laceration. Their wound is too big to be ignored!";
+		private string slashDamageDescOnLARGE = "{readableName} suffers from Rough Abrasion. Their guts are visable!";
+		private string pireceDamageDescOnNone = "{readableName} has no major breakages that may affect internal organs.";
+		private string pireceDamageDescOnSMALL= "{readableName} suffers from Minor Breakage.";
+		private string pireceDamageDescOnMEDIUM="{readableName} suffers from an Open Puncture.";
+		private string pireceDamageDescOnLARGE= "{readableName} suffers from a Ruptured Cavity.";
+		[SerializeField] private string internalDamageDesc	 = "This {readableName} is suffering from internal damage.";
+		[SerializeField] private string externalBleedingDesc = "This {readableName} is bleeding due to an open wound.";
+
+		public string GetFullBodyPartDamageDescReport()
+		{
+			string report = $"Analyizing damage report for {BodyPartReadableName}..";
+
+			report += "[Open Wound Size -> ";
+			switch (currentCutSize)
+			{
+				case (BodyPartCutSize.SMALL):
+					report += $"{BodyPartCutSize.SMALL}]\n";
+					break;
+				case (BodyPartCutSize.MEDIUM):
+					report += $"{BodyPartCutSize.MEDIUM}]\n";
+					break;
+				case (BodyPartCutSize.LARGE):
+					report += $"{BodyPartCutSize.LARGE}]\n";
+					break;
+				default:
+					report += $"{BodyPartCutSize.NONE}]\n";
+					break;
+			}
+
+			report += $"[Wound Bleeding -> {isBleedingExternally}]";
+
+			if(currentCutSize != BodyPartCutSize.NONE)
+			{
+				report += "[Wound Report]\n";
+				switch (currentPierceDamageLevel)
+				{
+					case (PierceDamageLevel.SMALL):
+						report += $"{pireceDamageDescOnSMALL}\n";
+						break;
+					case (PierceDamageLevel.MEDIUM):
+						report += $"{pireceDamageDescOnMEDIUM}\n";
+						break;
+					case (PierceDamageLevel.LARGE):
+						report += $"{pireceDamageDescOnLARGE}\n";
+						break;
+					default:
+						report += $"{pireceDamageDescOnNone}]\n";
+						break;
+				}
+				switch (currentSlashDamageLevel)
+				{
+					case (SlashDamageLevel.SMALL):
+						report += $"{slashDamageDescOnSMALL}\n";
+						break;
+					case (SlashDamageLevel.MEDIUM):
+						report += $"{slashDamageDescOnMEDIUM}\n";
+						break;
+					case (SlashDamageLevel.LARGE):
+						report += $"{slashDamageDescOnLARGE}\n";
+						break;
+					default:
+						report += $"{slashDamageDescOnNone}]\n";
+						break;
+				}
+			}
+			report += "[Burn Damage]\n";
+			switch (currentBurnDamageLevel)
+			{
+				case (BurnDamageLevels.MINOR):
+					report += $"{burnDamageDescOnMINOR}\n";
+					break;
+				case (BurnDamageLevels.MAJOR):
+					report += $"{burnDamageDescOnMAJOR}\n";
+					break;
+				case (BurnDamageLevels.CHARRED):
+					report += $"{burnDamageDescOnCHARRED}\n";
+					break;
+				default:
+					report += $"{burnDamageDescOnNone}\n";
+					break;
+			}
+
+			report = TranslateTags(report);
+			return report;
+		}
+
+		private string TranslateTags(string txt)
+		{
+			return txt.Replace("{readableName}", BodyPartReadableName);
+		}
+	}
+}
+

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamageDiscriptors.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamageDiscriptors.cs
@@ -26,7 +26,7 @@ namespace HealthV2
 
 		public string GetFullBodyPartDamageDescReport()
 		{
-			string report = $"Analyizing damage report for {BodyPartReadableName}..";
+			string report = $"Analyizing damage report for {BodyPartReadableName}.. \n";
 
 			report += "[Open Wound Size -> ";
 			switch (currentCutSize)
@@ -45,56 +45,61 @@ namespace HealthV2
 					break;
 			}
 
-			report += $"[Wound Bleeding -> {isBleedingExternally}]";
+			report += $"[Wound Bleeding -> {isBleedingExternally}] \n";
+
+			if (CanBleedInternally)
+			{
+				report += $"[Organ is internally bleeding -> {isBleedingInternally}] \n";
+			}
 
 			if(currentCutSize != BodyPartCutSize.NONE)
 			{
-				report += "[Wound Report]\n";
+				report += "[Wound Report] \n";
 				switch (currentPierceDamageLevel)
 				{
 					case (PierceDamageLevel.SMALL):
-						report += $"{pireceDamageDescOnSMALL}\n";
+						report += $"{pireceDamageDescOnSMALL} \n";
 						break;
 					case (PierceDamageLevel.MEDIUM):
-						report += $"{pireceDamageDescOnMEDIUM}\n";
+						report += $"{pireceDamageDescOnMEDIUM} \n";
 						break;
 					case (PierceDamageLevel.LARGE):
-						report += $"{pireceDamageDescOnLARGE}\n";
+						report += $"{pireceDamageDescOnLARGE} \n";
 						break;
 					default:
-						report += $"{pireceDamageDescOnNone}]\n";
+						report += $"{pireceDamageDescOnNone}] \n";
 						break;
 				}
 				switch (currentSlashDamageLevel)
 				{
 					case (SlashDamageLevel.SMALL):
-						report += $"{slashDamageDescOnSMALL}\n";
+						report += $"{slashDamageDescOnSMALL} \n";
 						break;
 					case (SlashDamageLevel.MEDIUM):
-						report += $"{slashDamageDescOnMEDIUM}\n";
+						report += $"{slashDamageDescOnMEDIUM} \n";
 						break;
 					case (SlashDamageLevel.LARGE):
-						report += $"{slashDamageDescOnLARGE}\n";
+						report += $"{slashDamageDescOnLARGE} \n";
 						break;
 					default:
-						report += $"{slashDamageDescOnNone}]\n";
+						report += $"{slashDamageDescOnNone}] \n";
 						break;
 				}
 			}
-			report += "[Burn Damage]\n";
+			report += "[Burn Damage] \n";
 			switch (currentBurnDamageLevel)
 			{
 				case (BurnDamageLevels.MINOR):
-					report += $"{burnDamageDescOnMINOR}\n";
+					report += $"{burnDamageDescOnMINOR} \n";
 					break;
 				case (BurnDamageLevels.MAJOR):
-					report += $"{burnDamageDescOnMAJOR}\n";
+					report += $"{burnDamageDescOnMAJOR} \n";
 					break;
 				case (BurnDamageLevels.CHARRED):
-					report += $"{burnDamageDescOnCHARRED}\n";
+					report += $"{burnDamageDescOnCHARRED} \n";
 					break;
 				default:
-					report += $"{burnDamageDescOnNone}\n";
+					report += $"{burnDamageDescOnNone} \n";
 					break;
 			}
 

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamageDiscriptors.cs.meta
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamageDiscriptors.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ea1e2bb926d46864c86625840fd2f0c0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -740,11 +740,11 @@ namespace HealthV2
 		{
 			if(DMMath.Prob(chance))
 			{
-				EffectsFactory.BloodSplat(RegisterTile.WorldPositionServer, BloodSplatSize.medium, BloodSplatType.red);
 				foreach (var bodyPartContainer in RootBodyPartContainers)
 				{
 					if (bodyPartContainer.BodyPartType == aimedBodyPart)
 					{
+						bodyPartContainer.healthMaster.CirculatorySystem.Bleed(damage);
 						bodyPartContainer.TakeSlashDamage(damage);
 					}
 				}
@@ -755,11 +755,11 @@ namespace HealthV2
 		{
 			if(DMMath.Prob(chance))
 			{
-				EffectsFactory.BloodSplat(RegisterTile.WorldPositionServer, BloodSplatSize.medium, BloodSplatType.red);
 				foreach (var bodyPartContainer in RootBodyPartContainers)
 				{
 					if (bodyPartContainer.BodyPartType == aimedBodyPart)
 					{
+						bodyPartContainer.healthMaster.CirculatorySystem.Bleed(damage);
 						bodyPartContainer.TakePierceDamage(damage);
 					}
 				}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -744,7 +744,7 @@ namespace HealthV2
 				{
 					if (bodyPartContainer.BodyPartType == aimedBodyPart)
 					{
-						bodyPartContainer.healthMaster.CirculatorySystem.Bleed(damage);
+						bodyPartContainer.healthMaster.CirculatorySystem.Bleed(2f);
 						bodyPartContainer.TakeSlashDamage(damage);
 					}
 				}
@@ -759,7 +759,7 @@ namespace HealthV2
 				{
 					if (bodyPartContainer.BodyPartType == aimedBodyPart)
 					{
-						bodyPartContainer.healthMaster.CirculatorySystem.Bleed(damage);
+						bodyPartContainer.healthMaster.CirculatorySystem.Bleed(2f);
 						bodyPartContainer.TakePierceDamage(damage);
 					}
 				}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -963,7 +963,7 @@ namespace HealthV2
 		/// ---------------------------
 		///<Summary>
 		/// Kills the creature, used for causes of death other than damage.
-		/// Currently not implemented
+		/// Currently not fully implemented
 		///</Summary>
 		public virtual void Death()
 		{

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -766,6 +766,17 @@ namespace HealthV2
 			}
 		}
 
+		public virtual void ApplyBurnDamage(BodyPartType aimedBodyPart, float damage)
+		{
+			foreach (var bodyPartContainer in RootBodyPartContainers)
+			{
+				if (bodyPartContainer.BodyPartType == aimedBodyPart)
+				{
+					bodyPartContainer.TakeBurnDamage(damage);
+				}
+			}
+		}
+
 		/// <summary>
 		/// Gets all body parts in a zone targetable by the UI (head, chest, left arm, etc)
 		/// </summary>

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Dissectible.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Dissectible.cs
@@ -335,7 +335,6 @@ namespace HealthV2
 
 				ThisSurgeryStep = SurgeryProcedureBase.SurgerySteps[CurrentStep];
 
-
 				if (ThisSurgeryStep != null)
 				{
 					if (Validations.HasItemTrait(interaction.HandObject, ThisSurgeryStep.RequiredTrait))
@@ -426,6 +425,11 @@ namespace HealthV2
 				SurgeryProcedureBase = inSurgeryProcedureBase;
 			}
 
+			/// <summary>
+			/// Replaces $ tags with their wanted names.
+			/// </summary>
+			/// <param name="toReplace">must have performer, Using and/or OnPart tags to replace.</param>
+			/// <returns></returns>
 			public string ApplyChatModifiers(string toReplace)
 			{
 				if (!string.IsNullOrWhiteSpace(toReplace))

--- a/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
@@ -136,6 +136,21 @@ namespace Items
 			set => pierceDamage = value;
 		}
 
+		[Tooltip("How much burn damage does this item cause?"),
+		Range(0,100),
+		SerializeField]
+		private float burnDamage = 0;
+		public float BurnDamage
+		{
+			get => burnDamage;
+			set => burnDamage = value;
+		}
+
+		[Tooltip("Can this item turn into ash?"),
+		SerializeField]
+		private bool cannotBeAshed = false;
+		public bool CannotBeAshed => cannotBeAshed;
+
 		[Tooltip("How many tiles to move per 0.1s when being thrown")]
 		[SerializeField]
 		private float throwSpeed = 2;

--- a/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
@@ -146,11 +146,6 @@ namespace Items
 			set => burnDamage = value;
 		}
 
-		[Tooltip("Can this item turn into ash?"),
-		SerializeField]
-		private bool cannotBeAshed = false;
-		public bool CannotBeAshed => cannotBeAshed;
-
 		[Tooltip("How many tiles to move per 0.1s when being thrown")]
 		[SerializeField]
 		private float throwSpeed = 2;

--- a/UnityProject/Assets/Scripts/Items/Medical/HealthScanner.cs
+++ b/UnityProject/Assets/Scripts/Items/Medical/HealthScanner.cs
@@ -85,6 +85,17 @@ namespace Items.Medical
 				scanMessage.Append("</mspace>");
 			}
 
+			if (interaction.IsAltClick && AdvancedHealthScanner)
+			{
+				foreach(BodyPart part in health.ImplantList)
+				{
+					if(part.BodyPartType == interaction.TargetBodyPart)
+					{
+						scanMessage.AppendLine(part.GetFullBodyPartDamageDescReport());
+					}
+				}
+			}
+
 			scanMessage.Append("----------------------------------------");
 
 			Chat.AddExamineMsgFromServer(interaction.Performer, $"</i>{scanMessage}<i>");

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
@@ -23,6 +23,8 @@ public class WeaponNetworkActions : NetworkBehaviour
 	private float pierceChance = 0f;
 	private float pierceDamage = 0f;
 
+	private float burnDamage = 0f;
+
 	private bool isForLerpBack;
 	private Vector3 lerpFrom;
 	public bool lerping { get; private set; } // needs to be read by Camera2DFollow
@@ -99,6 +101,7 @@ public class WeaponNetworkActions : NetworkBehaviour
 			slashDamage = weaponAttributes.SlashDamage;
 			pierceChance = weaponAttributes.PierceChance;
 			pierceDamage = weaponAttributes.PierceDamage;
+			burnDamage = weaponAttributes.BurnDamage;
 		}
 
 		LayerTile attackedTile = null;
@@ -147,6 +150,7 @@ public class WeaponNetworkActions : NetworkBehaviour
 					victimHealth.ApplyDamageToBodyPart(gameObject, damage, AttackType.Melee, damageType, damageZone);
 					victimHealth.ApplySlashDamage(slashChance, damageZone, slashDamage);
 					victimHealth.ApplyPierceDamage(pierceChance, damageZone, pierceDamage);
+					victimHealth.ApplyBurnDamage(damageZone, burnDamage);
 					didHit = true;
 				}
 				else if (victim.TryGetComponent<LivingHealthBehaviour>(out var victimHealthOld))

--- a/UnityProject/Assets/Scripts/Systems/Inventory/ItemStorage.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/ItemStorage.cs
@@ -170,11 +170,9 @@ public class ItemStorage : MonoBehaviour, IServerLifecycle, IServerInventoryMove
 			{
 				if(mobHealth != null)
 				{
-					Debug.Log("health found");
 					if(mobHealth.GetCurrentBurnDamage() > mobHealth.BodyPartAshesAboveThisDamage)
 					{
-						Debug.Log("TIME TO GET ASHED MOTHER FUCKER");
-						_ = Spawn.ServerPrefab(ashPrefab, Item.gameObject.RegisterTile().WorldPosition);
+						_ = Spawn.ServerPrefab(ashPrefab, mobHealth.HealthMaster.gameObject.RegisterTile().WorldPosition);
 						_ = Despawn.ServerSingle(slot.Item.gameObject);
 						return true;
 					}

--- a/UnityProject/Assets/Scripts/Systems/Inventory/ItemStorage.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/ItemStorage.cs
@@ -161,8 +161,8 @@ public class ItemStorage : MonoBehaviour, IServerLifecycle, IServerInventoryMove
 
 	public bool ServerTryRemove(GameObject InGameObject, bool Destroy = false)
 	{
-		ItemAttributesV2 Item = InGameObject.GetComponent<ItemAttributesV2>();
-		if (Item == null) return false;
+		ItemAttributesV2 item = InGameObject.GetComponent<ItemAttributesV2>();
+		if (item == null) return false;
 		IEnumerable<ItemSlot> slots = GetItemSlots();
 		HealthV2.BodyPart mobHealth = InGameObject.GetComponent<HealthV2.BodyPart>();
 		foreach (var slot in slots)

--- a/UnityProject/Assets/Scripts/Systems/Inventory/ItemStorage.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/ItemStorage.cs
@@ -80,6 +80,7 @@ public class ItemStorage : MonoBehaviour, IServerLifecycle, IServerInventoryMove
 	private SpawnInfo spawnInfo;
 
 	[SerializeField] private GameObject ashPrefab;
+	public GameObject AshPrefab => ashPrefab;
 
 	private void Awake()
 	{

--- a/UnityProject/Assets/Scripts/Systems/Inventory/ItemStorage.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/ItemStorage.cs.meta
@@ -1,3 +1,16 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: fdce8a163088453ca593c0e98f2c5f07
-timeCreated: 1572397832
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences:
+  - itemStorageStructure: {instanceID: 0}
+  - itemStorageCapacity: {instanceID: 0}
+  - itemStoragePopulator: {instanceID: 0}
+  - ashPrefab: {fileID: 2957035178188790827, guid: 9ac6968a3f3ed54428662c9aae5a4b32,
+      type: 3}
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
part of #6270 and #6272
Adds in the ability to deep fry your fellow crewmate's bodies until they're extra crisp. Body Parts can suffer from burn damage and when they're charred they have the ability to turn into ash. (Any items inside of these body parts that are marked with "CannotBeAshed" will not be destroyed and will simply drop on the ground.)
Advanced health scanners will now give you a detailed report on a body part's condition and what's inside of it.

### Notes:
Like usual, additions and changes are gradual and are contained in small PRs so players can test them quickly on staging.
While I wished that I had fixed surgery along side this PR, it's still going to wait a bit and will be added alongside another PR that tackles healing and infections for traumatic wounds.
This PR also comes with some small documentation for some things.

### Changelog:
CL: [New] - Players with burnt bodies will now visually appear burnt.
CL: [New] - Ashing has been added for body parts.
CL: [New] - Advanced health scanners have the ability now to give a detailed report on a body part when Alt-Clicking on the player you wish to diagnose.
CL: [Improvement] - Items like the Nuke Disk cannot be destroyed during Inventory drops or deletions.
CL: [Fix] - Fixes an error where body parts attempt to bleed out while they're no longer attached to a body.