### PR TITLE
Fixes food processors disappearing (again) and fixes bleeding issues with removed body parts (also again)

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Kitchen/FoodProcessor.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Kitchen/FoodProcessor.prefab
@@ -194,6 +194,7 @@ MonoBehaviour:
   syncInterval: 0.1
   matrixDebugLogging: 0
   objectType: 1
+  CurrentsortingGroup: {fileID: 0}
   AtmosPassable: 1
   ReachableThrough: 1
   initialPassable: 0
@@ -277,6 +278,7 @@ MonoBehaviour:
     Acid: 0
     Magic: 0
     Bio: 0
+    DismembermentProtectionChance: 0
   Resistances:
     LavaProof: 0
     FireProof: 0
@@ -390,6 +392,7 @@ MonoBehaviour:
   itemStorageCapacity: {fileID: 11400000, guid: 51557be05ba9141e7849ea1c1c3ed19d,
     type: 2}
   itemStoragePopulator: {fileID: 0}
+  forceSpawnContents: 0
   dropItemsOnDespawn: 0
   UesAddlistPopulater: 0
   Populater:

--- a/UnityProject/Assets/Scripts/Effects/LTEffect.cs
+++ b/UnityProject/Assets/Scripts/Effects/LTEffect.cs
@@ -51,7 +51,7 @@ namespace Effects
 
 		public void GetOriginalPosition()
 		{
-			originalPosition = transform.position;
+			originalPosition = this.gameObject.RegisterTile().WorldPositionServer;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
@@ -689,9 +689,16 @@ namespace HealthV2
 			while(isBleedingExternally)
 			{
 				yield return WaitFor.Seconds(4f);
-				if(Root.ContainsLimbs.Contains(this) != false) //This is to prevent rare moments where body parts still attempt to bleed when they no longer should.
+				if(Root != null) //This is to prevent rare moments where body parts still attempt to bleed when they no longer should.
 				{
-					healthMaster.CirculatorySystem.Bleed(UnityEngine.Random.Range(MinMaxInternalBleedingValues.x, MinMaxInternalBleedingValues.y));
+					if (Root.ContainsLimbs.Contains(this) != false) 
+					{
+						healthMaster.CirculatorySystem.Bleed(UnityEngine.Random.Range(MinMaxInternalBleedingValues.x, MinMaxInternalBleedingValues.y));
+					}
+				}
+				else
+				{
+					break;
 				}
 			}
 		}

--- a/UnityProject/Assets/Scripts/Objects/Machines/FoodProcessor.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/FoodProcessor.cs
@@ -196,7 +196,7 @@ namespace Objects.Kitchen
 			// time in seconds = 4 * items_in_processor / manipulator tier
 			int slotsOccupied = storage.GetNextFreeIndexedSlot().SlotIdentifier.SlotIndex;
 			processTimer = (float)(TIME_PER_ITEM * slotsOccupied / manipTier);
-			AnimateProcessor(1, processTimer, shakeValue, 0.1f);
+			AnimateProcessor(1, processTimer / 8, shakeValue, 0.1f);
 			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 			playAudioLoop = true;
 


### PR DESCRIPTION
CL: [Fix] - Fixed Food Processors disappearing after using them (again)
CL: [Fix] - Fixed Food Processors taking longer than they should to shake.
CL: [Fix] - Fixed a null error that would occur when limbs are bleeding and have been chopped off.
