### PR TITLE
Update logviewer defaults

### DIFF
--- a/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogManager.cs
+++ b/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogManager.cs
@@ -150,12 +150,12 @@ namespace IngameDebugConsole
 		/// <summary>
 		/// Determine whether Debug Log is collapsed
 		/// </summary>
-		private bool isCollapseOn = false;
+		private bool isCollapseOn = true;
 
 		/// <summary>
 		/// Filters to apply to the list of debug entries to show
 		/// </summary>
-		private DebugLogFilter logFilter = DebugLogFilter.All;
+		private DebugLogFilter logFilter = DebugLogFilter.Warning | DebugLogFilter.Error;
 
 		/// <summary>
 		/// If the last log item is completely visible (scrollbar is at the bottom),
@@ -210,10 +210,14 @@ namespace IngameDebugConsole
 					{ LogType.Assert, errorLog }
 				};
 
-				// Initially, all log types are visible
-				filterInfoButton.color = filterButtonsSelectedColor;
-				filterWarningButton.color = filterButtonsSelectedColor;
-				filterErrorButton.color = filterButtonsSelectedColor;
+				// Set initial button colors
+				collapseButton.color = isCollapseOn ? collapseButtonSelectedColor : collapseButtonNormalColor;
+				filterInfoButton.color = (logFilter & DebugLogFilter.Info) == DebugLogFilter.Info
+						? filterButtonsSelectedColor : filterButtonsNormalColor;
+				filterWarningButton.color = (logFilter & DebugLogFilter.Warning) == DebugLogFilter.Warning
+						? filterButtonsSelectedColor : filterButtonsNormalColor;
+				filterErrorButton.color = (logFilter & DebugLogFilter.Error) == DebugLogFilter.Error
+						? filterButtonsSelectedColor : filterButtonsNormalColor;
 
 				collapsedLogEntries = new List<DebugLogEntry>(128);
 				collapsedLogEntriesMap = new Dictionary<DebugLogEntry, int>(128);
@@ -221,6 +225,7 @@ namespace IngameDebugConsole
 				indicesOfListEntriesToShow = new DebugLogIndexList();
 
 				recycledListView.Initialize(this, collapsedLogEntries, indicesOfListEntriesToShow, logItemPrefab.Transform.sizeDelta.y);
+				recycledListView.SetCollapseMode(isCollapseOn);
 				recycledListView.UpdateItemsInTheList(true);
 
 				nullPointerEventData = new PointerEventData(null);


### PR DESCRIPTION
- Updates the in-game logviewer defaults.
    - Collapse mode is on by default.
    - Notices are hidden by default. Will now display only errors and warnings.