### PR TITLE
Fixes client overlays not being removed

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/ChangeTileWhenItemUsed.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/ChangeTileWhenItemUsed.cs
@@ -3,6 +3,7 @@ using System;
 //using NUnit.Framework.Internal;
 using UnityEngine;
 using Random = UnityEngine.Random;
+using TileManagement;
 
 /// <summary>
 /// Changes the tile to a different tile when an item with a particular

--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/ChangeTileWhenItemUsed.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/ChangeTileWhenItemUsed.cs
@@ -78,7 +78,7 @@ public class ChangeTileWhenItemUsed : TileInteraction
 				//change tile
 				interaction.TileChangeManager.UpdateTile(interaction.TargetCellPos, toTile);
 				//remove overlays
-				interaction.TileChangeManager.RemoveFloorWallOverlaysOfType(interaction.TargetCellPos, TileChangeManager.OverlayType.Cleanable);
+				interaction.TileChangeManager.RemoveFloorWallOverlaysOfType(interaction.TargetCellPos, OverlayType.Cleanable);
 				if (objectsToSpawn != null)
 				{
 					objectsToSpawn.SpawnAt(SpawnDestination.At(interaction.WorldPositionTarget));

--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/DeconstructWhenItemUsed.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/DeconstructWhenItemUsed.cs
@@ -1,6 +1,7 @@
 using System;
 using UnityEngine;
 using Random = UnityEngine.Random;
+using TileManagement;
 
 /// <summary>
 /// Deconstruct the tile and spawn its deconstruction object (if defined) and (optionally) additional objects when an item with a particular

--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/DeconstructWhenItemUsed.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/DeconstructWhenItemUsed.cs
@@ -58,7 +58,7 @@ public class DeconstructWhenItemUsed : TileInteraction
 			{
 
 				interaction.TileChangeManager.RemoveTile(interaction.TargetCellPos, interaction.BasicTile.LayerType);
-				interaction.TileChangeManager.RemoveFloorWallOverlaysOfType(interaction.TargetCellPos, TileChangeManager.OverlayType.Cleanable);
+				interaction.TileChangeManager.RemoveFloorWallOverlaysOfType(interaction.TargetCellPos, OverlayType.Cleanable);
 
 				//spawn things that need to be spawned
 				if (interaction.BasicTile.SpawnOnDeconstruct != null &&

--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/TableDeconstruction.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/TableDeconstruction.cs
@@ -1,6 +1,7 @@
 using System;
 using UnityEngine;
 using Random = UnityEngine.Random;
+using TileManagement;
 
 namespace Objects.Tables
 {

--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/TableDeconstruction.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/TableDeconstruction.cs
@@ -61,7 +61,7 @@ namespace Objects.Tables
 				{
 
 					interaction.TileChangeManager.RemoveTile(interaction.TargetCellPos, interaction.BasicTile.LayerType);
-					interaction.TileChangeManager.RemoveFloorWallOverlaysOfType(interaction.TargetCellPos, TileChangeManager.OverlayType.Cleanable);
+					interaction.TileChangeManager.RemoveFloorWallOverlaysOfType(interaction.TargetCellPos, OverlayType.Cleanable);
 
 					//spawn things that need to be spawned
 					if (interaction.BasicTile.SpawnOnDeconstruct != null &&

--- a/UnityProject/Assets/Scripts/Items/Tool/CrayonSprayCan.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/CrayonSprayCan.cs
@@ -195,7 +195,7 @@ namespace Items.Tool
 			}
 
 			var graffitiAlreadyOnTile = registerItem.TileChangeManager
-				.GetAllOverlayTiles(cellPos, isWall ? LayerType.Walls : LayerType.Floors, TileChangeManager.OverlayType.Cleanable)
+				.GetAllOverlayTiles(cellPos, isWall ? LayerType.Walls : LayerType.Floors, OverlayType.Cleanable)
 				.Where(t => t.IsGraffiti).ToList();
 
 			foreach (var graffiti in graffitiAlreadyOnTile)
@@ -213,7 +213,7 @@ namespace Items.Tool
 						{
 							if (charges > 0 || charges == -1)
 							{
-								registerItem.TileChangeManager.RemoveOverlaysOfName(cellPos, isWall ? LayerType.Walls : LayerType.Floors, graffiti.OverlayName);
+								registerItem.TileChangeManager.RemoveOverlaysOfType(cellPos, isWall ? LayerType.Walls : LayerType.Floors, OverlayType.Cleanable);
 								registerItem.TileChangeManager.AddOverlay(cellPos, tileToUse, chosenDirection, chosenColour);
 							}
 

--- a/UnityProject/Assets/Scripts/Items/Tool/CrayonSprayCan.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/CrayonSprayCan.cs
@@ -8,6 +8,7 @@ using UI.Action;
 using UnityEngine;
 using UnityEngine.Serialization;
 using Random = UnityEngine.Random;
+using TileManagement;
 
 namespace Items.Tool
 {

--- a/UnityProject/Assets/Scripts/Items/Tool/Pickaxe.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/Pickaxe.cs
@@ -49,7 +49,7 @@ namespace Items
 					var tile = interactableTiles.LayerTileAt(interaction.WorldPositionTarget) as BasicTile;
 					Spawn.ServerPrefab(tile.SpawnOnDeconstruct, interaction.WorldPositionTarget, count: tile.SpawnAmountOnDeconstruct);
 					interactableTiles.TileChangeManager.RemoveTile(cellPos, LayerType.Walls);
-					interactableTiles.TileChangeManager.RemoveOverlaysOfType(cellPos, LayerType.Effects, TileChangeManager.OverlayType.Mining);
+					interactableTiles.TileChangeManager.RemoveOverlaysOfType(cellPos, LayerType.Effects, OverlayType.Mining);
 				}
 			}
 

--- a/UnityProject/Assets/Scripts/Items/Tool/Pickaxe.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/Pickaxe.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using AddressableReferences;
 using Objects.Mining;
+using TileManagement;
 
 namespace Items
 {

--- a/UnityProject/Assets/Scripts/Messages/Server/RemoveTileMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/RemoveTileMessage.cs
@@ -10,7 +10,6 @@ namespace Messages.Server
 		{
 			public Vector3 Position;
 			public LayerType LayerType;
-			public bool RemoveAll;
 			public uint MatrixSyncNetId;
 		}
 
@@ -20,13 +19,11 @@ namespace Messages.Server
 		{
 			public Vector3 Position;
 			public LayerType LayerType;
-			public bool RemoveAll;
 			public uint MatrixSyncNetId;
-			public delayedData(Vector3 inPosition, LayerType inLayerType, bool inRemoveAll, uint inMatrixSyncNetId)
+			public delayedData(Vector3 inPosition, LayerType inLayerType, uint inMatrixSyncNetId)
 			{
 				Position = inPosition;
 				LayerType = inLayerType;
-				RemoveAll = inRemoveAll;
 				MatrixSyncNetId = inMatrixSyncNetId;
 			}
 		}
@@ -35,12 +32,12 @@ namespace Messages.Server
 			LoadNetworkObject(msg.MatrixSyncNetId);
 			if (NetworkObject == null)
 			{
-				DelayedStuff.Add(new delayedData(msg.Position, msg.LayerType, msg.RemoveAll, msg.MatrixSyncNetId));
+				DelayedStuff.Add(new delayedData(msg.Position, msg.LayerType, msg.MatrixSyncNetId));
 			}
 			else
 			{
 				var tileChangerManager = NetworkObject.transform.parent.GetComponent<TileChangeManager>();
-				tileChangerManager.InternalRemoveTile(msg.Position, msg.LayerType, msg.RemoveAll);
+				tileChangerManager.InternalRemoveTile(msg.Position, msg.LayerType);
 				TryDoNotDoneTiles();
 			}
 		}
@@ -54,20 +51,19 @@ namespace Messages.Server
 				if (NetworkObject != null)
 				{
 					var tileChangerManager = NetworkObject.transform.parent.GetComponent<TileChangeManager>();
-					tileChangerManager.InternalRemoveTile(DelayedStuff[i].Position, DelayedStuff[i].LayerType, DelayedStuff[i].RemoveAll);
+					tileChangerManager.InternalRemoveTile(DelayedStuff[i].Position, DelayedStuff[i].LayerType);
 					DelayedStuff.RemoveAt(i);
 					i--;
 				}
 			}
 		}
 
-		public static NetMessage Send(uint matrixSyncNetId, Vector3 position, LayerType layerType, bool removeAll)
+		public static NetMessage Send(uint matrixSyncNetId, Vector3 position, LayerType layerType)
 		{
 			NetMessage msg = new NetMessage
 			{
 				Position = position,
 				LayerType = layerType,
-				RemoveAll = removeAll,
 				MatrixSyncNetId = matrixSyncNetId
 			};
 

--- a/UnityProject/Assets/Scripts/Messages/Server/UpdateTileMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/UpdateTileMessage.cs
@@ -53,15 +53,7 @@ namespace Messages.Server
 			else
 			{
 				var tileChangerManager = NetworkObject.transform.parent.GetComponent<TileChangeManager>();
-				if (msg.TileName == "")
-				{
-					tileChangerManager.RemoveTile(msg.Position, msg.LayerType);
-				}
-				else
-				{
-					tileChangerManager.InternalUpdateTile(msg.Position, msg.TileType, msg.TileName, msg.TransformMatrix, msg.Colour);
-				}
-
+				tileChangerManager.InternalUpdateTile(msg.Position, msg.TileType, msg.TileName, msg.TransformMatrix, msg.Colour);
 				TryDoNotDoneTiles();
 			}
 		}

--- a/UnityProject/Assets/Scripts/NPC/AI/MobExplore.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobExplore.cs
@@ -232,7 +232,7 @@ namespace Systems.MobAIs
 					break;
 				case Target.missingFloor:
 					if (IsEmagged == false) interactableTiles.TileChangeManager.UpdateTile(checkPos, TileType.Floor, "Floor");
-					else interactableTiles.TileChangeManager.RemoveTile(checkPos, LayerType.Floors, true);
+					else interactableTiles.TileChangeManager.RemoveTile(checkPos, LayerType.Floors);
 
 					break;
 				case Target.injuredPeople:

--- a/UnityProject/Assets/Scripts/Systems/Explosions/ExplosionComponent.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/ExplosionComponent.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using HealthV2;
 using UnityEngine;
+using TileManagement;
 
 namespace Systems.Explosions
 {

--- a/UnityProject/Assets/Scripts/Systems/Explosions/ExplosionComponent.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/ExplosionComponent.cs
@@ -120,7 +120,7 @@ namespace Systems.Explosions
 
 			tileChangeManager.AddOverlay(position, TileType.Effects, "Fire");
 			yield return WaitFor.Seconds(time);
-			tileChangeManager.RemoveOverlaysOfName(position, LayerType.Effects, "Fire");
+			tileChangeManager.RemoveOverlaysOfType(position, LayerType.Effects, OverlayType.Fire);
 		}
 
 

--- a/UnityProject/Assets/Scripts/Systems/Spells/Spell.cs
+++ b/UnityProject/Assets/Scripts/Systems/Spells/Spell.cs
@@ -180,7 +180,7 @@ namespace Systems.Spells
 						IEnumerator DespawnAfterDelay()
 						{
 							yield return WaitFor.Seconds(SpellData.SummonLifespan);
-							matrixInfo.TileChangeManager.RemoveTile(localPos, tileToSummon.LayerType, false);
+							matrixInfo.TileChangeManager.RemoveTile(localPos, tileToSummon.LayerType);
 						}
 					}
 				}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
@@ -559,7 +559,7 @@ public class InteractableTiles : MonoBehaviour, IClientInteractable<PositionalHa
 		Spawn.ServerPrefab(getTile.SpawnOnDeconstruct, worldPosition,
 			count: getTile.SpawnAmountOnDeconstruct);
 		tileChangeManager.RemoveTile(cellPos, LayerType.Walls);
-		tileChangeManager.RemoveOverlaysOfType(cellPos, LayerType.Effects, TileChangeManager.OverlayType.Mining);
+		tileChangeManager.RemoveOverlaysOfType(cellPos, LayerType.Effects, OverlayType.Mining);
 
 		return true;
 	}
@@ -586,11 +586,7 @@ public class InteractableTiles : MonoBehaviour, IClientInteractable<PositionalHa
 
 		yield return WaitFor.Seconds(animationTime);
 
-		RemoveOverlay(cellPos, animatedTile);
+		tileChangeManager.RemoveOverlaysOfType(cellPos, LayerType.Effects, animatedTile.OverlayType);
 	}
 
-	private void RemoveOverlay(Vector3Int cellPos, AnimatedOverlayTile animatedTile)
-	{
-		tileChangeManager.RemoveOverlaysOfName(cellPos, LayerType.Effects, animatedTile.name);
-	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -6,6 +6,7 @@ using Chemistry.Components;
 using HealthV2;
 using UnityEngine;
 using Objects.Construction;
+using TileManagement;
 
 /// <summary>
 /// Holds and provides functionality for all the MetaDataTiles for a given matrix.

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -236,7 +236,7 @@ public class MetaDataLayer : MonoBehaviour
 		}
 
 		//check for any moppable overlays
-		matrix.TileChangeManager.RemoveFloorWallOverlaysOfType(localPosInt, TileChangeManager.OverlayType.Cleanable);
+		matrix.TileChangeManager.RemoveFloorWallOverlaysOfType(localPosInt, OverlayType.Cleanable);
 
 		if (MatrixManager.IsSpaceAt(worldPosInt, true) == false && makeSlippery)
 		{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
@@ -939,65 +939,13 @@ namespace TileManagement
 		}
 
 		/// <summary>
-		/// Get position of an overlay by name
-		/// </summary>
-		/// <param name="position"></param>
-		/// <param name="layerType"></param>
-		/// <param name="overlayName"></param>
-		/// <returns></returns>
-		public Vector3Int? GetOverlayPos(Vector3Int position, LayerType layerType, string overlayName)
-		{
-			if (layerType == LayerType.Objects)
-			{
-				Logger.LogError("Please use get objects instead of get tile");
-				return null;
-			}
-
-			TileLocation tileLocation = null;
-			OverlayTile overlayTile = null;
-			position.z = 1;
-
-			if (Layers.TryGetValue(layerType, out var layer))
-			{
-				//Go through overlays under the overlay limit. The first overlay checked will be at z = 1.
-				var count = 0;
-				while (count < OVERLAY_LIMIT)
-				{
-					lock (PresentTiles)
-					{
-						PresentTiles[layer].TryGetValue(position, out tileLocation);
-					}
-
-					if (tileLocation != null)
-					{
-						overlayTile = tileLocation.Tile as OverlayTile;
-
-						if (overlayTile != null && overlayTile.OverlayName == overlayName)
-						{
-							return position;
-						}
-					}
-
-					position.z++;
-					count++;
-				}
-			}
-			else
-			{
-				LogMissingLayer(position, layerType);
-			}
-
-			return null;
-		}
-
-		/// <summary>
 		/// Gets all positions with a specific overlay type
 		/// </summary>
 		/// <param name="position"></param>
 		/// <param name="layerType"></param>
 		/// <param name="overlayName"></param>
 		/// <returns></returns>
-		public List<Vector3Int> GetOverlayPosByType(Vector3Int position, LayerType layerType, TileChangeManager.OverlayType overlayType)
+		public List<Vector3Int> GetOverlayPosByType(Vector3Int position, LayerType layerType, OverlayType overlayType)
 		{
 			if (layerType == LayerType.Objects)
 			{
@@ -1103,7 +1051,7 @@ namespace TileManagement
 		/// <param name="layerType"></param>
 		/// <param name="overlayType"></param>
 		/// <returns></returns>
-		public List<OverlayTile> GetOverlayTilesByType(Vector3Int position, LayerType layerType, TileChangeManager.OverlayType overlayType)
+		public List<OverlayTile> GetOverlayTilesByType(Vector3Int position, LayerType layerType, OverlayType overlayType)
 		{
 			if (layerType == LayerType.Objects)
 			{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
@@ -1601,4 +1601,23 @@ namespace TileManagement
 
 		#endregion
 	}
+
+	public enum OverlayType
+	{
+		//none is used to say there is no overlay, add new category if you need a new type
+		None,
+		Gas,
+		Damage,
+		Cleanable,
+		Fire,
+		Mining,
+		KineticAnimation,
+		Plasma,
+		NO2,
+		WaterVapour,
+		Miasma,
+		Nitryl,
+		Tritium,
+		Freon
+	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/UnderFloorLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/UnderFloorLayer.cs
@@ -366,9 +366,7 @@ public class UnderFloorLayer : Layer
 			if (TileStore[(Vector2Int) position].Contains(tile))
 			{
 				int index = TileStore[(Vector2Int) position].IndexOf(tile);
-				matrix.TileChangeManager.RemoveTile(new Vector3Int(position.x, position.y, (-index) + 1),
-					LayerType.Underfloor,
-					false);
+				matrix.TileChangeManager.RemoveTile(new Vector3Int(position.x, position.y, (-index) + 1), LayerType.Underfloor);
 				TileStore[(Vector2Int) position][index] = null;
 			}
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSimulation.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSimulation.cs
@@ -208,7 +208,7 @@ namespace Systems.Atmospherics
 
 					node.RemoveGasOverlay(gas);
 
-					node.ReactionManager.TileChangeManager.RemoveOverlaysOfName(node.Position, LayerType.Effects, gas.TileName);
+					node.ReactionManager.TileChangeManager.RemoveOverlaysOfType(node.Position, LayerType.Effects, gas.OverlayType);
 				}
 			}
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Gas.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Gas.cs
@@ -9,22 +9,22 @@ namespace Systems.Atmospherics
 		// Gas constant
 		public const float R = 8.3144598f;
 
-		public static readonly Gas Plasma = new Gas("Plasma", 200, 40f, true, 0.4f, "Plasma", -4, 0);
-		public static readonly Gas Oxygen = new Gas("Oxygen", 20, 31.9988f, false, 0.4f, "NONE", -3, 0);
-		public static readonly Gas Nitrogen = new Gas("Nitrogen", 20, 28.0134f, false, 0.4f, "NONE", -3, 0);
-		public static readonly Gas CarbonDioxide = new Gas("Carbon Dioxide", 30, 44.01f, false, 0.4f, "NONE", -3, 0);
+		public static readonly Gas Plasma = new Gas("Plasma", 200, 40f, true, 0.4f, "Plasma", OverlayType.Plasma, -4, 0);
+		public static readonly Gas Oxygen = new Gas("Oxygen", 20, 31.9988f, false, 0.4f, "NONE", OverlayType.None, -3, 0);
+		public static readonly Gas Nitrogen = new Gas("Nitrogen", 20, 28.0134f, false, 0.4f, "NONE", OverlayType.None, -3, 0);
+		public static readonly Gas CarbonDioxide = new Gas("Carbon Dioxide", 30, 44.01f, false, 0.4f, "NONE", OverlayType.None, -3, 0);
 
-		public static readonly Gas NitrousOxide = new Gas("Nitrous Oxide", 40, 44.01f, true, 0.4f, "NO2", -5, 10);
-		public static readonly Gas Hydrogen = new Gas("Hydrogen", 30, 44.01f, false, 0.4f, "NONE", -3, 0);
-		public static readonly Gas WaterVapor = new Gas("Water Vapor", 40, 44.01f, true, 0.4f, "WaterVapour", -9, 8);
-		public static readonly Gas BZ = new Gas("BZ", 20, 44.01f, false, 0.4f, "NONE", -3, 8);
-		public static readonly Gas Miasma = new Gas("Miasma", 20, 44.01f, true, 0.4f, "Miasma", -7, 0);
-		public static readonly Gas Nitryl = new Gas("Nitryl", 20, 44.01f, true, 0.4f, "Nitryl", -6, 16);
-		public static readonly Gas Tritium = new Gas("Tritium", 10, 44.01f, true, 0.4f, "Tritium", -3, 1);
-		public static readonly Gas HyperNoblium = new Gas("Hyper-Noblium", 2000, 44.01f, false, 0.4f, "NONE", -3, 0);
-		public static readonly Gas Stimulum = new Gas("Stimulum", 5, 44.01f, false, 0.4f, "NONE", -3, 7);
-		public static readonly Gas Pluoxium = new Gas("Pluoxium", 80, 44.01f, false, 0.4f, "NONE", -3, -10);
-		public static readonly Gas Freon = new Gas("Freon", 300, 44.01f, true, 0.4f, "Freon", -8, -5);
+		public static readonly Gas NitrousOxide = new Gas("Nitrous Oxide", 40, 44.01f, true, 0.4f, "NO2", OverlayType.NO2, -5, 10);
+		public static readonly Gas Hydrogen = new Gas("Hydrogen", 30, 44.01f, false, 0.4f, "NONE", OverlayType.None, -3, 0);
+		public static readonly Gas WaterVapor = new Gas("Water Vapor", 40, 44.01f, true, 0.4f, "WaterVapour", OverlayType.WaterVapour, -9, 8);
+		public static readonly Gas BZ = new Gas("BZ", 20, 44.01f, false, 0.4f, "NONE", OverlayType.None, -3, 8);
+		public static readonly Gas Miasma = new Gas("Miasma", 20, 44.01f, true, 0.4f, "Miasma", OverlayType.Miasma, -7, 0);
+		public static readonly Gas Nitryl = new Gas("Nitryl", 20, 44.01f, true, 0.4f, "Nitryl", OverlayType.Nitryl, -6, 16);
+		public static readonly Gas Tritium = new Gas("Tritium", 10, 44.01f, true, 0.4f, "Tritium", OverlayType.Tritium, -3, 1);
+		public static readonly Gas HyperNoblium = new Gas("Hyper-Noblium", 2000, 44.01f, false, 0.4f, "NONE", OverlayType.None, -3, 0);
+		public static readonly Gas Stimulum = new Gas("Stimulum", 5, 44.01f, false, 0.4f, "NONE", OverlayType.None, -3, 7);
+		public static readonly Gas Pluoxium = new Gas("Pluoxium", 80, 44.01f, false, 0.4f, "NONE", OverlayType.None, -3, -10);
+		public static readonly Gas Freon = new Gas("Freon", 300, 44.01f, true, 0.4f, "Freon", OverlayType.Freon, -8, -5);
 
 		public readonly float
 			MolarHeatCapacity; //this is how many Joules are needed to raise 1 mole of the gas 1 degree Kelvin: J/K/mol
@@ -35,11 +35,12 @@ namespace Systems.Atmospherics
 		public readonly bool HasOverlay;
 		public readonly float MinMolesToSee;
 		public readonly string TileName;
+		public readonly OverlayType OverlayType;
 		public readonly int OverlayIndex;
 		public readonly int FusionPower;
 
 
-		private Gas(string name, float molarHeatCapacity, float molarMass, bool hasOverlay, float minMolesToSee, string tileName, int overlayIndex, int fusionPower)
+		private Gas(string name, float molarHeatCapacity, float molarMass, bool hasOverlay, float minMolesToSee, string tileName, OverlayType overlayType, int overlayIndex, int fusionPower)
 		{
 			MolarHeatCapacity = molarHeatCapacity;
 			MolarMass = molarMass;
@@ -48,6 +49,7 @@ namespace Systems.Atmospherics
 			HasOverlay = hasOverlay;
 			MinMolesToSee = minMolesToSee;
 			TileName = tileName;
+			OverlayType = overlayType;
 			OverlayIndex = overlayIndex;
 			FusionPower = fusionPower;
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Gas.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Gas.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using TileManagement;
 
 namespace Systems.Atmospherics
 {

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
@@ -125,9 +125,9 @@ namespace Systems.Atmospherics
 				    affectedNode.HasHotspot)
 				{
 					affectedNode.Hotspot = null;
-					tileChangeManager.RemoveOverlaysOfName(
+					tileChangeManager.RemoveOverlaysOfType(
 						new Vector3Int(affectedNode.Position.x, affectedNode.Position.y, FIRE_FX_Z),
-						LayerType.Effects, "Fire");
+						LayerType.Effects, OverlayType.Fire);
 					hotspots.TryRemove(removedHotspot, out var value);
 
 					if (!fireLightDictionary.ContainsKey(affectedNode.Position)) continue;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Profiling;
 using Random = UnityEngine.Random;
+using TileManagement;
 
 namespace Systems.Atmospherics
 {

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/TileChangeManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/TileChangeManager.cs
@@ -378,25 +378,6 @@ public class TileChangeManager : MonoBehaviour
 
 }
 
-public enum OverlayType
-{
-	//none is used to say there is no overlay, add new category if you need a new type
-	None,
-	Gas,
-	Damage,
-	Cleanable,
-	Fire,
-	Mining,
-	KineticAnimation,
-	Plasma,
-	NO2,
-	WaterVapour,
-	Miasma,
-	Nitryl,
-	Tritium,
-	Freon
-}
-
 [System.Serializable]
 public class TileChangeList
 {

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/TileChangeManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/TileChangeManager.cs
@@ -60,7 +60,7 @@ public class TileChangeManager : MonoBehaviour
 			// load tile & apply
 			if (entry.TileType.Equals(TileType.None))
 			{
-				InternalRemoveTile(entry.Position, entry.LayerType, entry.RemoveAll);
+				InternalRemoveTile(entry.Position, entry.LayerType);
 			}
 			else
 			{
@@ -136,17 +136,16 @@ public class TileChangeManager : MonoBehaviour
 	/// </summary>
 	/// <param name="cellPosition"></param>
 	/// <param name="layerType"></param>
-	/// <param name="removeAll"></param>
 	/// <returns></returns>
 	[Server]
-	public LayerTile RemoveTile(Vector3Int cellPosition, LayerType layerType, bool removeAll = true)
+	public LayerTile RemoveTile(Vector3Int cellPosition, LayerType layerType)
 	{
 		var layerTile = metaTileMap.GetTile(cellPosition, layerType);
 		if (metaTileMap.HasTile(cellPosition, layerType))
 		{
-			InternalRemoveTile(cellPosition, layerType, removeAll);
+			InternalRemoveTile(cellPosition, layerType);
 
-			RemoveTileMessage.Send(networkMatrix.MatrixSync.netId, cellPosition, layerType, false);
+			SpawnSafeThread.RemoveTileMessageSend(networkMatrix.MatrixSync.netId, cellPosition, layerType);
 
 			AddToChangeList(cellPosition, layerType);
 
@@ -204,34 +203,7 @@ public class TileChangeManager : MonoBehaviour
 	}
 
 	[Server]
-	public void RemoveOverlaysOfName(Vector3Int cellPosition, LayerType layerType,
-		string overlayName, bool onlyIfCleanable = false, TileType tileType = TileType.Effects)
-	{
-		cellPosition.z = 0;
-
-		var overlayPos = metaTileMap.GetOverlayPos(cellPosition, layerType, overlayName);
-		if(overlayPos == null) return;
-
-		cellPosition = overlayPos.Value;
-
-		if (onlyIfCleanable)
-		{
-			//only remove it if it's a cleanable tile
-			var tile = metaTileMap.GetTile(cellPosition, layerType) as OverlayTile;
-			//it's not an overlay tile or it's not cleanable so don't remove it
-			if (tile == null || !tile.IsCleanable) return;
-		}
-
-		InternalRemoveTile(cellPosition, layerType, false);
-
-		SpawnSafeThread.RemoveTileMessageSend(networkMatrix.MatrixSync.netId, cellPosition, layerType , tileType);
-
-		AddToChangeList(cellPosition, layerType);
-	}
-
-	[Server]
-	public void RemoveOverlaysOfType(Vector3Int cellPosition, LayerType layerType,
-		OverlayType overlayType, bool onlyIfCleanable = false)
+	public void RemoveOverlaysOfType(Vector3Int cellPosition, LayerType layerType, OverlayType overlayType, bool onlyIfCleanable = false)
 	{
 		cellPosition.z = 0;
 
@@ -250,9 +222,9 @@ public class TileChangeManager : MonoBehaviour
 				if (tile == null || !tile.IsCleanable) continue;
 			}
 
-			InternalRemoveTile(cellPosition, layerType, false);
+			InternalRemoveTile(cellPosition, layerType);
 
-			RemoveTileMessage.Send(networkMatrix.MatrixSync.netId, cellPosition, layerType, false);
+			SpawnSafeThread.RemoveTileMessageSend(networkMatrix.MatrixSync.netId, cellPosition, layerType);
 
 			AddToChangeList(cellPosition, layerType);
 		}
@@ -278,9 +250,9 @@ public class TileChangeManager : MonoBehaviour
 				if (tile == null || !tile.IsCleanable) continue;
 			}
 
-			InternalRemoveTile(cellPosition, layerType, false);
+			InternalRemoveTile(cellPosition, layerType);
 
-			RemoveTileMessage.Send(networkMatrix.MatrixSync.netId, cellPosition, layerType, false);
+			SpawnSafeThread.RemoveTileMessageSend(networkMatrix.MatrixSync.netId, cellPosition, layerType);
 
 			AddToChangeList(cellPosition, layerType);
 		}
@@ -323,7 +295,7 @@ public class TileChangeManager : MonoBehaviour
 		return metaTileMap.GetTile(cellPosition, layerType);
 	}
 
-	public void InternalRemoveTile(Vector3 position, LayerType layerType, bool removeAll)
+	public void InternalRemoveTile(Vector3 position, LayerType layerType)
 	{
 		Vector3Int p = position.RoundToInt();
 
@@ -362,7 +334,7 @@ public class TileChangeManager : MonoBehaviour
 	}
 
 	private void AddToChangeList(Vector3Int position, LayerType layerType = LayerType.None,
-		TileType tileType = TileType.None, string tileName = null, bool removeAll = false, Matrix4x4? transformMatrix = null,
+		TileType tileType = TileType.None, string tileName = null, Matrix4x4? transformMatrix = null,
 		Color? color = null)
 	{
 		changeList.List.Add(new TileChangeEntry()
@@ -371,15 +343,13 @@ public class TileChangeManager : MonoBehaviour
 			LayerType = layerType,
 			TileType = tileType,
 			TileName = tileName,
-			RemoveAll = removeAll,
 			transformMatrix = transformMatrix,
 			color = color
 		});
 	}
 
 	private void AddToChangeList(Vector3Int position, LayerTile layerTile, LayerType layerType = LayerType.None,
-		bool removeAll = false, Matrix4x4? transformMatrix = null,
-		Color? color = null)
+		Matrix4x4? transformMatrix = null, Color? color = null)
 	{
 		changeList.List.Add(new TileChangeEntry()
 		{
@@ -387,7 +357,6 @@ public class TileChangeManager : MonoBehaviour
 			LayerType = layerType,
 			TileType = layerTile.TileType,
 			TileName = layerTile.name,
-			RemoveAll = removeAll,
 			transformMatrix = transformMatrix,
 			color = color
 		});
@@ -407,16 +376,25 @@ public class TileChangeManager : MonoBehaviour
 		return metaTileMap.IsDifferent(position, layerTile, layerTile.LayerType, transformMatrix, color);
 	}
 
-	public enum OverlayType
-	{
-		//none is used to say there is no overlay, add new category if you need a new type
-		None,
-		Gas,
-		Damage,
-		Cleanable,
-		Fire,
-		Mining
-	}
+}
+
+public enum OverlayType
+{
+	//none is used to say there is no overlay, add new category if you need a new type
+	None,
+	Gas,
+	Damage,
+	Cleanable,
+	Fire,
+	Mining,
+	KineticAnimation,
+	Plasma,
+	NO2,
+	WaterVapour,
+	Miasma,
+	Nitryl,
+	Tritium,
+	Freon
 }
 
 [System.Serializable]
@@ -444,13 +422,9 @@ public class TileChangeEntry
 
 	public string TileName;
 
-	public bool RemoveAll;
-
 	public Matrix4x4? transformMatrix;
 
 	public Color? color;
-
-	public TileChangeManager.OverlayType overlayType;
 
 }
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
@@ -118,17 +118,17 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 			}
 			data.RemoveTileDamage(Layer.LayerType);
 			tileChangeManager.RemoveTile(data.Position, Layer.LayerType);
-			tileChangeManager.RemoveOverlaysOfType(data.Position, LayerType.Effects, TileChangeManager.OverlayType.Damage);
+			tileChangeManager.RemoveOverlaysOfType(data.Position, LayerType.Effects, OverlayType.Damage);
 
 			if (Layer.LayerType == LayerType.Floors || Layer.LayerType == LayerType.Base)
 			{
-				tileChangeManager.RemoveOverlaysOfType(data.Position, LayerType.Floors, TileChangeManager.OverlayType.Cleanable);
+				tileChangeManager.RemoveOverlaysOfType(data.Position, LayerType.Floors, OverlayType.Cleanable);
 			}
 
 			if (Layer.LayerType == LayerType.Walls)
 			{
-				tileChangeManager.RemoveOverlaysOfType(data.Position, LayerType.Walls, TileChangeManager.OverlayType.Cleanable);
-				tileChangeManager.RemoveOverlaysOfType(data.Position, LayerType.Effects, TileChangeManager.OverlayType.Mining);
+				tileChangeManager.RemoveOverlaysOfType(data.Position, LayerType.Walls, OverlayType.Cleanable);
+				tileChangeManager.RemoveOverlaysOfType(data.Position, LayerType.Effects, OverlayType.Mining);
 			}
 
 			//Add new tile if needed
@@ -230,7 +230,7 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 	{
 		var data = metaDataLayer.Get(cellPos);
 
-		tileChangeManager.RemoveOverlaysOfType(cellPos, LayerType.Effects, TileChangeManager.OverlayType.Damage);
+		tileChangeManager.RemoveOverlaysOfType(cellPos, LayerType.Effects, OverlayType.Damage);
 		data.ResetDamage(Layer.LayerType);
 	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Tiles/OverlayTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Tiles/OverlayTile.cs
@@ -1,6 +1,6 @@
-
 using UnityEngine;
 using UnityEngine.Serialization;
+using TileManagement;
 
 /// <summary>
 /// Tile which is merely an effect / overlay. Doesn't really

--- a/UnityProject/Assets/Scripts/Tilemaps/Tiles/OverlayTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Tiles/OverlayTile.cs
@@ -32,16 +32,16 @@ public class OverlayTile : LayerTile
 
 	[Tooltip("The type of overlay?")]
 	[SerializeField]
-	private TileChangeManager.OverlayType overlayType = TileChangeManager.OverlayType.None;
+	private OverlayType overlayType = OverlayType.None;
 
-	public TileChangeManager.OverlayType OverlayType => overlayType;
+	public OverlayType OverlayType => overlayType;
 
 	public override bool Equals(object other)
 	{
 		if (other != null && this.GetType().Equals(other.GetType()))
 		{
 			OverlayTile comparedOverlay = (OverlayTile)other;
-			return (overlayName == comparedOverlay.overlayName)
+			return (OverlayName == comparedOverlay.OverlayName)
 				&& (PreviewSprite == comparedOverlay.PreviewSprite)
 				&& (overlayType == comparedOverlay.OverlayType)
 				&& (isCleanable == comparedOverlay.isCleanable)

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Effects/AtmosOverlays/Fire.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Effects/AtmosOverlays/Fire.asset
@@ -19,7 +19,8 @@ MonoBehaviour:
   overlayName: Fire
   sprite: {fileID: 0}
   isCleanable: 0
-  overlayType: 1
+  isGraffiti: 0
+  overlayType: 4
   Sprites:
   - {fileID: 21300000, guid: 9b00a3ebed4596b46b91b8ea40b75729, type: 3}
   - {fileID: 21300002, guid: 9b00a3ebed4596b46b91b8ea40b75729, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Effects/AtmosOverlays/Freon.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Effects/AtmosOverlays/Freon.asset
@@ -19,7 +19,8 @@ MonoBehaviour:
   overlayName: Freon
   sprite: {fileID: 0}
   isCleanable: 0
-  overlayType: 1
+  isGraffiti: 0
+  overlayType: 13
   Sprites:
   - {fileID: 21300000, guid: 45424e7ce103b884e8b1b808bded8386, type: 3}
   - {fileID: 21300002, guid: 45424e7ce103b884e8b1b808bded8386, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Effects/AtmosOverlays/Miasma.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Effects/AtmosOverlays/Miasma.asset
@@ -19,7 +19,8 @@ MonoBehaviour:
   overlayName: Miasma
   sprite: {fileID: 0}
   isCleanable: 0
-  overlayType: 1
+  isGraffiti: 0
+  overlayType: 10
   Sprites:
   - {fileID: 21300000, guid: 4313cfd469a59f84caf96393a222ac92, type: 3}
   - {fileID: 21300002, guid: 4313cfd469a59f84caf96393a222ac92, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Effects/AtmosOverlays/NO2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Effects/AtmosOverlays/NO2.asset
@@ -19,7 +19,8 @@ MonoBehaviour:
   overlayName: NO2
   sprite: {fileID: 0}
   isCleanable: 0
-  overlayType: 1
+  isGraffiti: 0
+  overlayType: 8
   Sprites:
   - {fileID: 21300000, guid: bf0a2d81cbf37e44ea5687f2d080c531, type: 3}
   - {fileID: 21300002, guid: bf0a2d81cbf37e44ea5687f2d080c531, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Effects/AtmosOverlays/Nitryl.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Effects/AtmosOverlays/Nitryl.asset
@@ -19,7 +19,8 @@ MonoBehaviour:
   overlayName: Nitryl
   sprite: {fileID: 0}
   isCleanable: 0
-  overlayType: 1
+  isGraffiti: 0
+  overlayType: 11
   Sprites:
   - {fileID: 21300000, guid: 5b3a6da0951ff8842b8cfb28f7a5a9a8, type: 3}
   - {fileID: 21300002, guid: 5b3a6da0951ff8842b8cfb28f7a5a9a8, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Effects/AtmosOverlays/Plasma.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Effects/AtmosOverlays/Plasma.asset
@@ -19,7 +19,8 @@ MonoBehaviour:
   overlayName: Plasma
   sprite: {fileID: 0}
   isCleanable: 0
-  overlayType: 1
+  isGraffiti: 0
+  overlayType: 7
   Sprites:
   - {fileID: 21300000, guid: 835b8b57fad81c8488c8450d87805733, type: 3}
   - {fileID: 21300002, guid: 835b8b57fad81c8488c8450d87805733, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Effects/AtmosOverlays/Tritium.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Effects/AtmosOverlays/Tritium.asset
@@ -19,7 +19,8 @@ MonoBehaviour:
   overlayName: Tritium
   sprite: {fileID: 0}
   isCleanable: 0
-  overlayType: 1
+  isGraffiti: 0
+  overlayType: 12
   Sprites:
   - {fileID: 21300000, guid: c6fe51926cb4b604098f2d311c82fbb4, type: 3}
   - {fileID: 21300002, guid: c6fe51926cb4b604098f2d311c82fbb4, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Effects/AtmosOverlays/WaterVapour.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Effects/AtmosOverlays/WaterVapour.asset
@@ -19,7 +19,8 @@ MonoBehaviour:
   overlayName: WaterVapour
   sprite: {fileID: 0}
   isCleanable: 0
-  overlayType: 0
+  isGraffiti: 0
+  overlayType: 9
   Sprites:
   - {fileID: 21300000, guid: d41c9d9095c79954998819d0eee59eab, type: 3}
   - {fileID: 21300002, guid: d41c9d9095c79954998819d0eee59eab, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Effects/KineticAnimation.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Effects/KineticAnimation.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
   sprite: {fileID: 0}
   isCleanable: 0
   isGraffiti: 0
-  overlayType: 0
+  overlayType: 6
   Sprites:
   - {fileID: 21300000, guid: 764d7fb04c8f3aa4a8c35704a26d5290, type: 3}
   - {fileID: 21300002, guid: 764d7fb04c8f3aa4a8c35704a26d5290, type: 3}


### PR DESCRIPTION
### Purpose
Removes the unused 'RemoveAll' argument and variables in tile update changes code.
Removes RemoveOverlaysOfName() and GetOverlayPosByName(), all overlay removals will now use OverlayType instead.
All remove overlay server functions will now be thread safe.
Separates the update tile message and remove tile message in SpawnSafeThread into two.
Fixes clients not removing certain specific overlays.
Fixes one way to reproduce #6398 (with bombs, although the bug that I'm fixing seems to have been aded after that issue was created)
Fixes #6704