### PR TITLE
Fixes another case of eternal flames

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
@@ -29,7 +29,7 @@ public class Matrix : MonoBehaviour
 
 	private TileList serverObjects;
 
-	private TileList ServerObjects => serverObjects ??
+	public TileList ServerObjects => serverObjects ??
 	                                  (serverObjects = ((ObjectLayer) MetaTileMap.Layers[LayerType.Objects])
 		                                  .ServerObjects);
 
@@ -302,23 +302,6 @@ public class Matrix : MonoBehaviour
 
 		return true;
 	}
-
-	/// <summary>
-	/// Efficient way of iterating through the register tiles at a particular position which
-	/// also is safe against modifications made to the list of tiles while the action is running.
-	/// The limitation compared to Get<> is it can only get RegisterTiles, but the benefit is it avoids
-	/// GetComponent so there's no GC. The OTHER benefit is that normally iterating through these
-	/// would throw an exception if the RegisterTiles at this position were modified, such as
-	/// being destroyed are created. This method uses a locking mechanism to avoid
-	/// such issues.
-	/// </summary>
-	/// <param name="localPosition"></param>
-	/// <returns></returns>
-	public void ForEachRegisterTileSafe(IRegisterTileAction action, Vector3Int localPosition, bool isServer)
-	{
-		(isServer ? ServerObjects : ClientObjects).ForEachSafe(action, localPosition);
-	}
-
 
 	public IEnumerable<RegisterTile> GetRegisterTile(Vector3Int localPosition, bool isServer)
 	{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
@@ -331,7 +331,7 @@ namespace Systems.Atmospherics
 
 				//only expose to atmos impassable objects, since those are the things the flames would
 				//actually brush up against
-				matrix.ForEachRegisterTileSafe(applyExposure, atLocalPosition, true);
+				matrix.ServerObjects.InvokeOnObjects(applyExposure, atLocalPosition);
 				//expose the tiles there
 				foreach (var tilemapDamage in tilemapDamages)
 				{
@@ -344,7 +344,7 @@ namespace Systems.Atmospherics
 			{
 				Profiler.BeginSample("DirectExposure");
 				//direct exposure logic
-				matrix.ForEachRegisterTileSafe(applyExposure, atLocalPosition, true);
+				matrix.ServerObjects.InvokeOnObjects(applyExposure, atLocalPosition);
 				//expose the tiles
 				foreach (var tilemapDamage in tilemapDamages)
 				{

--- a/UnityProject/Assets/Scripts/Tilemaps/Utils/TileList.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Utils/TileList.cs
@@ -1,67 +1,38 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
 using UnityEngine;
-using UnityEngine.Rendering;
-
 
 /// <summary>
 /// Stores the RegisterTiles at each tile position.
-///
-/// Note that it has a locking mechanism for locking modifications to a particular position's RegisterTiles  -
-/// when a modification is performed while locked it actually goes into a queue and
-/// isn't applied until unlocked.
 /// </summary>
 public class TileList
 {
-	private readonly Dictionary<Vector3Int, List<RegisterTile>> _objects =
-		new Dictionary<Vector3Int, List<RegisterTile>>();
+	private readonly Dictionary<Vector3Int, List<RegisterTile>> _objects = new Dictionary<Vector3Int, List<RegisterTile>>();
 
 	private static readonly List<RegisterTile> emptyList = new List<RegisterTile>();
 
-	//position that is currently locked from modifications, thus will queue up any modifications.
-	//note this is not a thread safety mechanism, it is only there to allow modifications to the list
-	//withing the ForEachSafe action.
-	//Also it's only possible to lock a single position at a time.
-	private Vector3Int? lockedPosition = null;
-
-	private int LockedName = 0;
-	//queued operations to dequeue once iteration is complete.
-	private readonly List<QueuedOp> queuedOps = new List<QueuedOp>();
+	//permanent list to avoid the usage of ienumerators
+	private readonly List<RegisterTile> TempRegisterTiles = new List<RegisterTile>();
 
 	public List<RegisterTile> AllObjects {
 		get {
-			List<RegisterTile> list = new List<RegisterTile>();
-			foreach ( List<RegisterTile> x in _objects.Values ) {
-				for ( var i = 0; i < x.Count; i++ ) {
-					list.Add( x[i] );
+			var list = new List<RegisterTile>();
+			foreach (var x in _objects.Values) {
+				foreach (var registerTile in x)
+				{
+					list.Add(registerTile);
 				}
 			}
-
 			return list;
 		}
 	}
 
 	public void Add(Vector3Int position, RegisterTile obj)
 	{
-
-
-		//queue for later if it's locked
-		if (lockedPosition == position)
-		{
-			queuedOps.Add(new QueuedOp(false, position, obj));
-			return;
-		}
-
-
 		if (!_objects.ContainsKey(position))
 		{
 			_objects[position] = new List<RegisterTile>();
 		}
-
-
-
 		if (!_objects[position].Contains(obj))
 		{
 			_objects[position].Add(obj);
@@ -69,9 +40,24 @@ public class TileList
 		}
 	}
 
+	public void Remove(Vector3Int position, RegisterTile obj = null)
+	{
+		if (_objects.TryGetValue(position, out var objectsOut))
+		{
+			if (obj == null)
+			{
+				objectsOut.Clear();
+			}
+			else
+			{
+				objectsOut.Remove(obj);
+			}
+		}
+	}
+
 	private void ReorderObjects(Vector3Int position)
 	{
-		int offset = 0;
+		var offset = 0;
 		if (position.x % 2 != 0)
 		{
 			offset = position.y % 2 != 0 ? 1 : 0;
@@ -80,14 +66,13 @@ public class TileList
 		{
 			offset = position.y % 2 != 0 ? 3 : 2;
 		}
-		int i = 0;
+		var i = 0;
 		foreach (var register in _objects[position])
 		{
 			if (register.OrNull()?.CurrentsortingGroup == null) continue;
 			register.CurrentsortingGroup.sortingOrder = (i * 4) + offset;
 			i++;
 		}
-
 	}
 
 	public bool HasObjects(Vector3Int position)
@@ -105,128 +90,26 @@ public class TileList
 		{
 			return emptyList;
 		}
-
 		var list = new List<RegisterTile>();
-		foreach ( RegisterTile x in objectsOut )
+		foreach (var x in objectsOut)
 		{
-			if ( x.ObjectType == type ) {
-				list.Add( x );
+			if (x.ObjectType == type) {
+				list.Add(x);
 			}
 		}
-
 		return list;
 	}
 
-	public IEnumerable<T> Get<T>(Vector3Int position) where T : RegisterTile
+	public void InvokeOnObjects(IRegisterTileAction action, Vector3Int localPosition)
 	{
-		if (_objects.TryGetValue(position, out var objectsOut) == false)
+		TempRegisterTiles.Clear();
+		TempRegisterTiles.AddRange(Get(localPosition));
+		foreach (var registerTile in TempRegisterTiles)
 		{
-			return Enumerable.Empty<T>();
-		}
-
-		var list = new List<T>();
-		foreach ( RegisterTile t in objectsOut )
-		{
-			T unknown = t as T;
-			if ( t != null ) {
-				list.Add( unknown );
-			}
-		}
-
-		return list;
-	}
-
-	public RegisterTile GetFirst(Vector3Int position)
-	{
-		return Get(position).FirstOrDefault();
-	}
-
-	public T GetFirst<T>(Vector3Int position) where T : RegisterTile
-	{
-		return Get(position).OfType<T>().FirstOrDefault();
-	}
-
-	public void Remove(Vector3Int position, RegisterTile obj = null)
-	{
-		//queue for later if it's locked
-		if (position == lockedPosition)
-		{
-			queuedOps.Add(new QueuedOp(true, position, obj));
-			return;
-		}
-
-		if (_objects.TryGetValue(position, out var objectsOut))
-		{
-			if (obj == null)
+			if (registerTile != null) //explosions can delete many objects in this tile!
 			{
-				objectsOut.Clear();
+				action.Invoke(registerTile);
 			}
-			else
-			{
-				objectsOut.Remove(obj);
-			}
-		}
-	}
-
-
-	/// <summary>
-	/// Efficient way of iterating through the register tiles at a particular position which
-	/// also is safe against modifications made to the list of tiles while the action is running.
-	/// The limitation compared to Get<> is it can only get RegisterTiles, but the benefit is it avoids
-	/// GetComponent so there's no GC. The OTHER benefit is that normally iterating through these
-	/// would throw an exception if the RegisterTiles at this position were modified, such as
-	/// being destroyed are created within the specified action. This method uses a locking mechanism to avoid
-	/// such issues - it's safe to add / remove register tiles.
-	/// </summary>
-	/// <param name="localPosition"></param>
-	/// <returns></returns>
-	public void ForEachSafe(IRegisterTileAction action, Vector3Int localPosition)
-	{
-		if (lockedPosition != null)
-		{
-
-			Logger.LogErrorFormat("{2} Tried to lock tile at position {0} while position {1} is currently locked by {3}" +
-			                      " TileList only supports locking one position at a time. Please add this locking capability" +
-			                      " to TileList if it is really necessary. Action will be skipped", Category.Matrix, localPosition, lockedPosition,Thread.CurrentThread.ManagedThreadId ,  LockedName);
-			return;
-		}
-
-		lockedPosition = localPosition;
-		LockedName = Thread.CurrentThread.ManagedThreadId;
-		foreach (var registerTile in Get((Vector3Int)lockedPosition))
-		{
-			action.Invoke(registerTile);
-		}
-		lockedPosition = null;
-		LockedName = 0;
-		foreach (var queuedOp in queuedOps)
-		{
-			if (queuedOp.Remove)
-			{
-				Remove(queuedOp.Position, queuedOp.RegisterTile);
-			}
-			else
-			{
-				Add(queuedOp.Position, queuedOp.RegisterTile);
-			}
-		}
-
-		queuedOps.Clear();
-	}
-
-	private class QueuedOp
-	{
-		//if not remove, it's an add
-		public readonly bool Remove;
-		public readonly Vector3Int Position;
-		//to add or remove (or null to clear all)
-		public readonly RegisterTile RegisterTile;
-
-		public QueuedOp(bool remove, Vector3Int position, RegisterTile registerTile)
-		{
-			this.Remove = remove;
-			this.Position = position;
-			this.RegisterTile = registerTile;
 		}
 	}
 }


### PR DESCRIPTION
### Purpose
Fixes fires getting stuck in the case of a runtime happening during a fire exposure.
Removes the queue and semi-lock system from TileList to apply actions, replaced it with a temp list instead.
Fixes another case of #6398 (runtime on fire exposure, causing the lock variable ~now removed~ to get stuck forever)


