### PR TITLE
Fixes traitors having some uplink items missing

### DIFF
--- a/UnityProject/Assets/Scripts/UI/Items/PDA/GUI_PDAUplinkItem.cs
+++ b/UnityProject/Assets/Scripts/UI/Items/PDA/GUI_PDAUplinkItem.cs
@@ -24,13 +24,14 @@ namespace UI.Items.PDA
 		public void GenerateEntries(UplinkCategory category)
 		{
 			controller.SetBreadcrumb($"{controller.UPLINK_DIRECTORY}/categories/{category.CategoryName}/");
-			bool isNukie = controller.mainController.PDA.IsNukeOps;
-			for (int i = 0; i < category.ItemList.Count; i++)
+			var isNukie = controller.mainController.PDA.IsNukeOps;
+			foreach (var uplinkItem in category.ItemList)
 			{
-				if (isNukie || category.ItemList[i].IsNukeOps == false)
+				if (isNukie || uplinkItem.IsNukeOps == false)
 				{
 					dynamicList.AddItem();
-					dynamicList.Entries[i].GetComponent<GUI_PDAUplinkItemTemplate>().ReInit(category.ItemList[i]);
+					var entry = dynamicList.Entries[dynamicList.Entries.Length-1];
+					entry.GetComponent<GUI_PDAUplinkItemTemplate>().ReInit(uplinkItem);
 				}
 			}
 		}


### PR DESCRIPTION
### Purpose
Fixes traitors having some uplink items missing from their PDAs.
Fixes #6726
Fixes #6756

It was using the same index for both DynamicList and UplinkList, having it go out of range when an item wasn't added because nukie.

