### PR TITLE
Fixes explosions getting stuck in a destruction loop

### DIFF
--- a/UnityProject/Assets/Scripts/Systems/Explosions/ExplosionManager.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/ExplosionManager.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using Mirror;
 using UnityEngine;
 
@@ -35,11 +36,11 @@ namespace Systems.Explosions
 			}
 			SubCheckLines.Clear();
 
-			foreach (var CheckLoc in CheckLocations)
+			foreach (var explosionNode in CheckLocations.ToArray())
 			{
-				CheckLoc.Process();
+				CheckLocations.Remove(explosionNode); //lets not create infinite explosions in the case of a runtime
+				explosionNode.Process();
 			}
-			CheckLocations.Clear();
 		}
 	}
 }


### PR DESCRIPTION
### Purpose
Fixes explosions getting stuck in a loop in the case of a runtime happening when a explosion node is processing.
Fixes #6772

