### PR TITLE
Interaction code cleaning

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/DefaultWillInteract.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/DefaultWillInteract.cs
@@ -1,90 +1,61 @@
-
-/// <summary>
-/// Util class containing the default WIllinteract logic for each interaction type
-/// </summary>
 public static class DefaultWillInteract
 {
 	/// <summary>
-	/// Default Willinteract logic for the given interaction type T.
-	///
 	/// Chooses and invokes DefaultWillInteract method corresponding to the supplied type.
 	/// </summary>
 	/// <param name="interaction">interaction to check</param>
 	/// <param name="side">side of the network this is being checked on</param>
 	/// <typeparam name="T">type of interaction</typeparam>
-	/// <returns></returns>
 	public static bool Default<T>(T interaction, NetworkSide side) where T : Interaction
 	{
 		if (typeof(T) == typeof(PositionalHandApply))
 		{
-			return PositionalHandApply(interaction as PositionalHandApply, side);
+			var positionalHandApply = interaction as PositionalHandApply;
+			return Validations.CanApply(positionalHandApply.PerformerPlayerScript, positionalHandApply.TargetObject, side, targetVector: positionalHandApply.TargetVector);
 		}
-		else if (typeof(T) == typeof(HandApply))
+		if (typeof(T) == typeof(HandApply))
 		{
-			return HandApply(interaction as HandApply, side);
+			var handApply = interaction as HandApply;
+			return Validations.CanApply(handApply.PerformerPlayerScript, handApply.TargetObject, side);
 		}
-		else if (typeof(T) == typeof(AimApply))
+		if (typeof(T) == typeof(AimApply))
 		{
 			return AimApply(interaction as AimApply, side);
 		}
-		else if (typeof(T) == typeof(MouseDrop))
+		if (typeof(T) == typeof(MouseDrop))
 		{
-			return MouseDrop(interaction as MouseDrop, side);
+			return Validations.CanInteract(interaction.PerformerPlayerScript, side);
 		}
-		else if (typeof(T) == typeof(HandActivate))
+		if (typeof(T) == typeof(HandActivate))
 		{
-			return HandActivate(interaction as HandActivate, side);
+			return Validations.CanInteract(interaction.PerformerPlayerScript, side);
 		}
-		else if (typeof(T) == typeof(InventoryApply))
+		if (typeof(T) == typeof(InventoryApply))
 		{
-			return InventoryApply(interaction as InventoryApply, side);
+			return Validations.CanInteract(interaction.PerformerPlayerScript, side);
 		}
-		else if (typeof(T) == typeof(TileApply))
+		if (typeof(T) == typeof(TileApply))
 		{
-			return TileApply(interaction as TileApply, side);
+			var tileApply = interaction as TileApply;
+			return Validations.CanApply(tileApply.PerformerPlayerScript, tileApply.TargetInteractableTiles.gameObject, side, targetVector: tileApply.TargetVector);
 		}
-		else if (typeof(T) == typeof(ConnectionApply))
+		if (typeof(T) == typeof(ConnectionApply))
 		{
-			return ConnectionApply(interaction as ConnectionApply, side);
+			var connectionApply = interaction as ConnectionApply;
+			return Validations.CanApply(connectionApply.PerformerPlayerScript, connectionApply.TargetObject, side, targetVector: connectionApply.TargetVector);
 		}
-		else if (typeof(T) == typeof(ContextMenuApply))
+		if (typeof(T) == typeof(ContextMenuApply))
 		{
-			return ContextMenuApply(interaction as ContextMenuApply, side);
+			var contextMenuApply = interaction as ContextMenuApply;
+			return Validations.CanApply(contextMenuApply.PerformerPlayerScript, contextMenuApply.TargetObject, side);
 		}
 		Logger.LogError("Unable to recognize interaction type.", Category.Interaction);
 		return false;
 	}
 
-	/// <summary>
-	/// Default WillInteract logic for InventoryApply
-	/// </summary>
-	public static bool InventoryApply(InventoryApply interaction, NetworkSide side)
-	{
-		return Validations.CanInteract(interaction.Performer, side);
-	}
-
-	/// <summary>
-	/// Default WillInteract logic for Activate
-	/// </summary>
-	public static bool HandActivate(HandActivate interaction, NetworkSide side)
-	{
-		return Validations.CanInteract(interaction.Performer, side);
-	}
-
-	/// <summary>
-	/// Default WillInteract logic for MouseDrop
-	/// </summary>
-	public static bool MouseDrop(MouseDrop interaction, NetworkSide side)
-	{
-		return Validations.CanApply(interaction, side);
-	}
-
-	/// <summary>
-	/// Default WillInteract logic for AimApply
-	/// </summary>
 	public static bool AimApply(AimApply interaction, NetworkSide side)
 	{
-		if ( !Validations.CanInteract(interaction.Performer, side) )
+		if ( !Validations.CanInteract(interaction.PerformerPlayerScript, side) )
 		{
 			return false;
 		}
@@ -102,45 +73,5 @@ public static class DefaultWillInteract
 		}
 
 		return isNotHidden.GetValueOrDefault( true );
-	}
-
-	/// <summary>
-	/// Default WillInteract logic for HandApply
-	/// </summary>
-	public static bool HandApply(HandApply interaction, NetworkSide side)
-	{
-		return Validations.CanApply(interaction, side);
-	}
-
-	/// <summary>
-	/// Default WIllInteract logic for PositionalHandApply interactions
-	/// </summary>
-	public static bool PositionalHandApply(PositionalHandApply interaction, NetworkSide side)
-	{
-		return Validations.CanApply(interaction, side);
-	}
-
-	/// <summary>
-	/// Default WIllInteract logic for TileApply interactions
-	/// </summary>
-	public static bool TileApply(TileApply interaction, NetworkSide side)
-	{
-		return Validations.CanApply(interaction, side);
-	}
-
-	/// <summary>
-	/// Default WillInteract logic for ConnectionApply interactions
-	/// </summary>
-	public static bool ConnectionApply(ConnectionApply interaction, NetworkSide side)
-	{
-		return Validations.CanApply(interaction, side);
-	}
-
-	/// <summary>
-	/// Default WillInteract logic for ContextMenuApply interactions
-	/// </summary>
-	public static bool ContextMenuApply(ContextMenuApply interaction, NetworkSide side)
-	{
-		return Validations.CanApply(interaction, side);
 	}
 }

--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/MouseDraggable.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/MouseDraggable.cs
@@ -122,7 +122,7 @@ public class MouseDraggable : MonoBehaviour
 	/// </summary>
 	/// <param name="dragger">player attempting the drag</param>
 	/// <returns></returns>
-	public bool CanBeginDrag(GameObject dragger)
+	public bool CanBeginDrag(PlayerScript dragger)
 	{
 		return Validations.CanApply(dragger, gameObject, NetworkSide.Client, allowDragWhileSoftCrit,
 			draggerMustBeAdjacent ? ReachRange.Standard : ReachRange.Unlimited);

--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/TileInteraction.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/TileInteraction.cs
@@ -8,7 +8,10 @@ using UnityEngine;
 /// </summary>
 public abstract class TileInteraction : ScriptableObject, IPredictedCheckedInteractable<TileApply>
 {
-	public virtual bool WillInteract(TileApply interaction, NetworkSide side) { return DefaultWillInteract.TileApply(interaction, side); }
+	public virtual bool WillInteract(TileApply interaction, NetworkSide side)
+	{
+		return DefaultWillInteract.Default(interaction, side);
+	}
 
 	public virtual void ServerPerformInteraction(TileApply interaction) { }
 

--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Validations.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Validations.cs
@@ -118,22 +118,6 @@ public static class Validations
 	/// Checks if a player is allowed to interact with things (based on this player's status, such
 	/// as being conscious, and not cuffed).
 	/// </summary>
-	/// <param name="player">player gameobject to check</param>
-	/// <param name="side">side of the network the check is being performed on</param>
-	/// <param name="allowSoftCrit">whether interaction should be allowed if in soft crit</param>
-	/// <param name="allowCuffed">whether interaction should be allowed if cuffed</param>
-	/// <returns></returns>
-	public static bool CanInteract(GameObject player, NetworkSide side, bool allowSoftCrit = false, bool allowCuffed = false, bool isPlayerClick = true)
-	{
-		if (player == null) return false;
-
-		return CanInteract(player.GetComponent<PlayerScript>(), side, allowSoftCrit, allowCuffed, isPlayerClick);
-	}
-
-	/// <summary>
-	/// Checks if a player is allowed to interact with things (based on this player's status, such
-	/// as being conscious, and not cuffed).
-	/// </summary>
 	/// <param name="playerScript">playerscript of the player to check</param>
 	/// <param name="side">side of the network the check is being performed on</param>
 	/// <param name="allowSoftCrit">whether interaction should be allowed if in soft crit</param>
@@ -453,86 +437,11 @@ public static class Validations
 		}
 	}
 
-	/// <summary>
-	/// Validates if the performer is in range and capable of interaction -  all the typical requirements for all
-	/// various interactions. Works properly even if player is hidden in a ClosetControl. Can also optionally allow soft crit.
-	///
-	/// </summary>
-	/// <param name="player">player performing the interaction</param>
-	/// <param name="target">target object</param>
-	/// <param name="side">side of the network this is being checked on</param>
-	/// <param name="allowSoftCrit">whether to allow interaction while in soft crit</param>
-	/// <param name="reachRange">range to allow</param>
-	/// <param name="targetVector">target vector pointing from performer to the position they are trying to click,
-	/// if specified will use this to determine if in range rather than target object position.</param>
-	/// <param name="targetRegisterTile">target's register tile component. If you specify this it avoids garbage. Please provide this
-	/// if you can do so without using GetComponent, especially if you are calling this frequently.
-	/// This is an optimization so GetComponent call can be avoided to avoid
-	/// creating garbage.</param>
-	/// <returns></returns>
-	public static bool CanApply(GameObject player, GameObject target, NetworkSide side, bool allowSoftCrit = false,
-		ReachRange reachRange = ReachRange.Standard, Vector2? targetVector = null, RegisterTile targetRegisterTile = null, bool isPlayerClick = false)
-	{
-		if (player == null) return false;
-		return CanApply(player.GetComponent<PlayerScript>(), target, side, allowSoftCrit, reachRange, targetVector, targetRegisterTile, isPlayerClick);
-	}
-
 	private static bool ServerCanReachExtended(PlayerScript ps, TransformState state, GameObject context = null)
 	{
 		return ps.IsPositionReachable(state.WorldPosition, true) || ps.IsPositionReachable(state.WorldPosition - (Vector3)state.WorldImpulse, true, 1.75f, context: context);
 	}
 
-	/// <summary>
-	/// Validates if the performer is in range and not in crit for a HandApply interaction.
-	/// </summary>
-	/// <param name="toValidate">interaction to validate</param>
-	/// <param name="side">side of the network this is being checked on</param>
-	/// <param name="allowSoftCrit">whether to allow interaction while in soft crit</param>
-	/// <param name="reachRange">range to allow</param>
-	/// <returns></returns>
-	public static bool CanApply(HandApply toValidate, NetworkSide side, bool allowSoftCrit = false, ReachRange reachRange = ReachRange.Standard, bool isPlayerClick = false) =>
-		CanApply(toValidate.Performer, toValidate.TargetObject, side, allowSoftCrit, reachRange, isPlayerClick: isPlayerClick);
-
-	/// <summary>
-	/// Validates if the performer is in range and not in crit for a PositionalHandApply interaction.
-	/// Range check is based on the target vector of toValidate, not the distance to the object.
-	/// </summary>
-	/// <param name="toValidate">interaction to validate</param>
-	/// <param name="side">side of the network this is being checked on</param>
-	/// <param name="allowSoftCrit">whether to allow interaction while in soft crit</param>
-	/// <param name="reachRange">range to allow</param>
-	/// <returns></returns>
-	public static bool CanApply(PositionalHandApply toValidate, NetworkSide side, bool allowSoftCrit = false, ReachRange reachRange = ReachRange.Standard, bool isPlayerClick = false) =>
-		CanApply(toValidate.Performer, toValidate.TargetObject, side, allowSoftCrit, reachRange, toValidate.TargetVector, isPlayerClick: isPlayerClick);
-
-	/// <summary>
-	/// Validates if the performer is in range and not in crit for a TileApply interaction.
-	/// Range check is based on the target vector of toValidate, not the distance to the object.
-	/// </summary>
-	/// <param name="toValidate">interaction to validate</param>
-	/// <param name="side">side of the network this is being checked on</param>
-	/// <param name="allowSoftCrit">whether to allow interaction while in soft crit</param>
-	/// <param name="reachRange">range to allow</param>
-	/// <returns></returns>
-	public static bool CanApply(TileApply toValidate, NetworkSide side, bool allowSoftCrit = false, ReachRange reachRange = ReachRange.Standard, bool isPlayerClick = false) =>
-		CanApply(toValidate.Performer, toValidate.TargetInteractableTiles.gameObject, side, allowSoftCrit, reachRange, toValidate.TargetVector, isPlayerClick: isPlayerClick);
-
-	/// <summary>
-	/// Validates if the performer is in range and not in crit for a MouseDrop interaction.
-	/// </summary>
-	/// <param name="toValidate">interaction to validate</param>
-	/// <param name="side">side of the network this is being checked on</param>
-	/// <param name="allowSoftCrit">whether to allow interaction while in soft crit</param>
-	/// <param name="reachRange">range to allow</param>
-	/// <returns></returns>
-	public static bool CanApply(MouseDrop toValidate, NetworkSide side, bool allowSoftCrit = false, ReachRange reachRange = ReachRange.Standard, bool isPlayerClick = false) =>
-		CanApply(toValidate.Performer, toValidate.TargetObject, side, allowSoftCrit, reachRange, isPlayerClick: isPlayerClick);
-
-	public static bool CanApply(ConnectionApply toValidate, NetworkSide side, bool allowSoftCrit = false, ReachRange reachRange = ReachRange.Standard, bool isPlayerClick = false) =>
-		CanApply(toValidate.Performer, toValidate.TargetObject, side, allowSoftCrit, reachRange, toValidate.TargetVector, isPlayerClick: isPlayerClick);
-
-	public static bool CanApply(ContextMenuApply toValidate, NetworkSide side, bool allowSoftCrit = false, ReachRange reachRange = ReachRange.Standard, bool isPlayerClick = false) =>
-		CanApply(toValidate.Performer, toValidate.TargetObject, side, allowSoftCrit, reachRange, isPlayerClick: isPlayerClick);
 	#endregion
 
 
@@ -631,7 +540,7 @@ public static class Validations
 			Logger.LogError("Cannot put item to slot because the item is null playerScript > " +  playerScript + " itemSlot > " + itemSlot, Category.Inventory);
 			return false;
 		}
-		if (CanInteract(playerScript.gameObject, side, true) == false)
+		if (CanInteract(playerScript, side, true) == false)
 		{
 			Logger.LogTrace("Cannot put item to slot because the player cannot interact", Category.Inventory);
 			return false;

--- a/UnityProject/Assets/Scripts/Core/Input System/MouseInputController.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/MouseInputController.cs
@@ -505,7 +505,7 @@ public class MouseInputController : MonoBehaviour
 			MouseUtils.GetOrderedObjectsUnderMouse(null, go =>
 					go.GetComponent<MouseDraggable>() != null &&
 					go.GetComponent<MouseDraggable>().enabled &&
-					go.GetComponent<MouseDraggable>().CanBeginDrag(PlayerManager.LocalPlayer))
+					go.GetComponent<MouseDraggable>().CanBeginDrag(PlayerManager.LocalPlayerScript))
 				.FirstOrDefault();
 		if (draggable != null)
 		{

--- a/UnityProject/Assets/Scripts/Items/Glass/IceShard.cs
+++ b/UnityProject/Assets/Scripts/Items/Glass/IceShard.cs
@@ -102,7 +102,7 @@ namespace Items
 		//Used on shard on tile
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
-			if (DefaultWillInteract.HandApply(interaction, side) == false) return false;
+			if (DefaultWillInteract.Default(interaction, side) == false) return false;
 
 			if (Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.Welder)) return true;
 
@@ -117,7 +117,7 @@ namespace Items
 		//Used on shard in inventory
 		public bool WillInteract(InventoryApply interaction, NetworkSide side)
 		{
-			if (DefaultWillInteract.InventoryApply(interaction, side) == false) return false;
+			if (Validations.CanInteract(interaction.PerformerPlayerScript, side) == false) return false;
 
 			if (Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.Welder)) return true;
 

--- a/UnityProject/Assets/Scripts/Items/Medical/DefibrillatorPaddles.cs
+++ b/UnityProject/Assets/Scripts/Items/Medical/DefibrillatorPaddles.cs
@@ -15,7 +15,7 @@ public class DefibrillatorPaddles : MonoBehaviour, ICheckedInteractable<HandAppl
 
 	public bool WillInteract(HandApply interaction, NetworkSide side)
 	{
-		if (DefaultWillInteract.HandApply(interaction,side) == false) return false;
+		if (DefaultWillInteract.Default(interaction,side) == false) return false;
 		if (interaction.HandObject != this.gameObject) return false;
 		var Healthv2 = interaction.TargetObject.GetComponent<LivingHealthMasterBase>();
 		if (Healthv2 == null) return false;

--- a/UnityProject/Assets/Scripts/Items/Others/Horn.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/Horn.cs
@@ -94,7 +94,7 @@ public class Horn : MonoBehaviour, ICheckedInteractable<HandActivate>, ICheckedI
 	/// </summary>
 	public bool WillInteract( HandActivate interaction, NetworkSide side )
 	{
-		return Validations.CanInteract( interaction.Performer, side, true )
+		return Validations.CanInteract(interaction.PerformerPlayerScript, side, true)
 		       && allowUse;
 	}
 
@@ -104,7 +104,7 @@ public class Horn : MonoBehaviour, ICheckedInteractable<HandActivate>, ICheckedI
 	public bool WillInteract( PositionalHandApply interaction, NetworkSide side )
 	{
 		if (interaction.HandObject != gameObject) return false;
-		return Validations.CanApply(interaction.Performer, interaction.TargetObject, side, true, ReachRange.Unlimited, interaction.TargetVector)
+		return Validations.CanApply(interaction.PerformerPlayerScript, interaction.TargetObject, side, true, ReachRange.Unlimited, interaction.TargetVector)
 				&& allowUse;
 	}
 

--- a/UnityProject/Assets/Scripts/Messages/Server/TabUpdateMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/TabUpdateMessage.cs
@@ -132,7 +132,7 @@ namespace Messages.Server
 				case TabAction.Update:
 					// TODO: FIXME: duplication of NetTab.ValidatePeepers
 					// Not sending updates and closing tab for players that don't pass the validation anymore
-					var validate = Validations.CanApply(recipient, provider, NetworkSide.Server);
+					var validate = Validations.CanApply(recipient.GetComponent<PlayerScript>(), provider, NetworkSide.Server);
 					if (!validate)
 					{
 						Send(recipient, provider, type, TabAction.Close);

--- a/UnityProject/Assets/Scripts/Objects/Construction/Deconstructable.cs
+++ b/UnityProject/Assets/Scripts/Objects/Construction/Deconstructable.cs
@@ -23,7 +23,7 @@ namespace Objects.Construction
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
-			if (DefaultWillInteract.HandApply(interaction, side) == false) return false;
+			if (DefaultWillInteract.Default(interaction, side) == false) return false;
 
 			if (Validations.HasItemTrait(interaction.HandObject, deconstructToolTrait)) return true;
 

--- a/UnityProject/Assets/Scripts/Objects/Construction/Rack.cs
+++ b/UnityProject/Assets/Scripts/Objects/Construction/Rack.cs
@@ -27,9 +27,6 @@ namespace Objects.Construction
 		public bool WillInteract(PositionalHandApply interaction, NetworkSide side)
 		{
 			if (!DefaultWillInteract.Default(interaction, side)) return false;
-
-			if (!DefaultWillInteract.PositionalHandApply(interaction, NetworkSide.Client)) return false;
-
 			return true;
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/Engineering/Emitter.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/Emitter.cs
@@ -124,7 +124,7 @@ namespace Objects.Engineering
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
-			if (DefaultWillInteract.HandApply(interaction, side) == false) return false;
+			if (DefaultWillInteract.Default(interaction, side) == false) return false;
 
 			if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Wrench)) return true;
 

--- a/UnityProject/Assets/Scripts/Objects/Engineering/FieldGenerator.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/FieldGenerator.cs
@@ -490,7 +490,7 @@ namespace Objects.Engineering
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
-			if (DefaultWillInteract.HandApply(interaction, side) == false) return false;
+			if (DefaultWillInteract.Default(interaction, side) == false) return false;
 
 			if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Wrench)) return true;
 

--- a/UnityProject/Assets/Scripts/Objects/Engineering/ParticleAcceleratorControl.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/ParticleAcceleratorControl.cs
@@ -305,7 +305,7 @@ namespace Objects.Engineering
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
-			if (DefaultWillInteract.HandApply(interaction, side) == false) return false;
+			if (DefaultWillInteract.Default(interaction, side) == false) return false;
 
 			return Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Emag);
 		}

--- a/UnityProject/Assets/Scripts/Objects/Engineering/ParticleAcceleratorPart.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/ParticleAcceleratorPart.cs
@@ -103,7 +103,7 @@ namespace Objects.Engineering
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
-			if (DefaultWillInteract.HandApply(interaction, side) == false) return false;
+			if (DefaultWillInteract.Default(interaction, side) == false) return false;
 
 			if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Cable)) return true;
 

--- a/UnityProject/Assets/Scripts/Objects/Engineering/Reflector.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/Reflector.cs
@@ -121,7 +121,7 @@ namespace Objects.Engineering
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
-			if (DefaultWillInteract.HandApply(interaction, side) == false) return false;
+			if (DefaultWillInteract.Default(interaction, side) == false) return false;
 
 			if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Welder)) return true;
 

--- a/UnityProject/Assets/Scripts/Objects/Engineering/SuperMatter.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/SuperMatter.cs
@@ -1151,7 +1151,7 @@ namespace Objects.Engineering
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
-			if (DefaultWillInteract.HandApply(interaction, side) == false) return false;
+			if (DefaultWillInteract.Default(interaction, side) == false) return false;
 
 			//Dont destroy wrench, it is used to unwrench crystal
 			if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Wrench)) return false;

--- a/UnityProject/Assets/Scripts/Objects/Engineering/TeslaCoil.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/TeslaCoil.cs
@@ -143,7 +143,7 @@ namespace Objects.Engineering
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
-			if (!DefaultWillInteract.HandApply(interaction, side)) return false;
+			if (!DefaultWillInteract.Default(interaction, side)) return false;
 
 			if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Screwdriver)) return true;
 

--- a/UnityProject/Assets/Scripts/Objects/Medical/DNAScanner.cs
+++ b/UnityProject/Assets/Scripts/Objects/Medical/DNAScanner.cs
@@ -65,7 +65,7 @@ namespace Objects.Medical
 		{
 			if (side == NetworkSide.Server && IsClosed)
 				return false;
-			if (!Validations.CanInteract(interaction.Performer, side))
+			if (!Validations.CanInteract(interaction.PerformerPlayerScript, side))
 				return false;
 			if (!Validations.IsAdjacent(interaction.Performer, interaction.DroppedObject))
 				return false;

--- a/UnityProject/Assets/Scripts/Systems/Inventory/Pickupable.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/Pickupable.cs
@@ -128,7 +128,7 @@ public class Pickupable : NetworkBehaviour, IPredictedCheckedInteractable<HandAp
 		//hand needs to be empty for pickup
 		if (interaction.HandObject != null) return false;
 		//instead of the base logic, we need to use extended range check for CanApply
-		if (!Validations.CanApply(interaction, side, true, ReachRange.Standard, isPlayerClick: true)) return false;
+		if (!Validations.CanApply(interaction.PerformerPlayerScript, interaction.TargetObject, side, true, isPlayerClick: true)) return false;
 
 		return true;
 	}
@@ -236,7 +236,7 @@ public class Pickupable : NetworkBehaviour, IPredictedCheckedInteractable<HandAp
 		var interaction = HandApply.ByLocalPlayer(gameObject);
 		if (interaction.TargetObject != gameObject) return null;
 		if (interaction.HandObject != null) return null;
-		if (!Validations.CanApply(interaction, NetworkSide.Client, true, ReachRange.Standard, isPlayerClick: false)) return null;
+		if (!Validations.CanApply(interaction.PerformerPlayerScript, interaction.TargetObject, NetworkSide.Client, true, ReachRange.Standard, isPlayerClick: false)) return null;
 
 		return RightClickableResult.Create()
 				.AddElement("PickUp", RightClickInteract);

--- a/UnityProject/Assets/Scripts/UI/Core/Action/ItemActionButton.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/Action/ItemActionButton.cs
@@ -57,7 +57,7 @@ namespace UI.Action
 
 		public void CallActionServer(ConnectedPlayer SentByPlayer)
 		{
-			if (Validations.CanInteract(SentByPlayer.GameObject, NetworkSide.Server, allowSoftCrit: true))
+			if (Validations.CanInteract(SentByPlayer.Script , NetworkSide.Server, true))
 			{
 				ServerActionClicked?.Invoke();
 				UpdateButtonSprite(true);


### PR DESCRIPTION
### Purpose
Cleans up the duplicate calls for CanApply() and CanInteract() in Validations code as well as some clearing some code in DefaultWillInteract.
Now interactions will go through way less loops making it easier to debug and read.

There are no gameplay changes.