### PR TITLE
Cyborg and surplus prosthetic limbs no longer look like normal human ones.

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgLeftArm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgLeftArm.prefab
@@ -110,6 +110,18 @@ PrefabInstance:
       propertyPath: BodyPartDisembowlLogicOnCutSize
       value: 4
       objectReference: {fileID: 0}
+    - target: {fileID: 2934630090728222927, guid: 719377fefb0114b448fc6ca9f7a5a6df,
+        type: 3}
+      propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 6ae08a8dec2a6e64ebfca9945eba0188,
+        type: 2}
+    - target: {fileID: 2934630090728222927, guid: 719377fefb0114b448fc6ca9f7a5a6df,
+        type: 3}
+      propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 22461163953d0de4f93ab6abb841f931,
+        type: 2}
     - target: {fileID: 5603819714738991316, guid: 719377fefb0114b448fc6ca9f7a5a6df,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgLeftLeg.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgLeftLeg.prefab
@@ -17,6 +17,12 @@ PrefabInstance:
       propertyPath: BodyPartDisembowlLogicOnCutSize
       value: 4
       objectReference: {fileID: 0}
+    - target: {fileID: 1544594378003915950, guid: 2e6f2ff9beb985749940d242877d84f0,
+        type: 3}
+      propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: d3e2b11fd1d41e240a572b58bb3c1258,
+        type: 2}
     - target: {fileID: 2574131780916113488, guid: 2e6f2ff9beb985749940d242877d84f0,
         type: 3}
       propertyPath: initialName

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgRightArm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgRightArm.prefab
@@ -35,6 +35,18 @@ PrefabInstance:
       propertyPath: BodyPartDisembowlLogicOnCutSize
       value: 4
       objectReference: {fileID: 0}
+    - target: {fileID: 6313817628243374210, guid: ba9a875c31908af4ab3749cd127a2edb,
+        type: 3}
+      propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 14e93bb467f8ed649bd366a6cef200b7,
+        type: 2}
+    - target: {fileID: 6313817628243374210, guid: ba9a875c31908af4ab3749cd127a2edb,
+        type: 3}
+      propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 39e8bd810cff8b042ba80636a74b3505,
+        type: 2}
     - target: {fileID: 7010284919959774332, guid: ba9a875c31908af4ab3749cd127a2edb,
         type: 3}
       propertyPath: initialName

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgRightLeg.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgRightLeg.prefab
@@ -122,5 +122,11 @@ PrefabInstance:
       propertyPath: BodyPartDisembowlLogicOnCutSize
       value: 4
       objectReference: {fileID: 0}
+    - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
+        type: 3}
+      propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: dee4e2d62c8727f43a4a4d3c4e8ff6a9,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 51326f2264a075148a8aaa6bf95604c7, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightLeg.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightLeg.prefab
@@ -284,11 +284,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
         type: 3}
-      propertyPath: RelatedPresentSprites.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
-        type: 3}
       propertyPath: BodyTypesSprites.BodyTypes.Array.size
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/SurplusProsthetics/SurplusProstheticLeftArm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/SurplusProsthetics/SurplusProstheticLeftArm.prefab
@@ -89,6 +89,18 @@ PrefabInstance:
       value: A skeletal, robotic limb. Outdated and fragile, but it's still better
         than nothing.
       objectReference: {fileID: 0}
+    - target: {fileID: 3134263208076850617, guid: 6288c623448564447ad3e18185754a58,
+        type: 3}
+      propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 75daacd150eb34b47bdf127f59b739a1,
+        type: 2}
+    - target: {fileID: 3134263208076850617, guid: 6288c623448564447ad3e18185754a58,
+        type: 3}
+      propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 992d09f3670837845bec40346b8b7175,
+        type: 2}
     - target: {fileID: 5621056504391087522, guid: 6288c623448564447ad3e18185754a58,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/SurplusProsthetics/SurplusProstheticLeftLeg.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/SurplusProsthetics/SurplusProstheticLeftLeg.prefab
@@ -19,6 +19,12 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 745a0c2f6f5b17c419bdb49697f41548,
         type: 2}
+    - target: {fileID: 6491239688611912051, guid: eb43f0bbcf0aa6d45b1475262374be13,
+        type: 3}
+      propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 8954b713b625bee408472347b44c87a3,
+        type: 2}
     - target: {fileID: 7556842684862222771, guid: eb43f0bbcf0aa6d45b1475262374be13,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/SurplusProsthetics/SurplusProstheticRightArm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/SurplusProsthetics/SurplusProstheticRightArm.prefab
@@ -25,6 +25,18 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: bedffcd9d8de3c845b899dc160d9b19a,
         type: 2}
+    - target: {fileID: 5339358238428289753, guid: 05849a8c832dadc4dbdbb0e5bbe37ec8,
+        type: 3}
+      propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 4df6e6374131dd14f89f87c9fc3e8183,
+        type: 2}
+    - target: {fileID: 5339358238428289753, guid: 05849a8c832dadc4dbdbb0e5bbe37ec8,
+        type: 3}
+      propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 49e22d6e732fb2d449bba83c94a07a05,
+        type: 2}
     - target: {fileID: 8706582329726554649, guid: 05849a8c832dadc4dbdbb0e5bbe37ec8,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/SurplusProsthetics/SurplusProstheticRightLeg.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/SurplusProsthetics/SurplusProstheticRightLeg.prefab
@@ -7,6 +7,12 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 108926807988360621, guid: 5c22d550fc2d31941bf147d721294daa,
+        type: 3}
+      propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: be19305501f4cfc4b8cc7f00725c2f16,
+        type: 2}
     - target: {fileID: 3471699334241407877, guid: 5c22d550fc2d31941bf147d721294daa,
         type: 3}
       propertyPath: m_AssetId


### PR DESCRIPTION
<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->

### Purpose
- Sets the sprites for cyborg and surplus prosthetic limbs on humanoids to the correct ones. They were inheriting the normal human limb sprites before.
- Removed an extraneous "Related Present Sprites" from the human right leg.


### Changelog:

CL: **[Fix]** Cyborg and surplus prosthetic limbs on players no longer look like standard human limbs.
