### PR TITLE
Server crash hotfix

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/TileChangeManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/TileChangeManager.cs
@@ -405,7 +405,7 @@ public class TileChangeEntry
 
 	public Matrix4x4? transformMatrix;
 
-	public Color? color;
+	public Vector4? color;
 
 }
 


### PR DESCRIPTION
### Purpose
Hotfixes a server crash when a new player joins in an ongoing round with where coloured graffitis have been laid down.

### Notes:
The Newtonsoft seems to cause the server crash when serializing a unity color, but unity lets us swap them inbetween vector4 and colors easily to avoid this issue.

Not fully tested, I noticed latejoiners can't see old graffitis with this fix. Will fix soon.