### PR TITLE
Seed extractor tab scroll fix

### DIFF
--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/SeedExtractorEntry.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/SeedExtractorEntry.prefab
@@ -220,7 +220,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.5754717, g: 0.5754717, b: 0.5754717, a: 0.37254903}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabSeedExtractor.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabSeedExtractor.prefab
@@ -368,15 +368,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Hidden: 0
   isPopOut: 0
+  Type: 15
   OnTabClosed:
     m_PersistentCalls:
       m_Calls: []
   OnTabOpened:
     m_PersistentCalls:
       m_Calls: []
-  Provider: {fileID: 0}
-  ProviderRegisterTile: {fileID: 0}
-  Type: 15
   allowSell: 1
   cooldownTimer: 2
   seedTypeList: {fileID: 5922826956963295105}
@@ -452,7 +450,7 @@ MonoBehaviour:
   m_Elasticity: 0.1
   m_Inertia: 1
   m_DecelerationRate: 0.135
-  m_ScrollSensitivity: 5
+  m_ScrollSensitivity: 15
   m_Viewport: {fileID: 0}
   m_HorizontalScrollbar: {fileID: 0}
   m_VerticalScrollbar: {fileID: 0}
@@ -994,7 +992,7 @@ MonoBehaviour:
   m_Elasticity: 0.1
   m_Inertia: 1
   m_DecelerationRate: 0.135
-  m_ScrollSensitivity: 5
+  m_ScrollSensitivity: 15
   m_Viewport: {fileID: 0}
   m_HorizontalScrollbar: {fileID: 0}
   m_VerticalScrollbar: {fileID: 0}


### PR DESCRIPTION
### Purpose
Fixes the seed extractor scroll wheel from only working when mouseovering the button and not the background.
Increased the scroll speed in both scrolls of the seed extractor by 3 times.
Fixes #6668

basically the raycast wasnt set for the background of the tab entry so the scroll didn't do anything