### PR TITLE
Organizes human spawn steps slightly, fixes uplink code and spawning dead.

### DIFF
--- a/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPart.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPart.cs
@@ -218,7 +218,6 @@ namespace HealthV2
 			health = maxHealth;
 			DamageInitialisation();
 			UpdateSeverity();
-			Initialisation();
 
 			BodyPartModifications = this.GetComponents<BodyPartModification>().ToList();
 
@@ -229,14 +228,7 @@ namespace HealthV2
 			}
 		}
 
-		/// <summary>
-		/// Overridable method for variant body parts to use for their non-systems based initialisation
-		/// </summary>
-		public virtual void Initialisation()
-		{
-		}
-
-		public virtual void ImplantUpdate()
+		public void ImplantUpdate()
 		{
 			foreach (BodyPart prop in ContainBodyParts)
 			{
@@ -427,7 +419,6 @@ namespace HealthV2
 		public void SetUpBodyPart(BodyPart implant)
 		{
 			implant.HealthMaster = HealthMaster;
-			if (HealthMaster == null) return;
 			HealthMaster.AddNewImplant(implant);
 			SubBodyPartAdded(implant);
 
@@ -438,7 +429,6 @@ namespace HealthV2
 		/// </summary>
 		public virtual void SetUpSystems()
 		{
-			if (HealthMaster == null) return;
 			foreach (BodyPart prop in ContainBodyParts)
 			{
 				prop.SetUpSystems();

--- a/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/RootBodyPartController.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/RootBodyPartController.cs
@@ -9,17 +9,10 @@ using UnityEngine;
 public class RootBodyPartController : NetworkBehaviour
 {
 	[SyncVar(hook = nameof(UpdateCustomisations))]
-	private string PlayerSpritesData = "";
+	public string PlayerSpritesData = "";
 
 	[SyncVar(hook = nameof(UpdateChildren))]
 	private string SerialisedNetIDs = "";
-
-	[System.Serializable]
-	public struct StringClass
-	{
-		public string String;
-		public RootBodyPartContainer BodyPart;
-	}
 
 	public List<RootBodyPartContainer> RootBodyParts = new List<RootBodyPartContainer>();
 
@@ -41,32 +34,14 @@ public class RootBodyPartController : NetworkBehaviour
 
 	public void RequestUpdate(RootBodyPartContainer RootBodyPartContainer)
 	{
-		DictionaryToSerialised[RootBodyPartContainer.name] =
-			RootBodyPartContainer.InternalNetIDs;
-
-		UpdateChildren("", JsonConvert.SerializeObject(DictionaryToSerialised));
+		DictionaryToSerialised[RootBodyPartContainer.name] = RootBodyPartContainer.InternalNetIDs;
+		SerialisedNetIDs = JsonConvert.SerializeObject(DictionaryToSerialised);
 	}
 
 
 	public void UpdateChildren(string InOld, string InNew)
 	{
 		SerialisedNetIDs = InNew;
-		if (CustomNetworkManager.Instance._isServer) return;
-		StartCoroutine(WaitForStartChildren());
-	}
-
-
-	public void UpdateCustomisations(string InOld, string InNew)
-	{
-		PlayerSpritesData = InNew;
-		if (CustomNetworkManager.Instance._isServer) return;
-		StartCoroutine(WaitForStartCustomisations());
-	}
-
-	private IEnumerator WaitForStartChildren()
-	{
-		yield return null;
-		yield return null;
 		playerSprites.Addedbodypart.Clear();
 		DictionaryToSerialised = JsonConvert.DeserializeObject<Dictionary<string, List<uint>>>(SerialisedNetIDs);
 		foreach (var Entry in DictionaryToSerialised)
@@ -78,10 +53,10 @@ public class RootBodyPartController : NetworkBehaviour
 		}
 	}
 
-	private IEnumerator WaitForStartCustomisations()
+	public void UpdateCustomisations(string InOld, string InNew)
 	{
-		yield return null;
-		yield return null;
+		PlayerSpritesData = InNew;
 		playerSprites.UpdateChildren(JsonConvert.DeserializeObject<List<uint>>(PlayerSpritesData));
 	}
+
 }

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
@@ -692,7 +692,7 @@ namespace HealthV2
 				yield return WaitFor.Seconds(4f);
 				if(Root != null) //This is to prevent rare moments where body parts still attempt to bleed when they no longer should.
 				{
-					if (Root.ContainsLimbs.Contains(this) != false) 
+					if (Root.ContainsLimbs.Contains(this) != false)
 					{
 						healthMaster.CirculatorySystem.Bleed(UnityEngine.Random.Range(MinMaxInternalBleedingValues.x, MinMaxInternalBleedingValues.y));
 					}
@@ -804,7 +804,7 @@ namespace HealthV2
 			if(currentBurnDamageLevel == BurnDamageLevels.CHARRED && currentBurnDamage > bodyPartAshesAboveThisDamage)
 			{
 				IEnumerable<ItemSlot> internalItemList = Storage.GetItemSlots();
-				IEnumerable<ItemSlot> PlayerItemList = healthMaster.PlayerScriptOwner.DynamicItemStorage.GetItemSlots();
+				IEnumerable<ItemSlot> PlayerItemList = healthMaster.playerScript.DynamicItemStorage.GetItemSlots();
 				foreach(ItemSlot item in internalItemList)
 				{
 					Integrity itemObject = item.ItemObject.GetComponent<Integrity>();

--- a/UnityProject/Assets/Scripts/HealthV2/Living/PlayerHealthV2.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/PlayerHealthV2.cs
@@ -22,13 +22,6 @@ namespace HealthV2
 
 		private PlayerSprites playerSprites;
 
-
-		private PlayerScript playerScript;
-		/// <summary>
-		/// The associated Player Script
-		/// </summary>
-		public PlayerScript PlayerScript => playerScript;
-
 		private PlayerNetworkActions playerNetworkActions;
 
 		private RegisterPlayer registerPlayer;
@@ -46,8 +39,6 @@ namespace HealthV2
 
 		private DynamicItemStorage dynamicItemStorage;
 
-		private bool init = false;
-
 		/// <summary>
 		/// The percentage of players that start with common allergies.
 		/// </summary>
@@ -63,26 +54,21 @@ namespace HealthV2
 		//fixme: not actually set or modified. keep an eye on this!
 		public bool serverPlayerConscious { get; set; } = true; //Only used on the server
 
-		public override void EnsureInit()
+		public override void Awake()
 		{
-			if (init) return;
-			init = true;
-			base.EnsureInit();
+			base.Awake();
 			playerNetworkActions = GetComponent<PlayerNetworkActions>();
 			playerMove = GetComponent<PlayerMove>();
 			playerSprites = GetComponent<PlayerSprites>();
 			registerPlayer = GetComponent<RegisterPlayer>();
 			dynamicItemStorage = GetComponent<DynamicItemStorage>();
 			equipment = GetComponent<Equipment>();
-			playerScript = GetComponent<PlayerScript>();
 			OnConsciousStateChangeServer.AddListener(OnPlayerConsciousStateChangeServer);
 			registerPlayer.AddStatus(this);
 		}
 
 		private void OnPlayerConsciousStateChangeServer(ConsciousState oldState, ConsciousState newState)
 		{
-			if (playerNetworkActions == null || registerPlayer == null) EnsureInit();
-
 			if (isServer)
 			{
 				playerNetworkActions.OnConsciousStateChanged(oldState, newState);

--- a/UnityProject/Assets/Scripts/Items/ClothingItem.cs
+++ b/UnityProject/Assets/Scripts/Items/ClothingItem.cs
@@ -39,11 +39,6 @@ public class ClothingItem : MonoBehaviour
 	public PlayerScript thisPlayerScript;
 
 	/// <summary>
-	/// Player equipped or unequipped some clothing from ClothingItem slot
-	/// </summary>
-	public event OnClothingEquippedDelegate OnClothingEquipped;
-
-	/// <summary>
 	/// Direction clothing is facing (absolute)
 	/// </summary>
 	public Orientation Direction
@@ -97,7 +92,7 @@ public class ClothingItem : MonoBehaviour
 					thisPlayerScript.Equipment.obscuredSlots &= ~unequippedClothing.HiddenSlots;
 
 					if (unequippedClothing)
-						OnClothingEquipped?.Invoke(unequippedClothing, false);
+						thisPlayerScript.playerSprites.OnClothingEquipped(unequippedClothing, true);
 				}
 			}
 
@@ -126,8 +121,7 @@ public class ClothingItem : MonoBehaviour
 				// But for the others, we call the OnClothingEquipped event.
 				if (equippedClothing)
 				{
-					// call the event of equiped clothing
-					OnClothingEquipped?.Invoke(equippedClothing, true);
+					thisPlayerScript.playerSprites.OnClothingEquipped(equippedClothing, true);
 				}
 			}
 		}

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Heart.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Heart.cs
@@ -82,7 +82,7 @@ public class Heart : BodyPartModification
 		if(RelatedPart.CurrentInternalBleedingDamage > 50 && alarmedForInternalBleeding == false)
 		{
 			Chat.AddActionMsgToChat(RelatedPart.HealthMaster.gameObject,
-			$"You feel a sharp pain in your {RelatedPart.gameObject.ExpensiveName()}!", $"{RelatedPart.HealthMaster.PlayerScriptOwner.visibleName} holds their {RelatedPart.gameObject.ExpensiveName()} in pain!");
+			$"You feel a sharp pain in your {RelatedPart.gameObject.ExpensiveName()}!", $"{RelatedPart.HealthMaster.playerScript.visibleName} holds their {RelatedPart.gameObject.ExpensiveName()} in pain!");
 			alarmedForInternalBleeding = true;
 		}
 		if(RelatedPart.CurrentInternalBleedingDamage > RelatedPart.MaximumInternalBleedDamage)

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
@@ -249,7 +249,7 @@ public class Lungs : BodyPartModification
 			RelatedPart.HealthMaster.HealthStateController.SetSuffocating(true);
 			if (Random.value < 0.2)
 			{
-				Chat.AddActionMsgToChat(RelatedPart.HealthMaster.gameObject, "You gasp for breath", $"{RelatedPart.HealthMaster.PlayerScriptOwner.visibleName} gasps");
+				Chat.AddActionMsgToChat(RelatedPart.HealthMaster.gameObject, "You gasp for breath", $"{RelatedPart.HealthMaster.playerScript.visibleName} gasps");
 			}
 		}
 
@@ -265,7 +265,7 @@ public class Lungs : BodyPartModification
 			{
 				Chat.AddActionMsgToChat(RelatedPart.HealthMaster.gameObject,
 				"You gasp for air; but you drown in your own blood from the inside!",
-				$"{RelatedPart.HealthMaster.PlayerScriptOwner.visibleName} gasps for air!");
+				$"{RelatedPart.HealthMaster.playerScript.visibleName} gasps for air!");
 				RelatedPart.HealthMaster.HealthStateController.SetSuffocating(true);
 			}
 			else
@@ -275,7 +275,7 @@ public class Lungs : BodyPartModification
             if(DMMath.Prob(coughChanceWhenInternallyBleeding))
             {
 				Chat.AddActionMsgToChat(RelatedPart.HealthMaster.gameObject,
-				"You cough up blood!", $"{RelatedPart.HealthMaster.PlayerScriptOwner.visibleName} coughs up blood!");
+				"You cough up blood!", $"{RelatedPart.HealthMaster.playerScript.visibleName} coughs up blood!");
 				RelatedPart.CurrentInternalBleedingDamage -= Random.Range(RelatedPart.MinMaxInternalBleedingValues.x, RelatedPart.MinMaxInternalBleedingValues.y);
 
 				//TODO: TAKE BLOOD

--- a/UnityProject/Assets/Scripts/Items/Medical/Gauze.cs
+++ b/UnityProject/Assets/Scripts/Items/Medical/Gauze.cs
@@ -26,8 +26,8 @@ namespace Items.Medical
 			}
 			else
 			{
-				Chat.AddExamineMsgFromServer(interaction.Performer, 
-				$"{LHB.PlayerScriptOwner.visibleName}'s {interaction.TargetBodyPart} doesn't seem to be bleeding.");
+				Chat.AddExamineMsgFromServer(interaction.Performer,
+				$"{LHB.playerScript.visibleName}'s {interaction.TargetBodyPart} doesn't seem to be bleeding.");
 			}
 		}
 
@@ -44,13 +44,13 @@ namespace Items.Medical
 							limb.StopExternalBleeding();
 							if(interaction.Performer.Player().GameObject == interaction.TargetObject.Player().GameObject)
 							{
-								Chat.AddActionMsgToChat(interaction.Performer.gameObject, 
+								Chat.AddActionMsgToChat(interaction.Performer.gameObject,
 								$"You stopped your {interaction.TargetObject.Player().Script.visibleName}'s bleeding.",
 								$"{interaction.PerformerPlayerScript.visibleName} stopped their own bleeding from their {interaction.TargetObject.ExpensiveName()}.");
 							}
 							else
 							{
-								Chat.AddActionMsgToChat(interaction.Performer.gameObject, 
+								Chat.AddActionMsgToChat(interaction.Performer.gameObject,
 								$"You stopped {interaction.TargetObject.Player().Script.visibleName}'s bleeding.",
 								$"{interaction.PerformerPlayerScript.visibleName} stopped {interaction.TargetObject.Player().Script.visibleName}'s bleeding.");
 							}

--- a/UnityProject/Assets/Scripts/Objects/Medical/CloningPod.cs
+++ b/UnityProject/Assets/Scripts/Objects/Medical/CloningPod.cs
@@ -51,23 +51,9 @@ namespace Objects.Medical
 			if (record.mind.IsOnline())
 			{
 				var playerBody = PlayerSpawn.ServerClonePlayer(record.mind, transform.position.CutToInt()).GetComponent<LivingHealthMasterBase>();
-
-				void ApplyDamage()
-				{
-					ApplyCloningDamage(playerBody);
-				}
-
-				playerBody.OnFullyInitialised(ApplyDamage);
-				//GameObject
-				//Do cloning damage
-				//Initialisation order
+				playerBody.ApplyDamageAll(this.gameObject, LimbCloningDamage, AttackType.Internal, DamageType.Clone, false);
 			}
 			statusSync = CloningPodStatus.Empty;
-		}
-
-		public void ApplyCloningDamage(LivingHealthMasterBase Body)
-		{
-			Body.ApplyDamageAll(this.gameObject, LimbCloningDamage, AttackType.Internal, DamageType.Clone, false);
 		}
 
 		public bool CanClone()

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -112,7 +112,7 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		else if (playerScript.playerMove.IsCuffed) // Check if cuffed.
 		{
 			if (playerScript.playerSprites != null &&
-			    playerScript.playerSprites.clothes.TryGetValue("handcuffs", out var cuffsClothingItem))
+			    playerScript.playerSprites.clothes.TryGetValue(NamedSlot.handcuffs, out var cuffsClothingItem))
 			{
 				if (cuffsClothingItem != null &&
 				    cuffsClothingItem.TryGetComponent<RestraintOverlay>(out var restraintOverlay))
@@ -342,7 +342,7 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		if (!Cooldowns.TryStartServer(playerScript, CommonCooldowns.Instance.Interaction)) return;
 
 		if (playerScript.playerSprites != null &&
-		    playerScript.playerSprites.clothes.TryGetValue("handcuffs", out var cuffsClothingItem))
+		    playerScript.playerSprites.clothes.TryGetValue(NamedSlot.handcuffs, out var cuffsClothingItem))
 		{
 			if (cuffsClothingItem != null &&
 			    cuffsClothingItem.TryGetComponent<RestraintOverlay>(out var restraintOverlay))

--- a/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
@@ -57,8 +57,7 @@ public class PlayerSprites : MonoBehaviour
 	public CharacterSettings ThisCharacter;
 
 	//clothes for each clothing slot
-	//TODO: don't use string as the dictionary key
-	public readonly Dictionary<string, ClothingItem> clothes = new Dictionary<string, ClothingItem>();
+	public readonly Dictionary<NamedSlot, ClothingItem> clothes = new Dictionary<NamedSlot, ClothingItem>();
 
 	public readonly List<BodyPartSprites> Addedbodypart = new List<BodyPartSprites>();
 
@@ -76,13 +75,12 @@ public class PlayerSprites : MonoBehaviour
 	private PlayerHealthV2 playerHealth;
 	private PlayerSync playerSync;
 
-	private ClothingHideFlags hideClothingFlags = ClothingHideFlags.HIDE_NONE;
-	private ulong overflow = 0;
-
 	/// <summary>
 	/// Define which piece of clothing are hidden (not rendering) right now
 	/// </summary>
-	public ClothingHideFlags HideClothingFlags => hideClothingFlags;
+	private ClothingHideFlags hideClothingFlags = ClothingHideFlags.HIDE_NONE;
+
+	private ulong overflow = 0;
 
 	public SpriteHandlerNorder ToInstantiateSpriteCustomisation;
 
@@ -90,7 +88,7 @@ public class PlayerSprites : MonoBehaviour
 
 	public List<uint> InternalNetIDs;
 
-	public bool RootBodyPartsLoaded = false;
+	public bool RootBodyPartsLoaded;
 
 	[SerializeField]
 	private GameObject OverlaySprites;
@@ -100,27 +98,24 @@ public class PlayerSprites : MonoBehaviour
 		directional = GetComponent<Directional>();
 		playerHealth = GetComponent<PlayerHealthV2>();
 
-		foreach (ClothingItem c in GetComponentsInChildren<ClothingItem>())
+		foreach (var clothingItem in GetComponentsInChildren<ClothingItem>())
 		{
-			clothes[c.name] = c;
-			// add listener in case clothing was changed
-			c.OnClothingEquipped += OnClothingEquipped;
+			clothes.Add(clothingItem.Slot, clothingItem);
 		}
 
-		for (int i = 0; i < BodyParts.transform.childCount; i++)
+		for (var i = 0; i < BodyParts.transform.childCount; i++)
 		{
 			//TODO: Do we need to add listeners for implant removalv
 			bodyParts[BodyParts.transform.GetChild(i).name] = BodyParts.transform.GetChild(i).gameObject;
 		}
 
-
 		AddOverlayGameObjects();
 
 		directional.OnDirectionChange.AddListener(OnDirectionChange);
 		//TODO: Need to reimplement fire stacks on players.
-		playerHealth.EnsureInit();
 		playerHealth.OnClientFireStacksChange.AddListener(OnClientFireStacksChange);
-		OnClientFireStacksChange(playerHealth.FireStacks);
+		var healthStateController = GetComponent<HealthStateController>();
+		OnClientFireStacksChange(healthStateController.FireStacks);
 	}
 
 	private void OnDestroy()
@@ -157,7 +152,7 @@ public class PlayerSprites : MonoBehaviour
 		}
 	}
 
-	public void SetUpCharacter(CharacterSettings Character)
+	public void SetUpCharacter()
 	{
 		if (CustomNetworkManager.Instance._isServer)
 		{
@@ -224,25 +219,6 @@ public class PlayerSprites : MonoBehaviour
 		{
 			SubSetBodyPart(Limb, path);
 		}
-	}
-
-	public IEnumerator WaitForPlayerinitialisation()
-	{
-		//This is to prevent body parts being spawned in before server start, since they would get populated awake then populated again with server start, kind of buggy yo, if that happens
-		yield return null;
-		yield return null;
-		yield return null;
-		SetUpCharacter(ThisCharacter);
-		livingHealthMasterBase.CirculatorySystem.SetBloodType(RaceBodyparts.Base.BloodType);
-		yield return null;
-		SetupsSprites();
-	}
-
-	public void SetupCharacterData(CharacterSettings Character)
-	{
-		ThisCharacter = Character;
-		StartCoroutine(WaitForPlayerinitialisation());
-
 	}
 
 	public void SetupsSprites()
@@ -314,33 +290,8 @@ public class PlayerSprites : MonoBehaviour
 				}
 			}
 		}
+		GetComponent<RootBodyPartController>().PlayerSpritesData = JsonConvert.SerializeObject(ToClient);
 
-		this.GetComponent<RootBodyPartController>().UpdateCustomisations("", JsonConvert.SerializeObject(ToClient));
-
-		//TODOH
-
-		//Fetch Race Health Pack
-		// if(Character.Race == Race.Human)
-		// {
-		//
-		// }
-
-		//this is Target zone
-
-		//Instantiates Sprites
-		//TODOH
-		//Race data contain sprites order
-		//healing/Damage splits across body parts
-		//needs a generate sprites dynamically
-
-
-		//RaceBodyparts.Base.LegLeft.GetComponent<ItemStorage>()
-
-
-		//RaceTexture = Spawn.RaceData["human"];
-
-		//Loop through dimrphic body parts
-		//SetupBodySpritesByGender();
 		SetSurfaceColour();
 		OnDirectionChange(directional.CurrentDirection);
 	}
@@ -349,16 +300,7 @@ public class PlayerSprites : MonoBehaviour
 	{
 		if (ListToSpawn != null && ListToSpawn.Elements.Count > 0)
 		{
-			// var Set = ToSpawn.GetComponent<RootBodyPartContainer>();
-			// Set.PlayerSprites = this;
-			// Set.healthMaster = playerHealth;
-			// var InSpawnResult = Spawn.ServerPrefab(ToSpawn, Vector3.zero, InWhere, AutoOnSpawnServerHook: false);
-			// InSpawnResult.GameObject.transform.localPosition = Vector3.zero;
-
 			var rootBodyPartContainer = InWhere.GetComponent<RootBodyPartContainer>();
-			//rootBodyPartContainer.ItemStorage
-
-			//rootBodyPartContainer.ItemStorage.ServerTryAdd()
 			livingHealthMasterBase.RootBodyPartContainers.Add(rootBodyPartContainer);
 			rootBodyPartContainer.PlayerSprites = this;
 
@@ -367,18 +309,7 @@ public class PlayerSprites : MonoBehaviour
 				var InSpawnResult = Spawn.ServerPrefab(ToSpawn).GameObject;
 				rootBodyPartContainer.ItemStorage.ServerTryAdd(InSpawnResult);
 			}
-
-			//Spawn._ServerFireClientServerSpawnHooks(InSpawnResult);
 		}
-
-		// var rootBodyPartContainer = Spawn.ServerPrefab(ToSpawn, null ,InWhere).GameObject.GetComponent<RootBodyPartContainer>();
-		// if (rootBodyPartContainer != null)
-		// {
-		// rootBodyPartContainer.name = ToSpawn.name;
-		// livingHealthMasterBase.RootBodyPartContainers.Add(rootBodyPartContainer);
-		// rootBodyPartContainer.PlayerSprites = this;
-		// rootBodyPartContainer.healthMaster = playerHealth;
-		// }
 	}
 
 	public void SetSurfaceColour()
@@ -426,14 +357,14 @@ public class PlayerSprites : MonoBehaviour
 	private void OnDirectionChange(Orientation direction)
 	{
 		//update the clothing sprites
-		foreach (ClothingItem c in clothes.Values)
+		foreach (var clothingItem in clothes.Values)
 		{
-			c.Direction = direction;
+			clothingItem.Direction = direction;
 		}
 
-		foreach (var Sprite in OpenSprites)
+		foreach (var sprite in OpenSprites)
 		{
-			Sprite.OnDirectionChange(direction);
+			sprite.OnDirectionChange(direction);
 		}
 
 		foreach (var bodypart in Addedbodypart)
@@ -459,20 +390,6 @@ public class PlayerSprites : MonoBehaviour
 		else
 		{
 			electrocutedOverlay.StartOverlay(directional.CurrentDirection);
-		}
-	}
-
-	/// <summary>
-	/// Enables the electrocuted overlay for the player's mob.
-	/// </summary>
-	/// <param name="time">If provided and greater than zero, how long until the electrocuted overlay is disabled.</param>
-	public void EnableElectrocutedOverlay(float time = -1)
-	{
-		electrocutedOverlay.StartOverlay(directional.CurrentDirection);
-
-		if (time > 0)
-		{
-			StartCoroutine(StopElectrocutedOverlayAfter(time));
 		}
 	}
 
@@ -537,7 +454,9 @@ public class PlayerSprites : MonoBehaviour
 					RaceBodyparts = Race;
 				}
 			}
-			SetupCharacterData(characterSettings);
+			SetUpCharacter();
+			SetupsSprites();
+			livingHealthMasterBase.CirculatorySystem.SetBloodType(RaceBodyparts.Base.BloodType);
 		}
 	}
 
@@ -568,15 +487,7 @@ public class PlayerSprites : MonoBehaviour
 		muzzleFlash.gameObject.SetActive(false);
 	}
 
-	/// <summary>
-	/// Returns true if this playersprites has a clothing item for the specified named slot
-	/// </summary>
-	public bool HasClothingItem(NamedSlot? namedSlot)
-	{
-		return characterSprites.FirstOrDefault(ci => ci.Slot == namedSlot) != null;
-	}
-
-	private void OnClothingEquipped(ClothingV2 clothing, bool isEquipped)
+	public void OnClothingEquipped(ClothingV2 clothing, bool isEquipped)
 	{
 		//Logger.Log($"Clothing {clothing} was equipped {isEquiped}!", Category.Inventory);
 
@@ -649,7 +560,7 @@ public class PlayerSprites : MonoBehaviour
 		// TODO: Not implemented yet?
 		//ValidateHideFlag(ClothingHideFlags.HIDE_SUITSTORAGE, "suit_storage");
 	}
-
+/*
 	private void ValidateHideFlag(ClothingHideFlags hideFlag, string name)
 	{
 		// Check if dictionary has entry about such clothing item name
@@ -663,13 +574,7 @@ public class PlayerSprites : MonoBehaviour
 		var isVisible = !hideClothingFlags.HasFlag(hideFlag);
 		clothes[name].gameObject.SetActive(isVisible);
 	}
-
-	private IEnumerator StopElectrocutedOverlayAfter(float seconds)
-	{
-		yield return WaitFor.Seconds(seconds);
-		DisableElectrocutedOverlay();
-	}
-
+*/
 	public void UpdateChildren(List<uint> NewInternalNetIDs)
 	{
 		OpenSprites.Clear();

--- a/UnityProject/Assets/Scripts/Systems/Inventory/DynamicItemStorage.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/DynamicItemStorage.cs
@@ -755,24 +755,12 @@ public class DynamicItemStorage : NetworkBehaviour
 
 	public void SetUpOccupation(Occupation occupation)
 	{
-		StartCoroutine(InternalSetUpOccupation(occupation));
-	}
-
-
-	public IEnumerator InternalSetUpOccupation(Occupation occupation)
-	{
-		yield return null;
-		yield return null;
-		yield return null;
 		var NSP = occupation.InventoryPopulator as PlayerSlotStoragePopulator;
 		if (NSP != null)
 		{
 			NSP.PopulateDynamicItemStorage(this, registerPlayer.PlayerScript);
 		}
-
-		//
 	}
-
 
 	#region check conditionals
 

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/PlayerHealthUI.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/PlayerHealthUI.cs
@@ -219,7 +219,7 @@ public class PlayerHealthUI : MonoBehaviour
 		{
 			var Player = BbodyPart.HealthMaster as PlayerHealthV2;
 			if (Player == null) return false;
-			return PlayerManager.LocalPlayerScript == Player.PlayerScript;
+			return PlayerManager.LocalPlayerScript == Player.playerScript;
 		}
 	}
 }


### PR DESCRIPTION
### Purpose
Human spawn steps will now be slightly more organized.
Removes several IEnumerators that wait a few frames to try to wait for intiializations from other systems.
merges PlayerScriptOwner and playerScript in LivingHealthMasterBase.
Removes some EnsureInits from health code.
PlayerSprites clothes dictionary will now use NamedSlot enum instead of a string for its key.
Removes commented out code that seems outdated.
Fixes players having a chance to instantly die on spawn.
Fixes uplink code not appearing.
Fixes #6898
Fixes #6890
