### PR TITLE
Makes decorative rock objects mineable.

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Flora/_FloraRockBase.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Flora/_FloraRockBase.prefab
@@ -1,5 +1,18 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1912990431549250049
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1533278424013804078}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4b1a9eacdeba95b4cb0c7a488920e027, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mineTime: 3
 --- !u!1001 &4160617258287907905
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -114,3 +127,9 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bf1232ff5948494499fb98f10c1c1ef6, type: 3}
+--- !u!1 &1533278424013804078 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3240964181289162351, guid: bf1232ff5948494499fb98f10c1c1ef6,
+    type: 3}
+  m_PrefabInstance: {fileID: 4160617258287907905}
+  m_PrefabAsset: {fileID: 0}


### PR DESCRIPTION
<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->

### Purpose
- Title. Makes some decorative rock objects mineable because I discovered we have a component for that.
