### PR TITLE
Remove stylization from PR template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,10 +11,10 @@
 <!-- Add here individual lines with all your remarkable changes using the prefix ``CL:`` -->
 <!-- Mind that the changes meant to be logged in the in changelog are those that are remarkable for the end user, so things like new features and fixes of known bugs are perfect for this section -->
 
-<!-- CL: **[New]** For new features, things that didn't exist before the PR. -->
+<!-- CL: [New] For new features, things that didn't exist before the PR. -->
 
-<!-- CL: **[Improvement]** For any change on any existing feature. -->
+<!-- CL: [Improvement] For any change on any existing feature. -->
 
-<!-- CL: **[Balance]** For any change on an existing feature done in the sake of improving game balance. It's the only exception to the rule above. -->
+<!-- CL: [Balance] For any change on an existing feature done in the sake of improving game balance. It's the only exception to the rule above. -->
 
-<!-- CL: **[Fix]** For any change that fixes a bug. -->
+<!-- CL: [Fix] For any change that fixes a bug. -->


### PR DESCRIPTION

### Purpose
- Title. Removes the bolding from the changelog section in the template because the changelog generator does that automatically and also because it makes tests fail.


