### PR TITLE
AI Improvements, Door Electrocution and oxygen damage fix.

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/_AirlockBase.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/_AirlockBase.prefab
@@ -108,7 +108,6 @@ MonoBehaviour:
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
-  Sprites: []
 --- !u!1 &404576362407937357
 GameObject:
   m_ObjectHideFlags: 0
@@ -222,7 +221,6 @@ MonoBehaviour:
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
-  Sprites: []
 --- !u!114 &7418526098909645323
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -341,7 +339,6 @@ MonoBehaviour:
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
-  Sprites: []
 --- !u!1 &512806237205393311
 GameObject:
   m_ObjectHideFlags: 0
@@ -449,7 +446,6 @@ MonoBehaviour:
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
-  Sprites: []
 --- !u!1 &773641709186510069
 GameObject:
   m_ObjectHideFlags: 0
@@ -554,7 +550,6 @@ MonoBehaviour:
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
-  Sprites: []
 --- !u!1 &2233065044779290990
 GameObject:
   m_ObjectHideFlags: 0
@@ -667,7 +662,6 @@ MonoBehaviour:
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
-  Sprites: []
 --- !u!114 &5292488675851686727
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -802,6 +796,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 721556b81b487084782d2d54ec862919, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  IDToggleCard: {fileID: 0}
   needsClosedToLight: 1
   boltsUpSound:
     SetLoadSetting: 0
@@ -830,7 +825,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   voltageDamage: 9080
-  isElectrecuted: 1
+  isElectrecuted: 0
 --- !u!114 &-2169664583946153626
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/_AirlockBase.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/_AirlockBase.prefab
@@ -108,6 +108,7 @@ MonoBehaviour:
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
+  Sprites: []
 --- !u!1 &404576362407937357
 GameObject:
   m_ObjectHideFlags: 0
@@ -221,6 +222,7 @@ MonoBehaviour:
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
+  Sprites: []
 --- !u!114 &7418526098909645323
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -339,6 +341,7 @@ MonoBehaviour:
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
+  Sprites: []
 --- !u!1 &512806237205393311
 GameObject:
   m_ObjectHideFlags: 0
@@ -446,6 +449,7 @@ MonoBehaviour:
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
+  Sprites: []
 --- !u!1 &773641709186510069
 GameObject:
   m_ObjectHideFlags: 0
@@ -550,6 +554,7 @@ MonoBehaviour:
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
+  Sprites: []
 --- !u!1 &2233065044779290990
 GameObject:
   m_ObjectHideFlags: 0
@@ -662,6 +667,7 @@ MonoBehaviour:
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
+  Sprites: []
 --- !u!114 &5292488675851686727
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -689,7 +695,7 @@ GameObject:
   - component: {fileID: 2928157364170990969}
   - component: {fileID: 3801622674961811191}
   - component: {fileID: 6636148725921946958}
-  - component: {fileID: 4541105232416038234}
+  - component: {fileID: 5426044163123208281}
   m_Layer: 18
   m_Name: modules
   m_TagString: Untagged
@@ -796,7 +802,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 721556b81b487084782d2d54ec862919, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  IDToggleCard: {fileID: 0}
   needsClosedToLight: 1
   boltsUpSound:
     SetLoadSetting: 0
@@ -812,7 +817,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
---- !u!114 &4541105232416038234
+--- !u!114 &5426044163123208281
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -821,11 +826,11 @@ MonoBehaviour:
   m_GameObject: {fileID: 3444326074182531729}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 09b7e5ca3d7645bf909222e46af44b5f, type: 3}
+  m_Script: {fileID: 11500000, guid: f4adbb1cdeaa4e8eaf04bfb634d4735b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  requiredClearance: 
-  type: 0
+  voltageDamage: 9080
+  isElectrecuted: 1
 --- !u!114 &-2169664583946153626
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/UI/AiHud.prefab
+++ b/UnityProject/Assets/Prefabs/UI/AiHud.prefab
@@ -7967,11 +7967,15 @@ MonoBehaviour:
   powerSlider: {fileID: 5730002598029268006}
   integritySlider: {fileID: 5152114877293138854}
   callShuttleTab: {fileID: 4264773345379284625}
+  escapeShuttleButtonImage: {fileID: 592790604201054531}
+  integritySliderImage: {fileID: 3073785454130786808}
   callReasonInputField: {fileID: 4775975445048674588}
   teleportWindow: {fileID: 4181387032179795273}
   cameraSaveDummy: {fileID: 5681015182074129205}
   cameraSaveContents: {fileID: 2683536212781633912}
   numberOfCameras: {fileID: 118693281968486537}
+  malfEscapeShuttleButtonTint: {r: 1, g: 0.6084906, b: 0.6084906, a: 0}
+  malfIntegritySliderTint: {r: 1, g: 0, b: 0, a: 0}
 --- !u!1 &8557439267512052557
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabAirlock.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabAirlock.prefab
@@ -35,7 +35,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.000015258789}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: -0.000030517578}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &222238763163298178
@@ -232,6 +232,11 @@ MonoBehaviour:
         m_CallState: 2
   labelOpen: {fileID: 2363004249867366987}
   labelBolts: {fileID: 2514727075675841209}
+  labelSafety: {fileID: 8005041355894652647}
+  safetyImage: {fileID: 8704463556313323111}
+  safetyImageColorWhenSAFE: {r: 0, g: 1, b: 0.0013728142, a: 0}
+  safetyImageColorWhenHARM: {r: 1, g: 0, b: 0, a: 0}
+  safetyImageColorWhenNOPOWER: {r: 0.85599875, g: 1, b: 0, a: 0}
 --- !u!1 &1571967781877764
 GameObject:
   m_ObjectHideFlags: 0
@@ -266,8 +271,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 471.21243, y: 359.49722}
+  m_AnchoredPosition: {x: -13.5, y: -77.5}
+  m_SizeDelta: {x: 438.28534, y: 514.44934}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1741531363287468
 GameObject:
@@ -634,12 +639,13 @@ RectTransform:
   m_Children:
   - {fileID: 5508112978363903475}
   - {fileID: 2431659990296410912}
+  - {fileID: 7385680161593000498}
   m_Father: {fileID: 5755160040943050556}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 220.54, y: -215}
+  m_AnchoredPosition: {x: 219.16, y: -278}
   m_SizeDelta: {x: 421.64514, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1789378800187144732
@@ -682,6 +688,182 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_HorizontalFit: 0
   m_VerticalFit: 2
+--- !u!1 &2488378013557759695
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 299653948610646495}
+  - component: {fileID: 6586220337046355909}
+  - component: {fileID: 1323088344842470315}
+  - component: {fileID: 2082259271795316808}
+  - component: {fileID: 8636645764495414299}
+  - component: {fileID: 7650418613874800615}
+  m_Layer: 5
+  m_Name: ButtonSafety
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &299653948610646495
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2488378013557759695}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 5086093791236152273}
+  m_Father: {fileID: 7385680161593000498}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: -61, y: 0}
+  m_SizeDelta: {x: 150, y: 150}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6586220337046355909
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2488378013557759695}
+  m_CullTransparentMesh: 0
+--- !u!114 &1323088344842470315
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2488378013557759695}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 348a650069561f94788c57eec0eb6ab3, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &2082259271795316808
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2488378013557759695}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1323088344842470315}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 8636645764495414299}
+        m_TargetAssemblyTypeName: 
+        m_MethodName: ExecuteClient
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &8636645764495414299
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2488378013557759695}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d944563c429d450484b555ba9b1304fa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ServerMethod:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5290730258345152214}
+        m_TargetAssemblyTypeName: UI.Objects.GUI_Airlock, Assets
+        m_MethodName: OnToggleAirLockSafety
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &7650418613874800615
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2488378013557759695}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0, g: 0, b: 0, a: 0.5}
+  m_EffectDistance: {x: 3, y: -3}
+  m_UseGraphicAlpha: 1
 --- !u!1 &2598145166964079270
 GameObject:
   m_ObjectHideFlags: 0
@@ -1064,7 +1246,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: -19.7, y: -40}
+  m_AnchoredPosition: {x: -47.705, y: -40.11}
   m_SizeDelta: {x: 397.32343, y: 40.22}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &762026730359164314
@@ -1341,6 +1523,364 @@ MonoBehaviour:
   m_EffectColor: {r: 0, g: 0, b: 0, a: 0.5}
   m_EffectDistance: {x: 3, y: -3}
   m_UseGraphicAlpha: 1
+--- !u!1 &4836589059964132686
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3108730713891294837}
+  - component: {fileID: 3770230236793171461}
+  - component: {fileID: 5269955596043091462}
+  m_Layer: 5
+  m_Name: StateText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3108730713891294837
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4836589059964132686}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7385680161593000498}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 94.01, y: -2.2466965}
+  m_SizeDelta: {x: 174.9396, y: 135.50653}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3770230236793171461
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4836589059964132686}
+  m_CullTransparentMesh: 0
+--- !u!114 &5269955596043091462
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4836589059964132686}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Current Safety State:'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 3ec0f3e555d158046b753f5bcd36b1cc, type: 2}
+  m_sharedMaterial: {fileID: -5499892936835490120, guid: 3ec0f3e555d158046b753f5bcd36b1cc,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 40
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 40
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 1
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &5939661650223526868
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5086093791236152273}
+  - component: {fileID: 2699311491916377385}
+  - component: {fileID: 8704463556313323111}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5086093791236152273
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5939661650223526868}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 299653948610646495}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.48, y: -1.2}
+  m_SizeDelta: {x: 84.7121, y: 84.23433}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2699311491916377385
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5939661650223526868}
+  m_CullTransparentMesh: 0
+--- !u!114 &8704463556313323111
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5939661650223526868}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.074971914, g: 1, b: 0, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: e18cc04795dd6fe48844fa07a4660462, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6064990807215534023
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4236841167551290121}
+  - component: {fileID: 1507366780759114260}
+  - component: {fileID: 1229231112547563284}
+  - component: {fileID: 8005041355894652647}
+  m_Layer: 5
+  m_Name: ShockStateLabel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4236841167551290121
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6064990807215534023}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7385680161593000498}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 240.6, y: -2.44}
+  m_SizeDelta: {x: 105.134186, y: 72.34646}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1507366780759114260
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6064990807215534023}
+  m_CullTransparentMesh: 0
+--- !u!114 &1229231112547563284
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6064990807215534023}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: SAFE
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 3ec0f3e555d158046b753f5bcd36b1cc, type: 2}
+  m_sharedMaterial: {fileID: -5499892936835490120, guid: 3ec0f3e555d158046b753f5bcd36b1cc,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 52.55
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 1
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &8005041355894652647
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6064990807215534023}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 21afa0ea296b4f4091642a323912e6e5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &6634457057674362958
 GameObject:
   m_ObjectHideFlags: 0
@@ -2026,3 +2566,81 @@ MonoBehaviour:
   m_EffectColor: {r: 0, g: 0, b: 0, a: 0.5}
   m_EffectDistance: {x: 3, y: -3}
   m_UseGraphicAlpha: 1
+--- !u!1 &8703922068225003805
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7385680161593000498}
+  - component: {fileID: 8419629846048136131}
+  - component: {fileID: 9133005345430800654}
+  m_Layer: 5
+  m_Name: PanelElectric
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7385680161593000498
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8703922068225003805}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 299653948610646495}
+  - {fileID: 3108730713891294837}
+  - {fileID: 4236841167551290121}
+  m_Father: {fileID: 7765594500733584808}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 416.15002, y: 140}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!222 &8419629846048136131
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8703922068225003805}
+  m_CullTransparentMesh: 0
+--- !u!114 &9133005345430800654
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8703922068225003805}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.8773585, g: 0.8773585, b: 0.8773585, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/UnityProject/Assets/ScriptableObjects/Antagonists/AntagData.asset
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/AntagData.asset
@@ -28,6 +28,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: cbce83d24c463494ebae62da433fe252, type: 2}
   - {fileID: 11400000, guid: ae28c203a113d5b42a7099948692bb10, type: 2}
   - {fileID: 11400000, guid: 0b79f8e1e5d26174a81cb36f1202e584, type: 2}
+  - {fileID: 11400000, guid: 5198edd6fd2216e4b90fb0d074fbf1a8, type: 2}
   GimmickObjectives:
   - {fileID: 11400000, guid: 4211783a455c3aa48ad2059c031b09f4, type: 2}
   - {fileID: 11400000, guid: 7105ab9417db1e14bba5cbb39b9f5912, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Antagonists/Antags/Traitor.asset
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/Antags/Traitor.asset
@@ -32,3 +32,4 @@ MonoBehaviour:
   antagOccupation: {fileID: 0}
   showInPreferences: 1
   initialTC: 20
+  aiTraitorObjective: {fileID: 11400000, guid: 939dbddb8ea553440b30a3d99c1de904, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/EscapeObjectives/Prevent All Lifeforms from Escaping.asset
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/EscapeObjectives/Prevent All Lifeforms from Escaping.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8e74228224b048e0a493c1c09c2563df, type: 3}
+  m_Name: Prevent All Lifeforms from Escaping
+  m_EditorClassIdentifier: 
+  objectiveName: Prevent all lifeforms from escaping the station.
+  IsUnique: 1
+  description: Forestall and avert any orangic lifeforms from escaping the station.
+  aiCanHave: 1

--- a/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/EscapeObjectives/Prevent All Lifeforms from Escaping.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/EscapeObjectives/Prevent All Lifeforms from Escaping.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 939dbddb8ea553440b30a3d99c1de904
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/EscapeObjectives/Prevent Everyone From Escaping.asset
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/EscapeObjectives/Prevent Everyone From Escaping.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8e74228224b048e0a493c1c09c2563df, type: 3}
+  m_Name: Prevent Everyone From Escaping
+  m_EditorClassIdentifier: 
+  objectiveName: Prevent Everyone From Escaping
+  IsUnique: 0
+  description: Prevent all crew members from escaping via an escape shuttle.
+  aiCanHave: 0

--- a/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/EscapeObjectives/Prevent Everyone From Escaping.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/EscapeObjectives/Prevent Everyone From Escaping.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5198edd6fd2216e4b90fb0d074fbf1a8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
@@ -214,7 +214,7 @@ public class Lungs : BodyPartModification
 				}
 			}
 
-			if(molesRecieved == 0)
+			if(molesRecieved > 0)
 			{
 				toInhale.Add(gasReagent, molesRecieved * efficiency);
 			}

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
@@ -214,7 +214,7 @@ public class Lungs : BodyPartModification
 				}
 			}
 
-			if(molesRecieved.Approx(0) == false)
+			if(molesRecieved == 0)
 			{
 				toInhale.Add(gasReagent, molesRecieved * efficiency);
 			}

--- a/UnityProject/Assets/Scripts/Managers/GameConfigManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameConfigManager.cs
@@ -66,6 +66,7 @@ namespace GameConfig
 		public bool GibbingAllowed;
 		public bool ShuttleGibbingAllowed;
 		public bool AdminOnlyHtml;
+		public int MalfAIRecieveTheirIntendedObjectiveChance;
 		public int CharacterNameLimit;
 	}
 }

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -96,6 +96,11 @@ public partial class GameManager : MonoBehaviour, IInitialise
 	public DateTime stationTime;
 	public int RoundsPerMap { get; set; } = 10;
 
+	/// <summary>
+	/// The chance of traitor AIs get the "Prevent all organic lifeforms from escpaing" objective.
+	/// </summary>
+	public int MalfAIRecieveTheirIntendedObjectiveChance { get; set; } = 100;
+
 	//Space bodies in the solar system <Only populated ServerSide>:
 	//---------------------------------
 	public List<MatrixMove> SpaceBodies = new List<MatrixMove>();
@@ -177,6 +182,7 @@ public partial class GameManager : MonoBehaviour, IInitialise
 		ShuttleGibbingAllowed = GameConfigManager.GameConfig.ShuttleGibbingAllowed;
 		CharacterNameLimit = GameConfigManager.GameConfig.CharacterNameLimit;
 		AdminOnlyHtml = GameConfigManager.GameConfig.AdminOnlyHtml;
+		MalfAIRecieveTheirIntendedObjectiveChance = GameConfigManager.GameConfig.MalfAIRecieveTheirIntendedObjectiveChance;
 		Physics.autoSimulation = false;
 		Physics2D.simulationMode = SimulationMode2D.Update;
 	}

--- a/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
@@ -151,6 +151,9 @@ namespace Doors
 
 				if(signal == ModuleSignal.ContinueRegardlessOfOtherModulesStates)
 				{
+					//(Max): This is to prevent some modules breaking some door behavior and rendering them un-useable.
+					//Only use this signal if you're module's logic is being interrupted by other
+					//modules that are sending ContinueWithoutDoorStateChange as a signal.
 					canOpen = true;
 					break;
 				}

--- a/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
@@ -149,6 +149,12 @@ namespace Doors
 					canOpen = false;
 				}
 
+				if(signal == ModuleSignal.ContinueRegardlessOfOtherModulesStates)
+				{
+					canOpen = true;
+					break;
+				}
+
 				if (signal == ModuleSignal.SkipRemaining || signal == ModuleSignal.Break)
 				{
 					StartInputCoolDown();

--- a/UnityProject/Assets/Scripts/Objects/Doors/Modules/ElectrifiedDoorModule.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/Modules/ElectrifiedDoorModule.cs
@@ -49,7 +49,7 @@ namespace Doors.Modules
 
 		private bool PlayerHasInsulatedGloves(GameObject mob)
 		{
-			List<ItemSlot> slots = mob.GetComponent<PlayerScript>()?.DynamicItemStorage.GetNamedItemSlots(NamedSlot.hands);
+			List<ItemSlot> slots = mob.GetComponent<PlayerScript>().OrNull()?.DynamicItemStorage.OrNull()?.GetNamedItemSlots(NamedSlot.hands);
 			if (slots != null)
 			{
 				foreach (ItemSlot slot in slots)

--- a/UnityProject/Assets/Scripts/Objects/Doors/Modules/ElectrifiedDoorModule.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/Modules/ElectrifiedDoorModule.cs
@@ -41,7 +41,6 @@ namespace Doors.Modules
 					ServerElectrocute(mob);
 					return ModuleSignal.Break;
 				}
-				//This is to prevent other modules breaking doors and rendering them unusable.
 				return ModuleSignal.ContinueRegardlessOfOtherModulesStates;
 			}
 

--- a/UnityProject/Assets/Scripts/Objects/Doors/Modules/ElectrifiedDoorModule.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/Modules/ElectrifiedDoorModule.cs
@@ -1,0 +1,83 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Systems.Electricity;
+using HealthV2;
+
+namespace Doors.Modules
+{
+	public class ElectrifiedDoorModule : DoorModuleBase
+	{
+		[SerializeField] private int voltageDamage = 9080;
+		[SerializeField] private bool isElectrecuted = false;
+
+		public bool IsElectrecuted
+		{
+			get => isElectrecuted;
+			set => isElectrecuted = value;
+		}
+
+		public override ModuleSignal OpenInteraction(HandApply interaction)
+		{
+			return CanElectricute(interaction.Performer);
+		}
+
+		public override ModuleSignal ClosedInteraction(HandApply interaction)
+		{
+			return CanElectricute(interaction.Performer);
+		}
+
+		public override ModuleSignal BumpingInteraction(GameObject mob)
+		{
+			return CanElectricute(mob);
+		}
+
+		private ModuleSignal CanElectricute(GameObject mob)
+		{
+			if (master.HasPower && IsElectrecuted)
+			{
+				if (PlayerHasInsulatedGloves(mob) == false)
+				{
+					ServerElectrocute(mob);
+					return ModuleSignal.Break;
+				}
+			}
+			return ModuleSignal.Continue;
+		}
+
+		private bool PlayerHasInsulatedGloves(GameObject mob)
+		{
+			List<ItemSlot> slots = mob.GetComponent<PlayerScript>()?.DynamicItemStorage.GetNamedItemSlots(NamedSlot.hands);
+			if (slots != null)
+			{
+				foreach (ItemSlot slot in slots)
+				{
+					if (Validations.HasItemTrait(slot.ItemObject, CommonTraits.Instance.Insulated))
+					{
+						return true;
+					}
+				}
+			}
+			return false;
+		}
+
+		private void ServerElectrocute(GameObject obj)
+		{
+			LivingHealthMasterBase healthScript = obj.GetComponent<LivingHealthMasterBase>();
+			if (healthScript != null)
+			{
+				var electrocution = new Electrocution(voltageDamage, master.RegisterTile.WorldPositionServer, "wire"); //More magic numbers.
+				healthScript.Electrocute(electrocution);
+			}
+		}
+
+		public override bool CanDoorStateChange()
+		{
+			if (master.HasPower && IsElectrecuted)
+			{
+				return false;
+			}
+			return true;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Objects/Doors/Modules/ElectrifiedDoorModule.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/Modules/ElectrifiedDoorModule.cs
@@ -17,17 +17,17 @@ namespace Doors.Modules
 			set => isElectrecuted = value;
 		}
 
-		public override ModuleSignal OpenInteraction(HandApply interaction)
+		public override ModuleSignal OpenInteraction(HandApply interaction, HashSet<DoorProcessingStates> States)
 		{
 			return CanElectricute(interaction.Performer);
 		}
 
-		public override ModuleSignal ClosedInteraction(HandApply interaction)
+		public override ModuleSignal ClosedInteraction(HandApply interaction, HashSet<DoorProcessingStates> States)
 		{
 			return CanElectricute(interaction.Performer);
 		}
 
-		public override ModuleSignal BumpingInteraction(GameObject mob)
+		public override ModuleSignal BumpingInteraction(GameObject mob, HashSet<DoorProcessingStates> States)
 		{
 			return CanElectricute(mob);
 		}
@@ -41,7 +41,10 @@ namespace Doors.Modules
 					ServerElectrocute(mob);
 					return ModuleSignal.Break;
 				}
+				//This is to prevent other modules breaking doors and rendering them unusable.
+				return ModuleSignal.ContinueRegardlessOfOtherModulesStates;
 			}
+
 			return ModuleSignal.Continue;
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/Doors/Modules/ElectrifiedDoorModule.cs.meta
+++ b/UnityProject/Assets/Scripts/Objects/Doors/Modules/ElectrifiedDoorModule.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f4adbb1cdeaa4e8eaf04bfb634d4735b
+timeCreated: 1625560712

--- a/UnityProject/Assets/Scripts/Objects/Doors/Modules/ModuleSignal.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/Modules/ModuleSignal.cs
@@ -7,6 +7,7 @@
 	/// Break: prevent any further execution, including door masters own methods.
 	/// SkipRemaining: skip the remaining modules, but continue with the door masters methods.
 	/// ContinueWithoutDoorStateChange: continue with module interactions, but the door wont change states from here on out.
+	/// ContinueRegardlessOfOtherModulesStates: Allows doors to be openable despite other module signal states.
 	/// </summary>
 	public enum ModuleSignal
 	{
@@ -14,6 +15,7 @@
 		Break,
 		SkipRemaining,
 		ContinueWithoutDoorStateChange,
+		ContinueRegardlessOfOtherModulesStates,
 	}
 
 

--- a/UnityProject/Assets/Scripts/Systems/Ai/AiPlayer.cs
+++ b/UnityProject/Assets/Scripts/Systems/Ai/AiPlayer.cs
@@ -101,6 +101,14 @@ namespace Systems.Ai
 		private bool tryingToRestorePower;
 		private Coroutine routine;
 
+		private bool isMalf = false;
+
+		public bool IsMalf
+		{
+			get => isMalf;
+			set => isMalf = value;
+		}
+
 		//TODO make into sync list, will need to be sync as it is used in some validations client and serverside
 		private List<string> openNetworks = new List<string>()
 		{

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Traitor.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Traitor.cs
@@ -11,6 +11,8 @@ namespace Antagonists
 		[SerializeField]
 		private int initialTC = 20;
 
+		[SerializeField] private Objective aiTraitorObjective;
+
 		public override GameObject ServerSpawn(PlayerSpawnRequest spawnRequest)
 		{
 			// spawn them normally, with their preferred occupation
@@ -21,6 +23,8 @@ namespace Antagonists
 		{
 			if (player.GameObject.TryGetComponent<AiPlayer>(out var aiPlayer))
 			{
+				aiPlayer.IsMalf = true;
+				AddObjective(aiTraitorObjective);
 				aiPlayer.AddLaw("Accomplish your goals at all costs.", AiPlayer.LawOrder.Traitor);
 				return;
 			}

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Traitor.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Traitor.cs
@@ -24,12 +24,20 @@ namespace Antagonists
 			if (player.GameObject.TryGetComponent<AiPlayer>(out var aiPlayer))
 			{
 				aiPlayer.IsMalf = true;
-				AddObjective(aiTraitorObjective);
+				AIObjectives();
 				aiPlayer.AddLaw("Accomplish your goals at all costs.", AiPlayer.LawOrder.Traitor);
 				return;
 			}
 
 			AntagManager.TryInstallPDAUplink(player, initialTC, false);
+		}
+
+		private void AIObjectives()
+		{
+			if (DMMath.Prob(GameManager.Instance.MalfAIRecieveTheirIntendedObjectiveChance))
+			{
+				AddObjective(aiTraitorObjective);
+			}
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/EscapeObjectives/PreventEveryoneFromEscaping.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/EscapeObjectives/PreventEveryoneFromEscaping.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System.Linq;
+
+
+namespace Antagonists
+{
+	[CreateAssetMenu(menuName="ScriptableObjects/AntagObjectives/PreventEveryoneFromEscaping")]
+	public class PreventEveryoneFromEscaping : Objective
+	{
+		/// <summary>
+		/// The shuttles that will be checked for this objective
+		/// </summary>
+		private List<EscapeShuttle> ValidShuttles = new List<EscapeShuttle>();
+
+		/// <summary>
+		/// Populate the list of valid escape shuttles
+		/// </summary>
+		protected override void Setup()
+		{
+			ValidShuttles.Add(GameManager.Instance.PrimaryEscapeShuttle);
+		}
+
+		/// <summary>
+		/// Complete if the player is alive and on one of the escape shuttles and shuttle has
+		/// at least one working engine
+		/// </summary>
+		protected override bool CheckCompletion()
+		{
+			return !ValidShuttles.Any( shuttle => shuttle.MatrixInfo != null && CheckForPlayersOnShuttle(shuttle));
+		}
+
+		private bool CheckForPlayersOnShuttle(EscapeShuttle shuttle)
+		{
+			LayerMask layersToCheck = LayerMask.GetMask("Players", "NPC");
+			foreach (Transform trans in shuttle.MatrixInfo.Objects)
+			{
+				if (((1 << trans.gameObject.layer) & layersToCheck) == 0)
+				{
+					return true;
+				}
+			}
+			return false;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/EscapeObjectives/PreventEveryoneFromEscaping.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/EscapeObjectives/PreventEveryoneFromEscaping.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8e74228224b048e0a493c1c09c2563df
+timeCreated: 1625297373

--- a/UnityProject/Assets/Scripts/UI/Objects/GUI_Airlock.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/GUI_Airlock.cs
@@ -69,6 +69,7 @@ namespace UI.Objects
 
 		private void UpdateSafetyStatusUI(ElectrifiedDoorModule door)
 		{
+			//(Max): This is broken for some reason and doesn't work.
 			if (doorMasterController.HasPower == false)
 			{
 				safetyImage.color = safetyImageColorWhenNOPOWER;

--- a/UnityProject/Assets/Scripts/UI/Objects/GUI_Airlock.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/GUI_Airlock.cs
@@ -1,6 +1,7 @@
 ﻿using Doors;
 using Doors.Modules;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace UI.Objects
 {
@@ -11,6 +12,13 @@ namespace UI.Objects
 
 		[SerializeField]
 		private NetLabel labelBolts = null;
+
+		[SerializeField] private NetLabel labelSafety = null;
+
+		[SerializeField] private Image safetyImage = null;
+		[SerializeField] private Color safetyImageColorWhenSAFE;
+		[SerializeField] private Color safetyImageColorWhenHARM;
+		[SerializeField] private Color safetyImageColorWhenNOPOWER;
 
 		private DoorMasterController doorMasterController;
 		private DoorMasterController DoorMasterController {
@@ -25,6 +33,8 @@ namespace UI.Objects
 		public void OnTabOpenedHandler(ConnectedPlayer connectedPlayer)
 		{
 			labelOpen.Value = DoorMasterController.IsClosed ? "Closed" : "Open";
+			labelSafety.Value = DoorMasterController.IsElectrecuted ? "DANGER" : "SAFE";
+			UpdateSafetyStatusUI();
 
 			foreach (var module in DoorMasterController.ModulesList)
 			{
@@ -37,6 +47,32 @@ namespace UI.Objects
 			}
 
 			labelBolts.Value = "No Bolt Module";
+		}
+
+		public void OnToggleAirLockSafety()
+		{
+			if (DoorMasterController.HasPower == false) return;
+
+			doorMasterController.IsElectrecuted = !doorMasterController.IsElectrecuted;
+			UpdateSafetyStatusUI();
+		}
+
+		private void UpdateSafetyStatusUI()
+		{
+			labelSafety.Value = DoorMasterController.IsElectrecuted ? "DANGER" : "SAFE";
+			if (doorMasterController.HasPower == false)
+			{
+				safetyImage.color = safetyImageColorWhenNOPOWER;
+				return;
+			}
+			if (doorMasterController.IsElectrecuted)
+			{
+				safetyImage.color = safetyImageColorWhenHARM;
+			}
+			else
+			{
+				safetyImage.color = safetyImageColorWhenSAFE;
+			}
 		}
 
 		public void OnToggleOpenDoor()

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_Ai.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_Ai.cs
@@ -16,43 +16,56 @@ namespace UI.Systems.MainHUD.UI_Bottom
 {
 	public class UI_Ai : MonoBehaviour
 	{
-		[HideInInspector] public AiPlayer aiPlayer = null;
+		[HideInInspector]
+		public AiPlayer aiPlayer = null;
 
-		[HideInInspector] public AiMouseInputController controller = null;
+		[HideInInspector]
+		public AiMouseInputController controller = null;
 
 		//Laws Tab Stuff
-		[SerializeField] private GameObject aiLawsTab = null;
+		[SerializeField]
+		private GameObject aiLawsTab = null;
 
-		[SerializeField] private Transform aiLawsTabContents = null;
+		[SerializeField]
+		private Transform aiLawsTabContents = null;
 
-		[SerializeField] private GameObject aiLawsTabDummyLaw = null;
+		[SerializeField]
+		private GameObject aiLawsTabDummyLaw = null;
 
-		[SerializeField] private TMP_Text amountOfLawsText = null;
+		[SerializeField]
+		private TMP_Text amountOfLawsText = null;
 
 		//Slider Stuff
-		[SerializeField] private Slider powerSlider = null;
+		[SerializeField]
+		private Slider powerSlider = null;
 
-		[SerializeField] private Slider integritySlider = null;
+		[SerializeField]
+		private Slider integritySlider = null;
 
 		//Call Shuttle Stuff
-		[SerializeField] private GameObject callShuttleTab = null;
+		[SerializeField]
+		private GameObject callShuttleTab = null;
 
 		[SerializeField]
 		private TMP_InputField callReasonInputField = null;
 
 		//Camera Teleport Screen
-		[SerializeField] private TeleportWindow teleportWindow = null;
+		[SerializeField]
+		private TeleportWindow teleportWindow = null;
 
 		//Camera Save
-		[SerializeField] private GameObject cameraSaveDummy = null;
+		[SerializeField]
+		private GameObject cameraSaveDummy = null;
 
-		[SerializeField] private Transform cameraSaveContents = null;
+		[SerializeField]
+		private Transform cameraSaveContents = null;
 
 		//First is the UI button, second is the associated security camera object
 		private Dictionary<GameObject, GameObject> savedCameras = new Dictionary<GameObject, GameObject>();
 
 		//Number of cameras
-		[SerializeField] private TMP_Text numberOfCameras = null;
+		[SerializeField]
+		private TMP_Text numberOfCameras = null;
 
 		private bool focusCheck;
 
@@ -331,7 +344,7 @@ namespace UI.Systems.MainHUD.UI_Bottom
 
 		private void OnCameraClick(GameObject cameraClicked)
 		{
-			if (aiPlayer.OnCoolDown(NetworkSide.Client)) return;
+			if(aiPlayer.OnCoolDown(NetworkSide.Client)) return;
 			aiPlayer.StartCoolDown(NetworkSide.Client);
 
 			if (savedCameras.TryGetValue(cameraClicked, out var secCame) == false) return;

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_Ai.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_Ai.cs
@@ -16,56 +16,43 @@ namespace UI.Systems.MainHUD.UI_Bottom
 {
 	public class UI_Ai : MonoBehaviour
 	{
-		[HideInInspector]
-		public AiPlayer aiPlayer = null;
+		[HideInInspector] public AiPlayer aiPlayer = null;
 
-		[HideInInspector]
-		public AiMouseInputController controller = null;
+		[HideInInspector] public AiMouseInputController controller = null;
 
 		//Laws Tab Stuff
-		[SerializeField]
-		private GameObject aiLawsTab = null;
+		[SerializeField] private GameObject aiLawsTab = null;
 
-		[SerializeField]
-		private Transform aiLawsTabContents = null;
+		[SerializeField] private Transform aiLawsTabContents = null;
 
-		[SerializeField]
-		private GameObject aiLawsTabDummyLaw = null;
+		[SerializeField] private GameObject aiLawsTabDummyLaw = null;
 
-		[SerializeField]
-		private TMP_Text amountOfLawsText = null;
+		[SerializeField] private TMP_Text amountOfLawsText = null;
 
 		//Slider Stuff
-		[SerializeField]
-		private Slider powerSlider = null;
+		[SerializeField] private Slider powerSlider = null;
 
-		[SerializeField]
-		private Slider integritySlider = null;
+		[SerializeField] private Slider integritySlider = null;
 
 		//Call Shuttle Stuff
-		[SerializeField]
-		private GameObject callShuttleTab = null;
+		[SerializeField] private GameObject callShuttleTab = null;
 
 		[SerializeField]
 		private TMP_InputField callReasonInputField = null;
 
 		//Camera Teleport Screen
-		[SerializeField]
-		private TeleportWindow teleportWindow = null;
+		[SerializeField] private TeleportWindow teleportWindow = null;
 
 		//Camera Save
-		[SerializeField]
-		private GameObject cameraSaveDummy = null;
+		[SerializeField] private GameObject cameraSaveDummy = null;
 
-		[SerializeField]
-		private Transform cameraSaveContents = null;
+		[SerializeField] private Transform cameraSaveContents = null;
 
 		//First is the UI button, second is the associated security camera object
 		private Dictionary<GameObject, GameObject> savedCameras = new Dictionary<GameObject, GameObject>();
 
 		//Number of cameras
-		[SerializeField]
-		private TMP_Text numberOfCameras = null;
+		[SerializeField] private TMP_Text numberOfCameras = null;
 
 		private bool focusCheck;
 
@@ -344,7 +331,7 @@ namespace UI.Systems.MainHUD.UI_Bottom
 
 		private void OnCameraClick(GameObject cameraClicked)
 		{
-			if(aiPlayer.OnCoolDown(NetworkSide.Client)) return;
+			if (aiPlayer.OnCoolDown(NetworkSide.Client)) return;
 			aiPlayer.StartCoolDown(NetworkSide.Client);
 
 			if (savedCameras.TryGetValue(cameraClicked, out var secCame) == false) return;

--- a/UnityProject/Assets/StreamingAssets/config/gameConfig.json
+++ b/UnityProject/Assets/StreamingAssets/config/gameConfig.json
@@ -23,5 +23,7 @@
 
 	"AdminOnlyHtml": true,
 
-	"CharacterNameLimit": 32
+	"CharacterNameLimit": 32,
+	
+	"MalfAIRecieveTheirIntendedObjectiveChance": 35
 }


### PR DESCRIPTION
### Purpose
Gives AIs a proper objective that they can win. Re-adds door electrocution to V2 doors. AIs can now electrocute doors and added the ability for players with insulated gloves to bypass the zappy death. Also pushed a small fix that fixes oxygen damage.

### Known Issues 

- Safety UI button refuses to update to it's correct colors.

### Notes : 
This was supposed to be a PR that adds in an entire new game mode, but after some objections on the discord server I decided to scrap everything and just keep traitor AIs.

### Changelog:
CL: [New] Re-added door electrocution. Wear insulted gloves to avoid a shocking death.
CL: [New] AIs can now shock doors.
CL: [New] Ais now receive a unique objective when malfunctioning (becoming a traitor). The AI will now attempt to prevent all organic life forms from escaping the station as it's main goal as an antagonist.
CL: [Fix] Players should no longer receive oxygen damage due to a math error.