### PR TITLE
Fixes space not choking players

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Utils/AtmosUtils.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Utils/AtmosUtils.cs
@@ -135,7 +135,7 @@ namespace Systems.Atmospherics
 				return pressure * volume / (Gas.R * moles) * 1000;
 			}
 
-			return 0;
+			return 2.7f; //space radiation
 		}
 
 		/// <summary>


### PR DESCRIPTION
### Purpose
New moles forcefully added to empty gases will now have 2.7 temperature, removing divisions by 0 and other infinite/NaN issues.
Fixes being choked by space.
Fixes #6912
