### PR TITLE
Fixes particular mob invisibility, other small things

### DIFF
--- a/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainerFillVisualisation.cs
+++ b/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainerFillVisualisation.cs
@@ -79,7 +79,7 @@ public class ReagentContainerFillVisualisation : NetworkBehaviour, IServerSpawn
 		// Apply new state to sprite render
 		var newSprite = GetSpriteByFill(newState.fillPercent);
 		fillSpriteHandler.SetSprite(newSprite);
-		fillSpriteHandler.SetColor(newState.mixColor, NetWork: false);
+		fillSpriteHandler.SetColor(newState.mixColor, networked: false);
 	}
 
 	private Sprite GetSpriteByFill(float fillPercent)

--- a/UnityProject/Assets/Scripts/Clothing/ClothingV2.cs
+++ b/UnityProject/Assets/Scripts/Clothing/ClothingV2.cs
@@ -103,7 +103,7 @@ namespace Systems.Clothing
 			if (myItem.ItemSprites.IsPaletted)
 			{
 				//	myItem.SetPaletteOfCurrentSprite(palette);
-				clothingItem?.spriteHandler.SetPaletteOfCurrentSprite(palette, Network: false);
+				clothingItem?.spriteHandler.SetPaletteOfCurrentSprite(palette, networked: false);
 				pickupable.SetPalette(palette);
 			}
 		}

--- a/UnityProject/Assets/Scripts/Core/Chat/Chat.Process.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/Chat.Process.cs
@@ -300,7 +300,7 @@ public partial class Chat
 		}
 		else if ((modifiers & ChatModifier.ColdlyState) == ChatModifier.ColdlyState)
 		{
-			verb = " coldly states,";
+			verb = "coldly states,";
 		}
 		else if ((modifiers & ChatModifier.Exclaim) == ChatModifier.Exclaim)
 		{

--- a/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandler.cs
+++ b/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandler.cs
@@ -1,8 +1,8 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using Mirror;
-using UnityEditor;
 #if UNITY_EDITOR
 using Unity.EditorCoroutines.Editor;
 #endif
@@ -35,7 +35,8 @@ public class SpriteHandler : MonoBehaviour
 	[SerializeField]
 	private bool pushTextureOnStartUp = true;
 
-	[Range(0, 3)] [SerializeField] private int variantIndex = 0;
+	[SerializeField, Range(0, 3)]
+	private int variantIndex = 0;
 
 	private int cataloguePage = -1;
 
@@ -61,14 +62,11 @@ public class SpriteHandler : MonoBehaviour
 	/// </summary>
 	private bool isPaletteSet = false;
 
-	private bool Initialised = false;
+	private bool initialised = false;
 
-	private NetworkIdentity NetworkIdentity;
+	private NetworkIdentity networkIdentity;
 
 	private bool isSubCatalogueChanged = false;
-
-	[SerializeField]
-	private List<SerialisationStanding> Sprites =new List<SerialisationStanding>();
 
 	/// <summary>
 	/// The catalogue index representing the current sprite SO.
@@ -79,18 +77,18 @@ public class SpriteHandler : MonoBehaviour
 	/// Invokes when sprite just changed by animation or other script
 	/// Null if sprite became hidden
 	/// </summary>
-	public event System.Action<Sprite> OnSpriteChanged;
+	public event Action<Sprite> OnSpriteChanged;
 
 	/// <summary>
 	/// Invokes when sprite data scriptable object is changed
 	/// Null if sprite became hidden
 	/// </summary>
-	public event System.Action<SpriteDataSO> OnSpriteDataSOChanged;
+	public event Action<SpriteDataSO> OnSpriteDataSOChanged;
 
 	/// <summary>
 	/// Invoke when sprite handler has changed color of sprite
 	/// </summary>
-	public event System.Action<Color> OnColorChanged;
+	public event Action<Color> OnColorChanged;
 
 	/// <summary>
 	/// The amount of SubCatalogues defined for this SpriteHandler.
@@ -142,7 +140,7 @@ public class SpriteHandler : MonoBehaviour
 	/// <summary>
 	/// Check if this sprite hander is rendering
 	/// </summary>
-	public bool IsHiden
+	public bool IsHidden
 	{
 		get
 		{
@@ -152,79 +150,88 @@ public class SpriteHandler : MonoBehaviour
 
 	public NetworkIdentity GetMasterNetID()
 	{
-		return NetworkIdentity;
+		return networkIdentity;
 	}
 
-	public void ChangeSprite(int SubCataloguePage, bool Network = true)
+	/// <summary>
+	/// Changes the object's active <see cref="SpriteDataSO"></see>.
+	/// </summary>
+	/// <param name="cataloguePage">Index as defined via the inspector on the object.</param>
+	/// <param name="networked">Whether this change should be sent to clients, if server.</param>
+	public void ChangeSprite(int cataloguePage, bool networked = true)
 	{
-		InternalChangeSprite(SubCataloguePage, Network);
+		InternalChangeSprite(cataloguePage, networked);
 	}
 
 	/// <summary>
 	/// When the animation for the given SO is complete,
 	/// the current SO index is incremented (looping to 0 if needed) instead of looping the SO's animation.
 	/// </summary>
-	public void AnimateOnce(int SubCataloguePage, bool Network = true)
+	public void AnimateOnce(int cataloguePage, bool networked = true)
 	{
-		InternalChangeSprite(SubCataloguePage, Network, true);
+		InternalChangeSprite(cataloguePage, networked, true);
 	}
 
-	private void InternalChangeSprite(int SubCataloguePage, bool Network = true, bool AnimateOnce = false)
+	private void InternalChangeSprite(int cataloguePage, bool networked = true, bool animateOnce = false)
 	{
-		if (AnimateOnce == false)
+		if (animateOnce == false)
 		{
-			if ((cataloguePage > -1 && SubCataloguePage == cataloguePage) || SubCataloguePage < 0) return;
+			if ((this.cataloguePage > -1 && cataloguePage == this.cataloguePage) || cataloguePage < 0) return;
 		}
 
-		if (SubCataloguePage >= SubCatalogue.Count)
+		if (cataloguePage >= SubCatalogue.Count)
 		{
-			Logger.LogError($"Sprite catalogue index '{SubCataloguePage}' is out of bounds on {transform.parent.gameObject}.");
+			Logger.LogError($"Sprite catalogue index '{cataloguePage}' is out of bounds on {transform.parent.gameObject}.");
 			return;
 		}
 
-		cataloguePage = SubCataloguePage;
+		this.cataloguePage = cataloguePage;
 		if (isSubCatalogueChanged)
 		{
-			SetSpriteSO(SubCatalogue[SubCataloguePage]);
+			SetSpriteSO(SubCatalogue[cataloguePage]);
 		}
 		else
 		{
-			SetSpriteSO(SubCatalogue[SubCataloguePage], Network: false);
-			if (Network)
+			SetSpriteSO(SubCatalogue[cataloguePage], networked: false);
+			if (networked)
 			{
-				NetUpdate(NewCataloguePage: SubCataloguePage, NewAnimateOnce: AnimateOnce);
+				NetUpdate(newCataloguePage: cataloguePage, newAnimateOnce: animateOnce);
 			}
 		}
 
-		animateOnce = AnimateOnce;
+		this.animateOnce = animateOnce;
 	}
 
-	public void SetSpriteSO(SpriteDataSO NewspriteDataSO, Color? color = null, int NewvariantIndex = -1,
-		bool Network = true)
+	public void SetSpriteSO(SpriteDataSO newSpriteSO, Color? color = null, int newVariantIndex = -1,
+		bool networked = true)
 	{
-		if (NewspriteDataSO != PresentSpriteSet)
+		if (newSpriteSO != PresentSpriteSet)
 		{
 			isPaletteSet = false;
-			PresentSpriteSet = NewspriteDataSO;
+			PresentSpriteSet = newSpriteSO;
 			// TODO: Network, change to network catalogue message
 			// See https://github.com/unitystation/unitystation/pull/5675#pullrequestreview-540239428
-			cataloguePage = SubCatalogue.FindIndex(SO => SO == NewspriteDataSO);
-			PushTexture(Network);
-			if (Network)
+			cataloguePage = SubCatalogue.FindIndex(SO => SO == newSpriteSO);
+			PushTexture(networked);
+			if (networked)
 			{
-				NetUpdate(NewspriteDataSO);
+				NetUpdate(newSpriteSO);
 			}
-			OnSpriteDataSOChanged?.Invoke(NewspriteDataSO);
+			OnSpriteDataSOChanged?.Invoke(newSpriteSO);
 		}
 
 		if (color != null)
 		{
-			SetColor(color.GetValueOrDefault(Color.white), Network);
+			SetColor(color.GetValueOrDefault(Color.white), networked);
 		}
 
-		if (NewvariantIndex > -1)
+		if (newSpriteSO.Variance.Count - 1 < variantIndex)
 		{
-			ChangeSpriteVariant(NewvariantIndex, Network);
+			newVariantIndex = 0;
+		}
+		if (newVariantIndex > -1)
+		{
+			ChangeSpriteVariant(newVariantIndex, networked);
 		}
 	}
 
@@ -244,7 +251,7 @@ public class SpriteHandler : MonoBehaviour
 		TryToggleAnimationState(false);
 	}
 
-	public void ChangeSpriteVariant(int spriteVariant, bool NetWork = true)
+	public void ChangeSpriteVariant(int spriteVariant, bool networked = true)
 	{
 		if (PresentSpriteSet != null)
 		{
@@ -261,9 +268,9 @@ public class SpriteHandler : MonoBehaviour
 				SetSprite(Frame);
 
 				TryToggleAnimationState(PresentSpriteSet.Variance[variantIndex].Frames.Count > 1);
-				if (NetWork)
+				if (networked)
 				{
-					NetUpdate(NewVariantIndex: spriteVariant);
+					NetUpdate(newVariantIndex: spriteVariant);
 				}
 			}
 		}
@@ -279,9 +286,9 @@ public class SpriteHandler : MonoBehaviour
 		return setColour.Value;
 	}
 
-	public void SetColor(Color value, bool NetWork = true)
+	public void SetColor(Color value, bool networked = true)
 	{
-		if (Initialised == false) TryInit();
+		if (initialised == false) TryInit();
 		if (setColour == value) return;
 		setColour = value;
 		if (HasImageComponent() == false)
@@ -290,27 +297,27 @@ public class SpriteHandler : MonoBehaviour
 		}
 
 		SetImageColor(value);
-		if (NetWork)
+		if (networked)
 		{
-			NetUpdate(NewSetColour: value);
+			NetUpdate(newSetColor: value);
 		}
 	}
 
-	public void ClearPallet(bool Network = true)
+	public void ClearPalette(bool networked = true)
 	{
 		if (palette == null) return;
 		palette = null;
 		isPaletteSet = false;
 
-		if (Network)
+		if (networked)
 		{
-			NetUpdate(NewClearPallet: true);
+			NetUpdate(newClearPalette: true);
 		}
 	}
 
-	public void Empty(bool ClearSubCatalogue = false, bool Network = true)
+	public void Empty(bool clearCatalogue = false, bool networked = true)
 	{
-		if (ClearSubCatalogue)
+		if (clearCatalogue)
 		{
 			SubCatalogue = new List<SpriteDataSO>();
 		}
@@ -321,45 +328,41 @@ public class SpriteHandler : MonoBehaviour
 		PresentSpriteSet = null;
 		OnSpriteDataSOChanged?.Invoke(null);
 
-		if (Network)
+		if (networked)
 		{
-			NetUpdate(NewEmpty: true);
+			NetUpdate(newEmpty: true);
 		}
 	}
 
-	public void PushClear(bool Network = true)
+	public void PushClear(bool networked = true)
 	{
-		if (Initialised == false) TryInit();
+		if (initialised == false) TryInit();
 		if (HasSpriteInImageComponent() == false) return;
 
 		SetImageSprite(null);
 		TryToggleAnimationState(false);
-		if (Network)
+		if (networked)
 		{
-			NetUpdate(NewPushClear: true);
+			NetUpdate(newPushClear: true);
 		}
 	}
-
 
 	/// <summary>
 	/// Sets the sprite catalogue for server side only, Any calls to ChangeSprite Will automatically be networked In a different way
 	/// </summary>
-	/// <param name="NewCatalogue"></param>
-	/// <param name="JumpToPage"></param>
-	/// <param name="NetWork"></param>
-	public void SetCatalogue(List<SpriteDataSO> NewCatalogue, int JumpToPage = -1, bool NetWork = true)
+	public void SetCatalogue(List<SpriteDataSO> newCatalogue, int initialPage = -1, bool networked = true)
 	{
 		isSubCatalogueChanged = true;
-		SubCatalogue = NewCatalogue;
-		if (JumpToPage > -1)
+		SubCatalogue = newCatalogue;
+		if (initialPage > -1)
 		{
-			ChangeSprite(JumpToPage, NetWork);
+			ChangeSprite(initialPage, networked);
 		}
 	}
 
-	public void SetPaletteOfCurrentSprite(List<Color> newPalette, bool Network = true)
+	public void SetPaletteOfCurrentSprite(List<Color> newPalette, bool networked = true)
 	{
-		bool paletted = isPaletted();
+		bool paletted = IsPaletted();
 
 		Debug.Assert((paletted && newPalette == null) == false, "Paletted sprites should never have palette set to null");
 
@@ -371,15 +374,15 @@ public class SpriteHandler : MonoBehaviour
 		isPaletteSet = false;
 		palette = newPalette;
 		PushTexture(false);
-		if (Network)
+		if (networked)
 		{
-			NetUpdate(NewPalette: palette);
+			NetUpdate(newPalette: palette);
 		}
 	}
 
-	public void PushTexture(bool NetWork = true)
+	public void PushTexture(bool networked = true)
 	{
-		if (Initialised == false) TryInit();
+		if (initialised == false) TryInit();
 		if (PresentSpriteSet != null && PresentSpriteSet.Variance.Count > 0)
 		{
 			if (variantIndex < PresentSpriteSet.Variance.Count)
@@ -394,9 +397,9 @@ public class SpriteHandler : MonoBehaviour
 				SetSprite(Frame);
 
 				TryToggleAnimationState(PresentSpriteSet.Variance[variantIndex].Frames.Count > 1);
-				if (NetWork)
+				if (networked)
 				{
-					NetUpdate(NewPushTexture: true);
+					NetUpdate(newPushTexture: true);
 					//NetWork this a poke Basically
 				}
 
@@ -405,9 +408,9 @@ public class SpriteHandler : MonoBehaviour
 		}
 
 
-		if (NetWork && HasSpriteInImageComponent())
+		if (networked && HasSpriteInImageComponent())
 		{
-			NetUpdate(NewPushTexture: true);
+			NetUpdate(newPushTexture: true);
 		}
 
 		SetImageSprite(null);
@@ -418,34 +421,34 @@ public class SpriteHandler : MonoBehaviour
 	/// Toggles the SpriteRenderer texture. Calls PushTexture() if the new state is on, or PushClear() otherwise.
 	/// </summary>
 	/// <param name="newState">If on, sets the texture (to last known). If off, clears the texture.</param>
-	/// <param name="network">Will send update to clients if true (default).</param>
-	public void ToggleTexture(bool newState, bool network = true)
+	/// <param name="networked">Will send update to clients if true (default).</param>
+	public void ToggleTexture(bool newState, bool networked = true)
 	{
 		if (newState)
 		{
-			PushTexture(network);
+			PushTexture(networked);
 		}
 		else
 		{
-			PushClear(network);
+			PushClear(networked);
 		}
 	}
 
 	private void NetUpdate(
-		SpriteDataSO NewSpriteDataSO = null,
-		int NewVariantIndex = -1,
-		int NewCataloguePage = -1,
-		bool NewPushTexture = false,
-		bool NewEmpty = false,
-		bool NewPushClear = false,
-		bool NewClearPallet = false,
-		Color? NewSetColour = null,
-		List<Color> NewPalette = null,
-		bool NewAnimateOnce = false)
+		SpriteDataSO newSpriteSO = null,
+		int newVariantIndex = -1,
+		int newCataloguePage = -1,
+		bool newPushTexture = false,
+		bool newEmpty = false,
+		bool newPushClear = false,
+		bool newClearPalette = false,
+		Color? newSetColor = null,
+		List<Color> newPalette = null,
+		bool newAnimateOnce = false)
 	{
 		if (NetworkThis == false) return;
 		if (SpriteHandlerManager.Instance == null) return;
-		if (NetworkIdentity == null)
+		if (networkIdentity == null)
 		{
 			if (this?.gameObject == null) return;
 			var NetID = SpriteHandlerManager.GetRecursivelyANetworkBehaviour(this.gameObject);
@@ -456,8 +459,8 @@ public class SpriteHandler : MonoBehaviour
 				return;
 			}
 
-			NetworkIdentity = NetID;
-			if (NetworkIdentity == null)
+			networkIdentity = NetID;
+			if (networkIdentity == null)
 			{
 				var gamename = "";
 				if (this?.gameObject != null)
@@ -482,68 +485,68 @@ public class SpriteHandler : MonoBehaviour
 			spriteChange = SpriteHandlerManager.GetSpriteChange();
 		}
 
-		if (NewSpriteDataSO != null)
+		if (newSpriteSO != null)
 		{
-			if (NewSpriteDataSO.setID == -1)
+			if (newSpriteSO.setID == -1)
 			{
-				Logger.Log("NewSpriteDataSO NO ID!" + NewSpriteDataSO.name, Category.Sprites);
+				Logger.Log("NewSpriteDataSO NO ID!" + newSpriteSO.name, Category.Sprites);
 			}
 			if (spriteChange.Empty) spriteChange.Empty = false;
-			spriteChange.PresentSpriteSet = NewSpriteDataSO.setID;
+			spriteChange.PresentSpriteSet = newSpriteSO.setID;
 		}
 
-		if (NewVariantIndex != -1)
+		if (newVariantIndex != -1)
 		{
-			spriteChange.VariantIndex = NewVariantIndex;
+			spriteChange.VariantIndex = newVariantIndex;
 		}
 
-		if (NewCataloguePage != -1)
+		if (newCataloguePage != -1)
 		{
-			spriteChange.CataloguePage = NewCataloguePage;
+			spriteChange.CataloguePage = newCataloguePage;
 		}
 
-		if (NewPushTexture)
+		if (newPushTexture)
 		{
 			if (spriteChange.PushClear) spriteChange.PushClear = false;
-			spriteChange.PushTexture = NewPushTexture;
+			spriteChange.PushTexture = newPushTexture;
 		}
 
-		if (NewEmpty)
+		if (newEmpty)
 		{
 			if (spriteChange.PresentSpriteSet != -1) spriteChange.PresentSpriteSet = -1;
-			spriteChange.Empty = NewEmpty;
+			spriteChange.Empty = newEmpty;
 		}
 
-		if (NewPushClear)
+		if (newPushClear)
 		{
 			if (spriteChange.PushTexture) spriteChange.PushTexture = false;
-			spriteChange.PushClear = NewPushClear;
+			spriteChange.PushClear = newPushClear;
 		}
 
-		if (NewAnimateOnce)
+		if (newAnimateOnce)
 		{
 			if (spriteChange.AnimateOnce) spriteChange.AnimateOnce = false;
-			spriteChange.AnimateOnce = NewAnimateOnce;
+			spriteChange.AnimateOnce = newAnimateOnce;
 		}
 
-		if (NewClearPallet)
+		if (newClearPalette)
 		{
-			if (spriteChange.Pallet != null) spriteChange.Pallet = null;
-			spriteChange.ClearPallet = NewClearPallet;
+			if (spriteChange.Palette != null) spriteChange.Palette = null;
+			spriteChange.ClearPalette = newClearPalette;
 		}
 
-		if (NewSetColour != null)
+		if (newSetColor != null)
 		{
-			spriteChange.SetColour = NewSetColour;
+			spriteChange.SetColour = newSetColor;
 		}
 
-		if (NewPalette != null)
+		if (newPalette != null)
 		{
-			if (spriteChange.ClearPallet) spriteChange.ClearPallet = false;
-			spriteChange.Pallet = NewPalette;
+			if (spriteChange.ClearPalette) spriteChange.ClearPalette = false;
+			spriteChange.Palette = newPalette;
 		}
 
-		if (NetworkIdentity.netId == 0)
+		if (networkIdentity.netId == 0)
 		{
 			//Logger.Log("ID hasn't been set for " + this.transform.parent);
 			StartCoroutine(WaitForNetInitialisation(spriteChange));
@@ -558,9 +561,9 @@ public class SpriteHandler : MonoBehaviour
 	private IEnumerator WaitForNetInitialisation(SpriteHandlerManager.SpriteChange spriteChange)
 	{
 		yield return null;
-		if (NetworkIdentity.netId == 0)
+		if (networkIdentity.netId == 0)
 		{
-			Logger.LogError("ID hasn't been set for " + this.transform.parent, Category.Sprites);
+			Logger.LogError($"ID hasn't been set for ${this.transform.parent}.", Category.Sprites);
 			yield break;
 		}
 
@@ -622,7 +625,7 @@ public class SpriteHandler : MonoBehaviour
 	private void SetPaletteOnSpriteRenderer()
 	{
 		isPaletteSet = true;
-		var palette = getPaletteOrNull();
+		var palette = GetPaletteOrNull();
 		if (palette != null && palette.Count > 0 && palette.Count <= 256)
 		{
 			MaterialPropertyBlock block = new MaterialPropertyBlock();
@@ -644,7 +647,7 @@ public class SpriteHandler : MonoBehaviour
 
 	private void SetPaletteOnImage()
 	{
-		List<Color> paletteOrNull = getPaletteOrNull();
+		List<Color> paletteOrNull = GetPaletteOrNull();
 
 		if (paletteOrNull != null && palette.Count > 0 && palette.Count <= 256)
 		{
@@ -702,7 +705,7 @@ public class SpriteHandler : MonoBehaviour
 
 	public bool HasSpriteInImageComponent()
 	{
-		if (Initialised == false) TryInit();
+		if (initialised == false) TryInit();
 		if (spriteRenderer != null)
 		{
 			if (spriteRenderer.sprite != null)
@@ -738,11 +741,11 @@ public class SpriteHandler : MonoBehaviour
 		GetImageComponent();
 		bool Status = this.GetImageComponentStatus();
 		ImageComponentStatus(false);
-		Initialised = true;
+		initialised = true;
 
 		if (randomInitialSprite && CatalogueCount > 0)
 		{
-			ChangeSprite(Random.Range(0, CatalogueCount), NetworkThis);
+			ChangeSprite(UnityEngine.Random.Range(0, CatalogueCount), NetworkThis);
 		}
 		else if (PresentSpriteSet != null)
 		{
@@ -755,15 +758,15 @@ public class SpriteHandler : MonoBehaviour
 		ImageComponentStatus(Status);
 	}
 
-	private void ImageComponentStatus(bool Status)
+	private void ImageComponentStatus(bool newStatus)
 	{
 		if (spriteRenderer != null)
 		{
-			spriteRenderer.enabled = Status;
+			spriteRenderer.enabled = newStatus;
 		}
 		else if (image != null)
 		{
-			image.enabled = Status;
+			image.enabled = newStatus;
 		}
 	}
 
@@ -785,8 +788,8 @@ public class SpriteHandler : MonoBehaviour
 	{
 		if (Application.isPlaying && NetworkThis)
 		{
-			NetworkIdentity = SpriteHandlerManager.GetRecursivelyANetworkBehaviour(this.gameObject);
-			SpriteHandlerManager.RegisterHandler(this.NetworkIdentity, this);
+			networkIdentity = SpriteHandlerManager.GetRecursivelyANetworkBehaviour(this.gameObject);
+			SpriteHandlerManager.RegisterHandler(this.networkIdentity, this);
 		}
 
 		GetImageComponent();
@@ -801,7 +804,7 @@ public class SpriteHandler : MonoBehaviour
 		OnSpriteChanged?.Invoke(null);
 	}
 
-	private bool isPaletted()
+	private bool IsPaletted()
 	{
 		if (PresentSpriteSet == null)
 		{
@@ -811,9 +814,9 @@ public class SpriteHandler : MonoBehaviour
 		return PresentSpriteSet.IsPalette;
 	}
 
-	private List<Color> getPaletteOrNull()
+	private List<Color> GetPaletteOrNull()
 	{
-		if (isPaletted() == false)
+		if (IsPaletted() == false)
 			return null;
 
 		return palette;
@@ -848,11 +851,11 @@ public class SpriteHandler : MonoBehaviour
 		}
 	}
 
-	private void SetSprite(SpriteDataSO.Frame Frame)
+	private void SetSprite(SpriteDataSO.Frame frame)
 	{
 		timeElapsed = 0;
-		PresentFrame = Frame;
-		SetImageSprite(Frame.sprite);
+		PresentFrame = frame;
+		SetImageSprite(frame.sprite);
 	}
 
 	/// <summary>
@@ -881,10 +884,10 @@ public class SpriteHandler : MonoBehaviour
 	{
 		yield return new Unity.EditorCoroutines.Editor.EditorWaitForSeconds(PresentFrame.secondDelay);
 		UpdateMe();
-		EditorAnimating = null;
+		editorAnimating = null;
 		if (isAnimation && !(this == null))
 		{
-			EditorAnimating =
+			editorAnimating =
 				Unity.EditorCoroutines.Editor.EditorCoroutineUtility.StartCoroutine(EditorAnimations(), this);
 		}
 	}
@@ -914,7 +917,7 @@ public class SpriteHandler : MonoBehaviour
 	}
 
 #if UNITY_EDITOR
-	private EditorCoroutine EditorAnimating;
+	private EditorCoroutine editorAnimating;
 
 	private void OnValidate()
 	{
@@ -926,9 +929,9 @@ public class SpriteHandler : MonoBehaviour
 			return;
 		}
 		if (this.gameObject.scene.path != null && this.gameObject.scene.path.Contains("Scenes") == false &&
-		    EditorAnimating == null)
+		    editorAnimating == null)
 		{
-			Initialised = true;
+			initialised = true;
 			GetImageComponent();
 			PushTexture();
 		}
@@ -942,7 +945,7 @@ public class SpriteHandler : MonoBehaviour
 			if (turnOn && isAnimation == false)
 			{
 				if (this.gameObject.scene.path != null && this.gameObject.scene.path.Contains("Scenes") == false &&
-				    EditorAnimating == null)
+				    editorAnimating == null)
 				{
 					Unity.EditorCoroutines.Editor.EditorCoroutineUtility.StartCoroutine(EditorAnimations(), this);
 					isAnimation = true;
@@ -963,7 +966,7 @@ public class SpriteHandler : MonoBehaviour
 		return false;
 	}
 #endif
-	[System.Serializable]
+	[Serializable]
 	public class SerialisationStanding
 	{
 		public Texture2D Texture;

--- a/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandlerManager.cs
+++ b/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandlerManager.cs
@@ -239,9 +239,9 @@ public class SpriteHandlerManager : NetworkBehaviour
 		public bool PushTexture = false;
 		public bool Empty = false;
 		public bool PushClear = false;
-		public bool ClearPallet = false;
+		public bool ClearPalette = false;
 		public Color? SetColour = null;
-		public List<Color> Pallet = null;
+		public List<Color> Palette = null;
 		public bool AnimateOnce = false;
 
 		public void Clean()
@@ -252,9 +252,9 @@ public class SpriteHandlerManager : NetworkBehaviour
 			PushTexture = false;
 			Empty = false;
 			PushClear = false;
-			ClearPallet = false;
+			ClearPalette = false;
 			SetColour = null;
-			Pallet = null;
+			Palette = null;
 			AnimateOnce = false;
 		}
 
@@ -289,10 +289,10 @@ public class SpriteHandlerManager : NetworkBehaviour
 				Empty = spriteChange.Empty;
 			}
 
-			if (spriteChange.ClearPallet)
+			if (spriteChange.ClearPalette)
 			{
-				if (Pallet != null) Pallet = null;
-				ClearPallet = spriteChange.ClearPallet;
+				if (Palette != null) Palette = null;
+				ClearPalette = spriteChange.ClearPalette;
 			}
 
 			if (spriteChange.PushClear)
@@ -312,10 +312,10 @@ public class SpriteHandlerManager : NetworkBehaviour
 				SetColour = spriteChange.SetColour;
 			}
 
-			if (spriteChange.Pallet != null)
+			if (spriteChange.Palette != null)
 			{
-				if (ClearPallet) ClearPallet = false;
-				Pallet = spriteChange.Pallet;
+				if (ClearPalette) ClearPalette = false;
+				Palette = spriteChange.Palette;
 			}
 
 			if (pool)

--- a/UnityProject/Assets/Scripts/Items/ClothingItem.cs
+++ b/UnityProject/Assets/Scripts/Items/ClothingItem.cs
@@ -136,7 +136,7 @@ public class ClothingItem : MonoBehaviour
 		List<Color> palette = clothing.GetComponent<ItemAttributesV2>()?.ItemSprites?.Palette;
 		if (palette != null)
 		{
-			spriteHandler.SetPaletteOfCurrentSprite(palette, Network: false);
+			spriteHandler.SetPaletteOfCurrentSprite(palette, networked: false);
 		}
 
 
@@ -190,14 +190,14 @@ public class ClothingItem : MonoBehaviour
 		{
 			if (spriteType == SpriteHandType.RightHand)
 			{
-				spriteHandler.SetSpriteSO(_ItemsSprites.SpriteRightHand, Network: false);
+				spriteHandler.SetSpriteSO(_ItemsSprites.SpriteRightHand, networked: false);
 			}
 			else
 			{
-				spriteHandler.SetSpriteSO(_ItemsSprites.SpriteLeftHand, Network: false);
+				spriteHandler.SetSpriteSO(_ItemsSprites.SpriteLeftHand, networked: false);
 			}
 
-			spriteHandler.SetPaletteOfCurrentSprite(_ItemsSprites.Palette, Network: false);
+			spriteHandler.SetPaletteOfCurrentSprite(_ItemsSprites.Palette, networked: false);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Tool/AtmosphericAnalyser/AtmosphericAnalyser.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/AtmosphericAnalyser/AtmosphericAnalyser.cs
@@ -17,7 +17,7 @@ namespace Items.Atmospherics
 				var node = metaDataLayer.Get(interaction.Performer.transform.localPosition.RoundToInt());
 				if (node != null)
 				{
-					Chat.AddExamineMsgFromServer(interaction.Performer, $"</i><mspace=0.6em>{GetGasMixInfo(node.GasMix)}</mspace><i>");
+					Chat.AddExamineMsgFromServer(interaction.Performer, GetGasMixInfo(node.GasMix));
 				}
 			}
 		}
@@ -62,7 +62,7 @@ namespace Items.Atmospherics
 				}
 			}
 
-			return sb.ToString();
+			return $"</i>{sb}<i>";
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Messages/Server/SpritesMessages/SpriteUpdateMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/SpritesMessages/SpriteUpdateMessage.cs
@@ -60,7 +60,7 @@ namespace Messages.Server.SpritesMessages
 				{
 					var argument = spriteUpdateEntry.arg[argumentIndex];
 					argumentIndex++;
-					spriteHandler.SetSpriteSO(SpriteCatalogue.Instance.Catalogue[argument], Network: false);
+					spriteHandler.SetSpriteSO(SpriteCatalogue.Instance.Catalogue[argument], networked: false);
 				}
 				else if (spriteOperation == SpriteOperation.VariantIndex)
 				{
@@ -94,7 +94,7 @@ namespace Messages.Server.SpritesMessages
 				}
 				else if (spriteOperation == SpriteOperation.ClearPallet)
 				{
-					spriteHandler.ClearPallet(false);
+					spriteHandler.ClearPalette(false);
 				}
 				else if (spriteOperation == SpriteOperation.SetColour)
 				{
@@ -243,7 +243,7 @@ namespace Messages.Server.SpritesMessages
 						{
 							try
 							{
-								SP.SetSpriteSO(SpriteCatalogue.Instance.Catalogue[SpriteID], Network: false);
+								SP.SetSpriteSO(SpriteCatalogue.Instance.Catalogue[SpriteID], networked: false);
 							}
 							catch (Exception e)
 							{
@@ -264,7 +264,7 @@ namespace Messages.Server.SpritesMessages
 						int Variant = reader.ReadInt32();
 						if (ProcessSection)
 						{
-							SP.ChangeSpriteVariant(Variant, NetWork: false);
+							SP.ChangeSpriteVariant(Variant, networked: false);
 						}
 						else
 						{
@@ -342,7 +342,7 @@ namespace Messages.Server.SpritesMessages
 					{
 						if (ProcessSection)
 						{
-							SP.ClearPallet(false);
+							SP.ClearPalette(false);
 						}
 						else
 						{
@@ -447,7 +447,7 @@ namespace Messages.Server.SpritesMessages
 					writer.WriteByte((byte) 7);
 				}
 
-				if (spriteChange.ClearPallet)
+				if (spriteChange.ClearPalette)
 				{
 					writer.WriteByte((byte) 8);
 				}
@@ -458,11 +458,11 @@ namespace Messages.Server.SpritesMessages
 					writer.WriteColor(spriteChange.SetColour.Value);
 				}
 
-				if (spriteChange.Pallet != null)
+				if (spriteChange.Palette != null)
 				{
 					writer.WriteByte((byte) 10);
-					writer.WriteByte((byte) spriteChange.Pallet.Count);
-					foreach (Color Colour in spriteChange.Pallet)
+					writer.WriteByte((byte) spriteChange.Palette.Count);
+					foreach (Color Colour in spriteChange.Palette)
 					{
 						writer.WriteColor(Colour);
 					}

--- a/UnityProject/Assets/Scripts/Player/GhostSprites.cs
+++ b/UnityProject/Assets/Scripts/Player/GhostSprites.cs
@@ -38,19 +38,19 @@ public class GhostSprites : MonoBehaviour
 	{
 		if (Orientation.Down == direction)
 		{
-			SpriteHandler.ChangeSpriteVariant(0, NetWork:false);
+			SpriteHandler.ChangeSpriteVariant(0, networked:false);
 		}
 		else if (Orientation.Up == direction)
 		{
-			SpriteHandler.ChangeSpriteVariant(1, NetWork:false);
+			SpriteHandler.ChangeSpriteVariant(1, networked:false);
 		}
 		else if (Orientation.Right == direction)
 		{
-			SpriteHandler.ChangeSpriteVariant(2, NetWork:false);
+			SpriteHandler.ChangeSpriteVariant(2, networked:false);
 		}
 		else
 		{
-			SpriteHandler.ChangeSpriteVariant(3, NetWork:false);
+			SpriteHandler.ChangeSpriteVariant(3, networked:false);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobPlayer.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobPlayer.cs
@@ -1527,7 +1527,7 @@ namespace Blob
 				blobStructure.lightSprite.Color.a = 0.2f;
 			}
 
-			blobStructure.spriteHandler.SetSpriteSO(blobStructure.activeSprite, NewvariantIndex: Random.Range(0, blobStructure.activeSprite.Variance.Count));
+			blobStructure.spriteHandler.SetSpriteSO(blobStructure.activeSprite, newVariantIndex: Random.Range(0, blobStructure.activeSprite.Variance.Count));
 			blobStructure.spriteHandler.SetColor(currentStrain.color);
 		}
 

--- a/UnityProject/Assets/Scripts/Systems/Construction/LightFixtureConstruction.cs
+++ b/UnityProject/Assets/Scripts/Systems/Construction/LightFixtureConstruction.cs
@@ -49,11 +49,11 @@ namespace Objects.Construction
 			switch (constructionState)
 			{
 				case State.initial:
-					spriteHandler.SetSpriteSO(initialStateSprites, NewvariantIndex: SpritesDirectional.OrientationIndex(directional.CurrentDirection.AsEnum()));
+					spriteHandler.SetSpriteSO(initialStateSprites, newVariantIndex: SpritesDirectional.OrientationIndex(directional.CurrentDirection.AsEnum()));
 					break;
 				case State.wiresAdded:
 					lightSource.ServerChangeLightState(LightMountState.None);
-					spriteHandler.SetSpriteSO(wiresAddedStateSprites, NewvariantIndex: SpritesDirectional.OrientationIndex(directional.CurrentDirection.AsEnum()));
+					spriteHandler.SetSpriteSO(wiresAddedStateSprites, newVariantIndex: SpritesDirectional.OrientationIndex(directional.CurrentDirection.AsEnum()));
 					break;
 				case State.ready:
 				default:

--- a/UnityProject/Assets/Scripts/Systems/Inventory/Pickupable.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/Pickupable.cs
@@ -314,7 +314,7 @@ public class Pickupable : NetworkBehaviour, IPredictedCheckedInteractable<HandAp
 			var equipment = itemSlot.Player.GetComponent<Equipment>();
 			if (equipment == null) return;
 			var CT = equipment.GetClothingItem(itemSlot.NamedSlot.Value);
-			CT.spriteHandler.SetPaletteOfCurrentSprite(palette, Network:false);
+			CT.spriteHandler.SetPaletteOfCurrentSprite(palette, networked:false);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Spells/Wizard/InstantSummons.cs
+++ b/UnityProject/Assets/Scripts/Systems/Spells/Wizard/InstantSummons.cs
@@ -57,8 +57,8 @@ namespace Systems.Spells.Wizard
 		{
 			string summonedName = summonedObject.ExpensiveName();
 			Chat.AddActionMsgToChat(summonedObject,
-				"<color='red'>You feel a magical force transposing you!</color>",
-				$"<color='red'>The {summonedName} suddenly disappears!</color>");
+				"<color=red>You feel a magical force transposing you!</color>",
+				$"<color=red>The {summonedName} suddenly disappears!</color>");
 
 			TeleportObjectToPosition(summonedObject, caster.Script.WorldPos);
 
@@ -68,11 +68,11 @@ namespace Systems.Spells.Wizard
 				Inventory.ServerAdd(pickupable, slot);
 
 				Chat.AddActionMsgToChat(caster.GameObject, $"The {summonedName} appears in your hand!",
-					$"<color='red'>A {summonedName} suddenly appears in {caster.Script.visibleName}'s hand!</color>");
+					$"<color=red>A {summonedName} suddenly appears in {caster.Script.visibleName}'s hand!</color>");
 			}
 			else
 			{
-				string message = $"<color='red'>The {summonedName} suddenly appears!</color>";
+				string message = $"<color=red>The {summonedName} suddenly appears!</color>";
 				Chat.AddActionMsgToChat(caster.GameObject, message, message);
 			}
 		}

--- a/UnityProject/Assets/Scripts/UI/Core/Action/UIAction.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/Action/UIAction.cs
@@ -40,11 +40,11 @@ namespace UI.Action
 
 			if (actionData.Sprites.Count > 0)
 			{
-				IconFront.SetCatalogue(actionData.Sprites, 0, NetWork: false);
+				IconFront.SetCatalogue(actionData.Sprites, 0, networked: false);
 			}
 			if (actionData.Backgrounds.Count > 0)
 			{
-				IconBackground.SetCatalogue(actionData.Backgrounds, 0, NetWork: false);
+				IconBackground.SetCatalogue(actionData.Backgrounds, 0, networked: false);
 			}
 		}
 
@@ -52,7 +52,7 @@ namespace UI.Action
 		{
 			IconBackground.Empty(true, false);
 			IconFront.Empty(true, false);
-			IconBackground.SetSpriteSO(DefaultIconBackground, Network: false);
+			IconBackground.SetSpriteSO(DefaultIconBackground, networked: false);
 			gameObject.SetActive(false);
 		}
 
@@ -149,7 +149,7 @@ namespace UI.Action
 
 		private void ToggleOff()
 		{
-			IconFront.SetSpriteSO(actionData.Sprites[0], Network: false);
+			IconFront.SetSpriteSO(actionData.Sprites[0], networked: false);
 			UIActionManager.Instance.ActiveAction = null;
 
 			if (actionData.HasCustomCursor)
@@ -160,7 +160,7 @@ namespace UI.Action
 
 		private void ToggleOn()
 		{
-			IconFront.SetSpriteSO(actionData.ActiveSprite, Network: false);
+			IconFront.SetSpriteSO(actionData.ActiveSprite, networked: false);
 			UIActionManager.Instance.ActiveAction = this;
 
 			TrySetCustomCursor();

--- a/UnityProject/Assets/Scripts/UI/Core/Action/UIActionManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/Action/UIActionManager.cs
@@ -111,7 +111,7 @@ namespace UI.Action
 			if (Instance.DicIActionGUI.ContainsKey(iActionGUI))
 			{
 				var _UIAction = Instance.DicIActionGUI[iActionGUI];
-				_UIAction.IconFront.SetSpriteSO(sprite, Network: networked);
+				_UIAction.IconFront.SetSpriteSO(sprite, networked: networked);
 				_UIAction.IconFront.SetPaletteOfCurrentSprite(palette);
 			}
 			else

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterSprites.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterSprites.cs
@@ -75,7 +75,7 @@ namespace UI.CharacterCreator
 			// It's possible that UpdateSprite gets called before Awake
 			// so try to grab the image here just in case that happens
 			if(sprites != null || TryGetComponent(out sprites))
-				sprites.ChangeSpriteVariant(referenceOffset , NetWork:false);
+				sprites.ChangeSpriteVariant(referenceOffset , networked:false);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_GhostOptions.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_GhostOptions.cs
@@ -87,7 +87,7 @@ namespace UI.Systems.Ghost
 
 		public void NewGhostRoleAvailable(GhostRoleData role)
 		{
-			ghostRoleSpriteHandler.SetSpriteSO(role.Sprite, Network: false);
+			ghostRoleSpriteHandler.SetSpriteSO(role.Sprite, networked: false);
 			if (roleBtnAnimating) return; // Drop rapid subsequent notifications
 
 			StartCoroutine(GhostRoleNotify(role));
@@ -107,7 +107,7 @@ namespace UI.Systems.Ghost
 			ghostRoleAnimator.TriggerAnimation();
 
 			yield return WaitFor.Seconds(5);
-			ghostRoleSpriteHandler.ChangeSprite(0, Network: false);
+			ghostRoleSpriteHandler.ChangeSprite(0, networked: false);
 
 			roleBtnAnimating = false;
 		}

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemImage.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemImage.cs
@@ -81,7 +81,7 @@ public class UI_ItemImage
 			var image = ConnectFreeImageToHandler(handler);
 
 			// check if handler is hidden
-			image.gameObject.SetActive(!handler.IsHiden);
+			image.gameObject.SetActive(!handler.IsHidden);
 
 			// set sprite
 			var sprite = handler.CurrentSprite;


### PR DESCRIPTION
- CL: [Fix] Fixes mobs turning invisible when dying while not facing south. Closes #6427, and I assume closes #5519.
- CL: [Fix] Fixes superfluous space character in the automated announcer's message.
- CL: [Fix] Fixes less than ideal text formatting from the message response when hand-activating the atmospheric analyser.
- CL: [Fix] Fixes InstantSummons spell having incorrectly formatted colouring in messages. Closes #6719.
- Improves code styling in method signatures for `SpriteHandler` and related classes.