### PR TITLE
Mining satchel is smaller and now fits in backpacks.

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Storage/Bags/MiningSatchel.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Storage/Bags/MiningSatchel.prefab
@@ -47,6 +47,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2945219828330548335, guid: a4904005b4f886143a41a4b3c99a6845,
         type: 3}
+      propertyPath: initialSize
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2945219828330548335, guid: a4904005b4f886143a41a4b3c99a6845,
+        type: 3}
       propertyPath: initialDescription
       value: This little bugger can be used to store and transport ores.
       objectReference: {fileID: 0}


### PR DESCRIPTION
<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->

### Purpose
- The mining satchel is now medium sized, which means it fits in backpacks and some other storage containers.

### Changelog:

CL: [Balance] The mining satchel now fits in backpacks and other storage containers that can hold medium sized items.

