### PR TITLE
Deconstructing reinforced walls now correctly creates reinforced girders.

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/SpawnableLists/Tiles/RWallSheath.asset
+++ b/UnityProject/Assets/ScriptableObjects/SpawnableLists/Tiles/RWallSheath.asset
@@ -13,5 +13,5 @@ MonoBehaviour:
   m_Name: RWallSheath
   m_EditorClassIdentifier: 
   contents:
-  - {fileID: 756811348045008463, guid: d19f068f30aed4d468cdba7a0e5824a0, type: 3}
+  - {fileID: 5202598923472150623, guid: a41ce5ac5b947cc4482cd3c92ea67410, type: 3}
   - {fileID: 5331286249588652700, guid: 29ecbf5a1d918574cbcf5853927e0944, type: 3}


### PR DESCRIPTION
### Purpose
- Title, deconstructing reinforced walls created normal girders. Now they create reinforced girders again.

### Changelog
CL: [Fix] Fixed bug where deconstructing reinforced walls yielded standard girders instead of reinforced ones.