### PR TITLE
Fixes re-logging losing UI

### DIFF
--- a/UnityProject/Assets/Scripts/Player/PlayerManager.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerManager.cs
@@ -121,6 +121,18 @@ public class PlayerManager : MonoBehaviour
 		HasSpawned = true;
 
 		SetMovementControllable(movementControllable);
+
+		var Inventory = playerObjToControl.GetComponent<DynamicItemStorage>(); //Reset then reapply changes for the UI to realise that this is the player to show the UI for
+		if (Inventory != null)
+		{
+			var BackupData = Inventory.GetSetData;
+
+			if (string.IsNullOrEmpty(BackupData) == false)
+			{
+				Inventory.ProcessChangeClient("[]");
+				Inventory.ProcessChangeClient(BackupData);
+			}
+		}
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Systems/Inventory/DynamicItemStorage.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/DynamicItemStorage.cs
@@ -634,17 +634,16 @@ public class DynamicItemStorage : NetworkBehaviour
 	/// <param name="NewST"></param>
 	public void UpdateSlots(string oldST, string NewST)
 	{
-		StartCoroutine(WaitForInit(NewST));
-	}
-
-	private IEnumerator WaitForInit(string NewST)
-	{
-		yield return null;
-		yield return null;
-		yield return null;
+		SerialisedNetIDs = NewST;
 		ProcessChangeClient(NewST);
 	}
 
+
+	private IEnumerator WaitAFrame(string NewST)
+	{
+		yield return null;
+		ProcessChangeClient(NewST);
+	}
 
 	public void ProcessChangeClient(string NewST)
 	{
@@ -653,6 +652,12 @@ public class DynamicItemStorage : NetworkBehaviour
 		var incomingList = JsonConvert.DeserializeObject<List<uint>>(NewST);
 		foreach (var IntIn in incomingList)
 		{
+			if (NetworkIdentity.spawned.TryGetValue(IntIn, out var spawned) == false)
+			{
+				StartCoroutine(WaitAFrame(NewST));
+				return;
+			}
+
 			if (ClientUIBodyPartsToSerialise.Contains(IntIn) == false)
 			{
 				added.Add(IntIn);

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_SlotManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_SlotManager.cs
@@ -130,6 +130,7 @@ public class UI_SlotManager : MonoBehaviour
 
 	public void RemoveAll()
 	{
+		if (gameObject == null) return;
 		foreach (var Inslots in BodyPartToSlot.Keys.ToArray())
 		{
 			foreach (var Characteristics in Inslots.Storage)


### PR DESCRIPTION
made it so it was set when local player is set
it also now waits for objects being spawned in before trying to add to dynamic inventory on client

### Changelog:

CL: [Fix] fixes clients losing the UI when re-logging