### PR TITLE
Squarestation and RCS tweaks.

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Shuttle/Vernor RCS.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Shuttle/Vernor RCS.prefab
@@ -14,7 +14,6 @@ GameObject:
   - component: {fileID: 493828552897054551}
   - component: {fileID: 5745080215759849378}
   - component: {fileID: -8848886095367057909}
-  - component: {fileID: -4487154595025906358}
   - component: {fileID: -2051729626694222704}
   - component: {fileID: -3038391285617089312}
   - component: {fileID: 8715427869010766872}
@@ -66,7 +65,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  isDirty: 0
+  isDirty: 1
   sceneId: 0
   serverOnly: 0
   visible: 0
@@ -104,6 +103,7 @@ MonoBehaviour:
   syncInterval: 0.1
   matrixDebugLogging: 0
   objectType: 0
+  CurrentsortingGroup: {fileID: 0}
   AtmosPassable: 1
   ReachableThrough: 1
   initialPassable: 1
@@ -129,19 +129,6 @@ MonoBehaviour:
       m_Calls: []
   ChangeDirectionWithMatrix: 1
   DisableSyncing: 0
---- !u!114 &-4487154595025906358
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1395871990776010}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f227cc6622a9ad44f981a39d11d3d343, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  directional: {fileID: 0}
 --- !u!114 &-2051729626694222704
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -155,8 +142,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isMeleeable: 1
-  butcherTime: 2
-  butcherSound: 
 --- !u!114 &-3038391285617089312
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -191,6 +176,7 @@ MonoBehaviour:
     Acid: 0
     Magic: 0
     Bio: 0
+    DismembermentProtectionChance: 0
   Resistances:
     LavaProof: 0
     FireProof: 0
@@ -203,6 +189,7 @@ MonoBehaviour:
   HeatResistance: 100
   ExplosionsDamage: 100
   doDamageMessage: 1
+  CannotBeAshed: 0
 --- !u!114 &8715427869010766872
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
### Purpose
- Square changes
  - Potted plants are now all randomized ones that have inventories.
  - Added collision sensors on mining shuttle windows so it doesn't crash into shit from there.
  - Changed airlocks on some shuttles to windowed ones for better visibility while piloting.
  - Escape shuttle external airlocks now have tiny fans under them.
  - Replaced chairs on various shuttles with more appropriate shuttle chairs.
- The RCS thrusters no longer dissappear from certain angles.


### Changelog:

CL: [Fix] Fixed bug where the large mining shuttle on Squarestation would occasionally ram into stuff without being emagged.
