### PR TITLE
Server channel validation on chat message

### DIFF
--- a/UnityProject/Assets/Scripts/Messages/Client/PostToChatMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/PostToChatMessage.cs
@@ -17,7 +17,11 @@ namespace Messages.Client
 		{
 			if (SentByPlayer != ConnectedPlayer.Invalid)
 			{
-				Chat.AddChatMsgToChat(SentByPlayer, msg.ChatMessageText, msg.Channels);
+				msg.Channels &= SentByPlayer.Script.GetAvailableChannelsMask(true);
+				if (msg.Channels != ChatChannel.None)
+				{
+					Chat.AddChatMsgToChat(SentByPlayer, msg.ChatMessageText, msg.Channels);
+				}
 			}
 		}
 


### PR DESCRIPTION
### Purpose
The server will now validate the channels used when a player sends a chat message.
Fixes #6561