### PR TITLE
Fixes uplink entries being mixed up

### DIFF
--- a/UnityProject/Assets/Scripts/UI/Core/EmptyItemList.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/EmptyItemList.cs
@@ -14,7 +14,7 @@ public class EmptyItemList : NetUIDynamicList
 	{
 		for (int i = 0; i < count; i++)
 		{
-			AttemptAdd();
+			Add();
 		}
 		NetworkTabManager.Instance.Rescan(MasterTab.NetTabDescriptor);
 		UpdatePeepers();
@@ -24,7 +24,7 @@ public class EmptyItemList : NetUIDynamicList
 	{
 		while (count > Entries.Length)
 		{
-			AttemptAdd();
+			Add();
 		}
 
 		while (count < Entries.Length)
@@ -35,33 +35,15 @@ public class EmptyItemList : NetUIDynamicList
 		UpdatePeepers();
 	}
 
-	public bool AddItem()
+	public DynamicEntry AddItem()
 	{
-		if(!AttemptAdd())
-		{
-			return false;
-		}
+		var newEntry = Add();
 
 		//rescan elements  and notify
 		NetworkTabManager.Instance.Rescan(MasterTab.NetTabDescriptor);
 		UpdatePeepers();
 
-		return true;
+		return newEntry;
 	}
 
-	private bool AttemptAdd()
-	{
-		//add new entry
-		var newEntry = Add();
-		if (!newEntry)
-		{
-			Logger.LogWarningFormat("Problems adding {0}", Category.ItemSpawn,
-				newEntry);
-			return false;
-		}
-		Logger.LogFormat("ItemList: Item add success! newEntry={0}", Category.ItemSpawn,
-			newEntry);
-		return true;
-
-	}
 }

--- a/UnityProject/Assets/Scripts/UI/Items/PDA/GUI_PDAUplinkItem.cs
+++ b/UnityProject/Assets/Scripts/UI/Items/PDA/GUI_PDAUplinkItem.cs
@@ -29,8 +29,7 @@ namespace UI.Items.PDA
 			{
 				if (isNukie || uplinkItem.IsNukeOps == false)
 				{
-					dynamicList.AddItem();
-					var entry = dynamicList.Entries[dynamicList.Entries.Length-1];
+					var entry = dynamicList.AddItem();;
 					entry.GetComponent<GUI_PDAUplinkItemTemplate>().ReInit(uplinkItem);
 				}
 			}

--- a/UnityProject/Assets/Scripts/UI/Items/PDA/GUI_PDAUplinkItem.cs
+++ b/UnityProject/Assets/Scripts/UI/Items/PDA/GUI_PDAUplinkItem.cs
@@ -29,7 +29,7 @@ namespace UI.Items.PDA
 			{
 				if (isNukie || uplinkItem.IsNukeOps == false)
 				{
-					var entry = dynamicList.AddItem();;
+					var entry = dynamicList.AddItem();
 					entry.GetComponent<GUI_PDAUplinkItemTemplate>().ReInit(uplinkItem);
 				}
 			}

--- a/UnityProject/Assets/Scripts/UI/Objects/Cargo/GUI_CargoPageSupplies.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Cargo/GUI_CargoPageSupplies.cs
@@ -22,8 +22,7 @@ namespace UI.Objects.Cargo
 			{
 				if (cargoOrder.EmagOnly == false || cargoGUI.cargoConsole.Emagged)
 				{
-					orderList.AddItem();
-					var item = (GUI_CargoItem)orderList.Entries[orderList.Entries.Length-1];
+					var item = orderList.AddItem().GetComponent<GUI_CargoItem>();
 					item.SetValues(cargoOrder);
 				}
 			}

--- a/UnityProject/Assets/Scripts/UI/Objects/Medical/GUI_ChemMaster.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Medical/GUI_ChemMaster.cs
@@ -381,10 +381,12 @@ namespace UI.Objects.Chemistry
 			productList.Clear();
 			foreach (GameObject listItemin in ChemMaster.ChemMasterProducts)
 			{
-				if (listItemin != null) productList.AddItem();
-				GUI_ChemProductEntry thing = productList.Entries[ChemMaster.ChemMasterProducts.IndexOf(listItemin)]
-					as GUI_ChemProductEntry;
-				thing.ReInit(GetComponent<GUI_ChemMaster>());
+				if (listItemin == null)
+				{
+					continue;
+				}
+				var thing = productList.AddItem().GetComponent<GUI_ChemProductEntry>();
+				thing.ReInit(this);
 			}
 		}
 


### PR DESCRIPTION
Fixes cargo and antag uplink lists having the chance of having its entries mixed up.
Changed chem entry addition to use this same method, while also fixing a possible runtime based on how it was written originally.
Fixes #6752

Entries[Entries.Length-1] would not return the last added entry since Entries is not a list
 `public DynamicEntry[] Entries => GetComponentsInChildren<DynamicEntry>(false);`
you'd get the last enabled object based on the ingame heriarchy