### PR TITLE
Moth hair removal, poster in-hands, and potato seed fixes.

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Botany/Seeds/Roots/PotatoSeeds.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Botany/Seeds/Roots/PotatoSeeds.prefab
@@ -37,7 +37,8 @@ PrefabInstance:
         type: 3}
       propertyPath: plantData.ProduceObject
       value: 
-      objectReference: {fileID: 3279069433607158746}
+      objectReference: {fileID: 8320053050054170569, guid: acc71df94cbb60a4abe979bc8d32a4d2,
+        type: 3}
     - target: {fileID: 2472774062389222616, guid: 26abf4c2c542ffa4098216683cb5f652,
         type: 3}
       propertyPath: plantData.FullyGrownSpriteSO
@@ -173,9 +174,3 @@ PrefabInstance:
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 26abf4c2c542ffa4098216683cb5f652, type: 3}
---- !u!1 &3279069433607158746 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3867790606060242529, guid: 26abf4c2c542ffa4098216683cb5f652,
-    type: 3}
-  m_PrefabInstance: {fileID: 1741977534593940923}
-  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothHead.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothHead.prefab
@@ -60,6 +60,18 @@ PrefabInstance:
         type: 3}
       propertyPath: Populater.DeprecatedContents.Array.data[1]
       value: 
+      objectReference: {fileID: 5847522936213140177, guid: 3ae22e12733eb3541888020192a1ff8f,
+        type: 3}
+    - target: {fileID: 6786220533655849171, guid: 78253771c2047f94c9ae40161a6be7ee,
+        type: 3}
+      propertyPath: Populater.DeprecatedContents.Array.data[2]
+      value: 
+      objectReference: {fileID: 7224950701661798677, guid: 5c61c3c9e64efa740accb280f8923222,
+        type: 3}
+    - target: {fileID: 6786220533655849171, guid: 78253771c2047f94c9ae40161a6be7ee,
+        type: 3}
+      propertyPath: Populater.DeprecatedContents.Array.data[3]
+      value: 
       objectReference: {fileID: 671021013365695943, guid: b054a3a3b8b51b74ca3853fa734a304b,
         type: 3}
     - target: {fileID: 7585268129894669505, guid: 78253771c2047f94c9ae40161a6be7ee,

--- a/UnityProject/Assets/Prefabs/Items/Other/Rolled Poster.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/Rolled Poster.prefab
@@ -386,8 +386,8 @@ MonoBehaviour:
   CanBeUsedOnSelfOnHelpIntent: 0
   itemSprites:
     SpriteInventoryIcon: {fileID: 0}
-    SpriteLeftHand: {fileID: 0}
-    SpriteRightHand: {fileID: 0}
+    SpriteLeftHand: {fileID: 11400000, guid: 0b395bda1e929674e9fec2099782a493, type: 2}
+    SpriteRightHand: {fileID: 11400000, guid: 4111f042fe2174641bfba131ce87df1a, type: 2}
     Palette:
     - {r: 0, g: 0, b: 0, a: 0}
     - {r: 0, g: 0, b: 0, a: 0}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/Grenade.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/Grenade.prefab
@@ -20,7 +20,7 @@ MonoBehaviour:
   fuseLength: 3
   armbomb:
     SetLoadSetting: 0
-    AssetAddress: null
+    AssetAddress: Assets/Prefabs/Weapons/armbomb.prefab
     AssetReference:
       m_AssetGUID: 
       m_SubObjectName: 


### PR DESCRIPTION
### Purpose
- Moth heads no longer have hair and have antennae again.
- Posters now use the default generic in-hand sprites instead of none at all.
- Potato seeds now give potatoes as a product instead of more potato seeds, for some reason.
- Grenades (and minibombs by extension) properly path to the armed sound again. They still don't make sounds when armed though.

### Changelog:
CL: [Fix] Potato plants yield potatoes again.

CL: [Fix] Moths no longer have human hair and have antennae again.
