### PR TITLE
Readding pressure warning lights to airlocks.

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockAbductor.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockAbductor.prefab
@@ -308,5 +308,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: e04cf5988be3ddb4abf02dc7051a8482,
         type: 2}
+    - target: {fileID: 8542447127197164955, guid: 6af0a221ec6985a46956ac77fab1f771,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[6]
+      value: 
+      objectReference: {fileID: 11400000, guid: 9f90b9d724b9f284eac17814a51d69e5,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6af0a221ec6985a46956ac77fab1f771, type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockBronzeWindowed.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockBronzeWindowed.prefab
@@ -196,5 +196,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 4796aaa206e1787469d60db11c2e0ab0,
         type: 2}
+    - target: {fileID: 8542447127197164955, guid: 6af0a221ec6985a46956ac77fab1f771,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[6]
+      value: 
+      objectReference: {fileID: 11400000, guid: 3b1bea27b03a3f148a329bd1cfecc856,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6af0a221ec6985a46956ac77fab1f771, type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockCultRunedWindowed.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockCultRunedWindowed.prefab
@@ -238,5 +238,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 96a979c58804a9d4b884acfb799d6900,
         type: 2}
+    - target: {fileID: 8542447127197164955, guid: 6af0a221ec6985a46956ac77fab1f771,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[6]
+      value: 
+      objectReference: {fileID: 11400000, guid: f45b676ee2c2da44d9aad8e39e295ba0,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6af0a221ec6985a46956ac77fab1f771, type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockCultUnrunedWindowed.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockCultUnrunedWindowed.prefab
@@ -20,13 +20,13 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 2601214559837388399, guid: 8b06dfcbb399b9647b35d1161531f7b3,
         type: 3}
-      propertyPath: SubCatalogue.Array.data[0]
+      propertyPath: PresentSpriteSet
       value: 
       objectReference: {fileID: 11400000, guid: 0bae15c89cf3f1d47a1df3acfca73ecf,
         type: 2}
     - target: {fileID: 2601214559837388399, guid: 8b06dfcbb399b9647b35d1161531f7b3,
         type: 3}
-      propertyPath: PresentSpriteSet
+      propertyPath: SubCatalogue.Array.data[0]
       value: 
       objectReference: {fileID: 11400000, guid: 0bae15c89cf3f1d47a1df3acfca73ecf,
         type: 2}
@@ -86,15 +86,15 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 6278639043926953879, guid: 8b06dfcbb399b9647b35d1161531f7b3,
         type: 3}
-      propertyPath: SubCatalogue.Array.data[4]
-      value: 
-      objectReference: {fileID: 11400000, guid: 39675a2297fac3743a9d71bb71c0de2c,
-        type: 2}
-    - target: {fileID: 6278639043926953879, guid: 8b06dfcbb399b9647b35d1161531f7b3,
-        type: 3}
       propertyPath: SubCatalogue.Array.data[3]
       value: 
       objectReference: {fileID: 11400000, guid: e475cb0479f7b744285e8ea865b33202,
+        type: 2}
+    - target: {fileID: 6278639043926953879, guid: 8b06dfcbb399b9647b35d1161531f7b3,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[4]
+      value: 
+      objectReference: {fileID: 11400000, guid: 39675a2297fac3743a9d71bb71c0de2c,
         type: 2}
     - target: {fileID: 6443266578318017453, guid: 8b06dfcbb399b9647b35d1161531f7b3,
         type: 3}
@@ -132,6 +132,12 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 4afe64e79c3cc74439ba18febdc58ccd,
         type: 2}
+    - target: {fileID: 7111904526721846225, guid: 8b06dfcbb399b9647b35d1161531f7b3,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[6]
+      value: 
+      objectReference: {fileID: 11400000, guid: 89ac76707e71c3f418c9dbdfd48b122a,
+        type: 2}
     - target: {fileID: 7289519010921967778, guid: 8b06dfcbb399b9647b35d1161531f7b3,
         type: 3}
       propertyPath: m_Sprite
@@ -142,6 +148,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: AirlockCultUnrunedWindowed
+      objectReference: {fileID: 0}
+    - target: {fileID: 7375800842819211887, guid: 8b06dfcbb399b9647b35d1161531f7b3,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7375800842819211887, guid: 8b06dfcbb399b9647b35d1161531f7b3,
         type: 3}
@@ -160,6 +171,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7375800842819211887, guid: 8b06dfcbb399b9647b35d1161531f7b3,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7375800842819211887, guid: 8b06dfcbb399b9647b35d1161531f7b3,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -172,16 +188,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7375800842819211887, guid: 8b06dfcbb399b9647b35d1161531f7b3,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7375800842819211887, guid: 8b06dfcbb399b9647b35d1161531f7b3,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7375800842819211887, guid: 8b06dfcbb399b9647b35d1161531f7b3,
         type: 3}
@@ -206,15 +212,9 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 8464518138621891108, guid: 8b06dfcbb399b9647b35d1161531f7b3,
         type: 3}
-      propertyPath: SubCatalogue.Array.data[3]
+      propertyPath: SubCatalogue.Array.data[0]
       value: 
-      objectReference: {fileID: 11400000, guid: ba3d4ca3a4ec7864dbca5f94c5c6f628,
-        type: 2}
-    - target: {fileID: 8464518138621891108, guid: 8b06dfcbb399b9647b35d1161531f7b3,
-        type: 3}
-      propertyPath: SubCatalogue.Array.data[2]
-      value: 
-      objectReference: {fileID: 11400000, guid: 87f4c7d3a3300654ba6691e9e3799d17,
+      objectReference: {fileID: 11400000, guid: 6a2d481ba573f414fabfa2d527297a71,
         type: 2}
     - target: {fileID: 8464518138621891108, guid: 8b06dfcbb399b9647b35d1161531f7b3,
         type: 3}
@@ -224,9 +224,15 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 8464518138621891108, guid: 8b06dfcbb399b9647b35d1161531f7b3,
         type: 3}
-      propertyPath: SubCatalogue.Array.data[0]
+      propertyPath: SubCatalogue.Array.data[2]
       value: 
-      objectReference: {fileID: 11400000, guid: 6a2d481ba573f414fabfa2d527297a71,
+      objectReference: {fileID: 11400000, guid: 87f4c7d3a3300654ba6691e9e3799d17,
+        type: 2}
+    - target: {fileID: 8464518138621891108, guid: 8b06dfcbb399b9647b35d1161531f7b3,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[3]
+      value: 
+      objectReference: {fileID: 11400000, guid: ba3d4ca3a4ec7864dbca5f94c5c6f628,
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8b06dfcbb399b9647b35d1161531f7b3, type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockExternalWindowed.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockExternalWindowed.prefab
@@ -238,5 +238,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: adea870044c3901448fb065207c6eb3d,
         type: 2}
+    - target: {fileID: 8542447127197164955, guid: 6af0a221ec6985a46956ac77fab1f771,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[6]
+      value: 
+      objectReference: {fileID: 11400000, guid: 0d2671f4daa23aa4f9148fd472288853,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6af0a221ec6985a46956ac77fab1f771, type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockGrunge.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockGrunge.prefab
@@ -304,5 +304,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 5a0731f1679ca0746808691df35850ce,
         type: 2}
+    - target: {fileID: 8542447127197164955, guid: 6af0a221ec6985a46956ac77fab1f771,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[6]
+      value: 
+      objectReference: {fileID: 11400000, guid: 2d8d6b950a6d8a14ba8e78f66795eef4,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6af0a221ec6985a46956ac77fab1f771, type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockHatchGrunge.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockHatchGrunge.prefab
@@ -298,5 +298,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 05a34901423f3c04985605c866e6bd3c,
         type: 2}
+    - target: {fileID: 8542447127197164955, guid: 6af0a221ec6985a46956ac77fab1f771,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[6]
+      value: 
+      objectReference: {fileID: 11400000, guid: dce474c84c97dd34da847aadc43065d3,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6af0a221ec6985a46956ac77fab1f771, type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockHighSecurity.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockHighSecurity.prefab
@@ -293,5 +293,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 3ce391d5e1db83c48b4f127285c21346,
         type: 2}
+    - target: {fileID: 8542447127197164955, guid: 6af0a221ec6985a46956ac77fab1f771,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[6]
+      value: 
+      objectReference: {fileID: 11400000, guid: 49586f9f6a9a8c847963c06ef30f68c1,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6af0a221ec6985a46956ac77fab1f771, type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockLargeGlass.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockLargeGlass.prefab
@@ -32,7 +32,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 351e6395f394cab40b0b0616c8ff6f1f,
+      objectReference: {fileID: 21300000, guid: c3fd932f54dbc104c8aae0fb5e3f9eeb,
         type: 3}
     - target: {fileID: 2268823939221595730, guid: 6af0a221ec6985a46956ac77fab1f771,
         type: 3}
@@ -43,7 +43,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 351e6395f394cab40b0b0616c8ff6f1f,
+      objectReference: {fileID: 21300000, guid: c3fd932f54dbc104c8aae0fb5e3f9eeb,
         type: 3}
     - target: {fileID: 3425389632118777829, guid: 6af0a221ec6985a46956ac77fab1f771,
         type: 3}
@@ -84,7 +84,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 351e6395f394cab40b0b0616c8ff6f1f,
+      objectReference: {fileID: 21300000, guid: c3fd932f54dbc104c8aae0fb5e3f9eeb,
         type: 3}
     - target: {fileID: 4835852156939608541, guid: 6af0a221ec6985a46956ac77fab1f771,
         type: 3}
@@ -156,7 +156,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 351e6395f394cab40b0b0616c8ff6f1f,
+      objectReference: {fileID: 21300000, guid: c3fd932f54dbc104c8aae0fb5e3f9eeb,
         type: 3}
     - target: {fileID: 8149197489328545512, guid: 6af0a221ec6985a46956ac77fab1f771,
         type: 3}
@@ -253,6 +253,12 @@ PrefabInstance:
       propertyPath: SubCatalogue.Array.data[5]
       value: 
       objectReference: {fileID: 11400000, guid: 2c2c8d87d57d7384f80149676db795f7,
+        type: 2}
+    - target: {fileID: 8542447127197164955, guid: 6af0a221ec6985a46956ac77fab1f771,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[6]
+      value: 
+      objectReference: {fileID: 11400000, guid: d37b5be56d987d14fb53796d1e41d148,
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6af0a221ec6985a46956ac77fab1f771, type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockPublicWindowed.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockPublicWindowed.prefab
@@ -243,6 +243,12 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 5cf00286727ee0a469fc2423f9bfdbdb,
         type: 2}
+    - target: {fileID: 8542447127197164955, guid: 6af0a221ec6985a46956ac77fab1f771,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[6]
+      value: 
+      objectReference: {fileID: 11400000, guid: 6713eccb551041346acd9fe25c6aeaad,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6af0a221ec6985a46956ac77fab1f771, type: 3}
 --- !u!210 &171221538576478895 stripped

--- a/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockShuttleWindowed.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockShuttleWindowed.prefab
@@ -243,5 +243,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 776fa53613f6cd6408d5a2df5aa23ad2,
         type: 2}
+    - target: {fileID: 8542447127197164955, guid: 6af0a221ec6985a46956ac77fab1f771,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[6]
+      value: 
+      objectReference: {fileID: 11400000, guid: b241460af5a87ff458eb9ccc609d2d07,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6af0a221ec6985a46956ac77fab1f771, type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockSurvivalPodWindowed.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockSurvivalPodWindowed.prefab
@@ -218,5 +218,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: f8d9320d3e6d7984eb5dc060efb90637,
         type: 2}
+    - target: {fileID: 8542447127197164955, guid: 6af0a221ec6985a46956ac77fab1f771,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[6]
+      value: 
+      objectReference: {fileID: 11400000, guid: 3ebd345a857d16541829268e65480f41,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6af0a221ec6985a46956ac77fab1f771, type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockVault.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/AirlockVault.prefab
@@ -304,5 +304,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 91df217e1c8215048b7aa3dd11a47c73,
         type: 2}
+    - target: {fileID: 8542447127197164955, guid: 6af0a221ec6985a46956ac77fab1f771,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[6]
+      value: 
+      objectReference: {fileID: 11400000, guid: 280d2fdbd2bb4a449b6a59e94cafccda,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6af0a221ec6985a46956ac77fab1f771, type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/_AirlockBase.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/_AirlockBase.prefab
@@ -103,6 +103,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: da6382ff06977d74ab7be8a1b19f65bb, type: 2}
   - {fileID: 11400000, guid: ef6303a1b3b0ec4489e8f87ef315efd5, type: 2}
   - {fileID: 11400000, guid: bc54afa99f62d904c99dbc6717cebd88, type: 2}
+  - {fileID: 11400000, guid: f198981ae0bd7c64d8071596aee94a88, type: 2}
   PresentSpriteSet: {fileID: 11400000, guid: 7d2de9c440cedfa4a855277fac47f8d0, type: 2}
   randomInitialSprite: 0
   pushTextureOnStartUp: 1

--- a/UnityProject/Assets/Resources/ScriptableObjectsSingletons/SpriteCatalogueSingleton.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjectsSingletons/SpriteCatalogueSingleton.asset
@@ -23285,3 +23285,17 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 400a7a7666dd27f489eccbb765be8f75, type: 2}
   - {fileID: 11400000, guid: 1b91514c375169247aabece5c4e731bf, type: 2}
   - {fileID: 11400000, guid: 084d48f03f5a3b24d971692ae9b4792a, type: 2}
+  - {fileID: 11400000, guid: 280d2fdbd2bb4a449b6a59e94cafccda, type: 2}
+  - {fileID: 11400000, guid: 3ebd345a857d16541829268e65480f41, type: 2}
+  - {fileID: 11400000, guid: 6713eccb551041346acd9fe25c6aeaad, type: 2}
+  - {fileID: 11400000, guid: f198981ae0bd7c64d8071596aee94a88, type: 2}
+  - {fileID: 11400000, guid: b241460af5a87ff458eb9ccc609d2d07, type: 2}
+  - {fileID: 11400000, guid: 49586f9f6a9a8c847963c06ef30f68c1, type: 2}
+  - {fileID: 11400000, guid: dce474c84c97dd34da847aadc43065d3, type: 2}
+  - {fileID: 11400000, guid: d37b5be56d987d14fb53796d1e41d148, type: 2}
+  - {fileID: 11400000, guid: 0d2671f4daa23aa4f9148fd472288853, type: 2}
+  - {fileID: 11400000, guid: 89ac76707e71c3f418c9dbdfd48b122a, type: 2}
+  - {fileID: 11400000, guid: f45b676ee2c2da44d9aad8e39e295ba0, type: 2}
+  - {fileID: 11400000, guid: 3b1bea27b03a3f148a329bd1cfecc856, type: 2}
+  - {fileID: 11400000, guid: 2d8d6b950a6d8a14ba8e78f66795eef4, type: 2}
+  - {fileID: 0}

--- a/UnityProject/Assets/Resources/ScriptableObjectsSingletons/SpriteCatalogueSingleton.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjectsSingletons/SpriteCatalogueSingleton.asset
@@ -23298,4 +23298,3 @@ MonoBehaviour:
   - {fileID: 11400000, guid: f45b676ee2c2da44d9aad8e39e295ba0, type: 2}
   - {fileID: 11400000, guid: 3b1bea27b03a3f148a329bd1cfecc856, type: 2}
   - {fileID: 11400000, guid: 2d8d6b950a6d8a14ba8e78f66795eef4, type: 2}
-  - {fileID: 0}

--- a/UnityProject/Assets/Scripts/Objects/Doors/DoorAnimatorV2.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/DoorAnimatorV2.cs
@@ -48,6 +48,9 @@ namespace Doors
 
 		[SerializeField, Tooltip("Time this door's denied animation takes")]
 		private float deniedAnimationTime = 0.6f;
+
+		[SerializeField, Tooltip("Time this door's warning animation takes")]
+		private float warningAnimationTime = 0.6f;
 		#endregion
 
 		[SerializeField, Tooltip("Sound that plays when opening this door")]
@@ -154,7 +157,7 @@ namespace Doors
 				overlayFillHandler.ChangeSprite((int) DoorFrame.Closing, false);
 				doorBaseHandler.ChangeSprite((int) DoorFrame.Closing, false);
 				ClientPlaySound(closingSFX);
-				yield return WaitFor.Seconds(openingAnimationTime);
+				yield return WaitFor.Seconds(closingAnimationTime);
 			}
 
 			//Change to closed sprite after it is done closing
@@ -189,9 +192,14 @@ namespace Doors
 
 		public IEnumerator PlayPressureWarningAnimation()
 		{
+			int previousLightSprite = overlayLightsHandler.CurrentSpriteIndex;
+			overlayLightsHandler.ChangeSprite((int)Lights.PressureWarning);
 			ClientPlaySound(warningSFX);
+			yield return WaitFor.Seconds(warningAnimationTime);
+
+			if (previousLightSprite == -1) previousLightSprite = 0;
+			overlayLightsHandler.ChangeSprite(previousLightSprite);
 			AnimationFinished?.Invoke();
-			yield break;
 		}
 
 		private void ClientPlaySound(AddressableAudioSource sound)

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/centcom/overlays/overlays_lights_warning.asset
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/centcom/overlays/overlays_lights_warning.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
+  m_Name: overlays_lights_warning
+  m_EditorClassIdentifier: 
+  Variance:
+  - Frames:
+    - sprite: {fileID: 21300000, guid: a2b3bd8ad1b8c8c4d989b150d8c2ab03, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300002, guid: a2b3bd8ad1b8c8c4d989b150d8c2ab03, type: 3}
+      secondDelay: 0.1
+  IsPalette: 0
+  setID: 23284
+  DisplayName: 

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/centcom/overlays/overlays_lights_warning.asset.meta
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/centcom/overlays/overlays_lights_warning.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2d8d6b950a6d8a14ba8e78f66795eef4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/clockwork/overlays/overlays_lights_warning.asset
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/clockwork/overlays/overlays_lights_warning.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
+  m_Name: overlays_lights_warning
+  m_EditorClassIdentifier: 
+  Variance:
+  - Frames:
+    - sprite: {fileID: 21300000, guid: 101bf114b837d6942a34194a5f5bdee3, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300002, guid: 101bf114b837d6942a34194a5f5bdee3, type: 3}
+      secondDelay: 0.1
+  IsPalette: 0
+  setID: 23283
+  DisplayName: 

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/clockwork/overlays/overlays_lights_warning.asset.meta
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/clockwork/overlays/overlays_lights_warning.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3b1bea27b03a3f148a329bd1cfecc856
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/cult/runed/overlays/overlays_lights_warning.asset
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/cult/runed/overlays/overlays_lights_warning.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
+  m_Name: overlays_lights_warning
+  m_EditorClassIdentifier: 
+  Variance:
+  - Frames:
+    - sprite: {fileID: 21300000, guid: c73068001a6c7ba4bb2b4caefac894b1, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300002, guid: c73068001a6c7ba4bb2b4caefac894b1, type: 3}
+      secondDelay: 0.1
+  IsPalette: 0
+  setID: 23282
+  DisplayName: 

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/cult/runed/overlays/overlays_lights_warning.asset.meta
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/cult/runed/overlays/overlays_lights_warning.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f45b676ee2c2da44d9aad8e39e295ba0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/cult/unruned/overlays/overlays_lights_warning.asset
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/cult/unruned/overlays/overlays_lights_warning.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
+  m_Name: overlays_lights_warning
+  m_EditorClassIdentifier: 
+  Variance:
+  - Frames:
+    - sprite: {fileID: 21300000, guid: e84e3dcdf6afe984ea680f087a4049da, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300002, guid: e84e3dcdf6afe984ea680f087a4049da, type: 3}
+      secondDelay: 0.1
+  IsPalette: 0
+  setID: 23281
+  DisplayName: 

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/cult/unruned/overlays/overlays_lights_warning.asset.meta
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/cult/unruned/overlays/overlays_lights_warning.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 89ac76707e71c3f418c9dbdfd48b122a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/external/overlays/overlays_lights_warning.asset
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/external/overlays/overlays_lights_warning.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
+  m_Name: overlays_lights_warning
+  m_EditorClassIdentifier: 
+  Variance:
+  - Frames:
+    - sprite: {fileID: 21300000, guid: 7af760869f8828e4bb662f41549fb807, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300002, guid: 7af760869f8828e4bb662f41549fb807, type: 3}
+      secondDelay: 0.1
+  IsPalette: 0
+  setID: 23280
+  DisplayName: 

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/external/overlays/overlays_lights_warning.asset.meta
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/external/overlays/overlays_lights_warning.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0d2671f4daa23aa4f9148fd472288853
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/glass_large/overlays/overlays_lights_warning.asset
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/glass_large/overlays/overlays_lights_warning.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
+  m_Name: overlays_lights_warning
+  m_EditorClassIdentifier: 
+  Variance:
+  - Frames:
+    - sprite: {fileID: 21300000, guid: 3ee0b3c10586e114fb4d5b5725880f91, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300002, guid: 3ee0b3c10586e114fb4d5b5725880f91, type: 3}
+      secondDelay: 0.1
+  IsPalette: 0
+  setID: 23279
+  DisplayName: 

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/glass_large/overlays/overlays_lights_warning.asset.meta
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/glass_large/overlays/overlays_lights_warning.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d37b5be56d987d14fb53796d1e41d148
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/hatch/overlays/overlays_lights_warning.asset
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/hatch/overlays/overlays_lights_warning.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
+  m_Name: overlays_lights_warning
+  m_EditorClassIdentifier: 
+  Variance:
+  - Frames:
+    - sprite: {fileID: 21300000, guid: 5043103deff1a914a933ccebca3f679a, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300002, guid: 5043103deff1a914a933ccebca3f679a, type: 3}
+      secondDelay: 0.1
+  IsPalette: 0
+  setID: 23278
+  DisplayName: 

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/hatch/overlays/overlays_lights_warning.asset.meta
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/hatch/overlays/overlays_lights_warning.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dce474c84c97dd34da847aadc43065d3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/highsec/overlays/overlays_lights_warning.asset
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/highsec/overlays/overlays_lights_warning.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
+  m_Name: overlays_lights_warning
+  m_EditorClassIdentifier: 
+  Variance:
+  - Frames:
+    - sprite: {fileID: 21300000, guid: f6c1e0930f9dfd34c9cff2cb45c36c98, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300002, guid: f6c1e0930f9dfd34c9cff2cb45c36c98, type: 3}
+      secondDelay: 0.1
+  IsPalette: 0
+  setID: 23277
+  DisplayName: 

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/highsec/overlays/overlays_lights_warning.asset.meta
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/highsec/overlays/overlays_lights_warning.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 49586f9f6a9a8c847963c06ef30f68c1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/shuttle/overlays/overlays_lights_warning.asset
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/shuttle/overlays/overlays_lights_warning.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
+  m_Name: overlays_lights_warning
+  m_EditorClassIdentifier: 
+  Variance:
+  - Frames:
+    - sprite: {fileID: 21300000, guid: 7cb21dc60f3cc0a4f88e486deec056ba, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300002, guid: 7cb21dc60f3cc0a4f88e486deec056ba, type: 3}
+      secondDelay: 0.1
+  - Frames: []
+  IsPalette: 0
+  setID: 23276
+  DisplayName: 

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/shuttle/overlays/overlays_lights_warning.asset.meta
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/shuttle/overlays/overlays_lights_warning.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b241460af5a87ff458eb9ccc609d2d07
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/station/overlays/overlays_lights_warning.asset
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/station/overlays/overlays_lights_warning.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
+  m_Name: overlays_lights_warning
+  m_EditorClassIdentifier: 
+  Variance:
+  - Frames:
+    - sprite: {fileID: 21300000, guid: 62962b886ea310d42b9a403535bdcc49, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300002, guid: 62962b886ea310d42b9a403535bdcc49, type: 3}
+      secondDelay: 0.1
+  IsPalette: 0
+  setID: 23275
+  DisplayName: 

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/station/overlays/overlays_lights_warning.asset.meta
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/station/overlays/overlays_lights_warning.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f198981ae0bd7c64d8071596aee94a88
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/station2/overlays/overlays_lights_warning.asset
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/station2/overlays/overlays_lights_warning.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
+  m_Name: overlays_lights_warning
+  m_EditorClassIdentifier: 
+  Variance:
+  - Frames:
+    - sprite: {fileID: 21300000, guid: a64d9db2cd1b7db40b8860b4abae6268, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300002, guid: a64d9db2cd1b7db40b8860b4abae6268, type: 3}
+      secondDelay: 0.1
+  IsPalette: 0
+  setID: 23274
+  DisplayName: 

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/station2/overlays/overlays_lights_warning.asset.meta
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/station2/overlays/overlays_lights_warning.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6713eccb551041346acd9fe25c6aeaad
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/survival/survival_overlays/survival_overlays_lights_warning.asset
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/survival/survival_overlays/survival_overlays_lights_warning.asset
@@ -1,0 +1,38 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
+  m_Name: survival_overlays_lights_warning
+  m_EditorClassIdentifier: 
+  Variance:
+  - Frames:
+    - sprite: {fileID: 21300000, guid: 870a6f0a28b3dee49b80091b8bff17b6, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300008, guid: 870a6f0a28b3dee49b80091b8bff17b6, type: 3}
+      secondDelay: 0.1
+  - Frames:
+    - sprite: {fileID: 21300002, guid: 870a6f0a28b3dee49b80091b8bff17b6, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300010, guid: 870a6f0a28b3dee49b80091b8bff17b6, type: 3}
+      secondDelay: 0.1
+  - Frames:
+    - sprite: {fileID: 21300004, guid: 870a6f0a28b3dee49b80091b8bff17b6, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300012, guid: 870a6f0a28b3dee49b80091b8bff17b6, type: 3}
+      secondDelay: 0.1
+  - Frames:
+    - sprite: {fileID: 21300006, guid: 870a6f0a28b3dee49b80091b8bff17b6, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300014, guid: 870a6f0a28b3dee49b80091b8bff17b6, type: 3}
+      secondDelay: 0.1
+  IsPalette: 0
+  setID: 23273
+  DisplayName: 

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/survival/survival_overlays/survival_overlays_lights_warning.asset.meta
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/survival/survival_overlays/survival_overlays_lights_warning.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3ebd345a857d16541829268e65480f41
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/vault/overlays/overlays_lights_warning.asset
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/vault/overlays/overlays_lights_warning.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
+  m_Name: overlays_lights_warning
+  m_EditorClassIdentifier: 
+  Variance:
+  - Frames:
+    - sprite: {fileID: 21300000, guid: e79af1efde18c794588ccf0be9c042e3, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300002, guid: e79af1efde18c794588ccf0be9c042e3, type: 3}
+      secondDelay: 0.1
+  IsPalette: 0
+  setID: 23272
+  DisplayName: 

--- a/UnityProject/Assets/Textures/objects/doors/airlocks/vault/overlays/overlays_lights_warning.asset.meta
+++ b/UnityProject/Assets/Textures/objects/doors/airlocks/vault/overlays/overlays_lights_warning.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 280d2fdbd2bb4a449b6a59e94cafccda
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
- Readds pressure warning lights to airlocks. Deals with the sprite half of #6701.
  - Creates a couple of sprite SOs that reuse the emergency lights to act as the warning light sprites.
- Changes an extraneous instance of "openingAnimationTime" in DoorAnimatorV2.cs to "closingAnimationTime".

### Changelog
CL: [Fix] Airlocks have pressure warning lights appear again.