### PR TITLE
Rounds end limbo state fix

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -493,8 +493,8 @@ public partial class GameManager : MonoBehaviour, IInitialise
 		EventManager.Broadcast(Event.RoundEnded, true);
 		counting = false;
 
-		GameMode.EndRound();
 		StartCoroutine(WaitForRoundRestart());
+		GameMode.EndRoundReport();
 
 		_ = SoundManager.PlayNetworked(endOfRoundSounds.GetRandomClip());
 	}

--- a/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
+++ b/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
@@ -386,7 +386,7 @@ namespace GameModes
 		/// <summary>
 		/// End the round and display any relevant reports
 		/// </summary>
-		public virtual void EndRound()
+		public void EndRoundReport()
 		{
 			Logger.LogFormat("Ending {0} round!", Category.GameMode, Name);
 			StationObjectiveManager.Instance.ShowStationStatusReport();


### PR DESCRIPTION
### Purpose
The round end report will now happen after the coroutine for the round restart ends triggers, avoiding the round getting stuck in a limbo state in the case of a runtime happening inside the round end report.

Note: I'm not sure why would a runtime happen yet, and it did, but this will make sure the round actually starts and the server doesn't get stuck in a limbo