### PR TITLE
adds Redshield Officer occupation to Admin respawn list

### DIFF
--- a/UnityProject/Assets/Resources/ScriptableObjectsSingletons/adminJobsList.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjectsSingletons/adminJobsList.asset
@@ -26,6 +26,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 012e9a812b4b0ad49808adc61d47b5bd, type: 2}
   - {fileID: 11400000, guid: d027bfb27e11fad44bda23f24b158cab, type: 2}
   - {fileID: 11400000, guid: 032c8cad66c40cb4dad54307acad9b2d, type: 2}
+  - {fileID: 11400000, guid: eb0c7cba0cf11ea43a6433115290b787, type: 2}
   antags:
   - {fileID: 11400000, guid: 8e452e9949d197548ad09c2b68d7d879, type: 2}
   - {fileID: 11400000, guid: 4bc36e6d8aa946c4081073eabc2472eb, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Occupations/RedshieldOfficerPopulator.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Occupations/RedshieldOfficerPopulator.asset
@@ -1,0 +1,109 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0e76afb59ec4485caa0a5cc0f2d142e9, type: 3}
+  m_Name: RedshieldOfficerPopulator
+  m_EditorClassIdentifier: 
+  Entries:
+  - IndexSlot: 0
+    IfOccupiedFindEmptyIndexSlot: 1
+    UesIndex: 0
+    NamedSlot: 12
+    Prefab: {fileID: 3866854686736633298, guid: 760ad04c7b18eab4685694f1f5de66e9,
+      type: 3}
+    ReplacementStrategy: 0
+    namedSlotPopulatorEntrys: []
+  - IndexSlot: 0
+    IfOccupiedFindEmptyIndexSlot: 1
+    UesIndex: 0
+    NamedSlot: 1
+    Prefab: {fileID: 5316882905438950620, guid: 725d217f992b8d247b2f034c4a69136a,
+      type: 3}
+    ReplacementStrategy: 1
+    namedSlotPopulatorEntrys: []
+  - IndexSlot: 0
+    IfOccupiedFindEmptyIndexSlot: 1
+    UesIndex: 0
+    NamedSlot: 6
+    Prefab: {fileID: 3921521694364753778, guid: 453dfbebf99d34049a240acec7a49706,
+      type: 3}
+    ReplacementStrategy: 0
+    namedSlotPopulatorEntrys: []
+  - IndexSlot: 0
+    IfOccupiedFindEmptyIndexSlot: 1
+    UesIndex: 0
+    NamedSlot: 11
+    Prefab: {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73,
+      type: 3}
+    ReplacementStrategy: 1
+    namedSlotPopulatorEntrys: []
+  - IndexSlot: 0
+    IfOccupiedFindEmptyIndexSlot: 1
+    UesIndex: 0
+    NamedSlot: 3
+    Prefab: {fileID: 7106618204054676533, guid: eaeac5365190b4842bedb2b846ff15da,
+      type: 3}
+    ReplacementStrategy: 1
+    namedSlotPopulatorEntrys: []
+  - IndexSlot: 0
+    IfOccupiedFindEmptyIndexSlot: 1
+    UesIndex: 0
+    NamedSlot: 9
+    Prefab: {fileID: 3183123304414575785, guid: 0bcb9423721f44a418353bfcc987a1b9,
+      type: 3}
+    ReplacementStrategy: 1
+    namedSlotPopulatorEntrys: []
+  - IndexSlot: 0
+    IfOccupiedFindEmptyIndexSlot: 1
+    UesIndex: 0
+    NamedSlot: 10
+    Prefab: {fileID: 6150311403527200410, guid: 1a291489c8aa9da8598c8026ac53f935,
+      type: 3}
+    ReplacementStrategy: 0
+    namedSlotPopulatorEntrys: []
+  - IndexSlot: 0
+    IfOccupiedFindEmptyIndexSlot: 1
+    UesIndex: 0
+    NamedSlot: 0
+    Prefab: {fileID: 3630185853609166337, guid: 87f3ae414da12c240addea367416f45c,
+      type: 3}
+    ReplacementStrategy: 1
+    namedSlotPopulatorEntrys: []
+  - IndexSlot: 0
+    IfOccupiedFindEmptyIndexSlot: 1
+    UesIndex: 0
+    NamedSlot: 2
+    Prefab: {fileID: 8054706762914598631, guid: 14669856ddf44564fac40935a5a8e2b4,
+      type: 3}
+    ReplacementStrategy: 1
+    namedSlotPopulatorEntrys: []
+  - IndexSlot: 0
+    IfOccupiedFindEmptyIndexSlot: 1
+    UesIndex: 0
+    NamedSlot: 16
+    Prefab: {fileID: 2626574395781294155, guid: 4db12a6785da27f469cc7d36b637c2cd,
+      type: 3}
+    ReplacementStrategy: 1
+    namedSlotPopulatorEntrys: []
+  - IndexSlot: 0
+    IfOccupiedFindEmptyIndexSlot: 1
+    UesIndex: 0
+    NamedSlot: 15
+    Prefab: {fileID: 4303657253753073484, guid: a964a6c1326a47c40a104866a6ebce52,
+      type: 3}
+    ReplacementStrategy: 1
+    namedSlotPopulatorEntrys: []
+  skirtVariant: {fileID: 8666235253663602016, guid: a4e8364883b2aee4d90835ec0b5963ed,
+    type: 3}
+  duffelVariant: {fileID: 5246620180480384242, guid: ed03c800dbd4d674d8f01df08a62ce57,
+    type: 3}
+  satchelVariant: {fileID: 4491607388275499144, guid: 1ed809e1bad45b44ea65b44c81764ca9,
+    type: 3}

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Occupations/RedshieldOfficerPopulator.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Occupations/RedshieldOfficerPopulator.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6c9404f82a7d0fd448d109148b7b625b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Occupations/Centcom/Redshield Officer.asset
+++ b/UnityProject/Assets/ScriptableObjects/Occupations/Centcom/Redshield Officer.asset
@@ -1,0 +1,64 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c58d5c5a6190436e9d4ae8e32a26ee6a, type: 3}
+  m_Name: Redshield Officer
+  m_EditorClassIdentifier: 
+  jobType: 57
+  isCrewmember: 0
+  lateSpawnIsArrivals: 0
+  inventoryPopulator: {fileID: 11400000, guid: 6c9404f82a7d0fd448d109148b7b625b, type: 2}
+  limit: -1
+  priority: 0
+  allowedAccess: 51000000260000002200000031000000060000001b00000044000000430000001a000000
+  issuedClearance: 40000000120000000d0000000c000000020000002700000001000000370000001f000000
+  issuedLowPopClearance: 40000000120000000d0000000c000000020000002700000001000000370000001f000000
+  spells: []
+  progress: 75
+  choiceColor: {r: 0.8, g: 0.8, b: 1, a: 1}
+  previewSprite: {fileID: 21300000, guid: b28046094f565534fb33fd7c050a3f22, type: 3}
+  displayName: Redshield Officer
+  difficulty: 3
+  descriptionShort: "\u2022 Protect VIPs\n\u2022 Secure High Risk Items"
+  descriptionLong: 'Welcome, Redshield. You have been given special training by Central
+    Command, and been dispatched to serve as the personal bodyguard of everyone with
+    access to Command Comms.
+
+    
+
+    Most of your time will be spent shadowing
+    those you have been assigned to protect, making sure that they''re alive and
+    well, and keep an eye on a crew monitor to make sure they''re still on sensors.
+    Your job is to keep everyone in Command, as well as CentCom VIPs, alive.
+
+    
+
+    One
+    very important detail of your job is that you are not Security. Do not let your
+    Security (and Detective) access fool you. Your ID lets you reach every single
+    Command Office on the station. You should not be concerned with the goings-on
+    at Security, nor should you be doing their job for them. You are not a Security
+    Officer with elevated access and snazzy outfit. You are a bodyguard.'
+  customProperties:
+    m_keys: []
+    m_values: 
+  isTargeteable: 0
+  playSound: 1
+  spawnSound:
+    SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/AmbientTracks/SpawnSounds/departments/Command_Spawn.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  textColor: {r: 0.8000001, g: 0.8000001, b: 1, a: 1}
+  backgroundColor: {r: 1, g: 0, b: 0, a: 0}
+  specialPlayerPrefab: {fileID: 0}

--- a/UnityProject/Assets/ScriptableObjects/Occupations/Centcom/Redshield Officer.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Occupations/Centcom/Redshield Officer.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eb0c7cba0cf11ea43a6433115290b787
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Occupations/Security/Security Officer.asset
+++ b/UnityProject/Assets/ScriptableObjects/Occupations/Security/Security Officer.asset
@@ -30,7 +30,7 @@ MonoBehaviour:
   descriptionShort: "\u2022 Protect company assets\n\u2022 Follow standard operating
     procedure\n\u2022 Eat donuts"
   descriptionLong: "Welcome to the force, kid. Not only is the station and its crew
-    a constant threat to themselves, we have the constant menace of unknown, external
+    a continual threat to themselves, we have the constant menace of unknown, external
     enemies. We\u2019re not here to be loved or make friends, we\u2019re here because
     we\u2019re tough enough to deal with all the scum that roams the facility and
     the space beyond. Our duty is to make the place safe enough to keep producing

--- a/UnityProject/Assets/Scripts/Systems/Occupations/JobType.cs
+++ b/UnityProject/Assets/Scripts/Systems/Occupations/JobType.cs
@@ -66,6 +66,7 @@ public enum JobType
 	WIZARD = 54,
 	BLOB = 55,
 	ANCIENT_ENGINEER = 56,
+	REDSHIELD_OFFICER = 57,
 }
 
 public static class JobCategories
@@ -82,6 +83,7 @@ public static class JobCategories
 		JobType.ERT_ENGINEER,
 		JobType.ERT_CHAPLAIN,
 		JobType.ERT_JANITOR,
-		JobType.ERT_CLOWN
+		JobType.ERT_CLOWN,
+		JobType.REDSHIELD_OFFICER
 	};
 }


### PR DESCRIPTION
### Purpose

This PR adds a new job in the form of the Redshield Officer, a reflavour of the Blueshield Officer from Paradise. A Redshield is a member of a specially trained branch of NanoTrasen employees dispatched from Central Command to protect the Captain, Heads of Staff, and Centcom VIPs.

It is currently admin spawned only, and is meant to help facilitate events by providing Admins with the ability to spawn a lower authority bodyguard for Centcom Officials, meaning ERTs can remain as a more special occurence as intended. Redshields have security officer access (but _no_ forensics access. they do not solve crimes.), head access, and general centcom access.

- Added Redshield Officer
- Also fixed a bit of wording in the security Officer's description.

### Changelog:

<!-- CL: [New] Added Redshield Officer to the admin respawn list. Redshields are specially trained Security Officers that act as bodyguards of NanoTrasen to protect Centcom VIPs.
