### PR TITLE
Redshields are no longer pantsless and have a spawnpoint

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Occupations/RedshieldOfficerPopulator.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Occupations/RedshieldOfficerPopulator.asset
@@ -33,7 +33,7 @@ MonoBehaviour:
     IfOccupiedFindEmptyIndexSlot: 1
     UesIndex: 0
     NamedSlot: 6
-    Prefab: {fileID: 3921521694364753778, guid: 453dfbebf99d34049a240acec7a49706,
+    Prefab: {fileID: 3011710637427380133, guid: e6fa54b0b29a6437eb102c7605b5dab3,
       type: 3}
     ReplacementStrategy: 0
     namedSlotPopulatorEntrys: []

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnPoint.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnPoint.cs
@@ -135,6 +135,7 @@ namespace Systems.Spawns
 
 			{ JobType.CENTCOMM_COMMANDER, SpawnPointCategory.CentCommCommander },
 			{ JobType.CENTCOMM_OFFICER, SpawnPointCategory.CentComm },
+			{ JobType.REDSHIELD_OFFICER, SpawnPointCategory.CentComm },
 			{ JobType.CENTCOMM_INTERN, SpawnPointCategory.CentComm },
 			{ JobType.ERT_COMMANDER, SpawnPointCategory.EmergencyResponseTeam },
 			{ JobType.ERT_SECURITY, SpawnPointCategory.EmergencyResponseTeam },


### PR DESCRIPTION


### Purpose

- changes the redshield's inner wear to the security uniform
- adds redshields to spawnpoint.cs so they spawn with centcom officials and interns

