### PR TITLE
Quick fix for races in security records

### DIFF
--- a/UnityProject/Assets/Scripts/UI/Systems/Jobs/CrewManifestManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Jobs/CrewManifestManager.cs
@@ -104,8 +104,7 @@ namespace Systems
 			record.Rank = script.mind.occupation.JobType.JobString();
 			record.Occupation = OccupationList.Instance.Get(jobType);
 			record.Sex = script.characterSettings.BodyType.ToString();
-			//We don't have races yet. Or I didn't find them.
-			record.Species = "Human";
+			record.Species = script.characterSettings.Species.ToString();
 			//I don't know what to put in ID and Fingerprints
 			record.ID = $"{UnityEngine.Random.Range(111, 999).ToString()}-{UnityEngine.Random.Range(111, 999).ToString()}";
 			record.Fingerprints = UnityEngine.Random.Range(111111, 999999).ToString();


### PR DESCRIPTION
### Purpose
Quick fix for races in security records

### Changelog:
[Fix] Fixes security records always showing species as 'Human' erroneously.