### PR TITLE
Mid Round Antag Chance

### DIFF
--- a/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
+++ b/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
@@ -122,7 +122,8 @@ namespace GameModes
 
 		[Tooltip("The chance for for every possible mid round antag to spawn after start" +
 		         "E.G If the gamemode needs another antag say we need two but only have one currently, " +
-		         "then every time a player joins they will roll this chance for it." +
+		         "then every time a player joins they will roll this chance for it. " +
+		         "It is multiplied by the amount of open antag slots." +
 		         "This stops the players from guessing by player numbers when they should join to get the antag")]
 		[SerializeField]
 		private int midRoundAntagsChance = 25;

--- a/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
+++ b/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
@@ -245,7 +245,7 @@ namespace GameModes
 				//E.g if traitor with two open slots it will be 25 * 2 = 50% chance on spawn to get the antag
 				//This prevents midround players from guessing when they can join the game to guarantee antag status
 				var percentage = midRoundAntagsChance * (expectedAntagCount - AntagManager.Instance.AntagCount);
-				if (DMMath.Prob(Mathf.Clamp(percentage, 1, 100)))
+				if (DMMath.Prob(percentage))
 				{
 					return true;
 				}

--- a/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
+++ b/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
@@ -69,13 +69,13 @@ namespace GameModes
 		public float AntagRatio => antagRatio;
 
 		[Tooltip("The minimum amount of antags needed for the game mode to be possible. " +
-		         "If requiresMinAntags is false, the number of chosen antags will be rounded up to this number.")]
+		         "If forceMinAntags is true, the number of chosen antags will be rounded up to this number.")]
 		[SerializeField]
 		[Min(0)]
 		private int minAntags = 0;
 		/// <summary>
 		/// The minimum amount of antags needed for the game mode to be possible.
-		/// If <see cref="requiresMinAntags"/> is false, the number of chosen antags will be rounded up to this number.
+		/// If <see cref="forceMinAntags"/> is true, the number of chosen antags will be rounded up to this number.
 		/// </summary>
 		public int MinAntags => minAntags;
 
@@ -85,19 +85,22 @@ namespace GameModes
 		private int maxAntags = 100;
 		/// <summary>
 		/// The maximum amount of antags spawned in the gamemode.
-		/// If <see cref="requiresMinAntags"/> is false, the number of chosen antags will be rounded up to this number.
+		/// If <see cref="forceMinAntags"/> is true, the number of chosen antags will be rounded up to this number.
 		/// </summary>
 		public int MaxAntags => maxAntags;
 
+		[FormerlySerializedAs("requiresMinAntags")]
 		[Tooltip("Is the game mode possible if the player count multiplied by the antagRatio doesn't meet the minAntags? " +
-		         "E.g. If true, when antagRatio is 0.2 and minAntags is 1, you need at least 5 players to start the game mode.")]
+		         "E.g. If true, when antagRatio is 0.2 and minAntags is 1, you need at least 5 players to start the game mode." +
+		         "If false then it will force minAntags so 1, and then every 5 players after that if antagRatio is 0.2")]
 		[SerializeField]
-		private bool requiresMinAntags = false;
+		private bool forceMinAntags = false;
 		/// <summary>
 		/// Is the game mode possible if the <see cref="antagRatio"/> doesn't meet the <see cref="minAntags"/>?
 		/// E.g. If true, when antagRatio is 0.2 and minAntags is 1, then you need at least 5 players to start the game mode.
+		/// If false then it will force minAntags so 1, and then every 5 players after that if antagRatio is 0.2
 		/// </summary>
-		public bool RequiresMinAntags => requiresMinAntags;
+		public bool ForceMinAntags => forceMinAntags;
 
 		[Tooltip("Are antags on the same team or are they lone wolves?" +
 		         "Used for the end of round antag report.")]
@@ -116,6 +119,13 @@ namespace GameModes
 		/// Can antags spawn during the round?
 		/// </summary>
 		public bool MidRoundAntags => midRoundAntags;
+
+		[Tooltip("The chance for for every possible mid round antag to spawn after start" +
+		         "E.G If the gamemode needs another antag say we need two but only have one currently, " +
+		         "then every time a player joins they will roll this chance for it." +
+		         "This stops the players from guessing by player numbers when they should join to get the antag")]
+		[SerializeField]
+		private int midRoundAntagsChance = 25;
 
 		[Tooltip("The possible antagonists for this game mode")]
 		[SerializeField]
@@ -163,7 +173,7 @@ namespace GameModes
 		public virtual bool IsPossible()
 		{
 			int players = PlayerList.Instance.ReadyPlayers.Count;
-			return players >= MinPlayers && (!RequiresMinAntags ||
+			return players >= MinPlayers && (!ForceMinAntags ||
 			                                 (Math.Floor(players * antagRatio) >= MinAntags));
 		}
 
@@ -227,7 +237,21 @@ namespace GameModes
 			// Are there enough antags already?
 			int newPlayerCount = PlayerList.Instance.InGamePlayers.Count + 1;
 			var expectedAntagCount = Math.Min((int)Math.Floor(newPlayerCount * AntagRatio), maxAntags);
-			return AntagManager.Instance.AntagCount < expectedAntagCount;
+
+			if (AntagManager.Instance.AntagCount < expectedAntagCount)
+			{
+
+				//We times the percentage based on the amount of open antag spaces
+				//E.g if traitor with two open slots it will be 25 * 2 = 50% chance on spawn to get the antag
+				//This prevents midround players from guessing when they can join the game to guarantee antag status
+				var percentage = midRoundAntagsChance * (expectedAntagCount - AntagManager.Instance.AntagCount);
+				if (DMMath.Prob(Mathf.Clamp(percentage, 1, 100)))
+				{
+					return true;
+				}
+			}
+
+			return false;
 		}
 
 		/// <summary>
@@ -372,7 +396,7 @@ namespace GameModes
 		{
 			var antagCount = Math.Min((int)Math.Floor(playerCount * antagRatio), maxAntags);
 			// If RequiresMinAntags is true then round up to MinAntags if antagCount is below
-			return RequiresMinAntags ? Math.Max(MinAntags, antagCount) : antagCount;
+			return ForceMinAntags ? Math.Max(MinAntags, antagCount) : antagCount;
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
+++ b/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
@@ -241,7 +241,6 @@ namespace GameModes
 
 			if (AntagManager.Instance.AntagCount < expectedAntagCount)
 			{
-
 				//We times the percentage based on the amount of open antag spaces
 				//E.g if traitor with two open slots it will be 25 * 2 = 50% chance on spawn to get the antag
 				//This prevents midround players from guessing when they can join the game to guarantee antag status


### PR DESCRIPTION
-Adds a chance (default is 25% but changes based on amount of open antag slots) for late joiners to get the antag, so it will not be guarantee by the antag ratio anymore
