### PR TITLE
Fix access restricted guns throwing exception when firing

### DIFF
--- a/UnityProject/Assets/Scripts/Items/PDA/PDALogic.cs
+++ b/UnityProject/Assets/Scripts/Items/PDA/PDALogic.cs
@@ -537,7 +537,9 @@ namespace Items.PDA
 		// All the methods above will be obsolete as soon as we migrate
 		public IEnumerable<Clearance> GetClearance()
 		{
-			return IDCard.OrNull()?.GetComponent<IClearanceProvider>()?.GetClearance();
+			var idClearance = IDCard.OrNull()?.GetComponent<IClearanceProvider>();
+
+			return idClearance?.GetClearance();
 		}
 
 		#endregion IDAccess

--- a/UnityProject/Assets/Scripts/Items/Weapons/FiringPins/IDLockedPin.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/FiringPins/IDLockedPin.cs
@@ -34,12 +34,6 @@ namespace Weapons
 
 		public override void ServerBehaviour(AimApply interaction, bool isSuicide)
 		{
-			if (clearanceCheckable.HasClearance(interaction.Performer))
-			{
-				CallShotServer(interaction, isSuicide);
-				return;
-			}
-
 			/* --ACCESS REWORK--
 			 *  TODO Remove the AccessRestriction check when we finish migrating!
 			 *
@@ -59,6 +53,12 @@ namespace Weapons
 				// }
 
 				CallShotServer(interaction, isSuicide);
+				return; //we found access skip clearance check
+			}
+
+			if (clearanceCheckable.HasClearance(interaction.Performer))
+			{
+				CallShotServer(interaction, isSuicide);
 				return;
 			}
 
@@ -67,12 +67,6 @@ namespace Weapons
 
 		public override void ClientBehaviour(AimApply interaction, bool isSuicide)
 		{
-			if (clearanceCheckable.HasClearance(interaction.Performer))
-			{
-				CallShotClient(interaction, isSuicide);
-				return;
-			}
-
 			/* --ACCESS REWORK--
 			 *  TODO Remove the AccessRestriction check when we finish migrating!
 			 *
@@ -88,6 +82,13 @@ namespace Weapons
 				// }
 
 				CallShotClient(interaction, isSuicide);
+				return; //we found access skip clearance check
+			}
+
+			if (clearanceCheckable.HasClearance(interaction.Performer))
+			{
+				CallShotClient(interaction, isSuicide);
+
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Objects/Drawers/Cremator.cs
+++ b/UnityProject/Assets/Scripts/Objects/Drawers/Cremator.cs
@@ -50,8 +50,16 @@ namespace Objects.Drawers
 			 *  TODO Remove the AccessRestriction check when we finish migrating!
 			 *
 			 */
-			if (!accessRestrictions.CheckAccess(PlayerManager.LocalPlayer) ||
-			    !clearanceCheckable.HasClearance(PlayerManager.LocalPlayer)) return result;
+
+			if (accessRestrictions)
+			{
+				if (accessRestrictions.CheckAccess(PlayerManager.LocalPlayer) == false) return result;
+			}
+			else if (clearanceCheckable)
+			{
+				if (clearanceCheckable.HasClearance(PlayerManager.LocalPlayer) == false) return result;
+			}
+
 			var cremateInteraction = ContextMenuApply.ByLocalPlayer(gameObject, null);
 			if (!WillInteract(cremateInteraction, NetworkSide.Client)) return result;
 

--- a/UnityProject/Assets/Scripts/Objects/Engineering/Emitter.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/Emitter.cs
@@ -173,9 +173,8 @@ namespace Objects.Engineering
 			 */
 			if (accessRestrictions.CheckAccessCard(interaction.HandObject))
 			{
-				isLocked = !isLocked;
 				ToggleEmitter();
-				return;
+				return; //we found access, skip clearance check
 			}
 
 			if (clearanceCheckable.HasClearance(interaction.Performer))


### PR DESCRIPTION
### Purpose
Fixes error when trying to shoot with an access restricted weapon, like the syndie Migraine. 
The problem was I was checking for clearance first and returning at that point, producing an NRE. Now we will check for access first and return after that operation is done, effectively skipping the clearance check until that migration is finished.

Regarding the migration, some deep changes are needed for IDCard (and as consequence vendors and ore redemption machine), decoupling the little currency system from access. Other important changes will have to be done with how coupled are shutters, switches and firelocks to old doors.
