### PR TITLE
Fixes players being unable to move

### DIFF
--- a/UnityProject/Assets/Scripts/Player/PlayerMove.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerMove.cs
@@ -469,19 +469,30 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn, IActi
 
 	public void UpdateSpeeds()
 	{
-		RunSpeed = 0;
-		WalkSpeed = 0;
-		CrawlSpeed = 0;
+		float newRunSpeed = 0;
+		float newWalkSpeed = 0;
+		float newCrawlSpeed = 0;
 		foreach (var MovementAffect in MovementAffects)
 		{
-			RunSpeed += MovementAffect.RunningAdd;
-			WalkSpeed += MovementAffect.WalkingAdd;
-			CrawlSpeed+= MovementAffect.CrawlAdd;
+			newRunSpeed += MovementAffect.RunningAdd;
+			newWalkSpeed += MovementAffect.WalkingAdd;
+			newCrawlSpeed += MovementAffect.CrawlAdd;
 		}
-
-		if (RunSpeed < 0) RunSpeed = 0;
-		if (WalkSpeed < 0) WalkSpeed = 0;
-		if (CrawlSpeed < 0) CrawlSpeed = 0;
+		if (newRunSpeed < 0)
+		{
+			newRunSpeed = 0;
+		}
+		if (newWalkSpeed < 0)
+		{
+			newWalkSpeed = 0;
+		}
+		if (newCrawlSpeed < 0)
+		{
+			newCrawlSpeed = 0;
+		}
+ 		RunSpeed = newRunSpeed;
+		WalkSpeed = newWalkSpeed;
+		CrawlSpeed = newCrawlSpeed;
 	}
 
 	private void SyncRunSpeed(float oldSpeed, float newSpeed)

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
@@ -381,14 +381,7 @@ public partial class PlayerSync
 	{
 		if ( !playerScript.IsGhost )
 		{
-			if ( !playerScript.registerTile.IsLayingDown )
-			{
-				SpeedClient = action.isRun ? playerMove.RunSpeed : playerMove.WalkSpeed;
-			}
-			else
-			{
-				SpeedClient = playerMove.CrawlSpeed;
-			}
+			SpeedClient = ActionSpeed(action);
 		}
 
 		var nextState = NextState(state, action, isReplay);

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -519,7 +519,7 @@ public partial class PlayerSync
 
 		if (!playerScript.playerHealth || !playerScript.registerTile.IsLayingDown)
 		{
-			SpeedServer = action.isRun ? playerMove.RunSpeed : playerMove.WalkSpeed;
+			SpeedServer = ActionSpeed(action);
 		}
 
 		//we only lerp back if the client thinks it's passable  but server does not...if client

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.cs
@@ -639,9 +639,8 @@ public partial class PlayerSync : NetworkBehaviour, IPushable, IPlayerControllab
 
 	public void ReceivePlayerMoveAction(PlayerAction moveActions)
 	{
-		if (moveActions.moveActions.Length != 0 && !MoveCooldown
-		                                        && isLocalPlayer && playerMove != null
-		                                        && !didWiggle && ClientPositionReady)
+		if (moveActions.moveActions.Length != 0 && !MoveCooldown && isLocalPlayer && playerMove != null
+		    && !didWiggle && ClientPositionReady && ActionSpeed(moveActions) > 0)
 		{
 			bool beingDraggedWithCuffs = playerMove.IsCuffed && playerScript.pushPull.IsBeingPulledClient;
 
@@ -657,5 +656,26 @@ public partial class PlayerSync : NetworkBehaviour, IPushable, IPlayerControllab
 				}
 			}
 		}
+	}
+
+	private float ActionSpeed(PlayerAction action)
+	{
+		float speed = 0;
+		if (!playerScript.registerTile.IsLayingDown)
+		{
+			if (action.isRun)
+			{
+				speed = playerMove.RunSpeed;
+			}
+			if (speed <= 0 || speed < playerMove.WalkSpeed)
+			{
+				speed = playerMove.WalkSpeed;
+			}
+		}
+		if (speed <= 0 || speed < playerMove.CrawlSpeed)
+		{
+			speed = playerMove.CrawlSpeed;
+		}
+		return speed;
 	}
 }


### PR DESCRIPTION
### Purpose
Players will no longer start a movement with 0 speed, getting stuck in the process.
Run, walk and crawl syncvars will now only be updated once in the same frame.
Fixes #7081

Note: I only focused on onyloss related movement slowdown, if there's more ways to lose the control of your character it hasn't been taken into consideration on this PR