### PR TITLE
Hotfixes lockers being unable to be hit in harm intent

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
@@ -513,6 +513,8 @@ namespace Objects
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
 			if (!DefaultWillInteract.Default(interaction, side)) return false;
+			if (interaction.HandObject != null && interaction.Intent == Intent.Harm)
+				return false;
 
 			//only allow interactions targeting this closet
 			if (interaction.TargetObject != gameObject) return false;


### PR DESCRIPTION
### Purpose
Hotfixes lockers being unable to be hit in harm intent
Fixes #5313

### Notes:
interactable interfaces have huge flaws when it comes to overlapping eachother and need to be taken care of or these kind of non standarization issues will keep popping up