### PR TITLE
Enable deep profiling for dev builds

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Editor/BuildServer.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/BuildServer.cs
@@ -73,7 +73,7 @@ static class BuildScript
 
 		if (validatedOptions.TryGetValue("devBuild", out var devBuild))
 		{
-			Console.WriteLine("Found -devBuild argument. This build will be a devBuild");
+			Console.WriteLine("Found -devBuild argument. This build will be a devBuild and include deep profiling!");
 			validatedOptions["devBuild"] = "true";
 		}
 		else
@@ -111,6 +111,7 @@ static class BuildScript
 		if (devBuild.Equals("true"))
 		{
 			buildOptions.options |= BuildOptions.Development;
+			buildOptions.options |= BuildOptions.EnableDeepProfilingSupport;
 		}
 
 		ReportOptions(buildOptions);


### PR DESCRIPTION
### Purpose
Builds that append the ``-devBuild`` argument to command line when building will now also support deep profiling. In practical terms, this will affect the server build we make for staging but leave all client builds unchanged.