### PR TITLE
Fixes warops withdraw machine

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Misc/SyndicateWithdrawStation.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Misc/SyndicateWithdrawStation.prefab
@@ -33,7 +33,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: c779058a0b2fc234398ec562193ec458,
+      objectReference: {fileID: 21300000, guid: 7e1a39af3fcb3a74cb2fa0707f419fe7,
         type: 3}
     - target: {fileID: 4116897424394887774, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
@@ -100,6 +100,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4800765294880679425, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: CurrentsortingGroup
+      value: 
+      objectReference: {fileID: 8731991323667823606}
     - target: {fileID: 5737521361753715499, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
       propertyPath: m_AssetId
@@ -113,19 +118,27 @@ PrefabInstance:
     - target: {fileID: 6838691275677014393, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
       propertyPath: initialDescription
-      value: Its not just a duck we swear
+      value: Once the war begins, this console will start slowly charging new telecrystals
+        until the timer ends. Operatives will use their PDAs to transfer them into
+        their uplink.
       objectReference: {fileID: 0}
     - target: {fileID: 8652228875761003667, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
       propertyPath: PresentSpriteSet
       value: 
-      objectReference: {fileID: 11400000, guid: 348ff959f5db99a4b9b48b5277ca2a4b,
+      objectReference: {fileID: 11400000, guid: 5875e5b4e594a5548973441ba2daa701,
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
 --- !u!1 &6332761364594315078 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4197940402254186057, guid: ebb08cf966efc084aa918bd8d9429604,
+    type: 3}
+  m_PrefabInstance: {fileID: 7899428531546441999}
+  m_PrefabAsset: {fileID: 0}
+--- !u!210 &8731991323667823606 stripped
+SortingGroup:
+  m_CorrespondingSourceObject: {fileID: 1481169419180323577, guid: ebb08cf966efc084aa918bd8d9429604,
     type: 3}
   m_PrefabInstance: {fileID: 7899428531546441999}
   m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Scripts/Items/PDA/PDALogic.cs
+++ b/UnityProject/Assets/Scripts/Items/PDA/PDALogic.cs
@@ -359,11 +359,16 @@ namespace Items.PDA
 						$"After a moment it disappears, your Telecrystal counter ticks up a second later";
 
 					Chat.AddExamineMsgFromServer(player, uplinkMessage);
-					if (PDAGui)
-					{
-						PDAGui.uplinkPage.UpdateTCCounter();
-					}
+					UpdateTCCountGui();
 				}
+			}
+		}
+
+		public void UpdateTCCountGui()
+		{
+			if (PDAGui)
+			{
+				PDAGui.uplinkPage.UpdateTCCounter();
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/Consoles/SyndicateOpConsole.cs
+++ b/UnityProject/Assets/Scripts/Objects/Consoles/SyndicateOpConsole.cs
@@ -16,12 +16,10 @@ namespace SyndicateOps
 		public int TcIncrement = 14;
 
 		private bool warDeclared = false;
-		private bool rewardGiven = false;
+
 		[SerializeField] private int timer = 1200;
 
 		[SerializeField] private int tcToGive = 280;
-
-		[NonSerialized] public List<SpawnedAntag> Operatives = new List<SpawnedAntag>();
 
 		public int Timer => timer;
 
@@ -37,20 +35,9 @@ namespace SyndicateOps
 			}
 		}
 
-		private void OnEnable()
-		{
-			if (CustomNetworkManager.IsServer)
-			{
-				UpdateManager.Add(ServerUpdateTimer, 1f);
-			}
-		}
-
 		private void OnDisable()
 		{
-			if (CustomNetworkManager.IsServer)
-			{
-				UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, ServerUpdateTimer);
-			}
+			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, RewardTelecrystals);
 		}
 
 		public void AnnounceWar(string declarationMessage)
@@ -60,54 +47,23 @@ namespace SyndicateOps
 				warDeclared = true;
 
 				GameManager.Instance.CentComm.ChangeAlertLevel(CentComm.AlertLevel.Red, true);
-				CentComm.MakeAnnouncement(ChatTemplates.PriorityAnnouncement, 
+				CentComm.MakeAnnouncement(ChatTemplates.PriorityAnnouncement,
 				$"Attention all crew! An open message from the syndicate has been picked up on local radiowaves! Message Reads:\n" +
 				$"{declarationMessage}" ,CentComm.UpdateSound.Alert);
-
-				var antagPlayers = AntagManager.Instance.ActiveAntags;
-
-				foreach (var antag in antagPlayers )
-				{
-					if (antag.Antagonist.AntagJobType == JobType.SYNDICATE)
-					{
-						Operatives.Add(antag);
-					}
-				}
+				UpdateManager.Add(RewardTelecrystals, 60);
 			}
 		}
 
-		public void ServerUpdateTimer()
-		{
-			if (warDeclared == false || rewardGiven) return;
-
-			if (timer > 0)
-			{
-				timer--;
-			}
-
-			if (timer % 60 == 0)
-			{
-				RewardTelecrystals();
-			}
-		}
 		public void RewardTelecrystals()
 		{
-			if (tcToGive <= TcIncrement)
+			var amount = Mathf.Min(TcIncrement, tcToGive);
+			TcReserve += amount;
+			tcToGive -= amount;
+			if (tcToGive == 0)
 			{
-				rewardGiven = true;
+				UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, RewardTelecrystals);
 			}
 
-			if (tcToGive >= TcIncrement)
-			{	
-				TcReserve += TcIncrement;
-				tcToGive -= TcIncrement;
-			}
-
-			if (tcToGive < TcIncrement)
-			{
-				TcReserve += tcToGive;
-				tcToGive = 0;
-			}
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Objects/Consoles/SyndicateTelecrystalStation.cs
+++ b/UnityProject/Assets/Scripts/Objects/Consoles/SyndicateTelecrystalStation.cs
@@ -6,6 +6,7 @@ namespace SyndicateOps
 {
 	class SyndicateTelecrystalStation : MonoBehaviour,  ICheckedInteractable<HandApply>, IExaminable
 	{
+		private static int TransferAmount = 5;
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
 			if (DefaultWillInteract.Default(interaction, side)) return true;
@@ -19,9 +20,14 @@ namespace SyndicateOps
 
 		public void WithdrawTeleCrystals(HandApply interaction)
 		{
+			if (SyndicateOpConsole.Instance.TcReserve == 0)
+			{
+				Chat.AddExamineMsgFromServer(interaction.Performer, $"There are no telecrystals in reserve");
+				return;
+			}
 			if (interaction.UsedObject == null)
 			{
-				Chat.AddExamineMsgFromServer(interaction.Performer, $"It seems to have {SyndicateOpConsole.Instance.TcReserve} telecrystals in reserve");
+				Chat.AddExamineMsgFromServer(interaction.Performer, $"There are {SyndicateOpConsole.Instance.TcReserve} telecrystals in reserve");
 				return;
 			}
 			PDALogic pdaComp = interaction.UsedObject.GetComponent<PDALogic>();
@@ -29,12 +35,10 @@ namespace SyndicateOps
 			{
 				if (pdaComp.IsUplinkLocked == false)
 				{
-
-					int tc = Mathf.FloorToInt(SyndicateOpConsole.Instance.Operatives.Count / SyndicateOpConsole.Instance.TcIncrement);
-					//this is to prevent tc being unobtainable when the value above is bigger then the amount of tc left within the reserves
-					tc = Math.Min(tc, SyndicateOpConsole.Instance.TcReserve);
-					pdaComp.UplinkTC += tc;
-					SyndicateOpConsole.Instance.TcReserve -= tc;
+					var amount = Math.Min(TransferAmount, SyndicateOpConsole.Instance.TcReserve);
+					pdaComp.UplinkTC += amount;
+					SyndicateOpConsole.Instance.TcReserve -= amount;
+					Chat.AddExamineMsgFromServer(interaction.Performer, $"You successfully transfer {amount} telecrystals into the {interaction.TargetObject.ExpensiveName()}");
 				}
 				else
 				{
@@ -42,7 +46,7 @@ namespace SyndicateOps
 				}
 			}
 		}
-	
+
 		public string Examine(Vector3 vector)
 		{
 			return $"It seems to have {SyndicateOpConsole.Instance.TcReserve} telecrystals in reserve";

--- a/UnityProject/Assets/Scripts/Objects/Consoles/SyndicateTelecrystalStation.cs
+++ b/UnityProject/Assets/Scripts/Objects/Consoles/SyndicateTelecrystalStation.cs
@@ -37,6 +37,7 @@ namespace SyndicateOps
 				{
 					var amount = Math.Min(TransferAmount, SyndicateOpConsole.Instance.TcReserve);
 					pdaComp.UplinkTC += amount;
+					pdaComp.UpdateTCCountGui();
 					SyndicateOpConsole.Instance.TcReserve -= amount;
 					Chat.AddExamineMsgFromServer(interaction.Performer, $"You successfully transfer {amount} telecrystals into the {interaction.TargetObject.ExpensiveName()}");
 				}


### PR DESCRIPTION
### Purpose
Changes the temp duck sprite from the syndie tc withdraw console to its proper one.
Fixes TC's not being transferred to the the player's PDA.
The withdraw console will now transfer 5 TC's per use.
Simplifies the syndicate war console code.
Fixes #7029

note: the pda uplink wont visually update the TC change after the transfer unless its closed and reopened, I have to wait for #7095 to get merged first.
