### PR TITLE
Chat fixes: no more fadeaways and properly colored action text.

### DIFF
--- a/UnityProject/Assets/Prefabs/UI/ActionText.prefab
+++ b/UnityProject/Assets/Prefabs/UI/ActionText.prefab
@@ -298,7 +298,7 @@ RectTransform:
   m_LocalScale: {x: 0.5, y: 0.5, z: 1}
   m_Children: []
   m_Father: {fileID: 1342098051280551072}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -432,7 +432,7 @@ RectTransform:
   m_LocalScale: {x: 0.5, y: 0.5, z: 1}
   m_Children: []
   m_Father: {fileID: 1342098051280551072}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -565,8 +565,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.014, y: 0.014, z: 1}
   m_Children:
-  - {fileID: 4255611843299778718}
   - {fileID: 6948691429242389416}
+  - {fileID: 4255611843299778718}
   - {fileID: 4075245203103321142}
   m_Father: {fileID: 0}
   m_RootOrder: 0

--- a/UnityProject/Assets/Scripts/Core/Chat/ChatEntry.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/ChatEntry.cs
@@ -101,6 +101,7 @@ public class ChatEntry : MonoBehaviour
 		stackObject.SetActive(false);
 		entryLayoutElement.minHeight = 20f;
 		messageText.raycastTarget = false;
+		AnimateFade(1f, 0f);
 	}
 
 	#endregion


### PR DESCRIPTION

### Purpose
- Should fix the bug in which messages only properly appear in chat once they activate twice.
- Action text is now white with a black background instead of being black with a white background.