### PR TITLE
Hotfix for facehuggers performance issues

### DIFF
--- a/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/Xenomorphs/Facehugger.prefab
+++ b/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/Xenomorphs/Facehugger.prefab
@@ -13,7 +13,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   mobName: facehugger
-  knockedDownRotation: 0
   deathSounds:
   - SetLoadSetting: 0
     AssetAddress: Assets/Prefabs/NPC/Facehugger.prefab
@@ -50,7 +49,7 @@ MonoBehaviour:
   performingDecision: 0
   performingAction: 0
   activated: 0
-  tickRate: 0.3
+  tickRate: 1
   FollowTarget: {fileID: 0}
   targetOtherPlayersWhoGetInWay: 1
   onlyActOnTarget: 0

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHuggerAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHuggerAI.cs
@@ -40,7 +40,7 @@ namespace Systems.MobAIs
 		/// <returns>Gameobject of the first player it found</returns>
 		protected override GameObject SearchForTarget()
 		{
-			var hits = coneOfSight.GetObjectsInSight(hitMask, LayerTypeSelection.Walls , directional.CurrentDirection.Vector, 10f, 20);
+			var hits = coneOfSight.GetObjectsInSight(hitMask, LayerTypeSelection.Walls , directional.CurrentDirection.Vector, 10f, 10);
 			if (hits.Count == 0)
 			{
 				return null;


### PR DESCRIPTION
### Purpose
Reduces the amount of raycasts that the facehugger search cone does from 20 to 10 and increases the tick rate from 0.3 to 1.

### Notes:
Consider this as a temporal fix for performance issues with facehuggers
