### PR TITLE
Fixes Facehuggers knocking off masks through helmets

### DIFF
--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHugAction.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHugAction.cs
@@ -134,8 +134,8 @@ namespace Systems.MobAIs
 		}
 		private readonly List<NamedSlot> faceSlots = new List<NamedSlot>()
 		{
-			NamedSlot.eyes,
 			NamedSlot.head,
+			NamedSlot.eyes,
 			NamedSlot.mask
 		};
 	}


### PR DESCRIPTION
### Purpose
Fixes the bug where facehuggers would knock off mask and eyewear through antifacehugger helmets

### Notes:
The almighty power of changing one line

### Changelog:
CL: [Fix] Fixes facehuggers knocking of mask and eyewear through helmets
