### PR TITLE
Fixes Facehugger not changing sprite after impregnation (#7132)

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Clothing/Maskwear/FacehuggerMask.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Maskwear/FacehuggerMask.prefab
@@ -20,6 +20,7 @@ MonoBehaviour:
   facehugger: {fileID: 3580619421430961846, guid: 28f0f699598b8074389bd2fecadaaf7a,
     type: 3}
   larvae: {fileID: 7455546943915704510, guid: 2ba8c4b90a981a94fb6946f53f09667f, type: 3}
+  spriteHandler: {fileID: 2752188463777155398}
 --- !u!1001 &1877733125468623936
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -64,6 +65,23 @@ PrefabInstance:
       propertyPath: PresentSpriteSet
       value: 
       objectReference: {fileID: 11400000, guid: 4aa643bb597b9cc4881cd70a3cdf8994,
+        type: 2}
+    - target: {fileID: 4341101185987976454, guid: 05a135eab68164d34bb02b82fff3cde0,
+        type: 3}
+      propertyPath: SubCatalogue.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4341101185987976454, guid: 05a135eab68164d34bb02b82fff3cde0,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 4aa643bb597b9cc4881cd70a3cdf8994,
+        type: 2}
+    - target: {fileID: 4341101185987976454, guid: 05a135eab68164d34bb02b82fff3cde0,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 191b489a5fd0fe543942fe52c7097879,
         type: 2}
     - target: {fileID: 7560587375320734517, guid: 05a135eab68164d34bb02b82fff3cde0,
         type: 3}
@@ -134,7 +152,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 4866054b12864074ca72678ebef13a7c,
+      objectReference: {fileID: 21300008, guid: 4866054b12864074ca72678ebef13a7c,
         type: 3}
     - target: {fileID: 8040391005062056419, guid: 05a135eab68164d34bb02b82fff3cde0,
         type: 3}

--- a/UnityProject/Assets/Scripts/Clothing/FacehuggerImpregnation.cs
+++ b/UnityProject/Assets/Scripts/Clothing/FacehuggerImpregnation.cs
@@ -27,17 +27,16 @@ namespace Clothing
 		[Tooltip("Reference to larvae gameObject so we can spawn it")] [SerializeField]
 		private GameObject larvae = null;
 
-		[Tooltip("The SpriteHandler the facehugger should use once it successfully impregnates a host")] [SerializeField]
-		private SpriteHandler spriteHandler = default;
-
 		private bool isAlive = true;
 		private ClothingV2 clothingV2;
 		private ItemAttributesV2 itemAttributesV2;
+		private SpriteHandler spriteHandler;
 
 		private void Awake()
 		{
 			clothingV2 = GetComponent<ClothingV2>();
 			itemAttributesV2 = GetComponent<ItemAttributesV2>();
+			spriteHandler = GetComponentInChildren<SpriteHandler>();
 		}
 
 		public override void OnStartServer()

--- a/UnityProject/Assets/Scripts/Clothing/FacehuggerImpregnation.cs
+++ b/UnityProject/Assets/Scripts/Clothing/FacehuggerImpregnation.cs
@@ -27,6 +27,9 @@ namespace Clothing
 		[Tooltip("Reference to larvae gameObject so we can spawn it")] [SerializeField]
 		private GameObject larvae = null;
 
+		[Tooltip("The SpriteHandler the facehugger should use once it successfully impregnates a host")] [SerializeField]
+		private SpriteHandler spriteHandler = default;
+
 		private bool isAlive = true;
 		private ClothingV2 clothingV2;
 		private ItemAttributesV2 itemAttributesV2;
@@ -49,6 +52,7 @@ namespace Clothing
 		public void KillHugger()
 		{
 			isAlive = false;
+			spriteHandler.ChangeSprite(1);
 			clothingV2.ChangeSprite(1);
 			itemAttributesV2.ServerSetArticleDescription("It is not moving anymore.");
 		}


### PR DESCRIPTION

### Purpose
Fixes  #7132 causing facehuggers to once again change sprites after they impregnate a host, the code was updating the clothing data but not the sprite itself

### Changelog:
CL: [Fix] Fixes a bug where facehuggers will still have their alive animation even after dying from impregnating a host.
