### PR TITLE
fixes Atmospheric Tiles randomly becoming empty for like a millisecond

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/Atmospherics/Air.asset
+++ b/UnityProject/Assets/ScriptableObjects/Atmospherics/Air.asset
@@ -16,10 +16,10 @@ MonoBehaviour:
     GasData:
       GasesArray:
       - GasSO: {fileID: 11400000, guid: d7d4e6085864f9f4e83593f63d102d08, type: 2}
-        Moles: 22
+        Moles: 20.785606
       - GasSO: {fileID: 11400000, guid: ac2834f2705dcbc4da8731a53d3076fc, type: 2}
-        Moles: 83
-    Pressure: 80.92114
+        Moles: 83.142426
+    Pressure: 102.370125
     Volume: 2.5
     Temperature: 293.15
   volumeOverride: 2.5

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSimulation.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSimulation.cs
@@ -301,8 +301,8 @@ namespace Systems.Atmospherics
 		/// <returns>The mean gas mix.</returns>
 		private void CalcMeanGasMix()
 		{
-			meanGasMix.Copy(GasMixes.BaseEmptyMix);
-
+			meanGasMix.Clear();
+			
 			var targetCount = 0;
 
 			for (var i = 0; i < nodes.Count; i++)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSimulation.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSimulation.cs
@@ -318,7 +318,7 @@ namespace Systems.Atmospherics
 				if (node.IsOccupied == false && node.IsIsolatedNode == false)
 				{
 					meanGasMix.Volume += node.GasMix.Volume;
-					GasMix.TransferGas(meanGasMix, node.GasMix, node.GasMix.Moles);
+					GasMix.TransferGas(meanGasMix, node.GasMix, node.GasMix.Moles, true);
 					targetCount++;
 				}
 				else if(node.IsIsolatedNode == false)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
@@ -418,5 +418,20 @@ namespace Systems.Atmospherics
 		{
 			return $"{Pressure} kPA, {Temperature} K, {Moles} mol, {Volume}m^3 ";
 		}
+
+		public void Clear()
+		{
+			Temperature = 2.7f;
+			for (int i = 0; i < GasData.GasesArray.Length; i++)
+			{
+				var gas = GasData.GasesArray[i];
+				gas.Moles = 0;
+				GasData.GasesArray[i] = gas;
+			}
+			GasData.GasesArray = new GasValues[0];
+			GasData.GasesDict.Clear();
+			Pressure = 0;
+			Volume = 0;
+		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
@@ -421,13 +421,8 @@ namespace Systems.Atmospherics
 
 		public void Clear()
 		{
-			Temperature = 2.7f;
-			for (int i = 0; i < GasData.GasesArray.Length; i++)
-			{
-				var gas = GasData.GasesArray[i];
-				gas.Moles = 0;
-				GasData.GasesArray[i] = gas;
-			}
+			Temperature = AtmosDefines.SPACE_TEMPERATURE;
+
 			GasData.GasesArray = new GasValues[0];
 			GasData.GasesDict.Clear();
 			Pressure = 0;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
@@ -157,7 +157,7 @@ namespace Systems.Atmospherics
 		/// <summary>
 		/// Transfers moles from one gas to another
 		/// </summary>
-		public static void TransferGas(GasMix target, GasMix source, float molesToTransfer)
+		public static void TransferGas(GasMix target, GasMix source, float molesToTransfer, bool DoNotTouchOriginalMix = false)
 		{
 			var sourceStartMoles = source.Moles;
 			molesToTransfer = molesToTransfer.Clamp(0, sourceStartMoles);
@@ -178,8 +178,12 @@ namespace Systems.Atmospherics
 				//Add to target
 				target.GasData.ChangeMoles(gas.GasSO, transfer);
 
-				//Remove from source
-				source.GasData.ChangeMoles(gas.GasSO, -transfer);
+				if (DoNotTouchOriginalMix)
+				{
+					//Remove from source
+					source.GasData.ChangeMoles(gas.GasSO, -transfer);
+				}
+
 			}
 
 			if (CodeUtilities.IsEqual(target.Temperature, source.Temperature))


### PR DESCRIPTION
this was done by not modifying the tile data until it was fully Calculated, 
also reduces GC on atmospheric slightly