### PR TITLE
Fixed a wrong SO unit test output. Some vars in the test were renamed

### DIFF
--- a/UnityProject/Assets/Tests/Asset/MissingAssetReferences.cs
+++ b/UnityProject/Assets/Tests/Asset/MissingAssetReferences.cs
@@ -99,30 +99,30 @@ namespace Tests
 		/// <summary>
 		/// Check if there are scriptable objects that lost their script
 		/// </summary>
-		private void CheckMissingScriptableObjects(string path)
+		private void CheckMissingScriptableObjects(string sourceFolderPath)
 		{
 			// Get all assets paths
 			var allResourcesPaths = AssetDatabase.GetAllAssetPaths()
-				.Where(p => p.Contains(path));
+				.Where(p => p.Contains(sourceFolderPath));
 
 			// Find all .asset (almost always it is SO)
-			var allAssetPaths = allResourcesPaths.Where((a) => a.EndsWith(".asset")).ToArray();
+			var allAssetPaths = allResourcesPaths.Where(path => path.EndsWith(".asset")).ToArray();
 
 			var listResults = new List<string>();
-			foreach (var lookUpPath in allAssetPaths)
+			foreach (var assetFilePath in allAssetPaths)
 			{
-				var asset = AssetDatabase.LoadMainAssetAtPath(lookUpPath);
+				var asset = AssetDatabase.LoadMainAssetAtPath(assetFilePath);
 
 				// if we can't load it - something bad happend with SO
 				if (!asset)
-					listResults.Add(path);
+					listResults.Add(assetFilePath);
 			}
 
 			// Form report
 			var report = new StringBuilder();
-			foreach (string s in listResults)
+			foreach (string brokenAssetFilePath in listResults)
 			{
-				var fileName = Path.GetFileName(s);
+				var fileName = Path.GetFileName(brokenAssetFilePath);
 				var msg = $"Can't load asset {fileName}. Maybe linked ScriptableObject script is missing?";
 				Logger.Log(msg, Category.Tests);
 				report.AppendLine(msg);


### PR DESCRIPTION
Fixed SO unit test outputing a wrong path(a folder path instead of broken asset path):

![image](https://user-images.githubusercontent.com/42589308/127750314-b9e430ae-3755-4aef-899d-ffd8558f91bf.png)

![image](https://user-images.githubusercontent.com/42589308/127750317-953932ca-54f1-47e2-b540-2f284982a0b6.png)

Additionaly, some vars were renamed in order to avoid such confusion in the future.