### PR TITLE
Make it obvious if a player is disconnect/invalid instead of just "Kek"

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/ConnectedPlayer.cs
+++ b/UnityProject/Assets/Scripts/Managers/ConnectedPlayer.cs
@@ -16,7 +16,7 @@ public class ConnectedPlayer
 		Connection = null,
 		gameObject = null,
 		Username = null,
-		name = "kek",
+		name = "Invalid Player",
 		job = JobType.NULL,
 		ClientId = "",
 		UserId = ""


### PR DESCRIPTION
### Purpose
Disconnected/invalid players are given the name "Kek", which is confusing as hell and makes no sense in admin logs.
This fixes kek, and makes the name more informative.

### Notes:
<!-- Please enter any other relevant information here -->

### Changelog:
CL: [Fix] No more fake players names kek
