### PR TITLE
Adds Emag text feedback in chat

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Cards/Emag.cs
+++ b/UnityProject/Assets/Scripts/Items/Cards/Emag.cs
@@ -101,6 +101,10 @@ namespace Items
 		/// </summary>
 		public bool UseCharge(HandApply interaction)
 		{
+			Chat.AddActionMsgToChat(interaction,
+					$"You wave the Emag over the {interaction.TargetObject.ExpensiveName()}'s electrical panel.",
+						$"{interaction.Performer.ExpensiveName()} waves something over the {interaction.TargetObject.ExpensiveName()}'s electrical panel.");
+
 			if (Charges > 0)
 			{
 				//if this is the first charge taken off, add recharge loop

--- a/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
@@ -561,8 +561,12 @@ namespace Objects
 					AudioSourceParameters audioSourceParameters = new AudioSourceParameters(pitch: 1f);
 					SoundManager.PlayNetworkedAtPos(soundOnEmag, registerTile.WorldPositionServer, audioSourceParameters, gameObject);
 					//ServerHandleContentsOnStatusChange(false);
+
 					isEmagged = true;
 					emag.UseCharge(interaction);
+					Chat.AddActionMsgToChat(interaction,
+						"The access panel errors. A slight amount of smoke pours from behind the panel...",
+								"You can smell caustic smoke from somewhere...");
 
 					//SyncStatus(statusSync, ClosetStatus.Open);
 					BreakLock();

--- a/UnityProject/Assets/Scripts/Objects/Doors/InteractableDoor.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/InteractableDoor.cs
@@ -108,11 +108,9 @@ namespace Doors
 
 			if (Controller.IsClosed)
 			{
-
 				Controller.isEmagged = true;
 				emag.UseCharge(interaction);
 				TryOpen(interaction.Performer);
-
 				Chat.AddActionMsgToChat(interaction,
 					"The access panel errors. A slight amount of smoke pours from behind the panel...",
 							"You can smell caustic smoke from somewhere...");

--- a/UnityProject/Assets/Scripts/Objects/Doors/InteractableDoor.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/InteractableDoor.cs
@@ -108,9 +108,14 @@ namespace Doors
 
 			if (Controller.IsClosed)
 			{
+
 				Controller.isEmagged = true;
 				emag.UseCharge(interaction);
 				TryOpen(interaction.Performer);
+
+				Chat.AddActionMsgToChat(interaction,
+					"The access panel errors. A slight amount of smoke pours from behind the panel...",
+							"You can smell caustic smoke from somewhere...");
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/Drawers/Morgue.cs
+++ b/UnityProject/Assets/Scripts/Objects/Drawers/Morgue.cs
@@ -2,6 +2,7 @@
 using UnityEngine;
 using AddressableReferences;
 using HealthV2;
+using Items;
 
 namespace Objects.Drawers
 {
@@ -59,7 +60,12 @@ namespace Objects.Drawers
 		public override void ServerPerformInteraction(HandApply interaction)
 		{
 			if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Screwdriver)) UseScrewdriver(interaction);
-			else if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Emag)) UseEmag(interaction);
+			else if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Emag)
+				&& interaction.HandObject.TryGetComponent<Emag>(out var emag)
+				&& emag.EmagHasCharges())
+			{
+				UseEmag(emag, interaction);
+			}
 			else if (drawerState == DrawerState.Open) CloseDrawer();
 			else OpenDrawer();
 		}
@@ -122,14 +128,14 @@ namespace Objects.Drawers
 					() => ToggleBuzzer());
 		}
 
-		private void UseEmag(HandApply interaction)
+		private void UseEmag(Emag emag, HandApply interaction)
 		{
 #pragma warning disable CS0162 // Unreachable code detected
 			if (!ALARM_SYSTEM_ENABLED || !ALLOW_EMAGGING) return;
 #pragma warning restore CS0162 // Unreachable code detected
 			if (alarmBroken) return;
 			alarmBroken = true;
-
+			emag.UseCharge(interaction);
 			Chat.AddActionMsgToChat(interaction,
 					"The status panel flickers and the buzzer makes sickly popping noises. You can smell smoke...",
 							"You can smell caustic smoke from somewhere...");

--- a/UnityProject/Assets/Scripts/Objects/Drawers/Morgue.cs
+++ b/UnityProject/Assets/Scripts/Objects/Drawers/Morgue.cs
@@ -131,9 +131,8 @@ namespace Objects.Drawers
 			alarmBroken = true;
 
 			Chat.AddActionMsgToChat(interaction,
-					$"You wave the {interaction.HandObject.name.ToLower()} over the {name.ToLower()}'s electrical panel. " +
 					"The status panel flickers and the buzzer makes sickly popping noises. You can smell smoke...",
-					"You can smell caustic smoke from somewhere...");
+							"You can smell caustic smoke from somewhere...");
 			SoundManager.PlayNetworkedAtPos(emaggedSound, DrawerWorldPosition, sourceObj: gameObject);
 			StartCoroutine(PlayEmagAnimation());
 		}

--- a/UnityProject/Assets/Scripts/Objects/Vendor.cs
+++ b/UnityProject/Assets/Scripts/Objects/Vendor.cs
@@ -106,7 +106,6 @@ namespace Objects
 			{
 				isEmagged = true;
 				emag.UseCharge(interaction);
-
 				Chat.AddActionMsgToChat(interaction,
 					"The product lock shorts out. light fumes pour from the dispenser...",
 							"You can smell caustic smoke from somewhere...");

--- a/UnityProject/Assets/Scripts/Objects/Vendor.cs
+++ b/UnityProject/Assets/Scripts/Objects/Vendor.cs
@@ -106,6 +106,10 @@ namespace Objects
 			{
 				isEmagged = true;
 				emag.UseCharge(interaction);
+
+				Chat.AddActionMsgToChat(interaction,
+					"The product lock shorts out. light fumes pour from the dispenser...",
+							"You can smell caustic smoke from somewhere...");
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Robotics/Bots/InteractableBot.cs
+++ b/UnityProject/Assets/Scripts/Robotics/Bots/InteractableBot.cs
@@ -49,6 +49,9 @@ namespace Robotics
 
 			MobController.IsEmagged = true;
 			emag.UseCharge(interaction);
+			Chat.AddActionMsgToChat(interaction,
+					"The bot's behavior controls disengage. The bot begins to rattle and smolder",
+							"You can smell caustic smoke from somewhere...");
 
 			if (spriteHandler == null)
 			{

--- a/UnityProject/Assets/Scripts/Shuttles/EscapeShuttleConsole.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/EscapeShuttleConsole.cs
@@ -41,7 +41,7 @@ namespace Objects
 		{
 			if (beenEmagged)
 			{
-				Chat.AddExamineMsgFromServer(interaction.Performer, "The shuttle has already been hacked!");
+				Chat.AddExamineMsgFromServer(interaction.Performer, "The shuttle has already been Emagged!");
 				return;
 			}
 


### PR DESCRIPTION
### Purpose

This PR adds text feedback for when an Emag is used; closes #6687. In addition, more objects have flavor text for when they are emagged.

### Changelog:

CL: [Improvement] Emags give recognizable chat alerts to those nearby when used.

