### PR TITLE
Atmospheric analyzer is now small.

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Tools/AtmosphericAnalyzer.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/AtmosphericAnalyzer.prefab
@@ -121,6 +121,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
+      propertyPath: initialSize
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
       propertyPath: initialDescription
       value: A hand-held environmental scanner which reports current gas levels.
         Alt-Click to use the built in barometer function.


### PR DESCRIPTION
### Purpose
- Title. The atmospherics analyzer is now small and can fit in your pocket. Done to make it consistent with the health analyzer and the various engineering tools.