### PR TITLE
Convert coordinate conversion methods to static

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
@@ -622,7 +622,7 @@ public partial class MatrixManager : MonoBehaviour
 	public static InteractableDoor GetClosedDoorAt(Vector3Int worldOrigin, Vector3Int targetPos, bool isServer)
 	{
 		// Check door on the local tile first
-		Vector3Int localTarget = Instance.WorldToLocalInt(targetPos, AtPoint(targetPos, isServer).Matrix);
+		Vector3Int localTarget = WorldToLocalInt(targetPos, AtPoint(targetPos, isServer).Matrix);
 		var originDoorList = GetAt<InteractableDoor>(worldOrigin, isServer);
 		foreach (InteractableDoor originDoor in originDoorList)
 		{
@@ -631,7 +631,7 @@ public partial class MatrixManager : MonoBehaviour
 		}
 
 		// No closed door on local tile, check target tile
-		Vector3Int localOrigin = Instance.WorldToLocalInt(worldOrigin, AtPoint(worldOrigin, isServer).Matrix);
+		Vector3Int localOrigin = WorldToLocalInt(worldOrigin, AtPoint(worldOrigin, isServer).Matrix);
 		var targetDoorList = GetAt<InteractableDoor>(targetPos, isServer);
 		foreach (InteractableDoor targetDoor in targetDoorList)
 		{
@@ -647,7 +647,7 @@ public partial class MatrixManager : MonoBehaviour
 	public static DoorMasterController GetNewClosedDoorAt(Vector3Int worldOrigin, Vector3Int targetPos, bool isServer)
 	{
 		// Check door on the local tile first
-		Vector3Int localTarget = Instance.WorldToLocalInt(targetPos, AtPoint(targetPos, isServer).Matrix);
+		Vector3Int localTarget = WorldToLocalInt(targetPos, AtPoint(targetPos, isServer).Matrix);
 		var originDoorList = GetAt<DoorMasterController>(worldOrigin, isServer);
 		foreach (DoorMasterController originDoor in originDoorList)
 		{
@@ -656,7 +656,7 @@ public partial class MatrixManager : MonoBehaviour
 		}
 
 		// No closed door on local tile, check target tile
-		Vector3Int localOrigin = Instance.WorldToLocalInt(worldOrigin, AtPoint(worldOrigin, isServer).Matrix);
+		Vector3Int localOrigin = WorldToLocalInt(worldOrigin, AtPoint(worldOrigin, isServer).Matrix);
 		var targetDoorList = GetAt<DoorMasterController>(targetPos, isServer);
 		foreach (DoorMasterController targetDoor in targetDoorList)
 		{
@@ -734,7 +734,7 @@ public partial class MatrixManager : MonoBehaviour
 	private static void GetPushablesOneTile(ref List<PushPull> pushableList, Vector3Int pushableLocation, Vector2Int dir, GameObject pusher, bool isServer,
 		bool ignoreNonBlockable, bool isLeaving)
 	{
-		Vector3Int localPushableLocation = Instance.WorldToLocalInt(pushableLocation, AtPoint(pushableLocation, isServer).Matrix);
+		Vector3Int localPushableLocation = WorldToLocalInt(pushableLocation, AtPoint(pushableLocation, isServer).Matrix);
 		foreach (PushPull pushPull in GetAt<PushPull>(pushableLocation, isServer))
 		{
 			if (pushPull == null || pushPull.gameObject == pusher) continue;
@@ -1099,26 +1099,30 @@ public partial class MatrixManager : MonoBehaviour
 		return returnList;
 	}
 
-	/// Convert local matrix coordinates to world position. Keeps offsets in mind (+ rotation and pivot if MatrixMove is present)
-	public Vector3Int LocalToWorldInt(Vector3 localPos, Matrix matrix)
+	/// <summary>
+	/// <inheritdoc cref="LocalToWorld(Vector3, Matrix)"/>
+	/// <para>Rounds to <c>Vector3Int</c>.</para>
+	/// </summary>
+	public static Vector3Int LocalToWorldInt(Vector3 localPos, Matrix matrix)
 	{
 		return LocalToWorldInt(localPos, Get(matrix));
 	}
 
-	/// Convert local matrix coordinates to world position. Keeps offsets in mind (+ rotation and pivot if MatrixMove is present)
-	public static Vector3Int LocalToWorldInt(Vector3 localPos, MatrixInfo matrix,
-		MatrixState state = default(MatrixState))
+	/// <inheritdoc cref="LocalToWorldInt(Vector3, Matrix)"/>
+	public static Vector3Int LocalToWorldInt(Vector3 localPos, MatrixInfo matrix, MatrixState state = default(MatrixState))
 	{
 		return Vector3Int.RoundToInt(LocalToWorld(localPos, matrix, state));
 	}
 
+	/// <summary>
 	/// Convert local matrix coordinates to world position. Keeps offsets in mind (+ rotation and pivot if MatrixMove is present)
+	/// </summary>
 	public static Vector3 LocalToWorld(Vector3 localPos, Matrix matrix)
 	{
 		return LocalToWorld(localPos, Get(matrix));
 	}
 
-	/// Convert local matrix coordinates to world position. Keeps offsets in mind (+ rotation and pivot if MatrixMove is present)
+	/// <inheritdoc cref="LocalToWorld(Vector3, Matrix)"/>
 	public static Vector3 LocalToWorld(Vector3 localPos, MatrixInfo matrix, MatrixState state = default(MatrixState))
 	{
 		//Invalid matrix info provided
@@ -1148,8 +1152,8 @@ public partial class MatrixManager : MonoBehaviour
 			matrix.GetOffset(state); //adding back localPivot and applying localToWorldOffset
 		return rotatedPivoted;
 	}
-
-	/// Convert world position to local matrix coordinates. Keeps offsets in mind (+ rotation and pivot if MatrixMove is present)
+ 
+	/// <inheritdoc cref="WorldToLocal(Vector3, Matrix)"/>
 	public static Vector3 WorldToLocal(Vector3 worldPos, MatrixInfo matrix)
 	{
 		// Invalid matrix info provided
@@ -1169,26 +1173,31 @@ public partial class MatrixManager : MonoBehaviour
 				(worldPos - matrix.MatrixMove.Pivot - matrix.GetOffset(state))) + matrix.MatrixMove.Pivot;
 	}
 
-	/// Convert world position to local matrix coordinates. Keeps offsets in mind (+ rotation and pivot if MatrixMove is present)
+	/// <summary>
+	/// <inheritdoc cref="WorldToLocal(Vector3, Matrix)"/>
+	/// <para>Rounds to <c>Vector3Int</c>.</para>
+	/// </summary>
 	public static Vector3Int WorldToLocalInt(Vector3 worldPos, int id)
 	{
 		return WorldToLocalInt(worldPos, Get(id));
 	}
 
-	/// Convert world position to local matrix coordinates. Keeps offsets in mind (+ rotation and pivot if MatrixMove is present)
-	public Vector3Int WorldToLocalInt(Vector3 worldPos, Matrix matrix)
+	/// <inheritdoc cref="WorldToLocalInt(Vector3, int)"/>
+	public static Vector3Int WorldToLocalInt(Vector3 worldPos, Matrix matrix)
 	{
 		return WorldToLocalInt(worldPos, Get(matrix));
 	}
 
-	/// Convert world position to local matrix coordinates. Keeps offsets in mind (+ rotation and pivot if MatrixMove is present)
+	/// <inheritdoc cref="WorldToLocalInt(Vector3, int)"/>
 	public static Vector3Int WorldToLocalInt(Vector3 worldPos, MatrixInfo matrix)
 	{
 		return Vector3Int.RoundToInt(WorldToLocal(worldPos, matrix));
 	}
 
+	/// <summary>
 	/// Convert world position to local matrix coordinates. Keeps offsets in mind (+ rotation and pivot if MatrixMove is present)
-	public Vector3 WorldToLocal(Vector3 worldPos, Matrix matrix)
+	/// </summary>
+	public static Vector3 WorldToLocal(Vector3 worldPos, Matrix matrix)
 	{
 		return WorldToLocal(worldPos, Get(matrix));
 	}

--- a/UnityProject/Assets/Scripts/Objects/Mining/OreRedemptionMachine.cs
+++ b/UnityProject/Assets/Scripts/Objects/Mining/OreRedemptionMachine.cs
@@ -66,7 +66,7 @@ namespace Objects.Mining
 		}
 		public void ServerPerformInteraction(HandApply interaction)
 		{
-			var localPosInt = MatrixManager.Instance.WorldToLocalInt(registerObject.WorldPositionServer, registerObject.Matrix);
+			var localPosInt = MatrixManager.WorldToLocalInt(registerObject.WorldPositionServer, registerObject.Matrix);
 			var itemsOnFloor = registerObject.Matrix.Get<ItemAttributesV2>(localPosInt + Vector3Int.up, true);
 
 			if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.OreGeneral))

--- a/UnityProject/Assets/Scripts/Objects/Singularity.cs
+++ b/UnityProject/Assets/Scripts/Objects/Singularity.cs
@@ -425,7 +425,7 @@ namespace Objects
 			{
 				var matrixInfo = MatrixManager.AtPoint(coord, true);
 
-				var cellPos = MatrixManager.Instance.WorldToLocalInt(coord, matrixInfo.Matrix);
+				var cellPos = MatrixManager.WorldToLocalInt(coord, matrixInfo.Matrix);
 
 				var layerTile = matrixInfo.TileChangeManager.MetaTileMap
 					.GetTile(MatrixManager.WorldToLocalInt(coord, matrixInfo), LayerType.Walls);

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
@@ -170,8 +170,8 @@ public class RegisterTile : NetworkBehaviour, IServerDespawn
 	/// </summary>
 	public Vector3Int WorldPosition => isServer ? WorldPositionServer : WorldPositionClient;
 
-	public Vector3Int WorldPositionServer => MatrixManager.Instance.LocalToWorldInt(serverLocalPosition, Matrix);
-	public Vector3Int WorldPositionClient => MatrixManager.Instance.LocalToWorldInt(clientLocalPosition, Matrix);
+	public Vector3Int WorldPositionServer => MatrixManager.LocalToWorldInt(serverLocalPosition, Matrix);
+	public Vector3Int WorldPositionClient => MatrixManager.LocalToWorldInt(clientLocalPosition, Matrix);
 
 	/// <summary>
 	/// Registered local position of this object. Returns correct value depending on if this is on the


### PR DESCRIPTION
- Converts `MatrixManager` coordinate conversion methods to static.
- Converts method comments to documentation.