### PR TITLE
Fix Examination

### DIFF
--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemSlot.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemSlot.cs
@@ -299,10 +299,14 @@ public class UI_ItemSlot : TooltipMonoBehaviour
 		{
 			placeholderImage.color = Color.white;
 		}
+		
+		if (HasSubInventory)
+		{
+			HasSubInventory.itemStorage = null;
+		}
 
 		if (MoreInventoryImage)
 		{
-			HasSubInventory.itemStorage = null;
 			MoreInventoryImage.enabled = false;
 		}
 	}

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemSlot.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemSlot.cs
@@ -289,7 +289,7 @@ public class UI_ItemSlot : TooltipMonoBehaviour
 			return;
 		}
 
-		image.ClearAll();
+		image?.ClearAll();
 		if (amountText)
 		{
 			amountText.enabled = false;


### PR DESCRIPTION
Fixes #7189

~Havent tested but seems like the logical fix based on the only thing which could be null in Clear() being HasSubInventory and there are assets which have it null.~

Turns out it was the image being null, awake doesnt seem to be firing. Could be caused by the gameobject being disabled and functions still being called for it.

```
System.NullReferenceException: Object reference not set to an instance of an object
  at UI_ItemSlot.Clear () [0x0000d] in <2490596971144ec18a541d106c69b4ba>:0 
  at UI_ItemSlot.UpdateImage (UnityEngine.GameObject item, System.Nullable`1[T] color) [0x0015d] in <2490596971144ec18a541d106c69b4ba>:0 
  at UI_ItemSlot.RefreshImage () [0x0000f] in <2490596971144ec18a541d106c69b4ba>:0 
  at UI_ItemSlot.LinkSlot (ItemSlot linkedSlot) [0x00067] in <2490596971144ec18a541d106c69b4ba>:0 
  at UI.PlayerExaminationWindowSlot.SetUp (HealthV2.BodyPartUISlots+StorageCharacteristics StorageCharacteristics, ItemSlot ItemSlot, UI.Core.PlayerExaminationWindowUI toset) [0x00006] in <2490596971144ec18a541d106c69b4ba>:0 
  at UI.Core.PlayerExaminationWindowUI.ExaminePlayer (DynamicItemStorage itemStorage, System.String visibleName, System.String species, System.String job, System.String status, System.String additionalInformation) [0x000e0] in <2490596971144ec18a541d106c69b4ba>:0 
  at PlayerExaminationMessage.Process (PlayerExaminationMessage+NetMessage msg) [0x00064] in <2490596971144ec18a541d106c69b4ba>:0 
  at Messages.GameMessageBase`1[T].Process (Mirror.NetworkConnection sentBy, T msg) [0x00000] in <2490596971144ec18a541d106c69b4ba>:0 
```

![image](https://user-images.githubusercontent.com/56727168/128363477-cba9fe93-46ab-443e-9425-e973eb19ebfe.png)
