### PR TITLE
Move trauma damage code into it's own file + cleans up the code a little bit

### DIFF
--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
@@ -70,87 +70,7 @@ namespace HealthV2
 		/// </summary>
 		[HideInInspector] public DamageSeverity Severity = DamageSeverity.LightModerate;
 
-		/// <summary>
-		/// How much damage can this body part last before it breaks/gibs/Disembowles?
-		/// <summary>
-		public float DamageThreshold = 18f;
-		public DamageSeverity GibsOnSeverityLevel = DamageSeverity.Max;
-		public float GibChance = 0.15f;
-
-		/// <summary>
-		/// When does this body part take before it's contents in it's storage spill out?
-		/// </summary>
-		[SerializeField,
-		Tooltip("When does the contents of this body part's storage to spill out when a large enough cut exists?")]
-		private BodyPartCutSize BodyPartStorageContentsSpillOutOnCutSize = BodyPartCutSize.LARGE;
-
-		/// <summary>
-		/// When do we start applying Slash logic?
-		/// </summary>
-		[SerializeField,
-		Tooltip("At what cut size do we start applying slash logic?")]
-		private BodyPartCutSize BodyPartSlashLogicOnCutSize = BodyPartCutSize.SMALL;
-
-		/// <summary>
-		/// When do we start applying disembowel logic?
-		/// </summary>
-		[SerializeField,
-		Tooltip("At what cut size do we start applying disembowel logic?")]
-		private BodyPartCutSize BodyPartDisembowelLogicOnCutSize = BodyPartCutSize.MEDIUM;
-
-		/// <summary>
-		/// How likely does the contents of this body part's storage to spill out?
-		/// </summary>
-		[SerializeField,
-		Tooltip("How likely does the contents of this body part's storage to spill out when a large enough cut exists?"),
-		Range(0,1.0f)]
-		private float spillChanceWhenCutPresent = 0.5f;
-
-		/// <summary>
-		/// Does this body part have a cut and how big is it?
-		/// </summary>
-		private BodyPartCutSize currentCutSize = BodyPartCutSize.NONE;
-
-		public bool CanBleedInternally = false;
-
-		public bool CanBleedExternally = false;
-
-		[SerializeField] private bool gibsEntireBodyOnRemoval = false;
-
-		private bool isBleedingInternally = false;
-
-		private bool isBleedingExternally = false;
-
-		public bool IsBleedingInternally => isBleedingInternally;
-
-		public bool IsBleedingExternally => isBleedingExternally;
-
-		public Vector2 MinMaxInternalBleedingValues = new Vector2(5, 20);
-
-
-		[SerializeField] private float maximumInternalBleedDamage = 100;
-		public float InternalBleedingBloodLoss = 12;
-		public float ExternalBleedingBloodLoss = 6;
-
-		[SerializeField, Range(0.2f, 4.25f)] private float baseTraumaDamageMultiplier = 0.25f;
-
-		public float MaximumInternalBleedDamage => maximumInternalBleedDamage;
-
-		private float currentInternalBleedingDamage = 0;
-
-		[SerializeField]
-		private Color bodyPartColorWhenCharred = Color.black;
-
-		private float currentSlashCutDamage = 0;
-		private float currentPierceDamage   = 0;
-		private float currentBurnDamage     = 0;
-
-		[SerializeField] private float bodyPartAshesAboveThisDamage = 125;
-		public float BodyPartAshesAboveThisDamage => bodyPartAshesAboveThisDamage;
-
-		private PierceDamageLevel currentPierceDamageLevel = PierceDamageLevel.NONE;
-		private SlashDamageLevel currentSlashDamageLevel = SlashDamageLevel.NONE;
-		private BurnDamageLevels currentBurnDamageLevel = BurnDamageLevels.NONE;
+		
 
 		/// <summary>
 		/// Toxin damage taken
@@ -273,6 +193,11 @@ namespace HealthV2
 			}
 		}
 
+		public void DamageInitialisation()
+		{
+			this.AddModifier(DamageModifier);
+		}
+
 		/// <summary>
 		/// Adjusts the appropriate damage type by the given damage amount and updates body part
 		/// functionality based on its new health total
@@ -301,8 +226,15 @@ namespace HealthV2
 		/// <param name="attackType">Type of attack that is causing the damage</param>
 		/// <param name="damageType">The type of damage</param>
 		/// <param name="damageSplit">Should the damage be divided amongst the contained body parts or applied to a random body part</param>
-		public void TakeDamage(GameObject damagedBy, float damage, AttackType attackType, DamageType damageType,
-								bool damageSplit = false, bool DamageSubOrgans = true, float armorPenetration = 0)
+		public void TakeDamage(
+			GameObject damagedBy,
+			float damage,
+			AttackType attackType,
+			DamageType damageType,
+			bool damageSplit = false,
+			bool DamageSubOrgans = true,
+			float armorPenetration = 0
+		)
 		{
 			float damageToLimb = Armor.GetTotalDamage(
 				SelfArmor.GetDamage(damage, attackType, armorPenetration),
@@ -314,31 +246,33 @@ namespace HealthV2
 
 			// May be changed to individual damage
 			// May also want it so it can miss sub organs
-			if (DamageSubOrgans && OrganList.Count > 0)
+			if (DamageSubOrgans)
 			{
-				var organDamageRatingValue = SubOrganBodyPartArmour.GetRatingValue(attackType, armorPenetration);
-				if (maxHealth - Damages[(int) damageType] < SubOrganDamageIncreasePoint)
+				if (ContainBodyParts.Count > 0)
 				{
-					organDamageRatingValue +=
-						1 - ((maxHealth - Damages[(int) damageType]) / SubOrganDamageIncreasePoint);
-					organDamageRatingValue = Math.Min(1, organDamageRatingValue);
-				}
-
-				var subDamage = damage * organDamageRatingValue;
-
-				//TODO: remove BodyPart component from organ
-				if (damageSplit)
-				{
-					foreach (var organ in OrganList)
+					var organDamageRatingValue = SubOrganBodyPartArmour.GetRatingValue(attackType, armorPenetration);
+					if (maxHealth - Damages[(int) damageType] < SubOrganDamageIncreasePoint)
 					{
-						var organBodyPart = organ.GetComponent<BodyPart>();
-						organBodyPart.TakeDamage(damagedBy, subDamage / OrganList.Count, attackType, damageType, damageSplit);
+						organDamageRatingValue +=
+							1 - ((maxHealth - Damages[(int) damageType]) / SubOrganDamageIncreasePoint);
+						organDamageRatingValue = Math.Min(1, organDamageRatingValue);
 					}
-				}
-				else
-				{
-					var organBodyPart = OrganList.PickRandom().GetComponent<BodyPart>(); //It's not like you can aim for Someone's liver can you
-					organBodyPart.TakeDamage(damagedBy, subDamage, attackType, damageType);
+
+					var subDamage = damage * organDamageRatingValue;
+					if (damageSplit)
+					{
+						foreach (var bodyPart in ContainBodyParts)
+						{
+							bodyPart.TakeDamage(damagedBy, subDamage / ContainBodyParts.Count, attackType, damageType,
+								damageSplit);
+						}
+					}
+					else
+					{
+						var OrganToDamage =
+							ContainBodyParts.PickRandom(); //It's not like you can aim for Someone's liver can you
+						OrganToDamage.TakeDamage(damagedBy, subDamage, attackType, damageType);
+					}
 				}
 			}
 			if(damageType == DamageType.Brute) //Check damage type to avoid bugs where you can blow someone's head off with a shoe.
@@ -484,350 +418,11 @@ namespace HealthV2
 				Severity = DamageSeverity.Max;
 			}
 
-			if (DamageContributesToOverallHealth && oldSeverity != Severity && HealthMaster != null)
+			if (DamageContributesToOverallHealth && oldSeverity != Severity && healthMaster != null)
 			{
 				UpdateIcons();
 			}
 		}
-
-		/// <summary>
-		/// Checks if the bodypart is damaged to a point where it can be gibbed from the body
-		/// </summary>
-		protected void CheckBodyPartIntigrity(float lastDamage)
-		{
-			if(currentCutSize >= BodyPartSlashLogicOnCutSize)
-			{
-				if(OrganList.Count != 0)
-				{
-					Disembowel();
-				}
-			}
-			if(Severity >= GibsOnSeverityLevel && lastDamage >= DamageThreshold)
-			{
-				DismemberBodyPartWithChance();
-			}
-		}
-
-		/// <summary>
-		/// Applies trauma damage to the body part, checks if it has enough protective armor to cancel the trauma damage
-		/// and automatically checks how big is the body part's cut size.
-		/// </summary>
-		public void ApplyTraumaDamage(float tramuaDamage, TraumaticDamageTypes damageType = TraumaticDamageTypes.SLASH)
-		{
-			//We use dismember protection chance because it's the most logical value.
-			if(DMMath.Prob(SelfArmor.DismembermentProtectionChance * 100) == false)
-			{
-				if (damageType == TraumaticDamageTypes.SLASH) { currentSlashCutDamage += MultiplyTraumaDamage(tramuaDamage); }
-				if (damageType == TraumaticDamageTypes.PIERCE) { currentPierceDamage += MultiplyTraumaDamage(tramuaDamage); }
-				CheckCutSize();
-			}
-			//Burn damage checks for it's own armor damage type.
-			if (damageType == TraumaticDamageTypes.BURN)
-			{
-				TakeBurnDamage(MultiplyTraumaDamage(tramuaDamage));
-			}
-		}
-
-		private float MultiplyTraumaDamage(float baseDamage)
-		{
-			if (currentBurnDamageLevel >= BurnDamageLevels.CHARRED || currentCutSize >= BodyPartCutSize.LARGE
-			|| Severity >= DamageSeverity.Critical)
-			{
-				return baseDamage * (baseTraumaDamageMultiplier + 0.25f);
-			}
-			else if (currentBurnDamageLevel >= BurnDamageLevels.MAJOR || currentCutSize >= BodyPartCutSize.MEDIUM
-			|| Severity >= DamageSeverity.Bad)
-			{
-				return baseDamage * (baseTraumaDamageMultiplier + 0.15f);
-			}
-			else if (currentBurnDamageLevel >= BurnDamageLevels.MINOR || currentCutSize >= BodyPartCutSize.SMALL
-			|| Severity >= DamageSeverity.LightModerate)
-			{
-				return baseDamage * baseTraumaDamageMultiplier;
-			}
-			else
-			{
-				return baseDamage;
-			}
-		}
-
-			[ContextMenu("Debug - Apply 25 Slash Damage")]
-		private void DEBUG_ApplyTestSlash()
-		{
-			ApplyTraumaDamage(25);
-		}
-
-		[ContextMenu("Debug - Apply 25 Pierce Damage")]
-		private void DEBUG_ApplyTestPierce()
-		{
-			ApplyTraumaDamage(25, TraumaticDamageTypes.PIERCE);
-		}
-
-		/// <summary>
-		/// Checks how big is the cut is right now.
-		/// </summary>
-		private void CheckCutSize()
-		{
-			if(currentSlashCutDamage <= 0)
-			{
-				currentCutSize = BodyPartCutSize.NONE;
-			}
-			else if(currentSlashCutDamage > 75)
-			{
-				currentCutSize = BodyPartCutSize.LARGE;
-			}
-			else if(currentSlashCutDamage > 50)
-			{
-				currentCutSize = BodyPartCutSize.MEDIUM;
-			}
-			else if(currentSlashCutDamage > 25)
-			{
-				currentCutSize = BodyPartCutSize.SMALL;
-			}
-
-			if(currentCutSize >= BodyPartSlashLogicOnCutSize && CanBleedExternally)
-			{
-				StartCoroutine(ExternalBleedingLogic());
-			}
-		}
-
-		/// <summary>
-		/// Checks if the cut is big enough for the contained organs to escape.
-		/// If the cut isn't big enough or has failed a chance check, apply internal damage + bleeding.
-		/// </summary>
-		private void Disembowel()
-		{
-			BodyPart randomBodyPart = OrganList.GetRandom().GetComponent<BodyPart>();
-			BodyPart randomCustomBodyPart = OptionalOrgans.GetRandom();
-			if(currentCutSize >= BodyPartStorageContentsSpillOutOnCutSize)
-			{
-				float chance = UnityEngine.Random.Range(0.0f, 1.0f);
-				if(chance >= spillChanceWhenCutPresent)
-				{
-					HealthMaster.DismemberingBodyParts.Add(randomBodyPart);
-					if(randomCustomBodyPart != null)
-					{
-						HealthMaster.DismemberingBodyParts.Add(randomCustomBodyPart);
-					}
-				}
-				else
-				{
-					randomBodyPart.ApplyInternalDamage();
-					if(randomCustomBodyPart != null)
-					{
-						randomCustomBodyPart.ApplyInternalDamage();
-					}
-				}
-			}
-			else
-			{
-				randomBodyPart.ApplyInternalDamage();
-				if(randomCustomBodyPart != null)
-				{
-					randomCustomBodyPart.ApplyInternalDamage();
-				}
-			}
-		}
-
-		/// <summary>
-		/// Enables internal damage logic.
-		/// </summary>
-		[ContextMenu("Debug - Apply Internal Damage")]
-		private void ApplyInternalDamage()
-		{
-			if(CanBleedInternally)
-			{
-				isBleedingInternally = true;
-			}
-		}
-
-		/// <summary>
-		/// The logic executed for when a body part is externally bleeding.
-		/// checks if bleeding stops on it's own over time.
-		/// </summary>
-		public IEnumerator ExternalBleedingLogic()
-		{
-			if(isBleedingExternally)
-			{
-				yield break;
-			}
-			bool willCloseOnItsOwn = false;
-			isBleedingExternally = true;
-			StartCoroutine(Bleedout());
-			CheckCutSize();
-			if(currentSlashDamageLevel != SlashDamageLevel.LARGE || currentPierceDamageLevel == PierceDamageLevel.SMALL)
-			{
-				willCloseOnItsOwn = true;
-			}
-			if(willCloseOnItsOwn)
-			{
-				yield return WaitFor.Seconds(128);
-				CheckCutSize();
-				if(currentSlashDamageLevel != SlashDamageLevel.LARGE || currentPierceDamageLevel == PierceDamageLevel.SMALL)
-				{
-					isBleedingExternally = false;
-				}
-			}
-		}
-
-		/// <summary>
-		/// Limb bleed logic, continues on until isBleedingExternally is false.
-		/// </summary>
-		private IEnumerator Bleedout()
-		{
-			while(isBleedingExternally)
-			{
-				yield return WaitFor.Seconds(4f);
-				if (IsBleeding)
-				{
-					HealthMaster.CirculatorySystem.Bleed(UnityEngine.Random.Range(MinMaxInternalBleedingValues.x, MinMaxInternalBleedingValues.y));
-				}
-			}
-		}
-
-		/// <summary>
-		/// Stops a limb's external bleeding.
-		/// Does not reset cutsize or any damages.
-		/// </summary>
-		public void StopExternalBleeding()
-		{
-			if(isBleedingExternally)
-			{
-				isBleedingExternally = false;
-				StopCoroutine(Bleedout());
-			}
-		}
-
-		/// <summary>
-		/// Internal Bleeding logic, damage types can be overriden.
-		/// </summary>
-		public void InternalBleedingLogic(AttackType attackType = AttackType.Internal, DamageType damageType = DamageType.Brute)
-		{
-			float damageToTake = UnityEngine.Random.Range(MinMaxInternalBleedingValues.x, MinMaxInternalBleedingValues.y);
-			if(currentInternalBleedingDamage >= maximumInternalBleedDamage)
-			{
-				BodyPart currentParent = ContainedIn;
-				if(currentParent != null)
-				{
-					currentParent.TakeDamage(null, damageToTake, attackType, damageType, damageSplit: false, false, 0);
-				}
-			}
-			else
-			{
-				currentInternalBleedingDamage += damageToTake;
-			}
-		}
-
-		/// <summary>
-		/// Checks if the player is lucky enough and is wearing enough protective armor to avoid getting his bodypart removed.
-		/// </summary>
-		private void DismemberBodyPartWithChance()
-		{
-			float chance = UnityEngine.Random.RandomRange(0.0f, 1.0f);
-			float armorChanceModifer = GibChance + SelfArmor.DismembermentProtectionChance;
-			if(Severity == DamageSeverity.Max || currentCutSize == BodyPartCutSize.LARGE){armorChanceModifer -= 0.25f;} //Make it more likely that the bodypart can be gibbed in it's worst condition.
-			if(chance >= armorChanceModifer)
-			{
-				HealthMaster.DismemberingBodyParts.Add(this);
-			}
-		}
-
-		private void TakeBurnDamage(float burnDamage)
-		{
-			if(SelfArmor.Fire < burnDamage)
-			{
-				currentBurnDamage += burnDamage;
-				CheckBurnDamageLevels();
-			}
-		}
-
-		/// <summary>
-		/// Checks and sets what damage level this body part is on, once it becomes charred; the game displays it being charred.
-		/// </summary>
-		private void CheckBurnDamageLevels()
-		{
-			if (currentBurnDamage <= 0)
-			{
-				currentBurnDamageLevel = BurnDamageLevels.NONE;
-			}
-			if (currentBurnDamage >= 25)
-			{
-				currentBurnDamageLevel = BurnDamageLevels.MINOR;
-			}
-			if (currentBurnDamage >= 50)
-			{
-				currentBurnDamageLevel = BurnDamageLevels.MAJOR;
-			}
-			if (currentBurnDamage >= 75)
-			{
-				if(currentBurnDamageLevel != BurnDamageLevels.CHARRED) //So we can do this once.
-				{
-					foreach(var sprite in RelatedPresentSprites)
-					{
-						sprite.baseSpriteHandler.SetColor(bodyPartColorWhenCharred);
-					}
-				}
-				currentBurnDamageLevel = BurnDamageLevels.CHARRED;
-				AshBodyPart();
-			}
-		}
-
-
-		/// <summary>
-		/// Turns this body part into ash while protecting items inside of that cannot be ashed.
-		/// </summary>
-		private void AshBodyPart()
-		{
-			if(currentBurnDamageLevel == BurnDamageLevels.CHARRED && currentBurnDamage > bodyPartAshesAboveThisDamage)
-			{
-				IEnumerable<ItemSlot> internalItemList = OrganStorage.GetItemSlots();
-				foreach(ItemSlot item in internalItemList)
-				{
-					Integrity itemObject = item.ItemObject.OrNull()?.GetComponent<Integrity>();
-					if(itemObject != null) //Incase this is an empty slot
-					{
-						if (itemObject.CannotBeAshed || itemObject.Resistances.Indestructable)
-						{
-							Inventory.ServerDrop(item);
-						}
-					}
-					var organ = item.ItemObject.OrNull()?.GetComponent<BodyPart>();
-					if (organ != null)
-					{
-						if (organ.gibsEntireBodyOnRemoval)
-						{
-							HealthMaster.Gib();
-							return;
-						}
-						if (organ.DeathOnRemoval)
-						{
-							HealthMaster.Death();
-						}
-					}
-				}
-				if (DeathOnRemoval)
-				{
-					HealthMaster.Death();
-				}
-				_ = Spawn.ServerPrefab(OrganStorage.AshPrefab, HealthMaster.gameObject.RegisterTile().WorldPosition);
-				_ = Despawn.ServerSingle(this.gameObject);
-			}
-		}
-
-
-		public float GetCurrentBurnDamage()
-		{
-			return currentBurnDamage;
-		}
-		public float GetCurrentSlashDamage()
-		{
-			return currentSlashCutDamage;
-		}
-		public float GetCurrentPierceDamage()
-		{
-			return currentPierceDamage;
-		}
-
 
 		/// <summary>
 		/// Updates the player health UI if present

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -276,16 +276,13 @@ namespace HealthV2
 			while (isBleedingExternally)
 			{
 				yield return WaitFor.Seconds(4f);
-				if (Root != null) //This is to prevent rare moments where body parts still attempt to bleed when they no longer should.
-				{
-					if (Root.ContainsLimbs.Contains(this) != false)
-					{
-						healthMaster.CirculatorySystem.Bleed(UnityEngine.Random.Range(MinMaxInternalBleedingValues.x, MinMaxInternalBleedingValues.y));
-					}
-				}
-				else
+				if (Root == null) //This is to prevent rare moments where body parts still attempt to bleed when they no longer should.
 				{
 					break;
+				}
+				if (Root.ContainsLimbs.Contains(this) != false)
+				{
+					healthMaster.CirculatorySystem.Bleed(UnityEngine.Random.Range(MinMaxInternalBleedingValues.x, MinMaxInternalBleedingValues.y));
 				}
 			}
 		}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -78,8 +78,11 @@ namespace HealthV2
 		private Color bodyPartColorWhenCharred = Color.black;
 
 		private float currentSlashCutDamage = 0;
+		public float CurrentSlashCutDamage => currentSlashCutDamage;
 		private float currentPierceDamage = 0;
+		public float CurrentPierceDamage => currentPierceDamage;
 		private float currentBurnDamage = 0;
+		public float CurrentBurnDamage => currentBurnDamage;
 
 		[SerializeField] private float bodyPartAshesAboveThisDamage = 125;
 		public float BodyPartAshesAboveThisDamage => bodyPartAshesAboveThisDamage;
@@ -110,19 +113,19 @@ namespace HealthV2
 		/// Applies trauma damage to the body part, checks if it has enough protective armor to cancel the trauma damage
 		/// and automatically checks how big is the body part's cut size.
 		/// </summary>
-		public void ApplyTraumaDamage(float tramuaDamage, TraumaticDamageTypes damageType = TraumaticDamageTypes.SLASH)
+		public void ApplyTraumaDamage(float traumaDamage, TraumaticDamageTypes damageType = TraumaticDamageTypes.SLASH)
 		{
 			//We use dismember protection chance because it's the most logical value.
 			if (DMMath.Prob(SelfArmor.DismembermentProtectionChance * 100) == false)
 			{
-				if (damageType == TraumaticDamageTypes.SLASH) { currentSlashCutDamage += MultiplyTraumaDamage(tramuaDamage); }
-				if (damageType == TraumaticDamageTypes.PIERCE) { currentPierceDamage += MultiplyTraumaDamage(tramuaDamage); }
+				if (damageType == TraumaticDamageTypes.SLASH) { currentSlashCutDamage += MultiplyTraumaDamage(traumaDamage); }
+				if (damageType == TraumaticDamageTypes.PIERCE) { currentPierceDamage += MultiplyTraumaDamage(traumaDamage); }
 				CheckCutSize();
 			}
 			//Burn damage checks for it's own armor damage type.
 			if (damageType == TraumaticDamageTypes.BURN)
 			{
-				TakeBurnDamage(MultiplyTraumaDamage(tramuaDamage));
+				TakeBurnDamage(MultiplyTraumaDamage(traumaDamage));
 			}
 		}
 
@@ -325,7 +328,7 @@ namespace HealthV2
 		/// </summary>
 		private void DismemberBodyPartWithChance()
 		{
-			float chance = UnityEngine.Random.RandomRange(0.0f, 1.0f);
+			float chance = UnityEngine.Random.Range(0.0f, 1.0f);
 			float armorChanceModifer = GibChance + SelfArmor.DismembermentProtectionChance;
 			if (Severity == DamageSeverity.Max || currentCutSize == BodyPartCutSize.LARGE) { armorChanceModifer -= 0.25f; } //Make it more likely that the bodypart can be gibbed in it's worst condition.
 			if (chance >= armorChanceModifer)
@@ -420,18 +423,5 @@ namespace HealthV2
 			}
 		}
 
-
-		public float GetCurrentBurnDamage()
-		{
-			return currentBurnDamage;
-		}
-		public float GetCurrentSlashDamage()
-		{
-			return currentSlashCutDamage;
-		}
-		public float GetCurrentPierceDamage()
-		{
-			return currentPierceDamage;
-		}
 	}
 }

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -1,0 +1,440 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace HealthV2
+{
+	public partial class BodyPart
+	{
+		/// <summary>
+		/// How much damage can this body part last before it breaks/gibs/Disembowles?
+		/// <summary>
+		public float DamageThreshold = 18f;
+		public DamageSeverity GibsOnSeverityLevel = DamageSeverity.Max;
+		public float GibChance = 0.15f;
+
+		/// <summary>
+		/// When does this body part take before it's contents in it's storage spill out?
+		/// </summary>
+		[SerializeField,
+		Tooltip("When does the contents of this body part's storage to spill out when a large enough cut exists?")]
+		private BodyPartCutSize BodyPartStorageContentsSpillOutOnCutSize = BodyPartCutSize.LARGE;
+
+		/// <summary>
+		/// When do we start applying Slash logic?
+		/// </summary>
+		[SerializeField,
+		Tooltip("At what cut size do we start applying slash logic?")]
+		private BodyPartCutSize BodyPartSlashLogicOnCutSize = BodyPartCutSize.SMALL;
+
+		/// <summary>
+		/// When do we start applying disembowel logic?
+		/// </summary>
+		[SerializeField,
+		Tooltip("At what cut size do we start applying disembowel logic?")]
+		private BodyPartCutSize BodyPartDisembowelLogicOnCutSize = BodyPartCutSize.MEDIUM;
+
+		/// <summary>
+		/// How likely does the contents of this body part's storage to spill out?
+		/// </summary>
+		[SerializeField,
+		Tooltip("How likely does the contents of this body part's storage to spill out when a large enough cut exists?"),
+		Range(0, 1.0f)]
+		private float spillChanceWhenCutPresent = 0.5f;
+
+		/// <summary>
+		/// Does this body part have a cut and how big is it?
+		/// </summary>
+		private BodyPartCutSize currentCutSize = BodyPartCutSize.NONE;
+
+		public bool CanBleedInternally = false;
+
+		public bool CanBleedExternally = false;
+
+		[SerializeField] private bool gibsEntireBodyOnRemoval = false;
+
+		private bool isBleedingInternally = false;
+
+		private bool isBleedingExternally = false;
+
+		public bool IsBleedingInternally => isBleedingInternally;
+
+		public bool IsBleedingExternally => isBleedingExternally;
+
+		public Vector2 MinMaxInternalBleedingValues = new Vector2(5, 20);
+
+
+		[SerializeField] private float maximumInternalBleedDamage = 100;
+		public float InternalBleedingBloodLoss = 12;
+		public float ExternalBleedingBloodLoss = 6;
+
+		[SerializeField, Range(0.2f, 4.25f)] private float baseTraumaDamageMultiplier = 0.25f;
+
+		public float MaximumInternalBleedDamage => maximumInternalBleedDamage;
+
+		private float currentInternalBleedingDamage = 0;
+
+		[SerializeField]
+		private Color bodyPartColorWhenCharred = Color.black;
+
+		private float currentSlashCutDamage = 0;
+		private float currentPierceDamage = 0;
+		private float currentBurnDamage = 0;
+
+		[SerializeField] private float bodyPartAshesAboveThisDamage = 125;
+		public float BodyPartAshesAboveThisDamage => bodyPartAshesAboveThisDamage;
+
+		private PierceDamageLevel currentPierceDamageLevel = PierceDamageLevel.NONE;
+		private SlashDamageLevel currentSlashDamageLevel = SlashDamageLevel.NONE;
+		private BurnDamageLevels currentBurnDamageLevel = BurnDamageLevels.NONE;
+
+		/// <summary>
+		/// Checks if the bodypart is damaged to a point where it can be gibbed from the body
+		/// </summary>
+		protected void CheckBodyPartIntigrity(float lastDamage)
+		{
+			if (currentCutSize >= BodyPartSlashLogicOnCutSize)
+			{
+				if (ContainBodyParts.Count != 0)
+				{
+					Disembowel();
+				}
+			}
+			if (Severity >= GibsOnSeverityLevel && lastDamage >= DamageThreshold)
+			{
+				DismemberBodyPartWithChance();
+			}
+		}
+
+		/// <summary>
+		/// Applies trauma damage to the body part, checks if it has enough protective armor to cancel the trauma damage
+		/// and automatically checks how big is the body part's cut size.
+		/// </summary>
+		public void ApplyTraumaDamage(float tramuaDamage, TraumaticDamageTypes damageType = TraumaticDamageTypes.SLASH)
+		{
+			//We use dismember protection chance because it's the most logical value.
+			if (DMMath.Prob(SelfArmor.DismembermentProtectionChance * 100) == false)
+			{
+				if (damageType == TraumaticDamageTypes.SLASH) { currentSlashCutDamage += MultiplyTraumaDamage(tramuaDamage); }
+				if (damageType == TraumaticDamageTypes.PIERCE) { currentPierceDamage += MultiplyTraumaDamage(tramuaDamage); }
+				CheckCutSize();
+			}
+			//Burn damage checks for it's own armor damage type.
+			if (damageType == TraumaticDamageTypes.BURN)
+			{
+				TakeBurnDamage(MultiplyTraumaDamage(tramuaDamage));
+			}
+		}
+
+		private float MultiplyTraumaDamage(float baseDamage)
+		{
+			if (currentBurnDamageLevel >= BurnDamageLevels.CHARRED || currentCutSize >= BodyPartCutSize.LARGE
+			|| Severity >= DamageSeverity.Critical)
+			{
+				return baseDamage * (baseTraumaDamageMultiplier + 0.25f);
+			}
+			else if (currentBurnDamageLevel >= BurnDamageLevels.MAJOR || currentCutSize >= BodyPartCutSize.MEDIUM
+			|| Severity >= DamageSeverity.Bad)
+			{
+				return baseDamage * (baseTraumaDamageMultiplier + 0.15f);
+			}
+			else if (currentBurnDamageLevel >= BurnDamageLevels.MINOR || currentCutSize >= BodyPartCutSize.SMALL
+			|| Severity >= DamageSeverity.LightModerate)
+			{
+				return baseDamage * baseTraumaDamageMultiplier;
+			}
+			else
+			{
+				return baseDamage;
+			}
+		}
+
+		[ContextMenu("Debug - Apply 25 Slash Damage")]
+		private void DEBUG_ApplyTestSlash()
+		{
+			ApplyTraumaDamage(25);
+		}
+
+		[ContextMenu("Debug - Apply 25 Pierce Damage")]
+		private void DEBUG_ApplyTestPierce()
+		{
+			ApplyTraumaDamage(25, TraumaticDamageTypes.PIERCE);
+		}
+
+		/// <summary>
+		/// Checks how big is the cut is right now.
+		/// </summary>
+		private void CheckCutSize()
+		{
+			if (currentSlashCutDamage <= 0)
+			{
+				currentCutSize = BodyPartCutSize.NONE;
+			}
+			else if (currentSlashCutDamage > 25)
+			{
+				currentCutSize = BodyPartCutSize.SMALL;
+			}
+			else if (currentSlashCutDamage > 50)
+			{
+				currentCutSize = BodyPartCutSize.MEDIUM;
+			}
+			else if (currentSlashCutDamage > 75)
+			{
+				currentCutSize = BodyPartCutSize.LARGE;
+			}
+
+			if (currentCutSize >= BodyPartSlashLogicOnCutSize && CanBleedExternally)
+			{
+				StartCoroutine(ExternalBleedingLogic());
+			}
+		}
+
+		/// <summary>
+		/// Checks if the cut is big enough for the contained organs to escape.
+		/// If the cut isn't big enough or has failed a chance check, apply internal damage + bleeding.
+		/// </summary>
+		private void Disembowel()
+		{
+			BodyPart randomBodyPart = ContainBodyParts.GetRandom();
+			BodyPart randomCustomBodyPart = OptionalOrgans.GetRandom();
+			if (currentCutSize >= BodyPartStorageContentsSpillOutOnCutSize)
+			{
+				float chance = UnityEngine.Random.Range(0.0f, 1.0f);
+				if (chance >= spillChanceWhenCutPresent)
+				{
+					healthMaster.DismemberingBodyParts.Add(randomBodyPart);
+					if (randomCustomBodyPart != null)
+					{
+						healthMaster.DismemberingBodyParts.Add(randomCustomBodyPart);
+					}
+				}
+				else
+				{
+					randomBodyPart.ApplyInternalDamage();
+					if (randomCustomBodyPart != null)
+					{
+						randomCustomBodyPart.ApplyInternalDamage();
+					}
+				}
+			}
+			else
+			{
+				randomBodyPart.ApplyInternalDamage();
+				if (randomCustomBodyPart != null)
+				{
+					randomCustomBodyPart.ApplyInternalDamage();
+				}
+			}
+		}
+
+		/// <summary>
+		/// Enables internal damage logic.
+		/// </summary>
+		[ContextMenu("Debug - Apply Internal Damage")]
+		private void ApplyInternalDamage()
+		{
+			if (CanBleedInternally)
+			{
+				isBleedingInternally = true;
+			}
+		}
+
+		/// <summary>
+		/// The logic executed for when a body part is externally bleeding.
+		/// checks if bleeding stops on it's own over time.
+		/// </summary>
+		public IEnumerator ExternalBleedingLogic()
+		{
+			if (isBleedingExternally)
+			{
+				yield break;
+			}
+			bool willCloseOnItsOwn = false;
+			isBleedingExternally = true;
+			StartCoroutine(Bleedout());
+			CheckCutSize();
+			if (currentSlashDamageLevel != SlashDamageLevel.LARGE || currentPierceDamageLevel == PierceDamageLevel.SMALL)
+			{
+				willCloseOnItsOwn = true;
+			}
+			if (willCloseOnItsOwn)
+			{
+				yield return WaitFor.Seconds(128);
+				CheckCutSize();
+				if (currentSlashDamageLevel != SlashDamageLevel.LARGE || currentPierceDamageLevel == PierceDamageLevel.SMALL)
+				{
+					isBleedingExternally = false;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Limb bleed logic, continues on until isBleedingExternally is false.
+		/// </summary>
+		private IEnumerator Bleedout()
+		{
+			while (isBleedingExternally)
+			{
+				yield return WaitFor.Seconds(4f);
+				if (Root != null) //This is to prevent rare moments where body parts still attempt to bleed when they no longer should.
+				{
+					if (Root.ContainsLimbs.Contains(this) != false)
+					{
+						healthMaster.CirculatorySystem.Bleed(UnityEngine.Random.Range(MinMaxInternalBleedingValues.x, MinMaxInternalBleedingValues.y));
+					}
+				}
+				else
+				{
+					break;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Stops a limb's external bleeding.
+		/// Does not reset cutsize or any damages.
+		/// </summary>
+		public void StopExternalBleeding()
+		{
+			if (isBleedingExternally)
+			{
+				isBleedingExternally = false;
+				StopCoroutine(Bleedout());
+			}
+		}
+
+		/// <summary>
+		/// Internal Bleeding logic, damage types can be overriden.
+		/// </summary>
+		public void InternalBleedingLogic(AttackType attackType = AttackType.Internal, DamageType damageType = DamageType.Brute)
+		{
+			float damageToTake = UnityEngine.Random.Range(MinMaxInternalBleedingValues.x, MinMaxInternalBleedingValues.y);
+			if (currentInternalBleedingDamage >= maximumInternalBleedDamage)
+			{
+				BodyPart currentParent = ContainedIn;
+				if (currentParent != null)
+				{
+					currentParent.TakeDamage(null, damageToTake, attackType, damageType, damageSplit: false, false, 0);
+				}
+			}
+			else
+			{
+				currentInternalBleedingDamage += damageToTake;
+			}
+		}
+
+		/// <summary>
+		/// Checks if the player is lucky enough and is wearing enough protective armor to avoid getting his bodypart removed.
+		/// </summary>
+		private void DismemberBodyPartWithChance()
+		{
+			float chance = UnityEngine.Random.RandomRange(0.0f, 1.0f);
+			float armorChanceModifer = GibChance + SelfArmor.DismembermentProtectionChance;
+			if (Severity == DamageSeverity.Max || currentCutSize == BodyPartCutSize.LARGE) { armorChanceModifer -= 0.25f; } //Make it more likely that the bodypart can be gibbed in it's worst condition.
+			if (chance >= armorChanceModifer)
+			{
+				healthMaster.DismemberingBodyParts.Add(this);
+			}
+		}
+
+		private void TakeBurnDamage(float burnDamage)
+		{
+			if (SelfArmor.Fire < burnDamage)
+			{
+				currentBurnDamage += burnDamage;
+				CheckBurnDamageLevels();
+			}
+		}
+
+		/// <summary>
+		/// Checks and sets what damage level this body part is on, once it becomes charred; the game displays it being charred.
+		/// </summary>
+		private void CheckBurnDamageLevels()
+		{
+			if (currentBurnDamage <= 0)
+			{
+				currentBurnDamageLevel = BurnDamageLevels.NONE;
+			}
+			if (currentBurnDamage >= 25)
+			{
+				currentBurnDamageLevel = BurnDamageLevels.MINOR;
+			}
+			if (currentBurnDamage >= 50)
+			{
+				currentBurnDamageLevel = BurnDamageLevels.MAJOR;
+			}
+			if (currentBurnDamage >= 75)
+			{
+				if (currentBurnDamageLevel != BurnDamageLevels.CHARRED) //So we can do this once.
+				{
+					var spritesList = Root.ImplantBaseSpritesDictionary.Values;
+					foreach (var sprites in spritesList)
+					{
+						foreach (var sprite in sprites)
+						{
+							sprite.baseSpriteHandler.SetColor(bodyPartColorWhenCharred);
+						}
+					}
+				}
+				currentBurnDamageLevel = BurnDamageLevels.CHARRED;
+				AshBodyPart();
+			}
+		}
+
+
+		/// <summary>
+		/// Turns this body part into ash while protecting items inside of that cannot be ashed.
+		/// </summary>
+		private void AshBodyPart()
+		{
+			if (currentBurnDamageLevel == BurnDamageLevels.CHARRED && currentBurnDamage > bodyPartAshesAboveThisDamage)
+			{
+				IEnumerable<ItemSlot> internalItemList = Storage.GetItemSlots();
+				foreach (ItemSlot item in internalItemList)
+				{
+					Integrity itemObject = item.ItemObject.OrNull()?.GetComponent<Integrity>();
+					if (itemObject != null) //Incase this is an empty slot
+					{
+						if (itemObject.CannotBeAshed || itemObject.Resistances.Indestructable)
+						{
+							Inventory.ServerDrop(item);
+						}
+					}
+					var organ = item.ItemObject.OrNull()?.GetComponent<BodyPart>();
+					if (organ != null)
+					{
+						if (organ.gibsEntireBodyOnRemoval)
+						{
+							healthMaster.Gib();
+							return;
+						}
+						if (organ.DeathOnRemoval)
+						{
+							HealthMaster.Death();
+						}
+					}
+				}
+				if (DeathOnRemoval)
+				{
+					healthMaster.Death();
+				}
+				_ = Spawn.ServerPrefab(Storage.AshPrefab, HealthMaster.gameObject.RegisterTile().WorldPosition);
+				_ = Despawn.ServerSingle(this.gameObject);
+			}
+		}
+
+
+		public float GetCurrentBurnDamage()
+		{
+			return currentBurnDamage;
+		}
+		public float GetCurrentSlashDamage()
+		{
+			return currentSlashCutDamage;
+		}
+		public float GetCurrentPierceDamage()
+		{
+			return currentPierceDamage;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -78,11 +78,8 @@ namespace HealthV2
 		private Color bodyPartColorWhenCharred = Color.black;
 
 		private float currentSlashCutDamage = 0;
-		public float CurrentSlashCutDamage => currentSlashCutDamage;
 		private float currentPierceDamage = 0;
-		public float CurrentPierceDamage => currentPierceDamage;
 		private float currentBurnDamage = 0;
-		public float CurrentBurnDamage => currentBurnDamage;
 
 		[SerializeField] private float bodyPartAshesAboveThisDamage = 125;
 		public float BodyPartAshesAboveThisDamage => bodyPartAshesAboveThisDamage;
@@ -113,19 +110,19 @@ namespace HealthV2
 		/// Applies trauma damage to the body part, checks if it has enough protective armor to cancel the trauma damage
 		/// and automatically checks how big is the body part's cut size.
 		/// </summary>
-		public void ApplyTraumaDamage(float traumaDamage, TraumaticDamageTypes damageType = TraumaticDamageTypes.SLASH)
+		public void ApplyTraumaDamage(float tramuaDamage, TraumaticDamageTypes damageType = TraumaticDamageTypes.SLASH)
 		{
 			//We use dismember protection chance because it's the most logical value.
 			if (DMMath.Prob(SelfArmor.DismembermentProtectionChance * 100) == false)
 			{
-				if (damageType == TraumaticDamageTypes.SLASH) { currentSlashCutDamage += MultiplyTraumaDamage(traumaDamage); }
-				if (damageType == TraumaticDamageTypes.PIERCE) { currentPierceDamage += MultiplyTraumaDamage(traumaDamage); }
+				if (damageType == TraumaticDamageTypes.SLASH) { currentSlashCutDamage += MultiplyTraumaDamage(tramuaDamage); }
+				if (damageType == TraumaticDamageTypes.PIERCE) { currentPierceDamage += MultiplyTraumaDamage(tramuaDamage); }
 				CheckCutSize();
 			}
 			//Burn damage checks for it's own armor damage type.
 			if (damageType == TraumaticDamageTypes.BURN)
 			{
-				TakeBurnDamage(MultiplyTraumaDamage(traumaDamage));
+				TakeBurnDamage(MultiplyTraumaDamage(tramuaDamage));
 			}
 		}
 
@@ -279,13 +276,16 @@ namespace HealthV2
 			while (isBleedingExternally)
 			{
 				yield return WaitFor.Seconds(4f);
-				if (Root == null) //This is to prevent rare moments where body parts still attempt to bleed when they no longer should.
+				if (Root != null) //This is to prevent rare moments where body parts still attempt to bleed when they no longer should.
+				{
+					if (Root.ContainsLimbs.Contains(this) != false)
+					{
+						healthMaster.CirculatorySystem.Bleed(UnityEngine.Random.Range(MinMaxInternalBleedingValues.x, MinMaxInternalBleedingValues.y));
+					}
+				}
+				else
 				{
 					break;
-				}
-				if (Root.ContainsLimbs.Contains(this) != false)
-				{
-					healthMaster.CirculatorySystem.Bleed(UnityEngine.Random.Range(MinMaxInternalBleedingValues.x, MinMaxInternalBleedingValues.y));
 				}
 			}
 		}
@@ -328,7 +328,7 @@ namespace HealthV2
 		/// </summary>
 		private void DismemberBodyPartWithChance()
 		{
-			float chance = UnityEngine.Random.Range(0.0f, 1.0f);
+			float chance = UnityEngine.Random.RandomRange(0.0f, 1.0f);
 			float armorChanceModifer = GibChance + SelfArmor.DismembermentProtectionChance;
 			if (Severity == DamageSeverity.Max || currentCutSize == BodyPartCutSize.LARGE) { armorChanceModifer -= 0.25f; } //Make it more likely that the bodypart can be gibbed in it's worst condition.
 			if (chance >= armorChanceModifer)
@@ -423,5 +423,18 @@ namespace HealthV2
 			}
 		}
 
+
+		public float GetCurrentBurnDamage()
+		{
+			return currentBurnDamage;
+		}
+		public float GetCurrentSlashDamage()
+		{
+			return currentSlashCutDamage;
+		}
+		public float GetCurrentPierceDamage()
+		{
+			return currentPierceDamage;
+		}
 	}
 }

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs.meta
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 07471f83a315b0344b017a1ffea3332b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Systems/Inventory/ItemStorage.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/ItemStorage.cs
@@ -180,7 +180,7 @@ public class ItemStorage : MonoBehaviour, IServerLifecycle, IServerInventoryMove
 			{
 				if(mobHealth != null)
 				{
-					if(mobHealth.GetCurrentBurnDamage() > mobHealth.BodyPartAshesAboveThisDamage)
+					if(mobHealth.CurrentBurnDamage > mobHealth.BodyPartAshesAboveThisDamage)
 					{
 						_ = Spawn.ServerPrefab(ashPrefab, mobHealth.HealthMaster.gameObject.RegisterTile().WorldPosition);
 						_ = Despawn.ServerSingle(slot.Item.gameObject);


### PR DESCRIPTION
This PR does nothing major or changes anything, it just moves trauma code into a it's own script to make things a bit cleaner + to allow future forks of UnityStation to have an easier time disabling trauma damage if their server does not want things like breakable bones and internal bleeding.

In the next few PRs while im working on my bounty I'll try making disabling and enabling trauma damage much more easier with a single checkbox and allow/disallow it for individual body parts. But right now I need to focus on adding all functionality first.