### PR TITLE
Fixes the character position in the char creation UI

### DIFF
--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/CharacterCustomization.prefab
@@ -9978,7 +9978,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 191.28728, y: -129.32811}
+  m_AnchoredPosition: {x: 191.28728, y: -66.7}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &4923929657751647535


### PR DESCRIPTION
### Purpose
Moves the character image in the character creation window up, making it fit its correct position.


![image](https://user-images.githubusercontent.com/701959/128650845-3f617c95-b5d1-4946-a434-36ab23448ef1.png)
before and after