### PR TITLE
Remove Gib Check

### DIFF
--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -391,11 +391,6 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 			return;
 		}
 
-		if (!GameManager.Instance.GibbingAllowed)
-		{
-			return;
-		}
-
 		if (afterDeathDamage >= GIB_THRESHOLD)
 		{
 			Harvest();


### PR DESCRIPTION
Fixes #7204

-Players dont use old health so dont need to check for allowed gibbing

-Note: new health doesnt have gibbing check but it hasnt been reimplemented yet
