### PR TITLE
Examine text will now show how many items there is now in a stack

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Attributes.cs
+++ b/UnityProject/Assets/Scripts/Items/Attributes.cs
@@ -159,7 +159,16 @@ public class Attributes : NetworkBehaviour, IRightClickable, IExaminable
 			displayName = articleName;
 		}
 
-		string str = "This is a " + displayName + ".";
+		string str;
+		Stackable stacks = GetComponent<Stackable>();
+		if(stacks != null)
+		{
+			str = "This is a " + displayName + " (" + stacks.Amount + ").";
+		}
+		else
+		{
+			str = "This is a " + displayName + ".";
+		}
 
 		if (!string.IsNullOrEmpty(ArticleDescription))
 		{

--- a/UnityProject/Assets/Scripts/Items/Attributes.cs
+++ b/UnityProject/Assets/Scripts/Items/Attributes.cs
@@ -159,16 +159,7 @@ public class Attributes : NetworkBehaviour, IRightClickable, IExaminable
 			displayName = articleName;
 		}
 
-		string str;
-		Stackable stacks = GetComponent<Stackable>();
-		if(stacks != null)
-		{
-			str = "This is a " + displayName + " (" + stacks.Amount + ").";
-		}
-		else
-		{
-			str = "This is a " + displayName + ".";
-		}
+		string str = "This is a " + displayName + ".";
 
 		if (!string.IsNullOrEmpty(ArticleDescription))
 		{

--- a/UnityProject/Assets/Scripts/Items/Stackable.cs
+++ b/UnityProject/Assets/Scripts/Items/Stackable.cs
@@ -346,7 +346,7 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 	{
 		string displayName = gameObject.ExpensiveName();
 
-		string str = "This " + displayName + " contains (" + Amount + ") stacks.";
+		return $"This {gameObject.ExpensiveName()} contains {Amount} stacks.";
 
 		return str;
 	}

--- a/UnityProject/Assets/Scripts/Items/Stackable.cs
+++ b/UnityProject/Assets/Scripts/Items/Stackable.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 /// <summary>
 /// Allows an item to be stacked, occupying a single inventory slot.
 /// </summary>
-public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractable<InventoryApply>, ICheckedInteractable<HandApply>
+public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractable<InventoryApply>, ICheckedInteractable<HandApply>, IExaminable
 {
 	[Tooltip("Amount initially in the stack when this is spawned.")]
 	[SerializeField]
@@ -340,5 +340,14 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 	public void ServerPerformInteraction(HandApply interaction)
 	{
 		ServerCombine(interaction.TargetObject.GetComponent<Stackable>());
+	}
+
+	public string Examine(Vector3 worldPos)
+	{
+		string displayName = gameObject.ExpensiveName();
+
+		string str = "This is a " + displayName + " (" + Amount + ").";
+
+		return str;
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Stackable.cs
+++ b/UnityProject/Assets/Scripts/Items/Stackable.cs
@@ -346,7 +346,7 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 	{
 		string displayName = gameObject.ExpensiveName();
 
-		string str = "This is a " + displayName + " (" + Amount + ").";
+		string str = "This " + displayName + " contains (" + Amount + ") stacks.";
 
 		return str;
 	}

--- a/UnityProject/Assets/Scripts/Items/Stackable.cs
+++ b/UnityProject/Assets/Scripts/Items/Stackable.cs
@@ -344,10 +344,6 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 
 	public string Examine(Vector3 worldPos)
 	{
-		string displayName = gameObject.ExpensiveName();
-
 		return $"This {gameObject.ExpensiveName()} contains {Amount} stacks.";
-
-		return str;
 	}
 }


### PR DESCRIPTION
title. closes #7225 

### Changelog:
CL: [New] - Stackable items' examine text now shows how many items they're holding.