### PR TITLE
Xenos and spiders rebalance

### DIFF
--- a/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/GiantSpiders/GiantSpider.prefab
+++ b/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/GiantSpiders/GiantSpider.prefab
@@ -129,7 +129,7 @@ PrefabInstance:
     - target: {fileID: 6605674241141804935, guid: a65257a8eed4c0749a33323e8b6f2bde,
         type: 3}
       propertyPath: maxHealth
-      value: 200
+      value: 80
       objectReference: {fileID: 0}
     - target: {fileID: 6605674241141804935, guid: a65257a8eed4c0749a33323e8b6f2bde,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/GiantSpiders/GiantSpiderBroodmother.prefab
+++ b/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/GiantSpiders/GiantSpiderBroodmother.prefab
@@ -14,6 +14,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4080804458103442021, guid: 9c078bd06d8a43943ab0e581a334abf4,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080804458103442021, guid: 9c078bd06d8a43943ab0e581a334abf4,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -29,6 +34,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4080804458103442021, guid: 9c078bd06d8a43943ab0e581a334abf4,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080804458103442021, guid: 9c078bd06d8a43943ab0e581a334abf4,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
@@ -40,16 +50,6 @@ PrefabInstance:
     - target: {fileID: 4080804458103442021, guid: 9c078bd06d8a43943ab0e581a334abf4,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080804458103442021, guid: 9c078bd06d8a43943ab0e581a334abf4,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080804458103442021, guid: 9c078bd06d8a43943ab0e581a334abf4,
-        type: 3}
-      propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4080804458103442021, guid: 9c078bd06d8a43943ab0e581a334abf4,
@@ -79,9 +79,9 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7353154687105350156, guid: 9c078bd06d8a43943ab0e581a334abf4,
         type: 3}
-      propertyPath: SubCatalogue.Array.data[1]
+      propertyPath: PresentSpriteSet
       value: 
-      objectReference: {fileID: 11400000, guid: 95f204aa48628874a942a92b4624e4ae,
+      objectReference: {fileID: 11400000, guid: 9fbb19c06c2e24840b12607cad12c32f,
         type: 2}
     - target: {fileID: 7353154687105350156, guid: 9c078bd06d8a43943ab0e581a334abf4,
         type: 3}
@@ -91,10 +91,15 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 7353154687105350156, guid: 9c078bd06d8a43943ab0e581a334abf4,
         type: 3}
-      propertyPath: PresentSpriteSet
+      propertyPath: SubCatalogue.Array.data[1]
       value: 
-      objectReference: {fileID: 11400000, guid: 9fbb19c06c2e24840b12607cad12c32f,
+      objectReference: {fileID: 11400000, guid: 95f204aa48628874a942a92b4624e4ae,
         type: 2}
+    - target: {fileID: 8749912705822417641, guid: 9c078bd06d8a43943ab0e581a334abf4,
+        type: 3}
+      propertyPath: maxHealth
+      value: 60
+      objectReference: {fileID: 0}
     - target: {fileID: 8894695851082091797, guid: 9c078bd06d8a43943ab0e581a334abf4,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/GiantSpiders/GiantSpiderHunter.prefab
+++ b/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/GiantSpiders/GiantSpiderHunter.prefab
@@ -13,6 +13,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300008, guid: 6e965de74c66722498db7467155a5225,
         type: 3}
+    - target: {fileID: 3062659392533669830, guid: 843edc78b2c231249a2c4936447b61fe,
+        type: 3}
+      propertyPath: maxHealth
+      value: 60
+      objectReference: {fileID: 0}
     - target: {fileID: 3883941778682478371, guid: 843edc78b2c231249a2c4936447b61fe,
         type: 3}
       propertyPath: PresentSpriteSet
@@ -43,6 +48,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7731767184041791306, guid: 843edc78b2c231249a2c4936447b61fe,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7731767184041791306, guid: 843edc78b2c231249a2c4936447b61fe,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -58,6 +68,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7731767184041791306, guid: 843edc78b2c231249a2c4936447b61fe,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7731767184041791306, guid: 843edc78b2c231249a2c4936447b61fe,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
@@ -69,16 +84,6 @@ PrefabInstance:
     - target: {fileID: 7731767184041791306, guid: 843edc78b2c231249a2c4936447b61fe,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7731767184041791306, guid: 843edc78b2c231249a2c4936447b61fe,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7731767184041791306, guid: 843edc78b2c231249a2c4936447b61fe,
-        type: 3}
-      propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7731767184041791306, guid: 843edc78b2c231249a2c4936447b61fe,

--- a/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/GiantSpiders/GiantSpiderTarantula.prefab
+++ b/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/GiantSpiders/GiantSpiderTarantula.prefab
@@ -7,18 +7,32 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 650142583253974484, guid: 843edc78b2c231249a2c4936447b61fe,
+        type: 3}
+      propertyPath: armor.Fire
+      value: -25
+      objectReference: {fileID: 0}
+    - target: {fileID: 891984662868824982, guid: 843edc78b2c231249a2c4936447b61fe,
+        type: 3}
+      propertyPath: armor.Fire
+      value: -25
+      objectReference: {fileID: 0}
+    - target: {fileID: 2403005513873529339, guid: 843edc78b2c231249a2c4936447b61fe,
+        type: 3}
+      propertyPath: hitDamage
+      value: 30
+      objectReference: {fileID: 0}
     - target: {fileID: 2926602546202069050, guid: 843edc78b2c231249a2c4936447b61fe,
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300016, guid: b66515ad7b970f54ca08f76c0b8efd62,
+      objectReference: {fileID: 21300000, guid: b66515ad7b970f54ca08f76c0b8efd62,
         type: 3}
-    - target: {fileID: 3883941778682478371, guid: 843edc78b2c231249a2c4936447b61fe,
+    - target: {fileID: 3062659392533669830, guid: 843edc78b2c231249a2c4936447b61fe,
         type: 3}
-      propertyPath: SubCatalogue.Array.data[1]
-      value: 
-      objectReference: {fileID: 11400000, guid: 230822445aa6ad64dbc889257a2f2f1f,
-        type: 2}
+      propertyPath: maxHealth
+      value: 250
+      objectReference: {fileID: 0}
     - target: {fileID: 3883941778682478371, guid: 843edc78b2c231249a2c4936447b61fe,
         type: 3}
       propertyPath: PresentSpriteSet
@@ -31,6 +45,12 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: cafbd67f00b11394badd990f65ec1ddb,
         type: 2}
+    - target: {fileID: 3883941778682478371, guid: 843edc78b2c231249a2c4936447b61fe,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 230822445aa6ad64dbc889257a2f2f1f,
+        type: 2}
     - target: {fileID: 7698123779403150290, guid: 843edc78b2c231249a2c4936447b61fe,
         type: 3}
       propertyPath: m_AssetId
@@ -40,6 +60,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: GiantSpiderTarantula
+      objectReference: {fileID: 0}
+    - target: {fileID: 7731767184041791306, guid: 843edc78b2c231249a2c4936447b61fe,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7731767184041791306, guid: 843edc78b2c231249a2c4936447b61fe,
         type: 3}
@@ -58,6 +83,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7731767184041791306, guid: 843edc78b2c231249a2c4936447b61fe,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7731767184041791306, guid: 843edc78b2c231249a2c4936447b61fe,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
@@ -69,16 +99,6 @@ PrefabInstance:
     - target: {fileID: 7731767184041791306, guid: 843edc78b2c231249a2c4936447b61fe,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7731767184041791306, guid: 843edc78b2c231249a2c4936447b61fe,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7731767184041791306, guid: 843edc78b2c231249a2c4936447b61fe,
-        type: 3}
-      propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7731767184041791306, guid: 843edc78b2c231249a2c4936447b61fe,

--- a/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/GiantSpiders/GiantSpiderViper.prefab
+++ b/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/GiantSpiders/GiantSpiderViper.prefab
@@ -13,11 +13,16 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300016, guid: 346282a8763791442ba04be0095d500b,
         type: 3}
+    - target: {fileID: 3062659392533669830, guid: 843edc78b2c231249a2c4936447b61fe,
+        type: 3}
+      propertyPath: maxHealth
+      value: 40
+      objectReference: {fileID: 0}
     - target: {fileID: 3883941778682478371, guid: 843edc78b2c231249a2c4936447b61fe,
         type: 3}
-      propertyPath: SubCatalogue.Array.data[1]
+      propertyPath: PresentSpriteSet
       value: 
-      objectReference: {fileID: 11400000, guid: 09898993df7cd8242a292efbbc6df446,
+      objectReference: {fileID: 11400000, guid: d2e7ec96de320d54cb2784982665ba69,
         type: 2}
     - target: {fileID: 3883941778682478371, guid: 843edc78b2c231249a2c4936447b61fe,
         type: 3}
@@ -27,9 +32,9 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 3883941778682478371, guid: 843edc78b2c231249a2c4936447b61fe,
         type: 3}
-      propertyPath: PresentSpriteSet
+      propertyPath: SubCatalogue.Array.data[1]
       value: 
-      objectReference: {fileID: 11400000, guid: d2e7ec96de320d54cb2784982665ba69,
+      objectReference: {fileID: 11400000, guid: 09898993df7cd8242a292efbbc6df446,
         type: 2}
     - target: {fileID: 7698123779403150290, guid: 843edc78b2c231249a2c4936447b61fe,
         type: 3}
@@ -40,6 +45,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: GiantSpiderViper
+      objectReference: {fileID: 0}
+    - target: {fileID: 7731767184041791306, guid: 843edc78b2c231249a2c4936447b61fe,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7731767184041791306, guid: 843edc78b2c231249a2c4936447b61fe,
         type: 3}
@@ -58,6 +68,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7731767184041791306, guid: 843edc78b2c231249a2c4936447b61fe,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7731767184041791306, guid: 843edc78b2c231249a2c4936447b61fe,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
@@ -69,16 +84,6 @@ PrefabInstance:
     - target: {fileID: 7731767184041791306, guid: 843edc78b2c231249a2c4936447b61fe,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7731767184041791306, guid: 843edc78b2c231249a2c4936447b61fe,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7731767184041791306, guid: 843edc78b2c231249a2c4936447b61fe,
-        type: 3}
-      propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7731767184041791306, guid: 843edc78b2c231249a2c4936447b61fe,

--- a/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/GiantSpiders/Spiderling.prefab
+++ b/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/GiantSpiders/Spiderling.prefab
@@ -32,6 +32,16 @@ PrefabInstance:
       propertyPath: bloodColor
       value: 2
       objectReference: {fileID: 0}
+    - target: {fileID: 739318556774777865, guid: 64d782023543d4542b89ce3f9402b084,
+        type: 3}
+      propertyPath: armor.Fire
+      value: -50
+      objectReference: {fileID: 0}
+    - target: {fileID: 1092021894141176395, guid: 64d782023543d4542b89ce3f9402b084,
+        type: 3}
+      propertyPath: armor.Fire
+      value: -50
+      objectReference: {fileID: 0}
     - target: {fileID: 2166651219293684434, guid: 64d782023543d4542b89ce3f9402b084,
         type: 3}
       propertyPath: mobName

--- a/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/Xenomorphs/ChestbursterSimple.prefab
+++ b/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/Xenomorphs/ChestbursterSimple.prefab
@@ -96,6 +96,16 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 6029784556651730588, guid: cf769d410d94f0e47bab5eee03a3b07d,
+        type: 3}
+      propertyPath: armor.Fire
+      value: -50
+      objectReference: {fileID: 0}
+    - target: {fileID: 6254140286428870878, guid: cf769d410d94f0e47bab5eee03a3b07d,
+        type: 3}
+      propertyPath: armor.Fire
+      value: -50
+      objectReference: {fileID: 0}
     - target: {fileID: 7649476325489687081, guid: cf769d410d94f0e47bab5eee03a3b07d,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/Xenomorphs/Facehugger.prefab
+++ b/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/Xenomorphs/Facehugger.prefab
@@ -138,6 +138,16 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 6029784556651730588, guid: cf769d410d94f0e47bab5eee03a3b07d,
+        type: 3}
+      propertyPath: armor.Fire
+      value: -50
+      objectReference: {fileID: 0}
+    - target: {fileID: 6254140286428870878, guid: cf769d410d94f0e47bab5eee03a3b07d,
+        type: 3}
+      propertyPath: armor.Fire
+      value: -50
+      objectReference: {fileID: 0}
     - target: {fileID: 7649476325489687081, guid: cf769d410d94f0e47bab5eee03a3b07d,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/Xenomorphs/XenomorphDroneSimple.prefab
+++ b/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/Xenomorphs/XenomorphDroneSimple.prefab
@@ -7,6 +7,46 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 739857834287994787, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: armor.Laser
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 739857834287994787, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: armor.Melee
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 739857834287994787, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: armor.Bullet
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 739857834287994787, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: armor.Energy
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1090349022819334625, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: armor.Laser
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1090349022819334625, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: armor.Melee
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1090349022819334625, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: armor.Bullet
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1090349022819334625, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: armor.Energy
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 2456842461227463564, guid: 00a84f751afb412428a586d23cf90b39,
         type: 3}
       propertyPath: hitDamage
@@ -46,6 +86,11 @@ PrefabInstance:
         type: 3}
       propertyPath: mobName
       value: xenomorph drone
+      objectReference: {fileID: 0}
+    - target: {fileID: 6141197458528421439, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: disableAscension
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7495180291926065977, guid: 00a84f751afb412428a586d23cf90b39,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/Xenomorphs/XenomorphHunterSimple.prefab
+++ b/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/Xenomorphs/XenomorphHunterSimple.prefab
@@ -51,11 +51,11 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
-  playRandomSoundTimer: 3
+  playRandomSoundTimer: 6
   randomSoundProbability: 20
   searchTickRate: 0.5
   currentStatus: 0
-  disableAscension: 0
+  disableAscension: 1
   queenCap: 1
   queenPrefab: {fileID: 2058504753171968459, guid: 850a00ce2fc547b499ef46733c95c580,
     type: 3}
@@ -135,6 +135,66 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AssetId
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6029784556651730588, guid: cf769d410d94f0e47bab5eee03a3b07d,
+        type: 3}
+      propertyPath: armor.Rad
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6029784556651730588, guid: cf769d410d94f0e47bab5eee03a3b07d,
+        type: 3}
+      propertyPath: armor.Acid
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 6029784556651730588, guid: cf769d410d94f0e47bab5eee03a3b07d,
+        type: 3}
+      propertyPath: armor.Laser
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6029784556651730588, guid: cf769d410d94f0e47bab5eee03a3b07d,
+        type: 3}
+      propertyPath: armor.Melee
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 6029784556651730588, guid: cf769d410d94f0e47bab5eee03a3b07d,
+        type: 3}
+      propertyPath: armor.Bullet
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6029784556651730588, guid: cf769d410d94f0e47bab5eee03a3b07d,
+        type: 3}
+      propertyPath: armor.Energy
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6254140286428870878, guid: cf769d410d94f0e47bab5eee03a3b07d,
+        type: 3}
+      propertyPath: armor.Rad
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6254140286428870878, guid: cf769d410d94f0e47bab5eee03a3b07d,
+        type: 3}
+      propertyPath: armor.Acid
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 6254140286428870878, guid: cf769d410d94f0e47bab5eee03a3b07d,
+        type: 3}
+      propertyPath: armor.Laser
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6254140286428870878, guid: cf769d410d94f0e47bab5eee03a3b07d,
+        type: 3}
+      propertyPath: armor.Melee
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 6254140286428870878, guid: cf769d410d94f0e47bab5eee03a3b07d,
+        type: 3}
+      propertyPath: armor.Bullet
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6254140286428870878, guid: cf769d410d94f0e47bab5eee03a3b07d,
+        type: 3}
+      propertyPath: armor.Energy
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 7649476325489687081, guid: cf769d410d94f0e47bab5eee03a3b07d,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/Xenomorphs/XenomorphPraetorianSimple.prefab
+++ b/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/Xenomorphs/XenomorphPraetorianSimple.prefab
@@ -7,6 +7,71 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 739857834287994787, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: armor.Bomb
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 739857834287994787, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: armor.Fire
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 739857834287994787, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: armor.Laser
+      value: 35
+      objectReference: {fileID: 0}
+    - target: {fileID: 739857834287994787, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: armor.Melee
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 739857834287994787, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: armor.Bullet
+      value: 35
+      objectReference: {fileID: 0}
+    - target: {fileID: 739857834287994787, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: armor.Energy
+      value: 35
+      objectReference: {fileID: 0}
+    - target: {fileID: 1090349022819334625, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: armor.Bomb
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 1090349022819334625, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: armor.Fire
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 1090349022819334625, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: armor.Laser
+      value: 35
+      objectReference: {fileID: 0}
+    - target: {fileID: 1090349022819334625, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: armor.Melee
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 1090349022819334625, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: armor.Bullet
+      value: 35
+      objectReference: {fileID: 0}
+    - target: {fileID: 1090349022819334625, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: armor.Energy
+      value: 35
+      objectReference: {fileID: 0}
+    - target: {fileID: 3008832837752720817, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: maxHealth
+      value: 250
+      objectReference: {fileID: 0}
     - target: {fileID: 3160441142362989133, guid: 00a84f751afb412428a586d23cf90b39,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/Xenomorphs/XenomorphQueenSimple.prefab
+++ b/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/Xenomorphs/XenomorphQueenSimple.prefab
@@ -77,6 +77,16 @@ PrefabInstance:
       propertyPath: mobName
       value: xenomorph queen
       objectReference: {fileID: 0}
+    - target: {fileID: 1143423393386790465, guid: 2937fbb42f33c07428faabfd58578633,
+        type: 3}
+      propertyPath: playRandomSoundTimer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5151156347480821996, guid: 2937fbb42f33c07428faabfd58578633,
+        type: 3}
+      propertyPath: hitDamage
+      value: 30
+      objectReference: {fileID: 0}
     - target: {fileID: 5522932471367266001, guid: 2937fbb42f33c07428faabfd58578633,
         type: 3}
       propertyPath: maxHealth
@@ -153,5 +163,75 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 95b47db093e33d3448c2951ed087b77d,
         type: 2}
+    - target: {fileID: 7657617986430163585, guid: 2937fbb42f33c07428faabfd58578633,
+        type: 3}
+      propertyPath: armor.Rad
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 7657617986430163585, guid: 2937fbb42f33c07428faabfd58578633,
+        type: 3}
+      propertyPath: armor.Bomb
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 7657617986430163585, guid: 2937fbb42f33c07428faabfd58578633,
+        type: 3}
+      propertyPath: armor.Fire
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 7657617986430163585, guid: 2937fbb42f33c07428faabfd58578633,
+        type: 3}
+      propertyPath: armor.Laser
+      value: 35
+      objectReference: {fileID: 0}
+    - target: {fileID: 7657617986430163585, guid: 2937fbb42f33c07428faabfd58578633,
+        type: 3}
+      propertyPath: armor.Melee
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 7657617986430163585, guid: 2937fbb42f33c07428faabfd58578633,
+        type: 3}
+      propertyPath: armor.Bullet
+      value: 35
+      objectReference: {fileID: 0}
+    - target: {fileID: 7657617986430163585, guid: 2937fbb42f33c07428faabfd58578633,
+        type: 3}
+      propertyPath: armor.Energy
+      value: 35
+      objectReference: {fileID: 0}
+    - target: {fileID: 8007506324854043843, guid: 2937fbb42f33c07428faabfd58578633,
+        type: 3}
+      propertyPath: armor.Rad
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 8007506324854043843, guid: 2937fbb42f33c07428faabfd58578633,
+        type: 3}
+      propertyPath: armor.Bomb
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 8007506324854043843, guid: 2937fbb42f33c07428faabfd58578633,
+        type: 3}
+      propertyPath: armor.Fire
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 8007506324854043843, guid: 2937fbb42f33c07428faabfd58578633,
+        type: 3}
+      propertyPath: armor.Laser
+      value: 35
+      objectReference: {fileID: 0}
+    - target: {fileID: 8007506324854043843, guid: 2937fbb42f33c07428faabfd58578633,
+        type: 3}
+      propertyPath: armor.Melee
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 8007506324854043843, guid: 2937fbb42f33c07428faabfd58578633,
+        type: 3}
+      propertyPath: armor.Bullet
+      value: 35
+      objectReference: {fileID: 0}
+    - target: {fileID: 8007506324854043843, guid: 2937fbb42f33c07428faabfd58578633,
+        type: 3}
+      propertyPath: armor.Energy
+      value: 35
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2937fbb42f33c07428faabfd58578633, type: 3}

--- a/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/Xenomorphs/XenomorphSentinelSimple.prefab
+++ b/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/Xenomorphs/XenomorphSentinelSimple.prefab
@@ -7,6 +7,26 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 739857834287994787, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: armor.Bomb
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 739857834287994787, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: armor.Melee
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 1090349022819334625, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: armor.Bomb
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 1090349022819334625, guid: 00a84f751afb412428a586d23cf90b39,
+        type: 3}
+      propertyPath: armor.Melee
+      value: 25
+      objectReference: {fileID: 0}
     - target: {fileID: 2456842461227463564, guid: 00a84f751afb412428a586d23cf90b39,
         type: 3}
       propertyPath: hitDamage

--- a/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/_SimpleAnimalHostileBase.prefab
+++ b/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/_SimpleAnimalHostileBase.prefab
@@ -15,7 +15,7 @@ MonoBehaviour:
   mobName: =
   deathSounds: []
   randomSounds: []
-  playRandomSoundTimer: 3
+  playRandomSoundTimer: 6
   randomSoundProbability: 0
   searchTickRate: 0.5
   currentStatus: 0


### PR DESCRIPTION

### Purpose

Simple PR, rebalances the health and armor values of xenomorphs and spiders to be more in line with /tg/. Also doubles the pause between hostile mob noise cue as 25% chance every 3 seconds was a bit too frequent in my anecdotal experience. A room of 4 xenos would basically never stop making noise. It may in fact need to be lowered even further.

### Notes:

- all spiders got their /tg/ health values except the tarantula, which I lowered from 300 to 250 health.
- all xenomorphs got health and armor values from /tg/ with minor tweaks. 
- xenomorphs and the non-venomous spiders also got their attack damage values from /tg/.

One of the flaws with how xenomorph armor has been balanced is that there aren't very clear attack type weaknesses to be exploited when fighting xenos other than their weakness to fire, and that weakness exists only for low tier xenomorphs, as queens and praetorians reverse the fire weakness and instead get immunity to fire in /tg/. so, I added a general weakness to bomb damage to low tier xenos and dialed back the fire damage armor on the high tier xenos.

### Changelog:

CL: [Balance] Xenos have had a health and armor rebalance. Xenomorph queens and praetorians now have strong armor and high health pools.
CL: [Balance] giant spiders have had their health and damage rebalanced. Most saw their health decrease to get closer to their /tg/ versions, while the tarantula saw a large increase.

