### PR TITLE
Fixes pipes sharing the same tile affecting server performance

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Pipes/PipeItem.cs
+++ b/UnityProject/Assets/Scripts/Items/Pipes/PipeItem.cs
@@ -4,6 +4,11 @@ using UnityEngine;
 using Mirror;
 using Systems.Pipes;
 using Objects;
+using System.Collections;
+using UnityEngine;
+using Systems.Pipes;
+using Objects.Atmospherics;
+
 
 
 namespace Items.Atmospherics
@@ -49,27 +54,21 @@ namespace Items.Atmospherics
 			if (Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.Wrench))
 			{
 				var ZeroedLocation = new Vector3Int(x:registerItem.LocalPosition.x, y:registerItem.LocalPosition.y,0);
-				var metaData = registerItem.Matrix.MetaDataLayer.Get(ZeroedLocation);
-				var thisConnections = GetConnections();
+				var metaDataNode = registerItem.Matrix.MetaDataLayer.Get(ZeroedLocation);
+				var connections = GetConnections();
 				int Offset = PipeFunctions.GetOffsetAngle(transform.localEulerAngles.z);
-				thisConnections.Rotate(Offset);
-
-				foreach (var Pipeo in metaData.PipeData)
+				connections.Rotate(Offset);
+				if (PipeTile.CanAddPipe(metaDataNode, connections) == false)
 				{
-					var TheConnection = Pipeo.pipeData.Connections;
-					for (int i = 0; i < thisConnections.Directions.Length; i++)
-					{
-						if (thisConnections.Directions[i].Bool && TheConnection.Directions[i].Bool)
-						{
-							return;
-						}
-					}
+					return;
 				}
 				ToolUtils.ServerPlayToolSound(interaction);
 				BuildPipe();
 			}
-
-			rotatable.Rotate();
+			else
+			{
+				rotatable.Rotate();
+			}
 		}
 
 		public virtual bool WillInteract(HandActivate interaction, NetworkSide side)

--- a/UnityProject/Assets/Scripts/Objects/Pipes/PipeTile.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/PipeTile.cs
@@ -28,24 +28,30 @@ namespace Objects.Atmospherics
 			return connection;
 		}
 
-		public override bool AreUnderfloorSame(Matrix4x4 thisTransformMatrix,BasicTile basicTile, Matrix4x4 TransformMatrix)
+		public static bool CanAddPipe(MetaDataNode metaData, Connections incomingConnection)
 		{
-			if ((basicTile as PipeTile) != null)
+			foreach (var pipeNode in metaData.PipeData)
 			{
-				var TilePipeTile = (PipeTile) basicTile;
-				var TheConnection = GetRotatedConnection(TilePipeTile, TransformMatrix);
-				var thisConnection = GetRotatedConnection(this, thisTransformMatrix);
-				for (int i = 0; i < thisConnection.Directions.Length; i++)
+				var existingConnection = pipeNode.pipeData.Connections;
+				for (var i = 0; i < incomingConnection.Directions.Length; i++)
 				{
-					if (thisConnection.Directions[i].Bool && TheConnection.Directions[i].Bool)
+					if (incomingConnection.Directions[i].Bool && existingConnection.Directions[i].Bool)
 					{
-						return true;
+						return false;
 					}
 				}
-				return false;
 			}
+			return true;
+		}
 
-			return base.AreUnderfloorSame(thisTransformMatrix, basicTile, TransformMatrix);
+		public override bool IsTileRepeated(Matrix4x4 thisTransformMatrix,BasicTile basicTile, Matrix4x4 TransformMatrix, MetaDataNode metaDataNode)
+		{
+			var incomingConnection = GetRotatedConnection(this, thisTransformMatrix);
+			if (CanAddPipe(metaDataNode, incomingConnection) == false)
+			{
+				return true;
+			}
+			return false;
 		}
 
 		public void InitialiseNodeNew(Vector3Int Location, Matrix matrix, Matrix4x4 Matrix4x4)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/UnderFloorLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/UnderFloorLayer.cs
@@ -181,13 +181,16 @@ public class UnderFloorLayer : Layer
 		{
 			if (!Application.isPlaying) isServer = true;
 		}
+		var positionV2 = position.To2Int();
 
 		//We do not want to duplicate under floor tiles if they are the same:
-		if (TileStore.ContainsKey(position.To2Int()))
+		if (TileStore.ContainsKey(positionV2))
 		{
+			var metaDataNode = matrix.MetaDataLayer.Get(position);
 			foreach (var l in TileStore[position.To2Int()])
 			{
-				if ((tile as BasicTile).AreUnderfloorSame(transformMatrix, l as BasicTile, GetMatrix4x4(position, l)))
+
+				if ((tile as BasicTile).IsTileRepeated(transformMatrix, l as BasicTile, GetMatrix4x4(position, l), metaDataNode))
 				{
 					//duplicate found aborting
 					return;
@@ -197,22 +200,21 @@ public class UnderFloorLayer : Layer
 
 		if (isServer)
 		{
-			Vector2Int position2 = position.To2Int();
-			if (!TileStore.ContainsKey(position2))
+			if (!TileStore.ContainsKey(positionV2))
 			{
 				SetupNode(position);
 			}
 
-			int index = FindFirstEmpty(TileStore[position2]);
+			int index = FindFirstEmpty(TileStore[positionV2]);
 			if (index < 0)
 			{
-				position.z = 1 - TileStore[position2].Count;
-				TileStore[position2].Add((LayerTile) tile);
+				position.z = 1 - TileStore[positionV2].Count;
+				TileStore[positionV2].Add((LayerTile) tile);
 			}
 			else
 			{
 				position.z = 1 - index;
-				TileStore[position2][index] = (LayerTile) tile;
+				TileStore[positionV2][index] = (LayerTile) tile;
 			}
 
 
@@ -230,13 +232,9 @@ public class UnderFloorLayer : Layer
 					return;
 				}
 			}
+		}
 
-			base.SetTile(position, tile, transformMatrix, color);
-		}
-		else
-		{
-			base.SetTile(position, tile, transformMatrix, color);
-		}
+		base.SetTile(position, tile, transformMatrix, color);
 	}
 
 	private int FindFirstEmpty(List<LayerTile> LookThroughList)

--- a/UnityProject/Assets/Scripts/Tilemaps/Tiles/BasicTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Tiles/BasicTile.cs
@@ -200,7 +200,7 @@ public abstract class BasicTile : LayerTile
 	}
 
 	//yeah,This needs to be moved out into its own class
-	public virtual bool AreUnderfloorSame(Matrix4x4 thisTransformMatrix, BasicTile basicTile, Matrix4x4 TransformMatrix)
+	public virtual bool IsTileRepeated(Matrix4x4 thisTransformMatrix, BasicTile basicTile, Matrix4x4 TransformMatrix, MetaDataNode metaDataNode)
 	{
 		if (basicTile == this)
 		{


### PR DESCRIPTION
### Purpose
Fixes pipes sharing the same tile affecting performance and leaving a ghost pipe sprite once removed.

-what was wrong with the old check?
it saved and used a SO to check for directions, which were always the same