### PR TITLE
Improve microwaves

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Other/Dice/DieBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/Dice/DieBase.prefab
@@ -132,6 +132,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   CookTime: 15
   CookedProduct: {fileID: 0}
+  cookOnDestroyByBurn: 0
 --- !u!1001 &8783827724552596289
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Items/Dice/Roll8Ball.cs
+++ b/UnityProject/Assets/Scripts/Items/Dice/Roll8Ball.cs
@@ -1,14 +1,17 @@
 ﻿using UnityEngine;
 
-public class Roll8Ball : RollSpecialDie
+namespace Items.Dice
 {
-	public override string Examine(Vector3 worldPos = default)
+	public class Roll8Ball : RollSpecialDie
 	{
-		return GetMessage();
-	}
+		public override string Examine(Vector3 worldPos = default)
+		{
+			return GetMessage();
+		}
 
-	protected override string GetMessage()
-	{
-		return $"The {dieName} reads; '{specialFaces[result - 1]}'.";
+		protected override string GetMessage()
+		{
+			return $"The {dieName} reads; '{specialFaces[result - 1]}'.";
+		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Dice/RollD00.cs
+++ b/UnityProject/Assets/Scripts/Items/Dice/RollD00.cs
@@ -1,14 +1,17 @@
 ﻿using UnityEngine;
 
-public class RollD00 : RollDie
+namespace Items.Dice
 {
-	public override string Examine(Vector3 worldPos = default)
+	public class RollD00 : RollDie
 	{
-		return $"It is showing side {result - 1}0.";
-	}
+		public override string Examine(Vector3 worldPos = default)
+		{
+			return $"It is showing side {result - 1}0.";
+		}
 
-	protected override string GetMessage()
-	{
-		return $"The {dieName} lands a {result - 1}0.";
+		protected override string GetMessage()
+		{
+			return $"The {dieName} lands a {result - 1}0.";
+		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Dice/RollD20.cs
+++ b/UnityProject/Assets/Scripts/Items/Dice/RollD20.cs
@@ -1,15 +1,18 @@
-﻿public class RollD20 : RollDie
+﻿namespace Items.Dice
 {
-	protected override string GetMessage()
+	public class RollD20 : RollDie
 	{
-		string msg = base.GetMessage();
-
-		if (sides == 20)
+		protected override string GetMessage()
 		{
-			if (result == 1) return msg + " Ouch! Bad luck.";
-			else if (result == 20) return msg + " NAT 20!";
-		}
+			string msg = base.GetMessage();
 
-		return msg;
+			if (sides == 20)
+			{
+				if (result == 1) return msg + " Ouch! Bad luck.";
+				else if (result == 20) return msg + " NAT 20!";
+			}
+
+			return msg;
+		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Dice/RollDie.cs
+++ b/UnityProject/Assets/Scripts/Items/Dice/RollDie.cs
@@ -2,217 +2,210 @@
 using System.Collections;
 using Mirror;
 using UnityEngine;
-using UnityEngine.UIElements;
+using Items.Food;
 using Random = UnityEngine.Random;
 
-/// <summary>
-/// An extendable MonoBehaviour component to handle generic die rolling.
-/// </summary>
-public class RollDie : MonoBehaviour, IExaminable, ICheckedInteractable<HandActivate>
+namespace Items.Dice
 {
-	[Tooltip("The amount of sides this die has.")]
-	public int sides = 6;
-	[Tooltip("Whether the die can be rigged to give flawed results.")]
-	public bool isRiggable = true;
-
-	private Transform dieTransform;
-	private SpriteHandler faceOverlayHandler;
-	private CustomNetTransform netTransform;
-	private Cookable cookable;
-
-	private const float ROLL_TIME = 1; // In seconds.
-	protected string dieName = "die";
-	protected bool isRigged = false;
-	protected int riggedValue;
-	protected int result;
-
-	public bool IsRolling { get; private set; } = false;
-
-	protected HandActivate handRollInteraction;
-
-	private Coroutine waitForSide;
-	private Coroutine animateSides;
-	private Coroutine animateBounce;
-
-	#region Lifecycle
-
-	protected virtual void Awake()
+	/// <summary>
+	/// An extendable MonoBehaviour component to handle generic die rolling.
+	/// </summary>
+	public class RollDie : MonoBehaviour, IExaminable, ICheckedInteractable<HandActivate>
 	{
-		dieTransform = transform;
-		// This assumes that the Face GameObject, responsible for handling the dice sprite overlays,
-		// is in the second position of the dice hierarchy.
-		faceOverlayHandler = transform.GetChild(1).GetComponent<SpriteHandler>();
-		netTransform = GetComponent<CustomNetTransform>();
-		cookable = GetComponent<Cookable>();
-	}
+		[Tooltip("The amount of sides this die has.")]
+		public int sides = 6;
+		[Tooltip("Whether the die can be rigged to give flawed results.")]
+		public bool isRiggable = true;
 
-	protected virtual void Start()
-	{
-		dieName = gameObject.ExpensiveName();
+		private Transform dieTransform;
+		private SpriteHandler faceOverlayHandler;
+		private CustomNetTransform netTransform;
+		private Cookable cookable;
 
-		// Start the die with a random side.
-		result = Random.Range(1, sides);
-		UpdateOverlay();
-	}
+		private const float ROLL_TIME = 1; // In seconds.
+		protected string dieName = "die";
+		protected bool isRigged = false;
+		protected int riggedValue;
+		protected int result;
 
-	private void OnEnable()
-	{
-		netTransform.OnThrowStart.AddListener(ThrowStart);
-		netTransform.OnThrowEnd.AddListener(ThrowEnd);
+		public bool IsRolling { get; private set; } = false;
 
-		if (cookable != null && isRiggable)
+		protected HandActivate handRollInteraction;
+
+		private Coroutine waitForSide;
+		private Coroutine animateSides;
+		private Coroutine animateBounce;
+
+		#region Lifecycle
+
+		protected virtual void Awake()
 		{
-			cookable.OnCooked += Cook;
+			dieTransform = transform;
+			// This assumes that the Face GameObject, responsible for handling the dice sprite overlays,
+			// is in the second position of the dice hierarchy.
+			faceOverlayHandler = transform.GetChild(1).GetComponent<SpriteHandler>();
+			netTransform = GetComponent<CustomNetTransform>();
+			cookable = GetComponent<Cookable>();
 		}
-	}
 
-	private void OnDisable()
-	{
-		netTransform.OnThrowStart.RemoveListener(ThrowStart);
-		netTransform.OnThrowEnd.RemoveListener(ThrowEnd);
-
-		if (cookable != null)
+		protected virtual void Start()
 		{
-			cookable.OnCooked -= Cook;
+			dieName = gameObject.ExpensiveName();
+
+			// Start the die with a random side.
+			result = Random.Range(1, sides);
+			UpdateOverlay();
 		}
-	}
 
-	#endregion Lifecycle
-
-	#region Interactions
-
-	public bool WillInteract(HandActivate interaction, NetworkSide side)
-	{
-		return DefaultWillInteract.Default(interaction, side);
-	}
-
-	public void ServerPerformInteraction(HandActivate interaction)
-	{
-		handRollInteraction = interaction;
-
-		StartCoroutine(RollInHand());
-	}
-
-	public virtual string Examine(Vector3 worldPos = default)
-	{
-		return $"It is showing side {result}.";
-	}
-
-	#endregion Interactions
-
-	public void Cook()
-	{
-		if (isRiggable)
+		private void OnEnable()
 		{
-			isRigged = true;
-			riggedValue = result;
-		}
-	}
+			netTransform.OnThrowStart.AddListener(ThrowStart);
+			netTransform.OnThrowEnd.AddListener(ThrowEnd);
 
-	private IEnumerator RollInHand()
-	{
-		Chat.AddExamineMsgFromServer(handRollInteraction.Performer, $"You roll the {dieName} in your hands...");
-
-		IsRolling = true;
-		this.RestartCoroutine(AnimateSides(), ref animateSides);
-		yield return WaitFor.Seconds(ROLL_TIME);
-		IsRolling = false;
-
-		result = GetSide();
-		UpdateOverlay();
-		Chat.AddExamineMsgFromServer(handRollInteraction.Performer, GetMessage());
-	}
-
-	#region Throwing
-
-	private void ThrowStart(ThrowInfo throwInfo)
-	{
-		if(throwInfo.ThrownBy.GetComponent<NetworkIdentity>() == null) return;
-
-		Chat.AddActionMsgToChat(throwInfo.ThrownBy, $"You throw the {dieName}...", $"{throwInfo.ThrownBy.ExpensiveName()} throws the {dieName}...");
-	}
-
-	private void ThrowEnd(ThrowInfo throwInfo)
-	{
-		this.RestartCoroutine(WaitForSide(), ref waitForSide);
-	}
-
-	private IEnumerator WaitForSide()
-	{
-		IsRolling = true;
-		this.RestartCoroutine(AnimateSides(), ref animateSides);
-		this.RestartCoroutine(AnimateBounce(), ref animateBounce);
-		yield return WaitFor.Seconds(ROLL_TIME);
-		IsRolling = false;
-
-		result = GetSide();
-		UpdateOverlay();
-		Chat.AddLocalMsgToChat(GetMessage(), gameObject);
-	}
-
-	#endregion Throwing
-
-	#region Animations
-
-	protected IEnumerator AnimateSides()
-	{
-		while (IsRolling)
-		{
-			faceOverlayHandler.ChangeSpriteVariant(Random.Range(0, sides));
-			yield return WaitFor.Seconds(0.1f);
-		}
-	}
-
-	protected IEnumerator AnimateBounce()
-	{
-		// Rotate some limited angle from north, bounce in that direction, return to original position.
-		// TODO: Pretty bad bounce. Some lerping would help.
-		while (IsRolling)
-		{
-			dieTransform.Rotate(new Vector3(0, 0, Random.Range(-180, 180)), Space.World);
-			dieTransform.Translate(new Vector3(0, 0.2f, 0));
-			yield return WaitFor.Seconds(0.1f);
-
-			dieTransform.Translate(new Vector3(0, -0.2f, 0));
-			yield return WaitFor.Seconds(0.1f);
-		}
-	}
-
-	#endregion Animations
-
-	private void UpdateOverlay()
-	{
-		transform.Rotate(Vector3.zero, Space.World);
-		faceOverlayHandler.ChangeSpriteVariant(result - 1);
-	}
-
-	protected virtual int GetSide()
-	{
-		int result = Random.Range(1, sides + 1);
-
-		if (isRigged && result != riggedValue)
-		{
-			if (GetProbability(Mathf.Clamp((1 / sides) * 100, 25, 80)))
+			if (cookable != null && isRiggable)
 			{
-				return riggedValue;
+				cookable.OnCooked += Cook;
 			}
 		}
 
-		return result;
-	}
+		private void OnDisable()
+		{
+			netTransform.OnThrowStart.RemoveListener(ThrowStart);
+			netTransform.OnThrowEnd.RemoveListener(ThrowEnd);
 
-	protected virtual string GetMessage()
-	{
-		return $"The {dieName} lands a {result}.";
-	}
+			if (cookable != null)
+			{
+				cookable.OnCooked -= Cook;
+			}
+		}
 
-	/// <summary>
-	/// Gets the probability of a given value being within 0 and a number generated from 0 to 100.
-	/// </summary>
-	/// <param name="percent">The percentage value to check with</param>
-	/// <returns>True if the given value was less or equal to a random number between 0 and 100</returns>
-	protected bool GetProbability(int percent)
-	{
-		return Random.Range(0, 100) <= percent;
+		#endregion Lifecycle
+
+		#region Interactions
+
+		public bool WillInteract(HandActivate interaction, NetworkSide side)
+		{
+			return DefaultWillInteract.Default(interaction, side);
+		}
+
+		public void ServerPerformInteraction(HandActivate interaction)
+		{
+			handRollInteraction = interaction;
+
+			StartCoroutine(RollInHand());
+		}
+
+		public virtual string Examine(Vector3 worldPos = default)
+		{
+			return $"It is showing side {result}.";
+		}
+
+		#endregion Interactions
+
+		public void Cook()
+		{
+			if (isRiggable)
+			{
+				isRigged = true;
+				riggedValue = result;
+			}
+		}
+
+		private IEnumerator RollInHand()
+		{
+			Chat.AddExamineMsgFromServer(handRollInteraction.Performer, $"You roll the {dieName} in your hands...");
+
+			IsRolling = true;
+			this.RestartCoroutine(AnimateSides(), ref animateSides);
+			yield return WaitFor.Seconds(ROLL_TIME);
+			IsRolling = false;
+
+			result = GetSide();
+			UpdateOverlay();
+			Chat.AddExamineMsgFromServer(handRollInteraction.Performer, GetMessage());
+		}
+
+		#region Throwing
+
+		private void ThrowStart(ThrowInfo throwInfo)
+		{
+			if (throwInfo.ThrownBy.GetComponent<NetworkIdentity>() == null) return;
+
+			Chat.AddActionMsgToChat(throwInfo.ThrownBy, $"You throw the {dieName}...", $"{throwInfo.ThrownBy.ExpensiveName()} throws the {dieName}...");
+		}
+
+		private void ThrowEnd(ThrowInfo throwInfo)
+		{
+			this.RestartCoroutine(WaitForSide(), ref waitForSide);
+		}
+
+		private IEnumerator WaitForSide()
+		{
+			IsRolling = true;
+			this.RestartCoroutine(AnimateSides(), ref animateSides);
+			this.RestartCoroutine(AnimateBounce(), ref animateBounce);
+			yield return WaitFor.Seconds(ROLL_TIME);
+			IsRolling = false;
+
+			result = GetSide();
+			UpdateOverlay();
+			Chat.AddLocalMsgToChat(GetMessage(), gameObject);
+		}
+
+		#endregion Throwing
+
+		#region Animations
+
+		protected IEnumerator AnimateSides()
+		{
+			while (IsRolling)
+			{
+				faceOverlayHandler.ChangeSpriteVariant(Random.Range(0, sides));
+				yield return WaitFor.Seconds(0.1f);
+			}
+		}
+
+		protected IEnumerator AnimateBounce()
+		{
+			// Rotate some limited angle from north, bounce in that direction, return to original position.
+			// TODO: Pretty bad bounce. Some lerping would help.
+			while (IsRolling)
+			{
+				dieTransform.Rotate(new Vector3(0, 0, Random.Range(-180, 180)), Space.World);
+				dieTransform.Translate(new Vector3(0, 0.2f, 0));
+				yield return WaitFor.Seconds(0.1f);
+
+				dieTransform.Translate(new Vector3(0, -0.2f, 0));
+				yield return WaitFor.Seconds(0.1f);
+			}
+		}
+
+		#endregion Animations
+
+		private void UpdateOverlay()
+		{
+			transform.Rotate(Vector3.zero, Space.World);
+			faceOverlayHandler.ChangeSpriteVariant(result - 1);
+		}
+
+		protected virtual int GetSide()
+		{
+			int result = Random.Range(1, sides + 1);
+
+			if (isRigged && result != riggedValue)
+			{
+				if (DMMath.Prob(Mathf.Clamp((1 / sides) * 100, 25, 80)))
+				{
+					return riggedValue;
+				}
+			}
+
+			return result;
+		}
+
+		protected virtual string GetMessage()
+		{
+			return $"The {dieName} lands a {result}.";
+		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Dice/RollFudgeDie.cs
+++ b/UnityProject/Assets/Scripts/Items/Dice/RollFudgeDie.cs
@@ -1,25 +1,28 @@
 using UnityEngine;
 
-public class RollFudgeDie : RollSpecialDie
+namespace Items.Dice
 {
-	public override string Examine(Vector3 worldPos = default)
+	public class RollFudgeDie : RollSpecialDie
 	{
-		return $"It is showing {GetFudgeMessage()}";
-	}
-
-	protected override string GetMessage()
-	{
-		return $"The {dieName} lands {GetFudgeMessage()}";
-	}
-
-	private string GetFudgeMessage()
-	{
-		// Result 2 is a strange side, we modify the formatting such that it reads "a... what?".
-		if (result == 2)
+		public override string Examine(Vector3 worldPos = default)
 		{
-			return $"a{specialFaces[1]}";
+			return $"It is showing {GetFudgeMessage()}";
 		}
-		
-		return $"a {specialFaces[result - 1]}.";
+
+		protected override string GetMessage()
+		{
+			return $"The {dieName} lands {GetFudgeMessage()}";
+		}
+
+		private string GetFudgeMessage()
+		{
+			// Result 2 is a strange side, we modify the formatting such that it reads "a... what?".
+			if (result == 2)
+			{
+				return $"a{specialFaces[1]}";
+			}
+
+			return $"a {specialFaces[result - 1]}.";
+		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Dice/RollMultidimensionalDie.cs
+++ b/UnityProject/Assets/Scripts/Items/Dice/RollMultidimensionalDie.cs
@@ -1,28 +1,31 @@
 ﻿using System;
 using UnityEngine;
 
-/// <summary>
-/// For die that are multi-dimensional.
-/// </summary>
-public class RollMultidimensionalDie : RollDie
+namespace Items.Dice
 {
-	[Tooltip("The amount of sides a die for a single dimension has.")]
-	public int singleDieSides;
-
-	public override string Examine(Vector3 worldPos = default)
+	/// <summary>
+	/// For dice that are multi-dimensional.
+	/// </summary>
+	public class RollMultidimensionalDie : RollDie
 	{
-		return $"It is showing Cube-Side: {GetDimensionalMessage()}.";
-	}
+		[Tooltip("The amount of sides a die for a single dimension has.")]
+		public int singleDieSides;
 
-	protected override string GetMessage()
-	{
-		return $"It lands with Cube-Side: {GetDimensionalMessage()}.";
-	}
+		public override string Examine(Vector3 worldPos = default)
+		{
+			return $"It is showing Cube-Side: {GetDimensionalMessage()}.";
+		}
 
-	private string GetDimensionalMessage()
-	{
-		int remainder, quotient = Math.DivRem(result, singleDieSides, out remainder);
+		protected override string GetMessage()
+		{
+			return $"It lands with Cube-Side: {GetDimensionalMessage()}.";
+		}
 
-		return $"{quotient + 1}-{remainder + 1}";
+		private string GetDimensionalMessage()
+		{
+			int remainder, quotient = Math.DivRem(result, singleDieSides, out remainder);
+
+			return $"{quotient + 1}-{remainder + 1}";
+		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Dice/RollSpaceCube.cs
+++ b/UnityProject/Assets/Scripts/Items/Dice/RollSpaceCube.cs
@@ -1,22 +1,25 @@
 ﻿using Items;
 
-public class RollSpaceCube : RollDie
+namespace Items.Dice
 {
-	ItemAttributesV2 itemAttributes;
-
-	protected override void Awake()
+	public class RollSpaceCube : RollDie
 	{
-		base.Awake();
-		itemAttributes = GetComponent<ItemAttributesV2>();
-	}
+		ItemAttributesV2 itemAttributes;
 
-	protected override void Start()
-	{
-		base.Start();
-
-		if (GetProbability(10))
+		protected override void Awake()
 		{
-			itemAttributes.ServerSetArticleName("spess cube");
+			base.Awake();
+			itemAttributes = GetComponent<ItemAttributesV2>();
+		}
+
+		protected override void Start()
+		{
+			base.Start();
+
+			if (DMMath.Prob(10))
+			{
+				itemAttributes.ServerSetArticleName("spess cube");
+			}
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Dice/RollSpecialDie.cs
+++ b/UnityProject/Assets/Scripts/Items/Dice/RollSpecialDie.cs
@@ -1,22 +1,25 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
 
-/// <summary>
-/// For die that have special faces (shows the name of the face instead of the number).
-/// </summary>
-public class RollSpecialDie : RollDie
+namespace Items.Dice
 {
-	[SerializeField]
-	[Tooltip("A list of the possible side names.")]
-	protected List<string> specialFaces = new List<string>();
-
-	public override string Examine(Vector3 worldPos = default)
+	/// <summary>
+	/// For die that have special faces (shows the name of the face instead of the number).
+	/// </summary>
+	public class RollSpecialDie : RollDie
 	{
-		return $"It is showing side '{specialFaces[result - 1]}'.";
-	}
+		[SerializeField]
+		[Tooltip("A list of the possible side names.")]
+		protected List<string> specialFaces = new List<string>();
 
-	protected override string GetMessage()
-	{
-		return $"The {dieName} lands a '{specialFaces[result - 1]}'.";
+		public override string Examine(Vector3 worldPos = default)
+		{
+			return $"It is showing side '{specialFaces[result - 1]}'.";
+		}
+
+		protected override string GetMessage()
+		{
+			return $"The {dieName} lands a '{specialFaces[result - 1]}'.";
+		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Kitchen/Cookable.cs
+++ b/UnityProject/Assets/Scripts/Items/Kitchen/Cookable.cs
@@ -1,43 +1,63 @@
 ﻿using System;
-using System.Collections;
 using UnityEngine;
-using UnityEngine.Events;
 
-/// <summary>
-/// This class doesn't handle cooking itself; it merely stores the cooking times
-/// and products for other objects (e.g. the microwave) to use when cooking.
-/// The <see cref="OnCooked"/> event is raised when something cooks this, which other
-/// components can subscribe to, to perform extra logic (for e.g. microwaving dice to rig them)
-/// </summary>
-public class Cookable : MonoBehaviour
+
+namespace Items.Food
 {
-	[Tooltip("Minimum time to cook.")]
-	public int CookTime = 10;
-
-	[Tooltip("What this GameObject becomes when cooked. If not set, this GameObject will not change GameObject when cooked.")]
-	public GameObject CookedProduct;
-
 	/// <summary>
-	/// Raised when enough cooking time has been added (via <see cref="AddCookingTime(float)"/>)
+	/// This class doesn't handle cooking itself; it merely stores the cooking times
+	/// and products for other objects (e.g. the microwave) to use when cooking.
+	/// <para>The <see cref="OnCooked"/> event is raised when something cooks this, which other
+	/// components can subscribe to, to perform extra logic (for e.g. microwaving dice to rig them).</para>
 	/// </summary>
-	public event Action OnCooked;
-
-	private float timeSpentCooking;
-
-	/// <summary>
-	/// Adds the given cooking time to this object. Will return true if the item is now cooked.
-	/// </summary>
-	/// <param name="time">The amount of time in seconds to add to this object's time spent cooking.</param>
-	/// <returns>true if the added time and any previous time spent cooking was enough to exceed the required cooking time.</returns>
-	public bool AddCookingTime(float time)
+	public class Cookable : MonoBehaviour
 	{
-		timeSpentCooking += time;
-		if (timeSpentCooking > CookTime)
+		[Tooltip("Minimum time to cook.")]
+		public int CookTime = 10;
+
+		[Tooltip("What this GameObject becomes when cooked. If not set, this GameObject will not change GameObject when cooked.")]
+		public GameObject CookedProduct;
+
+		[SerializeField]
+		[Tooltip("Whether this object should turn into the cooked product when destroyed by burn damage.")]
+		private bool cookOnDestroyByBurn = true;
+
+		/// <summary>
+		/// Raised when enough cooking time has been added (via <see cref="AddCookingTime(float)"/>)
+		/// </summary>
+		public event Action OnCooked;
+
+		private float timeSpentCooking;
+
+		private void Awake()
 		{
-			OnCooked?.Invoke();
-			return true;
+			if (cookOnDestroyByBurn)
+			{
+				GetComponent<Integrity>().OnBurnUpServer += OnBurnUpServer;
+			}
 		}
 
-		return false;
+		/// <summary>
+		/// Adds the given cooking time to this object. Will return true if the item is now cooked.
+		/// </summary>
+		/// <param name="time">The amount of time in seconds to add to this object's time spent cooking.</param>
+		/// <returns>true if the added time and any previous time spent cooking was enough to exceed the required cooking time.</returns>
+		public bool AddCookingTime(float time)
+		{
+			timeSpentCooking += time;
+			if (timeSpentCooking > CookTime)
+			{
+				OnCooked?.Invoke();
+				return true;
+			}
+
+			return false;
+		}
+
+		private void OnBurnUpServer(DestructionInfo info)
+		{
+			_ = Despawn.ServerSingle(gameObject);
+			Spawn.ServerPrefab(CookedProduct, gameObject.RegisterTile().WorldPosition, transform.parent);
+		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Objects/Kitchen/InteractableMicrowave.cs
+++ b/UnityProject/Assets/Scripts/Objects/Kitchen/InteractableMicrowave.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Linq;
 using UnityEngine;
+
 
 namespace Objects.Kitchen
 {
@@ -38,17 +40,17 @@ namespace Objects.Kitchen
 
 		public string Examine(Vector3 worldPos = default)
 		{
-			return $"The microwave is currently {microwave.currentState.StateMsgForExamine}. " +
-					$"You see {(microwave.HasContents ? microwave.storageSlot.ItemObject.ExpensiveName() : "nothing")} inside. " +
-					$"There {(microwave.StorageSize() == 1 ? "is 1 slot" : $"are {microwave.StorageSize()} slots")} inside."+
-					$"The timer shows {Math.Ceiling(microwave.microwaveTimer)} seconds remaining.";
+			return $"The microwave is currently {microwave.CurrentState.StateMsgForExamine}. " +
+					$"You see {(microwave.HasContents ? string.Join(", ", microwave.Slots.Where(slot => slot.IsOccupied).Select(slot => slot.ItemObject.ExpensiveName())) : "nothing")} inside. " +
+					$"There {(microwave.StorageSize == 1 ? "is one slot" : $"are {microwave.StorageSize} slots")} available."+
+					$"The timer shows {Math.Ceiling(microwave.MicrowaveTimer)} seconds remaining.";
 		}
 
 		#region Interaction-PositionalHandApply
 
 		public bool WillInteract(PositionalHandApply interaction, NetworkSide side)
 		{
-			if (!DefaultWillInteract.Default(interaction, side)) return false;
+			if (DefaultWillInteract.Default(interaction, side) == false) return false;
 
 			return Validations.HasUsedItemTrait(interaction, CommonTraits.Instance.Screwdriver) == false;
 		}
@@ -57,7 +59,7 @@ namespace Objects.Kitchen
 		{
 			if (doorRegion.Contains(interaction.WorldPositionTarget))
 			{
-				microwave.RequestDoorInteraction(interaction.HandSlot);
+				microwave.RequestDoorInteraction(interaction);
 			}
 			else if (powerRegion.Contains(interaction.WorldPositionTarget))
 			{

--- a/UnityProject/Assets/Scripts/Systems/Inventory/ItemStorage.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/ItemStorage.cs
@@ -536,13 +536,13 @@ public class ItemStorage : MonoBehaviour, IServerLifecycle, IServerInventoryMove
 	}
 
 	/// <summary>
-	/// Drops all items in all slots at our current position.
+	/// Drops all items in all slots.
 	/// </summary>
-	public void ServerDropAll()
+	public void ServerDropAll(Vector2? worldTargetVector = null)
 	{
 		foreach (var itemSlot in GetItemSlots())
 		{
-			Inventory.ServerDrop(itemSlot);
+			Inventory.ServerDrop(itemSlot, worldTargetVector);
 		}
 	}
 }


### PR DESCRIPTION
- CL: [Fix] Fixes microwave glow effects not syncing to client.
![microwave lighting](https://user-images.githubusercontent.com/6926225/89893809-27f18480-dc2d-11ea-8fd1-abbf28371391.gif)
- CL: [Improvement] Adds better examination / interaction feedback for microwaves.
- CL: [Improvement] Microwaves can now be overvolted for faster cooking / screaming.
- Removes the legacy way of cooking, via the old `CraftingManager`, from the microwave in favour of the `Cookable` component.
- CL: [New] Items with the `Cookable` component now have the (enabled by default) option to be cooked when destroyed by burn damage (as per the `RawMeat` component).
- Small code tweaks, namespacing.