### PR TITLE
Random pitches for food and drink sounds.

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/PastrySnacks/Donuts/DonutApple.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/PastrySnacks/Donuts/DonutApple.prefab
@@ -88,11 +88,6 @@ PrefabInstance:
       propertyPath: initialDescription
       value: Goes great with a shot of cinnamon schnapps.
       objectReference: {fileID: 0}
-    - target: {fileID: 4845489334075017082, guid: c8966d5986e801548b806fb2ab2bbf3c,
-        type: 3}
-      propertyPath: sound.AssetAddress
-      value: null
-      objectReference: {fileID: 0}
     - target: {fileID: 6270160345599159643, guid: c8966d5986e801548b806fb2ab2bbf3c,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/PastrySnacks/Donuts/_DonutBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/PastrySnacks/Donuts/_DonutBase.prefab
@@ -21,7 +21,7 @@ MonoBehaviour:
       m_SubObjectName: 
       m_SubObjectType: 
   StartingNutrients: 165
-  Nutriment: {fileID: 0}
+  Nutriment: {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237, type: 2}
   healBruteDamage: 5
   healableJobs: 1700000021000000110000002a00000029000000
 --- !u!1001 &1205097671078976283

--- a/UnityProject/Assets/Scripts/Items/Food/DrinkableContainer.cs
+++ b/UnityProject/Assets/Scripts/Items/Food/DrinkableContainer.cs
@@ -20,7 +20,7 @@ public class DrinkableContainer : Consumable
 	[Tooltip("The name of the sound the player makes when drinking (must be in soundmanager")]
 	[SerializeField] private AddressableAudioSource drinkSound = null;
 
-	private float randomPitch => Random.Range( 0.7f, 1.3f );
+	private float RandomPitch => Random.Range( 0.7f, 1.3f );
 
 	private ReagentContainer container;
 	private ItemAttributesV2 itemAttributes;
@@ -88,7 +88,7 @@ public class DrinkableContainer : Consumable
 		// Play sound
 		if (item && drinkSound != null)
 		{
-			AudioSourceParameters audioSourceParameters = new AudioSourceParameters(randomPitch, spatialBlend: 1f);
+			AudioSourceParameters audioSourceParameters = new AudioSourceParameters(RandomPitch, spatialBlend: 1f);
 			SoundManager.PlayNetworkedAtPos(drinkSound, eater.WorldPos, audioSourceParameters, sourceObj: eater.gameObject);
 		}
 	}

--- a/UnityProject/Assets/Scripts/Items/Food/DrinkableContainer.cs
+++ b/UnityProject/Assets/Scripts/Items/Food/DrinkableContainer.cs
@@ -7,6 +7,7 @@ using ScriptableObjects;
 using UnityEngine;
 using AddressableReferences;
 using Messages.Server.SoundMessages;
+using Random = UnityEngine.Random;
 using WebSocketSharp;
 
 [RequireComponent(typeof(ItemAttributesV2))]
@@ -19,11 +20,11 @@ public class DrinkableContainer : Consumable
 	[Tooltip("The name of the sound the player makes when drinking (must be in soundmanager")]
 	[SerializeField] private AddressableAudioSource drinkSound = null;
 
+	private float randomPitch => Random.Range( 0.7f, 1.3f );
+
 	private ReagentContainer container;
 	private ItemAttributesV2 itemAttributes;
 	private RegisterItem item;
-
-	private AudioSourceParameters audioSourceParameters = new AudioSourceParameters(spatialBlend: 1f);
 
 	private static readonly StandardProgressActionConfig ProgressConfig
 		= new StandardProgressActionConfig(StandardProgressActionType.Restrain);
@@ -87,6 +88,7 @@ public class DrinkableContainer : Consumable
 		// Play sound
 		if (item && drinkSound != null)
 		{
+			AudioSourceParameters audioSourceParameters = new AudioSourceParameters(randomPitch, spatialBlend: 1f);
 			SoundManager.PlayNetworkedAtPos(drinkSound, eater.WorldPos, audioSourceParameters, sourceObj: eater.gameObject);
 		}
 	}

--- a/UnityProject/Assets/Scripts/Items/Food/Edible.cs
+++ b/UnityProject/Assets/Scripts/Items/Food/Edible.cs
@@ -7,6 +7,8 @@ using Chemistry;
 using Chemistry.Components;
 using UnityEngine;
 using UnityEngine.Serialization;
+using Random = UnityEngine.Random;
+using Messages.Server.SoundMessages;
 
 namespace Items.Food
 {
@@ -22,6 +24,8 @@ namespace Items.Food
 
 		[SerializeField]
 		private AddressableAudioSource sound = null;
+
+		private float randomPitch => Random.Range( 0.7f, 1.3f );
 
 		private static readonly StandardProgressActionConfig ProgressConfig
 			= new StandardProgressActionConfig(StandardProgressActionType.Restrain);
@@ -78,7 +82,8 @@ namespace Items.Food
 			if (eater == null)
 			{
 				// todo: implement non-player eating
-				SoundManager.PlayNetworkedAtPos(sound, item.WorldPosition);
+				AudioSourceParameters eatSoundParameters = new AudioSourceParameters(pitch: randomPitch);
+				SoundManager.PlayNetworkedAtPos(sound, item.WorldPosition, eatSoundParameters);
 				if (leavings != null)
 				{
 					Spawn.ServerPrefab(leavings, item.WorldPosition, transform.parent);
@@ -117,7 +122,8 @@ namespace Items.Food
 		public virtual void Eat(PlayerScript eater, PlayerScript feeder)
 		{
 			//TODO: Reimplement metabolism.
-			SoundManager.PlayNetworkedAtPos(sound, eater.WorldPos, sourceObj: eater.gameObject);
+			AudioSourceParameters eatSoundParameters = new AudioSourceParameters(pitch: randomPitch);
+			SoundManager.PlayNetworkedAtPos(sound, eater.WorldPos, eatSoundParameters, sourceObj: eater.gameObject);
 
 			var Stomachs = eater.playerHealth.GetStomachs();
 			if (Stomachs.Count == 0)

--- a/UnityProject/Assets/Scripts/Items/Food/Edible.cs
+++ b/UnityProject/Assets/Scripts/Items/Food/Edible.cs
@@ -25,7 +25,7 @@ namespace Items.Food
 		[SerializeField]
 		private AddressableAudioSource sound = null;
 
-		private float randomPitch => Random.Range( 0.7f, 1.3f );
+		private float RandomPitch => Random.Range( 0.7f, 1.3f );
 
 		private static readonly StandardProgressActionConfig ProgressConfig
 			= new StandardProgressActionConfig(StandardProgressActionType.Restrain);
@@ -82,7 +82,7 @@ namespace Items.Food
 			if (eater == null)
 			{
 				// todo: implement non-player eating
-				AudioSourceParameters eatSoundParameters = new AudioSourceParameters(pitch: randomPitch);
+				AudioSourceParameters eatSoundParameters = new AudioSourceParameters(pitch: RandomPitch);
 				SoundManager.PlayNetworkedAtPos(sound, item.WorldPosition, eatSoundParameters);
 				if (leavings != null)
 				{
@@ -122,7 +122,7 @@ namespace Items.Food
 		public virtual void Eat(PlayerScript eater, PlayerScript feeder)
 		{
 			//TODO: Reimplement metabolism.
-			AudioSourceParameters eatSoundParameters = new AudioSourceParameters(pitch: randomPitch);
+			AudioSourceParameters eatSoundParameters = new AudioSourceParameters(pitch: RandomPitch);
 			SoundManager.PlayNetworkedAtPos(sound, eater.WorldPos, eatSoundParameters, sourceObj: eater.gameObject);
 
 			var Stomachs = eater.playerHealth.GetStomachs();


### PR DESCRIPTION

### Purpose
- Food and drink sounds now have randomized pitches, to reduce monotony.
- Donuts now have a proper nutrition reagent and apple donuts no longer make no sounds.

CL: [Fix] Donuts now have a proper nutrition reagent and apple donuts no longer make no sounds.
CL: [Improvement] Food and drink sounds now have randomized pitches, to reduce monotony.