### PR TITLE
Fix == operator on MatrixInfo

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixInfo.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixInfo.cs
@@ -126,7 +126,7 @@ public class MatrixInfo : IEquatable<MatrixInfo>
 		}
 	}
 
-	public bool Equals(MatrixInfo other) => Id == other?.Id;
+	public bool Equals(MatrixInfo other) => other is null == false && Id == other.Id;
 
 	public override bool Equals(object obj) => obj is MatrixInfo other && Equals(other);
 
@@ -173,9 +173,7 @@ public class MatrixInfo : IEquatable<MatrixInfo>
 
 	public static IEqualityComparer<MatrixInfo> IdComparer { get; } = new IdEqualityComparer();
 
-	public static bool operator ==(MatrixInfo left, MatrixInfo right) =>
-		ReferenceEquals(left, null) == false && left.Equals(right);
+	public static bool operator ==(MatrixInfo left, MatrixInfo right) => left?.Equals(right) ?? right is null;
 
-	public static bool operator !=(MatrixInfo left, MatrixInfo right) =>
-		ReferenceEquals(left, null) == false && left.Equals(right) == false;
+	public static bool operator !=(MatrixInfo left, MatrixInfo right) => left == right == false;
 }

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixInfo.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixInfo.cs
@@ -173,7 +173,15 @@ public class MatrixInfo : IEquatable<MatrixInfo>
 
 	public static IEqualityComparer<MatrixInfo> IdComparer { get; } = new IdEqualityComparer();
 
-	public static bool operator ==(MatrixInfo left, MatrixInfo right) => left?.Equals(right) ?? right is null;
+	public static bool operator ==(MatrixInfo left, MatrixInfo right)
+	{
+		if (left is null)
+		{
+			return right is null;
+		}
+
+		return left.Equals(right);
+	}
 
 	public static bool operator !=(MatrixInfo left, MatrixInfo right) => left == right == false;
 }


### PR DESCRIPTION
### Purpose
MatrixInfo == operator is not behaving like an equality operator (a null MatrixInfo == null is false, excuse me what?). The == operator now behaves as it should.

Edit: Slightly more verbose at Gilles request.