### PR TITLE
Fix Escape Objectives Possible Checks

### DIFF
--- a/UnityProject/Assets/Scripts/Systems/Antagonists/AntagData.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/AntagData.cs
@@ -103,7 +103,6 @@ namespace Antagonists
 			{
 				// Add one escape type objective if needed
 				// Be careful not to remove all escape objectives from AntagData
-
 				var allowedEscapes = EscapeObjectives.Where(obj => obj.IsPossible(player)).ToList();
 				//TODO since checkUnique is false we dont need to remove the chosen object from EscapeObjectives
 				//TODO but we would if we ever want to allow for unique escape objectives
@@ -115,10 +114,10 @@ namespace Antagonists
 			if (antag.ChanceForGimmickObjective != 0 && DMMath.Prob(antag.ChanceForGimmickObjective))
 			{
 				// Add one gimmick objective
-				var allowedEscapes = GimmickObjectives.Where(obj => obj.IsPossible(player)).ToList();
+				var allowedGimmicks = GimmickObjectives.Where(obj => obj.IsPossible(player)).ToList();
 				//TODO since checkUnique is false we dont need to remove the chosen object from EscapeObjectives
 				//TODO but we would if we ever want to allow for unique gimmick objectives
-				newObjective = PickRandomObjective(ref allowedEscapes, false);
+				newObjective = PickRandomObjective(ref allowedGimmicks, false);
 				newObjective.DoSetup(player.mind);
 				generatedObjs.Add(newObjective);
 			}

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/AntagData.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/AntagData.cs
@@ -103,7 +103,11 @@ namespace Antagonists
 			{
 				// Add one escape type objective if needed
 				// Be careful not to remove all escape objectives from AntagData
-				newObjective = PickRandomObjective(ref EscapeObjectives, false);
+
+				var allowedEscapes = EscapeObjectives.Where(obj => obj.IsPossible(player)).ToList();
+				//TODO since checkUnique is false we dont need to remove the chosen object from EscapeObjectives
+				//TODO but we would if we ever want to allow for unique escape objectives
+				newObjective = PickRandomObjective(ref allowedEscapes, false);
 				newObjective.DoSetup(player.mind);
 				generatedObjs.Add(newObjective);
 			}
@@ -111,7 +115,10 @@ namespace Antagonists
 			if (antag.ChanceForGimmickObjective != 0 && DMMath.Prob(antag.ChanceForGimmickObjective))
 			{
 				// Add one gimmick objective
-				newObjective = PickRandomObjective(ref GimmickObjectives, false);
+				var allowedEscapes = GimmickObjectives.Where(obj => obj.IsPossible(player)).ToList();
+				//TODO since checkUnique is false we dont need to remove the chosen object from EscapeObjectives
+				//TODO but we would if we ever want to allow for unique gimmick objectives
+				newObjective = PickRandomObjective(ref allowedEscapes, false);
 				newObjective.DoSetup(player.mind);
 				generatedObjs.Add(newObjective);
 			}


### PR DESCRIPTION
-Escape objectives will now check for whether the objective is possible before choosing a random one

CL: [Fix] fixed escape objective checking whether it's possible to accomplish before assigning.