### PR TITLE
Add prefab-mode-only and scene-mode-only attributes

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Attributes.meta
+++ b/UnityProject/Assets/Scripts/Core/Attributes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: afac2c9f530e04242bdace68abcf1ce2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Core/Attributes/Attributes.cs
+++ b/UnityProject/Assets/Scripts/Core/Attributes/Attributes.cs
@@ -1,0 +1,14 @@
+﻿using UnityEngine;
+
+namespace Core.Editor.Attributes
+{
+	/// <summary>
+	/// Hides the inspector field when not in prefab-editing mode.
+	/// </summary>
+	public class PrefabModeOnlyAttribute : PropertyAttribute { }
+
+	/// <summary>
+	/// Hides the inspector field when not in scene-editing mode.
+	/// </summary>
+	public class SceneModeOnlyAttribute : PropertyAttribute { }
+}

--- a/UnityProject/Assets/Scripts/Core/Attributes/Attributes.cs.meta
+++ b/UnityProject/Assets/Scripts/Core/Attributes/Attributes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 445882a3c3603464ca82bd65cf949c25
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Core/Editor/CheckmarkMenuItems.meta
+++ b/UnityProject/Assets/Scripts/Core/Editor/CheckmarkMenuItems.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 74fe82283b8135c468661cfc5c5d747d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Core/Editor/CheckmarkMenuItems/CheckmarkMenuItems.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/CheckmarkMenuItems/CheckmarkMenuItems.cs
@@ -1,0 +1,27 @@
+﻿using UnityEditor;
+
+
+namespace Core.Editor
+{
+	[InitializeOnLoad]
+	public static class HideIrrelevantFields
+	{
+		private const string MenuPathName = "Tools/Inspector/Hide Irrelevant Fields";
+
+		public static bool IsEnabled { get; private set; } = true;
+
+		static HideIrrelevantFields()
+		{
+			IsEnabled = EditorPrefs.GetBool(MenuPathName, IsEnabled);
+		}
+
+		[MenuItem(MenuPathName)]
+		private static void ToggleItem()
+		{
+			IsEnabled = !IsEnabled;
+
+			Menu.SetChecked(MenuPathName, IsEnabled);
+			EditorPrefs.SetBool(MenuPathName, IsEnabled);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Core/Editor/CheckmarkMenuItems/CheckmarkMenuItems.cs.meta
+++ b/UnityProject/Assets/Scripts/Core/Editor/CheckmarkMenuItems/CheckmarkMenuItems.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 561840872c9057043986f0c898981df9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Core/Editor/PropertyDrawers.meta
+++ b/UnityProject/Assets/Scripts/Core/Editor/PropertyDrawers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7c727349a64ec66458cfd3b432770d65
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Core/Editor/PropertyDrawers/PropertyDrawers.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/PropertyDrawers/PropertyDrawers.cs
@@ -1,0 +1,37 @@
+﻿using UnityEngine;
+using UnityEditor;
+using UnityEditor.Experimental.SceneManagement;
+
+
+namespace Core.Editor.Attributes
+{
+	[CustomPropertyDrawer(typeof(PrefabModeOnlyAttribute))]
+	public class PrefabModeOnlyDrawer : PropertyDrawer
+	{
+		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+		{
+			return PrefabStageUtility.GetCurrentPrefabStage() == null ? 0 : EditorGUI.GetPropertyHeight(property, label);
+		}
+
+		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+		{
+			if (PrefabStageUtility.GetCurrentPrefabStage() == null) return;
+			EditorGUI.PropertyField(position, property, label);
+		}
+	}
+
+	[CustomPropertyDrawer(typeof(SceneModeOnlyAttribute))]
+	public class SceneModeOnlyDrawer : PropertyDrawer
+	{
+		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+		{
+			return PrefabStageUtility.GetCurrentPrefabStage() != null ? 0 : EditorGUI.GetPropertyHeight(property, label);
+		}
+
+		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+		{
+			if (PrefabStageUtility.GetCurrentPrefabStage() != null) return;
+			EditorGUI.PropertyField(position, property, label);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Core/Editor/PropertyDrawers/PropertyDrawers.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/PropertyDrawers/PropertyDrawers.cs
@@ -8,14 +8,16 @@ namespace Core.Editor.Attributes
 	[CustomPropertyDrawer(typeof(PrefabModeOnlyAttribute))]
 	public class PrefabModeOnlyDrawer : PropertyDrawer
 	{
+		private bool HideProperty => HideIrrelevantFields.IsEnabled && PrefabStageUtility.GetCurrentPrefabStage() == null;
+
 		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
 		{
-			return PrefabStageUtility.GetCurrentPrefabStage() == null ? 0 : EditorGUI.GetPropertyHeight(property, label);
+			return HideProperty ? 0 : EditorGUI.GetPropertyHeight(property, label);
 		}
 
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
 		{
-			if (PrefabStageUtility.GetCurrentPrefabStage() == null) return;
+			if (HideProperty) return;
 			EditorGUI.PropertyField(position, property, label);
 		}
 	}
@@ -23,14 +25,16 @@ namespace Core.Editor.Attributes
 	[CustomPropertyDrawer(typeof(SceneModeOnlyAttribute))]
 	public class SceneModeOnlyDrawer : PropertyDrawer
 	{
+		private bool HideProperty => HideIrrelevantFields.IsEnabled && PrefabStageUtility.GetCurrentPrefabStage() != null;
+
 		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
 		{
-			return PrefabStageUtility.GetCurrentPrefabStage() != null ? 0 : EditorGUI.GetPropertyHeight(property, label);
+			return HideProperty ? 0 : EditorGUI.GetPropertyHeight(property, label);
 		}
 
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
 		{
-			if (PrefabStageUtility.GetCurrentPrefabStage() != null) return;
+			if (HideProperty) return;
 			EditorGUI.PropertyField(position, property, label);
 		}
 	}

--- a/UnityProject/Assets/Scripts/Core/Editor/PropertyDrawers/PropertyDrawers.cs.meta
+++ b/UnityProject/Assets/Scripts/Core/Editor/PropertyDrawers/PropertyDrawers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cb587177dee0759419e3071199049540
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -1,16 +1,17 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using Systems.Atmospherics;
-using Systems.Explosions;
-using AddressableReferences;
-using DatabaseAPI;
 using UnityEngine;
 using UnityEngine.Events;
-using Mirror;
 using UnityEngine.Profiling;
+using Mirror;
+using Core.Editor.Attributes;
+using AddressableReferences;
+using DatabaseAPI;
 using Effects.Overlays;
 using ScriptableObjects;
+using Systems.Atmospherics;
+using Systems.Explosions;
+
 
 /// <summary>
 /// Component which allows an object to have an integrity value (basically an object's version of HP),
@@ -61,37 +62,43 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 	[Tooltip("This object's initial \"HP\"")]
 	public float initialIntegrity = 100f;
 
+	[PrefabModeOnly]
 	[Tooltip("Sound to play when damage applied.")]
 	public AddressableAudioSource soundOnHit;
 
+	[PrefabModeOnly]
 	[Tooltip("A damage threshold the attack needs to pass in order to apply damage to this item.")]
 	public float damageDeflection = 0;
 
 	/// <summary>
 	/// Armor for this object.
 	/// </summary>
+	[PrefabModeOnly]
 	[Tooltip("Armor for this object.")]
 	public Armor Armor = new Armor();
 
 	/// <summary>
 	/// resistances for this object.
 	/// </summary>
+	[PrefabModeOnly]
 	[Tooltip("Resistances of this object.")]
 	public Resistances Resistances = new Resistances();
 
 	/// <summary>
 	/// Below this temperature (in Kelvin) the object will be unaffected by fire exposure.
 	/// </summary>
+	[PrefabModeOnly]
 	[Tooltip("Below this temperature (in Kelvin) the object will be unaffected by fire exposure.")]
 	public float HeatResistance = 100;
 
 	/// <summary>
 	/// The explosion strength of this object if is set to explode on destroy
 	/// </summary>
+	[PrefabModeOnly]
 	[Tooltip("The explosion strength of this object if is set to explode on destroy")]
 	public float ExplosionsDamage = 100f;
 
-	[SerializeField]
+	[SerializeField, PrefabModeOnly]
 	private bool doDamageMessage = true;
 
 	public bool DoDamageMessage => doDamageMessage;
@@ -127,6 +134,7 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 
 	public float Resistance => pushable == null ? integrity : integrity * ((int)pushable.Size / 10f);
 
+	[PrefabModeOnly]
 	public bool CannotBeAshed = false;
 
 	private void Awake()

--- a/UnityProject/Assets/Scripts/Items/Attributes.cs
+++ b/UnityProject/Assets/Scripts/Items/Attributes.cs
@@ -1,7 +1,8 @@
 using System.Linq;
-using Messages.Client.Interaction;
 using UnityEngine;
 using Mirror;
+using Core.Editor.Attributes;
+using Messages.Client.Interaction;
 
 
 [RequireComponent(typeof(Integrity))]
@@ -29,11 +30,11 @@ public class Attributes : NetworkBehaviour, IRightClickable, IExaminable
 	private string initialDescription = null;
 
 	[Tooltip("Will this item highlight on mouseover?")]
-	[SerializeField]
+	[SerializeField, PrefabModeOnly]
 	private bool willHighlight = true;
 
 	[Tooltip("How much does one of these sell for when shipped on the cargo shuttle?")]
-	[SerializeField]
+	[SerializeField, PrefabModeOnly]
 	private int exportCost = 0;
 
 	public int ExportCost
@@ -51,12 +52,12 @@ public class Attributes : NetworkBehaviour, IRightClickable, IExaminable
 	}
 
 	[Tooltip("Should an alternate name be used when displaying this in the cargo console report?")]
-	[SerializeField]
+	[SerializeField, PrefabModeOnly]
 	private string exportName = "";
 	public string ExportName => exportName;
 
 	[Tooltip("Additional message to display in the cargo console report.")]
-	[SerializeField]
+	[SerializeField, PrefabModeOnly]
 	private string exportMessage = null;
 	public string ExportMessage => exportMessage;
 

--- a/UnityProject/Assets/Scripts/Items/Weapons/Meleeable.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Meleeable.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
+using Core.Editor.Attributes;
 using Items;
+
 
 namespace Systems.Interaction
 {
@@ -10,7 +12,7 @@ namespace Systems.Interaction
 	/// </summary>
 	public class Meleeable : MonoBehaviour, IPredictedCheckedInteractable<PositionalHandApply>
 	{
-		[SerializeField]
+		[SerializeField, PrefabModeOnly]
 		private bool isMeleeable = true;
 		// If it has this component, isn't it assumed to be meleeable? Is this still true for tilemaps?
 		public bool IsMeleeable

--- a/UnityProject/Assets/Scripts/Objects/Directionals/Directional.cs
+++ b/UnityProject/Assets/Scripts/Objects/Directionals/Directional.cs
@@ -1,8 +1,9 @@
 ﻿using System;
-using System.Collections;
 using UnityEngine;
 using UnityEngine.Events;
 using Mirror;
+using Core.Editor.Attributes;
+
 
 /// <summary>
 /// Component which allows an object to have an orientation (facing) which is synced over the network, supports client
@@ -24,6 +25,7 @@ public class Directional : NetworkBehaviour, IMatrixRotation
 	public OrientationEnum InitialDirection = OrientationEnum.Down;
 
 	private OrientationEnum editorInitialDirection;
+	[PrefabModeOnly]
 	public UnityEvent onEditorDirectionChange;
 
 	/// <summary>
@@ -41,6 +43,7 @@ public class Directional : NetworkBehaviour, IMatrixRotation
 	/// matrix rotation to match the matrix rotation that occurred. If false,
 	/// direction will not be changed regardless of matrix rotation.
 	/// </summary>
+	[PrefabModeOnly]
 	[Tooltip("If true, direction will be changed at the end of " +
 	         "matrix rotation to match the matrix rotation that occurred. If false," +
 	         " direction will not be changed regardless of matrix rotation.")]
@@ -48,6 +51,7 @@ public class Directional : NetworkBehaviour, IMatrixRotation
 
 	[Tooltip("If true this component will ignore all SyncVar updates. Useful if you just want to use" +
 	         "this component for easy direction changing at edit time")]
+	[PrefabModeOnly]
 	public bool DisableSyncing = false;
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Objects/Directionals/DirectionalRotatesParent.cs
+++ b/UnityProject/Assets/Scripts/Objects/Directionals/DirectionalRotatesParent.cs
@@ -1,6 +1,7 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using UnityEngine;
+using Core.Editor.Attributes;
+
 
 /// <summary>
 /// Component which causes ONLY parent to rotate based on Directional orientation
@@ -11,10 +12,10 @@ using UnityEngine;
 public class DirectionalRotatesParent : MonoBehaviour
 {
 	[Tooltip("Direction that the children of the root of this prefab are facing in.")]
-	[SerializeField]
+	[SerializeField, PrefabModeOnly]
 	private OrientationEnum prefabChildrenOrientation = OrientationEnum.Down;
 
-	[SerializeField]
+	[SerializeField, PrefabModeOnly]
 	private bool forceChildrenOpposite;
 
 	public OrientationEnum MappedOrientation

--- a/UnityProject/Assets/Scripts/Objects/Directionals/DirectionalSpriteV2.cs
+++ b/UnityProject/Assets/Scripts/Objects/Directionals/DirectionalSpriteV2.cs
@@ -1,4 +1,6 @@
 ﻿using UnityEngine;
+using Core.Editor.Attributes;
+
 
 namespace Core.Directionals
 {
@@ -13,28 +15,28 @@ namespace Core.Directionals
 	public class DirectionalSpriteV2 : MonoBehaviour
 	{
 		[Tooltip("Whether the sprite SO list should be changed instead of the variant, for some exceptional objects like morgues.")]
-		[SerializeField]
+		[SerializeField, PrefabModeOnly]
 		private bool isChangingSO = false;
 
 		[Header("SpriteHandler Indexes")]
 		[Tooltip("SpriteHandler index to use when facing down.")]
-		[SerializeField]
+		[SerializeField, PrefabModeOnly]
 		private int indexDown = 0;
 
 		[Tooltip("SpriteHandler index to use when facing up.")]
-		[SerializeField]
+		[SerializeField, PrefabModeOnly]
 		private int indexUp = 1;
 
 		[Tooltip("SpriteHandler index to use when facing right.")]
-		[SerializeField]
+		[SerializeField, PrefabModeOnly]
 		private int indexRight = 2;
 
 		[Tooltip("SpriteHandler index to use when facing left.")]
-		[SerializeField]
+		[SerializeField, PrefabModeOnly]
 		private int indexLeft = 3;
 
 		[Tooltip("The SpriteHandlers to control. Allows multiple for overlays.")]
-		[SerializeField]
+		[SerializeField, PrefabModeOnly]
 		private SpriteHandler[] spriteHandlers = default;
 
 		private Directional directional;

--- a/UnityProject/Assets/Scripts/Objects/Doors/DoorAnimatorV2.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/DoorAnimatorV2.cs
@@ -1,65 +1,65 @@
 ﻿using System;
 using System.Collections;
-using AddressableReferences;
-using NaughtyAttributes;
 using UnityEngine;
+using NaughtyAttributes;
+using Core.Editor.Attributes;
+using AddressableReferences;
 using Messages.Server;
+
 
 namespace Doors
 {
 	public class DoorAnimatorV2 : MonoBehaviour
 	{
 		#region Sprite layers
-		[BoxGroup("Sprite Layers"),
-		 Tooltip("Game object which represents the base of this door"),
-		 SerializeField]
+		[SerializeField, BoxGroup("Sprite Layers"), PrefabModeOnly]
+		[Tooltip("Game object which represents the base of this door")]
 		private GameObject doorBase = null;
 
-		[BoxGroup("Sprite Layers"),
-		 Tooltip("Game object which represents the light layer of this door"),
-		 SerializeField]
+		[SerializeField, BoxGroup("Sprite Layers"), PrefabModeOnly]
+		[Tooltip("Game object which represents the light layer of this door")]
 		private GameObject overlaySparks = null;
 
-		[BoxGroup("Sprite Layers"),
-		 Tooltip("Game object which represents the light layer of this door"),
-		 SerializeField]
+		[SerializeField, BoxGroup("Sprite Layers"), PrefabModeOnly]
+		[Tooltip("Game object which represents the light layer of this door")]
 		private GameObject overlayLights = null;
 
-		[BoxGroup("Sprite Layers"),
-		 Tooltip("Game object which represents the fill layer of this door"),
-		 SerializeField]
+		[SerializeField, BoxGroup("Sprite Layers"), PrefabModeOnly]
+		[Tooltip("Game object which represents the fill layer of this door")]
 		private GameObject overlayFill = null;
 
-		[BoxGroup("Sprite Layers"),
-		 Tooltip("Game object which represents the welded and effects layer for this door"),
-		 SerializeField]
+		[SerializeField, BoxGroup("Sprite Layers"), PrefabModeOnly]
+		[Tooltip("Game object which represents the welded and effects layer for this door")]
 		private GameObject overlayWeld = null;
 
-		[BoxGroup("Sprite Layers"),
-		 Tooltip("Game object which represents the hacking panel layer for this door"),
-		 SerializeField]
+		[SerializeField, BoxGroup("Sprite Layers"), PrefabModeOnly]
+		[Tooltip("Game object which represents the hacking panel layer for this door")]
 		private GameObject overlayHacking = null;
 
-		[SerializeField, Tooltip("Time this door's opening animation takes")]
+		[SerializeField, PrefabModeOnly]
+		[Tooltip("Time this door's opening animation takes")]
 		private float openingAnimationTime = 0.6f;
 
-		[SerializeField, Tooltip("Time this door's closing animation takes")]
+		[SerializeField, PrefabModeOnly]
+		[Tooltip("Time this door's closing animation takes")]
 		private float closingAnimationTime = 0.6f;
 
-		[SerializeField, Tooltip("Time this door's denied animation takes")]
+		[SerializeField, PrefabModeOnly]
+		[Tooltip("Time this door's denied animation takes")]
 		private float deniedAnimationTime = 0.6f;
 
-		[SerializeField, Tooltip("Time this door's warning animation takes")]
+		[SerializeField, PrefabModeOnly]
+		[Tooltip("Time this door's warning animation takes")]
 		private float warningAnimationTime = 0.6f;
 		#endregion
 
-		[SerializeField, Tooltip("Sound that plays when opening this door")]
+		[SerializeField, PrefabModeOnly, Tooltip("Sound that plays when opening this door")]
 		private AddressableAudioSource openingSFX;
-		[SerializeField, Tooltip("Sound that plays when closing this door")]
+		[SerializeField, PrefabModeOnly, Tooltip("Sound that plays when closing this door")]
 		private AddressableAudioSource closingSFX;
-		[SerializeField, Tooltip("Sound that plays when access is denied by this door")]
+		[SerializeField, PrefabModeOnly, Tooltip("Sound that plays when access is denied by this door")]
 		private AddressableAudioSource deniedSFX;
-		[SerializeField, Tooltip("Sound that plays when pressure warning is played by this door")]
+		[SerializeField, PrefabModeOnly, Tooltip("Sound that plays when pressure warning is played by this door")]
 		private AddressableAudioSource warningSFX;
 
 		public event Action AnimationFinished;

--- a/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
@@ -2,15 +2,16 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using UI.Core.Net;
 using UnityEngine;
 using Mirror;
+using Core.Editor.Attributes;
 using Messages.Client.NewPlayer;
 using Messages.Server;
 using Systems.Electricity;
 using Systems.Interaction;
 using Doors.Modules;
 using HealthV2;
-using UI.Core.Net;
 
 
 //TODO: Need to reimplement hacking with this system. Might be a nightmare, dk yet.
@@ -22,27 +23,28 @@ namespace Doors
 	public class DoorMasterController : NetworkBehaviour, ICheckedInteractable<HandApply>, ICheckedInteractable<AiActivate>, ICanOpenNetTab
 	{
 		#region inspector
-		[SerializeField]
+		[SerializeField, PrefabModeOnly]
 		[Tooltip("Toggle damaging any living entities caught in the door as it closes")]
 		private bool damageOnClose = false;
 
-		[SerializeField]
+		[SerializeField, PrefabModeOnly]
 		[Tooltip("Amount of damage when closed on someone.")]
 		private float damageClosed = 90;
 
-		[SerializeField]
+		[SerializeField, PrefabModeOnly]
 		[Tooltip("Does this door open automatically when you walk into it?")]
 		private bool isAutomatic = true;
 
-		[SerializeField]
+		[SerializeField, PrefabModeOnly]
 		[Tooltip("Is this door designed no matter what is under neath it?")]
 		private bool ignorePassableChecks = false;
 
 		//Maximum time the door will remain open before closing itself.
-		[SerializeField][Tooltip("Time this door will wait until autoclosing")]
+		[SerializeField, PrefabModeOnly]
+		[Tooltip("Time this door will wait until autoclosing")]
 		private float maxTimeOpen = 5;
 
-		[SerializeField]
+		[SerializeField, PrefabModeOnly]
 		[Tooltip("Prevent the door from auto closing when opened.")]
 		private bool blockAutoClose = false;
 
@@ -82,7 +84,10 @@ namespace Doors
 		private APCPoweredDevice apc;
 		public APCPoweredDevice Apc => apc;
 
-		[Tooltip("Does it have a glass window you can see trough?")] public bool isWindowedDoor;
+		[PrefabModeOnly]
+		[Tooltip("Does it have a glass window you can see trough?")]
+		public bool isWindowedDoor;
+
 		private int openLayer;
 		private int openSortingLayer;
 		private int closedLayer;

--- a/UnityProject/Assets/Scripts/Objects/Doors/FovDoorController.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/FovDoorController.cs
@@ -1,4 +1,6 @@
 ﻿using UnityEngine;
+using Core.Editor.Attributes;
+
 
 namespace Doors
 {
@@ -7,8 +9,11 @@ namespace Doors
 	/// </summary>
 	public class FovDoorController : MonoBehaviour
 	{
+		[PrefabModeOnly]
 		public Material normalMat;
+		[PrefabModeOnly]
 		public Material greyScaleMat;
+		[PrefabModeOnly]
 		public Material fovMaskMat;
 
 		private SpriteRenderer tileSpriteRenderer;

--- a/UnityProject/Assets/Scripts/Objects/Engineering/APC.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/APC.cs
@@ -10,7 +10,7 @@ using Systems.Electricity;
 using Systems.Electricity.NodeModules;
 using Systems.ObjectConnection;
 using Objects.Lighting;
-
+using Core.Editor.Attributes;
 
 namespace Objects.Engineering
 {
@@ -49,11 +49,12 @@ namespace Objects.Engineering
 		private ResistanceSourceModule resistanceSourceModule;
 
 
-		[SerializeField, FormerlySerializedAs("NetTabType")]
+		[SerializeField, PrefabModeOnly, FormerlySerializedAs("NetTabType")]
 		private NetTabType netTabType = NetTabType.APC;
 
 		[Tooltip("Sound used when the APC loses all power.")]
-		[SerializeField] private AddressableAudioSource NoPowerSound = null;
+		[SerializeField, PrefabModeOnly]
+		private AddressableAudioSource NoPowerSound = null;
 
 		[NonSerialized]
 		//Called every power network update
@@ -300,22 +301,27 @@ namespace Objects.Engineering
 		/// <summary>
 		/// The screen sprites which are currently being displayed
 		/// </summary>
+		[PrefabModeOnly]
 		Sprite[] loadedScreenSprites;
 		/// <summary>
 		/// The animation sprites for when the APC is in a critical state
 		/// </summary>
+		[PrefabModeOnly]
 		public Sprite[] criticalSprites;
 		/// <summary>
 		/// The animation sprites for when the APC is charging
 		/// </summary>
+		[PrefabModeOnly]
 		public Sprite[] chargingSprites;
 		/// <summary>
 		/// The animation sprites for when the APC is fully charged
 		/// </summary>
+		[PrefabModeOnly]
 		public Sprite[] fullSprites;
 		/// <summary>
 		/// The sprite renderer for the APC display
 		/// </summary>
+		[PrefabModeOnly]
 		public SpriteRenderer screenDisplay;
 		/// <summary>
 		/// The sprite index for the display animation

--- a/UnityProject/Assets/Scripts/Objects/Engineering/APCPoweredDevice.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/APCPoweredDevice.cs
@@ -4,13 +4,12 @@ using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.Serialization;
 using Mirror;
+using Core.Editor.Attributes;
 using Systems.ObjectConnection;
 using Objects.Engineering;
-using UnityEngine.Events;
 #if Unity_Editor
 using UnityEditor;
 #endif
-
 
 
 namespace Systems.Electricity
@@ -18,19 +17,19 @@ namespace Systems.Electricity
 	[ExecuteInEditMode]
 	public class APCPoweredDevice : NetworkBehaviour, IServerDespawn, IMultitoolSlaveable
 	{
-		[SerializeField]
+		[SerializeField, PrefabModeOnly]
 		[FormerlySerializedAs("MinimumWorkingVoltage")]
 		private float minimumWorkingVoltage = 190;
 
-		[SerializeField]
+		[SerializeField, PrefabModeOnly]
 		[FormerlySerializedAs("ExpectedRunningVoltage")]
 		private float expectedRunningVoltage = 240;
 
-		[SerializeField]
+		[SerializeField, PrefabModeOnly]
 		[FormerlySerializedAs("MaximumWorkingVoltage")]
 		private float maximumWorkingVoltage = 300;
 
-		[SerializeField]
+		[SerializeField, PrefabModeOnly]
 		[Tooltip("Category of this powered device. " +
 				"Different categories work like a set of breakers, so you can turn off lights and keep machines working.")]
 		private DeviceType deviceType = DeviceType.None;
@@ -41,7 +40,7 @@ namespace Systems.Electricity
 
 		public bool IsSelfPowered => isSelfPowered;
 
-		[SerializeField]
+		[SerializeField, PrefabModeOnly]
 		[Tooltip("Watts consumed per update when running at 240v")]
 		private float wattusage = 0.01f;
 
@@ -53,7 +52,7 @@ namespace Systems.Electricity
 			}
 		}
 
-		[SerializeField]
+		[SerializeField, PrefabModeOnly]
 		[FormerlySerializedAs("Resistance")]
 		private float resistance = 99999999;
 
@@ -64,8 +63,11 @@ namespace Systems.Electricity
 
 		[HideInInspector] public APC RelatedAPC;
 		private IAPCPowerable Powered;
+
+		[PrefabModeOnly]
 		public bool AdvancedControlToScript;
 
+		[PrefabModeOnly]
 		public bool StateUpdateOnClient = true;
 
 		[SyncVar(hook = nameof(UpdateSynchronisedState))]

--- a/UnityProject/Assets/Scripts/Objects/HasNetworkTab.cs
+++ b/UnityProject/Assets/Scripts/Objects/HasNetworkTab.cs
@@ -1,8 +1,9 @@
 using System;
+using UI.Core.Net;
 using UnityEngine;
+using Core.Editor.Attributes;
 using Messages.Server;
 using Systems.Interaction;
-using UI.Core.Net;
 
 
 namespace Objects
@@ -18,10 +19,11 @@ namespace Objects
 		[NonSerialized]
 		private GameObject playerInteracted;
 
+		[PrefabModeOnly]
 		[Tooltip("Network tab to display.")]
 		public NetTabType NetTabType = NetTabType.None;
 
-		[SerializeField]
+		[SerializeField, PrefabModeOnly]
 		private bool aiInteractable = true;
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/Objects/Pipes/MonoPipe.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/MonoPipe.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
+using Core.Editor.Attributes;
 using Systems.Interaction;
 using Systems.Pipes;
 using Items.Atmospherics;
@@ -9,9 +10,13 @@ namespace Objects.Atmospherics
 {
 	public class MonoPipe : MonoBehaviour, IServerLifecycle, ICheckedInteractable<HandApply>, ICheckedInteractable<AiActivate>
 	{
+		[PrefabModeOnly]
 		public SpriteHandler spritehandler;
+		[PrefabModeOnly]
 		public GameObject SpawnOnDeconstruct;
+		[PrefabModeOnly]
 		public RegisterTile registerTile;
+		[PrefabModeOnly]
 		public PipeData pipeData;
 		public Matrix Matrix => registerTile.Matrix;
 		public Vector3Int MatrixPos => registerTile.LocalPosition;

--- a/UnityProject/Assets/Scripts/Objects/UprightSprites.cs
+++ b/UnityProject/Assets/Scripts/Objects/UprightSprites.cs
@@ -1,7 +1,8 @@
-
 using System;
 using System.Linq;
 using UnityEngine;
+using Core.Editor.Attributes;
+
 
 /// <summary>
 /// Client side component. Keeps object's sprites upright no matter the orientation of their parent matrix.
@@ -10,13 +11,16 @@ using UnityEngine;
 [ExecuteInEditMode]
 public class UprightSprites : MonoBehaviour, IMatrixRotation
 {
+	[PrefabModeOnly]
 	[Tooltip("Defines how this object's sprites should behave during a matrix rotation")]
 	public SpriteMatrixRotationBehavior spriteMatrixRotationBehavior =
 		SpriteMatrixRotationBehavior.RotateUprightAtEndOfMatrixRotation;
 
+	[PrefabModeOnly]
 	[Tooltip("Ignore additional rotation (for example, when object is knocked down)")]
 	public SpriteRenderer[] ignoreExtraRotation = new SpriteRenderer[0];
 
+	[PrefabModeOnly]
 	public GameObject RotateParent = null;
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterDoor.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterDoor.cs
@@ -1,5 +1,7 @@
 ﻿using UnityEngine;
+using Core.Editor.Attributes;
 using Systems.Interaction;
+
 
 	[RequireComponent(typeof(Integrity))]
 	[RequireComponent(typeof(Meleeable))]
@@ -11,6 +13,7 @@ using Systems.Interaction;
 
 		private TileChangeManager tileChangeManager;
 
+		[PrefabModeOnly]
 		public bool OneDirectionRestricted;
 
 		[SerializeField]

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterObject.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterObject.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
-using Blob;
 using UnityEngine;
-using Mirror;
 using UnityEngine.Serialization;
+using Mirror;
+using Core.Editor.Attributes;
+
 
 /// <summary>
 /// <see cref="RegisterTile"/> for an object, adds additional logic to
@@ -13,6 +14,7 @@ using UnityEngine.Serialization;
 [ExecuteInEditMode]
 public class RegisterObject : RegisterTile
 {
+	[PrefabModeOnly]
 	public bool AtmosPassable = true;
 
 	[NonSerialized]
@@ -23,19 +25,21 @@ public class RegisterObject : RegisterTile
 	[SyncVar(hook = nameof(SetCrawlingPassable))]
 	public bool CrawlPassable = false;
 
+	[PrefabModeOnly]
 	[Tooltip("If true, this object won't block players from interacting with other objects")]
 	public bool ReachableThrough = true;
 
 
 	private bool initialAtmosPassable;
 
-	[SerializeField][FormerlySerializedAs("Passable")]
+	[SerializeField, FormerlySerializedAs("Passable"), PrefabModeOnly]
 	private bool initialPassable;
 
-	[SerializeField][FormerlySerializedAs("CrawlPassable")]
+	[SerializeField, FormerlySerializedAs("CrawlPassable"), PrefabModeOnly]
 	private bool initialCrawlPassable;
 
-	[SerializeField] private List<PassableExclusionTrait> passableExclusionsToThis = default;
+	[SerializeField, PrefabModeOnly]
+	private List<PassableExclusionTrait> passableExclusionsToThis = default;
 
 	protected override void Awake()
 	{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
@@ -5,6 +5,7 @@ using UnityEngine.Events;
 using UnityEngine.Rendering;
 using UnityEngine.Serialization;
 using Mirror;
+using Core.Editor.Attributes;
 using Tilemaps.Behaviours.Layers;
 using Systems.Electricity;
 using Systems.Pipes;
@@ -53,7 +54,8 @@ public class RegisterTile : NetworkBehaviour, IServerDespawn
 	/// </summary>
 	public TileChangeManager TileChangeManager => Matrix ? Matrix.TileChangeManager : null;
 
-	[Tooltip("The kind of object this is.")] [FormerlySerializedAs("ObjectType")] [SerializeField]
+	[SerializeField, FormerlySerializedAs("ObjectType"), PrefabModeOnly]
+	[Tooltip("The kind of object this is.")]
 	private ObjectType objectType = ObjectType.Item;
 
 	/// <summary>
@@ -267,6 +269,7 @@ public class RegisterTile : NetworkBehaviour, IServerDespawn
 	private PipeData pipeData;
 	public PipeData PipeData => pipeData;
 
+	[PrefabModeOnly]
 	public SortingGroup CurrentsortingGroup;
 
 	#region Lifecycle


### PR DESCRIPTION
- Adds prefab-editing mode and scene-editing only attributes.
Reduces inspector complexity significantly for mapping.
- Applies the former attribute to a bunch of common components.