### PR TITLE
Differentiate corner sprites for conveyor belts.

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Cargo/ConveyorBelts/ConveyorBelt.cs
+++ b/UnityProject/Assets/Scripts/Objects/Cargo/ConveyorBelts/ConveyorBelt.cs
@@ -178,21 +178,6 @@ namespace Construction.Conveyors
 			if (this == null) return;
 			spriteHandler.ChangeSprite((int)CurrentStatus);
 			var variant = (int)CurrentDirection;
-			switch (variant)
-			{
-				case 8:
-					variant = 4;
-					break;
-				case 9:
-					variant = 5;
-					break;
-				case 10:
-					variant = 6;
-					break;
-				case 11:
-					variant = 7;
-					break;
-			}
 
 			spriteHandler.ChangeSpriteVariant(variant);
 		}

--- a/UnityProject/Assets/Textures/objects/recycling/recycling_conveyor-1.asset
+++ b/UnityProject/Assets/Textures/objects/recycling/recycling_conveyor-1.asset
@@ -85,6 +85,42 @@ MonoBehaviour:
       secondDelay: 0.1
     - sprite: {fileID: 21300062, guid: 52a1eac3dd200734087b556da4454cca, type: 3}
       secondDelay: 0.1
+  - Frames:
+    - sprite: {fileID: 21300008, guid: 7bad4c90f1043ac46a9f96b15276172b, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300024, guid: 7bad4c90f1043ac46a9f96b15276172b, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300040, guid: 7bad4c90f1043ac46a9f96b15276172b, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300056, guid: 7bad4c90f1043ac46a9f96b15276172b, type: 3}
+      secondDelay: 0.1
+  - Frames:
+    - sprite: {fileID: 21300010, guid: 7bad4c90f1043ac46a9f96b15276172b, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300026, guid: 7bad4c90f1043ac46a9f96b15276172b, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300042, guid: 7bad4c90f1043ac46a9f96b15276172b, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300058, guid: 7bad4c90f1043ac46a9f96b15276172b, type: 3}
+      secondDelay: 0.1
+  - Frames:
+    - sprite: {fileID: 21300012, guid: 7bad4c90f1043ac46a9f96b15276172b, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300028, guid: 7bad4c90f1043ac46a9f96b15276172b, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300044, guid: 7bad4c90f1043ac46a9f96b15276172b, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300060, guid: 7bad4c90f1043ac46a9f96b15276172b, type: 3}
+      secondDelay: 0.1
+  - Frames:
+    - sprite: {fileID: 21300014, guid: 7bad4c90f1043ac46a9f96b15276172b, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300030, guid: 7bad4c90f1043ac46a9f96b15276172b, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300046, guid: 7bad4c90f1043ac46a9f96b15276172b, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300062, guid: 7bad4c90f1043ac46a9f96b15276172b, type: 3}
+      secondDelay: 0.1
   IsPalette: 0
   setID: 20941
   DisplayName: 

--- a/UnityProject/Assets/Textures/objects/recycling/recycling_conveyor-broken.asset
+++ b/UnityProject/Assets/Textures/objects/recycling/recycling_conveyor-broken.asset
@@ -37,6 +37,18 @@ MonoBehaviour:
   - Frames:
     - sprite: {fileID: 21300014, guid: 1991961a95d23ab44af48fa0e9202892, type: 3}
       secondDelay: 0
+  - Frames:
+    - sprite: {fileID: 21300008, guid: 1991961a95d23ab44af48fa0e9202892, type: 3}
+      secondDelay: 0
+  - Frames:
+    - sprite: {fileID: 21300010, guid: 1991961a95d23ab44af48fa0e9202892, type: 3}
+      secondDelay: 0
+  - Frames:
+    - sprite: {fileID: 21300012, guid: 1991961a95d23ab44af48fa0e9202892, type: 3}
+      secondDelay: 0
+  - Frames:
+    - sprite: {fileID: 21300014, guid: 1991961a95d23ab44af48fa0e9202892, type: 3}
+      secondDelay: 0
   IsPalette: 0
   setID: 20942
   DisplayName: 

--- a/UnityProject/Assets/Textures/objects/recycling/recycling_conveyor0.asset
+++ b/UnityProject/Assets/Textures/objects/recycling/recycling_conveyor0.asset
@@ -37,6 +37,18 @@ MonoBehaviour:
   - Frames:
     - sprite: {fileID: 21300014, guid: b741542666fee104e85d1e45811c983b, type: 3}
       secondDelay: 0
+  - Frames:
+    - sprite: {fileID: 21300008, guid: b741542666fee104e85d1e45811c983b, type: 3}
+      secondDelay: 0
+  - Frames:
+    - sprite: {fileID: 21300010, guid: b741542666fee104e85d1e45811c983b, type: 3}
+      secondDelay: 0
+  - Frames:
+    - sprite: {fileID: 21300012, guid: b741542666fee104e85d1e45811c983b, type: 3}
+      secondDelay: 0
+  - Frames:
+    - sprite: {fileID: 21300014, guid: b741542666fee104e85d1e45811c983b, type: 3}
+      secondDelay: 0
   IsPalette: 0
   setID: 20943
   DisplayName: 

--- a/UnityProject/Assets/Textures/objects/recycling/recycling_conveyor1.asset
+++ b/UnityProject/Assets/Textures/objects/recycling/recycling_conveyor1.asset
@@ -85,6 +85,42 @@ MonoBehaviour:
       secondDelay: 0.1
     - sprite: {fileID: 21300062, guid: 7bad4c90f1043ac46a9f96b15276172b, type: 3}
       secondDelay: 0.1
+  - Frames:
+    - sprite: {fileID: 21300008, guid: 52a1eac3dd200734087b556da4454cca, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300024, guid: 52a1eac3dd200734087b556da4454cca, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300040, guid: 52a1eac3dd200734087b556da4454cca, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300056, guid: 52a1eac3dd200734087b556da4454cca, type: 3}
+      secondDelay: 0.1
+  - Frames:
+    - sprite: {fileID: 21300010, guid: 52a1eac3dd200734087b556da4454cca, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300026, guid: 52a1eac3dd200734087b556da4454cca, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300042, guid: 52a1eac3dd200734087b556da4454cca, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300058, guid: 52a1eac3dd200734087b556da4454cca, type: 3}
+      secondDelay: 0.1
+  - Frames:
+    - sprite: {fileID: 21300012, guid: 52a1eac3dd200734087b556da4454cca, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300028, guid: 52a1eac3dd200734087b556da4454cca, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300044, guid: 52a1eac3dd200734087b556da4454cca, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300060, guid: 52a1eac3dd200734087b556da4454cca, type: 3}
+      secondDelay: 0.1
+  - Frames:
+    - sprite: {fileID: 21300014, guid: 52a1eac3dd200734087b556da4454cca, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300030, guid: 52a1eac3dd200734087b556da4454cca, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300046, guid: 52a1eac3dd200734087b556da4454cca, type: 3}
+      secondDelay: 0.1
+    - sprite: {fileID: 21300062, guid: 52a1eac3dd200734087b556da4454cca, type: 3}
+      secondDelay: 0.1
   IsPalette: 0
   setID: 20944
   DisplayName: 


### PR DESCRIPTION
<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->

### Purpose
- Title. Makes the corner sprites (specifically the ones that were just reversed versions of eachother) for conveyor belts different by adding additional sprites to the relevant SOs and by removing code from the conveyor belts script that forced reversed versions of corner belts use specific sprites.