### PR TITLE
Add crafting recipe versions of chemical reactions that create food.

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Chemistry/OpenContainers/Bowl.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Chemistry/OpenContainers/Bowl.prefab
@@ -252,7 +252,7 @@ PrefabInstance:
     - target: {fileID: 5745955074844693296, guid: 364841a08150e9345b119e71191c8dcf,
         type: 3}
       propertyPath: relatedRecipes.Array.size
-      value: 34
+      value: 35
       objectReference: {fileID: 0}
     - target: {fileID: 5745955074844693296, guid: 364841a08150e9345b119e71191c8dcf,
         type: 3}
@@ -457,6 +457,12 @@ PrefabInstance:
       propertyPath: relatedRecipes.Array.data[33].recipe
       value: 
       objectReference: {fileID: 11400000, guid: a8fd071f53eece344966d2002bf6c92a,
+        type: 2}
+    - target: {fileID: 5745955074844693296, guid: 364841a08150e9345b119e71191c8dcf,
+        type: 3}
+      propertyPath: relatedRecipes.Array.data[34].recipe
+      value: 
+      objectReference: {fileID: 11400000, guid: 5ca5a7f1e2a626f4ab60c0ba394557d7,
         type: 2}
     - target: {fileID: 5745955074844693296, guid: 364841a08150e9345b119e71191c8dcf,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/EggSnacks/BoiledEgg.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/EggSnacks/BoiledEgg.prefab
@@ -195,6 +195,12 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 1544809558474638353, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
+      propertyPath: relatedRecipes.Array.data[7].recipe
+      value: 
+      objectReference: {fileID: 11400000, guid: 47420424b08530a46931f56aa1a705de,
+        type: 2}
+    - target: {fileID: 1544809558474638353, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
       propertyPath: relatedRecipes.Array.data[1].ingredientIndex
       value: 1
       objectReference: {fileID: 0}
@@ -222,6 +228,11 @@ PrefabInstance:
         type: 3}
       propertyPath: relatedRecipes.Array.data[6].ingredientIndex
       value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1544809558474638353, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
+      propertyPath: relatedRecipes.Array.data[7].ingredientIndex
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5169367590891271744, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/MeatSnacks/Tofu.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/MeatSnacks/Tofu.prefab
@@ -9,6 +9,17 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 275102857289942383, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
+      propertyPath: AdditionalReactions.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 275102857289942383, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
+      propertyPath: AdditionalReactions.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 0c569379505444141a1bbba5190c95c9,
+        type: 2}
+    - target: {fileID: 275102857289942383, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
       propertyPath: initialReagentMix.reagents.m_keys.Array.size
       value: 1
       objectReference: {fileID: 0}
@@ -122,7 +133,7 @@ PrefabInstance:
     - target: {fileID: 1544809558474638353, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
       propertyPath: relatedRecipes.Array.size
-      value: 7
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 1544809558474638353, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
@@ -165,6 +176,12 @@ PrefabInstance:
       propertyPath: relatedRecipes.Array.data[6].recipe
       value: 
       objectReference: {fileID: 11400000, guid: 3dcb689c4f8fd15409ccfbefc36c68fc,
+        type: 2}
+    - target: {fileID: 1544809558474638353, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
+      propertyPath: relatedRecipes.Array.data[7].recipe
+      value: 
+      objectReference: {fileID: 11400000, guid: e1eaf4a7872294f499cd4603a028e423,
         type: 2}
     - target: {fileID: 1544809558474638353, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}

--- a/UnityProject/Assets/Resources/ScriptableObjectsSingletons/CraftingRecipeSingleton.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjectsSingletons/CraftingRecipeSingleton.asset
@@ -357,3 +357,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 1860642633aa46b479cd6ddf4029cf3d, type: 2}
   - {fileID: 11400000, guid: 97cc5a6c53831344dafe59906bd4e682, type: 2}
   - {fileID: 11400000, guid: e1eaf4a7872294f499cd4603a028e423, type: 2}
+  - {fileID: 11400000, guid: 5ca5a7f1e2a626f4ab60c0ba394557d7, type: 2}

--- a/UnityProject/Assets/Resources/ScriptableObjectsSingletons/CraftingRecipeSingleton.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjectsSingletons/CraftingRecipeSingleton.asset
@@ -15,7 +15,6 @@ MonoBehaviour:
   storedCraftingRecipes:
   - {fileID: 11400000, guid: 8ed6ec8ceda6e4241b239a45ba342b99, type: 2}
   - {fileID: 11400000, guid: dfba4c74ed8a4f0438f6c78195a6a609, type: 2}
-  - {fileID: 11400000, guid: c9462501f3931b2418e30590415226ec, type: 2}
   - {fileID: 11400000, guid: fde9f32f2dfd337418e31dfb38feb66c, type: 2}
   - {fileID: 11400000, guid: 538ae3c4efa0bbc4c8f5a150698a1896, type: 2}
   - {fileID: 11400000, guid: b200cf5f967ff154bbf62496d53b722e, type: 2}
@@ -348,3 +347,13 @@ MonoBehaviour:
   - {fileID: 11400000, guid: b8d4c40c7dce4fe4699d454073011b26, type: 2}
   - {fileID: 11400000, guid: fcdedf23f4a68a64ea5970ffe9800951, type: 2}
   - {fileID: 11400000, guid: 6667264bb4a429444970c55c22b85a6f, type: 2}
+  - {fileID: 11400000, guid: 47420424b08530a46931f56aa1a705de, type: 2}
+  - {fileID: 11400000, guid: 9515a7e3c2cb9914291844dca24cdfc3, type: 2}
+  - {fileID: 11400000, guid: a5a7defff8dfb184ca1a49ce001466fd, type: 2}
+  - {fileID: 11400000, guid: e4c0e053c2ed3ba45a17dbc716b9a1af, type: 2}
+  - {fileID: 11400000, guid: 5f25aeb9777c79449807dabfbe191a2e, type: 2}
+  - {fileID: 11400000, guid: 534754527e6349b4b904c4011c8b1f6b, type: 2}
+  - {fileID: 11400000, guid: fb7873ebb6b9ac6489486a9dfd8a0365, type: 2}
+  - {fileID: 11400000, guid: 1860642633aa46b479cd6ddf4029cf3d, type: 2}
+  - {fileID: 11400000, guid: 97cc5a6c53831344dafe59906bd4e682, type: 2}
+  - {fileID: 11400000, guid: e1eaf4a7872294f499cd4603a028e423, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Effects/Food/ImitationCarpMeat.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Effects/Food/ImitationCarpMeat.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb6d4d630c87c08449406917b1d1b8d6, type: 3}
+  m_Name: ImitationCarpMeat
+  m_EditorClassIdentifier: 
+  spawnItem: {fileID: 5144560459880948258, guid: 77e176923a462b14089caadd967f5b01,
+    type: 3}

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Effects/Food/ImitationCarpMeat.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Effects/Food/ImitationCarpMeat.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c7924cca7cd2dd748b7a79a1ac05cdf3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Effects/Food/Rice Bowl.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Effects/Food/Rice Bowl.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c7924cca7cd2dd748b7a79a1ac05cdf3
+guid: eae3f82cbe10d524cb787a295ddf200f
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Food/ImitationCarpMeat.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Food/ImitationCarpMeat.asset
@@ -1,0 +1,34 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 96e73ad475d1d24158bd2935f105cf3d, type: 3}
+  m_Name: ImitationCarpMeat
+  m_EditorClassIdentifier: 
+  ingredients:
+    m_keys:
+    - {fileID: 11400000, guid: 9d1090f4516aeb0f2aa5fec39d2127d5, type: 2}
+    m_values: 05000000
+  useExactAmounts: 0
+  catalysts:
+    m_keys: []
+    m_values: 
+  inhibitors:
+    m_keys: []
+    m_values: 
+  hasMinTemp: 0
+  serializableTempMin: 0
+  hasMaxTemp: 0
+  serializableTempMax: 0
+  results:
+    m_keys: []
+    m_values: 
+  effects:
+  - {fileID: 11400000, guid: c7924cca7cd2dd748b7a79a1ac05cdf3, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Food/ImitationCarpMeat.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Food/ImitationCarpMeat.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0c569379505444141a1bbba5190c95c9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Food/Rice Bowl.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Food/Rice Bowl.asset
@@ -24,8 +24,12 @@ MonoBehaviour:
   inhibitors:
     m_keys: []
     m_values: 
+  hasMinTemp: 0
+  serializableTempMin: 0
+  hasMaxTemp: 0
+  serializableTempMax: 0
   results:
     m_keys: []
     m_values: 
   effects:
-  - {fileID: 11400000, guid: c7924cca7cd2dd748b7a79a1ac05cdf3, type: 2}
+  - {fileID: 11400000, guid: eae3f82cbe10d524cb787a295ddf200f, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Crafting/DefaultHumanCraftingRecipes.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/DefaultHumanCraftingRecipes.asset
@@ -80,7 +80,6 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 6d62d4021b392c04489f60a50573c3c5, type: 2}
   - {fileID: 11400000, guid: eacbb44ce72b5ac44ad8e14d0e60699e, type: 2}
   - {fileID: 11400000, guid: 25ee4daabfd69db4aab84c7b6dd686fa, type: 2}
-  - {fileID: 11400000, guid: c9462501f3931b2418e30590415226ec, type: 2}
   - {fileID: 11400000, guid: be41053cac128e7478f92e3aa0b292c0, type: 2}
   - {fileID: 11400000, guid: 8ba8441061aec0348a1ec21dd35fc1eb, type: 2}
   - {fileID: 11400000, guid: 4b17e3204b9668a4f84b31fd6ebbd69c, type: 2}
@@ -348,3 +347,12 @@ MonoBehaviour:
   - {fileID: 11400000, guid: fe09abf82e38e4c4ca1d2035d3cc77b7, type: 2}
   - {fileID: 11400000, guid: 39508e4cf3fc5d24e8d76ff004d64aed, type: 2}
   - {fileID: 11400000, guid: af31a0d28a5bba44dbf8387db67b8ef5, type: 2}
+  - {fileID: 11400000, guid: e4c0e053c2ed3ba45a17dbc716b9a1af, type: 2}
+  - {fileID: 11400000, guid: 5f25aeb9777c79449807dabfbe191a2e, type: 2}
+  - {fileID: 11400000, guid: fb7873ebb6b9ac6489486a9dfd8a0365, type: 2}
+  - {fileID: 11400000, guid: 534754527e6349b4b904c4011c8b1f6b, type: 2}
+  - {fileID: 11400000, guid: 9515a7e3c2cb9914291844dca24cdfc3, type: 2}
+  - {fileID: 11400000, guid: a5a7defff8dfb184ca1a49ce001466fd, type: 2}
+  - {fileID: 11400000, guid: e1eaf4a7872294f499cd4603a028e423, type: 2}
+  - {fileID: 11400000, guid: 97cc5a6c53831344dafe59906bd4e682, type: 2}
+  - {fileID: 11400000, guid: 1860642633aa46b479cd6ddf4029cf3d, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Crafting/DefaultHumanCraftingRecipes.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/DefaultHumanCraftingRecipes.asset
@@ -356,3 +356,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: e1eaf4a7872294f499cd4603a028e423, type: 2}
   - {fileID: 11400000, guid: 97cc5a6c53831344dafe59906bd4e682, type: 2}
   - {fileID: 11400000, guid: 1860642633aa46b479cd6ddf4029cf3d, type: 2}
+  - {fileID: 11400000, guid: 5ca5a7f1e2a626f4ab60c0ba394557d7, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/ChemicalScannerRemovalRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/ChemicalScannerRemovalRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 6841223995504525407, guid: 9836e3299e1fcf54cb6028cd4310ed3c, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 326
+  indexInSingleton: 325

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/CowboyBootsRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/CowboyBootsRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 4245553451975094303, guid: d191bca37a379834bbdf6b672bcf012d, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 333
+  indexInSingleton: 332

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/DiagnosticHUDRemovalRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/DiagnosticHUDRemovalRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 3431291279286482953, guid: 89d026ca3c185844194baeb3ff3b4d98, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 323
+  indexInSingleton: 322

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/DiagnosticHUDSunglassesRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/DiagnosticHUDSunglassesRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 7809713149462729577, guid: fa58b85eb0d83874c99737ec86dc6af2, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 324
+  indexInSingleton: 323

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/DurathreadBandanaRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/DurathreadBandanaRecipe.asset
@@ -27,4 +27,4 @@ MonoBehaviour:
   - {fileID: 2778216794303504049, guid: 9286d158bd715894db3df20c4f6a3ac0, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 317
+  indexInSingleton: 316

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/DurathreadBeanieRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/DurathreadBeanieRecipe.asset
@@ -27,4 +27,4 @@ MonoBehaviour:
   - {fileID: 616735813865956089, guid: 64ad449873de9e640a19a5130227c050, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 316
+  indexInSingleton: 315

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/DurathreadBeretRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/DurathreadBeretRecipe.asset
@@ -27,4 +27,4 @@ MonoBehaviour:
   - {fileID: 6980020022460415521, guid: c54e94b479657484e86c4cb4f7622f91, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 315
+  indexInSingleton: 314

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/DurathreadHelmetRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/DurathreadHelmetRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 8937610153750975940, guid: bbf5929133a2c4e488ad3ea8b1a1ba21, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 313
+  indexInSingleton: 312

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/DurathreadJumpsuitRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/DurathreadJumpsuitRecipe.asset
@@ -27,4 +27,4 @@ MonoBehaviour:
   - {fileID: 3011710637427380133, guid: c2fa92cf2549540d4abc5269341aaed5, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 314
+  indexInSingleton: 313

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/DurathreadVestRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/DurathreadVestRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 4271478477210582251, guid: 1d19542eb4552e14e958bad02ee694f8, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 312
+  indexInSingleton: 311

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/FannypackRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/FannypackRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 3970365256639679988, guid: 50df01ef60a031640b4faafe2df999ce, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 318
+  indexInSingleton: 317

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/FollowerHoodieRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/FollowerHoodieRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 3921521694364753778, guid: 0355f7fdd3a96f24889bb2b06dd6e579, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 330
+  indexInSingleton: 329

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/GhostSheetRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/GhostSheetRecipe.asset
@@ -28,4 +28,4 @@ MonoBehaviour:
   - {fileID: 6204346116445057915, guid: 90a9678c803ac2b468555c05e1cea936, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 327
+  indexInSingleton: 326

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/LizardClocheHatAltRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/LizardClocheHatAltRecipe.asset
@@ -27,4 +27,4 @@ MonoBehaviour:
   - {fileID: 5917849292908968990, guid: 1ddc904aef53a8644a3502c456c3727e, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 334
+  indexInSingleton: 333

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/LizardClocheHatRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/LizardClocheHatRecipe.asset
@@ -27,4 +27,4 @@ MonoBehaviour:
   - {fileID: 5917849292908968990, guid: 1ddc904aef53a8644a3502c456c3727e, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 329
+  indexInSingleton: 328

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/LizardSkinBootsRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/LizardSkinBootsRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 4245553451975094303, guid: d191bca37a379834bbdf6b672bcf012d, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 328
+  indexInSingleton: 327

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/MedicalHUDRemovalRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/MedicalHUDRemovalRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 3431291279286482953, guid: ddd85a66da8b22448806f0f8454c01ab, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 322
+  indexInSingleton: 321

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/MedicalHUDSunglassesRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/MedicalHUDSunglassesRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 5532802377516091598, guid: 0038686c411d4f7428723a6a199a8863, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 321
+  indexInSingleton: 320

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/MummificationBandagesBodyRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/MummificationBandagesBodyRecipe.asset
@@ -28,4 +28,4 @@ MonoBehaviour:
   - {fileID: 3011710637427380133, guid: ba41c95ddca00aa4ca99feeed566e1d9, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 332
+  indexInSingleton: 331

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/MummificationBandagesMaskRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/MummificationBandagesMaskRecipe.asset
@@ -28,4 +28,4 @@ MonoBehaviour:
   - {fileID: 6404652678407139925, guid: f7c0d4c0fca38674a8e3d778edfb1a7e, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 331
+  indexInSingleton: 330

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/ScienceGlassesRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/ScienceGlassesRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 2679964424910470999, guid: 7919ffc0a7c666742a83c767f7cb427f, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 325
+  indexInSingleton: 324

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/SecurityHUDRemovalRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/SecurityHUDRemovalRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 3431291279286482953, guid: a04a2ac5c1ef5a142b26e818b8dfa3fb, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 320
+  indexInSingleton: 319

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/SecurityHUDSunglassesRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Clothing/SecurityHUDSunglassesRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 3183123304414575785, guid: 0bcb9423721f44a418353bfcc987a1b9, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 319
+  indexInSingleton: 318

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/BaguetteRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/BaguetteRecipe.asset
@@ -31,4 +31,4 @@ MonoBehaviour:
   - {fileID: 6952585937312028515, guid: 04970687af9a8114db43f25200a13676, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 272
+  indexInSingleton: 271

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/BananaNutBreadRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/BananaNutBreadRecipe.asset
@@ -35,4 +35,4 @@ MonoBehaviour:
   - {fileID: 7661217922564485807, guid: 4f9805413b48329458d0ffcfc031e65b, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 94
+  indexInSingleton: 93

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/ButterBiscuitRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/ButterBiscuitRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 1039328943071305826, guid: 8ab0c6744d91e854cb5bac5412e13efb, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 98
+  indexInSingleton: 97

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/ButterdogRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/ButterdogRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 7801189781532992908, guid: eca930a3661e5954dbca94bd2f4e7d29, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 100
+  indexInSingleton: 99

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/ButteredToastRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/ButteredToastRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 2370333706664158428, guid: 51dfc0f6218b07b479405f5c63b65a32, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 275
+  indexInSingleton: 274

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/CreamCheeseBreadRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/CreamCheeseBreadRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 2582312061748254010, guid: b095a85958379774db5bcdc15837a798, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 96
+  indexInSingleton: 95

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/DoughRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/DoughRecipe.asset
@@ -1,0 +1,31 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0a638c97a2384c54bee47631bd326e8b, type: 3}
+  m_Name: DoughRecipe
+  m_EditorClassIdentifier: 
+  category: 6
+  craftingTime: 0
+  recipeName: Dough
+  recipeIconOverride: {fileID: 0}
+  recipeDescription: 
+  requiredIngredients: []
+  requiredReagents:
+  - requiredAmount: 15
+    requiredReagent: {fileID: 11400000, guid: 0c4cf985d57ba9ce18282581b4f45fe9, type: 2}
+  - requiredAmount: 10
+    requiredReagent: {fileID: 11400000, guid: 522665e55a63647f6a9959f4b0a52c31, type: 2}
+  requiredToolTraits: []
+  result:
+  - {fileID: 6035652412496520804, guid: c806a0c93acc5b94a9986b18d70f8368, type: 3}
+  resultHandlers: []
+  isSimple: 0
+  indexInSingleton: 334

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/DoughRecipe.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/DoughRecipe.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 47420424b08530a46931f56aa1a705de
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/GarlicBreadRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/GarlicBreadRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 842010364166260439, guid: 7c5fd468505b27b4fab084f06135430b, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 99
+  indexInSingleton: 98

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/JelliedToastRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/JelliedToastRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 3872790865095015593, guid: 7bb1110214c6ccc4899301abbcf8ae88, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 274
+  indexInSingleton: 273

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/MeatBreadRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/MeatBreadRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 8288080284995933339, guid: d1a7f794eae43434da46c1ae06574f82, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 91
+  indexInSingleton: 90

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/MimanaBreadRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/MimanaBreadRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 5376177816146244158, guid: 03258b1012774a041ba1c4760b64e20f, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 97
+  indexInSingleton: 96

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/MoldyBreadRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/MoldyBreadRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 6341727172056241946, guid: 50ddf753015b97b418e540407c39402b, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 101
+  indexInSingleton: 100

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/SlimeToastRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/SlimeToastRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 589926329364796011, guid: 86093cb40d480d84e84da254b6422ccd, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 273
+  indexInSingleton: 272

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/SpidermeatBreadLoaf.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/SpidermeatBreadLoaf.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 6917349334481684020, guid: 6578ee11995c16f4ebaf4a703ff82881, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 93
+  indexInSingleton: 92

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/TofuBreadRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/TofuBreadRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 5507229201587329714, guid: 6997a90356098bf4594b1856b6e062c4, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 95
+  indexInSingleton: 94

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/TwoBreadRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/TwoBreadRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 5384367645255958940, guid: eba5b6be9b9eaf44ca93c9a270c642cc, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 276
+  indexInSingleton: 275

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/XenomeatBreadRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Breads/XenomeatBreadRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 1766600106453277603, guid: 145dd7fcad8ba0f4d9e228b7dd41f2b8, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 92
+  indexInSingleton: 91

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/BaconBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/BaconBurgerRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 6770591416323424979, guid: de86c46a7ce28944a88052580ec9d609, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 128
+  indexInSingleton: 127

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/BeargerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/BeargerRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 7122990096218605834, guid: 381d3bd9340163f43ac5e1d220354987, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 107
+  indexInSingleton: 106

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/BigBiteBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/BigBiteBurgerRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 2889400025622917504, guid: f280bbfa99a84e94d8d68df5d9bdcda8, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 122
+  indexInSingleton: 121

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/BlackBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/BlackBurgerRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 5361852687685769327, guid: 7c7265cafd41640409ee44eede279e47, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 119
+  indexInSingleton: 118

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/BlueBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/BlueBurgerRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 4411850355136999571, guid: 871c856072c6fab438c90f3e3860f485, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 117
+  indexInSingleton: 116

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/BrainBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/BrainBurgerRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 5878830202875765014, guid: 3bdfa86adb3580e4baf768b16725d655, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 105
+  indexInSingleton: 104

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/BurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/BurgerRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 2888119926246526625, guid: 3277c24106492ec45b5d4e08cdb06ad4, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 103
+  indexInSingleton: 102

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/CheeseBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/CheeseBurgerRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 5725882200388970429, guid: e1a7a3fe82e22174b89851be81a1ffdc, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 131
+  indexInSingleton: 130

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/CherryJellyBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/CherryJellyBurgerRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 6714368936730511477, guid: 48285f68ded775942855eabce315cb32, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 125
+  indexInSingleton: 124

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/ChickenSandwichRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/ChickenSandwichRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 6284376535474606757, guid: 2987c7eb61b73714bb3359d34f6f2cbc, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 135
+  indexInSingleton: 134

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/ClownBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/ClownBurgerRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 908666615324575057, guid: 9ba6eba4a485fa348a056213f283a66a, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 111
+  indexInSingleton: 110

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/CorgiBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/CorgiBurgerRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 8706679316623114290, guid: a4166c37a31bbe44f980b1f6d8575ab6, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 106
+  indexInSingleton: 105

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/CrabBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/CrabBurgerRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 6672354457938983197, guid: de3f012233edcc641a2d42defc25c31b, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 130
+  indexInSingleton: 129

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/EmpoweredBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/EmpoweredBurgerRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 5218511481997709313, guid: 812407326c71a07468a7d80c90951317, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 129
+  indexInSingleton: 128

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/FilletOCarpSandwichRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/FilletOCarpSandwichRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 7958028003220033422, guid: 81940625bbb1d8a4f9c5528b6420c9ca, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 108
+  indexInSingleton: 107

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/FiveAlarmBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/FiveAlarmBurgerRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 8841897170874440319, guid: 4219e5eced9dce047b54edeceded042f, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 126
+  indexInSingleton: 125

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/GhostBurger.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/GhostBurger.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 7200438476090162623, guid: 4deb6718fb5cbdb41846891267b37c5e, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 110
+  indexInSingleton: 109

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/GreenBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/GreenBurgerRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 6282296192746892833, guid: 5bf43fec45b686b4ba19ec042d702030, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 116
+  indexInSingleton: 115

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/HumanBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/HumanBurgerRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 5684851129158160658, guid: c9c26c949734c8343b059db46740603d, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 102
+  indexInSingleton: 101

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/McGuffinRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/McGuffinRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 7280168257234844371, guid: 62544d9f21c88f84486e852da45b40b6, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 134
+  indexInSingleton: 133

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/McRibRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/McRibRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 3963832682063048021, guid: 8da699db78a0abb4bbced088511da135, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 133
+  indexInSingleton: 132

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/MimeBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/MimeBurgerRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 2078783921278744091, guid: 8970e97a204eff84085d246e27be94ac, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 112
+  indexInSingleton: 111

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/OrangeBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/OrangeBurgerRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 6893331248808844613, guid: 56935f6dd6d900142af03bc59c506af5, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 114
+  indexInSingleton: 113

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/PurpleBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/PurpleBurgerRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 156444942928060774, guid: 0e8a0657484398d458f12eda5602b98f, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 118
+  indexInSingleton: 117

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/RatBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/RatBurgerRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 6529055890807643691, guid: 4d88878d0999ab348b9b3c6564070523, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 127
+  indexInSingleton: 126

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/RedBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/RedBurgerRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 4413684972170182855, guid: 845e65fe0c1282a4e9fb35d3fbf4c864, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 113
+  indexInSingleton: 112

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/SlimeJellyBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/SlimeJellyBurgerRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 1834523158994134889, guid: b7b6f8e50e69c6549a60a5f21fcf999a, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 124
+  indexInSingleton: 123

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/SoylentBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/SoylentBurgerRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 1340263404341817376, guid: 0694173686522a248af2e4893e35a754, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 132
+  indexInSingleton: 131

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/SpellBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/SpellBurgerRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 5671257737370965085, guid: 079965d2285d6874a8684275366fecb8, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 121
+  indexInSingleton: 120

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/SuperBiteBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/SuperBiteBurgerRecipe.asset
@@ -46,4 +46,4 @@ MonoBehaviour:
   - {fileID: 6070100026986470696, guid: a0212ee220305504084c689e55c1088a, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 123
+  indexInSingleton: 122

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/TofuBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/TofuBurgerRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 6617876684926902362, guid: f8386304aa559bf4cbdbdba1221130ee, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 109
+  indexInSingleton: 108

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/WhiteBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/WhiteBurgerRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 5669365232229316675, guid: 1ba0d3da7b6ee0245b09824929aaa10c, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 120
+  indexInSingleton: 119

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/XenoBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/XenoBurgerRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 3514055842472198938, guid: 1017ac82af80b86458ddd9ee5657caa3, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 104
+  indexInSingleton: 103

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/YelllowBurgerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Burgers/YelllowBurgerRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 56166540928091794, guid: e87af9f9d574eeb48a7b8f0adae31507, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 115
+  indexInSingleton: 114

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/AngelFoodCakeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/AngelFoodCakeRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 6243227979176518470, guid: df411ae0e19634a4ba43925037cbfcd3, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 83
+  indexInSingleton: 82

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/AppleCakeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/AppleCakeRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 3578122675324631673, guid: 4012ea1139271ac488669ea408a24ced, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 76
+  indexInSingleton: 75

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/BlackberryAndStrawberryChocolateCakeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/BlackberryAndStrawberryChocolateCakeRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 7790314712333124506, guid: 19db6c3a95d43e14f86f3377067218cc, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 86
+  indexInSingleton: 85

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/BlackberryAndStrawberryVanillaCakeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/BlackberryAndStrawberryVanillaCakeRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 7353342226250800505, guid: 32462b083f50ecd40906c18481801041, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 87
+  indexInSingleton: 86

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/BrainCakeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/BrainCakeRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 3411931085803903785, guid: 4a73dfc6e4451f14d9fc2d49bf6afecd, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 81
+  indexInSingleton: 80

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/CakeBatterRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/CakeBatterRecipe.asset
@@ -1,0 +1,33 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0a638c97a2384c54bee47631bd326e8b, type: 3}
+  m_Name: CakeBatterRecipe
+  m_EditorClassIdentifier: 
+  category: 8
+  craftingTime: 0
+  recipeName: Cake Batter
+  recipeIconOverride: {fileID: 0}
+  recipeDescription: 
+  requiredIngredients: []
+  requiredReagents:
+  - requiredAmount: 15
+    requiredReagent: {fileID: 11400000, guid: 0c4cf985d57ba9ce18282581b4f45fe9, type: 2}
+  - requiredAmount: 15
+    requiredReagent: {fileID: 11400000, guid: 81c39cb6183d269ba82af38936032f67, type: 2}
+  - requiredAmount: 5
+    requiredReagent: {fileID: 11400000, guid: 911271db97b77da51889f97d6688a103, type: 2}
+  requiredToolTraits: []
+  result:
+  - {fileID: 3963745021793217759, guid: f0694d96f4c13a246b3a6550a9b303dd, type: 3}
+  resultHandlers: []
+  isSimple: 0
+  indexInSingleton: 335

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/CakeBatterRecipe.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/CakeBatterRecipe.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9515a7e3c2cb9914291844dca24cdfc3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/CakeBatterVeganRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/CakeBatterVeganRecipe.asset
@@ -1,0 +1,33 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0a638c97a2384c54bee47631bd326e8b, type: 3}
+  m_Name: CakeBatterVeganRecipe
+  m_EditorClassIdentifier: 
+  category: 8
+  craftingTime: 0
+  recipeName: Cake Batter (Vegan)
+  recipeIconOverride: {fileID: 0}
+  recipeDescription: 
+  requiredIngredients: []
+  requiredReagents:
+  - requiredAmount: 15
+    requiredReagent: {fileID: 11400000, guid: 0c4cf985d57ba9ce18282581b4f45fe9, type: 2}
+  - requiredAmount: 15
+    requiredReagent: {fileID: 11400000, guid: 0c793b26027c29a1cb5806c738a7a556, type: 2}
+  - requiredAmount: 5
+    requiredReagent: {fileID: 11400000, guid: 911271db97b77da51889f97d6688a103, type: 2}
+  requiredToolTraits: []
+  result:
+  - {fileID: 3963745021793217759, guid: f0694d96f4c13a246b3a6550a9b303dd, type: 3}
+  resultHandlers: []
+  isSimple: 0
+  indexInSingleton: 336

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/CakeBatterVeganRecipe.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/CakeBatterVeganRecipe.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a5a7defff8dfb184ca1a49ce001466fd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/CarrotCakeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/CarrotCakeRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 6222397779083850046, guid: 9fc4662a69fe1794f81c6e6fd0baf785, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 74
+  indexInSingleton: 73

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/CheeseCakeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/CheeseCakeRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 2769650948998610985, guid: 9a8d21acf6e6ed046be628622bf6c7cd, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 75
+  indexInSingleton: 74

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/ChocolateCakeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/ChocolateCakeRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 153598002904487784, guid: 7a40ac61c27a1be4196aad7fde24dd1a, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 80
+  indexInSingleton: 79

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/ClownCakeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/ClownCakeRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 7994302924967574756, guid: 48c49ee6354eb9642b9b9c863d885be8, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 88
+  indexInSingleton: 87

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/HardwareCakeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/HardwareCakeRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 8648494620541382627, guid: 2e2302a72067da74f89b7cf977fdd23f, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 85
+  indexInSingleton: 84

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/LemonCakeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/LemonCakeRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 8595045810378424244, guid: f1e054cf2944268438ff08380f58acec, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 79
+  indexInSingleton: 78

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/LimeCakeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/LimeCakeRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 4334366326859978813, guid: 39f9d42f29a41414bbcea1d8ac43a9f8, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 78
+  indexInSingleton: 77

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/LivingCatCakeHybridRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/LivingCatCakeHybridRecipe.asset
@@ -42,4 +42,4 @@ MonoBehaviour:
   - {fileID: 5319019202480114209, guid: 3f2f2704988bd9346901595057b7513d, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 90
+  indexInSingleton: 89

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/OrangeCakeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/OrangeCakeRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 1792964719099430010, guid: c54f90932687dbb4fb017ea56d63be7f, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 77
+  indexInSingleton: 76

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/PoundCakeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/PoundCakeRecipe.asset
@@ -27,4 +27,4 @@ MonoBehaviour:
   - {fileID: 7604743614281660693, guid: 8b3fa0df9fb5cf94e9de16f862166a77, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 84
+  indexInSingleton: 83

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/PumpkinSpiceCakeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/PumpkinSpiceCakeRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 2477749340470310096, guid: e46bfc2fb681822488ad4beaf42c756a, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 82
+  indexInSingleton: 81

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/VanillaCakeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Cakes/VanillaCakeRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 3924462400795409834, guid: 1873b2bb97caf844aab74580f265ca38, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 89
+  indexInSingleton: 88

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Drinks/BlazaamBottleRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Drinks/BlazaamBottleRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 7305396868739561040, guid: 22245d367a5496149910e3ccd4975e96, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 64
+  indexInSingleton: 63

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Drinks/BottleOfNothingRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Drinks/BottleOfNothingRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 7305396868739561040, guid: 2f50a0183b975b847ba287eed2b4df83, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 70
+  indexInSingleton: 69

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Drinks/ChampagneBottleRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Drinks/ChampagneBottleRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 7305396868739561040, guid: e0aa44d3a83b00c4ebbd4cb25b853acc, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 65
+  indexInSingleton: 64

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Drinks/GoldschlagerBottleRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Drinks/GoldschlagerBottleRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 7305396868739561040, guid: a8f6461a21756c54eb238424878d9f82, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 67
+  indexInSingleton: 66

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Drinks/HolyWaterFlaskRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Drinks/HolyWaterFlaskRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 7305396868739561040, guid: f4e36e9b9d1527844a2f2db1840db407, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 69
+  indexInSingleton: 68

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Drinks/LizardWineRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Drinks/LizardWineRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 7305396868739561040, guid: bb9d87c87ea78994b86719cdf139a60f, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 72
+  indexInSingleton: 71

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Drinks/MoonshineJugRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Drinks/MoonshineJugRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 7305396868739561040, guid: 709095287aed6df4585ae42ed7fc4d78, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 71
+  indexInSingleton: 70

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Drinks/PatronBottleRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Drinks/PatronBottleRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 7305396868739561040, guid: 19fca94735350ae4b88590a577fc943f, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 68
+  indexInSingleton: 67

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Drinks/SmallCartonRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Drinks/SmallCartonRecipe.asset
@@ -27,4 +27,4 @@ MonoBehaviour:
   - {fileID: 8393056579400956317, guid: de081f691b1bd9b4e90d8d14b4ba9346, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 73
+  indexInSingleton: 72

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Drinks/TrappistBottleRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Drinks/TrappistBottleRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 7305396868739561040, guid: 449e03a70664f9d4b96200cbe184b274, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 66
+  indexInSingleton: 65

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/EggBasedFood/ChocolateEggRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/EggBasedFood/ChocolateEggRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 2897339443933191501, guid: aa9050d723294234c80a8d7fb9b69341, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 6
+  indexInSingleton: 5

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/EggBasedFood/EggBowlRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/EggBasedFood/EggBowlRecipe.asset
@@ -36,4 +36,4 @@ MonoBehaviour:
   - {fileID: 4592942297612569322, guid: 92eafdabb7898364a890de495a22594f, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 8
+  indexInSingleton: 7

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/EggBasedFood/EggsBenedictRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/EggBasedFood/EggsBenedictRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 2897339443933191501, guid: f64f0ad4c38bca042bbb63cbb2b9bef3, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 7
+  indexInSingleton: 6

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/EggBasedFood/FriedEggRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/EggBasedFood/FriedEggRecipe.asset
@@ -31,4 +31,4 @@ MonoBehaviour:
   - {fileID: 2897339443933191501, guid: c11463ffa84e33545a7c8a43ebc9a009, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 5
+  indexInSingleton: 4

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/EggBasedFood/WrapRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/EggBasedFood/WrapRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 3917522154864139689, guid: 450cfe5e20b04154f930ff38b66c6016, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 269
+  indexInSingleton: 268

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/FlatDoughRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/FlatDoughRecipe.asset
@@ -28,4 +28,4 @@ MonoBehaviour:
   - {fileID: 1449470387542250284, guid: 41220ca24fe3798478f533c5f8102248, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 3
+  indexInSingleton: 2

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/CornutoRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/CornutoRecipe.asset
@@ -36,4 +36,4 @@ MonoBehaviour:
   - {fileID: 3040265357538634785, guid: fe6948efb6cdc5147bf3997d9b3d0312, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 138
+  indexInSingleton: 137

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/IceCreamSandiwichRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/IceCreamSandiwichRecipe.asset
@@ -28,4 +28,4 @@ MonoBehaviour:
   - {fileID: 3486408137043295472, guid: 92ba7e6c5cff2dc49a496e870b7d4eb7, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 136
+  indexInSingleton: 135

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Popsicles/BerryCreamsicleRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Popsicles/BerryCreamsicleRecipe.asset
@@ -37,4 +37,4 @@ MonoBehaviour:
   - {fileID: 8938376424530961626, guid: 61172890db55d3943b1a2a923ad33ce5, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 157
+  indexInSingleton: 156

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Popsicles/JumboIcecreamRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Popsicles/JumboIcecreamRecipe.asset
@@ -38,4 +38,4 @@ MonoBehaviour:
   - {fileID: 518708270638934352, guid: ab00c973ec3aabc43b432cbb78ddcdb7, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 158
+  indexInSingleton: 157

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Popsicles/NoggaBlackRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Popsicles/NoggaBlackRecipe.asset
@@ -39,4 +39,4 @@ MonoBehaviour:
   - {fileID: 6640730685163190509, guid: bb047040cf3f7af478120848eb009187, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 159
+  indexInSingleton: 158

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Popsicles/OrangeCreamsicleRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Popsicles/OrangeCreamsicleRecipe.asset
@@ -37,4 +37,4 @@ MonoBehaviour:
   - {fileID: 6738723695642816798, guid: 6912188aeedf08e4597674ede9f0c62d, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 156
+  indexInSingleton: 155

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/AppleSnowconeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/AppleSnowconeRecipe.asset
@@ -31,4 +31,4 @@ MonoBehaviour:
   - {fileID: 7718796188763943595, guid: e798772e5c3d46a46929df22fb70e680, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 143
+  indexInSingleton: 142

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/BluecherrySnowconeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/BluecherrySnowconeRecipe.asset
@@ -31,4 +31,4 @@ MonoBehaviour:
   - {fileID: 4473377980784368051, guid: 978bc68ac1262294b81c7b95a70abef2, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 146
+  indexInSingleton: 145

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/CherrySnowconeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/CherrySnowconeRecipe.asset
@@ -31,4 +31,4 @@ MonoBehaviour:
   - {fileID: 3013044760572986705, guid: 6e2660365f630bb4ba2c1b10486134bc, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 147
+  indexInSingleton: 146

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/ClownSnowconeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/ClownSnowconeRecipe.asset
@@ -31,4 +31,4 @@ MonoBehaviour:
   - {fileID: 8532367197430492385, guid: d8b41fa2582a8f8419793aa2618793f0, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 150
+  indexInSingleton: 149

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/FlavorlessSnowconeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/FlavorlessSnowconeRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 6311023804873926905, guid: d2ef9e5590dc00048833d43a568feb07, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 139
+  indexInSingleton: 138

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/FruitSaladSnowconeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/FruitSaladSnowconeRecipe.asset
@@ -35,4 +35,4 @@ MonoBehaviour:
   - {fileID: 1182272761751909550, guid: 75a97a95701f04046b6b755444bcba7b, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 148
+  indexInSingleton: 147

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/GrapeSnowconeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/GrapeSnowconeRecipe.asset
@@ -31,4 +31,4 @@ MonoBehaviour:
   - {fileID: 6000773509972271861, guid: 4f0a1d167808ce74fa68c7391180e992, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 144
+  indexInSingleton: 143

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/HoneySnowconeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/HoneySnowconeRecipe.asset
@@ -31,4 +31,4 @@ MonoBehaviour:
   - {fileID: 5067621306455257484, guid: f2fafeba491b2654496e53736b4d2e12, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 154
+  indexInSingleton: 153

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/LemonSnowconeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/LemonSnowconeRecipe.asset
@@ -31,4 +31,4 @@ MonoBehaviour:
   - {fileID: 8135556003061427236, guid: 322f92d84b8dc994996641aead20c4ab, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 142
+  indexInSingleton: 141

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/LimeSnowconeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/LimeSnowconeRecipe.asset
@@ -31,4 +31,4 @@ MonoBehaviour:
   - {fileID: 1972071531609341274, guid: fe0f7a8d624564145b23fb3788c35e42, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 141
+  indexInSingleton: 140

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/MimeSnowconeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/MimeSnowconeRecipe.asset
@@ -31,4 +31,4 @@ MonoBehaviour:
   - {fileID: 7001277311572984462, guid: da7709eec58193c46bd52e5e2e4654f6, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 149
+  indexInSingleton: 148

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/OrangeSnowconeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/OrangeSnowconeRecipe.asset
@@ -31,4 +31,4 @@ MonoBehaviour:
   - {fileID: 6000773509972271861, guid: 4f0a1d167808ce74fa68c7391180e992, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 145
+  indexInSingleton: 144

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/PineappleSnowconeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/PineappleSnowconeRecipe.asset
@@ -31,4 +31,4 @@ MonoBehaviour:
   - {fileID: 788770009163432621, guid: d3eabd0b9c2d582449253c033a718866, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 140
+  indexInSingleton: 139

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/PwrGameSnowconeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/PwrGameSnowconeRecipe.asset
@@ -31,4 +31,4 @@ MonoBehaviour:
   - {fileID: 5408680039725575541, guid: 5da3ec9c50d7a764a8ea9952d7cabb31, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 153
+  indexInSingleton: 152

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/RainbowSnowconeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/RainbowSnowconeRecipe.asset
@@ -31,4 +31,4 @@ MonoBehaviour:
   - {fileID: 324917818606042841, guid: e4c875b3bfcc01a479afeec97a04e267, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 155
+  indexInSingleton: 154

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/SpaceColaSnowconeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/SpaceColaSnowconeRecipe.asset
@@ -31,4 +31,4 @@ MonoBehaviour:
   - {fileID: 3669299790051991274, guid: 4baf7816d024d8d42a9aaa9523b4075f, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 151
+  indexInSingleton: 150

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/SpaceMountainWindSnowconeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/Snowcones/SpaceMountainWindSnowconeRecipe.asset
@@ -31,4 +31,4 @@ MonoBehaviour:
   - {fileID: 5573946682171816502, guid: 0dd3809fa9445cc429bb637b83122d11, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 152
+  indexInSingleton: 151

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/StrawberryIcecreamSandiwichRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Frozen/StrawberryIcecreamSandiwichRecipe.asset
@@ -31,4 +31,4 @@ MonoBehaviour:
   - {fileID: 3767046870115088516, guid: e4b36eb23624a964ea341ece8f412110, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 137
+  indexInSingleton: 136

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/BBQRibsRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/BBQRibsRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 3419712584172487034, guid: dea1298ee1af57b499e592745616c76d, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 260
+  indexInSingleton: 259

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/ChickenNuggetRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/ChickenNuggetRecipe.asset
@@ -27,4 +27,4 @@ MonoBehaviour:
   - {fileID: 127002792104048084, guid: 0b2bbc86c2309e5458c80937419c663f, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 255
+  indexInSingleton: 254

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/CornedBeefAndCabbageRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/CornedBeefAndCabbageRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 8007816581662014884, guid: 297010948094c1f41a7aa2057e644d39, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 250
+  indexInSingleton: 249

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/EnchiladasRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/EnchiladasRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 4360159843426554666, guid: 6eddc9aafd2809049a979b24df6c9440, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 252
+  indexInSingleton: 251

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/FilletMigrawrRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/FilletMigrawrRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 7863187213937771497, guid: b490641ec7967dc44a9a2f80b119f343, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 251
+  indexInSingleton: 250

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/Fish/CubanCarpRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/Fish/CubanCarpRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 8943180787885337068, guid: fdd4129cf6114cb4488945131a603da1, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 245
+  indexInSingleton: 244

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/Fish/FishAndChipsRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/Fish/FishAndChipsRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 619069453893467040, guid: 845d84b426e36bc4095f7c85997c1d9f, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 246
+  indexInSingleton: 245

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/Fish/FishFingersRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/Fish/FishFingersRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 7973188587688279538, guid: cf52cab2d76aefa4296adbe1bb2a0fd3, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 247
+  indexInSingleton: 246

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/Fish/SashimiRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/Fish/SashimiRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 7259927398293264364, guid: 95f08b6a776370b4486944f73f43161c, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 248
+  indexInSingleton: 247

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/ImitationCarpFilletRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/ImitationCarpFilletRecipe.asset
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0a638c97a2384c54bee47631bd326e8b, type: 3}
+  m_Name: ImitationCarpFilletRecipe
+  m_EditorClassIdentifier: 
+  category: 10
+  craftingTime: 0
+  recipeName: Imitation Carp Fillet
+  recipeIconOverride: {fileID: 0}
+  recipeDescription: 
+  requiredIngredients:
+  - requiredAmount: 1
+    requiredItem: {fileID: 8206807289480147764, guid: 2751f86e853d6dd43a2b3614c3e6c24c,
+      type: 3}
+  requiredReagents:
+  - requiredAmount: 5
+    requiredReagent: {fileID: 11400000, guid: 9d1090f4516aeb0f2aa5fec39d2127d5, type: 2}
+  requiredToolTraits: []
+  result:
+  - {fileID: 5144560459880948258, guid: 77e176923a462b14089caadd967f5b01, type: 3}
+  resultHandlers: []
+  isSimple: 0
+  indexInSingleton: 343

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/ImitationCarpFilletRecipe.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/ImitationCarpFilletRecipe.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e1eaf4a7872294f499cd4603a028e423
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/Kebabs/DoubleRatKebabRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/Kebabs/DoubleRatKebabRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 4296264140864599532, guid: fe860678437cf6647a3e10b52f108497, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 258
+  indexInSingleton: 257

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/Kebabs/FiestaSkewerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/Kebabs/FiestaSkewerRecipe.asset
@@ -36,4 +36,4 @@ MonoBehaviour:
   - {fileID: 2317797655404034331, guid: f1cd290a600f6c94cba8a03149898f04, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 244
+  indexInSingleton: 243

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/Kebabs/HumanKebabRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/Kebabs/HumanKebabRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 1753251085583803218, guid: 6103b1da04734a54b83ed4c00ed4c5fa, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 240
+  indexInSingleton: 239

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/Kebabs/KebabRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/Kebabs/KebabRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 8751528303924010211, guid: 60d1a75dc181f78418b573fcf38ce4bf, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 241
+  indexInSingleton: 240

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/Kebabs/LizardTailKebabRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/Kebabs/LizardTailKebabRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 2984464565171275779, guid: 5eb37c88cebde544690d4473000f4a4c, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 243
+  indexInSingleton: 242

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/Kebabs/RatKebabRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/Kebabs/RatKebabRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 6308892662194402373, guid: 61e2b60df4f12c5409b1d382b94a6e8b, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 301
+  indexInSingleton: 300

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/Kebabs/TofuKebabRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/Kebabs/TofuKebabRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 1996339495931670011, guid: 359aae2e5fc4b394fb9869391977d25b, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 242
+  indexInSingleton: 241

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/MeatClownRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/MeatClownRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 1332629885960264366, guid: ae3913b215809aa4fad9fa98f567f3db, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 261
+  indexInSingleton: 260

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/MeatProductRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/MeatProductRecipe.asset
@@ -1,0 +1,33 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0a638c97a2384c54bee47631bd326e8b, type: 3}
+  m_Name: MeatProductRecipe
+  m_EditorClassIdentifier: 
+  category: 10
+  craftingTime: 0
+  recipeName: Meat Product
+  recipeIconOverride: {fileID: 0}
+  recipeDescription: 
+  requiredIngredients: []
+  requiredReagents:
+  - requiredAmount: 10
+    requiredReagent: {fileID: 11400000, guid: 3afb1893f74fb775d806cbc4563ed1e7, type: 2}
+  - requiredAmount: 10
+    requiredReagent: {fileID: 11400000, guid: 82692ea8680693d459ad97993dbda0f3, type: 2}
+  - requiredAmount: 10
+    requiredReagent: {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237, type: 2}
+  requiredToolTraits: []
+  result:
+  - {fileID: 3118597897089783227, guid: 66f25945c6372954e8ad2e628cc25b98, type: 3}
+  resultHandlers: []
+  isSimple: 0
+  indexInSingleton: 341

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/MeatProductRecipe.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/MeatProductRecipe.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1860642633aa46b479cd6ddf4029cf3d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/PigInABlanketRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/PigInABlanketRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 5865211538455731408, guid: 50409efd58801f94194ab85e1bd97b6f, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 257
+  indexInSingleton: 256

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/RawKhinkaliRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/RawKhinkaliRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 7589287290980887380, guid: 322da2df62f4aeb41a45d3730bf7755c, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 256
+  indexInSingleton: 255

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/RawSausageRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/RawSausageRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 8017736787133888042, guid: b719d2d5c55edec43b1e770960a9c795, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 254
+  indexInSingleton: 253

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/RiceAndPorkRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/RiceAndPorkRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 144872026979369123, guid: 6dcbb0d5ea7af0243a4d3a24742cfe3c, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 259
+  indexInSingleton: 258

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/SpiderEggsAndHamRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/SpiderEggsAndHamRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 8089669465796704766, guid: 5db9f90326720474c97d7a5ebca3b060, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 249
+  indexInSingleton: 248

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/StewedSoymeatRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/StewedSoymeatRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 5598041107416438808, guid: dbd57571cc15e98408ba47e5b5431697, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 253
+  indexInSingleton: 252

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/SynthmeatRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/SynthmeatRecipe.asset
@@ -1,0 +1,31 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0a638c97a2384c54bee47631bd326e8b, type: 3}
+  m_Name: SynthmeatRecipe
+  m_EditorClassIdentifier: 
+  category: 10
+  craftingTime: 0
+  recipeName: Synthmeat
+  recipeIconOverride: {fileID: 0}
+  recipeDescription: 
+  requiredIngredients: []
+  requiredReagents:
+  - requiredAmount: 5
+    requiredReagent: {fileID: 11400000, guid: eea05337a284c407e926bf3110b00916, type: 2}
+  - requiredAmount: 1
+    requiredReagent: {fileID: 11400000, guid: e2f90c460b3c44d23bc300bfebb63e2c, type: 2}
+  requiredToolTraits: []
+  result:
+  - {fileID: 2004955423375369696, guid: 7409d4735ac3a9543bd57359e3d7c2a9, type: 3}
+  resultHandlers: []
+  isSimple: 0
+  indexInSingleton: 342

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/SynthmeatRecipe.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Meat/SynthmeatRecipe.asset.meta
@@ -1,8 +1,8 @@
 fileFormatVersion: 2
-guid: c9462501f3931b2418e30590415226ec
+guid: 97cc5a6c53831344dafe59906bd4e682
 NativeFormatImporter:
   externalObjects: {}
-  mainObjectFileID: 0
+  mainObjectFileID: 11400000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/BeansRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/BeansRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 6203810862003151095, guid: 0e4331319d7848c45b3093e081deb2e7, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 270
+  indexInSingleton: 269

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/BranRequestsCerealRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/BranRequestsCerealRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 4054759479676373055, guid: 66b398a09d7595e4a95a070156439ad0, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 290
+  indexInSingleton: 289

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/BurritoRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/BurritoRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 1048836947887383213, guid: adb93c946c3a55c47ae3c87e5353e63d, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 277
+  indexInSingleton: 276

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/CandiedAppleRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/CandiedAppleRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 126161503251571608, guid: 86ddec36cce28a0458cdc2e7c5cb483e, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 262
+  indexInSingleton: 261

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/CarneDeAsadaBurritoRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/CarneDeAsadaBurritoRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 7243476603887130535, guid: 938014b21dda15d4eafb7003479f77dd, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 279
+  indexInSingleton: 278

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/CheeseWheelRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/CheeseWheelRecipe.asset
@@ -1,0 +1,31 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0a638c97a2384c54bee47631bd326e8b, type: 3}
+  m_Name: CheeseWheelRecipe
+  m_EditorClassIdentifier: 
+  category: 11
+  craftingTime: 0
+  recipeName: Cheese Wheel
+  recipeIconOverride: {fileID: 0}
+  recipeDescription: 
+  requiredIngredients: []
+  requiredReagents:
+  - requiredAmount: 40
+    requiredReagent: {fileID: 11400000, guid: a1724b1210d8177c097a28325415c0b1, type: 2}
+  - requiredAmount: 5
+    requiredReagent: {fileID: 11400000, guid: d634f341665a083d6b7627735a2c8635, type: 2}
+  requiredToolTraits: []
+  result:
+  - {fileID: 5342993422408371182, guid: 0bf643131a7f0e3469673a5d636ae7c2, type: 3}
+  resultHandlers: []
+  isSimple: 0
+  indexInSingleton: 339

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/CheeseWheelRecipe.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/CheeseWheelRecipe.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 534754527e6349b4b904c4011c8b1f6b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/CheesyBurritoRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/CheesyBurritoRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 2692296637139084127, guid: 62b925e5bb8a0594ea1375dd18612842, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 278
+  indexInSingleton: 277

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/CheesyFriesRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/CheesyFriesRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 5712917446212678678, guid: 5df72eb5c5bef6542b580ba9c9f28569, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 268
+  indexInSingleton: 267

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/CheesyNachosRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/CheesyNachosRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 7606690881681326808, guid: 377a80ddf7905a745ace5d56a9b3f9ad, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 283
+  indexInSingleton: 282

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/ChocolateBarRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/ChocolateBarRecipe.asset
@@ -1,0 +1,31 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0a638c97a2384c54bee47631bd326e8b, type: 3}
+  m_Name: ChocolateBarRecipe
+  m_EditorClassIdentifier: 
+  category: 11
+  craftingTime: 0
+  recipeName: Chocolate Bar
+  recipeIconOverride: {fileID: 0}
+  recipeDescription: 
+  requiredIngredients: []
+  requiredReagents:
+  - requiredAmount: 2
+    requiredReagent: {fileID: 11400000, guid: 5b5f8bbc79979ff58b9cbaa4a2a95eaf, type: 2}
+  - requiredAmount: 2
+    requiredReagent: {fileID: 11400000, guid: 911271db97b77da51889f97d6688a103, type: 2}
+  requiredToolTraits: []
+  result:
+  - {fileID: 442118255629855042, guid: b09e9d95fbf80594c8bbcf60be9b3f93, type: 3}
+  resultHandlers: []
+  isSimple: 0
+  indexInSingleton: 337

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/ChocolateBarRecipe.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/ChocolateBarRecipe.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e4c0e053c2ed3ba45a17dbc716b9a1af
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/ChocolateBarVeganRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/ChocolateBarVeganRecipe.asset
@@ -10,22 +10,24 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0a638c97a2384c54bee47631bd326e8b, type: 3}
-  m_Name: DoughRecipe
+  m_Name: ChocolateBarVeganRecipe
   m_EditorClassIdentifier: 
-  category: 6
-  craftingTime: 0.5
-  recipeName: Dough
+  category: 11
+  craftingTime: 0
+  recipeName: Chocolate Bar (Vegan)
   recipeIconOverride: {fileID: 0}
   recipeDescription: 
   requiredIngredients: []
   requiredReagents:
-  - requiredAmount: 10
-    requiredReagent: {fileID: 11400000, guid: 522665e55a63647f6a9959f4b0a52c31, type: 2}
-  - requiredAmount: 15
-    requiredReagent: {fileID: 11400000, guid: 0c4cf985d57ba9ce18282581b4f45fe9, type: 2}
+  - requiredAmount: 2
+    requiredReagent: {fileID: 11400000, guid: 0c793b26027c29a1cb5806c738a7a556, type: 2}
+  - requiredAmount: 2
+    requiredReagent: {fileID: 11400000, guid: 0d70c7e3be7f9db159f739339ff04b3e, type: 2}
+  - requiredAmount: 2
+    requiredReagent: {fileID: 11400000, guid: 911271db97b77da51889f97d6688a103, type: 2}
   requiredToolTraits: []
   result:
-  - {fileID: 6035652412496520804, guid: c806a0c93acc5b94a9986b18d70f8368, type: 3}
+  - {fileID: 442118255629855042, guid: b09e9d95fbf80594c8bbcf60be9b3f93, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 2
+  indexInSingleton: 338

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/ChocolateBarVeganRecipe.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/ChocolateBarVeganRecipe.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5f25aeb9777c79449807dabfbe191a2e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/ChocolateCoinRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/ChocolateCoinRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 7619549917515844980, guid: 24d6ac8c3ef48e74c8fbe4e5c285c58f, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 264
+  indexInSingleton: 263

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/ChocolateOrangeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/ChocolateOrangeRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 5893363679920937231, guid: 57a3218a67e8cbe49980968269936af5, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 266
+  indexInSingleton: 265

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/ClassicTacoRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/ClassicTacoRecipe.asset
@@ -36,4 +36,4 @@ MonoBehaviour:
   - {fileID: 4753295586405908985, guid: bffeda72b190ace48aaf60ec93957f88, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 288
+  indexInSingleton: 287

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/CrabRangoonRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/CrabRangoonRecipe.asset
@@ -35,4 +35,4 @@ MonoBehaviour:
   - {fileID: 249305219011617194, guid: 7769c3602197f1a489c7eda2addfaae0, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 292
+  indexInSingleton: 291

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/CubanNachosRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/CubanNachosRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 8273788606282598152, guid: 05f72151cd82e394697c5ce7a955328b, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 284
+  indexInSingleton: 283

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/EggplantParmigianaRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/EggplantParmigianaRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 8164262166481818058, guid: 7139ee5fc2dccaf4381222b43f87ec4f, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 271
+  indexInSingleton: 270

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/FudgeDiceRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/FudgeDiceRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 2668815145745030657, guid: 57206793d0f9f6c4a98b54bca4a1340a, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 265
+  indexInSingleton: 264

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/FuegoPlasmaBurritoRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/FuegoPlasmaBurritoRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 373271569340737334, guid: 3e43cec2e5d84f24dae1c60aa1404874, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 280
+  indexInSingleton: 279

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/HoneyNutBarRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/HoneyNutBarRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 2984539456848129675, guid: 2be359ffd60083d4abd78c115cab6a1c, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 286
+  indexInSingleton: 285

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/LoadedBakedPotatoRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/LoadedBakedPotatoRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 1420422943757928508, guid: 4bdb227b9a64d5047b79ff89ccbee020, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 267
+  indexInSingleton: 266

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/MelonFruitBowlRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/MelonFruitBowlRecipe.asset
@@ -42,4 +42,4 @@ MonoBehaviour:
   - {fileID: 8380978593962277333, guid: 6b9fa06cbc77b9b428020cd44eca843a, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 281
+  indexInSingleton: 280

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/MelonKegRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/MelonKegRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 3947008752395549006, guid: 5e7ae50544852984a9067aa575bca710, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 285
+  indexInSingleton: 284

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/NachosRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/NachosRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 2154208563272071456, guid: b78122d9936891947ac7175556d14fd7, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 282
+  indexInSingleton: 281

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/PlainTacoRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/PlainTacoRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 2467060199906660208, guid: ca25a62bcfe4e0242945227dd66cb621, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 289
+  indexInSingleton: 288

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/PowercrepeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/PowercrepeRecipe.asset
@@ -37,4 +37,4 @@ MonoBehaviour:
   - {fileID: 2984539456848129675, guid: 2be359ffd60083d4abd78c115cab6a1c, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 287
+  indexInSingleton: 286

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/RicePuddingRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/RicePuddingRecipe.asset
@@ -31,4 +31,4 @@ MonoBehaviour:
   - {fileID: 615237689564432334, guid: fdc294b695c8fa842b789bac6c4be815, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 291
+  indexInSingleton: 290

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/SpiderLollipopRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/SpiderLollipopRecipe.asset
@@ -34,4 +34,4 @@ MonoBehaviour:
   - {fileID: 6228365480409997059, guid: 3999b6e3c8785d44cb11e4f15017fb6a, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 263
+  indexInSingleton: 262

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/TofuRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/TofuRecipe.asset
@@ -1,0 +1,31 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0a638c97a2384c54bee47631bd326e8b, type: 3}
+  m_Name: TofuRecipe
+  m_EditorClassIdentifier: 
+  category: 11
+  craftingTime: 0
+  recipeName: Tofu
+  recipeIconOverride: {fileID: 0}
+  recipeDescription: 
+  requiredIngredients: []
+  requiredReagents:
+  - requiredAmount: 10
+    requiredReagent: {fileID: 11400000, guid: 0c793b26027c29a1cb5806c738a7a556, type: 2}
+  - requiredAmount: 5
+    requiredReagent: {fileID: 11400000, guid: d634f341665a083d6b7627735a2c8635, type: 2}
+  requiredToolTraits: []
+  result:
+  - {fileID: 8206807289480147764, guid: 2751f86e853d6dd43a2b3614c3e6c24c, type: 3}
+  resultHandlers: []
+  isSimple: 0
+  indexInSingleton: 340

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/TofuRecipe.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/MiscFood/TofuRecipe.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fb7873ebb6b9ac6489486a9dfd8a0365
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/BerryMuffinRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/BerryMuffinRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 2022550201114955498, guid: 1b249c532008b6443b73c3362716eb34, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 221
+  indexInSingleton: 220

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/BlueCherryCupcakeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/BlueCherryCupcakeRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 1634420442250272174, guid: 60e93ac939f3337438ee4d43ab1213ca, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 237
+  indexInSingleton: 236

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/BlueberryPancakeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/BlueberryPancakeRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 114917313034291055, guid: af1b909717de29d43a653522f2ec532d, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 212
+  indexInSingleton: 211

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/BooberryMuffinRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/BooberryMuffinRecipe.asset
@@ -35,4 +35,4 @@ MonoBehaviour:
   - {fileID: 7535144168076341333, guid: dde3cc86ff3f87e4a9399ae6df9722e1, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 222
+  indexInSingleton: 221

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/CannoliRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/CannoliRecipe.asset
@@ -31,4 +31,4 @@ MonoBehaviour:
   - {fileID: 7909602308677676447, guid: e3c31760717a2bf4ca926f064e06af5b, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 239
+  indexInSingleton: 238

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/ChawanmushiRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/ChawanmushiRecipe.asset
@@ -34,4 +34,4 @@ MonoBehaviour:
   - {fileID: 1222471923234717498, guid: 9948db8f8e5fd6446a6eb69b16760883, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 223
+  indexInSingleton: 222

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/CherryCupcakeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/CherryCupcakeRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 1634420442250272174, guid: 1c45afeffaa8d594a9debcdbfec4407a, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 236
+  indexInSingleton: 235

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/ChocoCornetRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/ChocoCornetRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 6736519495393363023, guid: b6ce7b0801ca2f0458cf26abeeda3180, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 232
+  indexInSingleton: 231

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/ChocolateChipCookieRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/ChocolateChipCookieRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 2176312772723587003, guid: 5922881ffc5c59842906e74798fa92bd, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 235
+  indexInSingleton: 234

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/ChocolateChipPancakeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/ChocolateChipPancakeRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 3141848189631731157, guid: d4ef8b78f9dbb774680b472fa6cd77e7, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 211
+  indexInSingleton: 210

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/CrackerRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/CrackerRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 1235464830935183441, guid: 64f112cff1b6def4bab9d81471b549f8, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 231
+  indexInSingleton: 230

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/DonkPockets/BerrypocketRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/DonkPockets/BerrypocketRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 2751226054693988105, guid: c7e2497f5aa608d45850eaf20ed2a5a0, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 218
+  indexInSingleton: 217

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/DonkPockets/DankpocketRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/DonkPockets/DankpocketRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 7905334612122207224, guid: 867e19285f496c34f968d50c65495b15, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 214
+  indexInSingleton: 213

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/DonkPockets/DonkpocketRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/DonkPockets/DonkpocketRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 4068550812654918663, guid: 03ecfa2b3ab8ecf4f86c295e0dc69792, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 213
+  indexInSingleton: 212

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/DonkPockets/GondolapocketRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/DonkPockets/GondolapocketRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 4068550812654918663, guid: 03ecfa2b3ab8ecf4f86c295e0dc69792, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 219
+  indexInSingleton: 218

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/DonkPockets/HonkpocketRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/DonkPockets/HonkpocketRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 3032260756878353940, guid: a4135902a43967e42a5f906d04bc95dd, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 302
+  indexInSingleton: 301

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/DonkPockets/PizzapocketRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/DonkPockets/PizzapocketRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 9072725429194834912, guid: 0ce99ba5ac47e8e4f96313267983218a, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 217
+  indexInSingleton: 216

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/DonkPockets/SpicypocketRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/DonkPockets/SpicypocketRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 3102783355916880414, guid: e826ddcefb2760747b1c17e17c572e54, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 215
+  indexInSingleton: 214

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/DonkPockets/TeriyakipocketRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/DonkPockets/TeriyakipocketRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 8334791526503842103, guid: 8b19ede438618a14094de3b94fa1a959, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 216
+  indexInSingleton: 215

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/Donuts/AppleDonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/Donuts/AppleDonutRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 6139046539730815374, guid: 73a900b219f52c2459c0a1c78c42ca10, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 186
+  indexInSingleton: 185

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/Donuts/BerryDonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/Donuts/BerryDonutRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 6542174723711969670, guid: 5023b937134f4764a91243f84a0cbabf, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 185
+  indexInSingleton: 184

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/Donuts/BlumpkinDonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/Donuts/BlumpkinDonutRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 5887408306302976262, guid: b4200e903f53b90478526a264e0c4625, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 189
+  indexInSingleton: 188

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/Donuts/BungoDonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/Donuts/BungoDonutRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 8819811271852087000, guid: dd8adeab0c2e6b245a484c119653f74b, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 190
+  indexInSingleton: 189

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/Donuts/CaramelDonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/Donuts/CaramelDonutRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 625993988406634000, guid: 3a35482a8584c964da096f526a3b3193, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 187
+  indexInSingleton: 186

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/Donuts/ChaosDonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/Donuts/ChaosDonutRecipe.asset
@@ -31,4 +31,4 @@ MonoBehaviour:
   - {fileID: 6931768227764898483, guid: 7935d60f19bfe2a4885031c4c2df648a, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 181
+  indexInSingleton: 180

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/Donuts/ChocolateDonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/Donuts/ChocolateDonutRecipe.asset
@@ -27,4 +27,4 @@ MonoBehaviour:
   - {fileID: 7421385548175240933, guid: 1a76995920e9e024a8936cacddd3e701, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 188
+  indexInSingleton: 187

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/Donuts/DonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/Donuts/DonutRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 2167258747849165, guid: 270ed493bf3f6684388bc3ad5696003b, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 180
+  indexInSingleton: 179

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/Donuts/MatchaDonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/Donuts/MatchaDonutRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 952026809150307588, guid: fb65b4cdb99dec54ba2893aa01f6f2f8, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 191
+  indexInSingleton: 190

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/Donuts/MeatDonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/Donuts/MeatDonutRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 5602298466666205948, guid: c3aae48c2e0c81140a838e4e5a6f5b2a, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 182
+  indexInSingleton: 181

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/FortuneCookieRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/FortuneCookieRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 4825644788774902061, guid: 41cffce9086697a4686f7fb3b26ba6c3, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 228
+  indexInSingleton: 227

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/HoneyBunRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/HoneyBunRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 3191340247094839358, guid: 2b61af1224ce0f04a9f74054d8d0801f, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 238
+  indexInSingleton: 237

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/HotDogRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/HotDogRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 8444707690030103156, guid: 21cd1fd338785b8429e7daa5c2029099, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 224
+  indexInSingleton: 223

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/JellyDonuts/AppleJellyDonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/JellyDonuts/AppleJellyDonutRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 8547045982116646323, guid: 937e21d372369de41b68006da00a9cbf, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 193
+  indexInSingleton: 192

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/JellyDonuts/BerryJellyDonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/JellyDonuts/BerryJellyDonutRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 3188918625565710729, guid: 21578009db1fe0440958d0c183a4fe84, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 192
+  indexInSingleton: 191

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/JellyDonuts/BlumpkinJellyDonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/JellyDonuts/BlumpkinJellyDonutRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 422444691247148413, guid: cd3d8c491f186f244a7b783ad8da2325, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 196
+  indexInSingleton: 195

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/JellyDonuts/BungoJellyDonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/JellyDonuts/BungoJellyDonutRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 4357136538261678828, guid: 100daf2a94818ad48b7722576f459975, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 197
+  indexInSingleton: 196

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/JellyDonuts/CaramelJellyDonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/JellyDonuts/CaramelJellyDonutRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 1269470344000249603, guid: 72dcb2095d0fc794e90083ff4d4e40bf, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 194
+  indexInSingleton: 193

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/JellyDonuts/ChocolateJellyDonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/JellyDonuts/ChocolateJellyDonutRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 6308244881549667084, guid: b612dbd376deb54458e3d35a9589d461, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 195
+  indexInSingleton: 194

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/JellyDonuts/JellyDonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/JellyDonuts/JellyDonutRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 4285381335472442606, guid: 5f558fb8ba78d4941ad12db8fb0a1dd4, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 183
+  indexInSingleton: 182

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/JellyDonuts/MatchaJellyDonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/JellyDonuts/MatchaJellyDonutRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 1805139189656934700, guid: a995292aef5bf2145a5b686d9861f4b5, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 198
+  indexInSingleton: 197

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/KhachapuriRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/KhachapuriRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 509582031640582521, guid: b3f43a6cef8c53f49bebfb34ee1f4d21, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 226
+  indexInSingleton: 225

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/MeatBunRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/MeatBunRecipe.asset
@@ -35,4 +35,4 @@ MonoBehaviour:
   - {fileID: 4472332188609659986, guid: 26d63ff35841ec74fb376fb80ec808b6, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 225
+  indexInSingleton: 224

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/MuffinRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/MuffinRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 6313053749959027295, guid: 736d32f5e1d2d4d40b9356bf97c38db8, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 220
+  indexInSingleton: 219

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/OatmealCookieRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/OatmealCookieRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 100425601344266544, guid: 6962974ce20e04c4eb2aa0e10c283de2, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 233
+  indexInSingleton: 232

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/PancakeRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/PancakeRecipe.asset
@@ -27,4 +27,4 @@ MonoBehaviour:
   - {fileID: 2757069092534841955, guid: 035adb3887f722a46a90a325f4096256, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 210
+  indexInSingleton: 209

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/PlumpHelmetBiscuitRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/PlumpHelmetBiscuitRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 2393610195619847970, guid: 8a70508f58c6a8e4286833ff4f771426, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 230
+  indexInSingleton: 229

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/PoppyPretzelRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/PoppyPretzelRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 6842837344771801099, guid: 6c6024297e6fc674c8c32866a22c19bb, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 229
+  indexInSingleton: 228

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/RaisinCookieRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/RaisinCookieRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 100425601344266544, guid: fdfae15235fe6164fbd269be37dde40c, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 234
+  indexInSingleton: 233

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/RoffleWafflesRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/RoffleWafflesRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 6023603170262547730, guid: ee74caa7bd68d6d4b904a99d64bd4677, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 209
+  indexInSingleton: 208

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/SlimeJellyDonuts/AppleSlimeDonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/SlimeJellyDonuts/AppleSlimeDonutRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 5922009110140050089, guid: d572df721bbca3944892c0ea607d0e37, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 205
+  indexInSingleton: 204

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/SlimeJellyDonuts/BerrySlimeDonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/SlimeJellyDonuts/BerrySlimeDonutRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 6814381510828774114, guid: c27fabff15b94934dba64c2f679b9782, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 204
+  indexInSingleton: 203

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/SlimeJellyDonuts/BlumpkinSlimeDonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/SlimeJellyDonuts/BlumpkinSlimeDonutRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 6659016200491831589, guid: ca540bba9341aa24691db7d7f5d15ad1, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 203
+  indexInSingleton: 202

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/SlimeJellyDonuts/BungoSlimeDonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/SlimeJellyDonuts/BungoSlimeDonutRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 8631095300417536066, guid: 16a47d67c518a0b428dfdc7d949b6a9e, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 202
+  indexInSingleton: 201

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/SlimeJellyDonuts/CaramelSlimeDonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/SlimeJellyDonuts/CaramelSlimeDonutRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 6200079751648480793, guid: 81275ef6f05d317459c02917ce4e891d, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 201
+  indexInSingleton: 200

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/SlimeJellyDonuts/ChocolateSlimeDonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/SlimeJellyDonuts/ChocolateSlimeDonutRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 7290941055536014969, guid: d73d0b6561e5a954f81058f3f72fbdd8, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 200
+  indexInSingleton: 199

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/SlimeJellyDonuts/MatchaSlimeDonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/SlimeJellyDonuts/MatchaSlimeDonutRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 4094474587764645026, guid: f2b881545aae9344c8dfe6edcba5b968, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 199
+  indexInSingleton: 198

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/SlimeJellyDonuts/SlimeJellyDonutRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/SlimeJellyDonuts/SlimeJellyDonutRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 7290191212285199944, guid: 0a2bc1035ffedcf45b194433f4a98ea5, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 184
+  indexInSingleton: 183

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/SoylentGreenRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/SoylentGreenRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 8079663187379722596, guid: 4851df8257ff0ca40a3ab4caed978213, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 208
+  indexInSingleton: 207

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/SoylentViridiansRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/SoylentViridiansRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 3168852994208216345, guid: 464beb89cf727c24499adea6e3278f03, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 207
+  indexInSingleton: 206

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/SugarCookieRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/SugarCookieRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 604469265663068536, guid: ad26bcebe49e6904b9340e00d2eef36e, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 227
+  indexInSingleton: 226

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/WafflesRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pastries/WafflesRecipe.asset
@@ -27,4 +27,4 @@ MonoBehaviour:
   - {fileID: 7160341899752804702, guid: 07d5d280fbd180b45a942ed021114f01, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 206
+  indexInSingleton: 205

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/PieDoughRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/PieDoughRecipe.asset
@@ -28,4 +28,4 @@ MonoBehaviour:
   - {fileID: 2890699226248425545, guid: 26f196165e6f56b4d85cb37248346dbd, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 293
+  indexInSingleton: 292

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/AmanitaPieRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/AmanitaPieRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 9077949775579336186, guid: e728e10178c603843af6e8c46c6f6db6, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 167
+  indexInSingleton: 166

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/ApplePieRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/ApplePieRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 4382868282513830306, guid: 966121d28aadb56448a966ecf48b1931, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 169
+  indexInSingleton: 168

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/BaklavaRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/BaklavaRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 2885993440868084006, guid: a097e6ce2cea8c94d99717f07c82b2a6, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 179
+  indexInSingleton: 178

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/BananaCreamPieRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/BananaCreamPieRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 9010739518231291243, guid: 6565654a1b6f90d4a8a1bd6a26c90728, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 160
+  indexInSingleton: 159

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/BearyPieRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/BearyPieRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 5132077943003395876, guid: 62b020939e0912d4e9f2eab77475de8a, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 166
+  indexInSingleton: 165

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/BerryClafoutisRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/BerryClafoutisRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 1992379070475182011, guid: 7dcf86c5f6d63fe489043ef5cc8c4ba7, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 165
+  indexInSingleton: 164

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/BerryTartRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/BerryTartRecipe.asset
@@ -34,4 +34,4 @@ MonoBehaviour:
   - {fileID: 8603295479948704953, guid: 322f1e55cecd3bf4e9f3a2f5a53e2b86, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 174
+  indexInSingleton: 173

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/BlumpkinPieRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/BlumpkinPieRecipe.asset
@@ -34,4 +34,4 @@ MonoBehaviour:
   - {fileID: 7489956930691193831, guid: f10d8e43c324d5a4abf9b4ea9a9bff29, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 176
+  indexInSingleton: 175

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/CherryPieRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/CherryPieRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 4097263963118774763, guid: 63cadec350d20c24aacb09c2fc6092b9, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 164
+  indexInSingleton: 163

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/ChocolateLavaTartRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/ChocolateLavaTartRecipe.asset
@@ -34,4 +34,4 @@ MonoBehaviour:
   - {fileID: 5743561980934201368, guid: 815f7a161088ba54b8a1ec2119f02ea1, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 175
+  indexInSingleton: 174

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/DulceDeBatataRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/DulceDeBatataRecipe.asset
@@ -31,4 +31,4 @@ MonoBehaviour:
   - {fileID: 5267316855268426051, guid: 0a36878b7d5196b45b592118937306fb, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 177
+  indexInSingleton: 176

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/FrostyPieRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/FrostyPieRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 7575837559379257464, guid: 9a79299f8a6ef3c41aaf9e36f46faec6, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 178
+  indexInSingleton: 177

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/GoldenAppleStreuselTartRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/GoldenAppleStreuselTartRecipe.asset
@@ -34,4 +34,4 @@ MonoBehaviour:
   - {fileID: 5325346273662142304, guid: 7aafd41668c29ca48ba6e2d0fb369566, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 171
+  indexInSingleton: 170

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/GrapeTartRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/GrapeTartRecipe.asset
@@ -34,4 +34,4 @@ MonoBehaviour:
   - {fileID: 6100789881494314878, guid: 300984309c0c8e74b8805b91c85059f8, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 172
+  indexInSingleton: 171

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/MeatPieRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/MeatPieRecipe.asset
@@ -34,4 +34,4 @@ MonoBehaviour:
   - {fileID: 5626849186631484974, guid: 2c1e608411ecefc43bea4067c2a48048, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 161
+  indexInSingleton: 160

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/MimeTartRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/MimeTartRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 2251022623875354407, guid: 848450d81e7ee094b8e87e4bf04eb30f, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 173
+  indexInSingleton: 172

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/PlumpPieRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/PlumpPieRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 6523725290757513577, guid: 024d4787dd72ad04aa84c018e10e609f, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 168
+  indexInSingleton: 167

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/PumpkinPieRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/PumpkinPieRecipe.asset
@@ -34,4 +34,4 @@ MonoBehaviour:
   - {fileID: 8338492867238052596, guid: c6ad829d196ea77478bdfdbf223068d7, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 170
+  indexInSingleton: 169

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/TofuPieRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/TofuPieRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 603234769027915435, guid: a126ccb64e211e643b16d9a9cbfd1ecc, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 162
+  indexInSingleton: 161

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/XenoPieRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pies/XenoPieRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 257652609067196263, guid: c8623f02b7262a84d993c33927cd8e9b, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 163
+  indexInSingleton: 162

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pizzas/ArnoldPizzaRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pizzas/ArnoldPizzaRecipe.asset
@@ -39,4 +39,4 @@ MonoBehaviour:
   - {fileID: 3394367362886323294, guid: c9aefb532cc70f44abd8ac39d9d784df, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 15
+  indexInSingleton: 14

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pizzas/DankPizzaRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pizzas/DankPizzaRecipe.asset
@@ -36,4 +36,4 @@ MonoBehaviour:
   - {fileID: 2214687450486280385, guid: 0cb800d6ab549db49ac6e01d3e7970e4, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 13
+  indexInSingleton: 12

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pizzas/DonkpocketPizzaRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pizzas/DonkpocketPizzaRecipe.asset
@@ -36,4 +36,4 @@ MonoBehaviour:
   - {fileID: 5491402170285736221, guid: a09b22cba1cc2524292c14edd7037211, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 11
+  indexInSingleton: 10

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pizzas/HawaiianPizzaRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pizzas/HawaiianPizzaRecipe.asset
@@ -39,4 +39,4 @@ MonoBehaviour:
   - {fileID: 8356633666052490034, guid: 95f5b7a192c4e424a8d825f6366be62d, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 9
+  indexInSingleton: 8

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pizzas/MargheritaPizzaRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pizzas/MargheritaPizzaRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 8421089631845725742, guid: dbb1082f0389c244d89f153b379e31c4, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 17
+  indexInSingleton: 16

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pizzas/MeatPizzaRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pizzas/MeatPizzaRecipe.asset
@@ -36,4 +36,4 @@ MonoBehaviour:
   - {fileID: 8421089631845725742, guid: dbb1082f0389c244d89f153b379e31c4, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 16
+  indexInSingleton: 15

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pizzas/MushroomPizzaRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pizzas/MushroomPizzaRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 6027159720349803130, guid: 17c6c3043e2f80247b8110ed8e260601, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 14
+  indexInSingleton: 13

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pizzas/SausagePizzaRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pizzas/SausagePizzaRecipe.asset
@@ -36,4 +36,4 @@ MonoBehaviour:
   - {fileID: 8820891359458226626, guid: e3db388746619344db4cdc07addc4f38, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 10
+  indexInSingleton: 9

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pizzas/VegetablePizzaRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Pizzas/VegetablePizzaRecipe.asset
@@ -39,4 +39,4 @@ MonoBehaviour:
   - {fileID: 2635048175138463619, guid: 2051dd9e472d44140859bd686a1b9957, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 12
+  indexInSingleton: 11

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Salads/AesirSaladRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Salads/AesirSaladRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 13123239374767236, guid: dbe5fa02a63b789458f2e7c26f2b4056, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 62
+  indexInSingleton: 61

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Salads/CitrusDelightRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Salads/CitrusDelightRecipe.asset
@@ -36,4 +36,4 @@ MonoBehaviour:
   - {fileID: 5081854417917036444, guid: 85b170b6b3a35904b9938dc5850248f5, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 56
+  indexInSingleton: 55

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Salads/FruitSaladRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Salads/FruitSaladRecipe.asset
@@ -39,4 +39,4 @@ MonoBehaviour:
   - {fileID: 6163901379544671154, guid: 2ef0b1a7e4c874a4199d84fc94341a63, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 58
+  indexInSingleton: 57

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Salads/HerbSaladRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Salads/HerbSaladRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 1995091385573460360, guid: 086a617ff70deb84b92d74d66c4208bc, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 61
+  indexInSingleton: 60

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Salads/JungleSaladRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Salads/JungleSaladRecipe.asset
@@ -39,4 +39,4 @@ MonoBehaviour:
   - {fileID: 6067883363511248879, guid: 1424129d892dc2a4da277c30ba3b2721, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 57
+  indexInSingleton: 56

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Salads/MonkeysDelightRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Salads/MonkeysDelightRecipe.asset
@@ -39,4 +39,4 @@ MonoBehaviour:
   - {fileID: 6704030164064318498, guid: b31eff8a4bd3a1f4796ca248bba27484, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 60
+  indexInSingleton: 59

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Salads/OatmealRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Salads/OatmealRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 8632914084572626695, guid: 09597f5302ff3b64eb0b09726602f2cf, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 59
+  indexInSingleton: 58

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Salads/RicebowlRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Salads/RicebowlRecipe.asset
@@ -1,0 +1,34 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0a638c97a2384c54bee47631bd326e8b, type: 3}
+  m_Name: RicebowlRecipe
+  m_EditorClassIdentifier: 
+  category: 15
+  craftingTime: 0
+  recipeName: Ricebowl
+  recipeIconOverride: {fileID: 0}
+  recipeDescription: 
+  requiredIngredients:
+  - requiredAmount: 1
+    requiredItem: {fileID: 3046611069451632629, guid: fe66ec36f566be84a9ccbc5a90aacd6f,
+      type: 3}
+  requiredReagents:
+  - requiredAmount: 10
+    requiredReagent: {fileID: 11400000, guid: 522665e55a63647f6a9959f4b0a52c31, type: 2}
+  - requiredAmount: 10
+    requiredReagent: {fileID: 11400000, guid: 5492c9211fc87fdb7bdab55f9cdcfccc, type: 2}
+  requiredToolTraits: []
+  result:
+  - {fileID: 5650794415485264529, guid: 2a53211e0815cf94ca865f63d3c50da6, type: 3}
+  resultHandlers: []
+  isSimple: 0
+  indexInSingleton: 344

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Salads/RicebowlRecipe.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Salads/RicebowlRecipe.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5ca5a7f1e2a626f4ab60c0ba394557d7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Salads/ValidSaladRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Salads/ValidSaladRecipe.asset
@@ -36,4 +36,4 @@ MonoBehaviour:
   - {fileID: 8225472833842515625, guid: 4da33c9fa452d6146835fc963e6e0f6a, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 63
+  indexInSingleton: 62

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Sandwiches/BlueCherryJellySandwichRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Sandwiches/BlueCherryJellySandwichRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 7046626200349769570, guid: d360b520e6b75e4429672f362388fd2e, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 54
+  indexInSingleton: 53

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Sandwiches/CheeseSandwichRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Sandwiches/CheeseSandwichRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 8002816927608544783, guid: 1272eb98f6bd9004c97ab3cc01734074, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 51
+  indexInSingleton: 50

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Sandwiches/CherryJellySandwichRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Sandwiches/CherryJellySandwichRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 7046626200349769570, guid: d360b520e6b75e4429672f362388fd2e, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 52
+  indexInSingleton: 51

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Sandwiches/NotASandwichRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Sandwiches/NotASandwichRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 3592428515785139941, guid: 7fccb737f995f144593021cc1a25a57d, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 55
+  indexInSingleton: 54

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Sandwiches/SandwichRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Sandwiches/SandwichRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 6625002238543969423, guid: b27d4769e571a0f40bb338759d431f76, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 50
+  indexInSingleton: 49

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Sandwiches/SlimeJellySandwichRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Sandwiches/SlimeJellySandwichRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 353349776252711342, guid: bdf291c70e12c68418beeb22b5384557, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 53
+  indexInSingleton: 52

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/AmanitaJellyRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/AmanitaJellyRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 4678234128228594260, guid: 267c7153d3a9acf4aa358d3e7b2d91cb, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 36
+  indexInSingleton: 35

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/BeetSoupRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/BeetSoupRecipe.asset
@@ -35,4 +35,4 @@ MonoBehaviour:
   - {fileID: 2792259881938458737, guid: d357dd8d1b63d324a96e8b6109308a90, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 28
+  indexInSingleton: 27

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/BisqueRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/BisqueRecipe.asset
@@ -35,4 +35,4 @@ MonoBehaviour:
   - {fileID: 366315251016598150, guid: 38b19b8182551384698a711962b9eb7d, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 27
+  indexInSingleton: 26

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/BloodSoupRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/BloodSoupRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 6489723366037143999, guid: bb692523645da3d418eb893213e15453, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 38
+  indexInSingleton: 37

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/BungoCurryRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/BungoCurryRecipe.asset
@@ -37,4 +37,4 @@ MonoBehaviour:
   - {fileID: 6091110170823168563, guid: 28b14df1d846de74b80bbb7cf591c087, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 25
+  indexInSingleton: 24

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/ChantrelleSoupRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/ChantrelleSoupRecipe.asset
@@ -34,4 +34,4 @@ MonoBehaviour:
   - {fileID: 6875262952992864959, guid: e7c18ce7555431546befbbe6b54ff91a, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 33
+  indexInSingleton: 32

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/ChiliConCarnivalReciep.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/ChiliConCarnivalReciep.asset
@@ -41,4 +41,4 @@ MonoBehaviour:
   - {fileID: 4895116066567793621, guid: c3947fffdea70144d819023e9113fd94, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 49
+  indexInSingleton: 48

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/ClownsTearsRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/ClownsTearsRecipe.asset
@@ -35,4 +35,4 @@ MonoBehaviour:
   - {fileID: 7707116476250492567, guid: 765d172b42be1bf4b984ee2b794b9eef, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 35
+  indexInSingleton: 34

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/ColdChiliRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/ColdChiliRecipe.asset
@@ -38,4 +38,4 @@ MonoBehaviour:
   - {fileID: 3067434802955445201, guid: f20b5d3b3444e1f4187b53717cefc671, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 48
+  indexInSingleton: 47

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/ElectronSoupRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/ElectronSoupRecipe.asset
@@ -34,4 +34,4 @@ MonoBehaviour:
   - {fileID: 4427006084209756639, guid: b8ea79ca48347214ab69ea808006acd1, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 24
+  indexInSingleton: 23

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/EyeballSoupRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/EyeballSoupRecipe.asset
@@ -35,4 +35,4 @@ MonoBehaviour:
   - {fileID: 4780390135248598030, guid: 7d6dfd0f880cc164cb22ddefa2bc3899, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 40
+  indexInSingleton: 39

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/FrenchOnionSoupRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/FrenchOnionSoupRecipe.asset
@@ -35,4 +35,4 @@ MonoBehaviour:
   - {fileID: 4786320701691123408, guid: abbc8e9c73b4ee749a23c67c3f5de237, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 26
+  indexInSingleton: 25

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/HotChiliRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/HotChiliRecipe.asset
@@ -38,4 +38,4 @@ MonoBehaviour:
   - {fileID: 6170906812806181108, guid: 1ec90db2dbf3ab346928e056f8bdad41, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 47
+  indexInSingleton: 46

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/MeatballSoupRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/MeatballSoupRecipe.asset
@@ -38,4 +38,4 @@ MonoBehaviour:
   - {fileID: 454091437535203555, guid: 49f3fbcb8409b8e42b416ba20dcc1513, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 42
+  indexInSingleton: 41

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/MiloSoupRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/MiloSoupRecipe.asset
@@ -35,4 +35,4 @@ MonoBehaviour:
   - {fileID: 2581782603538413228, guid: f0ccfd881235f3d489d404c21fd3fbde, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 39
+  indexInSingleton: 38

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/MysterySoupRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/MysterySoupRecipe.asset
@@ -41,4 +41,4 @@ MonoBehaviour:
   - {fileID: 7489184177900573214, guid: 330f751985aefdd4fa1fdedecf2bc60e, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 34
+  indexInSingleton: 33

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/NettleSoupRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/NettleSoupRecipe.asset
@@ -38,4 +38,4 @@ MonoBehaviour:
   - {fileID: 947441564626239873, guid: 8fbbaac6b13f8ff429c4985d5d219c8b, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 44
+  indexInSingleton: 43

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/RedBeetSoupRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/RedBeetSoupRecipe.asset
@@ -35,4 +35,4 @@ MonoBehaviour:
   - {fileID: 8866052430433229490, guid: e0483014068a9b548b606c8b85bdaa3f, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 29
+  indexInSingleton: 28

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/SlimeSoupRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/SlimeSoupRecipe.asset
@@ -31,4 +31,4 @@ MonoBehaviour:
   - {fileID: 9012491175635096735, guid: c6a30c7b1bb167543abf2e9c9bea5cfa, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 37
+  indexInSingleton: 36

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/SpacyLibertyDuffRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/SpacyLibertyDuffRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 8277591004579974983, guid: 6d982f62c30ad384c86340bad94fb5f0, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 31
+  indexInSingleton: 30

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/StewRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/StewRecipe.asset
@@ -47,4 +47,4 @@ MonoBehaviour:
   - {fileID: 5125781516587007529, guid: 7b2dee5202c6d504792184e6b6a17c08, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 32
+  indexInSingleton: 31

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/SweetPotatoSoupRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/SweetPotatoSoupRecipe.asset
@@ -34,4 +34,4 @@ MonoBehaviour:
   - {fileID: 5438683556905120477, guid: 3cda84b4ccd9aa441b94f1bf8e5856d8, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 30
+  indexInSingleton: 29

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/TomatoSoupRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/TomatoSoupRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 8105056670015690615, guid: 2dc7c7c735ea79348a460ae002251d89, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 41
+  indexInSingleton: 40

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/VegetableSoupRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/VegetableSoupRecipe.asset
@@ -41,4 +41,4 @@ MonoBehaviour:
   - {fileID: 7775026832209486375, guid: d0a4ee7fa3d0703408bf811e46bf7dd4, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 43
+  indexInSingleton: 42

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/WingfangchuRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/WingfangchuRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 7286597960625310698, guid: 1f69921468622a0458e4d5471d3b71c2, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 45
+  indexInSingleton: 44

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/WishSoupRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Soups/WishSoupRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 7091350424593414976, guid: 22459a50d6c71b34ea45089bb0ea70d1, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 46
+  indexInSingleton: 45

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Spaghettis/BeefNoodleRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Spaghettis/BeefNoodleRecipe.asset
@@ -36,4 +36,4 @@ MonoBehaviour:
   - {fileID: 822066545912306414, guid: 2c63c928145ab1740ba3990015c9d769, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 22
+  indexInSingleton: 21

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Spaghettis/ChowmeinRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Spaghettis/ChowmeinRecipe.asset
@@ -36,4 +36,4 @@ MonoBehaviour:
   - {fileID: 7305342860646798136, guid: cfd2708dfe0f14844837dd0d99f07696, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 23
+  indexInSingleton: 22

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Spaghettis/CopypastaRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Spaghettis/CopypastaRecipe.asset
@@ -27,4 +27,4 @@ MonoBehaviour:
   - {fileID: 935468322602067901, guid: 966461e0e354e3d4682a32a35df2fe73, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 21
+  indexInSingleton: 20

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Spaghettis/SpaghettiAndMeatballsRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Spaghettis/SpaghettiAndMeatballsRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 6882690696700555139, guid: cb6015947013c8d40b9559d4d2267151, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 20
+  indexInSingleton: 19

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Spaghettis/SpaghettiTomatoRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Spaghettis/SpaghettiTomatoRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 7146889895397617575, guid: 13e9d532c5f8c554e8fbee1e512d3b50, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 18
+  indexInSingleton: 17

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Spaghettis/SpesslawRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Food/Spaghettis/SpesslawRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 5504343432507252679, guid: 5067f16d8269f044c99b51119fca042a, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 19
+  indexInSingleton: 18

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/BambooLogToWoodenBambooRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/BambooLogToWoodenBambooRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 1456773918337913387, guid: a2244f15a03c7a742b4c962f6b2e982c, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 299
+  indexInSingleton: 298

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/OnionSlicesRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/OnionSlicesRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 492203606451765858, guid: 1195572c368c1dd41bb322da8213b5fc, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 297
+  indexInSingleton: 296

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/PineappleSlicesRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/PineappleSlicesRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 439626312426970334, guid: f12645657338dd04caed40797327f674, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 295
+  indexInSingleton: 294

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/RawPatties/RawBearPattyRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/RawPatties/RawBearPattyRecipe.asset
@@ -28,4 +28,4 @@ MonoBehaviour:
   - {fileID: 316650891620762542, guid: 2a5ae82c6059cae43a8aaf170a7fe6d7, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 307
+  indexInSingleton: 306

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/RawPatties/RawChickenPattyRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/RawPatties/RawChickenPattyRecipe.asset
@@ -28,4 +28,4 @@ MonoBehaviour:
   - {fileID: 5407627828266922246, guid: 52cdd8e314d884844ae8104796767fac, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 308
+  indexInSingleton: 307

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/RawPatties/RawCorgiPattyRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/RawPatties/RawCorgiPattyRecipe.asset
@@ -28,4 +28,4 @@ MonoBehaviour:
   - {fileID: 5088662099382998178, guid: b9dda15585cbe5c4d90e4004ab5f371f, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 309
+  indexInSingleton: 308

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/RawPatties/RawHumanPattyRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/RawPatties/RawHumanPattyRecipe.asset
@@ -28,4 +28,4 @@ MonoBehaviour:
   - {fileID: 3373808522932220691, guid: ee3ba3aa0a33d8a458d2154192ff065c, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 305
+  indexInSingleton: 304

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/RawPatties/RawLizardPattyRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/RawPatties/RawLizardPattyRecipe.asset
@@ -28,4 +28,4 @@ MonoBehaviour:
   - {fileID: 1349644775731228632, guid: 60463f306b8acd84499d18e34c6ef480, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 310
+  indexInSingleton: 309

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/RawPatties/RawPattyRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/RawPatties/RawPattyRecipe.asset
@@ -28,4 +28,4 @@ MonoBehaviour:
   - {fileID: 8017736787133888042, guid: 102e5ffa17eeb3b448ecc2d6a5cf7f41, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 304
+  indexInSingleton: 303

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/RawPatties/RawPenguinPattyRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/RawPatties/RawPenguinPattyRecipe.asset
@@ -28,4 +28,4 @@ MonoBehaviour:
   - {fileID: 708051136698692199, guid: fda0208da365cfb45816a5dc16deab50, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 311
+  indexInSingleton: 310

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/RawPatties/RawXenomorphPattyRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/RawPatties/RawXenomorphPattyRecipe.asset
@@ -28,4 +28,4 @@ MonoBehaviour:
   - {fileID: 2440408477683083496, guid: e9c330a7d91f039418eb16e91fb2108b, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 306
+  indexInSingleton: 305

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/RedOnionSlicesRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/RedOnionSlicesRecipe.asset
@@ -29,4 +29,4 @@ MonoBehaviour:
   - {fileID: 9072760469753373163, guid: 868d30ccaf18a9244b4a6a87d506ef4f, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 296
+  indexInSingleton: 295

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/SalamiRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/SalamiRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 1218177954615775911, guid: d16ac2711565bd74da7f833e0f7a4679, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 303
+  indexInSingleton: 302

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/SteelCapLogToMetalRodsRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/SteelCapLogToMetalRodsRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 7198241665461443898, guid: 5dce4d3e01518474bb9bb8085b718980, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 300
+  indexInSingleton: 299

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/WatermelonSlicesRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/WatermelonSlicesRecipe.asset
@@ -32,4 +32,4 @@ MonoBehaviour:
   - {fileID: 2753411037104107485, guid: 9159c32f31459f44181c80b5c7f33dbc, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 294
+  indexInSingleton: 293

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/WoodLogToWoodenPlanksRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Misc/WoodLogToWoodenPlanksRecipe.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
   - {fileID: 2663802320431471963, guid: 9ae38f6aa43b5cd4ba608cd31b462b24, type: 3}
   resultHandlers: []
   isSimple: 1
-  indexInSingleton: 298
+  indexInSingleton: 297

--- a/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Weapons/SpearRecipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/Recipes/Weapons/SpearRecipe.asset
@@ -33,4 +33,4 @@ MonoBehaviour:
   - {fileID: 5528209918886331922, guid: 6d093d86932670348bbbc367f3c19267, type: 3}
   resultHandlers: []
   isSimple: 0
-  indexInSingleton: 4
+  indexInSingleton: 3


### PR DESCRIPTION
### Purpose
CL: [Improvement] Chemical reactions that would create food are now also crafting recipes. This is so that players can know the exact requirements for them and also be aware that they exist.

### Notes:
- Since I had to remove an old dough recipe, all the recipe SOs got automatically modified to give them proper ordering in the crafting recipe index.
- Recipes whose chemical reaction equivalents would use catalysts use up the reagents that are supposed to be catalysts. These recipes are the cheese wheel and tofu recipes.
