### PR TITLE
Fixes ores not being generated on asteroids

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Initialisation/LoadManager.cs
+++ b/UnityProject/Assets/Scripts/Core/Initialisation/LoadManager.cs
@@ -23,7 +23,7 @@ namespace Initialisation
 
 		public List<DelayedAction> ToClear = new List<DelayedAction>();
 
-		public struct DelayedAction
+		public class DelayedAction
 		{
 			public float Frames;
 			public Action Action;


### PR DESCRIPTION
### Purpose
CL: [Fix] Fixed ores not being generated on asteroids.
Fixes #7311

### Notes:
its saving these horrible delayed actions that go against everything I believe in a list, and structs dont work that way when you take one out to edit it
