### PR TITLE
Fixes hivebot ghosts wandering around the station

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.cs
+++ b/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.cs
@@ -164,7 +164,7 @@ public partial class CustomNetTransform : NetworkBehaviour, IPushable
 		{
 			pos = pos.RoundToInt();
 		}
-		var matrixInfo = MatrixManager.AtPoint(Vector3Int.RoundToInt(pos), false);
+		var matrixInfo = matrix.MatrixInfo;
 
 		predictedState.MatrixId = matrixInfo.Id;
 		predictedState.WorldPosition = pos;


### PR DESCRIPTION
### Purpose
CL: [Fix] Fixed mobs in movable matrixes being in the incorrect position for clients

### Notes:
That function fails because the movable matrix values aren't ready and the WorldToLocal() fails, but we dont need to fetch the matrixinfo that way since we already have the matrix.
This of course doesnt mean things are good now, matrix initialization need a lot of work