### PR TITLE
Reads a null check in CustomNetTransform

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.cs
+++ b/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.cs
@@ -231,6 +231,13 @@ public partial class CustomNetTransform : NetworkBehaviour, IPushable
 	/// <returns>true if transform changed</returns>
 	private bool Synchronize()
 	{
+		if (this == null)
+		{
+			//Poke() can be hit in the middle of roundend/roundstart transition while our OnDisable() has already ran
+			//In that case the UpdateManager will carry a reference to the action from a deleted gameobject
+			//TODO: fix initialization order t
+			return false;
+		}
 		//Isn't run on server as clientValueChanged is always false for server
 		//Pokes the client to do changes if values have changed from syncvars
 		if (clientValueChanged)


### PR DESCRIPTION
### Purpose
Reads a null check in CustomNetTransform
Fixes the UpdateManager CallbackType.Update list after a round restart, which affects a lot of classes from just not working at all
Fixes #7355
Fixes #7357
Fixes #7354
Fixes #7361
Fixes #7368
Fixes #7364

CL: [Fix] fixed Players and mobs become incapable of taking damage on the second round and beyond.
CL: [Fix] fixed emitters not shooting on staging
CL: [Fix] fixed Gas canisters not releasing gas when opened unless you insert a gas tank.
CL: [Fix] fixed Quantum pads no longer teleporting you automatically when you step on them.
CL: [Fix] fixed Conveyor belts no longer moving things when turned on. 
CL: [Fix] Fixed using lit welding tools on fuel tanks not making them explode from the second round onwards. 