### PR TITLE
Fix changelogs, maybe

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -56,4 +56,5 @@ jobs:
                 if: ${{ steps.pr2changelog.outputs.generated_changelog == 1}}
                 uses: ad-m/github-push-action@master
                 with:
+                    force: true
                     github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Purpose
Since we adopted branch protection rules, changelog action broke. This little change would make the changelog push the changes with ``--force`` which *should* circumvent the review requirement.

