### PR TITLE
Examine Trauma

### DIFF
--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -47,6 +47,10 @@ namespace HealthV2
 		private TraumaDamageLevel currentSlashDamageLevel  = TraumaDamageLevel.NONE;
 		private TraumaDamageLevel currentBurnDamageLevel   = TraumaDamageLevel.NONE;
 
+		public TraumaDamageLevel CurrentPierceDamageLevel => currentPierceDamageLevel;
+		public TraumaDamageLevel CurrentSlashDamageLevel  => currentSlashDamageLevel ;
+		public TraumaDamageLevel CurrentBurnDamageLevel   => currentBurnDamageLevel;
+
 		public DamageSeverity GibsOnSeverityLevel = DamageSeverity.Max;
 		public float GibChance = 0.15f;
 

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -956,6 +956,26 @@ namespace HealthV2
 					$"<color=#b495bf>\n{theyPronoun} has a blank, absent-minded stare and appears completely unresponsive to anything. {theyPronoun} may snap out of it soon.</color>");
 			}
 
+			foreach (BodyPart part in BodyPartList)
+			{
+				if(part.IsSurface){continue;}
+
+				if (part.IsBleeding)
+				{
+					healthString.Append($"<color=red>\n their {part.BodyPartReadableName} is bleeding!</color>");
+				}
+
+				if (part.CurrentSlashDamageLevel >= TraumaDamageLevel.SERIOUS)
+				{
+					healthString.Append($"<color=red>\n their {part.BodyPartReadableName} is cut wide open!</color>");
+				}
+
+				if (part.CurrentPierceDamageLevel >= TraumaDamageLevel.SERIOUS)
+				{
+					healthString.Append($"<color=red>\n they have a huge hole in their {part.BodyPartReadableName}!</color>");
+				}
+			}
+
 			return healthString.ToString();
 		}
 

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -962,17 +962,17 @@ namespace HealthV2
 
 				if (part.IsBleeding)
 				{
-					healthString.Append($"<color=red>\n their {part.BodyPartReadableName} is bleeding!</color>");
+					healthString.Append($"<color=red>\n {theyPronoun} {part.BodyPartReadableName} is bleeding!</color>");
 				}
 
 				if (part.CurrentSlashDamageLevel >= TraumaDamageLevel.SERIOUS)
 				{
-					healthString.Append($"<color=red>\n their {part.BodyPartReadableName} is cut wide open!</color>");
+					healthString.Append($"<color=red>\n {theyPronoun} {part.BodyPartReadableName} is cut wide open!</color>");
 				}
 
 				if (part.CurrentPierceDamageLevel >= TraumaDamageLevel.SERIOUS)
 				{
-					healthString.Append($"<color=red>\n they have a huge hole in their {part.BodyPartReadableName}!</color>");
+					healthString.Append($"<color=red>\n {theyPronoun} have a huge hole in their {part.BodyPartReadableName}!</color>");
 				}
 			}
 

--- a/UnityProject/Assets/Scripts/Player/ExaminablePlayer.cs
+++ b/UnityProject/Assets/Scripts/Player/ExaminablePlayer.cs
@@ -191,11 +191,7 @@ namespace Player
 		public string GetPlayerSpeciesString()
 		{
 			// if face is visible - get species by face
-			if (IsFaceVisible)
-				// TODO: get player species
-			{
-				return "HUMAN";
-			}
+			if (IsFaceVisible) { return script.characterSettings.Species; }
 
 			//  try get species from security records
 			if (TryFindIDCard(out var idCard))
@@ -232,6 +228,10 @@ namespace Player
 			return UNKNOWN_VALUE;
 		}
 
+		/// <summary>
+		/// Reports back if the player is alive or dead.
+		/// </summary>
+		/// <returns></returns>
 		public string GetPlayerStatusString()
 		{
 			var healthString = new StringBuilder($"<color={LILAC_COLOR}>");


### PR DESCRIPTION
### Purpose
Part of #6272 
Should finally tick off the health and mob analyzer requirement completely.

Also adds in species examine so all players don't report as "HUMAN"

### Changelog:

CL: [New] - Added Examine Text for trauma damage
CL: [Improvement] - Players who play as non-humans won't be examined as "HUMAN" anymore.

