### PR TITLE
Fix osx builds for staging

### DIFF
--- a/UnityProject/Assets/Mirror/Runtime/Transport/Ignorance/Plugins/macOS/libenet.dylib.meta
+++ b/UnityProject/Assets/Mirror/Runtime/Transport/Ignorance/Plugins/macOS/libenet.dylib.meta
@@ -12,6 +12,17 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 0
+        Exclude WebGL: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+  - first:
       Any: 
     second:
       enabled: 0
@@ -21,12 +32,33 @@ PluginImporter:
     second:
       enabled: 1
       settings:
+        CPU: AnyCPU
         DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
   - first:
       Standalone: OSXUniversal
     second:
       enabled: 1
-      settings: {}
+      settings:
+        CPU: AnyCPU
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/UnityProject/Assets/Plugins/MacOS/sunvox.bundle.meta
+++ b/UnityProject/Assets/Plugins/MacOS/sunvox.bundle.meta
@@ -16,7 +16,12 @@ PluginImporter:
     second:
       enabled: 0
       settings:
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 0
+        Exclude WebGL: 1
         Exclude Win: 1
+        Exclude Win64: 1
   - first:
       : OSXIntel
     second:
@@ -37,12 +42,33 @@ PluginImporter:
     second:
       enabled: 1
       settings:
+        CPU: AnyCPU
         DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
   - first:
       Standalone: OSXUniversal
     second:
       enabled: 1
-      settings: {}
+      settings:
+        CPU: AnyCPU
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
   userData: 
   assetBundleName: 
   assetBundleVariant: 


### PR DESCRIPTION
<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->

### Purpose
Fix build so that required libraries for macOS are properly generated.
<!-- Describe the problem the PR fixes or the feature it introduces. --> <br>
<!-- Don't forget to use "Fixes #issuenumber" to select issues and auto close them on merge. -->
### Notes:
<!-- Please enter any other relevant information here -->
Sound and music for macOS builds on staging still do not work. I believe this is due to a pathing issue with the addressables for sound and music.

### Changelog:
<!-- Add here individual lines with all your remarkable changes using the prefix ``CL:`` -->
<!-- Mind that the changes meant to be logged in the in changelog are those that are remarkable for the end user, so things like new features and fixes of known bugs are perfect for this section -->

<!-- CL: [New] For new features, things that didn't exist before the PR. -->

<!-- CL: [Improvement] For any change on any existing feature. -->

<!-- CL: [Balance] For any change on an existing feature done in the sake of improving game balance. It's the only exception to the rule above. -->

<!-- CL: [Fix] For any change that fixes a bug. -->
CL: [Fix] Staging should now be playable on macOS
