### PR TITLE
Fixes mobs attacking once per frame and huge performance issues

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.Move.cs
+++ b/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.Move.cs
@@ -311,13 +311,12 @@ public partial class CustomNetTransform
 	/// Serverside lerping
 	private void ServerLerp()
 	{
-		Vector3 worldPos = serverState.Position;
-		Vector3 targetPos = worldPos.ToLocal(matrix);
+		var targetPos = serverState.Position;
 		//Set position immediately if not moving
 		if (serverState.Speed.Equals(0))
 		{
 			serverLerpState = serverState;
-			ServerOnTileReached(worldPos.RoundToInt());
+			ServerOnTileReached(serverState.WorldPosition.RoundToInt());
 			return;
 		}
 

--- a/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.cs
+++ b/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.cs
@@ -271,7 +271,7 @@ public partial class CustomNetTransform : NetworkBehaviour, IPushable
 			changed &= CheckFloatingServer();
 		}
 
-		if ((Vector2)predictedState.WorldPosition != (Vector2)transform.position)
+		if ((Vector2)predictedState.Position != (Vector2)transform.localPosition)
 		{
 			Lerp();
 			changed = true;


### PR DESCRIPTION
### Purpose
CL: [Fix] fixed server performance issues with objects not stopping processing positioning even after reaching their destination.
CL: [Fix] fixed mobs attacking once per frame.
Fixes #7363

