### PR TITLE
Fixes the health scanner showing the wrong value for oxy damage

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Medical/HealthScanner.cs
+++ b/UnityProject/Assets/Scripts/Items/Medical/HealthScanner.cs
@@ -66,8 +66,12 @@ namespace Items.Medical
 				{
 					fullDamage[i] += bodypart.Damages[i];
 				}
-
 				partMessages.AppendLine(GetBodypartMessage(bodypart));
+			}
+
+			if (health.brain)
+			{
+				fullDamage[(int) DamageType.Oxy] = health.brain.RelatedPart.Oxy;
 			}
 
 			if ((int)totalPercent != 100)
@@ -106,16 +110,15 @@ namespace Items.Medical
 			string partName = bodypart.gameObject.ExpensiveName();
 
 			// Not the best way to do this, need a list of races
-			if (partName.StartsWith("human ") || partName.StartsWith("lizard ") || partName.StartsWith("moth ") || partName.StartsWith("cat "))
+			if (partName.StartsWith("human ") || partName.StartsWith("lizard ") || partName.StartsWith("moth ") || partName.StartsWith("catperson "))
 			{
 				partName = partName.Substring(partName.IndexOf(" ") + 1);
 			}
 
-			return $"{textInfo.ToTitleCase(partName), -12}" +
-					$"<color=#{bruteColor}>{Mathf.Round(bodypart.Brute), 4}</color>" +
-					$"<color=#{burnColor}>{Mathf.Round(bodypart.Burn), 4}</color>" +
-					$"<color=#{toxinColor}>{Mathf.Round(bodypart.Toxin), 4}</color>" +
-					$"<color=#{oxylossColor}>{Mathf.Round(bodypart.Oxy), 4}</color>";
+			return $"{textInfo.ToTitleCase(partName),-12}" +
+			       $"<color=#{bruteColor}>{Mathf.Round(bodypart.Brute),4}</color>" +
+			       $"<color=#{burnColor}>{Mathf.Round(bodypart.Burn),4}</color>" +
+			       $"<color=#{toxinColor}>{Mathf.Round(bodypart.Toxin),4}</color>";
 		}
 	}
 }


### PR DESCRIPTION
### Purpose
CL: [Fix] Fixed the health scanner showing the wrong value for oxy damage
CL: [Fix] Fixed "catperson" string appearing in the health scanner output
Fixes #7344

players overall health is only affected by the brain oxy dmg, and now for the different body parts, but now this raises the question: Should health analyzers show oxy damage from the different body parts? If so, how?
I'm not sure if oxygen damage does anything outside of the brain organ