### PR TITLE
Trauma damage multiplier nerfs and improvements

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Implants/Lizard/HumanHead Variant 2.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Lizard/HumanHead Variant 2.prefab
@@ -41,7 +41,7 @@ PrefabInstance:
     - target: {fileID: 6597352703958914049, guid: 78253771c2047f94c9ae40161a6be7ee,
         type: 3}
       propertyPath: baseTraumaDamageMultiplier
-      value: 6
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6597352703958914049, guid: 78253771c2047f94c9ae40161a6be7ee,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Lizard/HumanLeftArm Variant 2.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Lizard/HumanLeftArm Variant 2.prefab
@@ -101,7 +101,7 @@ PrefabInstance:
     - target: {fileID: 2934630090728222927, guid: 719377fefb0114b448fc6ca9f7a5a6df,
         type: 3}
       propertyPath: baseTraumaDamageMultiplier
-      value: 1.5
+      value: 1.25
       objectReference: {fileID: 0}
     - target: {fileID: 2934630090728222927, guid: 719377fefb0114b448fc6ca9f7a5a6df,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Lizard/HumanLeftLeg Variant 2.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Lizard/HumanLeftLeg Variant 2.prefab
@@ -15,7 +15,7 @@ PrefabInstance:
     - target: {fileID: 1544594378003915950, guid: 2e6f2ff9beb985749940d242877d84f0,
         type: 3}
       propertyPath: baseTraumaDamageMultiplier
-      value: 1.5
+      value: 1.25
       objectReference: {fileID: 0}
     - target: {fileID: 1544594378003915950, guid: 2e6f2ff9beb985749940d242877d84f0,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Lizard/HumanRightArm Variant 2.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Lizard/HumanRightArm Variant 2.prefab
@@ -43,7 +43,7 @@ PrefabInstance:
     - target: {fileID: 6313817628243374210, guid: ba9a875c31908af4ab3749cd127a2edb,
         type: 3}
       propertyPath: baseTraumaDamageMultiplier
-      value: 1.5
+      value: 1.25
       objectReference: {fileID: 0}
     - target: {fileID: 6313817628243374210, guid: ba9a875c31908af4ab3749cd127a2edb,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Lizard/HumanRightLeg Variant 2.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Lizard/HumanRightLeg Variant 2.prefab
@@ -113,7 +113,7 @@ PrefabInstance:
     - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
         type: 3}
       propertyPath: baseTraumaDamageMultiplier
-      value: 1.5
+      value: 1.25
       objectReference: {fileID: 0}
     - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanHead.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanHead.prefab
@@ -251,7 +251,7 @@ PrefabInstance:
     - target: {fileID: 1673759363237950006, guid: e241039a7933eb347bd1a9bb67a9078a,
         type: 3}
       propertyPath: baseTraumaDamageMultiplier
-      value: 12
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 1673759363237950006, guid: e241039a7933eb347bd1a9bb67a9078a,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanLeftLeg.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanLeftLeg.prefab
@@ -167,7 +167,7 @@ PrefabInstance:
     - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
         type: 3}
       propertyPath: baseTraumaDamageMultiplier
-      value: 2
+      value: 1.75
       objectReference: {fileID: 0}
     - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightArm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightArm.prefab
@@ -351,7 +351,7 @@ PrefabInstance:
     - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
         type: 3}
       propertyPath: baseTraumaDamageMultiplier
-      value: 2
+      value: 1.5
       objectReference: {fileID: 0}
     - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightLeg.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightLeg.prefab
@@ -296,7 +296,7 @@ PrefabInstance:
     - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
         type: 3}
       propertyPath: baseTraumaDamageMultiplier
-      value: 2
+      value: 1.75
       objectReference: {fileID: 0}
     - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanHead Variant 1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanHead Variant 1.prefab
@@ -26,7 +26,7 @@ PrefabInstance:
     - target: {fileID: 6597352703958914049, guid: 78253771c2047f94c9ae40161a6be7ee,
         type: 3}
       propertyPath: baseTraumaDamageMultiplier
-      value: 12
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 6597352703958914049, guid: 78253771c2047f94c9ae40161a6be7ee,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanLeftArm Variant 1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanLeftArm Variant 1.prefab
@@ -86,7 +86,7 @@ PrefabInstance:
     - target: {fileID: 2934630090728222927, guid: 719377fefb0114b448fc6ca9f7a5a6df,
         type: 3}
       propertyPath: baseTraumaDamageMultiplier
-      value: 2
+      value: 1.25
       objectReference: {fileID: 0}
     - target: {fileID: 2934630090728222927, guid: 719377fefb0114b448fc6ca9f7a5a6df,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanLeftArm Variant 1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanLeftArm Variant 1.prefab
@@ -86,7 +86,7 @@ PrefabInstance:
     - target: {fileID: 2934630090728222927, guid: 719377fefb0114b448fc6ca9f7a5a6df,
         type: 3}
       propertyPath: baseTraumaDamageMultiplier
-      value: 1.25
+      value: 1.5
       objectReference: {fileID: 0}
     - target: {fileID: 2934630090728222927, guid: 719377fefb0114b448fc6ca9f7a5a6df,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanLeftLeg Variant 1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanLeftLeg Variant 1.prefab
@@ -15,7 +15,7 @@ PrefabInstance:
     - target: {fileID: 1544594378003915950, guid: 2e6f2ff9beb985749940d242877d84f0,
         type: 3}
       propertyPath: baseTraumaDamageMultiplier
-      value: 2
+      value: 1.75
       objectReference: {fileID: 0}
     - target: {fileID: 1544594378003915950, guid: 2e6f2ff9beb985749940d242877d84f0,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanRightArm Variant 1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanRightArm Variant 1.prefab
@@ -38,7 +38,7 @@ PrefabInstance:
     - target: {fileID: 6313817628243374210, guid: ba9a875c31908af4ab3749cd127a2edb,
         type: 3}
       propertyPath: baseTraumaDamageMultiplier
-      value: 2
+      value: 1.5
       objectReference: {fileID: 0}
     - target: {fileID: 6313817628243374210, guid: ba9a875c31908af4ab3749cd127a2edb,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanRightLeg Variant 1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanRightLeg Variant 1.prefab
@@ -103,7 +103,7 @@ PrefabInstance:
     - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
         type: 3}
       propertyPath: baseTraumaDamageMultiplier
-      value: 2
+      value: 1.75
       objectReference: {fileID: 0}
     - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Tools/FireExtinguishers/FireExtinguisher.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/FireExtinguishers/FireExtinguisher.prefab
@@ -5234,6 +5234,16 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
+      propertyPath: traumaDamageChance
+      value: 37
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: TraumaticDamageType
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
       propertyPath: hitSound.AssetAddress
       value: Assets/Prefabs/Effects/smash.prefab
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Tools/FireExtinguishers/FireExtinguisherEmpty.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/FireExtinguishers/FireExtinguisherEmpty.prefab
@@ -22,6 +22,16 @@ PrefabInstance:
       propertyPath: initialReagentMix.reagents.m_values.Array.size
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7726190153568297307, guid: 908afbc5b9f871148b5ccd0b81bd147f,
+        type: 3}
+      propertyPath: traumaDamageChance
+      value: 37
+      objectReference: {fileID: 0}
+    - target: {fileID: 7726190153568297307, guid: 908afbc5b9f871148b5ccd0b81bd147f,
+        type: 3}
+      propertyPath: TraumaticDamageType
+      value: 8
+      objectReference: {fileID: 0}
     - target: {fileID: 7800619582892077965, guid: 908afbc5b9f871148b5ccd0b81bd147f,
         type: 3}
       propertyPath: m_AssetId

--- a/UnityProject/Assets/Prefabs/Items/Tools/FireExtinguishers/PocketFireExtinguisher.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/FireExtinguishers/PocketFireExtinguisher.prefab
@@ -89,6 +89,16 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7726190153568297307, guid: 908afbc5b9f871148b5ccd0b81bd147f,
         type: 3}
+      propertyPath: traumaDamageChance
+      value: 37
+      objectReference: {fileID: 0}
+    - target: {fileID: 7726190153568297307, guid: 908afbc5b9f871148b5ccd0b81bd147f,
+        type: 3}
+      propertyPath: TraumaticDamageType
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7726190153568297307, guid: 908afbc5b9f871148b5ccd0b81bd147f,
+        type: 3}
       propertyPath: initialTraits.Array.size
       value: 2
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Tools/HandDrill.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/HandDrill.prefab
@@ -146,6 +146,16 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
         type: 3}
+      propertyPath: traumaDamageChance
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
+      propertyPath: TraumaticDamageType
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
       propertyPath: hitSound.AssetAddress
       value: Assets/Prefabs/Items/DrillHit.prefab
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Tools/PocketCrowbar Variant.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/PocketCrowbar Variant.prefab
@@ -77,5 +77,15 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: b31e9727bed0b4f4296b88b11f04ef92
       objectReference: {fileID: 0}
+    - target: {fileID: 7415335345799176407, guid: f709eab732189d6429ae3fa5beaf3fd3,
+        type: 3}
+      propertyPath: TraumaticDamageType
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7415335345799176407, guid: f709eab732189d6429ae3fa5beaf3fd3,
+        type: 3}
+      propertyPath: traumaDamageMultiplier
+      value: 3
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f709eab732189d6429ae3fa5beaf3fd3, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Tools/PocketCrowbar.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/PocketCrowbar.prefab
@@ -56,8 +56,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
         type: 3}
+      propertyPath: TraumaticDamageType
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
       propertyPath: attackVerbs.Array.size
       value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
+      propertyPath: traumaDamageMultiplier
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Tools/Screwdriver.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/Screwdriver.prefab
@@ -184,7 +184,7 @@ PrefabInstance:
     - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
         type: 3}
       propertyPath: TraumaticDamageType
-      value: 4
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Tools/SurgicalTools/CircularSaw.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/SurgicalTools/CircularSaw.prefab
@@ -80,6 +80,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
         type: 3}
+      propertyPath: traumaDamageMultiplier
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
       propertyPath: initialTraits.Array.size
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Tools/SurgicalTools/SurgicalDrill.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/SurgicalTools/SurgicalDrill.prefab
@@ -50,6 +50,16 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
         type: 3}
+      propertyPath: traumaDamageChance
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
+      propertyPath: TraumaticDamageType
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
       propertyPath: hitSound.AssetAddress
       value: Assets/Prefabs/Weapons/CircularSawHit.prefab
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Tools/Wrench.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/Wrench.prefab
@@ -70,6 +70,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
         type: 3}
+      propertyPath: traumaDamageMultiplier
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
       propertyPath: initialTraits.Array.size
       value: 2
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Tools/WrenchMedical.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/WrenchMedical.prefab
@@ -60,6 +60,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4791952605902770127, guid: 7976a84ef9209f14697cdd941b913e2a,
         type: 3}
+      propertyPath: traumaDamageMultiplier
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4791952605902770127, guid: 7976a84ef9209f14697cdd941b913e2a,
+        type: 3}
       propertyPath: attackVerbs.Array.data[0]
       value: healed
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Knives/ButchersCleaver.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Knives/ButchersCleaver.prefab
@@ -117,6 +117,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: 229f1c93e0e4ada439cfe4b781f65997,
         type: 3}
+      propertyPath: traumaDamageMultiplier
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7858931176587863443, guid: 229f1c93e0e4ada439cfe4b781f65997,
+        type: 3}
       propertyPath: attackVerbs.Array.data[7]
       value: cleaved
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/AtheistsFedora.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/AtheistsFedora.prefab
@@ -168,6 +168,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}
+      propertyPath: traumaDamageMultiplier
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
+        type: 3}
       propertyPath: attackVerbs.Array.data[0]
       value: enlightened
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/CarpSiePlushie.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/CarpSiePlushie.prefab
@@ -112,6 +112,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}
+      propertyPath: TraumaticDamageType
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
+        type: 3}
       propertyPath: attackVerbs.Array.size
       value: 3
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ChainsawHand.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ChainsawHand.prefab
@@ -131,6 +131,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}
+      propertyPath: traumaDamageMultiplier
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
+        type: 3}
       propertyPath: attackVerbs.Array.data[0]
       value: sawed
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ChaplainEnergySwordDark.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ChaplainEnergySwordDark.prefab
@@ -30,12 +30,17 @@ PrefabInstance:
     - target: {fileID: 4292656370289085150, guid: cda7add5dd20d954085fa9cc4264ac75,
         type: 3}
       propertyPath: TraumaticDamageType
-      value: 17
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 4292656370289085150, guid: cda7add5dd20d954085fa9cc4264ac75,
         type: 3}
       propertyPath: traumaticDamageType
       value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 4292656370289085150, guid: cda7add5dd20d954085fa9cc4264ac75,
+        type: 3}
+      propertyPath: traumaDamageMultiplier
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 4292656370289085150, guid: cda7add5dd20d954085fa9cc4264ac75,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ChaplainEnergySwordLight.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ChaplainEnergySwordLight.prefab
@@ -52,11 +52,16 @@ PrefabInstance:
     - target: {fileID: 5869444691453870322, guid: 9c123336301845541830989cb9e3d606,
         type: 3}
       propertyPath: TraumaticDamageType
-      value: 17
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 5869444691453870322, guid: 9c123336301845541830989cb9e3d606,
         type: 3}
       propertyPath: traumaticDamageType
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869444691453870322, guid: 9c123336301845541830989cb9e3d606,
+        type: 3}
+      propertyPath: traumaDamageMultiplier
       value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 5869444691453870322, guid: 9c123336301845541830989cb9e3d606,

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ClaymoreHoly.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ClaymoreHoly.prefab
@@ -172,6 +172,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}
+      propertyPath: TraumaticDamageType
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
+        type: 3}
       propertyPath: hitSound.AssetAddress
       value: Assets/Prefabs/Effects/BladeSlice.prefab
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ClownDagger.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ClownDagger.prefab
@@ -106,6 +106,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}
+      propertyPath: TraumaticDamageType
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
+        type: 3}
       propertyPath: attackVerbs.Array.size
       value: 8
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/GodHand.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/GodHand.prefab
@@ -146,6 +146,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}
+      propertyPath: traumaDamageMultiplier
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
+        type: 3}
       propertyPath: itemSprites.SpriteLeftHand
       value: 
       objectReference: {fileID: 11400000, guid: 8b0f674f074480d42ba28af423968c91,

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/NullRod.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/NullRod.prefab
@@ -146,6 +146,16 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}
+      propertyPath: traumaDamageChance
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
+        type: 3}
+      propertyPath: TraumaticDamageType
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
+        type: 3}
       propertyPath: initialTraits.Array.size
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/PrideStruckHammer.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/PrideStruckHammer.prefab
@@ -106,6 +106,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}
+      propertyPath: TraumaticDamageType
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
+        type: 3}
       propertyPath: attackVerbs.Array.size
       value: 5
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ReaperScythe.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ReaperScythe.prefab
@@ -152,6 +152,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}
+      propertyPath: traumaDamageMultiplier
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
+        type: 3}
       propertyPath: initialTraits.Array.size
       value: 2
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/RelicWarhammer.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/RelicWarhammer.prefab
@@ -106,7 +106,17 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}
+      propertyPath: TraumaticDamageType
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
+        type: 3}
       propertyPath: attackVerbs.Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
+        type: 3}
+      propertyPath: traumaDamageMultiplier
       value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/SacredChainsword.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/SacredChainsword.prefab
@@ -40,6 +40,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5869444691453870322, guid: 9c123336301845541830989cb9e3d606,
         type: 3}
+      propertyPath: traumaDamageMultiplier
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869444691453870322, guid: 9c123336301845541830989cb9e3d606,
+        type: 3}
       propertyPath: initialTraits.Array.size
       value: 2
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/UNREALSORD.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/UNREALSORD.prefab
@@ -118,12 +118,17 @@ PrefabInstance:
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}
       propertyPath: TraumaticDamageType
-      value: 17
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}
       propertyPath: attackVerbs.Array.size
       value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
+        type: 3}
+      propertyPath: traumaDamageMultiplier
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/UnholyPitchfork.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/UnholyPitchfork.prefab
@@ -122,7 +122,7 @@ PrefabInstance:
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}
       propertyPath: TraumaticDamageType
-      value: 4
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Resources/RollingPin.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Resources/RollingPin.prefab
@@ -148,6 +148,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}
+      propertyPath: traumaDamageMultiplier
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
+        type: 3}
       propertyPath: initialTraits.Array.size
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Resources/SupermatterScalpel.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Resources/SupermatterScalpel.prefab
@@ -107,7 +107,7 @@ PrefabInstance:
     - target: {fileID: 7858931176587863443, guid: f7a04efe5e6bebf44856e6d70b991929,
         type: 3}
       propertyPath: TraumaticDamageType
-      value: 17
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: f7a04efe5e6bebf44856e6d70b991929,
         type: 3}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -24,7 +24,7 @@ namespace HealthV2
 		public float InternalBleedingBloodLoss = 12;
 		public float ExternalBleedingBloodLoss = 6;
 
-		[SerializeField, Range(1.25f, 12.0f)] private float baseTraumaDamageMultiplier = 2.0f;
+		[SerializeField, Range(1.25f, 4.0f)] private float baseTraumaDamageMultiplier = 1.5f;
 
 		public float MaximumInternalBleedDamage => maximumInternalBleedDamage;
 
@@ -196,7 +196,7 @@ namespace HealthV2
 			if (currentBurnDamageLevel >= TraumaDamageLevel.CRITICAL || currentCutSize >= BodyPartCutSize.LARGE
 			|| Severity >= DamageSeverity.Max)
 			{
-				return baseDamage * (baseTraumaDamageMultiplier + 0.25f);
+				return baseDamage * baseTraumaDamageMultiplier;
 			}
 			return baseDamage;
 		}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -194,27 +194,14 @@ namespace HealthV2
 		private float MultiplyTraumaDamage(float baseDamage)
 		{
 			if (currentBurnDamageLevel >= TraumaDamageLevel.CRITICAL || currentCutSize >= BodyPartCutSize.LARGE
-			|| Severity >= DamageSeverity.Critical)
+			|| Severity >= DamageSeverity.Max)
 			{
 				return baseDamage * (baseTraumaDamageMultiplier + 0.25f);
 			}
-			else if (currentBurnDamageLevel >= TraumaDamageLevel.SERIOUS
-			         || currentCutSize >= BodyPartCutSize.MEDIUM || Severity >= DamageSeverity.Bad)
-			{
-				return baseDamage * (baseTraumaDamageMultiplier + 0.15f);
-			}
-			else if (currentBurnDamageLevel >= TraumaDamageLevel.SMALL
-			         || currentCutSize >= BodyPartCutSize.SMALL || Severity >= DamageSeverity.LightModerate)
-			{
-				return baseDamage * baseTraumaDamageMultiplier;
-			}
-			else
-			{
-				return baseDamage;
-			}
+			return baseDamage;
 		}
 
-			[ContextMenu("Debug - Apply 25 Slash Damage")]
+		[ContextMenu("Debug - Apply 25 Slash Damage")]
 		private void DEBUG_ApplyTestSlash()
 		{
 			ApplyTraumaDamage(25);

--- a/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
@@ -109,6 +109,18 @@ namespace Items
 			set => traumaDamageChance = value;
 		}
 
+		[SerializeField,
+		 Range(1, 8),
+		 Tooltip("To fine tune how strong trauma weapons are; use a value greater than 1 to increase their power. " +
+		         "Otherwise they'll continue to use the base damage value.")]
+		private int traumaDamageMultiplier = 1;
+
+		public int TraumaDamageMultiplier
+		{
+			get => traumaDamageMultiplier;
+			set => traumaDamageMultiplier = value;
+		}
+
 		[EnumFlag]
 		public TraumaticDamageTypes TraumaticDamageType;
 

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
@@ -20,6 +20,7 @@ public class WeaponNetworkActions : NetworkBehaviour
 
 	private float traumaDamageChance = 0;
 	private TraumaticDamageTypes tramuticDamageType;
+	private int traumaDamageMultiplier = 1;
 
 	private bool isForLerpBack;
 	private Vector3 lerpFrom;
@@ -95,6 +96,7 @@ public class WeaponNetworkActions : NetworkBehaviour
 			weaponSound = weaponAttributes.hitSoundSettings == SoundItemSettings.OnlyObject ? null : weaponAttributes.ServerHitSound;
 			tramuticDamageType = weaponAttributes.TraumaticDamageType;
 			traumaDamageChance = weaponAttributes.TraumaDamageChance;
+			traumaDamageMultiplier = weaponAttributes.TraumaDamageMultiplier;
 		}
 
 		LayerTile attackedTile = null;
@@ -143,7 +145,7 @@ public class WeaponNetworkActions : NetworkBehaviour
 					victimHealth.ApplyDamageToBodyPart(gameObject, damage, AttackType.Melee, damageType, damageZone);
 					if(DMMath.Prob(traumaDamageChance))
 					{
-						victimHealth.ApplyTraumaDamage(damageZone, damage, tramuticDamageType);
+						victimHealth.ApplyTraumaDamage(damageZone, damage * traumaDamageMultiplier, tramuticDamageType);
 					}
 					didHit = true;
 				}


### PR DESCRIPTION
### Purpose
Part of #6272 
Nerfs values to make them less common again and make their consequences more noticeable for stronger and dangerous weapons and when your body is at it's worst state.

On top of that weapons now have the ability to tweak how strong their trauma damage output is using a `traumaDamageMultiplier` variable that can be tweaked in the inspector.

Legs will now be more prone to trauma damage as they do in real life and heads won't instantly explode due to trauma damage for them being multiplied by 12 (yes i know, a bit too strong) when under serious critical damage.
To keep up with the tradition of some species being having more endurance than others; Lizards now are the strongest race to stand against trauma damage. With moths being the weakest and felines being slightly weaker than humans. 

### Notes:
merge #7409 to properly test this


### Changelog:
CL : [Balance] - Items have got slightly rebalanced to ensure they are not too overpowered or too weak considering how rare they are.
CL : [Balance] - Species have had their trauma multipliers rebalanced once more so they become more durable.
CL : [Balance] - Body trauma multipliers will only apply to MAX level severity of bodies.
CL : [Fix] - Some items had their trauma damage types incorrectly set due to Unity shenanigans 
CL : [Fix] - Fixed some items having zero chance ability to trigger trauma damage when they should.
