### PR TITLE
PlayerState & TransformState position variable rename

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.Move.cs
+++ b/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.Move.cs
@@ -189,7 +189,7 @@ public partial class CustomNetTransform
 		Logger.LogTraceFormat(STOPPED_FLOATING, Category.Movement, gameObject.name);
         if (IsTileSnap)
         {
-        	serverState.Position = Vector3Int.RoundToInt(serverState.Position);
+        	serverState.LocalPosition = Vector3Int.RoundToInt(serverState.LocalPosition);
         }
         else
         {
@@ -311,7 +311,7 @@ public partial class CustomNetTransform
 	/// Serverside lerping
 	private void ServerLerp()
 	{
-		var targetPos = serverState.Position;
+		var targetPos = serverState.LocalPosition;
 		//Set position immediately if not moving
 		if (serverState.Speed.Equals(0))
 		{
@@ -320,10 +320,10 @@ public partial class CustomNetTransform
 			return;
 		}
 
-		var deltaMaxDistance = serverState.Speed * Time.deltaTime * serverLerpState.Position.SpeedTo(targetPos);
-		serverLerpState.Position = Vector3.MoveTowards(serverLerpState.Position, targetPos, deltaMaxDistance);
+		var deltaMaxDistance = serverState.Speed * Time.deltaTime * serverLerpState.LocalPosition.SpeedTo(targetPos);
+		serverLerpState.LocalPosition = Vector3.MoveTowards(serverLerpState.LocalPosition, targetPos, deltaMaxDistance);
 
-		if (serverLerpState.Position == targetPos)
+		if (serverLerpState.LocalPosition == targetPos)
 		{
 			ServerOnTileReached(serverState.WorldPosition.RoundToInt());
 		}

--- a/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.cs
+++ b/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.cs
@@ -69,11 +69,11 @@ public partial class CustomNetTransform : NetworkBehaviour, IPushable
 	}
 
 	public Vector3Int ServerPosition => serverState.WorldPosition.RoundToInt();
-	public Vector3Int ServerLocalPosition => serverState.Position.RoundToInt();
+	public Vector3Int ServerLocalPosition => serverState.LocalPosition.RoundToInt();
 	public Vector3Int ClientPosition => predictedState.WorldPosition.RoundToInt();
-	public Vector3Int ClientLocalPosition => predictedState.Position.RoundToInt();
+	public Vector3Int ClientLocalPosition => predictedState.LocalPosition.RoundToInt();
 	public Vector3Int TrustedPosition => clientState.WorldPosition.RoundToInt();
-	public Vector3Int TrustedLocalPosition => clientState.Position.RoundToInt();
+	public Vector3Int TrustedLocalPosition => clientState.LocalPosition.RoundToInt();
 	public Vector3Int LastNonHiddenPosition { get; } = TransformState.HiddenPos; //todo: implement for CNT!
 
 	//Timer to unsubscribe from the UpdateManager if the object is still for too long
@@ -279,7 +279,7 @@ public partial class CustomNetTransform : NetworkBehaviour, IPushable
 			changed &= CheckFloatingServer();
 		}
 
-		if ((Vector2)predictedState.Position != (Vector2)transform.localPosition)
+		if ((Vector2)predictedState.LocalPosition != (Vector2)transform.localPosition)
 		{
 			Lerp();
 			changed = true;
@@ -297,14 +297,14 @@ public partial class CustomNetTransform : NetworkBehaviour, IPushable
 		}
 
 		//Checking if we should change matrix once per tile
-		if (server && registerTile.LocalPositionServer != Vector3Int.RoundToInt(serverState.Position) ) {
+		if (server && registerTile.LocalPositionServer != Vector3Int.RoundToInt(serverState.LocalPosition) ) {
 			CheckMatrixSwitch();
 			registerTile.UpdatePositionServer();
 			UpdateOccupant();
 			changed = true;
 		}
 		//Registering
-		if (registerTile.LocalPositionClient != Vector3Int.RoundToInt(predictedState.Position) )
+		if (registerTile.LocalPositionClient != Vector3Int.RoundToInt(predictedState.LocalPosition) )
 		{
 			if (registerTile.ServerSetNetworkedMatrixNetID(MatrixManager.Get(predictedState.MatrixId).NetID) == false)
 			{
@@ -440,8 +440,8 @@ public partial class CustomNetTransform : NetworkBehaviour, IPushable
 			Stop(notify: false);
 		}
 
-		serverState.Position = TransformState.HiddenPos;
-		serverLerpState.Position = TransformState.HiddenPos;
+		serverState.LocalPosition = TransformState.HiddenPos;
+		serverLerpState.LocalPosition = TransformState.HiddenPos;
 
 		if (resetRotation)
 		{
@@ -473,7 +473,7 @@ public partial class CustomNetTransform : NetworkBehaviour, IPushable
 	///     For CLIENT prediction purposes.
 	public void DisappearFromWorld()
 	{
-		predictedState.Position = TransformState.HiddenPos;
+		predictedState.LocalPosition = TransformState.HiddenPos;
 		UpdateActiveStatusClient();
 	}
 
@@ -574,7 +574,7 @@ public partial class CustomNetTransform : NetworkBehaviour, IPushable
 	public void SyncClientStateLocalPosition(Vector3 oldLocalPosition, Vector3 newLocalPosition)
 	{
 		clientStateLocalPosition = newLocalPosition;
-		clientState.Position = newLocalPosition;
+		clientState.LocalPosition = newLocalPosition;
 		ClientValueChanged();
 	}
 
@@ -617,7 +617,7 @@ public partial class CustomNetTransform : NetworkBehaviour, IPushable
 		clientStateSpeed = newState.speed;
 		clientStateWorldImpulse = newState.WorldImpulse;
 		clientStateMatrixId = newState.MatrixId;
-		clientStateLocalPosition = newState.Position;
+		clientStateLocalPosition = newState.LocalPosition;
 		clientStateIsFollowUpdate = newState.IsFollowUpdate;
 		clientStateSpinRotation = newState.SpinRotation;
 		clientStateSpinFactor = newState.SpinFactor;

--- a/UnityProject/Assets/Scripts/Core/Transform/TransformState.cs
+++ b/UnityProject/Assets/Scripts/Core/Transform/TransformState.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 /// Current state of transform, server modifies these and sends to clients.
 /// Clients can modify these as well for prediction
 public struct TransformState {
-	public bool Active => Position != HiddenPos;
+	public bool Active => LocalPosition != HiddenPos;
 	///Don't set directly, use Speed instead.
 	///public in order to be serialized :\
 	public float speed;
@@ -23,7 +23,7 @@ public struct TransformState {
 	public int MatrixId;
 
 	/// Local position on current matrix
-	public Vector3 Position;
+	public Vector3 LocalPosition;
 	/// World position, more expensive to use
 	public Vector3 WorldPosition
 	{
@@ -34,15 +34,15 @@ public struct TransformState {
 				return HiddenPos;
 			}
 
-			return MatrixManager.LocalToWorld( Position, MatrixManager.Get( MatrixId ) );
+			return MatrixManager.LocalToWorld( LocalPosition, MatrixManager.Get( MatrixId ) );
 		}
 		set {
 			if (value == HiddenPos) {
-				Position = HiddenPos;
+				LocalPosition = HiddenPos;
 			}
 			else
 			{
-				Position = MatrixManager.WorldToLocal( value, MatrixManager.Get( MatrixId ) );
+				LocalPosition = MatrixManager.WorldToLocal( value, MatrixManager.Get( MatrixId ) );
 			}
 		}
 	}
@@ -65,7 +65,7 @@ public struct TransformState {
 	public static readonly Vector3Int HiddenPos = new Vector3Int(0, 0, -100);
 	/// Should only be used for uninitialized transform states, should NOT be used for anything else.
 	public static readonly TransformState Uninitialized =
-		new TransformState{ Position = HiddenPos, ActiveThrow = ThrowInfo.NoThrow, MatrixId = -1};
+		new TransformState{ LocalPosition = HiddenPos, ActiveThrow = ThrowInfo.NoThrow, MatrixId = -1};
 
 
 	/// <summary>
@@ -80,15 +80,15 @@ public struct TransformState {
 		{
 			return "[Uninitialized]";
 		}
-		else if (Position == HiddenPos)
+		else if (LocalPosition == HiddenPos)
 		{
-			return  $"[{nameof( Position )}: Hidden, {nameof( WorldPosition )}: Hidden, " +
+			return  $"[{nameof( LocalPosition )}: Hidden, {nameof( WorldPosition )}: Hidden, " +
 			        $"{nameof( Speed )}: {Speed}, {nameof( WorldImpulse )}: {WorldImpulse}, {nameof( SpinRotation )}: {SpinRotation}, " +
 			        $"{nameof( SpinFactor )}: {SpinFactor}, {nameof( IsFollowUpdate )}: {IsFollowUpdate}, {nameof( MatrixId )}: {MatrixId}]";
 		}
 		else
 		{
-			return  $"[{nameof( Position )}: {(Vector2)Position}, {nameof( WorldPosition )}: {(Vector2)WorldPosition}, " +
+			return  $"[{nameof( LocalPosition )}: {(Vector2)LocalPosition}, {nameof( WorldPosition )}: {(Vector2)WorldPosition}, " +
 			        $"{nameof( Speed )}: {Speed}, {nameof( WorldImpulse )}: {WorldImpulse}, {nameof( SpinRotation )}: {SpinRotation}, " +
 			        $"{nameof( SpinFactor )}: {SpinFactor}, {nameof( IsFollowUpdate )}: {IsFollowUpdate}, {nameof( MatrixId )}: {MatrixId}]";
 		}

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -438,7 +438,7 @@ public class CustomNetworkManager : NetworkManager, IInitialise
 
 	private static void NudgeTransform(CustomNetTransform netTransform, Vector3 where)
 	{
-		netTransform.SetPosition(netTransform.ServerState.Position + where);
+		netTransform.SetPosition(netTransform.ServerState.LocalPosition + where);
 	}
 #endif
 }

--- a/UnityProject/Assets/Scripts/Player/PlayerState.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerState.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 /// </summary>
 public struct PlayerState : IEquatable<PlayerState>
 {
-	public bool Active => Position != TransformState.HiddenPos;
+	public bool Active => LocalPosition != TransformState.HiddenPos;
 
 	///Don't set directly, use Speed instead.
 	///public in order to be serialized :\
@@ -20,7 +20,7 @@ public struct PlayerState : IEquatable<PlayerState>
 	}
 
 	public int MoveNumber;
-	public Vector3 Position;
+	public Vector3 LocalPosition;
 
 	[NonSerialized] public Vector3 LastNonHiddenPosition;
 
@@ -33,17 +33,17 @@ public struct PlayerState : IEquatable<PlayerState>
 				return TransformState.HiddenPos;
 			}
 
-			return MatrixManager.LocalToWorld(Position, MatrixManager.Get(MatrixId));
+			return MatrixManager.LocalToWorld(LocalPosition, MatrixManager.Get(MatrixId));
 		}
 		set
 		{
 			if (value == TransformState.HiddenPos)
 			{
-				Position = TransformState.HiddenPos;
+				LocalPosition = TransformState.HiddenPos;
 			}
 			else
 			{
-				Position = MatrixManager.WorldToLocal(value, MatrixManager.Get(MatrixId));
+				LocalPosition = MatrixManager.WorldToLocal(value, MatrixManager.Get(MatrixId));
 				LastNonHiddenPosition = value;
 			}
 		}
@@ -79,20 +79,20 @@ public struct PlayerState : IEquatable<PlayerState>
 
 	/// Means that this player is hidden
 	public static readonly PlayerState HiddenState =
-		new PlayerState {Position = TransformState.HiddenPos, MatrixId = 0};
+		new PlayerState {LocalPosition = TransformState.HiddenPos, MatrixId = 0};
 
 	public override string ToString()
 	{
 		return
 			Equals(HiddenState)
 				? "[Hidden]"
-				: $"[Move #{MoveNumber}, localPos:{(Vector2) Position}, worldPos:{(Vector2) WorldPosition} {nameof(NoLerp)}:{NoLerp}, {nameof(WorldImpulse)}:{WorldImpulse}, " +
+				: $"[Move #{MoveNumber}, localPos:{(Vector2) LocalPosition}, worldPos:{(Vector2) WorldPosition} {nameof(NoLerp)}:{NoLerp}, {nameof(WorldImpulse)}:{WorldImpulse}, " +
 				  $"reset: {ResetClientQueue}, flight: {ImportantFlightUpdate}, follow: {IsFollowUpdate}, matrix #{MatrixId}]";
 	}
 
 	public bool Equals(PlayerState other)
 	{
-		return speed.Equals(other.speed) && MoveNumber == other.MoveNumber && Position.Equals(other.Position)
+		return speed.Equals(other.speed) && MoveNumber == other.MoveNumber && LocalPosition.Equals(other.LocalPosition)
 		       && LastNonHiddenPosition.Equals(other.LastNonHiddenPosition) && IsFollowUpdate == other.IsFollowUpdate
 		       && NoLerp == other.NoLerp && WorldImpulse.Equals(other.WorldImpulse) && ResetClientQueue == other.ResetClientQueue
 		       && ImportantFlightUpdate == other.ImportantFlightUpdate && MatrixId == other.MatrixId;
@@ -109,7 +109,7 @@ public struct PlayerState : IEquatable<PlayerState>
 		{
 			var hashCode = speed.GetHashCode();
 			hashCode = (hashCode * 397) ^ MoveNumber;
-			hashCode = (hashCode * 397) ^ Position.GetHashCode();
+			hashCode = (hashCode * 397) ^ LocalPosition.GetHashCode();
 			hashCode = (hashCode * 397) ^ LastNonHiddenPosition.GetHashCode();
 			hashCode = (hashCode * 397) ^ IsFollowUpdate.GetHashCode();
 			hashCode = (hashCode * 397) ^ NoLerp.GetHashCode();

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
@@ -33,12 +33,12 @@ public partial class PlayerSync
 	public bool CanPredictPush => ClientPositionReady;
 	public bool IsMovingClient => !ClientPositionReady;
 	public Vector3Int ClientPosition => predictedState.WorldPosition.RoundToInt();
-	public Vector3Int ClientLocalPosition => predictedState.Position.RoundToInt();
+	public Vector3Int ClientLocalPosition => predictedState.LocalPosition.RoundToInt();
 	public Vector3Int TrustedPosition => playerState.WorldPosition.RoundToInt();
-	public Vector3Int TrustedLocalPosition => playerState.Position.RoundToInt();
+	public Vector3Int TrustedLocalPosition => playerState.LocalPosition.RoundToInt();
 
 	/// Does client's transform pos match state pos? Ignores Z-axis. Unity's vectors might have 1E-05 of difference
-	private bool ClientPositionReady => Vector2.Distance( predictedState.Position, transform.localPosition ) < 0.001f
+	private bool ClientPositionReady => Vector2.Distance( predictedState.LocalPosition, transform.localPosition ) < 0.001f
 	                                    || playerState.WorldPosition == TransformState.HiddenPos;
 
 	//Pending Init state cache when the client is still loading in
@@ -496,7 +496,7 @@ public partial class PlayerSync
 			bool wrongFloatDir = playerState.MoveNumber < predictedState.MoveNumber &&
 							playerState.WorldImpulse != Vector2.zero &&
 							//note: since the Positions used below are local, we must use LocalImpulse to see if the prediction is actually wrong
-							playerState.LocalImpulse(this).normalized != (Vector2)(predictedState.Position - playerState.Position).normalized;
+							playerState.LocalImpulse(this).normalized != (Vector2)(predictedState.LocalPosition - playerState.LocalPosition).normalized;
 			if (spacewalkReset || wrongFloatDir)
 			{
 				//NOTE: This is currently generated when client is slipping indoors because there's no way for client
@@ -514,7 +514,7 @@ public partial class PlayerSync
 			//invalidate queue if serverstate was never predicted
 			bool serverAhead = playerState.MoveNumber > predictedState.MoveNumber;
 			bool posMismatch = playerState.MoveNumber == predictedState.MoveNumber
-							   && playerState.Position != predictedState.Position;
+							   && playerState.LocalPosition != predictedState.LocalPosition;
 			bool wrongMatrix = playerState.MatrixId != predictedState.MatrixId && playerState.MoveNumber == predictedState.MoveNumber;
 			if (serverAhead || posMismatch || wrongMatrix)
 			{
@@ -653,8 +653,8 @@ public partial class PlayerSync
 
 				//Extending prediction by one tile if player's transform reaches previously set goal
 				//note: position is local, so we must use local impulse to predict the new position
-				Vector3Int newGoal = Vector3Int.RoundToInt(predictedState.Position + (Vector3)predictedState.LocalImpulse(this));
-				predictedState.Position = newGoal;
+				Vector3Int newGoal = Vector3Int.RoundToInt(predictedState.LocalPosition + (Vector3)predictedState.LocalImpulse(this));
+				predictedState.LocalPosition = newGoal;
 
 				var newPos = predictedState.WorldPosition;
 

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -25,7 +25,7 @@ public partial class PlayerSync
 	public CollisionEvent OnHighSpeedCollision() => onHighSpeedCollision;
 
 	public Vector3Int ServerPosition => serverState.WorldPosition.RoundToInt();
-	public Vector3Int ServerLocalPosition => serverState.Position.RoundToInt();
+	public Vector3Int ServerLocalPosition => serverState.LocalPosition.RoundToInt();
 
 	public Vector3Int LastNonHiddenPosition => serverState.LastNonHiddenPosition.RoundToInt();
 
@@ -840,7 +840,7 @@ public partial class PlayerSync
 					//Extending prediction by one tile if player's transform reaches previously set goal
 					//note: since this is a local position, the impulse needs to be converted to a local rotation,
 					//hence the multiplication
-					Vector3Int newGoal = Vector3Int.RoundToInt(serverState.Position + (Vector3)serverState.LocalImpulse(this));
+					Vector3Int newGoal = Vector3Int.RoundToInt(serverState.LocalPosition + (Vector3)serverState.LocalImpulse(this));
 					Vector3Int intOrigin = Vector3Int.RoundToInt(registerPlayer.WorldPosition + (Vector3)serverState.LocalImpulse(this));
 
 					if (intOrigin.x > 18000 || intOrigin.x < -18000 || intOrigin.y > 18000 || intOrigin.y < -18000)
@@ -849,7 +849,7 @@ public partial class PlayerSync
 						Logger.Log($"Player {transform.name} was forced to stop at {intOrigin}", Category.Movement);
 						return;
 					}
-					serverState.Position = newGoal;
+					serverState.LocalPosition = newGoal;
 					ClearQueueServer();
 
 					var newPos = serverState.WorldPosition;

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.cs
@@ -509,7 +509,7 @@ public partial class PlayerSync : NetworkBehaviour, IPushable, IPlayerControllab
 					PlayerSpawn.ServerSpawnDummy(gameObject.transform);
 				}
 
-				if (serverState.Position != serverLerpState.Position)
+				if (serverState.LocalPosition != serverLerpState.LocalPosition)
 				{
 					ServerLerp();
 				}
@@ -521,7 +521,7 @@ public partial class PlayerSync : NetworkBehaviour, IPushable, IPlayerControllab
 		}
 
 		//Registering
-		if (registerPlayer.LocalPositionClient != Vector3Int.RoundToInt(predictedState.Position))
+		if (registerPlayer.LocalPositionClient != Vector3Int.RoundToInt(predictedState.LocalPosition))
 		{
 			if (registerPlayer.ServerSetNetworkedMatrixNetID(MatrixManager.Get(predictedState.MatrixId).NetID) == false)
 			{
@@ -529,7 +529,7 @@ public partial class PlayerSync : NetworkBehaviour, IPushable, IPlayerControllab
 			}
 		}
 
-		if (registerPlayer.LocalPositionServer != Vector3Int.RoundToInt(serverState.Position))
+		if (registerPlayer.LocalPositionServer != Vector3Int.RoundToInt(serverState.LocalPosition))
 		{
 			registerPlayer.UpdatePositionServer();
 		}
@@ -560,7 +560,7 @@ public partial class PlayerSync : NetworkBehaviour, IPushable, IPlayerControllab
 	{
 		var newState = state;
 		newState.MoveNumber++;
-		newState.Position = playerMove.GetNextPosition(Vector3Int.RoundToInt(state.Position), action, isReplay,
+		newState.LocalPosition = playerMove.GetNextPosition(Vector3Int.RoundToInt(state.LocalPosition), action, isReplay,
 			MatrixManager.Get(newState.MatrixId).Matrix);
 
 		var proposedWorldPos = newState.WorldPosition;


### PR DESCRIPTION
### Purpose
Renames PlayerState & TransformState copypaste variable Position to LocalPosition

### Notes
transform.position is worldpos so having a variable called position being local made everything way more confusing
just a variable name change, has no gameplay effect