### PR TITLE
Joint Dislocation

### DIFF
--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamageDiscriptors.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamageDiscriptors.cs
@@ -138,6 +138,43 @@ namespace HealthV2
 			return TranslateTags(report.ToString());
 		}
 
+		protected void AnnounceJointDislocationEvent()
+		{
+			PlayerScript script = HealthMaster.playerScript;
+			if (IsSurface)
+			{
+				Chat.AddActionMsgToChat(HealthMaster.gameObject,
+					$"Your {BodyPartReadableName} dislocates from it's place!",
+					$"{script.visibleName}'s {BodyPartReadableName} becomes visibly out of place!");
+			}
+			else
+			{
+				Chat.AddActionMsgToChat(HealthMaster.gameObject,
+					$"You wince and hold on to your {BodyPartReadableName} as it dislocates from your " +
+					$"{ContainedIn.gameObject.ExpensiveName()}.",
+					$"{script.visibleName} holds onto " +
+					$"{script.characterSettings.TheirPronoun(script)} {ContainedIn.gameObject.ExpensiveName()} in pain.");
+			}
+		}
+
+		protected void AnnounceJointHealEvent()
+		{
+			PlayerScript script = HealthMaster.playerScript;
+			if (IsSurface)
+			{
+				Chat.AddActionMsgToChat(HealthMaster.gameObject,
+					$"Your {BodyPartReadableName} pops back into place!",
+					$"{script.visibleName}'s {BodyPartReadableName} returns to it's original state!");
+			}
+			else
+			{
+				Chat.AddActionMsgToChat(HealthMaster.gameObject,
+					$"You scream out loud as your {BodyPartReadableName} pops back into place.",
+					$"{script.visibleName} screams out in pain as " +
+					$"a loud crack can be heard from their {ContainedIn.gameObject.ExpensiveName()}.");
+			}
+		}
+
 		private string TranslateTags(string txt)
 		{
 			return txt.Replace("{readableName}", BodyPartReadableName);

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -173,6 +173,11 @@ namespace HealthV2
 			{
 				bodyPart.health -= damage;
 				bodyPart.CheckIfBroken(true);
+				if (damage > 50)
+				{
+					//Force very strong blunt force damage that could cause immediate Joint Dislocation.
+					bodyPart.DislocateJoint();
+				}
 			}
 
 			foreach (ItemSlot slot in OrganStorage.GetIndexedSlots())

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -542,6 +542,7 @@ namespace HealthV2
 					Disembowel();
 				}
 			}
+			if(lastDamage > 50){DislocateJoint();}
 			if(Severity >= GibsOnSeverityLevel && lastDamage >= DamageThreshold)
 			{
 				DismemberBodyPartWithChance();

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -190,7 +190,7 @@ namespace HealthV2
 			}
 		}
 
-		public void CheckIfBroken(bool announceHurtDamage = false)
+		private void CheckIfBroken(bool announceHurtDamage = false)
 		{
 			if (CanBeBroken == false) { return; }
 


### PR DESCRIPTION
### Purpose
part of #6272 
Adds in Joint dislocation for blunt force trauma damage.

### Notes:
All species have a shared 25% chance for it to happen, later on once everything is tested we'll continue following the same balance philosophy of some species being much more durable than others.

If you receive more than 50 blunt trauma damage; you will skip the chance check.

### Changelog:
CL : [New] - Joint Dislocation has been added.