### PR TITLE
Trauma rework again

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanLeftLeg.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanLeftLeg.prefab
@@ -166,6 +166,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
         type: 3}
+      propertyPath: spillChanceWhenCutPresent
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
+        type: 3}
       propertyPath: baseTraumaDamageMultiplier
       value: 1.75
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightArm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightArm.prefab
@@ -350,6 +350,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
         type: 3}
+      propertyPath: spillChanceWhenCutPresent
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
+        type: 3}
       propertyPath: baseTraumaDamageMultiplier
       value: 1.5
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightLeg.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightLeg.prefab
@@ -295,6 +295,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
         type: 3}
+      propertyPath: spillChanceWhenCutPresent
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241952607628385263, guid: 6a1a4888888e8994187da2ccb8d6f1c2,
+        type: 3}
       propertyPath: baseTraumaDamageMultiplier
       value: 1.75
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanTorso.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanTorso.prefab
@@ -271,6 +271,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1673759363237950006, guid: e241039a7933eb347bd1a9bb67a9078a,
         type: 3}
+      propertyPath: spillChanceWhenCutPresent
+      value: 0.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 1673759363237950006, guid: e241039a7933eb347bd1a9bb67a9078a,
+        type: 3}
       propertyPath: baseTraumaDamageMultiplier
       value: 1.25
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanChest Variant 1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanChest Variant 1.prefab
@@ -35,6 +35,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5445495118236055813, guid: cc032f91cda505e44b066c36db32760d,
         type: 3}
+      propertyPath: spillChanceWhenCutPresent
+      value: 0.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 5445495118236055813, guid: cc032f91cda505e44b066c36db32760d,
+        type: 3}
       propertyPath: baseTraumaDamageMultiplier
       value: 1.25
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanHead Variant 1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanHead Variant 1.prefab
@@ -20,8 +20,18 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 6597352703958914049, guid: 78253771c2047f94c9ae40161a6be7ee,
         type: 3}
+      propertyPath: DamageThreshold
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 6597352703958914049, guid: 78253771c2047f94c9ae40161a6be7ee,
+        type: 3}
       propertyPath: CanBleedExternally
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6597352703958914049, guid: 78253771c2047f94c9ae40161a6be7ee,
+        type: 3}
+      propertyPath: spillChanceWhenCutPresent
+      value: 0.75
       objectReference: {fileID: 0}
     - target: {fileID: 6597352703958914049, guid: 78253771c2047f94c9ae40161a6be7ee,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanLeftArm Variant 1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanLeftArm Variant 1.prefab
@@ -85,6 +85,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2934630090728222927, guid: 719377fefb0114b448fc6ca9f7a5a6df,
         type: 3}
+      propertyPath: spillChanceWhenCutPresent
+      value: 0.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 2934630090728222927, guid: 719377fefb0114b448fc6ca9f7a5a6df,
+        type: 3}
       propertyPath: baseTraumaDamageMultiplier
       value: 1.5
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanLeftLeg Variant 1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanLeftLeg Variant 1.prefab
@@ -14,6 +14,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1544594378003915950, guid: 2e6f2ff9beb985749940d242877d84f0,
         type: 3}
+      propertyPath: spillChanceWhenCutPresent
+      value: 0.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 1544594378003915950, guid: 2e6f2ff9beb985749940d242877d84f0,
+        type: 3}
       propertyPath: baseTraumaDamageMultiplier
       value: 1.75
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanRightArm Variant 1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanRightArm Variant 1.prefab
@@ -37,6 +37,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6313817628243374210, guid: ba9a875c31908af4ab3749cd127a2edb,
         type: 3}
+      propertyPath: spillChanceWhenCutPresent
+      value: 0.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 6313817628243374210, guid: ba9a875c31908af4ab3749cd127a2edb,
+        type: 3}
       propertyPath: baseTraumaDamageMultiplier
       value: 1.5
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanRightLeg Variant 1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Template/HumanRightLeg Variant 1.prefab
@@ -102,6 +102,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
         type: 3}
+      propertyPath: spillChanceWhenCutPresent
+      value: 0.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
+        type: 3}
       propertyPath: baseTraumaDamageMultiplier
       value: 1.75
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Mining/EverburningCandle.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Mining/EverburningCandle.prefab
@@ -253,6 +253,16 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
+      propertyPath: traumaDamageChance
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: TraumaticDamageType
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
       propertyPath: hitSound.AssetAddress
       value: Assets/Prefabs/Effects/Tap.prefab
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Mining/MiningDrill.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Mining/MiningDrill.prefab
@@ -29,6 +29,16 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
+      propertyPath: traumaDamageChance
+      value: 27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
+        type: 3}
+      propertyPath: TraumaticDamageType
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
+        type: 3}
       propertyPath: hitSound.AssetAddress
       value: Assets/Prefabs/Weapons/Drill.prefab
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Mining/MiningDrillDiamondTipped.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Mining/MiningDrillDiamondTipped.prefab
@@ -100,6 +100,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4567172765289801393, guid: 4d508ff5a5539124bb4e3e4c33ff3dda,
         type: 3}
+      propertyPath: TraumaticDamageType
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4567172765289801393, guid: 4d508ff5a5539124bb4e3e4c33ff3dda,
+        type: 3}
       propertyPath: itemSprites.SpriteInventoryIcon
       value: 
       objectReference: {fileID: 11400000, guid: 62e58207be4a9a54fac30e1697846313,

--- a/UnityProject/Assets/Prefabs/Items/Mining/Pickaxe.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Mining/Pickaxe.prefab
@@ -138,6 +138,16 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
+      propertyPath: traumaDamageChance
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: TraumaticDamageType
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
       propertyPath: attackVerbs.Array.size
       value: 4
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Mining/PickaxeImprovised.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Mining/PickaxeImprovised.prefab
@@ -45,6 +45,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
+      propertyPath: traumaDamageChance
+      value: 33
+      objectReference: {fileID: 0}
+    - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
+        type: 3}
       propertyPath: initialTraits.Array.size
       value: 2
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Mining/PickaxeSilverPlated.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Mining/PickaxeSilverPlated.prefab
@@ -39,6 +39,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
+      propertyPath: traumaDamageChance
+      value: 27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2465993488309703667, guid: 82cb1c39112974a498a9756981eb07d0,
+        type: 3}
       propertyPath: itemSprites.SpriteLeftHand
       value: 
       objectReference: {fileID: 11400000, guid: 53463a11e7dacbe4c902d40ca99c5279,

--- a/UnityProject/Assets/Prefabs/Items/Mining/ShovelSerratedBone.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Mining/ShovelSerratedBone.prefab
@@ -112,6 +112,16 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6675016413124777475, guid: 1488f67a55cb9b84098e095e65e5a2b3,
         type: 3}
+      propertyPath: traumaDamageChance
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 6675016413124777475, guid: 1488f67a55cb9b84098e095e65e5a2b3,
+        type: 3}
+      propertyPath: TraumaticDamageType
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6675016413124777475, guid: 1488f67a55cb9b84098e095e65e5a2b3,
+        type: 3}
       propertyPath: attackVerbs.Array.data[0]
       value: slashed
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Mining/SonicJackhammer.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Mining/SonicJackhammer.prefab
@@ -90,6 +90,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4567172765289801393, guid: 4d508ff5a5539124bb4e3e4c33ff3dda,
         type: 3}
+      propertyPath: traumaDamageChance
+      value: 35
+      objectReference: {fileID: 0}
+    - target: {fileID: 4567172765289801393, guid: 4d508ff5a5539124bb4e3e4c33ff3dda,
+        type: 3}
       propertyPath: hitSound.AssetAddress
       value: Assets/Prefabs/Weapons/SonicJackhammer.prefab
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Storage/Toolboxes/EmergencyToolbox.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Storage/Toolboxes/EmergencyToolbox.prefab
@@ -26,6 +26,11 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 8072580136699404764, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
         type: 3}
+      propertyPath: traumaDamageChance
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 8072580136699404764, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
+        type: 3}
       propertyPath: itemSprites.SpriteLeftHand
       value: 
       objectReference: {fileID: 11400000, guid: c204a9914afeb6643881276428afbe23,

--- a/UnityProject/Assets/Prefabs/Items/Storage/Toolboxes/Toolbox.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Storage/Toolboxes/Toolbox.prefab
@@ -244,7 +244,7 @@ PrefabInstance:
     - target: {fileID: 3782347747540316177, guid: e46ba34aab52d654787ef10d896b0874,
         type: 3}
       propertyPath: traumaDamageChance
-      value: 100
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 3782347747540316177, guid: e46ba34aab52d654787ef10d896b0874,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Tools/Crowbar.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/Crowbar.prefab
@@ -127,7 +127,7 @@ PrefabInstance:
     - target: {fileID: 7415335345799176407, guid: f709eab732189d6429ae3fa5beaf3fd3,
         type: 3}
       propertyPath: traumaDamageChance
-      value: 75
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 7415335345799176407, guid: f709eab732189d6429ae3fa5beaf3fd3,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Tools/FireExtinguishers/PocketFireExtinguisher.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/FireExtinguishers/PocketFireExtinguisher.prefab
@@ -90,7 +90,7 @@ PrefabInstance:
     - target: {fileID: 7726190153568297307, guid: 908afbc5b9f871148b5ccd0b81bd147f,
         type: 3}
       propertyPath: traumaDamageChance
-      value: 37
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7726190153568297307, guid: 908afbc5b9f871148b5ccd0b81bd147f,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Tools/FireExtinguishers/PocketFireExtinguisherEmpty.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/FireExtinguishers/PocketFireExtinguisherEmpty.prefab
@@ -82,6 +82,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: fd46521c5d977d54ea8cc4aa528c7021
       objectReference: {fileID: 0}
+    - target: {fileID: 3368380433865782011, guid: 1d2a97390d806414381b5edafdddb3c3,
+        type: 3}
+      propertyPath: traumaDamageChance
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8136253521614098932, guid: 1d2a97390d806414381b5edafdddb3c3,
         type: 3}
       propertyPath: foreverID

--- a/UnityProject/Assets/Prefabs/Items/Tools/PocketCrowbar.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/PocketCrowbar.prefab
@@ -56,6 +56,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
         type: 3}
+      propertyPath: traumaDamageChance
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
       propertyPath: TraumaticDamageType
       value: 8
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Tools/Screwdriver.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/Screwdriver.prefab
@@ -179,7 +179,7 @@ PrefabInstance:
     - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
         type: 3}
       propertyPath: traumaDamageChance
-      value: 75
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Tools/ScrewdriverNuke.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/ScrewdriverNuke.prefab
@@ -133,6 +133,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9077323224761429490, guid: 366fb594c17e76346bbb29ad4ce021ad,
         type: 3}
+      propertyPath: traumaDamageChance
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 9077323224761429490, guid: 366fb594c17e76346bbb29ad4ce021ad,
+        type: 3}
       propertyPath: itemSprites.SpriteLeftHand
       value: 
       objectReference: {fileID: 11400000, guid: f20712867adbdf846a33fc6db756480a,

--- a/UnityProject/Assets/Prefabs/Items/Tools/Wrench.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/Wrench.prefab
@@ -56,7 +56,7 @@ PrefabInstance:
     - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
         type: 3}
       propertyPath: traumaDamageChance
-      value: 35
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Tools/WrenchMedical.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/WrenchMedical.prefab
@@ -46,7 +46,7 @@ PrefabInstance:
     - target: {fileID: 4791952605902770127, guid: 7976a84ef9209f14697cdd941b913e2a,
         type: 3}
       propertyPath: traumaDamageChance
-      value: 35
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 4791952605902770127, guid: 7976a84ef9209f14697cdd941b913e2a,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Knives/ButchersCleaver.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Knives/ButchersCleaver.prefab
@@ -112,6 +112,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: 229f1c93e0e4ada439cfe4b781f65997,
         type: 3}
+      propertyPath: traumaDamageChance
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 7858931176587863443, guid: 229f1c93e0e4ada439cfe4b781f65997,
+        type: 3}
       propertyPath: attackVerbs.Array.size
       value: 8
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Knives/KitchenKnife.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Knives/KitchenKnife.prefab
@@ -180,7 +180,7 @@ PrefabInstance:
     - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}
       propertyPath: traumaDamageChance
-      value: 50
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Knives/RitualKnife.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Knives/RitualKnife.prefab
@@ -104,5 +104,10 @@ PrefabInstance:
       propertyPath: initialDescription
       value: The unearthly energies that once powered this blade are now dormant.
       objectReference: {fileID: 0}
+    - target: {fileID: 7858931176587863443, guid: 229f1c93e0e4ada439cfe4b781f65997,
+        type: 3}
+      propertyPath: traumaDamageChance
+      value: 25
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 229f1c93e0e4ada439cfe4b781f65997, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Knives/SurvivalKnife.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Knives/SurvivalKnife.prefab
@@ -33,6 +33,11 @@ PrefabInstance:
       propertyPath: throwDamage
       value: 15
       objectReference: {fileID: 0}
+    - target: {fileID: 4824296599455833752, guid: 80bdfbc6ac7f8614abbfa237f98bf72d,
+        type: 3}
+      propertyPath: traumaDamageChance
+      value: 15
+      objectReference: {fileID: 0}
     - target: {fileID: 4903646652920302734, guid: 80bdfbc6ac7f8614abbfa237f98bf72d,
         type: 3}
       propertyPath: m_RootOrder

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/AncientSpear.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/AncientSpear.prefab
@@ -108,7 +108,7 @@ PrefabInstance:
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}
       propertyPath: traumaDamageChance
-      value: 40.7
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ArrhythmicKnife.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ArrhythmicKnife.prefab
@@ -103,12 +103,12 @@ PrefabInstance:
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}
       propertyPath: traumaDamageChance
-      value: 50
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}
       propertyPath: TraumaticDamageType
-      value: 4
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/AtheistsFedora.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/AtheistsFedora.prefab
@@ -149,7 +149,7 @@ PrefabInstance:
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}
       propertyPath: traumaDamageChance
-      value: 25
+      value: 75
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ChainsawHand.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ChainsawHand.prefab
@@ -117,7 +117,7 @@ PrefabInstance:
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}
       propertyPath: traumaDamageChance
-      value: 100
+      value: 45
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ChaplainEnergySwordDark.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ChaplainEnergySwordDark.prefab
@@ -25,7 +25,7 @@ PrefabInstance:
     - target: {fileID: 4292656370289085150, guid: cda7add5dd20d954085fa9cc4264ac75,
         type: 3}
       propertyPath: traumaDamageChance
-      value: 100
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 4292656370289085150, guid: cda7add5dd20d954085fa9cc4264ac75,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ChaplainEnergySwordLight.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ChaplainEnergySwordLight.prefab
@@ -47,7 +47,7 @@ PrefabInstance:
     - target: {fileID: 5869444691453870322, guid: 9c123336301845541830989cb9e3d606,
         type: 3}
       propertyPath: traumaDamageChance
-      value: 100
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 5869444691453870322, guid: 9c123336301845541830989cb9e3d606,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ClaymoreHoly.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ClaymoreHoly.prefab
@@ -168,7 +168,7 @@ PrefabInstance:
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}
       propertyPath: traumaDamageChance
-      value: 75
+      value: 35
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ClownDagger.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ClownDagger.prefab
@@ -106,6 +106,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}
+      propertyPath: traumaDamageChance
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
+        type: 3}
       propertyPath: TraumaticDamageType
       value: 2
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/HanzoSteel.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/HanzoSteel.prefab
@@ -35,6 +35,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5869444691453870322, guid: 9c123336301845541830989cb9e3d606,
         type: 3}
+      propertyPath: traumaDamageChance
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869444691453870322, guid: 9c123336301845541830989cb9e3d606,
+        type: 3}
       propertyPath: TraumaticDamageType
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/HighFrequencyBlade.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/HighFrequencyBlade.prefab
@@ -91,7 +91,7 @@ PrefabInstance:
     - target: {fileID: 961760323801569489, guid: 0776de7177938cb48a6339d82019bab9,
         type: 3}
       propertyPath: traumaDamageChance
-      value: 100
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 961760323801569489, guid: 0776de7177938cb48a6339d82019bab9,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/HolyStaffRed.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/HolyStaffRed.prefab
@@ -128,7 +128,7 @@ PrefabInstance:
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}
       propertyPath: traumaDamageChance
-      value: 26.8
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/PossessedChainsword.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/PossessedChainsword.prefab
@@ -30,6 +30,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6470034178287949386, guid: 7e7b4be15b786a3409887818a46638f3,
         type: 3}
+      propertyPath: traumaDamageChance
+      value: 35
+      objectReference: {fileID: 0}
+    - target: {fileID: 6470034178287949386, guid: 7e7b4be15b786a3409887818a46638f3,
+        type: 3}
       propertyPath: TraumaticDamageType
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ReaperScythe.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/ReaperScythe.prefab
@@ -138,7 +138,7 @@ PrefabInstance:
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}
       propertyPath: traumaDamageChance
-      value: 45
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/UnholyPitchfork.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/NullRod/UnholyPitchfork.prefab
@@ -117,7 +117,7 @@ PrefabInstance:
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}
       propertyPath: traumaDamageChance
-      value: 65
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: d70fb70bc4fe6534a85996e49221bb53,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Resources/Flyswatter.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Resources/Flyswatter.prefab
@@ -122,7 +122,7 @@ PrefabInstance:
     - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}
       propertyPath: traumaDamageChance
-      value: 100
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Resources/RollingPin.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Resources/RollingPin.prefab
@@ -139,7 +139,7 @@ PrefabInstance:
     - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}
       propertyPath: traumaDamageChance
-      value: 50
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Resources/Tribal Spear.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Resources/Tribal Spear.prefab
@@ -152,7 +152,7 @@ PrefabInstance:
     - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}
       propertyPath: traumaDamageChance
-      value: 50
+      value: 35
       objectReference: {fileID: 0}
     - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}

--- a/UnityProject/Assets/Scripts/HealthV2/HealthEnums.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/HealthEnums.cs
@@ -60,14 +60,6 @@ public enum DamageType
 	Radiation = 6
 }
 
-public enum BodyPartCutSize
-{
-	NONE,
-	SMALL,
-	MEDIUM,
-	LARGE
-}
-
 public enum TraumaDamageLevel
 {
 	NONE,

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
@@ -262,7 +262,9 @@ namespace HealthV2
 				}
 			}
 
-			if (attackType == AttackType.Fire || attackType == AttackType.Laser || attackType == AttackType.Energy)
+			if(Severity <= DamageSeverity.LightModerate){return;}
+			if (damageType == DamageType.Burn || attackType == AttackType.Fire
+			                                  || attackType == AttackType.Laser || attackType == AttackType.Energy)
 			{
 				ApplyTraumaDamage(TraumaticDamageTypes.BURN, true);
 			}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
@@ -264,7 +264,7 @@ namespace HealthV2
 
 			if (attackType == AttackType.Fire || attackType == AttackType.Laser || attackType == AttackType.Energy)
 			{
-				ApplyTraumaDamage(TraumaticDamageTypes.BURN);
+				ApplyTraumaDamage(TraumaticDamageTypes.BURN, true);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
@@ -255,7 +255,7 @@ namespace HealthV2
 			}
 			if(attackType == AttackType.Bomb)
 			{
-				TakeBluntDamage(damage);
+				TakeBluntDamage();
 				if(damageToLimb >= DamageThreshold)
 				{
 					DismemberBodyPartWithChance();
@@ -264,9 +264,8 @@ namespace HealthV2
 
 			if (attackType == AttackType.Fire || attackType == AttackType.Laser || attackType == AttackType.Energy)
 			{
-				ApplyTraumaDamage(damage, TraumaticDamageTypes.BURN);
+				ApplyTraumaDamage(TraumaticDamageTypes.BURN);
 			}
-			if(CanBeBroken){CheckIfBroken();} //If our external limb can be broken.
 		}
 
 
@@ -342,7 +341,7 @@ namespace HealthV2
 			if (severity <= 0)
 			{
 				Severity = DamageSeverity.None;
-				currentCutSize = BodyPartCutSize.NONE;
+				currentPierceDamageLevel = TraumaDamageLevel.NONE;
 			}
 			// If the limb is under 10% damage
 			else if (severity < 0.1)

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
@@ -256,13 +256,10 @@ namespace HealthV2
 			if(attackType == AttackType.Bomb)
 			{
 				TakeBluntDamage();
-				if(damageToLimb >= DamageThreshold)
-				{
-					DismemberBodyPartWithChance();
-				}
+				if(damageToLimb >= DamageThreshold) DismemberBodyPartWithChance();
 			}
 
-			if(Severity <= DamageSeverity.LightModerate){return;}
+			if(Severity <= DamageSeverity.LightModerate) return;
 			if (damageType == DamageType.Burn || attackType == AttackType.Fire
 			                                  || attackType == AttackType.Laser || attackType == AttackType.Energy)
 			{

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamageDiscriptors.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamageDiscriptors.cs
@@ -35,46 +35,22 @@ namespace HealthV2
 
 			if (CanBeBroken)
 			{
-				CheckIfBroken();
 				report.AppendLine("[Fracture Level]");
-				if (IsFracturedCompound)
+				switch (currentBluntDamageLevel)
 				{
-					report.AppendLine(BoneFracturedLvlThreeDesc);
-					return TranslateTags(report.ToString());
+					case TraumaDamageLevel.CRITICAL:
+						report.AppendLine(BoneFracturedLvlThreeDesc);
+						return TranslateTags(report.ToString());
+					case TraumaDamageLevel.SERIOUS:
+						report.AppendLine(BoneFracturedLvlTwoDesc);
+						return TranslateTags(report.ToString());
+					case TraumaDamageLevel.SMALL:
+						report.AppendLine("Joint Dislocation detected.");
+						return report.ToString();
+					default:
+						report.AppendLine($"{BodyPartReadableName} suffers no fractures and is healthy.");
+						return report.ToString();
 				}
-
-				if (IsFracturedHairline)
-				{
-					report.AppendLine(BoneFracturedLvlTwoDesc);
-					return TranslateTags(report.ToString());
-				}
-
-				if (Severity == DamageSeverity.Light)
-				{
-					report.AppendLine("Joint Dislocation detected.");
-					return report.ToString();
-				}
-
-				report.AppendLine($"{BodyPartReadableName} suffers no fractures and is healthy.");
-
-				return TranslateTags(report.ToString());
-			}
-
-			report.Append("[Open Wound Size -> ");
-			switch (currentCutSize)
-			{
-				case (BodyPartCutSize.SMALL):
-					report.AppendLine($"{BodyPartCutSize.SMALL}]");
-					break;
-				case (BodyPartCutSize.MEDIUM):
-					report.AppendLine($"{BodyPartCutSize.MEDIUM}]");
-					break;
-				case (BodyPartCutSize.LARGE):
-					report.AppendLine($"{BodyPartCutSize.LARGE}]");
-					break;
-				default:
-					report.AppendLine("{BodyPartCutSize.NONE}]");
-					break;
 			}
 
 			report.AppendLine($"[Wound Bleeding -> {isBleedingExternally}]");
@@ -84,7 +60,7 @@ namespace HealthV2
 				report.AppendLine($"[Organ is internally bleeding -> {isBleedingInternally}]");
 			}
 
-			if(currentCutSize != BodyPartCutSize.NONE)
+			if(currentSlashDamageLevel != TraumaDamageLevel.NONE || currentPierceDamageLevel != TraumaDamageLevel.NONE)
 			{
 				report.AppendLine("[Wound Report]");
 				switch (currentPierceDamageLevel)

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -204,14 +204,14 @@ namespace HealthV2
 			isBleedingExternally = true;
 			IsBleeding = true;
 			StartCoroutine(Bleedout());
-			if(currentSlashDamageLevel <= TraumaDamageLevel.CRITICAL || currentPierceDamageLevel <= TraumaDamageLevel.SMALL)
+			if(currentSlashDamageLevel <= TraumaDamageLevel.SERIOUS || currentPierceDamageLevel <= TraumaDamageLevel.SMALL)
 			{
 				willCloseOnItsOwn = true;
 			}
 			if(willCloseOnItsOwn)
 			{
 				yield return WaitFor.Seconds(128);
-				if(currentSlashDamageLevel <= TraumaDamageLevel.CRITICAL || currentPierceDamageLevel <= TraumaDamageLevel.SMALL)
+				if(currentSlashDamageLevel <= TraumaDamageLevel.SERIOUS || currentPierceDamageLevel <= TraumaDamageLevel.SMALL)
 				{
 					StopExternalBleeding();
 					isBleedingExternally = false;

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -227,7 +227,7 @@ namespace HealthV2
 		{
 			while(isBleedingExternally)
 			{
-				yield return WaitFor.Seconds(4f);
+				yield return WaitFor.Seconds(5f);
 				if (IsBleeding)
 				{
 					HealthMaster.CirculatorySystem.Bleed(UnityEngine.Random.Range(MinMaxInternalBleedingValues.x, MinMaxInternalBleedingValues.y));

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -83,12 +83,12 @@ namespace HealthV2
 		/// </summary>
 		public void ApplyTraumaDamage(TraumaticDamageTypes damageType = TraumaticDamageTypes.SLASH, bool ignoreSeverityCheck = false)
 		{
-			if(Severity < DamageSeverity.LightModerate && ignoreSeverityCheck == false){return;}
+			if(Severity < DamageSeverity.LightModerate && ignoreSeverityCheck == false) return;
 			//We use dismember protection chance because it's the most logical value.
 			if(DMMath.Prob(SelfArmor.DismembermentProtectionChance * 100) == false)
 			{
-				if (damageType == TraumaticDamageTypes.SLASH)  { currentSlashDamageLevel   += 1;}
-				if (damageType == TraumaticDamageTypes.PIERCE) { currentPierceDamageLevel  += 1;}
+				if (damageType == TraumaticDamageTypes.SLASH)  currentSlashDamageLevel   += 1;
+				if (damageType == TraumaticDamageTypes.PIERCE) currentPierceDamageLevel  += 1;
 			}
 			//Burn and blunt damage checks for it's own armor damage type.
 			if (damageType == TraumaticDamageTypes.BURN)
@@ -117,10 +117,10 @@ namespace HealthV2
 
 			foreach (ItemSlot slot in OrganStorage.GetIndexedSlots())
 			{
-				if (slot.IsEmpty) { return; }
+				if (slot.IsEmpty) return;
 				if (slot.Item.gameObject.TryGetComponent<BodyPart>(out var bodyPart))
 				{
-					if (bodyPart.CanBeBroken) { TakeBluntLogic(bodyPart);}
+					if (bodyPart.CanBeBroken) TakeBluntLogic(bodyPart);
 				}
 			}
 		}
@@ -168,10 +168,10 @@ namespace HealthV2
 			else
 			{
 				randomBodyPart.ApplyInternalDamage();
-				if(randomCustomBodyPart != null) { randomCustomBodyPart.ApplyInternalDamage(); }
+				if(randomCustomBodyPart != null) randomCustomBodyPart.ApplyInternalDamage();
 			}
 
-			if (currentPierceDamageLevel >= TraumaDamageLevel.SMALL) { StartCoroutine(ExternalBleedingLogic()); }
+			if (currentPierceDamageLevel >= TraumaDamageLevel.SMALL) StartCoroutine(ExternalBleedingLogic());
 		}
 
 		/// <summary>
@@ -192,10 +192,7 @@ namespace HealthV2
 		/// </summary>
 		public IEnumerator ExternalBleedingLogic()
 		{
-			if(isBleedingExternally || IsSurface == false)
-			{
-				yield break;
-			}
+			if(isBleedingExternally || IsSurface == false) yield break;
 			bool willCloseOnItsOwn = false;
 			isBleedingExternally = true;
 			IsBleeding = true;
@@ -349,7 +346,7 @@ namespace HealthV2
 				}
 			}
 
-			if (currentSlashDamageLevel >= TraumaDamageLevel.SERIOUS) { StartCoroutine(ExternalBleedingLogic());}
+			if (currentSlashDamageLevel >= TraumaDamageLevel.SERIOUS) StartCoroutine(ExternalBleedingLogic());
 			if(Severity >= GibsOnSeverityLevel && lastDamage >= DamageThreshold || currentSlashDamageLevel > TraumaDamageLevel.CRITICAL)
 			{
 				DismemberBodyPartWithChance();

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -144,16 +144,15 @@ namespace HealthV2
 
 		private void CheckCharredBodyPart()
 		{
-			if (currentBurnDamageLevel >= TraumaDamageLevel.CRITICAL)
+			if (currentBurnDamageLevel >= TraumaDamageLevel.SERIOUS)
 			{
-				if(currentBurnDamageLevel == TraumaDamageLevel.CRITICAL) //So we can do this once.
+				if(currentBurnDamageLevel == TraumaDamageLevel.SERIOUS) //So we can do this once.
 				{
 					foreach(var sprite in RelatedPresentSprites)
 					{
 						sprite.baseSpriteHandler.SetColor(bodyPartColorWhenCharred);
 					}
 				}
-				currentBurnDamageLevel = TraumaDamageLevel.CRITICAL;
 				AshBodyPart();
 			}
 		}
@@ -306,7 +305,7 @@ namespace HealthV2
 		/// </summary>
 		private void AshBodyPart()
 		{
-			if(currentBurnDamageLevel == TraumaDamageLevel.CRITICAL)
+			if(currentBurnDamageLevel >= TraumaDamageLevel.CRITICAL)
 			{
 				IEnumerable<ItemSlot> internalItemList = OrganStorage.GetItemSlots();
 				foreach(ItemSlot item in internalItemList)

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -348,7 +348,7 @@ namespace HealthV2
 		/// </summary>
 		protected void CheckBodyPartIntigrity(float lastDamage)
 		{
-			if(currentSlashDamageLevel >= TraumaDamageLevel.CRITICAL || currentPierceDamageLevel >= TraumaDamageLevel.SERIOUS)
+			if(currentPierceDamageLevel >= TraumaDamageLevel.SERIOUS)
 			{
 				if(OrganList.Count != 0)
 				{

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -153,7 +153,6 @@ namespace HealthV2
 						sprite.baseSpriteHandler.SetColor(bodyPartColorWhenCharred);
 					}
 				}
-				AshBodyPart();
 			}
 		}
 
@@ -297,6 +296,7 @@ namespace HealthV2
 			{
 				currentBurnDamageLevel += 1;
 				CheckCharredBodyPart();
+				AshBodyPart();
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -33,7 +33,7 @@ namespace HealthV2
 		private TraumaDamageLevel currentPierceDamageLevel = TraumaDamageLevel.NONE;
 		private TraumaDamageLevel currentSlashDamageLevel  = TraumaDamageLevel.NONE;
 		private TraumaDamageLevel currentBurnDamageLevel   = TraumaDamageLevel.NONE;
-		private TraumaDamageLevel currentBluntDamageLevel  = TraumaDamageLevel.NONE; //TODO : MERGE #7432 TO FINISH
+		private TraumaDamageLevel currentBluntDamageLevel  = TraumaDamageLevel.NONE; //TODO : MERGE #7434 TO FINISH #7432
 
 		public TraumaDamageLevel CurrentPierceDamageLevel => currentPierceDamageLevel;
 		public TraumaDamageLevel CurrentSlashDamageLevel  => currentSlashDamageLevel ;

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -85,8 +85,9 @@ namespace HealthV2
 		/// Applies trauma damage to the body part, checks if it has enough protective armor to cancel the trauma damage
 		/// and automatically checks how big is the body part's cut size.
 		/// </summary>
-		public void ApplyTraumaDamage(TraumaticDamageTypes damageType = TraumaticDamageTypes.SLASH)
+		public void ApplyTraumaDamage(TraumaticDamageTypes damageType = TraumaticDamageTypes.SLASH, bool ignoreSeverityCheck = false)
 		{
+			if(Severity < DamageSeverity.LightModerate && ignoreSeverityCheck == false){return;}
 			//We use dismember protection chance because it's the most logical value.
 			if(DMMath.Prob(SelfArmor.DismembermentProtectionChance * 100) == false)
 			{
@@ -131,13 +132,13 @@ namespace HealthV2
 		[ContextMenu("Debug - Apply 25 Slash Damage")]
 		private void DEBUG_ApplyTestSlash()
 		{
-			ApplyTraumaDamage();
+			ApplyTraumaDamage(TraumaticDamageTypes.SLASH, true);
 		}
 
 		[ContextMenu("Debug - Apply 25 Pierce Damage")]
 		private void DEBUG_ApplyTestPierce()
 		{
-			ApplyTraumaDamage(TraumaticDamageTypes.PIERCE);
+			ApplyTraumaDamage(TraumaticDamageTypes.PIERCE, true);
 		}
 
 		private void CheckCharredBodyPart()

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -200,7 +200,7 @@ namespace HealthV2
 		/// </summary>
 		public IEnumerator ExternalBleedingLogic()
 		{
-			if(isBleedingExternally)
+			if(isBleedingExternally || CanBleedExternally == false)
 			{
 				yield break;
 			}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -68,7 +68,7 @@ namespace HealthV2
 
 		[SerializeField] private bool gibsEntireBodyOnRemoval = false;
 
-		[HideInInspector] public float CurrentInternalBleedingDamage
+		public float CurrentInternalBleedingDamage
 		{
 			get
 			{

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -143,14 +143,11 @@ namespace HealthV2
 
 		private void CheckCharredBodyPart()
 		{
-			if (currentBurnDamageLevel >= TraumaDamageLevel.SERIOUS)
+			if (currentBurnDamageLevel == TraumaDamageLevel.SERIOUS) //So we can do this once.
 			{
-				if(currentBurnDamageLevel == TraumaDamageLevel.SERIOUS) //So we can do this once.
+				foreach (var sprite in RelatedPresentSprites)
 				{
-					foreach(var sprite in RelatedPresentSprites)
-					{
-						sprite.baseSpriteHandler.SetColor(bodyPartColorWhenCharred);
-					}
+					sprite.baseSpriteHandler.SetColor(bodyPartColorWhenCharred);
 				}
 			}
 		}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -8,21 +8,17 @@ namespace HealthV2
 {
 	public partial class BodyPart
 	{
-		private bool isBleedingInternally = false;
-
-		private bool isBleedingExternally = false;
-
-		public bool IsBleedingInternally => isBleedingInternally;
-
-		public bool IsBleedingExternally => isBleedingExternally;
 
 		[Header("Trauma Damage settings")]
-		public Vector2 MinMaxInternalBleedingValues = new Vector2(2, 14);
-
-
 		[SerializeField] private float maximumInternalBleedDamage = 100;
-		public float InternalBleedingBloodLoss = 12;
+		[SerializeField] private Vector2 minMaxInternalBleedingBloodLoss = new Vector2(2,4);
+		[SerializeField] private Vector2 minMaxExternalBleedingValues    = new Vector2(2, 14);
 
+		public Vector2 MinMaxExternalBleedingValues => minMaxExternalBleedingValues;
+		private bool isBleedingInternally = false;
+		private bool isBleedingExternally = false;
+		public bool IsBleedingInternally => isBleedingInternally;
+		public bool IsBleedingExternally => isBleedingExternally;
 		public float MaximumInternalBleedDamage => maximumInternalBleedDamage;
 
 		private float currentInternalBleedingDamage = 0;
@@ -230,7 +226,7 @@ namespace HealthV2
 				yield return WaitFor.Seconds(4f);
 				if (IsBleeding)
 				{
-					HealthMaster.CirculatorySystem.Bleed(UnityEngine.Random.Range(MinMaxInternalBleedingValues.x, MinMaxInternalBleedingValues.y));
+					HealthMaster.CirculatorySystem.Bleed(UnityEngine.Random.Range(MinMaxExternalBleedingValues.x, MinMaxExternalBleedingValues.y));
 				}
 			}
 		}
@@ -253,7 +249,7 @@ namespace HealthV2
 		/// </summary>
 		public void InternalBleedingLogic(AttackType attackType = AttackType.Internal, DamageType damageType = DamageType.Brute)
 		{
-			float damageToTake = UnityEngine.Random.Range(MinMaxInternalBleedingValues.x, MinMaxInternalBleedingValues.y);
+			float damageToTake = UnityEngine.Random.Range(minMaxInternalBleedingBloodLoss.x, minMaxInternalBleedingBloodLoss.y);
 			if(currentInternalBleedingDamage >= maximumInternalBleedDamage)
 			{
 				BodyPart currentParent = ContainedIn;

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -17,7 +17,7 @@ namespace HealthV2
 		public bool IsBleedingExternally => isBleedingExternally;
 
 		[Header("Trauma Damage settings")]
-		public Vector2 MinMaxInternalBleedingValues = new Vector2(5, 20);
+		public Vector2 MinMaxInternalBleedingValues = new Vector2(2, 14);
 
 
 		[SerializeField] private float maximumInternalBleedDamage = 100;
@@ -53,8 +53,6 @@ namespace HealthV2
 		private float spillChanceWhenCutPresent = 0.5f;
 
 		public bool CanBleedInternally = false;
-
-		public bool CanBleedExternally = false;
 
 		public bool CanBeBroken        = false;
 
@@ -200,7 +198,7 @@ namespace HealthV2
 		/// </summary>
 		public IEnumerator ExternalBleedingLogic()
 		{
-			if(isBleedingExternally || CanBleedExternally == false)
+			if(isBleedingExternally || IsSurface == false)
 			{
 				yield break;
 			}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -60,7 +60,7 @@ namespace HealthV2
 		/// <summary>
 		/// How much damage can this body part last before it breaks/gibs/Disembowles?
 		/// <summary>
-		public float DamageThreshold = 18f;
+		public float DamageThreshold = 21f;
 
 		[SerializeField] private DamageSeverity BoneFracturesOnDamageSevarity = DamageSeverity.Moderate;
 		[SerializeField] private DamageSeverity BoneBreaksOnDamageSevarity    = DamageSeverity.Bad;

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -178,6 +178,8 @@ namespace HealthV2
 				randomBodyPart.ApplyInternalDamage();
 				if(randomCustomBodyPart != null) { randomCustomBodyPart.ApplyInternalDamage(); }
 			}
+
+			if (currentPierceDamageLevel >= TraumaDamageLevel.SMALL) { StartCoroutine(ExternalBleedingLogic()); }
 		}
 
 		/// <summary>
@@ -354,6 +356,8 @@ namespace HealthV2
 					Disembowel();
 				}
 			}
+
+			if (currentSlashDamageLevel >= TraumaDamageLevel.SERIOUS) { StartCoroutine(ExternalBleedingLogic());}
 			if(Severity >= GibsOnSeverityLevel && lastDamage >= DamageThreshold || currentSlashDamageLevel > TraumaDamageLevel.CRITICAL)
 			{
 				DismemberBodyPartWithChance();

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -33,7 +33,7 @@ namespace HealthV2
 		private TraumaDamageLevel currentPierceDamageLevel = TraumaDamageLevel.NONE;
 		private TraumaDamageLevel currentSlashDamageLevel  = TraumaDamageLevel.NONE;
 		private TraumaDamageLevel currentBurnDamageLevel   = TraumaDamageLevel.NONE;
-		private TraumaDamageLevel currentBluntDamageLevel  = TraumaDamageLevel.NONE;
+		private TraumaDamageLevel currentBluntDamageLevel  = TraumaDamageLevel.NONE; //TODO : MERGE #7432 TO FINISH
 
 		public TraumaDamageLevel CurrentPierceDamageLevel => currentPierceDamageLevel;
 		public TraumaDamageLevel CurrentSlashDamageLevel  => currentSlashDamageLevel ;

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -227,7 +227,7 @@ namespace HealthV2
 		{
 			while(isBleedingExternally)
 			{
-				yield return WaitFor.Seconds(5f);
+				yield return WaitFor.Seconds(4f);
 				if (IsBleeding)
 				{
 					HealthMaster.CirculatorySystem.Bleed(UnityEngine.Random.Range(MinMaxInternalBleedingValues.x, MinMaxInternalBleedingValues.y));

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -626,14 +626,10 @@ namespace HealthV2
 		[Server]
 		public void ApplyTraumaDamage(BodyPartType aimedBodyPart, TraumaticDamageTypes damageType)
 		{
-			TraumaticDamageTypes selectedType = TraumaticDamageTypes.NONE;
-			if (damageType.HasFlag(TraumaticDamageTypes.NONE) == false)
-			{
-				Random random = new Random();
-				TraumaticDamageTypes[] typeToSelectFrom =
-					Enum.GetValues(typeof(TraumaticDamageTypes)).Cast<TraumaticDamageTypes>().Where(x => damageType.HasFlag(x)).ToArray();
-				selectedType = typeToSelectFrom[random.Next(1, typeToSelectFrom.Length)];
-			}
+			Random random = new Random();
+			TraumaticDamageTypes[] typeToSelectFrom =
+				Enum.GetValues(typeof(TraumaticDamageTypes)).Cast<TraumaticDamageTypes>().Where(x => damageType.HasFlag(x)).ToArray();
+			TraumaticDamageTypes selectedType = typeToSelectFrom[random.Next(1, typeToSelectFrom.Length)];
 
 			foreach (var bodyPart in BodyPartList)
 			{

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -623,7 +623,7 @@ namespace HealthV2
 		/// <param name="damage">The Trauma damage value</param>
 		/// <param name="damageType">TraumaticDamageType enum, can be Slash, Burn and/or Pierce.</param>
 		[Server]
-		public void ApplyTraumaDamage(BodyPartType aimedBodyPart, float damage, TraumaticDamageTypes damageType)
+		public void ApplyTraumaDamage(BodyPartType aimedBodyPart, TraumaticDamageTypes damageType)
 		{
 			foreach (var bodyPart in BodyPartList)
 			{
@@ -631,21 +631,20 @@ namespace HealthV2
 				{
 					if (damageType.HasFlag(TraumaticDamageTypes.BURN))
 					{
-						bodyPart.ApplyTraumaDamage(damage, TraumaticDamageTypes.BURN);
+						bodyPart.ApplyTraumaDamage(TraumaticDamageTypes.BURN);
 					}
 					if (damageType.HasFlag(TraumaticDamageTypes.SLASH))
 					{
-						bodyPart.ApplyTraumaDamage(damage);
+						bodyPart.ApplyTraumaDamage();
 					}
 					if (damageType.HasFlag(TraumaticDamageTypes.PIERCE))
 					{
-						bodyPart.ApplyTraumaDamage(damage, TraumaticDamageTypes.PIERCE);
+						bodyPart.ApplyTraumaDamage(TraumaticDamageTypes.PIERCE);
 					}
 					if (damageType.HasFlag(TraumaticDamageTypes.BLUNT))
 					{
-						bodyPart.ApplyTraumaDamage(damage, TraumaticDamageTypes.BLUNT);
+						bodyPart.ApplyTraumaDamage(TraumaticDamageTypes.BLUNT);
 					}
-					CheckDismemberBody();
 					return;
 				}
 			}
@@ -717,25 +716,25 @@ namespace HealthV2
 			{
 				if (bodyPart.BodyPartType == partType)
 				{
-					if (bodyPart.CurrentBurnDamage > 0)
+					if (bodyPart.CurrentSlashDamageLevel  > TraumaDamageLevel.NONE)
 						return true;
-					if (bodyPart.CurrentSlashCutDamage > 0)
+					if (bodyPart.CurrentPierceDamageLevel > TraumaDamageLevel.NONE)
 						return true;
-					if (bodyPart.CurrentPierceDamage > 0)
+					if (bodyPart.CurrentBurnDamageLevel   > TraumaDamageLevel.NONE)
 						return true;
-					return bodyPart.IsFracturedCompound;
+					return bodyPart.CurrentBluntDamageLevel != TraumaDamageLevel.NONE;
 				}
 			}
 			return false;
 		}
 
-		public void HealTraumaDamage(float healAmount, BodyPartType targetBodyPartToHeal, TraumaticDamageTypes typeToHeal)
+		public void HealTraumaDamage(BodyPartType targetBodyPartToHeal, TraumaticDamageTypes typeToHeal)
 		{
 			foreach(var bodyPart in BodyPartList)
 			{
 				if (bodyPart.BodyPartType == targetBodyPartToHeal)
 				{
-					bodyPart.HealTraumaticDamage(healAmount, typeToHeal);
+					bodyPart.HealTraumaticDamage(typeToHeal);
 				}
 			}
 		}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -11,6 +11,7 @@ using Mirror;
 using UnityEngine;
 using UnityEngine.Events;
 using Newtonsoft.Json;
+using Random = System.Random;
 
 namespace HealthV2
 {
@@ -625,26 +626,17 @@ namespace HealthV2
 		[Server]
 		public void ApplyTraumaDamage(BodyPartType aimedBodyPart, TraumaticDamageTypes damageType)
 		{
+			Random random = new Random();
+			TraumaticDamageTypes[] typeToSelectFrom =
+				Enum.GetValues(typeof(TraumaticDamageTypes)).Cast<TraumaticDamageTypes>().Where(x => damageType.HasFlag(x)).ToArray();
+
+			TraumaticDamageTypes selectedType = typeToSelectFrom[random.Next(1, typeToSelectFrom.Length)];
+
 			foreach (var bodyPart in BodyPartList)
 			{
 				if (bodyPart.BodyPartType == aimedBodyPart)
 				{
-					if (damageType.HasFlag(TraumaticDamageTypes.BURN))
-					{
-						bodyPart.ApplyTraumaDamage(TraumaticDamageTypes.BURN);
-					}
-					if (damageType.HasFlag(TraumaticDamageTypes.SLASH))
-					{
-						bodyPart.ApplyTraumaDamage();
-					}
-					if (damageType.HasFlag(TraumaticDamageTypes.PIERCE))
-					{
-						bodyPart.ApplyTraumaDamage(TraumaticDamageTypes.PIERCE);
-					}
-					if (damageType.HasFlag(TraumaticDamageTypes.BLUNT))
-					{
-						bodyPart.ApplyTraumaDamage(TraumaticDamageTypes.BLUNT);
-					}
+					bodyPart.ApplyTraumaDamage(selectedType);
 					return;
 				}
 			}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -626,11 +626,14 @@ namespace HealthV2
 		[Server]
 		public void ApplyTraumaDamage(BodyPartType aimedBodyPart, TraumaticDamageTypes damageType)
 		{
-			Random random = new Random();
-			TraumaticDamageTypes[] typeToSelectFrom =
-				Enum.GetValues(typeof(TraumaticDamageTypes)).Cast<TraumaticDamageTypes>().Where(x => damageType.HasFlag(x)).ToArray();
-
-			TraumaticDamageTypes selectedType = typeToSelectFrom[random.Next(1, typeToSelectFrom.Length)];
+			TraumaticDamageTypes selectedType = TraumaticDamageTypes.NONE;
+			if (damageType.HasFlag(TraumaticDamageTypes.NONE) == false)
+			{
+				Random random = new Random();
+				TraumaticDamageTypes[] typeToSelectFrom =
+					Enum.GetValues(typeof(TraumaticDamageTypes)).Cast<TraumaticDamageTypes>().Where(x => damageType.HasFlag(x)).ToArray();
+				selectedType = typeToSelectFrom[random.Next(1, typeToSelectFrom.Length)];
+			}
 
 			foreach (var bodyPart in BodyPartList)
 			{

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
@@ -276,7 +276,7 @@ public class Lungs : Organ
             {
 				Chat.AddActionMsgToChat(RelatedPart.HealthMaster.gameObject,
 				"You cough up blood!", $"{RelatedPart.HealthMaster.playerScript.visibleName} coughs up blood!");
-				RelatedPart.CurrentInternalBleedingDamage -= RelatedPart.InternalBleedingBloodLoss;
+				RelatedPart.CurrentInternalBleedingDamage -= 4;
 
 				//TODO: TAKE BLOOD
 				var bloodLoss = new ReagentMix();

--- a/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
@@ -109,18 +109,6 @@ namespace Items
 			set => traumaDamageChance = value;
 		}
 
-		[SerializeField,
-		 Range(1, 8),
-		 Tooltip("To fine tune how strong trauma weapons are; use a value greater than 1 to increase their power. " +
-		         "Otherwise they'll continue to use the base damage value.")]
-		private int traumaDamageMultiplier = 1;
-
-		public int TraumaDamageMultiplier
-		{
-			get => traumaDamageMultiplier;
-			set => traumaDamageMultiplier = value;
-		}
-
 		[EnumFlag]
 		public TraumaticDamageTypes TraumaticDamageType;
 

--- a/UnityProject/Assets/Scripts/Items/Medical/HealsTheLiving.cs
+++ b/UnityProject/Assets/Scripts/Items/Medical/HealsTheLiving.cs
@@ -101,7 +101,7 @@ public class HealsTheLiving : MonoBehaviour, ICheckedInteractable<HandApply>
 	{
 		if (livingHealth.HasTraumaDamage(interaction.TargetBodyPart))
 		{
-			livingHealth.HealTraumaDamage(TraumaDamageToHeal, interaction.TargetBodyPart, TraumaTypeToHeal);
+			livingHealth.HealTraumaDamage(interaction.TargetBodyPart, TraumaTypeToHeal);
 			Chat.AddActionMsgToChat(interaction,
 			$"You apply the {gameObject.ExpensiveName()} to {livingHealth.playerScript.visibleName}",
 			$"{interaction.Performer.ExpensiveName()} applies {name} to {livingHealth.playerScript.visibleName}.");

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
@@ -20,7 +20,6 @@ public class WeaponNetworkActions : NetworkBehaviour
 
 	private float traumaDamageChance = 0;
 	private TraumaticDamageTypes tramuticDamageType;
-	private int traumaDamageMultiplier = 1;
 
 	private bool isForLerpBack;
 	private Vector3 lerpFrom;
@@ -96,7 +95,6 @@ public class WeaponNetworkActions : NetworkBehaviour
 			weaponSound = weaponAttributes.hitSoundSettings == SoundItemSettings.OnlyObject ? null : weaponAttributes.ServerHitSound;
 			tramuticDamageType = weaponAttributes.TraumaticDamageType;
 			traumaDamageChance = weaponAttributes.TraumaDamageChance;
-			traumaDamageMultiplier = weaponAttributes.TraumaDamageMultiplier;
 		}
 
 		LayerTile attackedTile = null;

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
@@ -145,7 +145,7 @@ public class WeaponNetworkActions : NetworkBehaviour
 					victimHealth.ApplyDamageToBodyPart(gameObject, damage, AttackType.Melee, damageType, damageZone);
 					if(DMMath.Prob(traumaDamageChance))
 					{
-						victimHealth.ApplyTraumaDamage(damageZone, damage * traumaDamageMultiplier, tramuticDamageType);
+						victimHealth.ApplyTraumaDamage(damageZone, tramuticDamageType);
 					}
 					didHit = true;
 				}

--- a/UnityProject/Assets/Scripts/Systems/Inventory/ItemStorage.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/ItemStorage.cs
@@ -202,7 +202,7 @@ public class ItemStorage : MonoBehaviour, IServerLifecycle, IServerInventoryMove
 			{
 				if(mobHealth != null)
 				{
-					if(mobHealth.CurrentBurnDamage > mobHealth.BodyPartAshesAboveThisDamage)
+					if(mobHealth.CurrentBurnDamageLevel == TraumaDamageLevel.CRITICAL)
 					{
 						_ = Spawn.ServerPrefab(ashPrefab, mobHealth.HealthMaster.gameObject.RegisterTile().WorldPosition);
 						_ = Despawn.ServerSingle(slot.Item.gameObject);


### PR DESCRIPTION
### Purpose
part of #6272 
Small rework by the request of @PerfectTangent . The changes are as follow : 
- Trauma damage is no longer tracked by numbers and is instead an effect that happens due to a fatal blow.
- Weapons that have the ability to inflict multiple traumas no longer apply multiple of them at once, they randomly get chosen from.
- Due to the removal of `cutSize`, Slash no longer contributes to the ability of dismbowling someone and is now fully reserved for pierce attacks.
- Blunt is now a tracked level rather than three bools. _(Still need to implement #7432 after this is merged)_
- Bodyparts get charred when in a serious condition instead of a critical one now.
- Pierce now causes external bleeding on the first level while slash only starts it on the second.
- Trauma applying armor chances only happen if your body is above light-moderate damage severity. This check is skipped for cases like a bomb explosion or extreme fire damage.
- Weapons no longer have the ability to have a 100% chance to cause trauma and the general balance philosophy when balancing weapons now is that weapons should only have a 0-50% chance for trauma rolls hitting. (2.5-10% for most common items, 15-25% for most weapons that make sense for them to cause trauma, 30%+ for special items, 50% for rare and items that specialize in dismemberment.) 


### Notes:
~~This PR requires extensive testing before merging and I'd like people to report any issues they find.~~
~~This PR should be good to go **after** all weapons and limbs have been rebalanced to the new current rework. Code reviews are welcome now.~~
**TIME TO MERGE** WOOHOO

### Changelog:
CL: [New] - Fully healing a body part will now cause Punctures to close on their own.
CL: [New] - Trauma is no longer tracked by numbers and are now caused by "fatal blows".
CL: [Balance] - Blood loss values has been reduced from 5-20 to 2-18
CL: [Balance] - Internal bleeding values has been reduced to 2-4 instead of 4-18
CL: [Balance] - Weapons can no longer apply multiple traumas at once.
CL: [Balance] - Weapons can no longer apply traumas unless the body part has received light moderate total damage.
CL: [Balance] - Bleeding is now caused by Minor Breakage and Open Lacerations.
CL: [Balance] - Increased default damage thresholds to 21 instead of 18
CL: [Balance] - You can no longer slash someone until their organs fall out.
CL: [Fix] - Burn damage visuals should now correctly display on Third Degree Burns.
CL: [Fix] - Fixed some issues where some traumas were not getting applied.
CL: [Fix] - Fixed an issue where Weeping Avulsions would cause bleeding to never stop.
CL: [Fix] - Fixed an issue where Prosthetics would have the ability to bleed.