### PR TITLE
Limb reattachment surgery hotfix

### DIFF
--- a/UnityProject/Assets/Scripts/Messages/Server/SpritesMessages/SpriteUpdateMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/SpritesMessages/SpriteUpdateMessage.cs
@@ -356,7 +356,12 @@ namespace Messages.Server.SpritesMessages
 						Color TheColour = reader.ReadColor();
 						if (ProcessSection)
 						{
-							SP.SetColor(TheColour, false);
+							if (SP)
+							{
+								//TODO: remove this check - registering arrives after the sprite update, all clients will disconnect after a runtime
+								//removing and readding a bodypart through surgery would cause it, since the network identity already exists unlike the creation of a new human
+								SP.SetColor(TheColour, false);
+							}
 						}
 						else
 						{


### PR DESCRIPTION
### Purpose
CL: [Fix] Hotfixes players being disconnecting themselves after a removed limb is reattached through surgery.
Fixes #7435

### Notes:
the reattachment wont be visible for clients