### PR TITLE
Sets Reload Domain to be on by default.

### DIFF
--- a/UnityProject/ProjectSettings/EditorSettings.asset
+++ b/UnityProject/ProjectSettings/EditorSettings.asset
@@ -23,7 +23,7 @@ EditorSettings:
   m_CachingShaderPreprocessor: 0
   m_PrefabModeAllowAutoSave: 1
   m_EnterPlayModeOptionsEnabled: 1
-  m_EnterPlayModeOptions: 1
+  m_EnterPlayModeOptions: 0
   m_GameObjectNamingDigits: 1
   m_GameObjectNamingScheme: 0
   m_AssetNamingUsesSpace: 1


### PR DESCRIPTION
<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->

### Purpose
- TItle. Edits EditorSettings.asset so that Reload Domain is turned on by default again. This should prevent devs from having to manually turn it on constantly and prevent them from experiencing crashes due to it.
