### PR TITLE
Two fixes + Exposing the customization API Part 1

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Implants/Lizard/HumanHead Variant 2.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Lizard/HumanHead Variant 2.prefab
@@ -20,6 +20,11 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 6597352703958914049, guid: 78253771c2047f94c9ae40161a6be7ee,
         type: 3}
+      propertyPath: DamageThreshold
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 6597352703958914049, guid: 78253771c2047f94c9ae40161a6be7ee,
+        type: 3}
       propertyPath: CanBleedExternally
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothAntennae.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothAntennae.prefab
@@ -9,6 +9,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2282787501680206576, guid: 2cdfee5611d505240ab3835c94a38fa8,
         type: 3}
+      propertyPath: DamageThreshold
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 2282787501680206576, guid: 2cdfee5611d505240ab3835c94a38fa8,
+        type: 3}
       propertyPath: LobbyCustomisation
       value: 
       objectReference: {fileID: 7311007552350428261, guid: 05ba287f03eccc04bb3616bb3542c3f3,

--- a/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothChest.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothChest.prefab
@@ -31,7 +31,7 @@ PrefabInstance:
     - target: {fileID: 5445495118236055813, guid: cc032f91cda505e44b066c36db32760d,
         type: 3}
       propertyPath: DamageThreshold
-      value: 15
+      value: 21
       objectReference: {fileID: 0}
     - target: {fileID: 5445495118236055813, guid: cc032f91cda505e44b066c36db32760d,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothEyes.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothEyes.prefab
@@ -20,6 +20,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6088606689303362185, guid: 5c61c3c9e64efa740accb280f8923222,
         type: 3}
+      propertyPath: DamageThreshold
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 6088606689303362185, guid: 5c61c3c9e64efa740accb280f8923222,
+        type: 3}
       propertyPath: LobbyCustomisation
       value: 
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothHead.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothHead.prefab
@@ -20,6 +20,11 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 6597352703958914049, guid: 78253771c2047f94c9ae40161a6be7ee,
         type: 3}
+      propertyPath: DamageThreshold
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 6597352703958914049, guid: 78253771c2047f94c9ae40161a6be7ee,
+        type: 3}
       propertyPath: CanBleedExternally
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothLeftArm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothLeftArm.prefab
@@ -95,6 +95,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2934630090728222927, guid: 719377fefb0114b448fc6ca9f7a5a6df,
         type: 3}
+      propertyPath: DamageThreshold
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 2934630090728222927, guid: 719377fefb0114b448fc6ca9f7a5a6df,
+        type: 3}
       propertyPath: DismembermentChance
       value: 0.1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothLeftArm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothLeftArm.prefab
@@ -67,6 +67,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1807782268030479055, guid: 719377fefb0114b448fc6ca9f7a5a6df,
+        type: 3}
+      propertyPath: customNetTransform
+      value: 
+      objectReference: {fileID: 6276861095716975216}
     - target: {fileID: 1807895052203439847, guid: 719377fefb0114b448fc6ca9f7a5a6df,
         type: 3}
       propertyPath: m_AssetId
@@ -145,3 +150,15 @@ PrefabInstance:
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 719377fefb0114b448fc6ca9f7a5a6df, type: 3}
+--- !u!114 &6276861095716975216 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1808041456854836867, guid: 719377fefb0114b448fc6ca9f7a5a6df,
+    type: 3}
+  m_PrefabInstance: {fileID: 5624036924989560051}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothLeftLeg.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothLeftLeg.prefab
@@ -9,6 +9,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1544594378003915950, guid: 2e6f2ff9beb985749940d242877d84f0,
         type: 3}
+      propertyPath: DamageThreshold
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 1544594378003915950, guid: 2e6f2ff9beb985749940d242877d84f0,
+        type: 3}
       propertyPath: DismembermentChance
       value: 0.1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothMarkings.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothMarkings.prefab
@@ -79,6 +79,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2378934203328871246, guid: 1ce21cfcc54d23d42825f0d4a9b15d49,
         type: 3}
+      propertyPath: DamageThreshold
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 2378934203328871246, guid: 1ce21cfcc54d23d42825f0d4a9b15d49,
+        type: 3}
       propertyPath: LobbyCustomisation
       value: 
       objectReference: {fileID: 7311007552350428261, guid: 1cdb6616b987ef0489edf7a59858a221,

--- a/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothRightArm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothRightArm.prefab
@@ -32,6 +32,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6313817628243374210, guid: ba9a875c31908af4ab3749cd127a2edb,
         type: 3}
+      propertyPath: DamageThreshold
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 6313817628243374210, guid: ba9a875c31908af4ab3749cd127a2edb,
+        type: 3}
       propertyPath: DismembermentChance
       value: 0.1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothRightLeg.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothRightLeg.prefab
@@ -107,6 +107,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
         type: 3}
+      propertyPath: DamageThreshold
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
+        type: 3}
       propertyPath: DismembermentChance
       value: 0.1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothWings.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Moth/MothWings.prefab
@@ -20,6 +20,11 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 5688082005075186663, guid: d243d9aff97ede04581d82563a576f0c,
         type: 3}
+      propertyPath: DamageThreshold
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 5688082005075186663, guid: d243d9aff97ede04581d82563a576f0c,
+        type: 3}
       propertyPath: LobbyCustomisation
       value: 
       objectReference: {fileID: 7311007552350428261, guid: fa19af5f944e46e448ad7c8e663f71e6,

--- a/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawn.cs
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawn.cs
@@ -413,8 +413,7 @@ public static class PlayerSpawn
 		{
 			var dummy = ServerCreatePlayer(spawnTransform.position.RoundToInt());
 
-			CharacterSettings randomSettings = new CharacterSettings();
-			randomSettings = CharacterSettings.RandomizeCharacterSettings();
+			CharacterSettings randomSettings = CharacterSettings.RandomizeCharacterSettings();
 
 			ServerTransferPlayer(null, dummy, null, Event.PlayerSpawned, randomSettings);
 

--- a/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawn.cs
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawn.cs
@@ -7,6 +7,7 @@ using Systems.Spawns;
 using Managers;
 using Messages.Server;
 using Messages.Server.LocalGuiMessages;
+using UI.CharacterCreator;
 
 /// <summary>
 /// Main API for dealing with spawning players and related things.
@@ -412,11 +413,14 @@ public static class PlayerSpawn
 		{
 			var dummy = ServerCreatePlayer(spawnTransform.position.RoundToInt());
 
-			ServerTransferPlayer(null, dummy, null, Event.PlayerSpawned, new CharacterSettings());
+			CharacterSettings randomSettings = new CharacterSettings();
+			randomSettings = CharacterCustomization.RandomizeCharacterSettings();
+
+			ServerTransferPlayer(null, dummy, null, Event.PlayerSpawned, randomSettings);
 
 
 			//fire all hooks
-			var info = SpawnInfo.Player(OccupationList.Instance.Get(JobType.ASSISTANT), new CharacterSettings(), CustomNetworkManager.Instance.humanPlayerPrefab,
+			var info = SpawnInfo.Player(OccupationList.Instance.Get(JobType.ASSISTANT), randomSettings, CustomNetworkManager.Instance.humanPlayerPrefab,
 				SpawnDestination.At(spawnTransform.gameObject));
 			Spawn._ServerFireClientServerSpawnHooks(SpawnResult.Single(info, dummy));
 		}

--- a/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawn.cs
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawn.cs
@@ -414,7 +414,7 @@ public static class PlayerSpawn
 			var dummy = ServerCreatePlayer(spawnTransform.position.RoundToInt());
 
 			CharacterSettings randomSettings = new CharacterSettings();
-			randomSettings = CharacterCustomization.RandomizeCharacterSettings();
+			randomSettings = CharacterSettings.RandomizeCharacterSettings();
 
 			ServerTransferPlayer(null, dummy, null, Event.PlayerSpawned, randomSettings);
 

--- a/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPart.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPart.cs
@@ -324,7 +324,22 @@ namespace HealthV2
 				{
 					bodyPart.IsBleeding = true;
 				}
+
+				if (bodyPart.BodyPartType == BodyPartType.LeftArm || bodyPart.BodyPartType == BodyPartType.RightArm
+				|| bodyPart.BodyPartType == BodyPartType.LeftHand || bodyPart.BodyPartType == BodyPartType.RightHand)
+				{
+					DynamicItemStorage storge = HealthMaster.playerScript.DynamicItemStorage;
+					foreach (ItemSlot itemSlot in storge.GetNamedItemSlots(NamedSlot.leftHand))
+					{
+						Inventory.ServerDrop(itemSlot);
+					}
+					foreach (var itemSlot in storge.GetNamedItemSlots(NamedSlot.rightHand))
+					{
+						Inventory.ServerDrop(itemSlot);
+					}
+				}
 			}
+
 			HealthMaster.BodyPartStorage.ServerTryRemove(gameObject);
 			var bodyPartUISlot = GetComponent<BodyPartUISlots>();
 			var dynamicItemStorage = HealthMaster.GetComponent<DynamicItemStorage>();

--- a/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPart.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPart.cs
@@ -324,23 +324,9 @@ namespace HealthV2
 				{
 					bodyPart.IsBleeding = true;
 				}
-
-				if (bodyPart.BodyPartType == BodyPartType.LeftArm || bodyPart.BodyPartType == BodyPartType.RightArm
-				|| bodyPart.BodyPartType == BodyPartType.LeftHand || bodyPart.BodyPartType == BodyPartType.RightHand
-				|| bodyPart.DeathOnRemoval)
-				{
-					DynamicItemStorage storge = HealthMaster.playerScript.DynamicItemStorage;
-					foreach (ItemSlot itemSlot in storge.GetNamedItemSlots(NamedSlot.leftHand))
-					{
-						Inventory.ServerDrop(itemSlot);
-					}
-					foreach (var itemSlot in storge.GetNamedItemSlots(NamedSlot.rightHand))
-					{
-						Inventory.ServerDrop(itemSlot);
-					}
-				}
 			}
 
+			DropItemsOnDismemberment(this);
 			HealthMaster.BodyPartStorage.ServerTryRemove(gameObject);
 			var bodyPartUISlot = GetComponent<BodyPartUISlots>();
 			var dynamicItemStorage = HealthMaster.GetComponent<DynamicItemStorage>();
@@ -358,6 +344,42 @@ namespace HealthV2
 			if (gibsEntireBodyOnRemoval && beingGibbed == false)
 			{
 				HealthMaster.Gib();
+			}
+		}
+
+		/// <summary>
+		/// Drops items from a player's bodyPart inventory upon dismemberment.
+		/// </summary>
+		/// <param name="bodyPart">The bodyPart that's cut off</param>
+		private void DropItemsOnDismemberment(BodyPart bodyPart)
+		{
+			DynamicItemStorage storge = HealthMaster.playerScript.DynamicItemStorage;
+
+			void RemoveItemsFromSlot(NamedSlot namedSlot)
+			{
+				foreach (ItemSlot itemSlot in storge.GetNamedItemSlots(namedSlot))
+				{
+					Inventory.ServerDrop(itemSlot);
+				}
+			}
+
+			//We remove items from both hands to simulate a pain effect, because usually when you lose your arm the other one goes into shock
+			if (bodyPart.BodyPartType == BodyPartType.LeftArm
+			    || bodyPart.BodyPartType == BodyPartType.RightArm || bodyPart.BodyPartType == BodyPartType.LeftHand
+			    || bodyPart.BodyPartType == BodyPartType.RightHand || bodyPart.DeathOnRemoval)
+			{
+				RemoveItemsFromSlot(NamedSlot.leftHand);
+				RemoveItemsFromSlot(NamedSlot.rightHand);
+			}
+			if(bodyPart.BodyPartType == BodyPartType.RightLeg || bodyPart.BodyPartType == BodyPartType.LeftLeg ||
+			   bodyPart.BodyPartType == BodyPartType.LeftFoot || bodyPart.BodyPartType == BodyPartType.RightFoot)
+			{
+				RemoveItemsFromSlot(NamedSlot.feet);
+			}
+
+			if (bodyPart.BodyPartType == BodyPartType.Head)
+			{
+				RemoveItemsFromSlot(NamedSlot.head);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPart.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPart.cs
@@ -326,7 +326,8 @@ namespace HealthV2
 				}
 
 				if (bodyPart.BodyPartType == BodyPartType.LeftArm || bodyPart.BodyPartType == BodyPartType.RightArm
-				|| bodyPart.BodyPartType == BodyPartType.LeftHand || bodyPart.BodyPartType == BodyPartType.RightHand)
+				|| bodyPart.BodyPartType == BodyPartType.LeftHand || bodyPart.BodyPartType == BodyPartType.RightHand
+				|| bodyPart.DeathOnRemoval)
 				{
 					DynamicItemStorage storge = HealthMaster.playerScript.DynamicItemStorage;
 					foreach (ItemSlot itemSlot in storge.GetNamedItemSlots(NamedSlot.leftHand))

--- a/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
@@ -202,6 +202,7 @@ public class PlayerSprites : MonoBehaviour
 
 		if (ThisCharacter.SerialisedBodyPartCustom == null)
 		{
+			//TODO : (Max) - Fix SerialisedBodyPartCustom being null on Dummy players
 			Logger.LogError($"{gameObject} has spawned with null bodyPart customizations. This error should only appear for Dummy players only.");
 			return;
 		}

--- a/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
@@ -199,15 +199,7 @@ public class PlayerSprites : MonoBehaviour
 	{
 
 		CustomisationStorage customisationStorage = null;
-		//(Max) : We need to find a way to fix customizations for Dummy players.
-		//Dummy players can be re-usable for other stuff in the future so I'm working on a PR to fix this;
-		//Until then I think this check should be left here.
-		if (ThisCharacter.SerialisedBodyPartCustom == null)
-		{
-			Logger.LogWarning($"{ThisCharacter.Name} has no Serialised customizations, This issue should be only related " +
-			                  $"to dummy players.");
-			return;
-		}
+
 		foreach (var Custom in ThisCharacter.SerialisedBodyPartCustom)
 		{
 			if (livingHealthMasterBase.name == Custom.path)

--- a/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
@@ -200,6 +200,12 @@ public class PlayerSprites : MonoBehaviour
 
 		CustomisationStorage customisationStorage = null;
 
+		if (ThisCharacter.SerialisedBodyPartCustom == null)
+		{
+			Logger.LogError($"{gameObject} has spawned with null bodyPart customizations. This error should only appear for Dummy players only.");
+			return;
+		}
+
 		foreach (var Custom in ThisCharacter.SerialisedBodyPartCustom)
 		{
 			if (livingHealthMasterBase.name == Custom.path)

--- a/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
@@ -199,6 +199,15 @@ public class PlayerSprites : MonoBehaviour
 	{
 
 		CustomisationStorage customisationStorage = null;
+		//(Max) : We need to find a way to fix customizations for Dummy players.
+		//Dummy players can be re-usable for other stuff in the future so I'm working on a PR to fix this;
+		//Until then I think this check should be left here.
+		if (ThisCharacter.SerialisedBodyPartCustom == null)
+		{
+			Logger.LogWarning($"{ThisCharacter.Name} has no Serialised customizations, This issue should be only related " +
+			                  $"to dummy players.");
+			return;
+		}
 		foreach (var Custom in ThisCharacter.SerialisedBodyPartCustom)
 		{
 			if (livingHealthMasterBase.name == Custom.path)

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -1490,7 +1490,7 @@ namespace UI.CharacterCreator
 			random.Name = RandomizeCharacterName(random);
 			random.Age  = UnityEngine.Random.Range(19, 78);
 			random.SkinTone = RandomizeCharacterSkinToneHTMLString(random);
-			GetRandomUnderwearCustomisation(random);
+			random.SerialisedExternalCustom = GetRandomUnderwearCustomisation(random);
 
 			//Randomises player accents. (Italian, Scottish, etc)
 			random.Speech = RandomizeCharachterAccent();
@@ -1498,49 +1498,36 @@ namespace UI.CharacterCreator
 			return random;
 		}
 
-		public static void GetRandomUnderwearCustomisation(CharacterSettings data)
+		public static List<ExternalCustomisation> GetRandomUnderwearCustomisation(CharacterSettings data)
 		{
 			var RaceData = GetRaceData(data);
+			List<ExternalCustomisation> externalCustomisations = new List<ExternalCustomisation>();
+
+			void logic(CustomisationAllowedSetting setting)
+			{
+				PlayerCustomisationData customizationToAdd = setting.CustomisationGroup.PlayerCustomisations.PickRandom();
+				ExternalCustomisation newExternalCustomisation = new ExternalCustomisation();
+				newExternalCustomisation.Key = customizationToAdd.name;
+				newExternalCustomisation.SerialisedValue = SerialiseCustomizationData(customizationToAdd);
+				externalCustomisations.Add(newExternalCustomisation);
+			}
+
 			foreach (CustomisationAllowedSetting customisation in RaceData.Base.CustomisationSettings)
 			{
-				Debug.Log($"Checking {customisation} || {customisation.CustomisationGroup.name}");
-				if (customisation.CustomisationGroup.name == "PlayerUnderShirt")
-				{
-					PlayerCustomisationData customizationToAdd = customisation.CustomisationGroup.PlayerCustomisations.PickRandom();
-					Debug.Log(customizationToAdd.Name);
-					ExternalCustomisation newExternalCustomisation = new ExternalCustomisation();
-					newExternalCustomisation.Key = customizationToAdd.name;
-					newExternalCustomisation.SerialisedValue = SerialiseCustomizationData(customizationToAdd);
-					Debug.Log(newExternalCustomisation);
-					data.SerialisedExternalCustom.Append(newExternalCustomisation);
-				}
-				if (customisation.CustomisationGroup.name == "PlayerUnderWear")
-				{
-					PlayerCustomisationData customizationToAdd = customisation.CustomisationGroup.PlayerCustomisations.PickRandom();
-					Debug.Log(customizationToAdd.Name);
-					ExternalCustomisation newExternalCustomisation = new ExternalCustomisation();
-					newExternalCustomisation.Key = customizationToAdd.name;
-					newExternalCustomisation.SerialisedValue = SerialiseCustomizationData(customizationToAdd);
-					Debug.Log(newExternalCustomisation);
-					data.SerialisedExternalCustom.Append(newExternalCustomisation);
-				}
-				if (customisation.CustomisationGroup.name == "PlayerSocks")
-				{
-					PlayerCustomisationData customizationToAdd = customisation.CustomisationGroup.PlayerCustomisations.PickRandom();
-					Debug.Log(customizationToAdd.Name);
-					ExternalCustomisation newExternalCustomisation = new ExternalCustomisation();
-					newExternalCustomisation.Key = customizationToAdd.name;
-					newExternalCustomisation.SerialisedValue = SerialiseCustomizationData(customizationToAdd);
-					Debug.Log(newExternalCustomisation);
-					data.SerialisedExternalCustom.Append(newExternalCustomisation);
-				}
+				if (customisation.CustomisationGroup.name == "PlayerUnderShirt") logic(customisation);
+				if (customisation.CustomisationGroup.name == "PlayerUnderWear") logic(customisation);
+				if (customisation.CustomisationGroup.name == "PlayerSocks") logic(customisation);
 			}
+
+			return externalCustomisations;
 		}
 
 		public static CharacterSettings.CustomisationClass SerialiseCustomizationData(PlayerCustomisationData data)
 		{
 			var newcurrentSetting = new CharacterSettings.CustomisationClass();
-			newcurrentSetting.Colour = "#" + ColorUtility.ToHtmlStringRGB(Color.white);
+			newcurrentSetting.Colour = "#" + ColorUtility.ToHtmlStringRGB(new Color(UnityEngine.Random.Range(0.1f, 1f),
+				UnityEngine.Random.Range(0.1f, 1f),
+				UnityEngine.Random.Range(0.1f, 1f), 1f));
 			newcurrentSetting.SelectedName = data.Name;
 			return newcurrentSetting;
 

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -669,7 +669,7 @@ namespace UI.CharacterCreator
 
 		public void RollRandomCharacter()
 		{
-			currentCharacter = RandomizeCharacterSettings();
+			currentCharacter = CharacterSettings.RandomizeCharacterSettings();
 
 			//Randomises player accents. (Italian, Scottish, etc)
 
@@ -1471,120 +1471,6 @@ namespace UI.CharacterCreator
 					ThisSetRace = Race;
 				}
 			}
-		}
-
-		#endregion
-
-		#region StaticCustomizationFunctions
-
-		public static CharacterSettings RandomizeCharacterSettings()
-		{
-			CharacterSettings random = new CharacterSettings();
-			// Randomise gender
-			Type gender = typeof(BodyType);
-			Array genders = gender.GetEnumValues();
-			int index = UnityEngine.Random.Range(0,3);
-			random.BodyType = (BodyType)genders.GetValue(index);
-
-			//Randomises player name and age and skin tone.
-			random.Name = RandomizeCharacterName(random);
-			random.Age  = UnityEngine.Random.Range(19, 78);
-			random.SkinTone = RandomizeCharacterSkinToneHTMLString(random);
-			random.SerialisedExternalCustom = GetRandomUnderwearCustomisation(random);
-
-			//Randomises player accents. (Italian, Scottish, etc)
-			random.Speech = RandomizeCharachterAccent();
-
-			return random;
-		}
-
-		public static List<ExternalCustomisation> GetRandomUnderwearCustomisation(CharacterSettings data)
-		{
-			var RaceData = GetRaceData(data);
-			List<ExternalCustomisation> externalCustomisations = new List<ExternalCustomisation>();
-
-			void logic(CustomisationAllowedSetting setting)
-			{
-				PlayerCustomisationData customizationToAdd = setting.CustomisationGroup.PlayerCustomisations.PickRandom();
-				ExternalCustomisation newExternalCustomisation = new ExternalCustomisation();
-				newExternalCustomisation.Key = customizationToAdd.name;
-				newExternalCustomisation.SerialisedValue = SerialiseCustomizationData(customizationToAdd);
-				externalCustomisations.Add(newExternalCustomisation);
-			}
-
-			foreach (CustomisationAllowedSetting customisation in RaceData.Base.CustomisationSettings)
-			{
-				if (customisation.CustomisationGroup.name == "PlayerUnderShirt") logic(customisation);
-				if (customisation.CustomisationGroup.name == "PlayerUnderWear") logic(customisation);
-				if (customisation.CustomisationGroup.name == "PlayerSocks") logic(customisation);
-			}
-
-			return externalCustomisations;
-		}
-
-		public static CharacterSettings.CustomisationClass SerialiseCustomizationData(PlayerCustomisationData data)
-		{
-			var newcurrentSetting = new CharacterSettings.CustomisationClass();
-			newcurrentSetting.Colour = "#" + ColorUtility.ToHtmlStringRGB(new Color(UnityEngine.Random.Range(0.1f, 1f),
-				UnityEngine.Random.Range(0.1f, 1f),
-				UnityEngine.Random.Range(0.1f, 1f), 1f));
-			newcurrentSetting.SelectedName = data.Name;
-			return newcurrentSetting;
-
-		}
-
-		public static string RandomizeCharacterSkinToneHTMLString(CharacterSettings data)
-		{
-			var RaceData = GetRaceData(data);
-
-			List<Color> raceSkinColors = RaceData.Base.SkinColours;
-			if (raceSkinColors.Count != 0)
-			{
-				return "#" + ColorUtility.ToHtmlStringRGB(raceSkinColors[UnityEngine.Random.Range(0, raceSkinColors.Count - 1)]);
-			}
-			return "#" + ColorUtility.ToHtmlStringRGBA(new Color(UnityEngine.Random.Range(0.1f, 1f),
-					UnityEngine.Random.Range(0.1f, 1f),
-					UnityEngine.Random.Range(0.1f, 1f), 1f));
-		}
-
-		public static string RandomizeCharacterName(CharacterSettings data, bool isNotPlayerDebug = true)
-		{
-			switch (data.BodyType)
-			{
-				case BodyType.Male:
-					return StringManager.GetRandomMaleName();
-				case BodyType.Female:
-					return StringManager.GetRandomFemaleName();
-				default:
-					if (isNotPlayerDebug) return StringManager.GetRandomName(Gender.NonBinary);
-					else return "Cuban Pete";
-			}
-		}
-
-		public static PlayerHealthData GetRaceData(CharacterSettings data)
-		{
-			foreach (var Race in RaceSOSingleton.Instance.Races)
-			{
-				if (Race.name == data.Species)
-				{
-					return Race;
-				}
-			}
-			Logger.LogError($"Unable to get PlayerHealthData from {data.Name} / {data.Username}");
-			return new PlayerHealthData();
-		}
-
-		public static Speech RandomizeCharachterAccent()
-		{
-			int accentChance = UnityEngine.Random.Range(0, 100);
-			if(accentChance <= 35)
-			{
-				Type accent = typeof(Speech);
-				Array accents = accent.GetEnumValues();
-				int index = UnityEngine.Random.Range(0, 7);
-				return (Speech)accents.GetValue(index);
-			}
-			return Speech.None;
 		}
 
 		#endregion

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -1490,11 +1490,43 @@ namespace UI.CharacterCreator
 			random.Name = RandomizeCharacterName(random);
 			random.Age  = UnityEngine.Random.Range(19, 78);
 			random.SkinTone = RandomizeCharacterSkinToneHTMLString(random);
+			GetRandomUnderwearCustomisation(random);
 
 			//Randomises player accents. (Italian, Scottish, etc)
 			random.Speech = RandomizeCharachterAccent();
 
 			return random;
+		}
+
+		public static void GetRandomUnderwearCustomisation(CharacterSettings data)
+		{
+			var RaceData = GetRaceData(data);
+			foreach (CustomisationAllowedSetting customisation in RaceData.Base.CustomisationSettings)
+			{
+				Debug.Log($"Checking {customisation} || {customisation.CustomisationGroup.name}");
+				if (customisation.CustomisationGroup.name == "PlayerUnderShirt")
+				{
+					PlayerCustomisationData customizationToAdd = customisation.CustomisationGroup.PlayerCustomisations.PickRandom();
+					Debug.Log(customizationToAdd.Name);
+					ExternalCustomisation serializedCustom = new ExternalCustomisation();
+					serializedCustom.SerialisedValue.SelectedName = customizationToAdd.Name;
+					data.SerialisedExternalCustom.Append(serializedCustom);
+				}
+				if (customisation.CustomisationGroup.name == "PlayerUnderWear")
+				{
+					PlayerCustomisationData customizationToAdd = customisation.CustomisationGroup.PlayerCustomisations.PickRandom();
+					ExternalCustomisation serializedCustom = new ExternalCustomisation();
+					serializedCustom.SerialisedValue.SelectedName = customizationToAdd.Name;
+					data.SerialisedExternalCustom.Append(serializedCustom);
+				}
+				if (customisation.CustomisationGroup.name == "PlayerSocks")
+				{
+					PlayerCustomisationData customizationToAdd = customisation.CustomisationGroup.PlayerCustomisations.PickRandom();
+					ExternalCustomisation serializedCustom = new ExternalCustomisation();
+					serializedCustom.SerialisedValue.SelectedName = customizationToAdd.Name;
+					data.SerialisedExternalCustom.Append(serializedCustom);
+				}
+			}
 		}
 
 		public static string RandomizeCharacterSkinToneHTMLString(CharacterSettings data)

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -1508,25 +1508,42 @@ namespace UI.CharacterCreator
 				{
 					PlayerCustomisationData customizationToAdd = customisation.CustomisationGroup.PlayerCustomisations.PickRandom();
 					Debug.Log(customizationToAdd.Name);
-					ExternalCustomisation serializedCustom = new ExternalCustomisation();
-					serializedCustom.SerialisedValue.SelectedName = customizationToAdd.Name;
-					data.SerialisedExternalCustom.Append(serializedCustom);
+					ExternalCustomisation newExternalCustomisation = new ExternalCustomisation();
+					newExternalCustomisation.Key = customizationToAdd.name;
+					newExternalCustomisation.SerialisedValue = SerialiseCustomizationData(customizationToAdd);
+					Debug.Log(newExternalCustomisation);
+					data.SerialisedExternalCustom.Append(newExternalCustomisation);
 				}
 				if (customisation.CustomisationGroup.name == "PlayerUnderWear")
 				{
 					PlayerCustomisationData customizationToAdd = customisation.CustomisationGroup.PlayerCustomisations.PickRandom();
-					ExternalCustomisation serializedCustom = new ExternalCustomisation();
-					serializedCustom.SerialisedValue.SelectedName = customizationToAdd.Name;
-					data.SerialisedExternalCustom.Append(serializedCustom);
+					Debug.Log(customizationToAdd.Name);
+					ExternalCustomisation newExternalCustomisation = new ExternalCustomisation();
+					newExternalCustomisation.Key = customizationToAdd.name;
+					newExternalCustomisation.SerialisedValue = SerialiseCustomizationData(customizationToAdd);
+					Debug.Log(newExternalCustomisation);
+					data.SerialisedExternalCustom.Append(newExternalCustomisation);
 				}
 				if (customisation.CustomisationGroup.name == "PlayerSocks")
 				{
 					PlayerCustomisationData customizationToAdd = customisation.CustomisationGroup.PlayerCustomisations.PickRandom();
-					ExternalCustomisation serializedCustom = new ExternalCustomisation();
-					serializedCustom.SerialisedValue.SelectedName = customizationToAdd.Name;
-					data.SerialisedExternalCustom.Append(serializedCustom);
+					Debug.Log(customizationToAdd.Name);
+					ExternalCustomisation newExternalCustomisation = new ExternalCustomisation();
+					newExternalCustomisation.Key = customizationToAdd.name;
+					newExternalCustomisation.SerialisedValue = SerialiseCustomizationData(customizationToAdd);
+					Debug.Log(newExternalCustomisation);
+					data.SerialisedExternalCustom.Append(newExternalCustomisation);
 				}
 			}
+		}
+
+		public static CharacterSettings.CustomisationClass SerialiseCustomizationData(PlayerCustomisationData data)
+		{
+			var newcurrentSetting = new CharacterSettings.CustomisationClass();
+			newcurrentSetting.Colour = "#" + ColorUtility.ToHtmlStringRGB(Color.white);
+			newcurrentSetting.SelectedName = data.Name;
+			return newcurrentSetting;
+
 		}
 
 		public static string RandomizeCharacterSkinToneHTMLString(CharacterSettings data)

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterSettings.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterSettings.cs
@@ -262,7 +262,7 @@ public class CharacterSettings
 		//Randomises player name and age and skin tone.
 		random.Name = RandomizeCharacterName(random);
 		random.Age  = UnityEngine.Random.Range(19, 78);
-		random.SkinTone = RandomizeCharacterSkinToneHTMLString(random);
+		random.SkinTone = RandomizeCharacterSkinToneHtmlString(random);
 		random.SerialisedExternalCustom = GetRandomUnderwearCustomisation(random);
 
 		//Randomises player accents. (Italian, Scottish, etc)
@@ -276,7 +276,7 @@ public class CharacterSettings
 		var RaceData = GetRaceData(data);
 		List<ExternalCustomisation> externalCustomisations = new List<ExternalCustomisation>();
 
-		void logic(CustomisationAllowedSetting setting)
+		void Logic(CustomisationAllowedSetting setting)
 		{
 			PlayerCustomisationData customizationToAdd = setting.CustomisationGroup.PlayerCustomisations.PickRandom();
 			ExternalCustomisation newExternalCustomisation = new ExternalCustomisation();
@@ -287,9 +287,9 @@ public class CharacterSettings
 
 		foreach (CustomisationAllowedSetting customisation in RaceData.Base.CustomisationSettings)
 		{
-			if (customisation.CustomisationGroup.name == "PlayerUnderShirt") logic(customisation);
-			if (customisation.CustomisationGroup.name == "PlayerUnderWear") logic(customisation);
-			if (customisation.CustomisationGroup.name == "PlayerSocks") logic(customisation);
+			if (customisation.CustomisationGroup.name == "PlayerUnderShirt") Logic(customisation);
+			if (customisation.CustomisationGroup.name == "PlayerUnderWear")  Logic(customisation);
+			if (customisation.CustomisationGroup.name == "PlayerSocks")      Logic(customisation);
 		}
 
 		return externalCustomisations;
@@ -304,7 +304,7 @@ public class CharacterSettings
 		return newcurrentSetting;
 	}
 
-	public static string RandomizeCharacterSkinToneHTMLString(CharacterSettings data)
+	public static string RandomizeCharacterSkinToneHtmlString(CharacterSettings data)
 	{
 		var RaceData = GetRaceData(data);
 

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterSettings.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterSettings.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using UI.CharacterCreator;
+using UnityEngine;
 
 /// <summary>
 /// Class containing all character preferences for a player
@@ -246,4 +247,117 @@ public class CharacterSettings
 				return "have";
 		}
 	}
+
+	#region StaticCustomizationFunctions
+
+	public static CharacterSettings RandomizeCharacterSettings()
+	{
+		CharacterSettings random = new CharacterSettings();
+		// Randomise gender
+		Type gender = typeof(BodyType);
+		Array genders = gender.GetEnumValues();
+		int index = UnityEngine.Random.Range(0,3);
+		random.BodyType = (BodyType)genders.GetValue(index);
+
+		//Randomises player name and age and skin tone.
+		random.Name = RandomizeCharacterName(random);
+		random.Age  = UnityEngine.Random.Range(19, 78);
+		random.SkinTone = RandomizeCharacterSkinToneHTMLString(random);
+		random.SerialisedExternalCustom = GetRandomUnderwearCustomisation(random);
+
+		//Randomises player accents. (Italian, Scottish, etc)
+		random.Speech = RandomizeCharachterAccent();
+
+		return random;
+	}
+
+	public static List<ExternalCustomisation> GetRandomUnderwearCustomisation(CharacterSettings data)
+	{
+		var RaceData = GetRaceData(data);
+		List<ExternalCustomisation> externalCustomisations = new List<ExternalCustomisation>();
+
+		void logic(CustomisationAllowedSetting setting)
+		{
+			PlayerCustomisationData customizationToAdd = setting.CustomisationGroup.PlayerCustomisations.PickRandom();
+			ExternalCustomisation newExternalCustomisation = new ExternalCustomisation();
+			newExternalCustomisation.Key = customizationToAdd.name;
+			newExternalCustomisation.SerialisedValue = SerialiseCustomizationData(customizationToAdd);
+			externalCustomisations.Add(newExternalCustomisation);
+		}
+
+		foreach (CustomisationAllowedSetting customisation in RaceData.Base.CustomisationSettings)
+		{
+			if (customisation.CustomisationGroup.name == "PlayerUnderShirt") logic(customisation);
+			if (customisation.CustomisationGroup.name == "PlayerUnderWear") logic(customisation);
+			if (customisation.CustomisationGroup.name == "PlayerSocks") logic(customisation);
+		}
+
+		return externalCustomisations;
+	}
+
+	public static CustomisationClass SerialiseCustomizationData(PlayerCustomisationData data)
+	{
+		var newcurrentSetting = new CustomisationClass();
+		newcurrentSetting.Colour = "#" + ColorUtility.ToHtmlStringRGB(new Color(UnityEngine.Random.Range(0.1f, 1f),
+			UnityEngine.Random.Range(0.1f, 1f), UnityEngine.Random.Range(0.1f, 1f), 1f));
+		newcurrentSetting.SelectedName = data.Name;
+		return newcurrentSetting;
+	}
+
+	public static string RandomizeCharacterSkinToneHTMLString(CharacterSettings data)
+	{
+		var RaceData = GetRaceData(data);
+
+		List<Color> raceSkinColors = RaceData.Base.SkinColours;
+		if (raceSkinColors.Count != 0)
+		{
+			return "#" +
+			       ColorUtility.ToHtmlStringRGB(raceSkinColors[UnityEngine.Random.Range(0, raceSkinColors.Count - 1)]);
+		}
+
+		return "#" + ColorUtility.ToHtmlStringRGBA(new Color(UnityEngine.Random.Range(0.1f, 1f),
+			UnityEngine.Random.Range(0.1f, 1f),
+			UnityEngine.Random.Range(0.1f, 1f), 1f));
+	}
+
+	public static string RandomizeCharacterName(CharacterSettings data, bool isNotPlayerDebug = true)
+	{
+		switch (data.BodyType)
+		{
+			case BodyType.Male:
+				return StringManager.GetRandomMaleName();
+			case BodyType.Female:
+				return StringManager.GetRandomFemaleName();
+			default:
+				if (isNotPlayerDebug) return StringManager.GetRandomName(Gender.NonBinary);
+				else return "Cuban Pete";
+		}
+	}
+
+	public static PlayerHealthData GetRaceData(CharacterSettings data)
+	{
+		foreach (var Race in RaceSOSingleton.Instance.Races)
+		{
+			if (Race.name == data.Species) return Race;
+		}
+
+		Logger.LogError($"Unable to get PlayerHealthData from {data.Name} / {data.Username}");
+		return new PlayerHealthData();
+	}
+
+	public static Speech RandomizeCharachterAccent()
+	{
+		int accentChance = UnityEngine.Random.Range(0, 100);
+		if (accentChance <= 35)
+		{
+			Type accent = typeof(Speech);
+			Array accents = accent.GetEnumValues();
+			int index = UnityEngine.Random.Range(0, 7);
+			return (Speech) accents.GetValue(index);
+		}
+
+		return Speech.None;
+	}
+
+	#endregion
 }


### PR DESCRIPTION
fixes #7350 
fixes an issue related to moth and lizard numbers being wrong for trauma damage.

This PR is the first step for exposing the customization functions to be able to create fully customizable characters during runtime.
This is more meant for things like NPCs, Dummy characters, changing your underwear and hair style when interacting with a mirror or drawer, etc.

### Changelog :
CL : [Fix] - Moths will no longer turn their hands into burnt sticks by just touching light bulbs
CL : [Fix] - Fixed an issue where lizard heads were weaker than humans
CL : [Fix] - Fixed an issue where you wouldn't drop the items you were holding in your hand upon getting your limbs dismembered.
