### PR TITLE
Decreases max chunk size for TileChange Message. Catches some left over NRE's

### DIFF
--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -323,7 +323,7 @@ namespace HealthV2
 						}
 					}
 				}
-				if (DeathOnRemoval)
+				if (DeathOnRemoval && HealthMaster != null)
 				{
 					HealthMaster.Death();
 				}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -327,8 +327,17 @@ namespace HealthV2
 				{
 					HealthMaster.Death();
 				}
-				_ = Spawn.ServerPrefab(OrganStorage.AshPrefab, HealthMaster.gameObject.RegisterTile().WorldPosition);
-				_ = Despawn.ServerSingle(this.gameObject);
+
+				try
+				{
+					_ = Spawn.ServerPrefab(OrganStorage.AshPrefab,
+						HealthMaster.gameObject.RegisterTile().WorldPosition);
+					_ = Despawn.ServerSingle(this.gameObject);
+				}
+				catch (NullReferenceException exception)
+				{
+					Logger.LogError("Caught a NRE in BodyPartTraumaDamage.AshBodyPart() ", Category.Health);
+				}
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Messages/Server/TileChangesNewClientSync.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/TileChangesNewClientSync.cs
@@ -16,7 +16,7 @@ namespace Messages.Server
 		}
 
 		//just a best guess, try increasing it until the message exceeds mirror's limit
-		private static readonly int MAX_CHANGES_PER_MESSAGE = 100;
+		private static readonly int MAX_CHANGES_PER_MESSAGE = 30;
 
 		public override void Process(NetMessage msg)
 		{

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -135,12 +135,12 @@ public class JoinedViewer : NetworkBehaviour
 			yield break;
 		}
 
-		while (netIdentity != null && !netIdentity.observers.ContainsKey(this.connectionToClient.connectionId))
+		while (netIdentity != null && connectionToClient != null && !netIdentity.observers.ContainsKey(this.connectionToClient.connectionId))
 		{
 			yield return WaitFor.EndOfFrame;
 		}
 
-		if (netIdentity != null)
+		if (netIdentity != null && connectionToClient != null)
 		{
 			yield return WaitFor.EndOfFrame;
 			TargetLocalPlayerRejoinUI(connectionToClient);

--- a/UnityProject/Assets/Scripts/Player/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerScript.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text;
 using Systems.Ai;
 using UnityEngine;
@@ -344,7 +345,21 @@ public class PlayerScript : NetworkBehaviour, IMatrixRotation, IAdminInfo, IActi
 	/// <summary>
 	/// True if this player is a ghost, meaning they exist in the ghost layer
 	/// </summary>
-	public bool IsGhost => gameObject == null || PlayerUtils.IsGhost(gameObject);
+	public bool IsGhost
+	{
+		get
+		{
+			try
+			{
+				return gameObject == null || PlayerUtils.IsGhost(gameObject);
+			}
+			catch (NullReferenceException exception)
+			{
+				Logger.LogError("Caught an NRE in PlayerScript.IsGhost() " + exception.Message, Category.Mobs);
+				return true; //might as well consider it a ghost then
+			}
+		}
+	}
 
 	/// <summary>
 	/// Same as is ghost, but also true when player inside his dead body


### PR DESCRIPTION
Small PR to try to eliminate the buffer exceed errors on new joins. 