### PR TITLE
Fixes gateway trap

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Gateway/StationGateway.cs
+++ b/UnityProject/Assets/Scripts/Objects/Gateway/StationGateway.cs
@@ -1,4 +1,5 @@
-﻿using Mirror;
+﻿using System.Collections;
+using Mirror;
 using UnityEngine;
 using System.Linq;
 using UnityEditor;
@@ -31,6 +32,8 @@ namespace Objects
 		private Sprite[] Offline = null;
 		[SerializeField]
 		private Sprite[] PowerOff = null;
+
+		private bool isOnCooldown = false;
 
 		private WorldGateway selectedWorld;// The world from the list that was chosen
 
@@ -118,7 +121,8 @@ namespace Objects
 
 			if (loadNormally)
 			{
-				WaitTimeBeforeActivation = Random.Range(RandomCountBegining, RandomCountEnd);
+				//WaitTimeBeforeActivation = Random.Range(RandomCountBegining, RandomCountEnd);
+				WaitTimeBeforeActivation = 30f;
 			}
 
 			Invoke(nameof(ConnectToWorld), WaitTimeBeforeActivation);
@@ -146,14 +150,14 @@ namespace Objects
 				if (APCPoweredDevice.IsOn(CurrentState) == false) return;
 
 				timeElapsedServer += Time.deltaTime;
-				if (timeElapsedServer > DetectionTime && isOn)
+				if (timeElapsedServer > DetectionTime && isOn && isOnCooldown == false)
 				{
 					DetectPlayer();
 					timeElapsedServer = 0;
 				}
 
 				timeElapsedServerSound += Time.deltaTime;
-				if (timeElapsedServerSound > SoundLength && isOn)
+				if (timeElapsedServerSound > SoundLength && isOn && isOnCooldown == false)
 				{
 					DetectPlayer();
 					SoundManager.PlayNetworkedAtPos(CommonSounds.Instance.MachineHum4, Position + Vector3Int.up);
@@ -239,6 +243,15 @@ namespace Objects
 			{
 				TransportUtility.TransportObjectAndPulled(item, TeleportTargetCoord);
 			}
+
+			StartCoroutine(TeleporterCooldown());
+		}
+
+		IEnumerator TeleporterCooldown()
+		{
+			isOnCooldown = true;
+			yield return new WaitForSeconds(1.2f);
+			isOnCooldown = false;
 		}
 
 		public virtual void SetOnline()

--- a/UnityProject/Assets/Scripts/Objects/Gateway/StationGateway.cs
+++ b/UnityProject/Assets/Scripts/Objects/Gateway/StationGateway.cs
@@ -121,8 +121,7 @@ namespace Objects
 
 			if (loadNormally)
 			{
-				//WaitTimeBeforeActivation = Random.Range(RandomCountBegining, RandomCountEnd);
-				WaitTimeBeforeActivation = 30f;
+				WaitTimeBeforeActivation = Random.Range(RandomCountBegining, RandomCountEnd);
 			}
 
 			Invoke(nameof(ConnectToWorld), WaitTimeBeforeActivation);
@@ -247,6 +246,11 @@ namespace Objects
 			StartCoroutine(TeleporterCooldown());
 		}
 
+
+		/// <summary>
+		/// Halts DetectPlayer() to stop a bug where the player would get stuck on the gateway
+		/// </summary>
+		/// <returns>Wait for 1.2 seconds</returns>
 		IEnumerator TeleporterCooldown()
 		{
 			isOnCooldown = true;

--- a/UnityProject/Assets/Scripts/Objects/Gateway/StationGateway.cs
+++ b/UnityProject/Assets/Scripts/Objects/Gateway/StationGateway.cs
@@ -158,7 +158,6 @@ namespace Objects
 				timeElapsedServerSound += Time.deltaTime;
 				if (timeElapsedServerSound > SoundLength && isOn && isOnCooldown == false)
 				{
-					DetectPlayer();
 					SoundManager.PlayNetworkedAtPos(CommonSounds.Instance.MachineHum4, Position + Vector3Int.up);
 					timeElapsedServerSound = 0;
 				}


### PR DESCRIPTION
fixes #7392 

`UpdateMe()` was acting a little bit weird and has often called `DetectPlayer()` more than once which caused weird issues where if two players walked in less than a second they'd both be teleported back to teleport cords even if players did not get trapped and one of them has moved a couple of tiles away from the teleporter.
This is without the mentioning of the bug where for some reason the player's matrix would get stuck on the teleporter if we don't halt `DetectPlayer()` which was the whole reason I looked into this.

Has been tested locally and on a client and could no longer reproduce this bug after introducing this fix.