### PR TITLE
Gives AI back its power. Fixes 7471

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Engineering/APCPoweredDevice.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/APCPoweredDevice.cs
@@ -322,22 +322,17 @@ namespace Systems.Electricity
 
 		public bool ConnectToClosestApc()
 		{
-			var apcs = Physics2D.OverlapCircleAll(registerTile.WorldPositionServer.To2Int(), 30);
+			var apcs = FindObjectsOfType<APC>();
 
-			apcs = apcs.Where(a => a.gameObject.GetComponent<APC>() != null).ToArray();
-
-			if (apcs.Length == 0)
-			{
-				return false;
-			}
+			apcs = apcs.Where(item => item.gameObject.GetComponent<APC>() != null).ToArray();
 
 			APC bestTarget = null;
-			float closestDistance = Mathf.Infinity;
-			var devicePosition = gameObject.transform.position;
+			float closestDistance = 30;
+			var devicePosition = gameObject.RegisterTile().WorldPositionServer;
 
 			foreach (var potentialTarget in apcs)
 			{
-				var directionToTarget = potentialTarget.gameObject.transform.position - devicePosition;
+				var directionToTarget = potentialTarget.gameObject.RegisterTile().WorldPositionServer - devicePosition;
 				float dSqrToTarget = directionToTarget.sqrMagnitude;
 
 				if (dSqrToTarget >= closestDistance) continue;


### PR DESCRIPTION
### Purpose
Fixes a bug where the APCPoweredDevice ConnectToClosest function would always return false.

### Notes:
The colliders for the APCs are remaining disabled during runtime, so Physics2D overlaps don't work. Gonna try find out why this is happening so this is a draft for now. The Pr does work in its current state, but is not ideal

### Changelog:
CL: [Fix] AI's now connect to the APC on spawn again
