### PR TITLE
Fix Server Colliders

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.cs
+++ b/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.cs
@@ -187,11 +187,13 @@ public partial class CustomNetTransform : NetworkBehaviour, IPushable
 		{
 			InitServerState();
 		}
-
-		Collider2D[] colls = GetComponents<Collider2D>();
-		foreach (var c in colls)
+		else
 		{
-			c.enabled = false;
+			Collider2D[] colls = GetComponents<Collider2D>();
+			foreach (var c in colls)
+			{
+				c.enabled = false;
+			}
 		}
 
 		Initialized = true;


### PR DESCRIPTION
Note: is untested, but previously the function to turn off colliders was only called from OnStartClient, this now prevents the server running it.

Fixes #7471