### PR TITLE
Fixes lavaland teleport loop

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
@@ -358,7 +358,7 @@ public class RegisterTile : NetworkBehaviour, IServerDespawn
 		{
 			if (objectLayer)
 			{
-				objectLayer.ServerObjects.Remove(LocalPositionClient, this);
+				objectLayer.ServerObjects.Remove(LocalPositionServer, this);
 				objectLayer.ClientObjects.Remove(LocalPositionClient, this);
 			}
 			objectLayer = newObjectLayer;


### PR DESCRIPTION
### Purpose
CL: [Fix] Fixes players having the chance of getting stuck in a teleport loop when using a teleport pad to and from lavaland.
Fixes the server not removing a registertile from the objectlayer dictionary list by using the correct position vector.