### PR TITLE
Properly adds the dough recipe to the crafting menu.

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/Crafting/DefaultHumanCraftingRecipes.asset
+++ b/UnityProject/Assets/ScriptableObjects/Crafting/DefaultHumanCraftingRecipes.asset
@@ -358,3 +358,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 1860642633aa46b479cd6ddf4029cf3d, type: 2}
   - {fileID: 11400000, guid: 5ca5a7f1e2a626f4ab60c0ba394557d7, type: 2}
   - {fileID: 11400000, guid: 4f83294ff021e9141a3b8870d2b5aae4, type: 2}
+  - {fileID: 11400000, guid: 47420424b08530a46931f56aa1a705de, type: 2}


### PR DESCRIPTION
### Purpose
- Title. I forgot to add it to the crafting menu so I did it.

CL: [Fix] re-added the missing dough recipe to the craft menu