### PR TITLE
Fixes #5478 vending supply infinite restocking

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Other/VendingRefills/ResupplyCanister.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/VendingRefills/ResupplyCanister.prefab
@@ -15,21 +15,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   pickupAnimSpeed: 0.2
---- !u!114 &925730788071798659
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8283241700425776467}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ea5951407d88fbaeca82abe370373eae, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  pickupAnimSpeed: 0.2
 --- !u!1001 &8282237999971058153
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -90,6 +75,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 5b03a0d328244a244bde82abc2b3e98a
       objectReference: {fileID: 0}
+    - target: {fileID: 114776788309089574, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: customNetTransform
+      value: 
+      objectReference: {fileID: 8315425228552147075}
     - target: {fileID: 114883521337486670, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: Armor.Acid
@@ -240,3 +230,15 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 8282237999971058153}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &8315425228552147075 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 114341119007412586, guid: a7abba22164ce49f0bf9b9b219f39298,
+    type: 3}
+  m_PrefabInstance: {fileID: 8282237999971058153}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8283241700425776467}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 


### PR DESCRIPTION
Fixes #5478

### Notes 
I don't know why
~~I don't even want to know why~~
But all canister units had two restock scripts for no reason and removing one of them fixes this issue.
Why is this a thing and how did we not any kind of errors for this? I have no clue.

Edit : I've looked on google for problems similar to this and I couldn't find anything. I know want to know why because this doesn't make sense to my tiny brain.

CL: [Fix] fixed infinite vending supply restocking.