### PR TITLE
Removes an expensive null check in matrix get from a fixed runtime

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
@@ -321,12 +321,6 @@ public class Matrix : MonoBehaviour
 		var filtered = new List<T>();
 		foreach (RegisterTile t in (isServer ? ServerObjects : ClientObjects).Get(localPosition))
 		{
-			if (t == null)
-			{
-				Logger.LogError("Caught NRE in Matrix.Get() foreach loop, ln 326. Continuing loop without considering this RegisterTile.", Category.TileMaps);
-				continue;
-			}
-
 			T x = t.GetComponent<T>();
 			if (x != null)
 			{


### PR DESCRIPTION
### Purpose
Removes an expensive null check in matrix get from a fixed runtime.
Fixed in #7489