### PR TITLE
Adds Apelinsaft's unique sound for CentCom announcements.

### DIFF
--- a/UnityProject/Assets/Resources/ScriptableObjectsSingletons/SingletonSOSounds.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjectsSingletons/SingletonSOSounds.asset
@@ -243,6 +243,13 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  AnnouncementCentCom:
+    SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/AI/centcomm_announcement.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   AnnouncementAlert:
     SetLoadSetting: 0
     AssetAddress: Assets/Prefabs/Effects/Notice1.prefab

--- a/UnityProject/Assets/Scripts/Core/Addressables/CommonSounds.cs
+++ b/UnityProject/Assets/Scripts/Core/Addressables/CommonSounds.cs
@@ -49,6 +49,7 @@ public class CommonSounds : SingletonScriptableObject<CommonSounds>
    //Ai announcements
    public AddressableAudioSource AnnouncementNotice = null;
    public AddressableAudioSource AnnouncementAnnounce = null;
+   public AddressableAudioSource AnnouncementCentCom = null;
    public AddressableAudioSource AnnouncementAlert = null;
    public AddressableAudioSource AnnouncementWelcome = null;
    public AddressableAudioSource AnnouncementIntercept = null;

--- a/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
@@ -217,7 +217,7 @@ namespace AdminCommands
 		{
 			if (IsAdmin(adminId, adminToken, sender) == false) return;
 
-			CentComm.MakeAnnouncement(ChatTemplates.CentcomAnnounce, text, CentComm.UpdateSound.Notice);
+			CentComm.MakeAnnouncement(ChatTemplates.CentcomAnnounce, text, CentComm.UpdateSound.CentComAnnounce);
 
 			LogAdminAction($"{PlayerList.Instance.GetByUserID(adminId).Username}: made a central command ANNOUNCEMENT. \n {text}");
 		}

--- a/UnityProject/Assets/Scripts/Managers/CentComm.cs
+++ b/UnityProject/Assets/Scripts/Managers/CentComm.cs
@@ -60,7 +60,8 @@ namespace Managers
 			{
 				{UpdateSound.Notice, CommonSounds.Instance.Notice2},
 				{UpdateSound.Alert, CommonSounds.Instance.Notice1},
-				{UpdateSound.Announce, CommonSounds.Instance.AnnouncementAnnounce}
+				{UpdateSound.Announce, CommonSounds.Instance.AnnouncementAnnounce},
+				{UpdateSound.CentComAnnounce, CommonSounds.Instance.AnnouncementCentCom}
 			};
 		}
 
@@ -281,6 +282,7 @@ namespace Managers
 			Notice,
 			Alert,
 			Announce,
+			CentComAnnounce,
 			NoSound
 		}
 


### PR DESCRIPTION
<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->

### Purpose
- Added a unique sound for CentCom announcements made by admins, courtesy of Apelinsaft on Discord.

### Changelog:
<!-- Add here individual lines with all your remarkable changes using the prefix ``CL:`` -->
<!-- Mind that the changes meant to be logged in the in changelog are those that are remarkable for the end user, so things like new features and fixes of known bugs are perfect for this section -->

CL: [New] Added a unique sound for CentCom announcements.

