### PR TITLE
Update AlienEggCycle.cs for Issue #7133

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Alien/AlienEggCycle.cs
+++ b/UnityProject/Assets/Scripts/Objects/Alien/AlienEggCycle.cs
@@ -215,7 +215,8 @@ namespace Alien
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
-			return !(interaction.Intent == Intent.Harm && currentState == EggState.Grown);
+			return DefaultWillInteract.Default(interaction, side) &&
+				!(interaction.Intent == Intent.Harm && currentState == EggState.Grown);
 		}
 
 		public enum EggState

--- a/UnityProject/Assets/Scripts/Objects/Alien/AlienEggCycle.cs
+++ b/UnityProject/Assets/Scripts/Objects/Alien/AlienEggCycle.cs
@@ -8,7 +8,7 @@ using Messages.Server.SoundMessages;
 
 namespace Alien
 {
-	public class AlienEggCycle : MonoBehaviour, IInteractable<HandApply>, IServerSpawn, IServerDespawn, ICheckedInteractable<HandApply>
+	public class AlienEggCycle : MonoBehaviour, IServerSpawn, IServerDespawn, ICheckedInteractable<HandApply>
 	{
 		[SerializeField] private AddressableAudioSource squishSFX = null;
 
@@ -215,8 +215,9 @@ namespace Alien
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
-			return DefaultWillInteract.Default(interaction, side) &&
-				!(interaction.Intent == Intent.Harm && currentState == EggState.Grown);
+			if (DefaultWillInteract.Default(interaction, side) == false) return false;
+
+			return side == NetworkSide.Server ? !(interaction.Intent == Intent.Harm && currentState == EggState.Grown) : true;
 		}
 
 		public enum EggState

--- a/UnityProject/Assets/Scripts/Objects/Alien/AlienEggCycle.cs
+++ b/UnityProject/Assets/Scripts/Objects/Alien/AlienEggCycle.cs
@@ -8,7 +8,7 @@ using Messages.Server.SoundMessages;
 
 namespace Alien
 {
-	public class AlienEggCycle : MonoBehaviour, IInteractable<HandApply>, IServerSpawn, IServerDespawn
+	public class AlienEggCycle : MonoBehaviour, IInteractable<HandApply>, IServerSpawn, IServerDespawn, ICheckedInteractable<HandApply>
 	{
 		[SerializeField] private AddressableAudioSource squishSFX = null;
 
@@ -164,10 +164,7 @@ namespace Alien
 					Squish(interaction);
 					break;
 				case EggState.Grown:
-					if (interaction.Intent == Intent.Harm)
-						Squish(interaction);
-					else
-						Open(interaction);
+					Open(interaction);
 					break;
 				default:
 					UpdatePhase(EggState.Burst);
@@ -216,6 +213,10 @@ namespace Alien
 				$"{interaction.Performer.ExpensiveName()} touches the slimy egg!");
 		}
 
+		public bool WillInteract(HandApply interaction, NetworkSide side)
+		{
+			return !(interaction.Intent == Intent.Harm && currentState == EggState.Grown);
+		}
 
 		public enum EggState
 		{


### PR DESCRIPTION
### Purpose
Fixes #7133
This commit fixes issue, where player is unable to get rid of eggs, which are in burst state and are blocking player movement. It also fixes bug where player interacts with egg in grown state.
<!-- Describe the problem the PR fixes or the feature it introduces. --> <br>
<!-- Don't forget to use "Fixes #issuenumber" to select issues and auto close them on merge. -->

### Notes:
An issue was fixed by adding an option to sqish bursted egg with harm intent. 
While I was testing it, there was another bug, where if player interacted with an egg in grown state it bursted, but coroutines didn't stop, so an egg opened again after some time. So now can player with harm intent squish grown egg, otherwise it opens.

### Changelog:
CL: [Fix] Fixed interactions with bursted and grown xeno eggs.

