### PR TITLE
Map ACUs on Square engineering

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Editor/Inspector/SlaveDeviceInspector.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/Inspector/SlaveDeviceInspector.cs
@@ -134,7 +134,10 @@ namespace CustomInspectors
 		private void Save()
 		{
 			EditorUtility.SetDirty((Component) thisDevice);
-			EditorUtility.SetDirty((Component) thisDevice.Master);
+			if (thisDevice.Master != null)
+			{
+				EditorUtility.SetDirty((Component) thisDevice.Master);
+			}
 			EditorSceneManager.MarkSceneDirty(SceneManager.GetActiveScene());
 		}
 	}

--- a/UnityProject/Assets/Scripts/Core/Editor/Inspector/SlaveDeviceInspector.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/Inspector/SlaveDeviceInspector.cs
@@ -134,6 +134,7 @@ namespace CustomInspectors
 		private void Save()
 		{
 			EditorUtility.SetDirty((Component) thisDevice);
+			EditorUtility.SetDirty((Component) thisDevice.Master);
 			EditorSceneManager.MarkSceneDirty(SceneManager.GetActiveScene());
 		}
 	}


### PR DESCRIPTION
CL: [Improvement] Maps ACUs on Square, engineering.
CL: [Improvement] Maps atmospheric sensors into each atmospherics tank.
CL: [Improvement] Replaces scrubbers for injectors on extract mode for each atmospherics tank.
- Fixes APCs not saving after using `SlaveDeviceInspector`.

> Looks like there's an issue somewhere with `NameValidator` tool that makes it tedious to use, as such I've only named the ACUs.