### PR TITLE
Removes a trycatch and a null check in bodypart ashing

### DIFF
--- a/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
+++ b/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
@@ -273,7 +273,7 @@ namespace IngameDebugConsole
 		{
 			if (CustomNetworkManager.Instance._isServer)
 			{
-				PlayerManager.LocalPlayerScript.playerHealth.ApplyDamageToRandom(null, 99999f, AttackType.Internal, DamageType.Brute);
+				PlayerManager.LocalPlayerScript.playerHealth.ApplyDamageToBodyPart(null, 99999f, AttackType.Internal, DamageType.Brute);
 			}
 		}
 #if UNITY_EDITOR

--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -134,9 +134,6 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 
 	public float Resistance => pushable == null ? integrity : integrity * ((int)pushable.Size / 10f);
 
-	[PrefabModeOnly]
-	public bool CannotBeAshed = false;
-
 	private void Awake()
 	{
 		EnsureInit();

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
@@ -140,11 +140,7 @@ public class WeaponNetworkActions : NetworkBehaviour
 				// The attack hit.
 				if (victim.TryGetComponent<LivingHealthMasterBase>(out var victimHealth))
 				{
-					victimHealth.ApplyDamageToBodyPart(gameObject, damage, AttackType.Melee, damageType, damageZone);
-					if(DMMath.Prob(traumaDamageChance))
-					{
-						victimHealth.ApplyTraumaDamage(damageZone, tramuticDamageType);
-					}
+					victimHealth.ApplyDamageToBodyPart(gameObject, damage, AttackType.Melee, damageType, damageZone, traumaDamageChance: traumaDamageChance, tramuticDamageType: tramuticDamageType);
 					didHit = true;
 				}
 				else if (victim.TryGetComponent<LivingHealthBehaviour>(out var victimHealthOld))

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobPlayer.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobPlayer.cs
@@ -715,7 +715,7 @@ namespace Blob
 
 					foreach (var playerDamage in currentStrain.playerDamages)
 					{
-						npcPlayerComponent.ApplyDamageToRandom(gameObject, playerDamage.damageDone, AttackType.Melee, playerDamage.damageType);
+						npcPlayerComponent.ApplyDamageToBodyPart(gameObject, playerDamage.damageDone, AttackType.Melee, playerDamage.damageType);
 					}
 
 					PlayAttackEffect(pos);


### PR DESCRIPTION
### Purpose
Removes the CannotBeAshed bool, ashing will now check for fire resistance.
Organizes bodyPart damage, organ damage and trauma calls.
Removes unneeded an unneeded try catch in body part ashing.
Adds DamageOrgans() to differentiate, separate and organize the damage inbetween a body part and an organ.

