### PR TITLE
Removes an unnecesary null check in ItemSlot ItemStorageNetID 

### DIFF
--- a/UnityProject/Assets/Scripts/Systems/Inventory/ItemSlot.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/ItemSlot.cs
@@ -52,7 +52,7 @@ public class ItemSlot
 	/// <summary>
 	/// Net ID of the ItemStorage this slot exists in
 	/// </summary>
-	public uint ItemStorageNetID => itemStorage != null ? itemStorage.GetComponent<NetworkIdentity>().netId : NetId.Invalid;
+	public uint ItemStorageNetID => itemStorage.GetComponent<NetworkIdentity>().netId;
 
 	/// <summary>
 	/// ItemAttributes of item in this slot, null if no item or item doesn't have any attributes.


### PR DESCRIPTION
### Purpose
Removes an unneeded null check in ItemSlot ItemStorageNetID over a bodypart not removed properly.

--- DONT MERGE UNTIL #7503 IS MERGED --- 
here's where the ashed bodyparts get fixed and start being removed properly


it doesnt make any sense anyways, it just bumps the error a few lines later