### PR TITLE
Fix chat stacker logic

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Chat/ChatEntry.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/ChatEntry.cs
@@ -268,7 +268,7 @@ public class ChatEntry : MonoBehaviour
 
 	private void SetStackPos()
 	{
-		if (messageText.textInfo.characterInfo.Length - 1 <= messageText.textInfo.characterCount - 1)
+		if (messageText.textInfo.characterCount - 1 < messageText.textInfo.characterInfo.Length)
 		{
 			var lastCharacter = messageText.textInfo.characterInfo[messageText.textInfo.characterCount - 1];
 			var charWorld = messageText.transform.TransformPoint(lastCharacter.bottomRight);


### PR DESCRIPTION
CL: [Fix] Fixed chat stack icons being positioned poorly and an erroneous client error.