### PR TITLE
Expands the discord round end message

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Chat/DiscordWebhookMessage.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/DiscordWebhookMessage.cs
@@ -264,8 +264,13 @@ namespace DiscordWebhook
 
 		void HandleLog(string logString, string stackTrace, LogType type)
 		{
-			if ((type == LogType.Exception || type == LogType.Error) && !ErrorMessageHashSet.Contains(stackTrace))
+			if (type == LogType.Exception || type == LogType.Error)
 			{
+				GameManager.Instance.errorCounter++;
+				if (ErrorMessageHashSet.Contains(stackTrace))
+					return;
+				GameManager.Instance.uniqueErrorCounter++;
+
 				ErrorMessageHashSet.Add(stackTrace);
 
 				if (logString.Contains("Can't get home directory!")) return;
@@ -280,7 +285,6 @@ namespace DiscordWebhook
 
 				logToSend = $"```\n{logToSend}```";
 
-				GameManager.Instance.errorCounter++;
 				AddWebHookMessageToQueue(DiscordWebhookURLs.DiscordWebhookErrorLogURL, logToSend, "");
 			}
 		}

--- a/UnityProject/Assets/Scripts/Core/Chat/DiscordWebhookMessage.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/DiscordWebhookMessage.cs
@@ -280,6 +280,7 @@ namespace DiscordWebhook
 
 				logToSend = $"```\n{logToSend}```";
 
+				GameManager.Instance.errorCounter++;
 				AddWebHookMessageToQueue(DiscordWebhookURLs.DiscordWebhookErrorLogURL, logToSend, "");
 			}
 		}

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -137,6 +137,8 @@ public partial class GameManager : MonoBehaviour, IInitialise
 	[SerializeField]
 	private AudioClipsArray endOfRoundSounds = null;
 
+	public int errorCounter;
+
 	void IInitialise.Initialise()
 	{
 		// Set up server defaults, needs to be loaded here to ensure gameConfigManager is load.

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -138,6 +138,7 @@ public partial class GameManager : MonoBehaviour, IInitialise
 	private AudioClipsArray endOfRoundSounds = null;
 
 	public int errorCounter;
+	public int uniqueErrorCounter;
 
 	void IInitialise.Initialise()
 	{

--- a/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
+++ b/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
@@ -419,8 +419,9 @@ namespace GameModes
 			var roundDuration = GameManager.Instance.stationTime.AddHours(-12);
 			var output = $"A round has ended. Round duration: {roundDuration.ToString("HH:mm")}.";
 			DiscordWebhookMessage.Instance.AddWebHookMessageToQueue(DiscordWebhookURLs.DiscordWebhookOOCURL, $"`{output}`", "");
-			DiscordWebhookMessage.Instance.AddWebHookMessageToQueue(DiscordWebhookURLs.DiscordWebhookErrorLogURL, $"```{output} Total errors: {GameManager.Instance.errorCounter}.```", "");
+			DiscordWebhookMessage.Instance.AddWebHookMessageToQueue(DiscordWebhookURLs.DiscordWebhookErrorLogURL, $"```{output} Total errors: {GameManager.Instance.errorCounter}. Unique errors: {GameManager.Instance.uniqueErrorCounter}```", "");
 			GameManager.Instance.errorCounter = 0;
+			GameManager.Instance.uniqueErrorCounter = 0;
 
 			Logger.LogFormat("Ending {0} round!", Category.GameMode, Name);
 			StationObjectiveManager.Instance.ShowStationStatusReport();

--- a/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
+++ b/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
@@ -416,8 +416,11 @@ namespace GameModes
 		/// </summary>
 		public void EndRoundReport()
 		{
-			DiscordWebhookMessage.Instance.AddWebHookMessageToQueue(DiscordWebhookURLs.DiscordWebhookOOCURL, "`A round has ended`", "");
-			DiscordWebhookMessage.Instance.AddWebHookMessageToQueue(DiscordWebhookURLs.DiscordWebhookErrorLogURL, "```A round has ended```", "");
+			var roundDuration = GameManager.Instance.stationTime.AddHours(-12);
+			var output = $"A round has ended. Round duration: {roundDuration.ToString("HH:mm")}.";
+			DiscordWebhookMessage.Instance.AddWebHookMessageToQueue(DiscordWebhookURLs.DiscordWebhookOOCURL, $"`{output}`", "");
+			DiscordWebhookMessage.Instance.AddWebHookMessageToQueue(DiscordWebhookURLs.DiscordWebhookErrorLogURL, $"```{output} Total errors: {GameManager.Instance.errorCounter}.```", "");
+			GameManager.Instance.errorCounter = 0;
 
 			Logger.LogFormat("Ending {0} round!", Category.GameMode, Name);
 			StationObjectiveManager.Instance.ShowStationStatusReport();


### PR DESCRIPTION
### Purpose
The small round end discord message will now show the round duration, and for the errorlog the total amount of errors.
Expands the round end discord message to separate total errors and unique errors amount.
