### PR TITLE
Adding Settings.asset and FovGenerator.mat files to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,9 @@ UnityProject/AddressablePackingProjects/SoundAndMusic/Logs/*
 UnityProject/AddressablePackingProjects/SoundAndMusic/.vsconfig
 
 UnityProject/.vsconfig
+
+UnityProject/Assets/Materials/PostProcess/Post-FloorFovGenerator Material.mat
+
+UnityProject/Assets/Materials/PostProcess/Post-FovGenerator.mat
+
+UnityProject/ProjectSettings/Packages/com.xeleh.enhancer/Settings.asset


### PR DESCRIPTION
### Purpose
- Adds three files to .gitignore that had a habit of changing according to Git even though no one ever touched them. This should make things a bit less annoying for Unity contributors now that they don't have to constantly discard these files and such.
