### PR TITLE
Reduce tile change batch size

### DIFF
--- a/UnityProject/Assets/Scripts/Messages/Server/TileChangesNewClientSync.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/TileChangesNewClientSync.cs
@@ -16,7 +16,7 @@ namespace Messages.Server
 		}
 
 		//just a best guess, try increasing it until the message exceeds mirror's limit
-		private static readonly int MAX_CHANGES_PER_MESSAGE = 30;
+		private static readonly int MAX_CHANGES_PER_MESSAGE = 25; // 20 seemed ok, 30 caused issues
 
 		public override void Process(NetMessage msg)
 		{


### PR DESCRIPTION
- Reduces tile change batch size. Looks like 30 still caused issues. Let's see how 25 behaves.