### PR TITLE
Fixes players missing tile updates if pipes were modified 

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Lifecycle/SpawnSafeThread.cs
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/SpawnSafeThread.cs
@@ -10,8 +10,8 @@ public static class SpawnSafeThread
 {
 	private static ConcurrentQueue<SpawnSafeThreadData> prefabsToSpawn = new ConcurrentQueue<SpawnSafeThreadData>();
 
-	private static ConcurrentQueue<Tuple<uint, Vector3Int, TileType, string, Matrix4x4, Color, LayerType>> tilesToUpdate
-		= new ConcurrentQueue<Tuple<uint, Vector3Int, TileType, string, Matrix4x4, Color, LayerType>>();
+	private static ConcurrentQueue<Tuple<uint, Vector3Int, TileType, string, OrientationEnum, Color, LayerType>> tilesToUpdate
+		= new ConcurrentQueue<Tuple<uint, Vector3Int, TileType, string, OrientationEnum, Color, LayerType>>();
 
 	private static ConcurrentQueue<Tuple<uint, Vector3Int, LayerType>> tilesToRemove
 		= new ConcurrentQueue<Tuple<uint, Vector3Int, LayerType>>();
@@ -41,7 +41,7 @@ public static class SpawnSafeThread
 
 		if (!tilesToUpdate.IsEmpty)
 		{
-			Tuple<uint, Vector3Int, TileType, string, Matrix4x4, Color, LayerType> tuple;
+			Tuple<uint, Vector3Int, TileType, string, OrientationEnum, Color, LayerType> tuple;
 			while (tilesToUpdate.TryDequeue(out tuple))
 			{
 				UpdateTileMessage.Send(tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4, tuple.Item5, tuple.Item6,
@@ -67,11 +67,11 @@ public static class SpawnSafeThread
 	}
 
 	public static void UpdateTileMessageSend(uint matrixSyncNetID, Vector3Int position, TileType tileType,
-		string tileName, Matrix4x4 transformMatrix, Color colour)
+		string tileName, OrientationEnum orientation, Color colour)
 	{
 		tilesToUpdate.Enqueue(
-			new Tuple<uint, Vector3Int, TileType, string, Matrix4x4, Color, LayerType>
-				(matrixSyncNetID, position, tileType, tileName, transformMatrix, colour, LayerType.None));
+			new Tuple<uint, Vector3Int, TileType, string, OrientationEnum, Color, LayerType>
+				(matrixSyncNetID, position, tileType, tileName, orientation, colour, LayerType.None));
 	}
 
 	public static void RemoveTileMessageSend(uint matrixSyncNetID, Vector3Int cellPosition, LayerType layerType)

--- a/UnityProject/Assets/Scripts/Items/Tool/CrayonSprayCan.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/CrayonSprayCan.cs
@@ -185,7 +185,6 @@ namespace Items.Tool
 		{
 			//Work out colour
 			var chosenColour = GetColour();
-			var chosenDirection = GetDirection();
 
 			var tileToUse = GetTileFromIndex(isWall);
 
@@ -215,7 +214,7 @@ namespace Items.Tool
 							if (charges > 0 || charges == -1)
 							{
 								registerItem.TileChangeManager.RemoveOverlaysOfType(cellPos, isWall ? LayerType.Walls : LayerType.Floors, OverlayType.Cleanable);
-								registerItem.TileChangeManager.AddOverlay(cellPos, tileToUse, chosenDirection, chosenColour);
+								registerItem.TileChangeManager.AddOverlay(cellPos, tileToUse, orientation, chosenColour);
 							}
 
 							UseAndCheckCharges(interaction);
@@ -246,7 +245,7 @@ namespace Items.Tool
 				{
 					if (charges > 0 || charges == -1)
 					{
-						registerItem.TileChangeManager.AddOverlay(cellPos, tileToUse, chosenDirection, chosenColour);
+						registerItem.TileChangeManager.AddOverlay(cellPos, tileToUse, orientation, chosenColour);
 					}
 
 					UseAndCheckCharges(interaction);
@@ -276,23 +275,6 @@ namespace Items.Tool
 
 			//chosen value
 			return PickableColours[SetCrayonColour];
-		}
-
-		private Matrix4x4 GetDirection()
-		{
-			switch (orientation)
-			{
-				case OrientationEnum.Up:
-					return Matrix4x4.identity;
-				case OrientationEnum.Right:
-					return Matrix4x4.TRS(Vector3.zero,  Quaternion.Euler(0f, 0f, 270f), Vector3.one);
-				case OrientationEnum.Left:
-					return Matrix4x4.TRS(Vector3.zero,  Quaternion.Euler(0f, 0f, 90f), Vector3.one);
-				case OrientationEnum.Down:
-					return Matrix4x4.TRS(Vector3.zero,  Quaternion.Euler(0f, 0f, 180f), Vector3.one);
-				default:
-					return Matrix4x4.identity;
-			}
 		}
 
 		private void UseAndCheckCharges(PositionalHandApply interaction)

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
@@ -12,6 +12,7 @@ using Systems.Atmospherics;
 using Objects.Construction;
 using Player.Movement;
 using Mirror;
+using Messages.Client.NewPlayer;
 
 /// <summary>
 /// Defines collision type we expect
@@ -180,6 +181,7 @@ public partial class MatrixManager : MonoBehaviour
 		{
 			var subsystemManager = matrixInfo.Matrix.GetComponentInParent<SubsystemManager>();
 			subsystemManager.Initialize();
+			TileChangeNewPlayer.Send(matrixInfo.NetID);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Messages/Server/TileChangesNewClientSync.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/TileChangesNewClientSync.cs
@@ -16,7 +16,7 @@ namespace Messages.Server
 		}
 
 		//just a best guess, try increasing it until the message exceeds mirror's limit
-		private static readonly int MAX_CHANGES_PER_MESSAGE = 20; // 25 caused issues
+		private static readonly int MAX_CHANGES_PER_MESSAGE = 200; // 25 caused issues
 
 		public override void Process(NetMessage msg)
 		{

--- a/UnityProject/Assets/Scripts/Messages/Server/TileChangesNewClientSync.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/TileChangesNewClientSync.cs
@@ -16,7 +16,7 @@ namespace Messages.Server
 		}
 
 		//just a best guess, try increasing it until the message exceeds mirror's limit
-		private static readonly int MAX_CHANGES_PER_MESSAGE = 200; // 25 caused issues
+		private static readonly int MAX_CHANGES_PER_MESSAGE = 200;
 
 		public override void Process(NetMessage msg)
 		{

--- a/UnityProject/Assets/Scripts/Messages/Server/UpdateTileMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/UpdateTileMessage.cs
@@ -12,7 +12,7 @@ namespace Messages.Server
 			public TileType TileType;
 			public LayerType LayerType;
 			public string TileName;
-			public Matrix4x4 TransformMatrix;
+			public OrientationEnum Orientation;
 			public Color Colour;
 			public uint MatrixSyncNetID;
 		}
@@ -25,17 +25,17 @@ namespace Messages.Server
 			public TileType TileType;
 			public LayerType layerType;
 			public string TileName;
-			public Matrix4x4 TransformMatrix;
+			public OrientationEnum Orientation;
 			public Color Colour;
 			public uint MatrixSyncNetID;
 
-			public delayedData(Vector3Int inPosition, TileType inTileType, string inTileName, Matrix4x4 inTransformMatrix,
+			public delayedData(Vector3Int inPosition, TileType inTileType, string inTileName, OrientationEnum orientation,
 				Color inColour, uint inMatrixSyncNetID, LayerType inlayerType)
 			{
 				Position = inPosition;
 				TileType = inTileType;
 				TileName = inTileName;
-				TransformMatrix = inTransformMatrix;
+				Orientation = orientation;
 				Colour = inColour;
 				MatrixSyncNetID = inMatrixSyncNetID;
 				layerType = inlayerType;
@@ -49,12 +49,12 @@ namespace Messages.Server
 			LoadNetworkObject(msg.MatrixSyncNetID);
 			if (NetworkObject == null)
 			{
-				DelayedStuff.Add(new delayedData(msg.Position, msg.TileType, msg.TileName, msg.TransformMatrix, msg.Colour, msg.MatrixSyncNetID, msg.LayerType));
+				DelayedStuff.Add(new delayedData(msg.Position, msg.TileType, msg.TileName, msg.Orientation, msg.Colour, msg.MatrixSyncNetID, msg.LayerType));
 			}
 			else
 			{
 				var tileChangerManager = NetworkObject.transform.parent.GetComponent<TileChangeManager>();
-				tileChangerManager.InternalUpdateTile(msg.Position, msg.TileType, msg.TileName, msg.TransformMatrix, msg.Colour);
+				tileChangerManager.InternalUpdateTile(msg.Position, msg.TileType, msg.TileName, msg.Orientation, msg.Colour);
 				TryDoNotDoneTiles();
 			}
 		}
@@ -69,7 +69,7 @@ namespace Messages.Server
 				{
 					var tileChangerManager = NetworkObject.transform.parent.GetComponent<TileChangeManager>();
 					tileChangerManager.InternalUpdateTile(DelayedStuff[i].Position, DelayedStuff[i].TileType,
-						DelayedStuff[i].TileName, DelayedStuff[i].TransformMatrix, DelayedStuff[i].Colour);
+						DelayedStuff[i].TileName, DelayedStuff[i].Orientation, DelayedStuff[i].Colour);
 					DelayedStuff.RemoveAt(i);
 					i--;
 				}
@@ -77,15 +77,14 @@ namespace Messages.Server
 		}
 
 		public static NetMessage Send(uint matrixSyncNetID, Vector3Int position, TileType tileType,
-			string tileName,
-			Matrix4x4 transformMatrix, Color colour, LayerType LayerType)
+			string tileName, OrientationEnum orientation, Color colour, LayerType LayerType)
 		{
 			NetMessage msg = new NetMessage
 			{
 				Position = position,
 				TileType = tileType,
 				TileName = tileName,
-				TransformMatrix = transformMatrix,
+				Orientation = orientation,
 				Colour = colour,
 				MatrixSyncNetID = matrixSyncNetID,
 				LayerType = LayerType

--- a/UnityProject/Assets/Scripts/Objects/Disposals/DisposalPipeObject.cs
+++ b/UnityProject/Assets/Scripts/Objects/Disposals/DisposalPipeObject.cs
@@ -214,9 +214,8 @@ namespace Objects.Disposals
 			DisposalPipe pipeTileToSpawn = GetPipeTileByOrientation(orientation);
 			if (pipeTileToSpawn != null)
 			{
-				var matrixTransform = Matrix4x4.TRS(Vector3.zero, Quaternion.identity, Vector3.one);
 				Color pipeColor = GetComponentInChildren<SpriteRenderer>().color;
-				registerTile.Matrix.TileChangeManager.UpdateTile(registerTile.LocalPositionServer, pipeTileToSpawn, matrixTransform, pipeColor);
+				registerTile.Matrix.TileChangeManager.UpdateTile(registerTile.LocalPositionServer, pipeTileToSpawn, orientation.AsEnum(), pipeColor);
 				_ = Despawn.ServerSingle(gameObject);
 			}
 			else

--- a/UnityProject/Assets/Scripts/Objects/Pipes/PipeItemTile.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/PipeItemTile.cs
@@ -15,10 +15,11 @@ namespace Items.Atmospherics
 			var tile = GetPipeTile();
 			if (tile == null) return;
 
+			var orientation = Orientation.GetOrientation(transform.localEulerAngles.z).AsEnum();
 			int Offset = PipeFunctions.GetOffsetAngle(transform.localEulerAngles.z);
 			Quaternion rot = Quaternion.Euler(0.0f, 0.0f, Offset);
 			var Matrix = Matrix4x4.TRS(Vector3.zero, rot, Vector3.one);
-			searchVec = registerItem.Matrix.TileChangeManager.UpdateTile(searchVec, tile, Matrix, Colour);
+			searchVec = registerItem.Matrix.TileChangeManager.UpdateTile(searchVec, tile, orientation, Colour);
 			tile.InitialiseNodeNew(searchVec, registerItem.Matrix, Matrix);
 			_ = Despawn.ServerSingle(this.gameObject);
 

--- a/UnityProject/Assets/Scripts/Shuttles/MatrixSync.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/MatrixSync.cs
@@ -58,7 +58,6 @@ namespace Shuttles
 			base.OnStartClient();
 
 			networkedMatrix.OnStartClient();
-			TileChangeNewPlayer.Send(netId);
 
 			if (matrixMove != null)
 			{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Layer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Layer.cs
@@ -155,13 +155,30 @@ public class Layer : MonoBehaviour
 		}
 	}
 
-	public virtual void SetTile(Vector3Int position, GenericTile tile, Matrix4x4 transformMatrix, Color color)
+	public virtual void SetTile(Vector3Int position, GenericTile tile, OrientationEnum orientation, Color color)
 	{
 		InternalSetTile(position, tile);
 
 		tilemap.SetColor(position, color);
-		tilemap.SetTransformMatrix(position, transformMatrix);
+		tilemap.SetTransformMatrix(position, GetMatrix4x4(orientation));
 		subsystemManager?.UpdateAt(position);
+	}
+
+	public static Matrix4x4 GetMatrix4x4(OrientationEnum orientation)
+	{
+		switch (orientation)
+		{
+			case OrientationEnum.Up:
+				return Matrix4x4.identity;
+			case OrientationEnum.Right:
+				return Matrix4x4.TRS(Vector3.zero,  Quaternion.Euler(0f, 0f, 270f), Vector3.one);
+			case OrientationEnum.Left:
+				return Matrix4x4.TRS(Vector3.zero,  Quaternion.Euler(0f, 0f, 90f), Vector3.one);
+			case OrientationEnum.Down:
+				return Matrix4x4.TRS(Vector3.zero,  Quaternion.Euler(0f, 0f, 180f), Vector3.one);
+			default:
+				return Matrix4x4.identity;
+		}
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
@@ -497,7 +497,7 @@ public class Matrix : MonoBehaviour
 
 		if (Tile != null)
 		{
-			TileChangeManager.UpdateTile(position, Tile, Matrix4x4.identity, Color.white);
+			TileChangeManager.UpdateTile(position, Tile);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/ObjectLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/ObjectLayer.cs
@@ -29,7 +29,7 @@ public class ObjectLayer : Layer
 
 	}
 
-	public override void SetTile(Vector3Int position, GenericTile tile, Matrix4x4 transformMatrix, Color color)
+	public override void SetTile(Vector3Int position, GenericTile tile, OrientationEnum orientation, Color color)
 	{
 		ObjectTile objectTile = tile as ObjectTile;
 
@@ -39,7 +39,7 @@ public class ObjectLayer : Layer
 			base.InternalSetTile(position, tile);
 			base.InternalSetTile(position, null);
 
-			objectTile.SpawnObject(position, tilemap, transformMatrix);
+			objectTile.SpawnObject(position, tilemap, orientation);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/TileLocation.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/TileLocation.cs
@@ -43,6 +43,8 @@ namespace TileManagement
 			}
 		}
 
+		public OrientationEnum orientation;
+
 		private Matrix4x4 transformMatrix = Matrix4x4.identity;
 
 		public Matrix4x4 TransformMatrix

--- a/UnityProject/Assets/Scripts/Tilemaps/Editor/Brushes/LevelBrush.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Editor/Brushes/LevelBrush.cs
@@ -87,7 +87,7 @@ public class LevelBrush : GridBrush
 			}
 			else
 			{
-				layer.GetComponent<Layer>().SetTile(position, null, Matrix4x4.identity, Color.white);
+				layer.GetComponent<Layer>().SetTile(position, null, OrientationEnum.Default, Color.white);
 			}
 		}
 	}
@@ -114,8 +114,8 @@ public class LevelBrush : GridBrush
 	{
 		foreach (LayerTile tile in metaTile.GetTiles())
 		{
-			//metaTileMap.RemoveTileWithlayer(position, tile.LayerType);
-			metaTileMap.SetTile(position, tile, cells[0].matrix, isPlaying: false);
+			var orientation = Orientation.GetOrientation(cells[0].matrix.rotation.z).AsEnum();
+			metaTileMap.SetTile(position, tile, orientation, isPlaying: false);
 		}
 	}
 
@@ -132,6 +132,7 @@ public class LevelBrush : GridBrush
 			SetTile(metaTileMap, position, requiredTile);
 		}
 
-		metaTileMap.SetTile(position, tile, cells[0].matrix, cells[0].color, isPlaying: false);
+		var orientation = Orientation.GetOrientation(cells[0].matrix.rotation.z).AsEnum();
+		metaTileMap.SetTile(position, tile, orientation, cells[0].color, isPlaying: false);
 	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Tiles/ObjectTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Tiles/ObjectTile.cs
@@ -69,7 +69,7 @@ public class ObjectTile : BasicTile
 	}
 #endif
 
-	public void SpawnObject(Vector3Int position, Tilemap tilemap, Matrix4x4 transformMatrix)
+	public void SpawnObject(Vector3Int position, Tilemap tilemap, OrientationEnum orientation)
 	{
 		if (!Object)
 		{
@@ -86,14 +86,14 @@ public class ObjectTile : BasicTile
 		go.SetActive(false);
 		go.transform.parent = tilemap.transform;
 
-		Vector3 objectOffset = !Offset ? Vector3.zero : transformMatrix.rotation * Vector3.up;
+		Vector3 objectOffset = !Offset ? Vector3.zero : Orientation.FromEnum(orientation).Degrees * Vector3.up;
 
 		go.transform.localPosition = position + objectOffset;
 		go.transform.rotation = tilemap.transform.rotation;
 
 		if (!KeepOrientation)
 		{
-			go.transform.rotation *= transformMatrix.rotation;
+			go.transform.rotation = new Quaternion(0,0, Orientation.FromEnum(orientation).Degrees,0 );;
 		}
 
 		go.name = Object.name;

--- a/UnityProject/Assets/Scripts/Tilemaps/Utils/TileMapBuilder.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Utils/TileMapBuilder.cs
@@ -15,45 +15,45 @@ using UnityEngine;
 
 		public void PlaceTile(Vector3Int position, GenericTile tile)
 		{
-			PlaceTile(position, tile, Matrix4x4.identity);
+			PlaceTile(position, tile, OrientationEnum.Default);
 		}
 
-		public void PlaceTile(Vector3Int position, GenericTile tile, Matrix4x4 matrixTransform)
+		public void PlaceTile(Vector3Int position, GenericTile tile, OrientationEnum orientation)
 		{
 			if (tile is LayerTile)
 			{
-				PlaceLayerTile(position, (LayerTile) tile, matrixTransform);
+				PlaceLayerTile(position, (LayerTile) tile, orientation);
 			}
 			else if (tile is MetaTile)
 			{
-				PlaceMetaTile(position, (MetaTile) tile, matrixTransform);
+				PlaceMetaTile(position, (MetaTile) tile, orientation);
 			}
 		}
 
-		private void PlaceMetaTile(Vector3Int position, MetaTile metaTile, Matrix4x4 matrixTransform)
+		private void PlaceMetaTile(Vector3Int position, MetaTile metaTile, OrientationEnum orientation)
 		{
 			foreach (LayerTile tile in metaTile.GetTiles())
 			{
-				PlaceLayerTile(position, tile, matrixTransform);
+				PlaceLayerTile(position, tile, orientation);
 			}
 		}
 
-		private void PlaceLayerTile(Vector3Int position, LayerTile tile, Matrix4x4 matrixTransform)
+		private void PlaceLayerTile(Vector3Int position, LayerTile tile, OrientationEnum orientation)
 		{
 			if (!importMode)
 			{
 				metaTileMap.RemoveTileWithlayer(position, tile.LayerType);
 			}
-			SetTile(position, tile, matrixTransform);
+			SetTile(position, tile, orientation);
 		}
 
-		private void SetTile(Vector3Int position, LayerTile tile, Matrix4x4 matrixTransform)
+		private void SetTile(Vector3Int position, LayerTile tile, OrientationEnum orientation)
 		{
 			foreach (LayerTile requiredTile in tile.RequiredTiles)
 			{
-				SetTile(position, requiredTile, matrixTransform);
+				SetTile(position, requiredTile, orientation);
 			}
 
-			metaTileMap.SetTile(position, tile, matrixTransform);
+			metaTileMap.SetTile(position, tile, orientation);
 		}
 	}


### PR DESCRIPTION
### Purpose
The server will now use an enum to dictate the orientation of a tile instead of sending an entire matrix4x4
Clients will now ask for the tile updates after the matrix are initialized.
Increases the max chunk size of a new player tile updates from 25 to 200.
