### PR TITLE
Fixes radiation not dealing damage

### DIFF
--- a/UnityProject/Assets/Scripts/HealthV2/HealthEnums.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/HealthEnums.cs
@@ -56,8 +56,7 @@ public enum DamageType
 	Tox  = 2,
 	Oxy = 3,
 	Clone = 4,
-	Stamina = 5,
-	Radiation = 6
+	Stamina = 5
 }
 
 public enum TraumaDamageLevel

--- a/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPart.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPart.cs
@@ -152,7 +152,7 @@ namespace HealthV2
 
 		/// <summary>
 		/// Updates the body part and all contained body parts relative to their related
-		/// systems (default: blood system, radiation damage)
+		/// systems (default: blood system)
 		/// </summary>
 		public void ImplantPeriodicUpdate()
 		{
@@ -166,7 +166,6 @@ namespace HealthV2
 				}
 			}
 			BloodUpdate();
-			CalculateRadiationDamage();
 
 			if(IsBleeding)
 			{


### PR DESCRIPTION
### Purpose
Fixes radiation not dealing damage.
Removes radiation damage from bodyparts.
Adds radiation stacks to LivingHealthMasterBase.
Radiation will deal a maximum of 1 toxin damage per tick as long as there are radiation stacks.
Fixes #7391