### PR TITLE
Fix declaring war not counting down, and fix syndies being unable to shoot their guns

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Consoles/SyndicateOpConsole.cs
+++ b/UnityProject/Assets/Scripts/Objects/Consoles/SyndicateOpConsole.cs
@@ -38,6 +38,7 @@ namespace SyndicateOps
 		private void OnDisable()
 		{
 			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, RewardTelecrystals);
+			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, CountDown);
 		}
 
 		public void AnnounceWar(string declarationMessage)
@@ -51,6 +52,7 @@ namespace SyndicateOps
 				$"Attention all crew! An open message from the syndicate has been picked up on local radiowaves! Message Reads:\n" +
 				$"{declarationMessage}" ,CentComm.UpdateSound.Alert);
 				UpdateManager.Add(RewardTelecrystals, 60);
+				UpdateManager.Add(CountDown, 1);
 			}
 		}
 
@@ -63,7 +65,14 @@ namespace SyndicateOps
 			{
 				UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, RewardTelecrystals);
 			}
-
+		}
+		public void CountDown()
+		{
+			timer -= 1;
+			if(timer == 0)
+			{
+				UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, CountDown);
+			}
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Clearance/ClearanceCheckable.cs
+++ b/UnityProject/Assets/Scripts/Systems/Clearance/ClearanceCheckable.cs
@@ -30,6 +30,12 @@ namespace Systems.Clearance
 			{
 				return true;
 			}
+			// If the player has null or no defined access, access is denied
+			if (requesterClearance == null ||
+			    requesterClearance.Any() == false)
+			{
+				return false;
+			}
 
 			switch (type)
 			{

--- a/UnityProject/Assets/Scripts/Systems/Clearance/ClearanceCheckable.cs
+++ b/UnityProject/Assets/Scripts/Systems/Clearance/ClearanceCheckable.cs
@@ -30,9 +30,8 @@ namespace Systems.Clearance
 			{
 				return true;
 			}
-			// If the player has null or no defined access, access is denied
-			if (requesterClearance == null ||
-			    requesterClearance.Any() == false)
+			// If the player has null access, access is denied
+			if (requesterClearance == null)
 			{
 				return false;
 			}

--- a/UnityProject/Assets/Scripts/Systems/Occupations/AccessRestrictions.cs
+++ b/UnityProject/Assets/Scripts/Systems/Occupations/AccessRestrictions.cs
@@ -54,14 +54,12 @@ public class AccessRestrictions : MonoBehaviour
 
 	public static IDCard GetIDCard(GameObject idCardObj)
 	{
-		var idCard = idCardObj.GetComponent<IDCard>();
-		var pda = idCardObj.GetComponent<PDALogic>();
-		if (idCard != null)
+		if (idCardObj.TryGetComponent<IDCard>(out var idCard))
 		{
 			return idCard;
 		}
 
-		if (pda != null)
+		if (idCardObj.TryGetComponent<PDALogic>(out var pda))
 		{
 			return pda.IDCard;
 		}


### PR DESCRIPTION
partially closes #7532 and fully closes #6186 
IN DETAIL: declaring war now has the timer actually count down instead of remaining 20:00, and syndicates can fire ID locked weapons without causing an NRE when their ID is in a PDA.

CL: [Fix] Fixed declaring war not counting down
CL: [Fix] Fixed syndies being unable to shoot their guns