### PR TITLE
Removes unneeded  Cool down ( fixes plasma cutter )

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Validations.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Validations.cs
@@ -19,11 +19,6 @@ using Objects.Wallmounts;
 /// </summary>
 public static class Validations
 {
-	//Monitors the time between interactions and limits it by the min cool down time
-	private static Dictionary<GameObject, DateTime> playerCoolDown = new Dictionary<GameObject, DateTime>();
-	private static Dictionary<GameObject, int> playersMaxClick = new Dictionary<GameObject, int>();
-	private static double minCoolDown = 0.1f;
-	private static int maxClicks = 5;
 
 	/// <summary>
 	/// Check if this game object is not null has the specified component
@@ -138,37 +133,6 @@ public static class Validations
 			return false;
 		}
 
-		return true;
-	}
-
-	//Monitors the interaction rate of a player. If its too fast we return false
-	private static bool CanInteractByCoolDownState(GameObject playerObject)
-	{
-		if (playersMaxClick.ContainsKey(playerObject) == false)
-		{
-			playersMaxClick.Add(playerObject, 0);
-		}
-
-		if (playerCoolDown.ContainsKey(playerObject) == false)
-		{
-			playerCoolDown.Add(playerObject, DateTime.Now);
-			return true;
-		}
-
-		var totalSeconds = (DateTime.Now - playerCoolDown[playerObject]).TotalSeconds;
-		if(totalSeconds < minCoolDown)
-		{
-			playersMaxClick[playerObject]++;
-			if (playersMaxClick[playerObject] <= maxClicks)
-			{
-				return true;
-			}
-
-			return false;
-		}
-
-		playerCoolDown[playerObject] = DateTime.Now;
-		playersMaxClick[playerObject] = 0;
 		return true;
 	}
 

--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Validations.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Validations.cs
@@ -126,10 +126,9 @@ public static class Validations
 	/// <param name="allowSoftCrit">whether interaction should be allowed if in soft crit</param>
 	/// <param name="allowCuffed">whether interaction should be allowed if cuffed</param>
 	/// <returns></returns>
-	public static bool CanInteract(PlayerScript playerScript, NetworkSide side, bool allowSoftCrit = false, bool allowCuffed = false, bool isPlayerClick = true)
+	public static bool CanInteract(PlayerScript playerScript, NetworkSide side, bool allowSoftCrit = false, bool allowCuffed = false)
 	{
 		if (playerScript == null) return false;
-		if (isPlayerClick && CanInteractByCoolDownState(playerScript.gameObject) == false) return false;
 
 		if ((allowCuffed == false && playerScript.playerMove.IsCuffed) ||
 		    playerScript.IsGhost ||
@@ -210,15 +209,14 @@ public static class Validations
 		bool allowSoftCrit = false,
 		ReachRange reachRange = ReachRange.Standard,
 		Vector2? targetVector = null,
-		RegisterTile targetRegisterTile = null,
-		bool isPlayerClick = false
+		RegisterTile targetRegisterTile = null
 	)
 	{
 		if (playerScript == null) return false;
 
 		var playerObjBehavior = playerScript.pushPull;
 
-		if (CanInteract(playerScript, side, allowSoftCrit, isPlayerClick: isPlayerClick) == false)
+		if (CanInteract(playerScript, side, allowSoftCrit) == false)
 		{
 			return false;
 		}

--- a/UnityProject/Assets/Scripts/Systems/Inventory/Pickupable.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/Pickupable.cs
@@ -128,7 +128,7 @@ public class Pickupable : NetworkBehaviour, IPredictedCheckedInteractable<HandAp
 		//hand needs to be empty for pickup
 		if (interaction.HandObject != null) return false;
 		//instead of the base logic, we need to use extended range check for CanApply
-		if (!Validations.CanApply(interaction.PerformerPlayerScript, interaction.TargetObject, side, true, isPlayerClick: true)) return false;
+		if (!Validations.CanApply(interaction.PerformerPlayerScript, interaction.TargetObject, side, true)) return false;
 
 		return true;
 	}
@@ -236,7 +236,7 @@ public class Pickupable : NetworkBehaviour, IPredictedCheckedInteractable<HandAp
 		var interaction = HandApply.ByLocalPlayer(gameObject);
 		if (interaction.TargetObject != gameObject) return null;
 		if (interaction.HandObject != null) return null;
-		if (!Validations.CanApply(interaction.PerformerPlayerScript, interaction.TargetObject, NetworkSide.Client, true, ReachRange.Standard, isPlayerClick: false)) return null;
+		if (!Validations.CanApply(interaction.PerformerPlayerScript, interaction.TargetObject, NetworkSide.Client, true, ReachRange.Standard)) return null;
 
 		return RightClickableResult.Create()
 				.AddElement("PickUp", RightClickInteract);


### PR DESCRIPTION
why remove cool down?

I could have tried fixing it but the way it is implemented that since it's on the will interact side it will always trigger to a point where it will block random interaction,  the equivalent for server the form interaction is already implemented before the interaction takes place on an object, so I don't see much use for this since intrinsically will just cause issues down the line

closes #6907 
