### PR TITLE
Fixes clients missing objects

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.Server.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.Server.cs
@@ -74,8 +74,11 @@ public partial class SubSceneManager
 		var netIds = NetworkIdentity.spawned.Values.ToList();
 		foreach (var n in netIds)
 		{
-			if (n == null || n.gameObject == null ||
-			    n.gameObject.scene != sceneContext) continue;
+			if (n == null || n.gameObject == null || n.gameObject.scene != sceneContext)
+				continue;
+
+			if (connToAdd.identity == null) //connection dc midway, we're out
+				yield break;
 
 			n.AddPlayerObserver(connToAdd);
 			objCount++;


### PR DESCRIPTION
### Purpose
CL: [Fix] Fixed servers having the chance of not sending object data to new logged in clients.
This includes the possible lack of matrixes' initialization
Fixes #7246
