### PR TITLE
fixed deconstruction for SMES and microwave

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Engineering/SMES.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/SMES.cs
@@ -4,6 +4,7 @@ using Mirror;
 using Systems.Electricity.NodeModules;
 using Systems.Explosions;
 using Systems.Interaction;
+using Objects.Machines;
 
 
 namespace Objects.Engineering
@@ -22,6 +23,7 @@ namespace Objects.Engineering
 		private ElectricalNodeControl electricalNodeControl;
 		private BatterySupplyingModule batterySupplyingModule;
 		private GameObject currentSparkEffect;
+		private Machine machine;
 
 
 		private SpriteHandler baseSpriteHandler;
@@ -66,6 +68,7 @@ namespace Objects.Engineering
 			chargeLevelIndicator = transform.GetChild(3).GetComponent<SpriteHandler>();
 			registerTile = GetComponent<RegisterTile>();
 			objectBehaviour = GetComponent<ObjectBehaviour>();
+			machine = GetComponent<Machine>();
 
 			electricalNodeControl = GetComponent<ElectricalNodeControl>();
 			batterySupplyingModule = GetComponent<BatterySupplyingModule>();
@@ -126,7 +129,10 @@ namespace Objects.Engineering
 		{
 			if (!DefaultWillInteract.Default(interaction, side)) return false;
 			if (interaction.TargetObject != gameObject) return false;
-			if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Crowbar)) return true;
+			if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Crowbar))
+			{
+				return !machine.GetPanelOpen();
+			} 
 			if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Wrench)) return true;
 			if (interaction.HandObject != null) return false;
 

--- a/UnityProject/Assets/Scripts/Objects/Kitchen/InteractableMicrowave.cs
+++ b/UnityProject/Assets/Scripts/Objects/Kitchen/InteractableMicrowave.cs
@@ -56,7 +56,8 @@ namespace Objects.Kitchen
 		{
 			if (DefaultWillInteract.Default(interaction, side) == false) return false;
 
-			return Validations.HasUsedItemTrait(interaction, CommonTraits.Instance.Screwdriver) == false;
+			return (Validations.HasUsedItemTrait(interaction, CommonTraits.Instance.Screwdriver) 
+				|| Validations.HasUsedItemTrait(interaction, CommonTraits.Instance.Crowbar)) == false;
 		}
 
 		public void ServerPerformInteraction(PositionalHandApply interaction)

--- a/UnityProject/Assets/Scripts/Systems/Construction/Machine.cs
+++ b/UnityProject/Assets/Scripts/Systems/Construction/Machine.cs
@@ -78,7 +78,6 @@ namespace Objects.Machines
 
 		public void ServerPerformInteraction(HandApply interaction)
 		{
-
 			if (Validations.HasUsedItemTrait(interaction, CommonTraits.Instance.Screwdriver))
 			{
 				AudioSourceParameters audioSourceParameters = new AudioSourceParameters(pitch: UnityEngine.Random.Range(0.8f, 1.2f));
@@ -242,6 +241,10 @@ namespace Objects.Machines
 			{
 				refresh.InitialParts(basicPartsUsed);
 			}
+		}
+
+		public bool GetPanelOpen() {
+			return panelopen;
 		}
 	}
 


### PR DESCRIPTION
<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->

### Purpose
<!-- Describe the problem the PR fixes or the feature it introduces. --> <br>
<!-- Don't forget to use "Fixes #issuenumber" to select issues and auto close them on merge. -->
Fixes deconstruction SMS and microwave during crowbar step. SMS had crowbar interactions that conflicted with the deconstruction process. Solution was to check if the panel was open to use deconstruction and if closed then adjust the charge input rate. For the microwave, it was just not properly handling crowbar interactions.
Fixes #7462

### Notes:
<!-- Please enter any other relevant information here -->

### Changelog:

CL: [Fix] SMES and Microwave can now be deconstructed