### PR TITLE
It is dirty! fixes issues with Synchronise lists not updating clients

### DIFF
--- a/UnityProject/Assets/Scripts/Items/IDCard.cs
+++ b/UnityProject/Assets/Scripts/Items/IDCard.cs
@@ -205,6 +205,7 @@ public class IDCard : NetworkBehaviour, IServerInventoryMove, IServerSpawn, IInt
 	{
 		if (!HasAccess(access)) return;
 		accessSyncList.Remove((int)access);
+		netIdentity.isDirty = true;
 	}
 
 	/// <summary>
@@ -215,6 +216,7 @@ public class IDCard : NetworkBehaviour, IServerInventoryMove, IServerSpawn, IInt
 	{
 		if (HasAccess(access)) return;
 		accessSyncList.Add((int)access);
+		netIdentity.isDirty = true;
 	}
 
 	/// <summary>
@@ -256,7 +258,12 @@ public class IDCard : NetworkBehaviour, IServerInventoryMove, IServerSpawn, IInt
 	[Server]
 	public void ServerChangeOccupation(Occupation occupation, bool grantDefaultAccess = true, bool clear = true)
 	{
-		if (clear) accessSyncList.Clear();
+		if (clear)
+		{
+			accessSyncList.Clear();
+			netIdentity.isDirty = true;
+		}
+
 		if (grantDefaultAccess)
 		{
 			ServerAddAccess(occupation.AllowedAccess);

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.SceneList.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.SceneList.cs
@@ -82,6 +82,7 @@ public partial class SubSceneManager
 			SceneName = serverChosenMainStation,
 			SceneType = SceneType.MainStation
 		});
+		netIdentity.isDirty = true;
 	}
 
 	//Load all the asteroids on the server
@@ -98,6 +99,7 @@ public partial class SubSceneManager
 				SceneName = asteroid,
 				SceneType = SceneType.Asteroid
 			});
+			netIdentity.isDirty = true;
 		}
 	}
 
@@ -123,7 +125,7 @@ public partial class SubSceneManager
 				SceneName = centComData.CentComSceneName,
 				SceneType = SceneType.AdditionalScenes
 			});
-
+			netIdentity.isDirty = true;
 			yield break;
 		}
 
@@ -137,6 +139,7 @@ public partial class SubSceneManager
 			SceneName = pickedMap,
 			SceneType = SceneType.AdditionalScenes
 		});
+		netIdentity.isDirty = true;
 	}
 
 	//Load all the asteroids on the server
@@ -174,6 +177,7 @@ public partial class SubSceneManager
 				SceneName = additionalScene,
 				SceneType = SceneType.AdditionalScenes
 			});
+			netIdentity.isDirty = true;
 		}
 	}
 
@@ -211,6 +215,7 @@ public partial class SubSceneManager
 				SceneName = serverChosenAwaySite,
 				SceneType = SceneType.AwaySite
 			});
+			netIdentity.isDirty = true;
 		}
 	}
 
@@ -238,6 +243,7 @@ public partial class SubSceneManager
 			SceneName = pickedMap,
 			SceneType = SceneType.AdditionalScenes
 		});
+		netIdentity.isDirty = true;
 
 		SyndicateScene = SceneManager.GetSceneByName(pickedMap);
 		SyndicateLoaded = true;
@@ -256,6 +262,7 @@ public partial class SubSceneManager
 			SceneName = pickedScene,
 			SceneType = SceneType.AdditionalScenes
 		});
+		netIdentity.isDirty = true;
 
 		WizardLoaded = true;
 	}

--- a/UnityProject/Assets/Scripts/Messages/Server/DoorUpdateMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/DoorUpdateMessage.cs
@@ -25,6 +25,17 @@ namespace Messages.Server
 			LoadNetworkObject(msg.Door);
 			if (NetworkObject == null)  return;
 
+			//old doors //needed for fire locks and directional doors
+			var doorAnimator = NetworkObject.GetComponent<DoorAnimator>();
+			if (doorAnimator != null)
+			{
+				if (doorAnimator.isActiveAndEnabled == false) return;
+
+				doorAnimator.PlayAnimation(msg.Type, msg.SkipAnimation);
+				return;
+			}
+
+			//new doors
 			var doorMasterController = NetworkObject.GetComponent<DoorMasterController>();
 			if (doorMasterController != null)
 			{

--- a/UnityProject/Assets/Scripts/Systems/Clearance/BasicClearanceProvider.cs
+++ b/UnityProject/Assets/Scripts/Systems/Clearance/BasicClearanceProvider.cs
@@ -63,6 +63,7 @@ namespace Systems.Clearance
 			foreach (var c in newClearance)
 			{
 				syncedClearance.Add(c);
+				netIdentity.isDirty = true;
 			}
 		}
 
@@ -79,6 +80,7 @@ namespace Systems.Clearance
 			foreach (var c in newClearance)
 			{
 				syncedLowpopClearance.Add(c);
+				netIdentity.isDirty = true;
 			}
 		}
 
@@ -86,18 +88,21 @@ namespace Systems.Clearance
 		public void ServerClearClearance()
 		{
 			syncedClearance.Clear();
+			netIdentity.isDirty = true;
 		}
 
 		[Server]
 		public void ServerClearLowPopClearance()
 		{
 			syncedLowpopClearance.Clear();
+			netIdentity.isDirty = true;
 		}
 
 		// ReSharper disable Unity.PerformanceAnalysis
 		private void OnClearanceListUpdated(SyncList<Clearance>.Operation op, int index, Clearance oldAccess,
 			Clearance newAccess )
 		{
+			netIdentity.isDirty = true;
 			switch (op)
 			{
 				case SyncList<Clearance>.Operation.OP_ADD:
@@ -124,6 +129,7 @@ namespace Systems.Clearance
 		private void OnLowPopClearanceListUpdated(SyncList<Clearance>.Operation op, int index, Clearance oldAccess,
 			Clearance newAccess )
 		{
+			netIdentity.isDirty = true;
 			switch (op)
 			{
 				case SyncList<Clearance>.Operation.OP_ADD:

--- a/UnityProject/Assets/Scripts/Systems/Construction/MachineFrame.cs
+++ b/UnityProject/Assets/Scripts/Systems/Construction/MachineFrame.cs
@@ -309,6 +309,8 @@ namespace Objects.Construction
 					allowedTraits.Add(new AllowedTraitList(list.itemTrait));
 				}
 
+				netIdentity.isDirty = true;
+
 				Inventory.ServerTransfer(interaction.HandSlot, circuitBoardSlot);
 				stateful.ServerChangeState(circuitAddedState);
 				putBoardInManually = true;
@@ -695,6 +697,8 @@ namespace Objects.Construction
 					allowedTraits.Add(new AllowedTraitList(list.itemTrait));
 				}
 			}
+
+			netIdentity.isDirty = true;
 
 			// Put it in
 			Inventory.ServerAdd(board, circuitBoardSlot);

--- a/docs/development/Notes-on-SyncObject-and-SyncList.md
+++ b/docs/development/Notes-on-SyncObject-and-SyncList.md
@@ -1,0 +1,19 @@
+
+# Note SyncObject And SyncList Usage
+If present on a network behaviour it will synchronise the current state of the object to the client, 
+however due to some of our changes to optimise mirror, if you change any element or  change the SyncObject  in anyway, 
+you have to manually mark the netIdentity.isDirty = true, like so
+
+        :::csharp
+        public SyncList<SceneInfo> loadedScenesList = new SyncList<SceneInfo>();
+        
+        public void addSceneInfo()
+        {
+            loadedScenesList.Add(new SceneInfo
+            {
+            	SceneName = serverChosenMainStation,
+            	SceneType = SceneType.MainStation
+            });
+            netIdentity.isDirty = true;
+        }
+


### PR DESCRIPTION
The md has more information on it but basically, the synchronise list has no way of setting the network identity dirty so it has to be done manually