### PR TITLE
server performance optimisation

### DIFF
--- a/UnityProject/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/UnityProject/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -516,11 +516,13 @@ namespace Mirror
         // true if syncInterval elapsed and any SyncVar or SyncObject is dirty
         public bool IsDirty()
         {
-            if (Time.time - lastSyncTime >= syncInterval)
-            {
-                return syncVarDirtyBits != 0L || AnySyncObjectDirty();
-            }
-            return false;
+	        //CUSTOM UNITYSTATION CODE// It's presumed to be dirty already since The addition of is dirty on the network component
+	        return true;
+	        // if (Time.time - lastSyncTime >= syncInterval)
+	        // {
+	        // return syncVarDirtyBits != 0L || AnySyncObjectDirty();
+	        // }
+	        // return false;
         }
 
         /// <summary>Override to do custom serialization (instead of SyncVars/SyncLists). Use OnDeserialize too.</summary>

--- a/UnityProject/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/UnityProject/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1552,8 +1552,9 @@ namespace Mirror
                     // NOTE: this is what we did before push->pull
                     //       broadcasting. let's keep doing this for
                     //       feature parity to not break anyone's project.
-                    //       TODO make this more simple / unnecessary later.
-                    identity.ClearDirtyComponentsDirtyBits();
+                    //       TODO make this more simple / unnecessary later.#
+                    //CUSTOM UNITYSTATION CODE// commented this out \/
+                    //identity.ClearDirtyComponentsDirtyBits();
                 }
                 // spawned list should have no null entries because we
                 // always call Remove in OnObjectDestroy everywhere.

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.cs
@@ -490,11 +490,13 @@ public partial class PlayerSync : NetworkBehaviour, IPushable, IPlayerControllab
 
 		if (Matrix != null)
 		{
-			CheckMovementClient();
-
 			if (server)
 			{
 				CheckMovementServer();
+			}
+			else
+			{
+				CheckMovementClient();
 			}
 
 			if (!ClientPositionReady)


### PR DESCRIPTION
removed the is dirty from mirrors implementation, 
since it is badly optimised, opting to completely rely on our custom is dirty check,
note : all data tied with the network identity Will be serialised and sent 

with testing if it's worse or better with our setup
removed unnecessary clean dirty bits
 and client movement check is moved to client only
 Was tested with builds connected to each other and That work Fine