### PR TITLE
Lightbulbs no longer contain the sun in them

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Lighting/LightSource.cs
+++ b/UnityProject/Assets/Scripts/Core/Lighting/LightSource.cs
@@ -50,6 +50,7 @@ namespace Objects.Lighting
 		[SerializeField] private Vector4 collLeftSetting = Vector4.zero;
 		[SerializeField] private SpritesDirectional spritesStateOnEffect = null;
 		[SerializeField] private SOLightMountStatesMachine mountStatesMachine = null;
+		[SerializeField, Range(0,100f)] private float maximumDamageOnTouch = 3f;
 		private SOLightMountState currentState;
 		private ObjectBehaviour objectBehaviour;
 		private LightFixtureConstruction construction;
@@ -313,11 +314,12 @@ namespace Objects.Lighting
 				                                     !Validations.HasItemTrait(handSlot.ItemObject,
 					                                     CommonTraits.Instance.BlackGloves)))
 				{
+					float damage = Random.Range(0, maximumDamageOnTouch);
 					var playerHealth = interaction.PerformerPlayerScript.playerHealth;
 					var burntBodyPart = interaction.HandSlot.NamedSlot == NamedSlot.leftHand
 						? BodyPartType.LeftArm
 						: BodyPartType.RightArm;
-					playerHealth.ApplyDamageToBodyPart(gameObject, 10f, AttackType.Energy, DamageType.Burn,
+					playerHealth.ApplyDamageToBodyPart(gameObject, damage, AttackType.Energy, DamageType.Burn,
 						burntBodyPart);
 
 					Chat.AddExamineMsgFromServer(interaction.Performer,


### PR DESCRIPTION
fixes #7592

CL: [balance] Lights do now a damage between 0 and 3
- Added the ability for mappers to specify how much damage a LightSource object should do upon touch (In English: It's not hardcoded)