### PR TITLE
Fixes aHealing on AIs

### DIFF
--- a/UnityProject/Assets/Scripts/HealthV2/IFullyHealable.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/IFullyHealable.cs
@@ -1,0 +1,6 @@
+﻿
+public interface IFullyHealable
+{
+
+	void FullyHeal();
+}

--- a/UnityProject/Assets/Scripts/HealthV2/IFullyHealable.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/IFullyHealable.cs
@@ -1,6 +1,8 @@
 ﻿
-public interface IFullyHealable
+namespace HealthV2
 {
-
-	void FullyHeal();
+	public interface IFullyHealable
+	{
+		void FullyHeal();
+	}
 }

--- a/UnityProject/Assets/Scripts/HealthV2/IFullyHealable.cs.meta
+++ b/UnityProject/Assets/Scripts/HealthV2/IFullyHealable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d6c24c1f108e004fb679a2a3b4b0164
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Items/Medical/DefibrillatorPaddles.cs
+++ b/UnityProject/Assets/Scripts/Items/Medical/DefibrillatorPaddles.cs
@@ -61,26 +61,10 @@ public class DefibrillatorPaddles : MonoBehaviour, ICheckedInteractable<HandAppl
 			{
 				return;
 			}
-			foreach (var BodyPart in livingHealthMaster.BodyPartList)
-			{
-				foreach (var organ in BodyPart.OrganList)
-				{
-					if (organ is Heart heart)
-					{
-						heart.HeartAttack = false;
-						heart.CanTriggerHeartAttack = false;
-						heart.CurrentPulse = 0;
-					}
-				}
-			}
-			livingHealthMaster.CalculateOverallHealth();
+			livingHealthMaster.RestartHeart();
 			if (livingHealthMaster.IsDead == false)
 			{
-				var ghost = livingHealthMaster.playerScript.mind?.ghost;
-				if (ghost)
-				{
-					ghost.playerNetworkActions.GhostEnterBody();
-				}
+				livingHealthMaster.playerScript.ReturnGhostToBody();
 			}
 		}
 		var bar = StandardProgressAction.Create(new StandardProgressActionConfig(StandardProgressActionType.CPR, false, false, true), Perform);

--- a/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
@@ -318,9 +318,9 @@ namespace AdminCommands
 				string message;
 
 				//Does this player have a body that can be healed?
-				if (playerBody != null)
+				if (playerBody != null && playerBody.TryGetComponent<IFullyHealable>(out var healable))
 				{
-					playerBody.playerHealth.RevivePlayerToFullHealth();
+					healable.FullyHeal();
 					message = $"{admin.Username}: Healed up Username: {player.Username} ({player.Name})";
 				}
 				else

--- a/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
@@ -8,7 +8,7 @@ using Managers;
 using Messages.Server;
 using Messages.Server.AdminTools;
 using Strings;
-
+using HealthV2;
 
 namespace AdminCommands
 {

--- a/UnityProject/Assets/Scripts/Player/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerScript.cs
@@ -366,6 +366,15 @@ public class PlayerScript : NetworkBehaviour, IMatrixRotation, IAdminInfo, IActi
 	// If the player acts like a ghost but is still playing ingame, used for blobs and in the future maybe AI.
 	public bool IsPlayerSemiGhost => playerState == PlayerStates.Blob || playerState == PlayerStates.Ai;
 
+	public void ReturnGhostToBody()
+	{
+		var ghost = mind?.ghost;
+		if (ghost != null)
+		{
+			ghost.playerNetworkActions.GhostEnterBody();
+		}
+	}
+
 	public object Chat { get; internal set; }
 
 	public bool IsGameObjectReachable(GameObject go, bool isServer, float interactDist = interactionDistance, GameObject context=null)

--- a/UnityProject/Assets/Scripts/Systems/Ai/AiPlayer.cs
+++ b/UnityProject/Assets/Scripts/Systems/Ai/AiPlayer.cs
@@ -13,6 +13,7 @@ using Objects.Engineering;
 using Objects.Research;
 using UI.Systems.MainHUD.UI_Bottom;
 using UnityEngine;
+using HealthV2;
 
 namespace Systems.Ai
 {

--- a/UnityProject/Assets/Scripts/Systems/Ai/AiPlayer.cs
+++ b/UnityProject/Assets/Scripts/Systems/Ai/AiPlayer.cs
@@ -21,7 +21,7 @@ namespace Systems.Ai
 	/// This isn't the class which is on the AiCore or InteliCard that is AiVessel
 	/// Sync vars in this class only get sync'd to the object owner
 	/// </summary>
-	public class AiPlayer : NetworkBehaviour, IAdminInfo
+	public class AiPlayer : NetworkBehaviour, IAdminInfo, IFullyHealable
 	{
 		[SerializeField]
 		private GameObject corePrefab = null;
@@ -72,8 +72,10 @@ namespace Systems.Ai
 		private float power;
 
 		[SyncVar(hook = nameof(SyncIntegrity))]
-		private float integrity = 100;
+		private float integrity = StartingIntegrity;
 		public float Integrity => integrity;
+
+		public static readonly float StartingIntegrity = 100;
 
 		[SyncVar(hook = nameof(SyncNumberOfCameras))]
 		private uint numberOfCameras = 100;
@@ -778,7 +780,7 @@ namespace Systems.Ai
 			var newIntegrity = integrity + byValue;
 
 			//Integrity has to be between 0 and 100 due to the slider setting for the intelicard GUI
-			newIntegrity = Mathf.Clamp(newIntegrity, 0, 100);
+			newIntegrity = Mathf.Clamp(newIntegrity, 0, StartingIntegrity);
 
 			integrity = newIntegrity;
 
@@ -792,6 +794,11 @@ namespace Systems.Ai
 			{
 				vesselObject.GetComponent<AiVessel>().UpdateGui();
 			}
+		}
+
+		public void FullyHeal()
+		{
+			ChangeIntegrity(StartingIntegrity);
 		}
 
 		[Command]


### PR DESCRIPTION
### Purpose
CL: [Fix] Fixed aHealing from disconnecting the admin if the target was an AI.
Removes some copypaste code for restarting the heart.
CL: [Fix] aHealing will now return ghosts to their bodies.
Fixes #6734

