### PR TITLE
Removes unneeded raycasts  From AI

### DIFF
--- a/UnityProject/Assets/Scripts/NPC/AI/Friendly/CatAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Friendly/CatAI.cs
@@ -77,17 +77,16 @@ namespace Systems.MobAIs
 		{
 			var hits = coneOfSight.GetObjectsInSight(mobMask, LayerTypeSelection.Walls,
 				directional.CurrentDirection.Vector,
-				10f,
-				20);
+				10f);
 
 			foreach (var coll in hits)
 			{
-				if (coll.GameObject == null) continue;
+				if (coll == null) continue;
 
-				if (coll.GameObject != gameObject && coll.GameObject.GetComponent<MouseAI>() != null
-				                                  && !coll.GameObject.GetComponent<LivingHealthBehaviour>().IsDead)
+				if (coll != gameObject && coll.GetComponent<MouseAI>() != null
+				                                  && !coll.GetComponent<LivingHealthBehaviour>().IsDead)
 				{
-					return coll.GameObject.GetComponent<MouseAI>();
+					return coll.GetComponent<MouseAI>();
 				}
 			}
 			return null;

--- a/UnityProject/Assets/Scripts/NPC/AI/Friendly/CorgiAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Friendly/CorgiAI.cs
@@ -191,15 +191,15 @@ namespace Systems.MobAIs
 
 		CatAI AnyCatsNearby()
 		{
-			var hits = coneOfSight.GetObjectsInSight(mobMask, LayerTypeSelection.Walls, directional.CurrentDirection.Vector, 10f, 5);
+			var hits = coneOfSight.GetObjectsInSight(mobMask, LayerTypeSelection.Walls, directional.CurrentDirection.Vector, 10f);
 			foreach (var coll in hits)
 			{
-				if (coll.GameObject == null) continue;
+				if (coll == null) continue;
 
-				if (coll.GameObject != gameObject && coll.GameObject.GetComponent<CatAI>() != null
-				                                  && !coll.GameObject.GetComponent<LivingHealthBehaviour>().IsDead)
+				if (coll != gameObject && coll.GetComponent<CatAI>() != null
+				                                  && !coll.GetComponent<LivingHealthBehaviour>().IsDead)
 				{
-					return coll.GameObject.GetComponent<CatAI>();
+					return coll.GetComponent<CatAI>();
 				}
 			}
 			return null;

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHuggerAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHuggerAI.cs
@@ -40,7 +40,7 @@ namespace Systems.MobAIs
 		/// <returns>Gameobject of the first player it found</returns>
 		protected override GameObject SearchForTarget()
 		{
-			var hits = coneOfSight.GetObjectsInSight(hitMask, LayerTypeSelection.Walls , directional.CurrentDirection.Vector, 10f, 10);
+			var hits = coneOfSight.GetObjectsInSight(hitMask, LayerTypeSelection.Walls , directional.CurrentDirection.Vector, 10f);
 			if (hits.Count == 0)
 			{
 				return null;
@@ -48,11 +48,9 @@ namespace Systems.MobAIs
 
 			foreach (var coll in hits)
 			{
-				if (coll.GameObject == null) continue;
-
-				if (coll.GameObject.layer == playersLayer)
+				if (coll.layer == playersLayer)
 				{
-					return coll.GameObject;
+					return coll;
 				}
 			}
 

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/StatueAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/StatueAI.cs
@@ -60,18 +60,18 @@ namespace Systems.MobAIs
 
 		private bool IsSomeoneLookingAtMe()
 		{
-			var hits = coneOfSight.GetObjectsInSight(hitMask, LayerTypeSelection.None , directional.CurrentDirection.Vector, 10f, 20);
+			var hits = coneOfSight.GetObjectsInSight(hitMask, LayerTypeSelection.None , directional.CurrentDirection.Vector, 10f);
 			if (hits.Count == 0) return false;
 
 			foreach (var coll in hits)
 			{
-				if (coll.GameObject == null) continue;
+				if (coll == null) continue;
 
-				var dir = (transform.position - coll.GameObject.transform.position).normalized;
+				var dir = (transform.position - coll.transform.position).normalized;
 
-				if (coll.GameObject.layer == playersLayer
-				    && !coll.GameObject.GetComponent<LivingHealthMasterBase>().IsDead
-				    && coll.GameObject.GetComponent<Directional>()?.CurrentDirection == orientations[DirToInt(dir)])
+				if (coll.layer == playersLayer
+				    && !coll.GetComponent<LivingHealthMasterBase>().IsDead
+				    && coll.GetComponent<Directional>()?.CurrentDirection == orientations[DirToInt(dir)])
 				{
 					Freeze();
 					return true;

--- a/UnityProject/Assets/Scripts/NPC/ConeOfSight/ConeOfSight.cs
+++ b/UnityProject/Assets/Scripts/NPC/ConeOfSight/ConeOfSight.cs
@@ -15,8 +15,8 @@ public class ConeOfSight : MonoBehaviour
 	/// Provide the direction to look and
 	/// include the layers you want to test for in the hitMask
 	/// </summary>
-	public List<MatrixManager.CollisionHit> GetObjectsInSight(LayerMask hitMask,LayerTypeSelection hitLayers , Vector2 direction, float lengthOfSight,
-		int rayCount = 5)
+	public List<GameObject> GetObjectsInSight(LayerMask hitMask, LayerTypeSelection hitLayers, Vector2 direction,
+		float lengthOfSight)
 	{
 		var angleOfDir = Vector3.Angle(direction, transform.up);
 		var cw = Vector3.Cross(transform.up, direction).z < 0f;
@@ -26,23 +26,48 @@ public class ConeOfSight : MonoBehaviour
 		}
 
 		var offsetDegrees = fieldOfView / 2f;
-		List<MatrixManager.CollisionHit> hitColls = new List<MatrixManager.CollisionHit>();
+		List<GameObject> hitColls = new List<GameObject>();
 
-		for (int i = 0; i < rayCount; i++)
+		var Hits = Physics2D.OverlapCircleAll(transform.position, lengthOfSight, hitMask);
+
+		var v1 = transform.position +
+		         (Quaternion.AngleAxis(-angleOfDir, Vector3.forward) * Quaternion.Euler(0, 0, -offsetDegrees)) *
+		         Vector3.up * lengthOfSight;
+		var v2 = transform.position +
+		         (Quaternion.AngleAxis(-angleOfDir, Vector3.forward) * Quaternion.Euler(0, 0, offsetDegrees)) *
+		         Vector3.up * lengthOfSight;
+
+
+		foreach (var hit in Hits)
 		{
-			var step = (float) i / ((float) rayCount - 1);
-			var offset = Mathf.Lerp(-offsetDegrees, offsetDegrees, step);
-			var castDir = (Quaternion.AngleAxis(-angleOfDir, Vector3.forward) * Quaternion.Euler(0,0, -offset)) * Vector3.up;
-
-			var hit = MatrixManager.RayCast(transform.position + castDir, castDir, lengthOfSight, hitLayers, hitMask);
-			// Debug.DrawRay(transform.position, castDir, Color.blue, 10f);
-			if (hit.ItHit)
+			if (isInsideSector(hit.transform.position.To2(), transform.position.To2(),
+				transform.position.To2() - v2.To2(), transform.position.To2() - v1.To2() ))
 			{
-				hitColls.Add(hit.CollisionHit);
+				var RayHit = MatrixManager.RayCast(transform.position, Vector2.zero, lengthOfSight, hitLayers,
+					WorldTo: hit.gameObject.transform.position);
+
+				if (RayHit.ItHit == false) //No obstructions
+				{
+					hitColls.Add(hit.gameObject);
+				}
 			}
 		}
 
+
+
 		return hitColls;
+	}
+
+	bool areClockwise(Vector2 v1, Vector2 v2)
+	{
+		return -v1.x * v2.y + v1.y * v2.x > 0;
+	}
+
+	bool isInsideSector(Vector2 point, Vector2 center, Vector2 sectorStart, Vector2 sectorEnd) //TODO Might bug out at 0,0 coordinates
+	{
+		var relPoint = new Vector2(point.x - center.x, point.y - center.y);
+		return !areClockwise(sectorStart, relPoint) &&
+		       areClockwise(sectorEnd, relPoint);
 	}
 
 	/// <summary>
@@ -50,7 +75,8 @@ public class ConeOfSight : MonoBehaviour
 	/// A world position is returned. It is advisable to use this
 	/// with matrix manager so all matricies are considered
 	/// </summary>
-	public Vector2 GetFurthestPositionInSight(Vector2 originWorldPos,LayerTypeSelection layerMask, LayerMask hitMask, Vector2 direction, float lengthOfSight,
+	public Vector2 GetFurthestPositionInSight(Vector2 originWorldPos, LayerTypeSelection layerMask, LayerMask hitMask,
+		Vector2 direction, float lengthOfSight,
 		int rayCount = 5)
 	{
 		var angleOfDir = Vector3.Angle(direction, transform.up);
@@ -65,8 +91,8 @@ public class ConeOfSight : MonoBehaviour
 		var furthestPoint = Vector2.zero;
 
 		//First see how far the initial direction is
-		var  dirHit = MatrixManager.RayCast(originWorldPos, direction, lengthOfSight, layerMask , hitMask);
-	//	Debug.DrawRay(originWorldPos, direction, Color.red, 10f);
+		var dirHit = MatrixManager.RayCast(originWorldPos, direction, lengthOfSight, layerMask, hitMask);
+		//	Debug.DrawRay(originWorldPos, direction, Color.red, 10f);
 		if (dirHit.ItHit == false)
 		{
 			furthestDist = lengthOfSight;
@@ -84,17 +110,18 @@ public class ConeOfSight : MonoBehaviour
 			var step = (float) i / ((float) rayCount - 1);
 			var offset = Mathf.Lerp(-offsetDegrees, offsetDegrees, step);
 
-			var castDir = (Quaternion.AngleAxis(-angleOfDir, Vector3.forward) * Quaternion.Euler(0,0, -offset)) * Vector3.up;
+			var castDir = (Quaternion.AngleAxis(-angleOfDir, Vector3.forward) * Quaternion.Euler(0, 0, -offset)) *
+			              Vector3.up;
 
 			var hit = MatrixManager.RayCast(originWorldPos, castDir, lengthOfSight, layerMask, hitMask);
-		//	Debug.DrawRay(originWorldPos, castDir, Color.blue, 10f);
+			//	Debug.DrawRay(originWorldPos, castDir, Color.blue, 10f);
 			if (hit.ItHit)
 			{
 				if (hit.Distance > furthestDist)
 				{
 					//this ray is longer, calculate the general position:
 					furthestDist = hit.Distance;
-					furthestPoint = originWorldPos + (Vector2)((castDir * hit.Distance) - (castDir * 1.5f));
+					furthestPoint = originWorldPos + (Vector2) ((castDir * hit.Distance) - (castDir * 1.5f));
 				}
 			}
 		}

--- a/UnityProject/Assets/Scripts/NPC/ConeOfSight/ConeOfSight.cs
+++ b/UnityProject/Assets/Scripts/NPC/ConeOfSight/ConeOfSight.cs
@@ -40,7 +40,7 @@ public class ConeOfSight : MonoBehaviour
 
 		foreach (var hit in Hits)
 		{
-			if (isInsideSector(hit.transform.position.To2(), transform.position.To2(),
+			if (IsInsideSector(hit.transform.position.To2(), transform.position.To2(),
 				transform.position.To2() - v2.To2(), transform.position.To2() - v1.To2() ))
 			{
 				var RayHit = MatrixManager.RayCast(transform.position, Vector2.zero, lengthOfSight, hitLayers,
@@ -58,16 +58,16 @@ public class ConeOfSight : MonoBehaviour
 		return hitColls;
 	}
 
-	bool areClockwise(Vector2 v1, Vector2 v2)
+	bool AreClockwise(Vector2 v1, Vector2 v2)
 	{
 		return -v1.x * v2.y + v1.y * v2.x > 0;
 	}
 
-	bool isInsideSector(Vector2 point, Vector2 center, Vector2 sectorStart, Vector2 sectorEnd) //TODO Might bug out at 0,0 coordinates
+	bool IsInsideSector(Vector2 point, Vector2 center, Vector2 sectorStart, Vector2 sectorEnd) //TODO Might bug out at 0,0 coordinates
 	{
 		var relPoint = new Vector2(point.x - center.x, point.y - center.y);
-		return !areClockwise(sectorStart, relPoint) &&
-		       areClockwise(sectorEnd, relPoint);
+		return !AreClockwise(sectorStart, relPoint) &&
+		       AreClockwise(sectorEnd, relPoint);
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Util/ConverterExtensions.cs
+++ b/UnityProject/Assets/Scripts/Util/ConverterExtensions.cs
@@ -5,6 +5,11 @@ using UnityEngine;
 
 public static class ConverterExtensions
 {
+	public static Vector2 To2(this Vector3 other)
+	{
+		return new Vector2(other.x, other.y);
+	}
+
 	public static Vector3Int RoundToInt(this Vector3 other)
 	{
 		return Vector3Int.RoundToInt(other);


### PR DESCRIPTION
Circle overlap is much more efficient than shooting at a ray and hope to hit a player, this only does raycasts if there is a player in range and within vision cone off-site
 
 