### PR TITLE
Fix chest damage suffication

### DIFF
--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamageDescriptors.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamageDescriptors.cs
@@ -114,40 +114,44 @@ namespace HealthV2
 			return TranslateTags(report.ToString());
 		}
 
-		protected void AnnounceJointDislocationEvent()
+		protected void AnnounceJointDislocationEvent(LivingHealthMasterBase healthMaster, BodyPart containedIn)
 		{
-			PlayerScript script = HealthMaster.playerScript;
+			if (healthMaster == null) healthMaster = HealthMaster;
+			if (containedIn == null) containedIn = ContainedIn;
+			PlayerScript script = healthMaster.playerScript;
 			if (IsSurface)
 			{
-				Chat.AddActionMsgToChat(HealthMaster.gameObject,
+				Chat.AddActionMsgToChat(healthMaster.gameObject,
 					$"Your {BodyPartReadableName} dislocates from it's place!",
 					$"{script.visibleName}'s {BodyPartReadableName} becomes visibly out of place!");
 			}
 			else
 			{
-				Chat.AddActionMsgToChat(HealthMaster.gameObject,
+				Chat.AddActionMsgToChat(healthMaster.gameObject,
 					$"You wince and hold on to your {BodyPartReadableName} as it dislocates from your " +
-					$"{ContainedIn.gameObject.ExpensiveName()}.",
+					$"{containedIn.gameObject.ExpensiveName()}.",
 					$"{script.visibleName} holds onto " +
-					$"{script.characterSettings.TheirPronoun(script)} {ContainedIn.gameObject.ExpensiveName()} in pain.");
+					$"{script.characterSettings.TheirPronoun(script)} {containedIn.gameObject.ExpensiveName()} in pain.");
 			}
 		}
 
-		protected void AnnounceJointHealEvent()
+		protected void AnnounceJointHealEvent(LivingHealthMasterBase healthMaster, BodyPart containedIn)
 		{
-			PlayerScript script = HealthMaster.playerScript;
+			if (healthMaster == null) healthMaster = HealthMaster;
+			if (containedIn == null) containedIn = ContainedIn;
+			PlayerScript script = healthMaster.playerScript;
 			if (IsSurface)
 			{
-				Chat.AddActionMsgToChat(HealthMaster.gameObject,
+				Chat.AddActionMsgToChat(healthMaster.gameObject,
 					$"Your {BodyPartReadableName} pops back into place!",
 					$"{script.visibleName}'s {BodyPartReadableName} returns to it's original state!");
 			}
 			else
 			{
-				Chat.AddActionMsgToChat(HealthMaster.gameObject,
+				Chat.AddActionMsgToChat(healthMaster.gameObject,
 					$"You scream out loud as your {BodyPartReadableName} pops back into place.",
 					$"{script.visibleName} screams out in pain as " +
-					$"a loud crack can be heard from {script.characterSettings.TheirPronoun(script)} {ContainedIn.gameObject.ExpensiveName()}.");
+					$"a loud crack can be heard from {script.characterSettings.TheirPronoun(script)} {containedIn.gameObject.ExpensiveName()}.");
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -96,29 +96,26 @@ namespace HealthV2
 			}
 		}
 
+		public void TakeBluntLogic(LivingHealthMasterBase healthmaster, BodyPart containedIn)
+		{
+			if (currentBluntDamageLevel == TraumaDamageLevel.SMALL && DMMath.Prob(dislocationAutoHealPercent))
+			{
+				currentBluntDamageLevel = TraumaDamageLevel.NONE;
+				AnnounceJointHealEvent(healthmaster, containedIn);
+				return;
+			}
+			currentBluntDamageLevel += 1;
+			AnnounceJointDislocationEvent(healthmaster, containedIn);
+		}
+
 		public void TakeBluntDamage()
 		{
-			void TakeBluntLogic(BodyPart bodyPart)
-			{
-				if (bodyPart.currentBluntDamageLevel == TraumaDamageLevel.SMALL && DMMath.Prob(dislocationAutoHealPercent))
-				{
-					bodyPart.currentBluntDamageLevel = TraumaDamageLevel.NONE;
-					AnnounceJointHealEvent();
-					return;
-				}
-				bodyPart.currentBluntDamageLevel += 1;
-				if (BodyPartType != BodyPartType.Chest)
-				{
-					AnnounceJointDislocationEvent();
-				}
-			}
-
 			foreach (ItemSlot slot in OrganStorage.GetIndexedSlots())
 			{
 				if (slot.IsEmpty) return;
 				if (slot.Item.gameObject.TryGetComponent<BodyPart>(out var bodyPart))
 				{
-					if (bodyPart.CanBeBroken) TakeBluntLogic(bodyPart);
+					if (bodyPart.CanBeBroken) bodyPart.TakeBluntLogic(HealthMaster, this);
 				}
 			}
 		}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -107,7 +107,10 @@ namespace HealthV2
 					return;
 				}
 				bodyPart.currentBluntDamageLevel += 1;
-				AnnounceJointDislocationEvent();
+				if (BodyPartType != BodyPartType.Chest)
+				{
+					AnnounceJointDislocationEvent();
+				}
 			}
 
 			foreach (ItemSlot slot in OrganStorage.GetIndexedSlots())

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Organ.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Organ.cs
@@ -7,6 +7,7 @@ namespace HealthV2
 {
 	public class Organ : MonoBehaviour
 	{
+		protected BodyPart bodyPart;
 		[NonSerialized]
 		public BodyPart RelatedPart;
 		public virtual void ImplantPeriodicUpdate(){}
@@ -19,6 +20,11 @@ namespace HealthV2
 		public virtual void InternalDamageLogic()
 		{
 			RelatedPart.InternalBleedingLogic();
+		}
+
+		private void Awake()
+		{
+			bodyPart = GetComponent<BodyPart>();
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Heart.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Heart.cs
@@ -44,6 +44,13 @@ public class Heart : Organ
 
 	private bool alarmedForInternalBleeding = false;
 
+	private BodyPart bodyPart;
+
+	private void Awake()
+	{
+		bodyPart = GetComponent<BodyPart>();
+	}
+
 	public override void ImplantPeriodicUpdate()
 	{
 		base.ImplantPeriodicUpdate();
@@ -109,14 +116,14 @@ public class Heart : Organ
 		}
 
 		var TotalModified = 1f;
-		foreach (var Modifier in RelatedPart.AppliedModifiers)
+		foreach (var Modifier in bodyPart.AppliedModifiers)
 		{
 			var toMultiply = 1f;
-			if (Modifier == RelatedPart.DamageModifier)
+			if (Modifier == bodyPart.DamageModifier)
 			{
-				toMultiply = Mathf.Max(0f,Mathf.Max(RelatedPart.MaxHealth - RelatedPart.TotalDamageWithoutOxyCloneRadStam, 0) / RelatedPart.MaxHealth);
+				toMultiply = Mathf.Max(0f,Mathf.Max(bodyPart.MaxHealth - bodyPart.TotalDamageWithoutOxyCloneRadStam, 0) / bodyPart.MaxHealth);
 			}
-			else if (Modifier == RelatedPart.HungerModifier)
+			else if (Modifier == bodyPart.HungerModifier)
 			{
 				continue;
 			}

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Heart.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Heart.cs
@@ -44,13 +44,6 @@ public class Heart : Organ
 
 	private bool alarmedForInternalBleeding = false;
 
-	private BodyPart bodyPart;
-
-	private void Awake()
-	{
-		bodyPart = GetComponent<BodyPart>();
-	}
-
 	public override void ImplantPeriodicUpdate()
 	{
 		base.ImplantPeriodicUpdate();
@@ -116,20 +109,20 @@ public class Heart : Organ
 		}
 
 		var TotalModified = 1f;
-		foreach (var Modifier in bodyPart.AppliedModifiers)
+		foreach (var modifier in bodyPart.AppliedModifiers)
 		{
 			var toMultiply = 1f;
-			if (Modifier == bodyPart.DamageModifier)
+			if (modifier == bodyPart.DamageModifier)
 			{
 				toMultiply = Mathf.Max(0f,Mathf.Max(bodyPart.MaxHealth - bodyPart.TotalDamageWithoutOxyCloneRadStam, 0) / bodyPart.MaxHealth);
 			}
-			else if (Modifier == bodyPart.HungerModifier)
+			else if (modifier == bodyPart.HungerModifier)
 			{
 				continue;
 			}
 			else
 			{
-				toMultiply = Mathf.Max(0f, Modifier.Multiplier);
+				toMultiply = Mathf.Max(0f, modifier.Multiplier);
 			}
 			TotalModified *= toMultiply;
 		}

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
@@ -54,22 +54,29 @@ public class Lungs : Organ
 	[SerializeField] private float internalBleedingCooldown = 4f;
 	private bool onCooldown = false;
 
+	private BodyPart bodyPart;
+
+	private void Awake()
+	{
+		bodyPart = GetComponent<BodyPart>();
+	}
+
 	public override void ImplantPeriodicUpdate()
 	{
 		base.ImplantPeriodicUpdate();
 		Vector3Int position = RelatedPart.HealthMaster.ObjectBehaviour.AssumedWorldPositionServer();
 		MetaDataNode node = MatrixManager.GetMetaDataAt(position);
 		var TotalModified = 1f;
-		foreach (var Modifier in RelatedPart.AppliedModifiers)
+		foreach (var Modifier in bodyPart.AppliedModifiers)
 		{
 			var toMultiply = 1f;
-			if (Modifier == RelatedPart.DamageModifier)
+			if (Modifier == bodyPart.DamageModifier)
 			{
 				toMultiply = Mathf.Max(0f,
-					Mathf.Max(RelatedPart.MaxHealth - RelatedPart.TotalDamageWithoutOxyCloneRadStam, 0) /
-					RelatedPart.MaxHealth);
+					Mathf.Max(bodyPart.MaxHealth - bodyPart.TotalDamageWithoutOxyCloneRadStam, 0) /
+					bodyPart.MaxHealth);
 			}
-			else if (Modifier == RelatedPart.HungerModifier)
+			else if (Modifier == bodyPart.HungerModifier)
 			{
 				continue;
 			}

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
@@ -54,35 +54,28 @@ public class Lungs : Organ
 	[SerializeField] private float internalBleedingCooldown = 4f;
 	private bool onCooldown = false;
 
-	private BodyPart bodyPart;
-
-	private void Awake()
-	{
-		bodyPart = GetComponent<BodyPart>();
-	}
-
 	public override void ImplantPeriodicUpdate()
 	{
 		base.ImplantPeriodicUpdate();
 		Vector3Int position = RelatedPart.HealthMaster.ObjectBehaviour.AssumedWorldPositionServer();
 		MetaDataNode node = MatrixManager.GetMetaDataAt(position);
 		var TotalModified = 1f;
-		foreach (var Modifier in bodyPart.AppliedModifiers)
+		foreach (var modifier in bodyPart.AppliedModifiers)
 		{
 			var toMultiply = 1f;
-			if (Modifier == bodyPart.DamageModifier)
+			if (modifier == bodyPart.DamageModifier)
 			{
 				toMultiply = Mathf.Max(0f,
 					Mathf.Max(bodyPart.MaxHealth - bodyPart.TotalDamageWithoutOxyCloneRadStam, 0) /
 					bodyPart.MaxHealth);
 			}
-			else if (Modifier == bodyPart.HungerModifier)
+			else if (modifier == bodyPart.HungerModifier)
 			{
 				continue;
 			}
 			else
 			{
-				toMultiply = Mathf.Max(0f, Modifier.Multiplier);
+				toMultiply = Mathf.Max(0f, modifier.Multiplier);
 			}
 
 			TotalModified *= toMultiply;


### PR DESCRIPTION
<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->

### Purpose
<!-- Describe the problem the PR fixes or the feature it introduces. --> <br>
<!-- Don't forget to use "Fixes #issuenumber" to select issues and auto close them on merge. -->
Whenever you take at least 30 damage to the chest you start suffocating. Caused by the heart and lungs using the torso health for efficiency modification. Also it was possible to dislocate the torso.
Fixes #7576

### Notes:
<!-- Please enter any other relevant information here -->
Made lungs and heart use its own bodypart for tracking its health rather than use its parent bodypart.
Added a check during dislocation to not dislocate when its the torso specifically.


### Changelog:
<!-- Add here individual lines with all your remarkable changes using the prefix ``CL:`` -->
<!-- Mind that the changes meant to be logged in the in changelog are those that are remarkable for the end user, so things like new features and fixes of known bugs are perfect for this section -->

<!-- CL: [New] For new features, things that didn't exist before the PR. -->

<!-- CL: [Improvement] For any change on any existing feature. -->

<!-- CL: [Balance] For any change on an existing feature done in the sake of improving game balance. It's the only exception to the rule above. -->

<!-- CL: [Fix] For any change that fixes a bug. -->
CL: [Fix] Lungs and heart no long use torso for health modified efficiency tracking
