### PR TITLE
Fixes random items not being added to cargo crate orders + shuttle console exception

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Cards/Emag.cs
+++ b/UnityProject/Assets/Scripts/Items/Cards/Emag.cs
@@ -101,11 +101,7 @@ namespace Items
 		/// </summary>
 		public bool UseCharge(HandApply interaction)
 		{
-			Chat.AddActionMsgToChat(interaction,
-					$"You wave the Emag over the {interaction.TargetObject.ExpensiveName()}'s electrical panel.",
-						$"{interaction.Performer.ExpensiveName()} waves something over the {interaction.TargetObject.ExpensiveName()}'s electrical panel.");
-
-			return UseChargeLogic(interaction.Performer);
+			return UseCharge(interaction.TargetObject, interaction.Performer);
 		}
 
 		public bool UseCharge(GameObject TargetObject, GameObject Performer)

--- a/UnityProject/Assets/Scripts/Shuttles/CargoShuttle.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/CargoShuttle.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -254,10 +254,9 @@ namespace Systems.Cargo
 			//ensure it is added to crate
 			if (obj.TryGetComponent<RandomItemSpot>(out var randomItem))
 			{
-				randomItem.RollRandomPool(true);
-				var registerTile = randomItem.gameObject.RegisterTile();
+				var registerTile = container.gameObject.RegisterTile();
 				var items = registerTile.Matrix.Get<ObjectBehaviour>(registerTile.LocalPositionServer, ObjectType.Item, true)
-						.Select(ob => ob.gameObject).Where(go => go != gameObject && go.TryGetComponent<ObjectContainer>(out _) == false);
+						.Select(ob => ob.gameObject).Where(go => go != obj);
 
 				container.StoreObjects(items);
 			}

--- a/UnityProject/Assets/Scripts/UI/Objects/Shuttles/GUI_ShuttleControl.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Shuttles/GUI_ShuttleControl.cs
@@ -127,23 +127,16 @@ namespace UI.Objects.Shuttles
 					  && (mm.HasWorkingThrusters || mm.gameObject.name.Equals("Escape Pod")) //until pod gets engines
 			));
 
-			try
-			{
-				EntryList.AddItems(MapIconType.Asteroids, GetObjectsOf<Asteroid>());
-				var stationBounds = MatrixManager.Get(0).MetaTileMap.GetBounds();
-				int stationRadius = (int) Mathf.Abs(stationBounds.center.x - stationBounds.xMin);
-				EntryList.AddStaticItem(MapIconType.Station, stationBounds.center, stationRadius);
+			EntryList.AddItems(MapIconType.Asteroids, GetObjectsOf<Asteroid>());
+			var stationBounds = MatrixManager.MainStationMatrix.MetaTileMap.GetBounds();
+			int stationRadius = (int) Mathf.Abs(stationBounds.center.x - stationBounds.xMin);
+			EntryList.AddStaticItem(MapIconType.Station, stationBounds.center, stationRadius);
 
-				EntryList.AddItems(MapIconType.Waypoint, new List<GameObject>(new[] {Waypoint}));
+			EntryList.AddItems(MapIconType.Waypoint, new List<GameObject>(new[] {Waypoint}));
 
-				RescanElements();
+			RescanElements();
 
-				StartRefresh();
-			}
-			catch (NullReferenceException exception)
-			{
-				Logger.LogError("Caught NRE in GUI_ShuttleControl.StartNormalOperation: " + exception.StackTrace, Category.Shuttles);
-			}
+			StartRefresh();
 		}
 		/// <summary>
 		/// Add secret emag functionality to radar


### PR DESCRIPTION
CL: [Fix] Fixes random items not being added to cargo crate orders.
- Potentially fixes exception in shuttle console GUI code. Not entirely certain why fetching by ID is problematic or if that is indeed the issue. At the very least, slightly more legible.