### PR TITLE
Clients will no longer use the subsystem manager

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
@@ -180,8 +180,9 @@ public partial class MatrixManager : MonoBehaviour
 	{
 		foreach (var matrixInfo in ActiveMatrices.Values)
 		{
-			var subsystemManager = matrixInfo.Matrix.GetComponentInParent<SubsystemManager>();
-			subsystemManager.Initialize();
+			//TODO fixme: expensive and overly complicated way to make tiles interactable by the client (wrenching pipe tiles, etc)
+			matrixInfo.Matrix.MetaTileMap.InitialiseUnderFloorUtilities(CustomNetworkManager.IsServer);
+
 			TileChangeNewPlayer.Send(matrixInfo.NetID);
 		}
 	}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSystem.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using ScriptableObjects.Atmospherics;
 using UnityEngine;
+using Mirror;
 
 namespace Systems.Atmospherics
 {
@@ -13,11 +14,9 @@ namespace Systems.Atmospherics
 
 		private Dictionary<int, RoomGasSetter> toSet = new Dictionary<int, RoomGasSetter>();
 
+		[Server]
 		public override void Initialize()
 		{
-			if (!CustomNetworkManager.IsServer)
-				return;
-
 			//We have bool to stop null checks on every pos
 			var hasCustomMix = defaultRoomGasMixOverride != null;
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using Systems.Atmospherics;
 using Tilemaps.Behaviours.Meta;
 using UnityEngine;
+using Mirror;
 
 /// <summary>
 /// Subsystem behavior which manages updating the MetaDataNodes and simulation that affects them for a given matrix.
@@ -54,6 +54,7 @@ public class MetaDataSystem : SubsystemBehaviour
 		}
 	}
 
+	[Server]
 	public override void Initialize()
 	{
 		Stopwatch sw = new Stopwatch();
@@ -61,7 +62,7 @@ public class MetaDataSystem : SubsystemBehaviour
 
 		if (MatrixManager.IsInitialized)
 		{
-			if (CustomNetworkManager.IsServer) LocateRooms();
+			LocateRooms();
 			Stopwatch Dsw = new Stopwatch();
 			Dsw.Start();
 			matrix.MetaTileMap.InitialiseUnderFloorUtilities(CustomNetworkManager.IsServer);

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/SubsystemManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/SubsystemManager.cs
@@ -2,14 +2,15 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Initialisation;
 using UnityEngine;
+using Mirror;
 
 public class SubsystemManager : MonoBehaviour
 {
 	private List<SubsystemBehaviour> systems = new List<SubsystemBehaviour>();
 	private bool initialized;
-	
+
+	[Server]
 	public void Initialize()
 	{
 		systems = systems.OrderByDescending(s => s.Priority).ToList();


### PR DESCRIPTION
### Purpose
Clients will no longer use the subsystem manager to have underfloor interactables active.
Adds a TODO with a tiny description of how expensive and unnecesary InitialiseUnderFloorUtilities() is for a client

Basically nothing changes, instead of using the subsystem manager to call InitialiseUnderFloorUtilities() and slap a bunch of if(isserver) just call it from here

Stole the idea from bod's pr
I believe this way its easier to read and understand, I'm already doubting of why we even have a subsystem manager that only sets up the pipes and environmental atmos managers