### PR TITLE
Update disposals to ObjectContainer

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Disposals/DisposalBin.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Disposals/DisposalBin.prefab
@@ -21,6 +21,7 @@ GameObject:
   - component: {fileID: 114061922499461510}
   - component: {fileID: 7239127982659121932}
   - component: {fileID: 1330345529673600466}
+  - component: {fileID: 6707578277650812142}
   m_Layer: 11
   m_Name: DisposalBin
   m_TagString: Untagged
@@ -103,7 +104,7 @@ MonoBehaviour:
   syncInterval: 0.1
   matrixDebugLogging: 0
   objectType: 1
-  customNetTransform: {fileID: 0}
+  customNetTransform: {fileID: 114770898345557290}
   prefabTracker: {fileID: 0}
   CurrentsortingGroup: {fileID: 0}
   AtmosPassable: 1
@@ -187,7 +188,6 @@ MonoBehaviour:
   HeatResistance: 100
   ExplosionsDamage: 100
   doDamageMessage: 1
-  CannotBeAshed: 0
 --- !u!114 &2759009461426029734
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -342,6 +342,20 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+--- !u!114 &6707578277650812142
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000010167295674}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b69764f5a0c65e247b0ecdf6e2d40c8f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  initialContents: {fileID: 0}
+  spawnContentsAtRoundstart: 1
 --- !u!1 &1000010229813120
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Objects/Disposals/DisposalIntake.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Disposals/DisposalIntake.prefab
@@ -16,9 +16,9 @@ MonoBehaviour:
   syncInterval: 0.1
   matrixDebugLogging: 0
   objectType: 1
-  customNetTransform: {fileID: 0}
+  customNetTransform: {fileID: 3464330467401233505}
   prefabTracker: {fileID: 0}
-  CurrentsortingGroup: {fileID: 0}
+  CurrentsortingGroup: {fileID: 3925827565069146067}
   AtmosPassable: 1
   ReachableThrough: 1
   initialPassable: 0
@@ -117,6 +117,20 @@ MonoBehaviour:
   spriteMatrixRotationBehavior: 1
   ignoreExtraRotation: []
   RotateParent: {fileID: 0}
+--- !u!114 &4324874224188435965
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1781006999364248419}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b69764f5a0c65e247b0ecdf6e2d40c8f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  initialContents: {fileID: 0}
+  spawnContentsAtRoundstart: 1
 --- !u!1001 &1347533324463388387
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -173,17 +187,17 @@ PrefabInstance:
     - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
         type: 3}
@@ -285,6 +299,24 @@ PrefabInstance:
 --- !u!1 &1781006999364248419 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 721717256067945856, guid: b06b702714bab49b9ad949eab1ca4534,
+    type: 3}
+  m_PrefabInstance: {fileID: 1347533324463388387}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &3464330467401233505 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2495170526828774018, guid: b06b702714bab49b9ad949eab1ca4534,
+    type: 3}
+  m_PrefabInstance: {fileID: 1347533324463388387}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1781006999364248419}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!210 &3925827565069146067 stripped
+SortingGroup:
+  m_CorrespondingSourceObject: {fileID: 2650422487074349360, guid: b06b702714bab49b9ad949eab1ca4534,
     type: 3}
   m_PrefabInstance: {fileID: 1347533324463388387}
   m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Objects/Disposals/DisposalVirtualContainer.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Disposals/DisposalVirtualContainer.prefab
@@ -19,7 +19,7 @@ MonoBehaviour:
   isInitiallyNotPushable: 1
   pushPullSound:
     SetLoadSetting: 0
-    AssetAddress: 
+    AssetAddress: null
     AssetReference:
       m_AssetGUID: 
       m_SubObjectName: 
@@ -49,6 +49,20 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+--- !u!114 &406488744750735638
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 721717256067945856}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b69764f5a0c65e247b0ecdf6e2d40c8f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  initialContents: {fileID: 0}
+  spawnContentsAtRoundstart: 1
 --- !u!1001 &3478496936370901961
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/DisposalsManager.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/DisposalsManager.prefab
@@ -46,3 +46,10 @@ MonoBehaviour:
   VirtualContainerPrefab: {fileID: 721717256067945856, guid: db8a2e4c2c7146b48abcc5b32a5ccd26,
     type: 3}
   TileTraversalsPerSecond: 20
+  disposalEjectionHiss:
+    SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/Machines/DisposalMachines/DisposalEjectionHiss.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 

--- a/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
@@ -219,13 +219,7 @@ namespace Objects
 
 		public void CollectObjects()
 		{
-			var entitiesOnCloset = Matrix.Get<ObjectBehaviour>(registerObject.LocalPositionServer, true)
-					.Where(entity => entity.gameObject != gameObject && entity.IsPushable).Select(entity => entity.gameObject);
-
-			foreach (var entity in entitiesOnCloset)
-			{
-				container.StoreObject(entity, entity.transform.position - transform.position);
-			}
+			container.GatherObjects();
 		}
 
 		public void ReleaseObjects()

--- a/UnityProject/Assets/Scripts/Objects/Disposals/DisposalBin.cs.meta
+++ b/UnityProject/Assets/Scripts/Objects/Disposals/DisposalBin.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {fileID: 2800000, guid: 9d245b225417b3a42bd7c3d7102c4adf, type: 3}
+  icon: {instanceID: 0}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Objects/Disposals/DisposalIntake.cs.meta
+++ b/UnityProject/Assets/Scripts/Objects/Disposals/DisposalIntake.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {fileID: 2800000, guid: 8fe14c5c45fedc24dbd1a34a13fdcc55, type: 3}
+  icon: {instanceID: 0}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Objects/Disposals/DisposalMachine.cs
+++ b/UnityProject/Assets/Scripts/Objects/Disposals/DisposalMachine.cs
@@ -28,6 +28,7 @@ namespace Objects.Disposals
 		protected RegisterObject registerObject;
 		protected ObjectAttributes objectAttributes;
 		protected ObjectBehaviour objectBehaviour;
+		protected ObjectContainer container;
 		protected SpriteHandler baseSpriteHandler;
 
 		protected PositionalHandApply currentInteraction;
@@ -48,6 +49,7 @@ namespace Objects.Disposals
 			registerObject = GetComponent<RegisterObject>();
 			objectAttributes = GetComponent<ObjectAttributes>();
 			objectBehaviour = GetComponent<ObjectBehaviour>();
+			container = GetComponent<ObjectContainer>();
 
 			baseSpriteHandler = transform.GetChild(0).GetComponent<SpriteHandler>();
 		}
@@ -132,13 +134,6 @@ namespace Objects.Disposals
 		}
 
 		#endregion Interactions
-
-		protected DisposalVirtualContainer SpawnNewContainer()
-		{
-			GameObject containerObject = DisposalsManager.SpawnVirtualContainer(registerObject.WorldPositionServer);
-			containerObject.GetComponent<ObjectBehaviour>().parentContainer = objectBehaviour;
-			return containerObject.GetComponent<DisposalVirtualContainer>();
-		}
 
 		#region Construction
 

--- a/UnityProject/Assets/Scripts/Objects/Disposals/DisposalOutlet.cs
+++ b/UnityProject/Assets/Scripts/Objects/Disposals/DisposalOutlet.cs
@@ -69,14 +69,7 @@ namespace Objects.Disposals
 
 		private void UpdateSpriteState()
 		{
-			if (IsOperating)
-			{
-				baseSpriteHandler.ChangeSprite((int) SpriteState.Operating);
-			}
-			else
-			{
-				baseSpriteHandler.ChangeSprite((int) SpriteState.Idle);
-			}
+			baseSpriteHandler.ChangeSprite((int) (IsOperating ? SpriteState.Operating : SpriteState.Idle));
 		}
 
 		private void UpdateSpriteOrientation()
@@ -159,7 +152,7 @@ namespace Objects.Disposals
 				// Outlet orifice open. Release the charge.
 				foreach (DisposalVirtualContainer container in receivedContainers)
 				{
-					container.EjectContentsAndThrow(directional.CurrentDirection.Vector);
+					container.EjectContentsWithVector(directional.CurrentDirection.Vector);
 					_ = Despawn.ServerSingle(container.gameObject);
 				}
 				receivedContainers.Clear();

--- a/UnityProject/Assets/Scripts/Objects/Disposals/DisposalOutlet.cs.meta
+++ b/UnityProject/Assets/Scripts/Objects/Disposals/DisposalOutlet.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {fileID: 2800000, guid: f77ee08febe2f384297670906a532d45, type: 3}
+  icon: {instanceID: 0}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Objects/Disposals/DisposalVirtualContainer.cs
+++ b/UnityProject/Assets/Scripts/Objects/Disposals/DisposalVirtualContainer.cs
@@ -61,9 +61,6 @@ namespace Objects.Disposals
 
 			foreach (var obj in objects)
 			{
-				// may have despawned while in storage (e.g. grenade)
-				if (obj == null) continue;
-
 				if (obj.TryGetComponent<IPushable>(out var pushable) == false) continue;
 
 				if (obj.TryGetComponent<RegisterObject>(out _) == false && obj.TryGetComponent<CustomNetTransform>(out var cnt))

--- a/UnityProject/Assets/Scripts/Objects/Disposals/DisposalVirtualContainer.cs
+++ b/UnityProject/Assets/Scripts/Objects/Disposals/DisposalVirtualContainer.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
-using AddressableReferences;
-using Messages.Server;
+using System.Linq;
 using UnityEngine;
+using AddressableReferences;
 
 namespace Objects.Disposals
 {
@@ -9,216 +9,37 @@ namespace Objects.Disposals
 	/// A virtual container for disposal instances. Contains the disposed contents,
 	/// and allows the contents to be dealt with when the disposal instance ends.
 	/// </summary>
-	public class DisposalVirtualContainer : MonoBehaviour, IServerDespawn, IExaminable
+	public class DisposalVirtualContainer : MonoBehaviour, IExaminable, IEscapable
 	{
 		[Tooltip("The sound made when someone is trying to move in pipes.")]
 		[SerializeField]
-		private AddressableAudioSource ClangSound;
+		private AddressableAudioSource ClangSound = default;
 
-		private ObjectBehaviour ContainerBehaviour;
+		private ObjectContainer container;
 
 		// transform.position seems to be the only reliable method after OnDespawnServer() has been called.
 		private Vector3 ContainerWorldPosition => transform.position;
 
-		// We store each type of entity separately, because each entity type requires different operations.
-		private readonly List<ObjectBehaviour> containedItems = new List<ObjectBehaviour>();
-		private readonly List<ObjectBehaviour> containedObjects = new List<ObjectBehaviour>();
-		private readonly List<ObjectBehaviour> containedPlayers = new List<ObjectBehaviour>();
-
-		public int ContentsCount => containedItems.Count + containedObjects.Count + containedPlayers.Count;
-		public bool HasContents => ContentsCount > 0;
-
 		private void Awake()
 		{
-			ContainerBehaviour = GetComponent<ObjectBehaviour>();
+			container = GetComponent<ObjectContainer>();
 		}
-
-		#region AddContents
-
-		public void AddItems(IEnumerable<ObjectBehaviour> items)
-		{
-			foreach (ObjectBehaviour item in items)
-			{
-				AddItem(item);
-			}
-		}
-
-		public void AddObjects(IEnumerable<ObjectBehaviour> objects)
-		{
-			foreach (ObjectBehaviour entity in objects)
-			{
-				AddObject(entity);
-			}
-		}
-
-		public void AddPlayers(IEnumerable<ObjectBehaviour> players)
-		{
-			foreach (ObjectBehaviour player in players)
-			{
-				AddPlayer(player);
-			}
-		}
-
-		public void AddItem(ObjectBehaviour item)
-		{
-			containedItems.Add(item);
-			SetContainerAndMakeInvisible(item);
-		}
-
-		public void AddObject(ObjectBehaviour entity)
-		{
-			containedObjects.Add(entity);
-			SetContainerAndMakeInvisible(entity);
-		}
-
-		public void AddPlayer(ObjectBehaviour player)
-		{
-			containedPlayers.Add(player);
-			SetContainerAndMakeInvisible(player);
-			FollowCameraMessage.Send(player.gameObject, gameObject);
-		}
-
-		void SetContainerAndMakeInvisible(ObjectBehaviour entity)
-		{
-			entity.parentContainer = ContainerBehaviour;
-			entity.VisibleState = false;
-		}
-
-		#endregion AddContents
-
-		#region RemoveContents
-
-		public void RemoveItem(ObjectBehaviour item)
-		{
-			if (containedItems.Remove(item))
-			{
-				EjectItemOrObject(item);
-			}
-		}
-
-		public void RemoveObject(ObjectBehaviour entity)
-		{
-			if (containedObjects.Remove(entity))
-			{
-				EjectItemOrObject(entity);
-			}
-		}
-
-		public void RemovePlayer(ObjectBehaviour player)
-		{
-			if (containedPlayers.Remove(player))
-			{
-				EjectPlayer(player);
-			}
-		}
-
-		#endregion RemoveContents
 
 		#region EjectContents
 
-		private void EjectContainedItems()
+		private void ThrowItem(CustomNetTransform cnt, Vector3 throwVector)
 		{
-			foreach (ObjectBehaviour item in containedItems)
-			{
-				EjectItemOrObject(item);
-			}
-		}
-
-		private void EjectContainedObjects()
-		{
-			foreach (ObjectBehaviour entity in containedObjects)
-			{
-				EjectItemOrObject(entity);
-			}
-		}
-
-		private void EjectContainedPlayers()
-		{
-			foreach (ObjectBehaviour player in containedPlayers)
-			{
-				EjectPlayer(player);
-			}
-		}
-
-		private void EjectItemOrObject(ObjectBehaviour entity)
-		{
-			if (entity == null) return;
-
-			entity.parentContainer = null;
-			if (entity.TryGetComponent<CustomNetTransform>(out var netTransform))
-			{
-				netTransform.SetPosition(ContainerWorldPosition);
-			}
-		}
-
-		private void EjectPlayer(ObjectBehaviour player)
-		{
-			if (player == null) return;
-
-			player.parentContainer = null;
-			if (player.TryGetComponent<PlayerSync>(out var playerSync))
-			{
-				playerSync.SetPosition(ContainerWorldPosition);
-				FollowCameraMessage.Send(player.gameObject, player.gameObject);
-			}
-		}
-
-		private void ThrowContainedItems(Vector3 throwVector)
-		{
-			foreach (ObjectBehaviour item in containedItems)
-			{
-				if(item == null) continue;
-				ThrowItem(item, throwVector);
-			}
-		}
-
-		private void ThrowContainedObjects(Vector3 throwVector)
-		{
-			foreach (ObjectBehaviour entity in containedObjects)
-			{
-				// Objects cannot currently be thrown, so just push them in the direction for now.
-				PushObject(entity, throwVector);
-			}
-		}
-
-		private void ThrowContainedPlayers(Vector3 throwVector)
-		{
-			foreach (ObjectBehaviour player in containedPlayers)
-			{
-				// Players cannot currently be thrown, so just push them in the direction for now.
-				PushPlayer(player, throwVector);
-			}
-		}
-
-		private void ThrowItem(ObjectBehaviour item, Vector3 throwVector)
-		{
-			Vector3 vector = item.transform.rotation * throwVector;
+			Vector3 vector = cnt.transform.rotation * throwVector;
 			ThrowInfo throwInfo = new ThrowInfo
 			{
 				ThrownBy = gameObject,
-				Aim = BodyPartType.Chest,
+				Aim = (BodyPartType) Random.Range(0, 13),
 				OriginWorldPos = ContainerWorldPosition,
 				WorldTrajectory = vector,
-				SpinMode = SpinMode.Clockwise // TODO: randomise this
+				SpinMode = DMMath.Prob(50) ? SpinMode.Clockwise : SpinMode.CounterClockwise
 			};
 
-			CustomNetTransform itemTransform = item.GetComponent<CustomNetTransform>();
-			if (itemTransform == null) return;
-			itemTransform.Throw(throwInfo);
-		}
-
-		private void PushObject(ObjectBehaviour entity, Vector3 pushVector)
-		{
-			entity.QueuePush(pushVector.NormalizeTo2Int());
-			//entity.TryPush(pushVector.NormalizeTo2Int());
-			//GetComponent<CustomNetTransform>().Push(pushVector.NormalizeTo2Int());
-		}
-
-		private void PushPlayer(ObjectBehaviour player, Vector3 pushVector)
-		{
-			//PushObject(player, pushVector);
-			player.GetComponent<RegisterPlayer>().ServerStun();
-			player.QueuePush(pushVector.NormalizeTo2Int());
+			cnt.Throw(throwInfo);
 		}
 
 		/// <summary>
@@ -226,62 +47,50 @@ namespace Objects.Disposals
 		/// </summary>
 		public void EjectContents()
 		{
-			EjectContainedItems();
-			EjectContainedObjects();
-			EjectContainedPlayers();
-
-			containedItems.Clear();
-			containedObjects.Clear();
-			containedPlayers.Clear();
+			container.RetrieveObjects();
 		}
 
 		/// <summary>
-		/// Ejects contents at the virtual container's position, then throws each entity with the given throw vector.
+		/// Ejects contents at the virtual container's position, then throws or pushes each entity with the given exit vector.
 		/// </summary>
-		/// <param name="throwVector">The direction and distance to throw the contents with</param>
-		public void EjectContentsAndThrow(Vector3 throwVector)
+		/// <param name="exitVector">The direction (and distance) to throw or push the contents with</param>
+		public void EjectContentsWithVector(Vector3 exitVector)
 		{
-			EjectContainedItems();
-			EjectContainedObjects();
-			EjectContainedPlayers();
-			ThrowContainedItems(throwVector);
-			ThrowContainedObjects(throwVector);
-			ThrowContainedPlayers(throwVector);
+			var objects = container.GetStoredObjects().ToArray();
+			container.RetrieveObjects();
 
-			containedItems.Clear();
-			containedObjects.Clear();
-			containedPlayers.Clear();
+			foreach (var obj in objects)
+			{
+				// may have despawned while in storage (e.g. grenade)
+				if (obj == null) continue;
+
+				if (obj.TryGetComponent<IPushable>(out var pushable) == false) continue;
+
+				if (obj.TryGetComponent<RegisterObject>(out _) == false && obj.TryGetComponent<CustomNetTransform>(out var cnt))
+				{
+					ThrowItem(cnt, exitVector);
+					return;
+				}
+
+				pushable.Push(exitVector.To2Int());
+
+				if (obj.TryGetComponent<PlayerScript>(out var script))
+				{
+					script.registerTile.ServerStun();
+				}
+			}
 		}
 
 		#endregion EjectContents
 
-		public void PlayerTryEscaping(GameObject player)
+		public void EntityTryEscape(GameObject entity)
 		{
-			if (player.TryGetComponent<ObjectBehaviour>(out var playerBehaviour) == false) return;
-			if (containedPlayers.Contains(playerBehaviour) == false) return;
-			if (ContainerBehaviour.parentContainer == null) return;
-
-			GameObject disposalMachine = ContainerBehaviour.parentContainer.gameObject;
-			if (disposalMachine == null)
-			{
-				// Must be in the disposal pipes
-				SoundManager.PlayNetworkedAtPos(ClangSound, ContainerWorldPosition);
-			}
-			else if (disposalMachine.TryGetComponent<DisposalBin>(out var disposalBin))
-			{
-				// In a disposal bin
-				disposalBin.PlayerTryClimbingOut(player);
-			}
-		}
-
-		public void OnDespawnServer(DespawnInfo info)
-		{
-			EjectContents();
+			SoundManager.PlayNetworkedAtPos(ClangSound, ContainerWorldPosition);
 		}
 
 		public string Examine(Vector3 worldPos = default)
 		{
-			int contentsCount = ContentsCount;
+			int contentsCount = container.GetStoredObjects().Count();
 			return $"There {(contentsCount == 1 ? "is one entity" : $"are {contentsCount} entities")} inside.";
 		}
 	}

--- a/UnityProject/Assets/Scripts/Objects/Disposals/DisposalVirtualContainer.cs.meta
+++ b/UnityProject/Assets/Scripts/Objects/Disposals/DisposalVirtualContainer.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {fileID: 2800000, guid: 9924bb6a497a5ca42910fe6ccf96eba5, type: 3}
+  icon: {instanceID: 0}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.cs
@@ -438,12 +438,6 @@ public partial class PlayerSync : NetworkBehaviour, IPushable, IPlayerControllab
 		{
 			escapable.EntityTryEscape(gameObject);
 		}
-
-		// TODO: convert to IEscapable
-		if (parentContainer.TryGetComponent(out Objects.Disposals.DisposalVirtualContainer disposalContainer))
-		{
-			disposalContainer.PlayerTryEscaping(gameObject);
-		}
 	}
 
 	private void UpdateMe()

--- a/UnityProject/Assets/Scripts/Systems/Disposals/DisposalTraversal.cs
+++ b/UnityProject/Assets/Scripts/Systems/Disposals/DisposalTraversal.cs
@@ -20,9 +20,6 @@ namespace Systems.Disposals
 		public bool CurrentlyDelayed = false;
 		public bool TraversalFinished = false;
 
-		[SerializeField]
-		private AddressableAudioSource DisposalEjectionHiss = null;
-
 		private bool justStarted;
 		private DisposalPipe currentPipe;
 		private Vector3Int currentPipeLocalPos;
@@ -157,9 +154,9 @@ namespace Systems.Disposals
 		{
 			TryDamageTileFromEjection(NextPipeLocalPosition);
 			var worldPos = MatrixManager.LocalToWorld(NextPipeLocalPosition, matrix);
-			SoundManager.PlayNetworkedAtPos(DisposalEjectionHiss, worldPos);
+			SoundManager.PlayNetworkedAtPos(DisposalsManager.Instance.DisposalEjectionHiss, worldPos);
 			TransferContainerToVector(NextPipeVector);
-			virtualContainer.EjectContentsAndThrow(currentPipeOutputSide.Vector);
+			virtualContainer.EjectContentsWithVector(currentPipeOutputSide.Vector);
 			DespawnContainerAndFinish();
 		}
 
@@ -175,7 +172,7 @@ namespace Systems.Disposals
 				// Ended at a pipe terminal, but no disposal machinery was detected at its location. Ejecting upwards...
 				TryDamageTileFromEjection(currentPipeLocalPos);
 				// Eject contents with zero vector to give spin on contents.
-				virtualContainer.EjectContentsAndThrow(Vector3.zero);
+				virtualContainer.EjectContentsWithVector(Vector3.zero);
 				DespawnContainerAndFinish();
 			}
 		}

--- a/UnityProject/Assets/Scripts/Systems/Disposals/DisposalsManager.cs
+++ b/UnityProject/Assets/Scripts/Systems/Disposals/DisposalsManager.cs
@@ -1,34 +1,27 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using AddressableReferences;
 using Objects.Disposals;
+using Objects;
 
 namespace Systems.Disposals
 {
 	/// <summary>
 	/// Creates, updates, and removes all disposal instances.
 	/// </summary>
-	public class DisposalsManager : MonoBehaviour
+	public class DisposalsManager : MonoBehaviourSingleton<DisposalsManager>
 	{
-		private static DisposalsManager instance;
-		public static DisposalsManager Instance {
-			get {
-				if (instance == null)
-				{
-					instance = FindObjectOfType<DisposalsManager>();
-				}
-
-				return instance;
-			}
-			set { instance = value; }
-		}
-
 		[SerializeField]
 		[Tooltip("Set the virtual container prefab to be used in disposal instances.")]
 		public GameObject VirtualContainerPrefab;
 		[SerializeField]
 		[Tooltip("Set how many tiles every disposal instance can traverse in one second.")]
 		private float TileTraversalsPerSecond = 20;
+		[SerializeField]
+		private AddressableAudioSource disposalEjectionHiss = default;
+
+		public AddressableAudioSource DisposalEjectionHiss => disposalEjectionHiss;
 
 		private readonly List<DisposalTraversal> disposalInstances = new List<DisposalTraversal>();
 
@@ -75,10 +68,13 @@ namespace Systems.Disposals
 		/// <summary>
 		/// Create a new disposal instance, which will move its contents along the disposal pipe network.
 		/// </summary>
-		/// <param name="container">The virtual container holding the entities to be disposed of.</param>
-		public void NewDisposal(DisposalVirtualContainer container)
+		/// <param name="sourceContainer">The container holding the entities to be disposed of.</param>
+		public void NewDisposal(ObjectContainer sourceContainer)
 		{
-			DisposalTraversal traversal = new DisposalTraversal(container);
+			var disposalContainer = SpawnVirtualContainer(sourceContainer.gameObject.RegisterTile().WorldPositionServer);
+			sourceContainer.TransferObjectsTo(disposalContainer.GetComponent<ObjectContainer>());
+
+			var traversal = new DisposalTraversal(disposalContainer.GetComponent<DisposalVirtualContainer>());
 			disposalInstances.Add(traversal);
 		}
 

--- a/UnityProject/Assets/Scripts/UI/Objects/Atmospherics/GUI_DisposalBin.cs.meta
+++ b/UnityProject/Assets/Scripts/UI/Objects/Atmospherics/GUI_DisposalBin.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {fileID: 2800000, guid: 9d245b225417b3a42bd7c3d7102c4adf, type: 3}
+  icon: {instanceID: 0}
   userData: 
   assetBundleName: 
   assetBundleVariant: 


### PR DESCRIPTION
- Updates disposals to use `ObjectContainer`.
May or may not fix #4654 part 4.
Likely fixes part 5 of #4654.
Fixes part of #4654, though there seems to be an issue where the dropped item is ejected invisible.
- CL: [Fix] Fixes air ejection hiss sound not playing when a disposal traversal instance reaches an open-ended disposal pipe.
- Converts `DisposalsManager` to `SingletonManager` as per #7638.