### PR TITLE
Fix admin overlay message too long

### DIFF
--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/AdminOverlay.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/AdminOverlay.cs
@@ -144,11 +144,11 @@ namespace AdminTools
 			panel.SetAdminOverlayPanel(entry.infos, Instance, obj.transform, entry.offset);
 		}
 
-		public static void ClientFullUpdate(AdminInfoUpdate update)
+		public static void ClientFullUpdate(AdminInfosEntry[] entries)
 		{
 			Instance.ReturnAllPanelsToPool();
 
-			foreach (var e in update.entries)
+			foreach (var e in entries)
 			{
 				ClientAddEntry(e);
 			}


### PR DESCRIPTION
CL: [Fix] Fix admins getting kicked from too many admin info updates by making the network messages more efficient. Might still occur in the future, which will require a refactor, but let's see if that's required.