### PR TITLE
Fixes clients having lighttubes and other sprites on the wrong direction

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Lighting/LightSource.cs
+++ b/UnityProject/Assets/Scripts/Core/Lighting/LightSource.cs
@@ -170,6 +170,7 @@ namespace Objects.Lighting
 		{
 			mState = newState;
 			ChangeCurrentState(newState);
+			SetSprites();
 			SetAnimation();
 		}
 
@@ -179,7 +180,6 @@ namespace Objects.Lighting
 			{
 				currentState = mountStatesMachine.LightMountStates[newState];
 			}
-			SetSprites();
 		}
 
 		public void EditorDirectionChange()

--- a/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandlerManager.cs
+++ b/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandlerManager.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using Messages.Client.SpriteMessages;
 using Messages.Server.SpritesMessages;
 using Mirror;
 using UnityEngine;
@@ -135,19 +134,6 @@ public class SpriteHandlerManager : NetworkBehaviour
 			}
 		}
 		SpriteUpdateMessage.SendToSpecified(requestedBy, Newtem);
-	}
-
-
-	public override void OnStartClient()
-	{
-		StartCoroutine(WaitForNetInitialisation());
-		base.OnStartClient();
-	}
-
-	private IEnumerator WaitForNetInitialisation()
-	{
-		yield return WaitFor.Seconds(3);
-		SpriteRequestCurrentStateMessage.Send(this.GetComponent<NetworkIdentity>().netId);
 	}
 
 	void LateUpdate()

--- a/UnityProject/Assets/Scripts/Effects/Fire/BurningOverlay.cs
+++ b/UnityProject/Assets/Scripts/Effects/Fire/BurningOverlay.cs
@@ -14,6 +14,10 @@ namespace Effects.Overlays
 		private void Awake()
 		{
 			spriteHandler = GetComponent<SpriteHandler>();
+		}
+
+		private void Start()
+		{
 			//wait until we are told to burn
 			StopBurning();
 		}

--- a/UnityProject/Assets/Scripts/Items/Cards/Emag.cs
+++ b/UnityProject/Assets/Scripts/Items/Cards/Emag.cs
@@ -34,16 +34,8 @@ namespace Items
 		#region SyncVarFuncs
 		void Awake()
 		{
-			EnsureInit();
-		}
-
-		private void EnsureInit()
-		{
-			if (spriteHandler == null)
-			{
-				charges = startCharges;
-				spriteHandler = gameObject.transform.Find("Charges").GetComponent<SpriteHandler>();
-			}
+			charges = startCharges;
+			spriteHandler = gameObject.transform.Find("Charges").GetComponent<SpriteHandler>();
 		}
 
 		public void OnDisable()
@@ -56,7 +48,6 @@ namespace Items
 
 		public override void OnStartClient()
 		{
-			EnsureInit();
 			SyncCharges(Charges, charges);
 			base.OnStartClient();
 		}
@@ -69,9 +60,7 @@ namespace Items
 
 		private void SyncCharges(int oldCharges, int newCharges)
 		{
-			EnsureInit();
 			charges = newCharges;
-
 		}
 
 		public string Examine(Vector3 worldPos)

--- a/UnityProject/Assets/Scripts/Items/ClothingItem.cs
+++ b/UnityProject/Assets/Scripts/Items/ClothingItem.cs
@@ -59,11 +59,6 @@ public class ClothingItem : MonoBehaviour
 		get { return spriteType == SpriteHandType.RightHand || spriteType == SpriteHandType.LeftHand; }
 	}
 
-	private void Awake()
-	{
-		UpdateSprite();
-	}
-
 	public void SetColor(Color value)
 	{
 		if (spriteHandler != null)

--- a/UnityProject/Assets/Scripts/Items/Glass/GlassShard.cs
+++ b/UnityProject/Assets/Scripts/Items/Glass/GlassShard.cs
@@ -20,11 +20,6 @@ public class GlassShard : NetworkBehaviour, IServerSpawn
 
 	void Awake()
 	{
-		EnsureInit();
-	}
-
-	private void EnsureInit()
-	{
 		spriteRenderer = GetComponentInChildren<SpriteRenderer>();
 		netTransform = GetComponent<CustomNetTransform>();
 		spriteHandler = GetComponentInChildren<SpriteHandler>();
@@ -32,7 +27,6 @@ public class GlassShard : NetworkBehaviour, IServerSpawn
 
 	public void OnSpawnServer(SpawnInfo info)
 	{
-		EnsureInit();
 		SetSpriteAndScatter(Random.Range(0, spriteHandler.CatalogueCount));
 	}
 
@@ -51,7 +45,6 @@ public class GlassShard : NetworkBehaviour, IServerSpawn
 
 	private void SyncSpriteRotation(Quaternion oldValue, Quaternion newValue)
 	{
-		EnsureInit();
 		spriteRotation = newValue;
 
 		if (spriteRenderer != null)

--- a/UnityProject/Assets/Scripts/Items/Others/Paper.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/Paper.cs
@@ -29,12 +29,6 @@ public class Paper : NetworkBehaviour, IServerSpawn
 
 	private void Awake()
 	{
-		EnsureInit();
-	}
-
-	private void EnsureInit()
-	{
-		if (pickupable != null) return;
 		pickupable = GetComponent<Pickupable>();
 		spriteHandler = GetComponentInChildren<SpriteHandler>();
 	}
@@ -61,7 +55,6 @@ public class Paper : NetworkBehaviour, IServerSpawn
 
 	private void UpdateState(SpriteState state)
 	{
-		EnsureInit();
 		spriteHandler.ChangeSprite((int) state);
 	}
 

--- a/UnityProject/Assets/Scripts/Items/Weapons/Melee/EnergySword.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Melee/EnergySword.cs
@@ -60,11 +60,6 @@ public class EnergySword : NetworkBehaviour, ICheckedInteractable<HandActivate>,
 		itemAttributes = GetComponent<ItemAttributesV2>();
 		lightControl = GetComponent<ItemLightControl>();
 		spriteHandler = GetComponentInChildren<SpriteHandler>();
-		if (color == SwordColor.Random)
-		{
-			// Get random color
-			color = (SwordColor)Enum.GetValues(typeof(SwordColor)).GetValue(Random.Range(1, 5));
-		}
 	}
 
 	private void Start()
@@ -74,6 +69,11 @@ public class EnergySword : NetworkBehaviour, ICheckedInteractable<HandActivate>,
 		offHitDamage = itemAttributes.ServerHitDamage;
 		offThrowDamage = itemAttributes.ServerThrowDamage;
 		offAttackVerbs = new List<string>(itemAttributes.ServerAttackVerbs);
+		if (color == SwordColor.Random)
+		{
+			// Get random color
+			color = (SwordColor)Enum.GetValues(typeof(SwordColor)).GetValue(Random.Range(1, 5));
+		}
 	}
 
 	#endregion Lifecycle

--- a/UnityProject/Assets/Scripts/Items/Weapons/SawnOff.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/SawnOff.cs
@@ -12,7 +12,7 @@ namespace Weapons
 {
 	[RequireComponent(typeof(ItemAttributesV2))]
 	[RequireComponent(typeof(Gun))]
-	public class SawnOff : MonoBehaviour, ICheckedInteractable<InventoryApply>
+	public class SawnOff : MonoBehaviour, ICheckedInteractable<InventoryApply>, IServerSpawn
 	{
 
 		private ItemAttributesV2 itemAttComp;
@@ -26,7 +26,7 @@ namespace Weapons
 
 		[SerializeField, Tooltip("Sawn off item size")]
 		private ItemSize sawnSize = ItemSize.Medium;
-	
+
 		[SerializeField, Tooltip("Value that determines how far a shot will deviate. (Never set this higher then 0.5 unless you want questionable results.)")]
 		private float sawnMaxRecoilVariance;
 
@@ -38,6 +38,10 @@ namespace Weapons
 			spriteHandler = GetComponentInChildren<SpriteHandler>();
 			itemAttComp = gameObject.GetComponent<ItemAttributesV2>();
 			gunComp = gameObject.GetComponent<Gun>();
+		}
+
+		public void OnSpawnServer(SpawnInfo info)
+		{
 			spriteHandler.ChangeSprite(0);
 		}
 
@@ -94,7 +98,7 @@ namespace Weapons
 				}
 			}
 
-			// Propagates the InventoryApply Interaction to the Gun component for all basic gun InventoryApply interactions.	
+			// Propagates the InventoryApply Interaction to the Gun component for all basic gun InventoryApply interactions.
 			gunComp.ServerPerformInteraction(interaction);
 		}
 	}

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
+using Messages.Client.SpriteMessages;
 using System.Linq;
 using Chemistry;
 using Doors;
@@ -187,6 +187,7 @@ public partial class MatrixManager : MonoBehaviour
 			matrixInfo.Matrix.MetaTileMap.InitialiseUnderFloorUtilities(CustomNetworkManager.IsServer);
 
 			TileChangeNewPlayer.Send(matrixInfo.NetID);
+			SpriteRequestCurrentStateMessage.Send(SpriteHandlerManager.Instance.GetComponent<NetworkIdentity>().netId);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
@@ -122,7 +122,12 @@ namespace Objects
 
 		private void Awake()
 		{
-			EnsureInit();
+			registerObject = GetComponent<RegisterObject>();
+			attributes = GetComponent<ObjectAttributes>();
+			container = GetComponent<ObjectContainer>();
+			pushPull = GetComponent<PushPull>();
+			accessRestrictions = GetComponent<AccessRestrictions>();
+
 			lockState = isLockable ? Lock.Locked : Lock.NoLock;
 			GetComponent<Integrity>().OnWillDestroyServer.AddListener(OnWillDestroyServer);
 
@@ -130,20 +135,8 @@ namespace Objects
 			closetName = gameObject.ExpensiveName();
 		}
 
-		private void EnsureInit()
-		{
-			if (registerObject != null) return;
-
-			registerObject = GetComponent<RegisterObject>();
-			attributes = GetComponent<ObjectAttributes>();
-			container = GetComponent<ObjectContainer>();
-			pushPull = GetComponent<PushPull>();
-			accessRestrictions = GetComponent<AccessRestrictions>();
-		}
-
 		public override void OnStartClient()
 		{
-			EnsureInit();
 			SyncDoorState(doorState, doorState);
 		}
 
@@ -181,7 +174,7 @@ namespace Objects
 			{
 				lockSpritehandler.ChangeSprite((int) (IsOpen ? Lock.NoLock : lockState));
 			}
-			
+
 			SoundManager.PlayNetworkedAtPos(IsOpen ? soundOnOpen : soundOnClose, registerObject.WorldPositionServer, sourceObj: gameObject);
 
 			if (IsOpen)
@@ -291,7 +284,6 @@ namespace Objects
 
 		private void SyncDoorState(Door oldValue, Door value)
 		{
-			EnsureInit();
 			doorState = value;
 			SetPassableAndLayer(); // required on client
 		}

--- a/UnityProject/Assets/Scripts/Objects/Closets/InteractableFireCabinet.cs
+++ b/UnityProject/Assets/Scripts/Objects/Closets/InteractableFireCabinet.cs
@@ -32,29 +32,15 @@ namespace Objects.Wallmounts
 
 		private void Awake()
 		{
-			EnsureInit();
-			//TODO: Can probably refactor this component to rely more on ItemStorage and do less of its own logic.
-		}
-
-		private void EnsureInit()
-		{
-			if (storageObject != null) return;
-			//we have an item storage with only 1 slot.
 			storageObject = GetComponent<ItemStorage>();
 			slot = storageObject.GetIndexedItemSlot(0);
+			//TODO: Can probably refactor this component to rely more on ItemStorage and do less of its own logic.
 		}
 
 		public override void OnStartServer()
 		{
-			EnsureInit();
 			IsClosed = true;
 			base.OnStartServer();
-		}
-
-		public override void OnStartClient()
-		{
-			EnsureInit();
-			base.OnStartClient();
 		}
 
 		#endregion

--- a/UnityProject/Assets/Scripts/Objects/Machines/FoodProcessor.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/FoodProcessor.cs
@@ -66,13 +66,13 @@ namespace Objects.Kitchen
 
 		private void Awake()
 		{
-			EnsureInit();
+			registerTile = GetComponent<RegisterTile>();
+			spriteHandler = GetComponentInChildren<SpriteHandler>();
+			storage = GetComponent<ItemStorage>();
 		}
 
 		public void OnSpawnServer(SpawnInfo spawn)
 		{
-			EnsureInit();
-
 			SetState(new ProcessorUnpowered(this));
 
 			// Get the machine stock parts used in this instance and get the tier of each part.
@@ -101,13 +101,6 @@ namespace Objects.Kitchen
 					binTier = part.GetComponent<StockTier>().Tier;
 				}
 			}
-		}
-
-		private void EnsureInit()
-		{
-			registerTile = GetComponent<RegisterTile>();
-			spriteHandler = GetComponentInChildren<SpriteHandler>();
-			storage = GetComponent<ItemStorage>();
 		}
 
 		private void OnDisable()
@@ -319,7 +312,6 @@ namespace Objects.Kitchen
 		/// <param name="state">The power state to set the processor's state with.</param>
 		public void StateUpdate(PowerState state)
 		{
-			EnsureInit(); // This method could be called before the component's Awake().
 			if (isServer) // Since state changes affect animations (and call an Rpc animation function), only server can do this.
 			{
 				if (currentState == null)

--- a/UnityProject/Assets/Scripts/Objects/Machines/Griddle.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/Griddle.cs
@@ -19,7 +19,7 @@ namespace Objects.Kitchen
 {
 	/// <summary>
 	/// A machine which can have meat items placed on top to cook them.
-	/// If the item has the Cookable component, the item will be cooked 
+	/// If the item has the Cookable component, the item will be cooked
 	/// once enough time has lapsed as determined in that component.
 	/// </summary>
 	public class Griddle : NetworkBehaviour, IAPCPowerable, IRefreshParts
@@ -47,7 +47,7 @@ namespace Objects.Kitchen
 		private int magnetronWattage = 850;
 
 		private RegisterTile registerTile;
-		
+
 		private Matrix Matrix => registerTile.Matrix;
 		private SpriteHandler spriteHandler;
 		private APCPoweredDevice poweredDevice;
@@ -75,21 +75,13 @@ namespace Objects.Kitchen
 
 		#region Lifecycle
 
-		// Interfaces can call this script before Awake() is called.
-		private void EnsureInit()
+		private void Awake()
 		{
-			if (CurrentState != null) return;
-
 			registerTile = GetComponent<RegisterTile>();
 			spriteHandler = GetComponentInChildren<SpriteHandler>();
 			poweredDevice = GetComponent<APCPoweredDevice>();
 
 			SetState(new GriddleUnpowered(this));
-		}
-
-		private void Start()
-		{
-			EnsureInit();
 		}
 
 		private void OnDisable()
@@ -210,8 +202,6 @@ namespace Objects.Kitchen
 
 		public void RefreshParts(IDictionary<GameObject, int> partsInFrame)
 		{
-			EnsureInit();
-
 			// Get the machine stock parts used in this instance and get the tier of each part.
 			// Collection is unorganized so run through the whole list.
 			foreach (GameObject part in partsInFrame.Keys)
@@ -234,7 +224,6 @@ namespace Objects.Kitchen
 		/// <param name="state">The power state to set the griddle's state with.</param>
 		public void StateUpdate(PowerState state)
 		{
-			EnsureInit();
 			CurrentState.PowerStateUpdate(state);
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/Machines/Microwave.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/Microwave.cs
@@ -107,7 +107,7 @@ namespace Objects.Kitchen
 		private bool ovenGlowEnabled = false;
 
 		public bool IsOperating => CurrentState is MicrowaveRunning;
-		
+
 		public IEnumerable<ItemSlot> Slots => storage.GetItemSlots();
 		public bool HasContents => Slots.Any(Slot => Slot.IsOccupied);
 		public int StorageSize => storage.StorageSize();
@@ -133,11 +133,8 @@ namespace Objects.Kitchen
 
 		#region Lifecycle
 
-		// Interfaces can call this script before Awake() is called.
-		private void EnsureInit()
+		private void Awake()
 		{
-			if (CurrentState != null) return;
-
 			registerTile = GetComponent<RegisterTile>();
 			spriteHandler = GetComponentInChildren<SpriteHandler>();
 			storage = GetComponent<ItemStorage>();
@@ -148,8 +145,6 @@ namespace Objects.Kitchen
 
 		private void Start()
 		{
-			EnsureInit();
-
 			MicrowaveTimer = DefaultTimerTime;
 		}
 
@@ -235,7 +230,7 @@ namespace Objects.Kitchen
 				}
 				else
 				{
-					var item = stack.ServerRemoveOne(); 
+					var item = stack.ServerRemoveOne();
 					added = Inventory.ServerAdd(item, storageSlot);
 					if(!added)
 					{
@@ -409,8 +404,6 @@ namespace Objects.Kitchen
 
 		public void RefreshParts(IDictionary<GameObject, int> partsInFrame)
 		{
-			EnsureInit();
-
 			// Get the machine stock parts used in this instance and get the tier of each part.
 			// Collection is unorganized so run through the whole list.
 			foreach (GameObject part in partsInFrame.Keys)
@@ -441,7 +434,6 @@ namespace Objects.Kitchen
 		/// <param name="state">The power state to set the microwave's state with.</param>
 		public void StateUpdate(PowerState state)
 		{
-			EnsureInit();
 			CurrentState.PowerStateUpdate(state);
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/Machines/Oven.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/Oven.cs
@@ -92,7 +92,7 @@ namespace Objects.Kitchen
 		private bool ovenGlowEnabled = false;
 
 		public bool IsOperating => CurrentState is OvenRunning;
-		
+
 		public IEnumerable<ItemSlot> Slots => storage.GetItemSlots();
 		public bool HasContents => Slots.Any(Slot => Slot.IsOccupied);
 		public int StorageSize => storage.StorageSize();
@@ -115,21 +115,13 @@ namespace Objects.Kitchen
 
 		#region Lifecycle
 
-		// Interfaces can call this script before Awake() is called.
-		private void EnsureInit()
+		private void Awake()
 		{
-			if (CurrentState != null) return;
-
 			registerTile = GetComponent<RegisterTile>();
 			storage = GetComponent<ItemStorage>();
 			poweredDevice = GetComponent<APCPoweredDevice>();
 
 			SetState(new OvenUnpowered(this));
-		}
-
-		private void Start()
-		{
-			EnsureInit();
 		}
 
 		private void OnDisable()
@@ -197,7 +189,7 @@ namespace Objects.Kitchen
 				}
 				else
 				{
-					var item = stack.ServerRemoveOne(); 
+					var item = stack.ServerRemoveOne();
 					added = Inventory.ServerAdd(item, storageSlot);
 					if(!added)
 					{
@@ -327,8 +319,6 @@ namespace Objects.Kitchen
 
 		public void RefreshParts(IDictionary<GameObject, int> partsInFrame)
 		{
-			EnsureInit();
-
 			// Get the machine stock parts used in this instance and get the tier of each part.
 			// Collection is unorganized so run through the whole list.
 			foreach (GameObject part in partsInFrame.Keys)
@@ -359,7 +349,6 @@ namespace Objects.Kitchen
 		/// <param name="state">The power state to set the oven's state with.</param>
 		public void StateUpdate(PowerState state)
 		{
-			EnsureInit();
 			CurrentState.PowerStateUpdate(state);
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/Machines/QuantumPad.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/QuantumPad.cs
@@ -71,7 +71,6 @@ namespace Objects.Science
 		{
 			registerTile = GetComponent<RegisterTile>();
 			spriteHandler = GetComponentInChildren<SpriteHandler>();
-			spriteHandler.ChangeSprite(0);
 		}
 
 		private void Start()
@@ -97,6 +96,8 @@ namespace Objects.Science
 			{
 				LavaLandManager.Instance.LavaLandBase2Connector = this;
 			}
+
+			spriteHandler.ChangeSprite(0);
 		}
 
 		public void OnSpawnServer(SpawnInfo info)

--- a/UnityProject/Assets/Scripts/Objects/Medical/DNAScanner.cs
+++ b/UnityProject/Assets/Scripts/Objects/Medical/DNAScanner.cs
@@ -50,7 +50,6 @@ namespace Objects.Medical
 		public override void OnStartClient()
 		{
 			base.OnStartClient();
-			Awake();
 			SyncPowered(powered, powered);
 		}
 
@@ -181,12 +180,6 @@ namespace Objects.Medical
 
 		public void StateUpdate(PowerState state)
 		{
-			if (container == null)
-			{
-				// stateUpdate can be called before Awake()
-				Awake();
-			}
-
 			if (state == PowerState.Off || state == PowerState.LowVoltage)
 			{
 				SyncPowered(powered, false);

--- a/UnityProject/Assets/Scripts/Player/GhostSprites.cs
+++ b/UnityProject/Assets/Scripts/Player/GhostSprites.cs
@@ -7,7 +7,7 @@ using Mirror;
 /// Handles displaying the ghost sprites.
 /// </summary>
 [RequireComponent(typeof(Directional))]
-public class GhostSprites : MonoBehaviour
+public class GhostSprites : MonoBehaviour, IServerSpawn
 {
 	//sprite renderer showing the ghost
 	private SpriteHandler SpriteHandler;
@@ -18,20 +18,30 @@ public class GhostSprites : MonoBehaviour
 
 	private Directional directional;
 
+	private bool AdminGhost;
+
 	protected void Awake()
 	{
 		directional = GetComponent<Directional>();
 		directional.OnDirectionChange.AddListener(OnDirectionChange);
 		SpriteHandler = GetComponentInChildren<SpriteHandler>();
-		if (CustomNetworkManager.Instance._isServer == false) return;
+	}
 
-
-		SpriteHandler.SetSpriteSO(GhostSpritesSOs.PickRandom());
+	public void OnSpawnServer(SpawnInfo info)
+	{
+		if (AdminGhost)
+		{
+			SpriteHandler.SetSpriteSO(AdminGhostSpriteSOs.PickRandom());
+		}
+		else
+		{
+			SpriteHandler.SetSpriteSO(GhostSpritesSOs.PickRandom());
+		}
 	}
 
 	public void SetAdminGhost()
 	{
-		SpriteHandler.SetSpriteSO(AdminGhostSpriteSOs.PickRandom());
+		AdminGhost = true;
 	}
 
 	private void OnDirectionChange(Orientation direction)

--- a/UnityProject/Assets/Scripts/Player/Overlays/PlayerDirectionalOverlay.cs
+++ b/UnityProject/Assets/Scripts/Player/Overlays/PlayerDirectionalOverlay.cs
@@ -11,26 +11,20 @@ namespace Effects.Overlays
 	{
 		private SpriteHandler spriteHandler;
 
-		private bool init = false;
-
 		public bool OverlayActive { get; private set; } = true; // PresentSpriteSO is set on startup
 
 		private void Awake()
 		{
-			EnsureInit();
+			spriteHandler = GetComponent<SpriteHandler>();
 		}
 
-		private void OnDisable()
+		private void Start()
 		{
 			StopOverlay();
 		}
 
-		private void EnsureInit()
+		private void OnDisable()
 		{
-			if (init) return;
-			init = true;
-
-			spriteHandler = GetComponent<SpriteHandler>();
 			StopOverlay();
 		}
 
@@ -40,8 +34,6 @@ namespace Effects.Overlays
 		/// <param name="direction"></param>
 		public void StartOverlay(Orientation direction)
 		{
-			EnsureInit();
-
 			spriteHandler.ChangeSprite(0); // Load sprite into SpriteRenderer
 			spriteHandler.ChangeSpriteVariant(GetOrientationVariant(direction));
 			OverlayActive = true;


### PR DESCRIPTION
### Purpose
Organizes the SpriteHandler initialization.
New clients will now request the spritehandler updates after all matrix are set up instead of counting down from 3 seconds.
Fixes #7406
CL: [Fix] fixed clients seeing light tubes and other sprites with wrong rotations.
Tested connecting to staging and following the order of sprites values being set. 