### PR TITLE
Fix fuel gauge

### DIFF
--- a/UnityProject/Assets/Scripts/Shuttles/ShuttleFuelSystem.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/ShuttleFuelSystem.cs
@@ -26,6 +26,9 @@ namespace Systems.Shuttles
 			if (MatrixMove == null)
 			{
 				MatrixMove = this.GetComponent<MatrixMove>();
+			}
+			if (MatrixMove)
+			{
 				MatrixMove.RegisterShuttleFuelSystem(this);
 			}
 
@@ -60,7 +63,7 @@ namespace Systems.Shuttles
 				{
 					MatrixMove.IsFueled = true;
 				}
-				FuelLevel = Connector.canister.GasContainer.GasMix.GetMoles(Gas.Plasma) / 60000;
+				FuelLevel = Connector.canister.GasContainer.GasMix.GetMoles(Gas.Plasma) / Connector.canister.GasContainer.MaximumMoles;
 			}
 			else
 			{

--- a/UnityProject/Assets/Scripts/UI/Objects/Shuttles/GUI_ShuttleControl.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Shuttles/GUI_ShuttleControl.cs
@@ -304,9 +304,9 @@ namespace UI.Objects.Shuttles
 			var fuelGauge = (NetUIElement<string>)this["FuelGauge"];
 			if (MatrixMove.ShuttleFuelSystem == null)
 			{
-				if (fuelGauge.Value != "100")
+				if (fuelGauge.Value != "0")
 				{
-					fuelGauge.SetValueServer((100).ToString());
+					fuelGauge.SetValueServer((0).ToString());
 				}
 
 			}


### PR DESCRIPTION
<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->

### Purpose
fix #6905
I just want to show my solution )) 

### Notes:
By default, the fuel gauge will show 0 and not 100%, as it was before. Which is logical, because the canister is not connected. The fuel gauge did not work because `MatrixMove.RegisterShuttleFuelSystem(this)` not called. It was because `MatrixMove` not equal to null when `OnEnable()` colled.

### Changelog:
CL: [Fix] Shuttle fuel gauge has been fixed.
