### PR TITLE
Fixes clients being stuck on preparing

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -375,6 +375,7 @@ public class CustomNetworkManager : NetworkManager, IInitialise
 		//now we can call mirror's normal disconnect logic, which will destroy all the player's owned objects
 		//which will preserve their actual body because they no longer own it
 		base.OnServerDisconnect(conn);
+		SubSceneManager.Instance.RemoveSceneObserver(conn);
 	}
 
 	private void OnLevelFinishedLoading(Scene oldScene, Scene newScene)

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.Server.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.Server.cs
@@ -24,10 +24,15 @@ public partial class SubSceneManager
 	{
 		if (NetworkServer.observerSceneList.ContainsKey(conn))
 		{
-			NetworkServer.observerSceneList.Remove(conn);
+			RemoveSceneObserver(conn);
 		}
 
 		NetworkServer.observerSceneList.Add(conn, new List<Scene> {SceneManager.GetActiveScene()});
+	}
+
+	public void RemoveSceneObserver(NetworkConnection conn)
+	{
+		NetworkServer.observerSceneList.Remove(conn);
 	}
 
 	/// <summary>


### PR DESCRIPTION
### Purpose
CL: [Fix] Fixes clients being stuck on preparing

### Notes:
If a client disconnected while the scenes were being loaded on the server, the objects would still set the connection ID to its observer list due to this scene observer list (two different lists, in this case im refering to the one im changing in the commit) never clearing on player disconnect.
Afterwards, if a player connected and received the same connectionID, the SubSceneManager networkbehaivour would never start as the spawn message was stopped by the server once it checked that the connectionID is in the observer list of said networkidentity

did I make it sound too confusing? 