### PR TITLE
Fixes disposal pipes construction and deconstruction

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
@@ -544,16 +544,12 @@ public partial class MatrixManager : MonoBehaviour
 		return true;
 	}
 
-	public static bool IsConstructable(Vector3Int worldPos)
+	public static bool IsConstructable(Vector3Int worldPos, MatrixInfo matrixInfo)
 	{
-		foreach (var matrixInfo in Instance.ActiveMatrices.Values)
+		if (matrixInfo.Matrix.MetaTileMap.IsConstructable(WorldToLocalInt(worldPos, matrixInfo)))
 		{
-			if (matrixInfo.Matrix.MetaTileMap.IsConstructable(WorldToLocalInt(worldPos, matrixInfo)))
-			{
-				return true;
-			}
+			return true;
 		}
-
 		return false;
 	}
 

--- a/UnityProject/Assets/Scripts/Objects/Disposals/DisposalPipe.cs
+++ b/UnityProject/Assets/Scripts/Objects/Disposals/DisposalPipe.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using UnityEngine;
+using Systems.DisposalPipes;
 
 namespace Objects.Disposals
 {
@@ -15,6 +16,7 @@ namespace Objects.Disposals
 
 		[Tooltip("Set the sprite this particular disposal pipe should use.")]
 		public Sprite sprite;
+
 		public override Sprite PreviewSprite => sprite;
 
 		[SerializeField]
@@ -53,6 +55,16 @@ namespace Objects.Disposals
 				return new ConnectablePoint(pair);
 			}
 		}
+
+		public void InitialiseNode(Vector3Int Location, Matrix matrix)
+		{
+			var ZeroedLocation = new Vector3Int(x: Location.x, y: Location.y, 0);
+			var metaData = matrix.MetaDataLayer.Get(ZeroedLocation);
+			var disPipeNode = new DisposalPipeNode();
+			disPipeNode.Initialise(this, Location);
+			metaData.DisposalPipeData.Add(disPipeNode);
+		}
+
 
 		public string Examine(Vector3 worldPos = default)
 		{

--- a/UnityProject/Assets/Scripts/Objects/Disposals/DisposalPipe.cs.meta
+++ b/UnityProject/Assets/Scripts/Objects/Disposals/DisposalPipe.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: da9a6cbf0b6d881488fe2e0cbe135069, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Objects/Disposals/DisposalPipeObject.cs
+++ b/UnityProject/Assets/Scripts/Objects/Disposals/DisposalPipeObject.cs
@@ -12,7 +12,6 @@ namespace Objects.Disposals
 		private float weldTime = 3;
 
 		private RegisterTile registerTile;
-		private TileChangeManager tileChangeManager;
 		private ObjectBehaviour behaviour;
 
 		[SerializeField]
@@ -39,7 +38,6 @@ namespace Objects.Disposals
 		private void Awake()
 		{
 			registerTile = gameObject.RegisterTile();
-			tileChangeManager = registerTile.TileChangeManager;
 			behaviour = GetComponent<ObjectBehaviour>();
 		}
 
@@ -127,7 +125,7 @@ namespace Objects.Disposals
 
 		private bool VerboseFloorExists()
 		{
-			if (MatrixManager.IsConstructable(registerTile.WorldPositionServer))
+			if (MatrixManager.IsConstructable(registerTile.WorldPositionServer, registerTile.Matrix.MatrixInfo))
 			{
 				return true;
 			}
@@ -137,7 +135,7 @@ namespace Objects.Disposals
 
 		private bool VerbosePlatingExposed()
 		{
-			if (tileChangeManager.MetaTileMap.HasTile(registerTile.LocalPositionServer, LayerType.Floors) == false) return true;
+			if (registerTile.TileChangeManager.MetaTileMap.HasTile(registerTile.LocalPositionServer, LayerType.Floors) == false) return true;
 
 			Chat.AddExamineMsg(
 					currentInteraction.Performer,
@@ -216,7 +214,8 @@ namespace Objects.Disposals
 			{
 				var matrixTransform = Matrix4x4.TRS(Vector3.zero, Quaternion.identity, Vector3.one);
 				Color pipeColor = GetComponentInChildren<SpriteRenderer>().color;
-				registerTile.Matrix.TileChangeManager.UpdateTile(registerTile.LocalPositionServer, pipeTileToSpawn, matrixTransform, pipeColor);
+				Vector3Int searchVec = registerTile.Matrix.TileChangeManager.UpdateTile(registerTile.LocalPositionServer, pipeTileToSpawn, matrixTransform, pipeColor);
+				pipeTileToSpawn.InitialiseNode(searchVec, registerTile.Matrix);
 				_ = Despawn.ServerSingle(gameObject);
 			}
 			else

--- a/UnityProject/Assets/Scripts/Systems/Disposals/DisposalPipeNode.cs
+++ b/UnityProject/Assets/Scripts/Systems/Disposals/DisposalPipeNode.cs
@@ -1,0 +1,19 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Objects.Disposals;
+
+namespace Systems.DisposalPipes
+{
+	public class DisposalPipeNode
+	{
+		public Vector3Int NodeLocation;
+		public DisposalPipe DisposalPipeTile;
+
+		public void Initialise(DisposalPipe TileToTake, Vector3Int position)
+		{
+			DisposalPipeTile = TileToTake;
+			NodeLocation = position;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/Disposals/DisposalPipeNode.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/Disposals/DisposalPipeNode.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 178bd6d44a133a6458f56e4016f73bd6
+guid: da1e029a3eaf1564d863c551ef2b00f1
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
@@ -488,16 +488,20 @@ namespace TileManagement
 
 		public bool IsConstructable(Vector3Int position)
 		{
-			TileLocation tileLocation = null;
-			var canConstruct = false;
+			bool canConstruct = false;
 			foreach (var layer in LayersValues)
 			{
+				TileLocation tileLocation = null;
+				Dictionary<Vector3Int, TileLocation> tiles;
 				if (layer.LayerType == LayerType.Objects)
 					continue;
 
 				lock (PresentTiles)
 				{
-					PresentTiles[layer].TryGetValue(position, out tileLocation);
+					if (PresentTiles.TryGetValue(layer, out tiles))
+					{
+						tiles.TryGetValue(position, out tileLocation);
+					}
 				}
 
 				if (tileLocation?.Tile == null)
@@ -1952,6 +1956,12 @@ namespace TileManagement
 									{
 										layer.matrix.AddElectricalNode(new Vector3Int(n, p, localPlace.z),
 											electricalCableTile);
+									}
+
+									var disposalPipeTile = getTile as Objects.Disposals.DisposalPipe;
+									if (disposalPipeTile != null)
+									{
+										disposalPipeTile.InitialiseNode(localPlace, layer.matrix);
 									}
 
 									var pipeTile = getTile as Objects.Atmospherics.PipeTile;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataNode.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataNode.cs
@@ -9,6 +9,7 @@ using Systems.Electricity;
 using Systems.Explosions;
 using Systems.Pipes;
 using Systems.Radiation;
+using Systems.DisposalPipes;
 
 
 /// <summary>
@@ -42,6 +43,11 @@ public class MetaDataNode : IGasMixContainer
 	/// This contains all the pipe data needed On the tile
 	/// </summary>
 	public List<PipeNode> PipeData = new List<PipeNode>();
+
+	/// <summary>
+	/// This contains all the disposal pipe data needed On the tile
+	/// </summary>
+	public List<DisposalPipeNode> DisposalPipeData = new List<DisposalPipeNode>();
 
 	/// <summary>
 	/// Local position of this tile in its parent matrix.


### PR DESCRIPTION
<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->

### Purpose
Fix #7482

### Notes:
In general, it is a big problem that underfloor objects use one layer. In order to distinguish these objects, z-coordinate is used. We have a method that, when loading a map, goes through each cell of all matrices and if there are several objects on the underfloor layer, it assigns them a unique z coordinate. But this method did not count the disposal pipes. So, i fixed it.

### Changelog:
CL: [Fix] Disposal pipes construction and deconstruction has been fixed.
