### PR TITLE
Fixes AI camera tracking & door electrocution

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.cs
+++ b/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.cs
@@ -187,14 +187,6 @@ public partial class CustomNetTransform : NetworkBehaviour, IPushable
 		{
 			InitServerState();
 		}
-		else
-		{
-			Collider2D[] colls = GetComponents<Collider2D>();
-			foreach (var c in colls)
-			{
-				c.enabled = false;
-			}
-		}
 
 		Initialized = true;
 	}

--- a/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.cs
+++ b/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.cs
@@ -188,6 +188,15 @@ public partial class CustomNetTransform : NetworkBehaviour, IPushable
 			InitServerState();
 		}
 
+		if (pos == TransformState.HiddenPos)
+		{
+			Collider2D[] colls = GetComponents<Collider2D>();
+			foreach (var c in colls)
+			{
+				c.enabled = false;
+			}
+		}
+
 		Initialized = true;
 	}
 

--- a/UnityProject/Assets/Scripts/NPC/AI/MobAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobAI.cs
@@ -25,7 +25,7 @@ namespace Systems.MobAIs
 		protected CustomNetTransform cnt;
 		public CustomNetTransform Cnt => cnt;
 
-		protected RegisterObject registerObject;
+		public RegisterObject registerObject;
 		protected UprightSprites uprightSprites;
 		protected bool isServer;
 		private float followingTime = 0f;

--- a/UnityProject/Assets/Scripts/Objects/Doors/Modules/ElectrifiedDoorModule.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/Modules/ElectrifiedDoorModule.cs
@@ -34,7 +34,8 @@ namespace Doors.Modules
 
 		public void ToggleElectrocution()
 		{
-			if (master.HasPower) return;
+			if (master.HasPower == false)
+				return;
 			IsElectrecuted = !IsElectrecuted;
 		}
 

--- a/UnityProject/Assets/Scripts/Systems/Ai/AiPlayer.cs
+++ b/UnityProject/Assets/Scripts/Systems/Ai/AiPlayer.cs
@@ -598,9 +598,7 @@ namespace Systems.Ai
 				if(checkPlayerScript.gameObject == gameObject) return null;
 
 				//If we are player get position
-				objectPos = CustomNetworkManager.IsServer
-					? checkPlayerScript.PlayerSync.ServerPosition
-					: checkPlayerScript.PlayerSync.ClientPosition;
+				objectPos = checkPlayerScript.registerTile.WorldPosition;
 			}
 			else
 			{
@@ -608,9 +606,7 @@ namespace Systems.Ai
 				if (objectToCheck.TryGetComponent<MobAI>(out var mobAI))
 				{
 					//Get mob position
-					objectPos = CustomNetworkManager.IsServer
-						? mobAI.Cnt.ServerPosition
-						: mobAI.Cnt.ClientPosition;
+					objectPos =  mobAI.registerObject.WorldPosition;
 				}
 				else
 				{


### PR DESCRIPTION
### Purpose
Fixes #7494
CL: [Fix] Fixes AIs not being able to track living forms on clients.
Removes the disabling of Collider2D on clients.
CL: [Fix] Fixes electrocution toggle on doors not working.