### PR TITLE
Fixes and simplifies escape shuttle timers

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/CentComm.cs
+++ b/UnityProject/Assets/Scripts/Managers/CentComm.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using AddressableReferences;
-using Google.Protobuf.WellKnownTypes;
 using Initialisation;
 using Map;
 using Messages.Server.SoundMessages;

--- a/UnityProject/Assets/Scripts/Managers/CentComm.cs
+++ b/UnityProject/Assets/Scripts/Managers/CentComm.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using AddressableReferences;
+using Google.Protobuf.WellKnownTypes;
 using Initialisation;
 using Map;
 using Messages.Server.SoundMessages;
@@ -23,8 +24,8 @@ namespace Managers
 		private GameObject paperPrefab = default;
 
 		public StatusDisplayUpdateEvent OnStatusDisplayUpdate = new StatusDisplayUpdateEvent();
-		[NonSerialized] public string CommandStatusString;
-		[NonSerialized] public string EscapeShuttleTimeString;
+		[NonSerialized] public string CommandStatusString = string.Empty;
+		[NonSerialized] public string EscapeShuttleTimeString = string.Empty;
 
 		public void UpdateStatusDisplay(StatusDisplayChannel channel, string text)
 		{


### PR DESCRIPTION
### Purpose
Simplifies escape shuttle code reducing the amount of event invokes and functions inside functions.
CL: [Fix] Fixes shuttles not being able to be recalled.
CL: [Fix] Fixes the escape shuttle time being wrong on code blue.
CL: [Fix] Fixes status display not returning to its original channel once the shuttle is recalled.
CL: [Fix] Fixes status display not showing the recall timer.
Fixes #7033

