### PR TITLE
fixes blob

### DIFF
--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -551,7 +551,7 @@ namespace HealthV2
 		{
 			if (bodyPartAim == BodyPartType.None)
 			{
-				BodyPartType.Chest.Randomize(0);
+				bodyPartAim = BodyPartType.Chest.Randomize(0);
 			}
 			LastDamagedBy = damagedBy;
 

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobPlayer.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobPlayer.cs
@@ -201,7 +201,7 @@ namespace Blob
 
 			playerScript.SetPermanentName(overmindName);
 
-			var result = Spawn.ServerPrefab(blobCorePrefab, playerSync.ServerPosition, gameObject.transform.parent);
+			var result = Spawn.ServerPrefab(blobCorePrefab, registerPlayer.WorldPositionServer, gameObject.transform.parent);
 
 			if (!result.Successful)
 			{
@@ -1718,7 +1718,7 @@ namespace Blob
 
 		private void AttackAllSides(DamageInfo info)
 		{
-			var pos = info.AttackedIntegrity.gameObject.WorldPosServer();
+			var pos = info.AttackedIntegrity.RegisterTile.WorldPositionServer;
 
 			foreach (var offset in coords)
 			{

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobPlayer.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobPlayer.cs
@@ -201,7 +201,7 @@ namespace Blob
 
 			playerScript.SetPermanentName(overmindName);
 
-			var result = Spawn.ServerPrefab(blobCorePrefab, playerSync.ServerPosition, gameObject.transform);
+			var result = Spawn.ServerPrefab(blobCorePrefab, playerSync.ServerPosition, gameObject.transform.parent);
 
 			if (!result.Successful)
 			{
@@ -662,7 +662,7 @@ namespace Blob
 		{
 			if (!autoExpanding && !ValidateCost(normalBlobCost, blobNormalPrefab)) return;
 
-			var result = Spawn.ServerPrefab(blobNormalPrefab, worldPos, gameObject.transform);
+			var result = Spawn.ServerPrefab(blobNormalPrefab, worldPos, gameObject.transform.parent);
 
 			if (!result.Successful) return;
 
@@ -927,7 +927,7 @@ namespace Blob
 
 		private void PlayAttackEffect(Vector3 worldPos)
 		{
-			Spawn.ServerPrefab(attackEffect, worldPos, gameObject.transform);
+			Spawn.ServerPrefab(attackEffect, worldPos, gameObject.transform.parent);
 		}
 
 		#endregion
@@ -964,7 +964,7 @@ namespace Blob
 		{
 			if (ValidateCost(cost, prefab) == false) return;
 
-			var result = Spawn.ServerPrefab(prefab, worldPos, gameObject.transform);
+			var result = Spawn.ServerPrefab(prefab, worldPos, gameObject.transform.parent);
 
 			if (result.Successful == false) return;
 
@@ -1042,7 +1042,7 @@ namespace Blob
 
 					if (!ValidateCost(cost, prefab)) return;
 
-					var result = Spawn.ServerPrefab(prefab, worldPos, gameObject.transform);
+					var result = Spawn.ServerPrefab(prefab, worldPos, gameObject.transform.parent);
 
 					if (!result.Successful) return;
 

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobStarter.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobStarter.cs
@@ -270,7 +270,7 @@ namespace Blob
 				gameObject.GetComponent<PlayerSync>().SetPosition(position, true);
 			}
 
-			var spawnResult = Spawn.ServerPrefab(AntagManager.Instance.blobPlayerViewer, gameObject.GetComponent<PlayerSync>().ServerPosition, gameObject.transform.parent);
+			var spawnResult = Spawn.ServerPrefab(AntagManager.Instance.blobPlayerViewer, gameObject.RegisterTile().WorldPositionServer, gameObject.transform.parent);
 
 			if (!spawnResult.Successful)
 			{

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobStarter.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobStarter.cs
@@ -254,9 +254,12 @@ namespace Blob
 
 			var bound = MatrixManager.MainStationMatrix.Bounds;
 
+			//To ensure that it has to be station matrix
+			var on = MatrixManager.AtPoint(gameObject.AssumedWorldPosServer().RoundToInt(), true);
+
 			//Teleport user to random location on station if outside radius of 600 or on a space tile
 			if (((gameObject.AssumedWorldPosServer() - MatrixManager.MainStationMatrix.GameObject.AssumedWorldPosServer())
-				.magnitude > 600f) || MatrixManager.IsSpaceAt(gameObject.GetComponent<PlayerSync>().ServerPosition, true))
+				.magnitude > 600f) || MatrixManager.IsSpaceAt(gameObject.GetComponent<PlayerSync>().ServerPosition, true) || on != MatrixManager.MainStationMatrix)
 			{
 				Vector3 position = new Vector3(Random.Range(bound.xMin, bound.xMax), Random.Range(bound.yMin, bound.yMax), 0);
 				while (MatrixManager.IsSpaceAt(Vector3Int.FloorToInt(position), true) || MatrixManager.IsWallAtAnyMatrix(Vector3Int.FloorToInt(position), true))

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobStarter.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobStarter.cs
@@ -255,7 +255,7 @@ namespace Blob
 			var bound = MatrixManager.MainStationMatrix.Bounds;
 
 			//To ensure that it has to be station matrix
-			var on = MatrixManager.AtPoint(gameObject.AssumedWorldPosServer().RoundToInt(), true);
+			var on = this.GetComponent<RegisterTile>().Matrix.MatrixInfo;
 
 			//Teleport user to random location on station if outside radius of 600 or on a space tile
 			if (((gameObject.AssumedWorldPosServer() - MatrixManager.MainStationMatrix.GameObject.AssumedWorldPosServer())


### PR DESCRIPTION
reasons why blob was broken
A it was set to non where it would not set the randomized zone properly so doing no damage
B it would spawn extra blob structures underneath the parent for some reason not the object layer
CL: [Fix] fixed blob spawning blob structures improperly.
CL: [Fix] fixed blob randomized damage actually causing no damage.
also tightened up blob spawning, meaning it has to be on station to be valid