### PR TITLE
Fix pipe dispenser

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Disposals/PipeDispenser.cs
+++ b/UnityProject/Assets/Scripts/Objects/Disposals/PipeDispenser.cs
@@ -68,7 +68,7 @@ namespace Objects.Atmospherics
 			if (spawnResult.Successful == false)
 			{
 				Logger.LogError(
-						$"Failed to spawn an object from {name}!" +
+						$"Failed to spawn an object from {name}! " +
 						$"Is {nameof(UI.Objects.Atmospherics.GUI_PipeDispenser)} missing reference to object prefab?",
 						Category.Pipes);
 				return;


### PR DESCRIPTION
- Fixes error when using the pipe dispenser.
CL: [Fix] Fixes objects spawned from the pipe dispenser not spawning with the requested colour.
- Pipe dispenser dispensables with multiple SpriteHandlers are now coloured correctly. Fixes part 8. of #4654.
- Pipe dispenser script is no longer a `NetworkBehaviour`. 🥳 