### PR TITLE
Fixes projectiles fired by clients always hitting on the chest

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Interactions/AimApply.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Interactions/AimApply.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 /// fires continuously while the mouse button is being held down, and fires once on the initial click and
 /// also on the release. This is used for things like guns.
 /// </summary>
-public class AimApply : Interaction
+public class AimApply : BodyPartTargetedInteraction
 {
 	//cache player layermask
 	private static LayerMask PLAYER_LAYER_MASK = -1;
@@ -53,8 +53,9 @@ public class AimApply : Interaction
 	/// or ending.</param>
 	/// <param name="targetVector">vector pointing from shooter to the spot they are targeting - should NOT be normalized. Set to
 	/// Vector2.zero if aiming at self.</param>
-	private AimApply(GameObject performer, GameObject handObject, ItemSlot handSlot, MouseButtonState buttonState, Vector2 targetVector, Intent intent) :
-		base(performer, handObject, intent)
+	private AimApply(GameObject performer, GameObject handObject, ItemSlot handSlot, MouseButtonState buttonState,
+		Vector2 targetVector, BodyPartType bodyPartType, Intent intent) :
+		base(performer, handObject, null, bodyPartType, intent)
 	{
 		this.targetVector = targetVector;
 		this.handSlot = handSlot;
@@ -88,7 +89,7 @@ public class AimApply : Interaction
 		return new AimApply(PlayerManager.LocalPlayer, PlayerManager.LocalPlayerScript.DynamicItemStorage.GetActiveHandSlot().ItemObject,
 			PlayerManager.LocalPlayerScript.DynamicItemStorage.GetActiveHandSlot(),
 			buttonState,
-			selfAim ? Vector2.zero : targetVector, UIManager.CurrentIntent);
+			selfAim ? Vector2.zero : targetVector, UIManager.DamageZone, UIManager.CurrentIntent);
 	}
 
 	/// <summary>
@@ -105,9 +106,9 @@ public class AimApply : Interaction
 	/// <returns>a hand apply by the client, targeting the specified object with the item in the active hand</returns>
 	/// <param name="mouseButtonState">state of the mouse button</param>
 	public static AimApply ByClient(GameObject clientPlayer, Vector2 targetVector, GameObject handObject, ItemSlot handSlot, MouseButtonState mouseButtonState,
-		Intent intent)
+		BodyPartType TargetBodyPart, Intent intent)
 	{
-		return new AimApply(clientPlayer, handObject, handSlot,  mouseButtonState, targetVector, intent);
+		return new AimApply(clientPlayer, handObject, handSlot,  mouseButtonState, targetVector, TargetBodyPart, intent);
 	}
 }
 

--- a/UnityProject/Assets/Scripts/Items/Weapons/FiringPins/PinBase.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/FiringPins/PinBase.cs
@@ -12,13 +12,13 @@ namespace Weapons
 
 		protected void CallShotServer(AimApply interaction, bool isSuicide)
 		{
-			gunComp.ServerShoot(interaction.Performer, interaction.TargetVector.normalized, UIManager.DamageZone, isSuicide);
+			gunComp.ServerShoot(interaction.Performer, interaction.TargetVector.normalized, interaction.TargetBodyPart, isSuicide);
 		}
 
 		protected void CallShotClient(AimApply interaction, bool isSuicide)
 		{
 			var dir = gunComp.ApplyRecoil(interaction.TargetVector.normalized);
-			gunComp.DisplayShot(PlayerManager.LocalPlayer, dir, UIManager.DamageZone, isSuicide, gunComp.CurrentMagazine.containedBullets[0].name, gunComp.CurrentMagazine.containedProjectilesFired[0]);
+			gunComp.DisplayShot(PlayerManager.LocalPlayer, dir, interaction.TargetBodyPart, isSuicide, gunComp.CurrentMagazine.containedBullets[0].name, gunComp.CurrentMagazine.containedProjectilesFired[0]);
 		}
 
 		protected JobType GetJobServer(GameObject player)

--- a/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInteractMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInteractMessage.cs
@@ -199,7 +199,7 @@ namespace Messages.Client.Interaction
 				var processorObj = NetworkObject;
 				CheckMatrixSync(ref processorObj);
 
-				var interaction = AimApply.ByClient(performer, TargetVector, usedObject, usedSlot, MouseButtonState, Intent);
+				var interaction = AimApply.ByClient(performer, TargetVector, usedObject, usedSlot, MouseButtonState, TargetBodyPart, Intent);
 				ProcessInteraction(interaction, processorObj, ComponentType);
 			}
 			else if (InteractionType == typeof(MouseDrop))
@@ -523,6 +523,7 @@ namespace Messages.Client.Interaction
 				var casted = interaction as AimApply;
 				msg.TargetVector = casted.TargetVector;
 				msg.MouseButtonState = casted.MouseButtonState;
+				msg.TargetBodyPart = casted.TargetBodyPart;
 			}
 			else if (typeof(T) == typeof(MouseDrop))
 			{
@@ -706,6 +707,7 @@ namespace Messages.Client.Interaction
 			{
 				message.TargetVector = reader.ReadVector2();
 				message.MouseButtonState = reader.ReadBool() ? MouseButtonState.PRESS : MouseButtonState.HOLD;
+				message.TargetBodyPart = (BodyPartType) reader.ReadUInt();
 			}
 			else if (message.InteractionType == typeof(MouseDrop))
 			{
@@ -787,6 +789,7 @@ namespace Messages.Client.Interaction
 			{
 				writer.WriteVector2(message.TargetVector);
 				writer.WriteBool(message.MouseButtonState == MouseButtonState.PRESS);
+				writer.WriteInt((int) message.TargetBodyPart);
 			}
 			else if (message.InteractionType == typeof(MouseDrop))
 			{

--- a/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInteractMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInteractMessage.cs
@@ -776,20 +776,20 @@ namespace Messages.Client.Interaction
 			{
 				writer.WriteUInt(message.TargetObject);
 				writer.WriteVector2(message.TargetVector);
-				writer.WriteInt((int) message.TargetBodyPart);
+				writer.WriteUInt((uint) message.TargetBodyPart);
 				writer.WriteBool(message.IsAltUsed);
 			}
 			else if (message.InteractionType == typeof(HandApply))
 			{
 				writer.WriteUInt(message.TargetObject);
-				writer.WriteInt((int) message.TargetBodyPart);
+				writer.WriteUInt((uint) message.TargetBodyPart);
 				writer.WriteBool(message.IsAltUsed);
 			}
 			else if (message.InteractionType == typeof(AimApply))
 			{
 				writer.WriteVector2(message.TargetVector);
 				writer.WriteBool(message.MouseButtonState == MouseButtonState.PRESS);
-				writer.WriteInt((int) message.TargetBodyPart);
+				writer.WriteUInt((uint) message.TargetBodyPart);
 			}
 			else if (message.InteractionType == typeof(MouseDrop))
 			{


### PR DESCRIPTION
### Purpose
CL: [Fix] Fixes projectiles fired by clients always hitting on the chest
Fixes #7499

It was using the server's target, and in headless it never changes
