### PR TITLE
Fixes all possible remaining cases of stuck in preparing

### DIFF
--- a/UnityProject/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/UnityProject/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1129,6 +1129,14 @@ namespace Mirror
                 return;
             }
 
+            /// <CUSTOM UNITYSTATION CODE>
+            if (conn.identity == null)
+            {
+	            Debug.LogError($"The server tried to add a disconnected player to the list of {gameObject.name} NetworkIdentity observers");
+	            return;
+            }
+            /// </CUSTOM UNITYSTATION CODE>
+
             // Debug.Log("Added observer " + conn.address + " added for " + gameObject);
 
             observers[conn.connectionId] = conn;


### PR DESCRIPTION
### Purpose
Objects will now check if the connection is disconnected before adding it to its observers list and print an error.

### Notes
I dont know what could cause this error but id rather have a stacktrace with the error than investigating reading line by line.

CL: [Fix] fixed another case of players being stuck preparing to join a server.