### PR TITLE
Increases performance in playersync

### DIFF
--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -90,10 +90,10 @@ public partial class PlayerSync
 		{
 			if (registerPlayer.IsSlippingServer)
 			{
-				return Matrix.IsNoGravityAt(serverState.WorldPosition.RoundToInt(), true)
-					|| Matrix.MetaDataLayer.IsSlipperyAt(serverState.WorldPosition.RoundToInt());
+				return Matrix.IsNoGravityAt(serverState.LocalPosition.RoundToInt(), true)
+					|| Matrix.MetaDataLayer.IsSlipperyAt(serverState.LocalPosition.RoundToInt());
 			}
-			return !playerScript.IsGhost && Matrix.IsNonStickyAt(serverState.WorldPosition.RoundToInt(), true);
+			return !playerScript.IsGhost && Matrix.IsNonStickyAt(serverState.LocalPosition.RoundToInt(), true);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -90,10 +90,10 @@ public partial class PlayerSync
 		{
 			if (registerPlayer.IsSlippingServer)
 			{
-				return MatrixManager.IsNoGravityAt(serverState.WorldPosition.RoundToInt(), true)
-					|| MatrixManager.IsSlipperyAt(serverState.WorldPosition.RoundToInt());
+				return Matrix.IsNoGravityAt(serverState.WorldPosition.RoundToInt(), true)
+					|| Matrix.MetaDataLayer.IsSlipperyAt(serverState.WorldPosition.RoundToInt());
 			}
-			return !playerScript.IsGhost && MatrixManager.IsNonStickyAt(serverState.WorldPosition.RoundToInt(), true);
+			return !playerScript.IsGhost && Matrix.IsNonStickyAt(serverState.WorldPosition.RoundToInt(), true);
 		}
 	}
 


### PR DESCRIPTION
### Purpose
Increases playersync idle performance by not searching the matrix where the human is and using the one in registerTile when doing gravity checks


![image](https://user-images.githubusercontent.com/701959/139849165-249c285d-6a4f-4195-812e-ddebe872dd98.png)
with 50 humans: before and after

CL: [Fix] large performance increase for player movement when player is *not* actively moving (92% improvement).