### PR TITLE
Fixes ghosts being hit by thrown objects freezing all players

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.Move.cs
+++ b/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.Move.cs
@@ -664,7 +664,8 @@ public partial class CustomNetTransform
 		RegisterPlayers.AddRange(Matrix.Matrix.GetAs<RegisterPlayer>(Localposition, isServer));
 		foreach (var registerPlayer in RegisterPlayers)
 		{
-			if (registerPlayer.PlayerScript.playerHealth.IsDead == false)
+			var playerScript = registerPlayer.PlayerScript;
+			if (playerScript.IsGhost == false && playerScript.playerHealth.IsDead == false)
 			{
 				if (CanHitObject(registerPlayer))
 				{


### PR DESCRIPTION
### Purpose
Fixes a runtime when an object hit a ghost

should fix #7689

CL: [Fix] Fixes ghosts being hit by thrown objects freezing all players