### PR TITLE
Atmospheric Analyser Inventory action

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Interactions/InventoryApply.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Interactions/InventoryApply.cs
@@ -25,14 +25,14 @@ public class InventoryApply : TargetedInteraction
 	public ItemSlot TargetSlot => targetSlot;
 
 	/// <summary>
-	/// True iff the FromSlot is one of the performer's hands
+	/// True if the FromSlot is one of the performer's hands
 	/// </summary>
 	public bool IsFromHandSlot => fromSlot.ItemStorage.Player.OrNull()?.gameObject == Performer &&
 	                              (fromSlot.SlotIdentifier.NamedSlot == NamedSlot.leftHand ||
 	                              fromSlot.SlotIdentifier.NamedSlot == NamedSlot.rightHand);
 
 	/// <summary>
-	/// True iff the target slot is one of the performer's hands
+	/// True if the target slot is one of the performer's hands
 	/// </summary>
 	public bool IsToHandSlot => fromSlot.ItemStorage.Player.OrNull()?.gameObject == Performer &&
 	                              (targetSlot.SlotIdentifier.NamedSlot == NamedSlot.leftHand ||

--- a/UnityProject/Assets/Scripts/Items/Tool/AtmosphericAnalyser/AtmosphericAnalyser.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/AtmosphericAnalyser/AtmosphericAnalyser.cs
@@ -7,7 +7,7 @@ using Objects.Atmospherics;
 
 namespace Items.Atmospherics
 {
-	public class AtmosphericAnalyser : MonoBehaviour, ICheckedInteractable<HandActivate>, ICheckedInteractable<PositionalHandApply>
+	public class AtmosphericAnalyser : MonoBehaviour, ICheckedInteractable<HandActivate>, ICheckedInteractable<PositionalHandApply>, ICheckedInteractable<InventoryApply>
 	{
 		public bool WillInteract(HandActivate interaction, NetworkSide side)
 		{
@@ -65,6 +65,28 @@ namespace Items.Atmospherics
 				var gasMix = metaDataNode.PipeData[0].pipeData.GetMixAndVolume.GetGasMix();
 				Chat.AddExamineMsgFromServer(interaction.Performer, GetGasMixInfo(gasMix));
 			}
+		}
+
+		public bool WillInteract(InventoryApply interaction, NetworkSide side)
+		{
+			if (DefaultWillInteract.Default(interaction, side) == false) return false;
+
+			if (interaction.TargetObject == null) return false;
+
+			if (interaction.UsedObject == null) return false;
+
+			if (interaction.TargetObject == gameObject) return false;
+
+			if (interaction.UsedObject != gameObject) return false;
+
+			return interaction.TargetObject.TryGetComponent<GasContainer>(out _);
+		}
+
+		public void ServerPerformInteraction(InventoryApply interaction)
+		{
+			if(interaction.TargetObject.TryGetComponent<GasContainer>(out var container) == false) return;
+
+			Chat.AddExamineMsgFromServer(interaction.Performer, GetGasMixInfo(container.GasMix));
 		}
 
 		private static string GetGasMixInfo(GasMix gasMix)

--- a/UnityProject/Assets/Scripts/Items/Tool/AtmosphericAnalyser/AtmosphericAnalyser.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/AtmosphericAnalyser/AtmosphericAnalyser.cs
@@ -71,12 +71,12 @@ namespace Items.Atmospherics
 		{
 			if (DefaultWillInteract.Default(interaction, side) == false) return false;
 
-			if (interaction.TargetObject == null) return false;
+			if (interaction.TargetObject == null || interaction.UsedObject == null) return false;
 
-			if (interaction.UsedObject == null) return false;
-
+			//Dont target self
 			if (interaction.TargetObject == gameObject) return false;
 
+			//Make sure used object is ourself
 			if (interaction.UsedObject != gameObject) return false;
 
 			return interaction.TargetObject.TryGetComponent<GasContainer>(out _);


### PR DESCRIPTION
Fixes #7707
CL: [Improvement] atmospheric analysers can now be used on items inside player inventories