### PR TITLE
Fixes clients not seeing ores on lavaland

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
@@ -111,6 +111,14 @@ public class Matrix : MonoBehaviour
 		tileChangeManager = GetComponentInParent<TileChangeManager>();
 		underFloorLayer = GetComponentInChildren<UnderFloorLayer>();
 		tilemapsDamage = GetComponentsInChildren<TilemapDamage>().ToList();
+
+		if (MatrixManager.Instance.InitializingMatrixes.ContainsKey(gameObject.scene) == false)
+		{
+			MatrixManager.Instance.InitializingMatrixes.Add(gameObject.scene, new List<Matrix>());
+		}
+		MatrixManager.Instance.InitializingMatrixes[gameObject.scene].Add(this);
+
+
 		OnEarthquake.AddListener((worldPos, magnitude) =>
 		{
 			var cellPos = metaTileMap.WorldToCell(worldPos);


### PR DESCRIPTION
### Purpose
CL: [Fix] Fixes clients not seeing ores on lavaland and some asteroids
CL: [Fix] Fixes clients requesting for tile and sprite updates before the matrixes were ready.
