### PR TITLE
Fix caramel reaction and RPG reloading.

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/Ammo84mmRocketPM9HE.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/Ammo84mmRocketPM9HE.prefab
@@ -1,25 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-2625148932084804424
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7885618348377886950}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e01cf0e4c6ebb4443a9ca96c6f09f22c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  magType: 0
-  initalProjectile: {fileID: 3848343717668343118, guid: 1ff9dd0fc4df49c4e8e6201312a8d2f5,
-    type: 3}
-  ProjectilesFired: 1
-  ammoType: 20
-  magazineSize: 1
 --- !u!1001 &9101648509990566412
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -138,3 +118,23 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 9101648509990566412}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &-2625148932084804424
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7885618348377886950}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e01cf0e4c6ebb4443a9ca96c6f09f22c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  magType: 1
+  initalProjectile: {fileID: 3848343717668343118, guid: 1ff9dd0fc4df49c4e8e6201312a8d2f5,
+    type: 3}
+  ProjectilesFired: 1
+  ammoType: 20
+  magazineSize: 1

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/ReactionSets/DefaultReactions.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/ReactionSets/DefaultReactions.asset
@@ -178,3 +178,6 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 872e327eb3362ab42adc64fca6b6a298, type: 2}
   - {fileID: 11400000, guid: 7c0ca27e0e996da498c1899b5d4023e0, type: 2}
   - {fileID: 11400000, guid: 03aaef7fe5be2a2429d542673d596f7b, type: 2}
+  - {fileID: 11400000, guid: 06bf860ba183258408f0041f3f29bdbe, type: 2}
+  - {fileID: 11400000, guid: 1b84899d58923c944b9a68198ecadd09, type: 2}
+  - {fileID: 11400000, guid: b9b2d19afaa324540a0b5a9d8bb203af, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Food/Caramel.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Food/Caramel.asset
@@ -23,8 +23,8 @@ MonoBehaviour:
   inhibitors:
     m_keys: []
     m_values: 
-  hasMinTemp: 0
-  serializableTempMin: 0
+  hasMinTemp: 1
+  serializableTempMin: 413.15
   hasMaxTemp: 0
   serializableTempMax: 0
   results:

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Food/CaramelBurned.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Food/CaramelBurned.asset
@@ -23,8 +23,8 @@ MonoBehaviour:
   inhibitors:
     m_keys: []
     m_values: 
-  hasMinTemp: 0
-  serializableTempMin: 0
+  hasMinTemp: 1
+  serializableTempMin: 483.15
   hasMaxTemp: 0
   serializableTempMax: 0
   results:

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Food/CornSyrup.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Food/CornSyrup.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
     m_keys:
     - {fileID: 11400000, guid: bcfadcef446d8271fa8576b781a24a13, type: 2}
     - {fileID: 11400000, guid: 43a6ef917538f898ca86fa22a81babd4, type: 2}
-    m_values: 0400000001000000
+    m_values: 0100000001000000
   useExactAmounts: 0
   catalysts:
     m_keys: []
@@ -24,8 +24,8 @@ MonoBehaviour:
   inhibitors:
     m_keys: []
     m_values: 
-  hasMinTemp: 0
-  serializableTempMin: 0
+  hasMinTemp: 1
+  serializableTempMin: 374
   hasMaxTemp: 0
   serializableTempMax: 0
   results:


### PR DESCRIPTION
### Purpose
- Gives the caramel reactions minimum temperatures and properly adds them to the default reaction set so they can occur. Now sugar can be properly turned into caramel by heating it over 413.5 K.
- Makes rockets into clips so you can reload the RPGL with them. Fixes #7672

### Changelog:

CL: [Fix] Heating sugar above 413.5 K will now actually create caramel as intended.
CL: [Fix] Rockets can now be used to reload the RPGL.
