### PR TITLE
Increases performance in MatrixManager helpers

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Input System/WallMountHandApplySpawn.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/WallMountHandApplySpawn.cs
@@ -25,7 +25,7 @@ public class WallMountHandApplySpawn : MonoBehaviour, ICheckedInteractable<Posit
 		{
 			return;
 		}
-		if (!MatrixManager.IsWallAtAnyMatrix(roundTargetWorldPosition, true))
+		if (!MatrixManager.IsWallAt(roundTargetWorldPosition, true))
 		{
 			return;
 		}
@@ -35,7 +35,7 @@ public class WallMountHandApplySpawn : MonoBehaviour, ICheckedInteractable<Posit
 
 		//is there a wall in the direction of the new wallmount? taking into account diagonal clicking
 		var tileInFront = roundTargetWorldPosition + new Vector3Int(PlaceDirection.x, 0, 0);
-		if (!MatrixManager.IsWallAtAnyMatrix(tileInFront, true))
+		if (!MatrixManager.IsWallAt(tileInFront, true))
 		{
 			if (PlaceDirection.x > 0)
 			{
@@ -49,7 +49,7 @@ public class WallMountHandApplySpawn : MonoBehaviour, ICheckedInteractable<Posit
 		else
 		{
 			tileInFront = roundTargetWorldPosition + new Vector3Int(0, PlaceDirection.y, 0);
-			if (!MatrixManager.IsWallAtAnyMatrix(tileInFront, true))
+			if (!MatrixManager.IsWallAt(tileInFront, true))
 			{
 				if (PlaceDirection.y > 0)
 				{

--- a/UnityProject/Assets/Scripts/Items/Engineering/CableCoil.cs
+++ b/UnityProject/Assets/Scripts/Items/Engineering/CableCoil.cs
@@ -54,7 +54,7 @@ namespace Objects.Electrical
 			//can only be used on tiles
 			if (!Validations.HasComponent<InteractableTiles>(interaction.TargetObject)) return false;
 			// If there's a table, we should drop there
-			if (MatrixManager.IsTableAtAnyMatrix(Vector3Int.RoundToInt(interaction.WorldPositionTarget), side == NetworkSide.Server))
+			if (MatrixManager.IsTableAt(Vector3Int.RoundToInt(interaction.WorldPositionTarget), side == NetworkSide.Server))
 			{
 				return false;
 			}

--- a/UnityProject/Assets/Scripts/Items/Others/NukeDiskScript.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/NukeDiskScript.cs
@@ -123,7 +123,7 @@ namespace Items.Command
 		private void Teleport()
 		{
 			Vector3 position = new Vector3(Random.Range(bound.xMin, bound.xMax), Random.Range(bound.yMin, bound.yMax), 0);
-			while (MatrixManager.IsSpaceAt(Vector3Int.FloorToInt(position), true) || MatrixManager.IsWallAtAnyMatrix(Vector3Int.FloorToInt(position), true))
+			while (MatrixManager.IsSpaceAt(Vector3Int.FloorToInt(position), true) || MatrixManager.IsWallAt(Vector3Int.FloorToInt(position), true))
 			{
 				position = new Vector3(Random.Range(bound.xMin, bound.xMax), Random.Range(bound.yMin, bound.yMax), 0);
 			}

--- a/UnityProject/Assets/Scripts/Items/Tool/Mop.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/Mop.cs
@@ -42,7 +42,7 @@ public class Mop : MonoBehaviour, ICheckedInteractable<PositionalHandApply>, IEx
 		if (!Validations.HasComponent<InteractableTiles>(interaction.TargetObject)) return false;
 
 		//don't attempt to mop walls
-		if (MatrixManager.IsWallAtAnyMatrix(interaction.WorldPositionTarget.RoundToInt(), isServer: side == NetworkSide.Server))
+		if (MatrixManager.IsWallAt(interaction.WorldPositionTarget.RoundToInt(), isServer: side == NetworkSide.Server))
 		{
 			return false;
 		}

--- a/UnityProject/Assets/Scripts/Items/Tool/Soap.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/Soap.cs
@@ -38,7 +38,7 @@ namespace Items
 
 		public void ServerPerformInteraction(PositionalHandApply interaction)
 		{
-			var isWall = MatrixManager.IsWallAtAnyMatrix(interaction.WorldPositionTarget.RoundToInt(), true);
+			var isWall = MatrixManager.IsWallAt(interaction.WorldPositionTarget.RoundToInt(), true);
 
 			//server is performing server-side logic for the interaction
 			//do the scrubbing

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using Chemistry;
 using Doors;
 using TileManagement;
@@ -280,27 +278,20 @@ public partial class MatrixManager : SingletonManager<MatrixManager>
 	/// Finds first matrix that is not empty at given world pos
 	public static MatrixInfo AtPoint(Vector3Int worldPos, bool isServer)
 	{
-		try
+
+		for (int i = 0; i < Instance.ActiveMatricesList.Count; i++)
 		{
-			for (int i = 0; i < Instance.ActiveMatricesList.Count; i++)
+			var LocalPos = WorldToLocalInt(worldPos, Instance.ActiveMatricesList[i]);
+			if (Instance.ActiveMatricesList[i].Bounds.Contains(LocalPos) == false) continue;
+
+			if (Instance.ActiveMatricesList[i].Matrix == Instance.spaceMatrix) continue;
+			if (Instance.ActiveMatricesList[i].Matrix.IsEmptyAt(LocalPos, isServer) == false)
 			{
-				var LocalPos = WorldToLocalInt(worldPos, Instance.ActiveMatricesList[i]);
-				if (Instance.ActiveMatricesList[i].Bounds.Contains(LocalPos) == false) continue;
-
-				if (Instance.ActiveMatricesList[i].Matrix == Instance.spaceMatrix) continue;
-				if (Instance.ActiveMatricesList[i].Matrix.IsEmptyAt(LocalPos, isServer) == false)
-				{
-					return Instance.ActiveMatricesList[i];
-				}
+				return Instance.ActiveMatricesList[i];
 			}
+		}
 
-			return Instance.ActiveMatrices[Instance.spaceMatrix.Id];
-		}
-		catch (NullReferenceException exception)
-		{
-			Logger.LogError("Caught an NRE on client in MatrixManager.AtPoint() " + exception.Message, Category.Matrix);
-			return null;
-		}
+		return Instance.ActiveMatrices[Instance.spaceMatrix.Id];
 	}
 
 	public static CustomPhysicsHit Linecast(Vector3 Worldorigin, LayerTypeSelection layerMask, LayerMask? Layermask2D,
@@ -492,59 +483,6 @@ public partial class MatrixManager : SingletonManager<MatrixManager>
 		return true;
 	}
 
-	public static void ListAllMatrices()
-	{
-		foreach (var matrixInfo in Instance.ActiveMatricesList)
-		{
-			Logger.Log("MATRIX: " + matrixInfo.Name, Category.Matrix);
-		}
-	}
-
-	///Cross-matrix edition of <see cref="Matrix.IsFloatingAt(UnityEngine.Vector3Int,bool)"/>
-	///<inheritdoc cref="Matrix.IsFloatingAt(UnityEngine.Vector3Int,bool)"/>
-	public static bool IsFloatingAt(Vector3Int worldPos, bool isServer)
-	{
-		return AllMatchInternal(mat => mat.Matrix.IsFloatingAt(WorldToLocalInt(worldPos, mat), isServer));
-	}
-
-	///Cross-matrix edition of <see cref="Matrix.IsFloatingAt(UnityEngine.Vector3Int,bool)"/>
-	///<inheritdoc cref="Matrix.IsFloatingAt(UnityEngine.Vector3Int,bool)"/>
-	public static bool IsNonStickyAt(Vector3Int worldPos, bool isServer)
-	{
-		return AllMatchInternal(mat => mat.Matrix.IsNonStickyAt(WorldToLocalInt(worldPos, mat), isServer));
-	}
-
-	///Cross-matrix edition of <see cref="Matrix.IsNoGravityAt"/>
-	///<inheritdoc cref="Matrix.IsNoGravityAt"/>
-	public static bool IsNoGravityAt(Vector3Int worldPos, bool isServer)
-	{
-		return AllMatchInternal(mat => mat.Matrix.IsNoGravityAt(WorldToLocalInt(worldPos, mat), isServer));
-	}
-
-	/// <summary>
-	/// Server only.
-	/// Returns true if it's slippery or no gravity at provided position.
-	/// </summary>
-	public static bool IsSlipperyOrNoGravityAt(Vector3Int worldPos)
-	{
-		return IsSlipperyAt(worldPos) || IsNoGravityAt(worldPos, isServer: true);
-	}
-
-	///Cross-matrix edition of <see cref="Matrix.IsFloatingAt(GameObject[],UnityEngine.Vector3Int,bool)"/>
-	///<inheritdoc cref="Matrix.IsFloatingAt(GameObject[],UnityEngine.Vector3Int,bool)"/>
-	public static bool IsFloatingAt(GameObject context, Vector3Int worldPos, bool isServer)
-	{
-		return AllMatchInternal(mat =>
-			mat.Matrix.IsFloatingAt(new[] {context}, WorldToLocalInt(worldPos, mat), isServer));
-	}
-
-	///Cross-matrix edition of <see cref="Matrix.IsFloatingAt(GameObject[],UnityEngine.Vector3Int)"/>
-	///<inheritdoc cref="Matrix.IsFloatingAt(GameObject[],UnityEngine.Vector3Int)"/>
-	public static bool IsFloatingAt(GameObject[] context, Vector3Int worldPos, bool isServer)
-	{
-		return AllMatchInternal(mat => mat.Matrix.IsFloatingAt(context, WorldToLocalInt(worldPos, mat), isServer));
-	}
-
 	///Cross-matrix edition of <see cref="Matrix.IsSpaceAt"/>
 	///<inheritdoc cref="Matrix.IsSpaceAt"/>
 	public static bool IsSpaceAt(Vector3Int worldPos, bool isServer)
@@ -583,35 +521,6 @@ public partial class MatrixManager : SingletonManager<MatrixManager>
 
 		return true;
 	}
-
-	/// <inheritdoc cref="ObjectLayer.HasAnyDepartureBlockedByRegisterTile(Vector3Int, bool, RegisterTile)"/>
-	public static bool HasAnyDepartureBlockedAnyMatrix(Vector3Int to, bool isServer, RegisterTile context)
-	{
-		return AnyMatchInternal(mat =>
-			mat.Matrix.HasAnyDepartureBlockedOneMatrix(WorldToLocalInt(to, mat), isServer, context));
-	}
-
-	///Cross-matrix edition of <see cref="Matrix.IsPassableAt(UnityEngine.Vector3Int,UnityEngine.Vector3Int,bool,GameObject)"/>
-	///<inheritdoc cref="Matrix.IsPassableAt(UnityEngine.Vector3Int,UnityEngine.Vector3Int,bool,GameObject)"/>
-	public static bool IsPassableAtAllMatrices(Vector3Int worldOrigin, Vector3Int worldTarget, bool isServer,
-		CollisionType collisionType = CollisionType.Player, bool includingPlayers = true, GameObject context = null,
-		int[] excludeList = null, List<LayerType> excludeLayers = null, bool isReach = false,
-		bool onlyExcludeLayerOnDestination = false)
-	{
-		// Gets the list of Matrixes to actually check
-		MatrixInfo[] includeList = excludeList != null
-			? ExcludeFromAllMatrixes(excludeList)
-			: Instance.ActiveMatricesList.ToArray();
-
-		return AllMatchInternal(mat =>
-				mat.Matrix.IsPassableAtOneMatrix(WorldToLocalInt(worldOrigin, mat), WorldToLocalInt(worldTarget, mat),
-					isServer,
-					collisionType: collisionType, includingPlayers: includingPlayers, context: context,
-					excludeLayers: excludeLayers, isReach: isReach,
-					onlyExcludeLayerOnDestination: onlyExcludeLayerOnDestination),
-			includeList);
-	}
-
 
 	/// <summary>
 	/// Server only.
@@ -927,34 +836,6 @@ public partial class MatrixManager : SingletonManager<MatrixManager>
 		       IsAtmosPassableAt(worldTarget, isServer) == false;
 	}
 
-	///Cross-matrix edition of <see cref="Matrix.IsPassableAt(UnityEngine.Vector3Int,bool)"/>
-	///<inheritdoc cref="Vector3Int"/>
-	public static bool IsPassableAtAllMatricesOneTile(Vector3Int worldTarget, bool isServer,
-		bool includingPlayers = true,
-		List<LayerType> excludeLayers = null, List<TileType> excludeTiles = null, GameObject context = null,
-		bool ignoreObjects = false,
-		bool onlyExcludeLayerOnDestination = false)
-	{
-		return AllMatchInternal(mat =>
-			mat.Matrix.IsPassableAtOneMatrixOneTile(WorldToLocalInt(worldTarget, mat), isServer, includingPlayers,
-				excludeLayers, excludeTiles, context, ignoreObjects, onlyExcludeLayerOnDestination));
-	}
-
-	/// <summary>
-	/// Serverside only: checks if tile is slippery
-	/// </summary>
-	public static bool IsSlipperyAt(Vector3Int worldPos)
-	{
-		return AnyMatchInternal(mat => mat.MetaDataLayer.IsSlipperyAt(WorldToLocalInt(worldPos, mat)));
-	}
-
-	///Cross-matrix edition of <see cref="Matrix.IsAtmosPassableAt(UnityEngine.Vector3Int,bool)"/>
-	///<inheritdoc cref="Matrix.IsAtmosPassableAt(UnityEngine.Vector3Int,bool)"/>
-	public static bool IsAtmosPassableAt(Vector3Int worldTarget, bool isServer)
-	{
-		return AllMatchInternal(mat => mat.Matrix.IsAtmosPassableAt(WorldToLocalInt(worldTarget, mat), isServer));
-	}
-
 	/// <see cref="Matrix.Get{T}(UnityEngine.Vector3Int,bool)"/>
 	public static List<T> GetAt<T>(Vector3Int worldPos, bool isServer) where T : MonoBehaviour
 	{
@@ -1045,11 +926,62 @@ public partial class MatrixManager : SingletonManager<MatrixManager>
 		return GetAt<T>((Vector3Int) targetObject.TileWorldPosition(), side == NetworkSide.Server);
 	}
 
-	private static bool AllMatchInternal(Func<MatrixInfo, bool> condition, MatrixInfo[] matrixInfos)
+	///Cross-matrix edition of <see cref="Matrix.IsPassableAt(UnityEngine.Vector3Int,bool)"/>
+	///<inheritdoc cref="Vector3Int"/>
+	public static bool IsPassableAtAllMatricesOneTile(Vector3Int worldPos, bool isServer,
+		bool includingPlayers = true,
+		List<LayerType> excludeLayers = null, List<TileType> excludeTiles = null, GameObject context = null,
+		bool ignoreObjects = false,
+		bool onlyExcludeLayerOnDestination = false)
 	{
-		for (var i = 0; i < matrixInfos.Length; i++)
+		var matrixInfo = AtPoint(worldPos, isServer);
+		var localPos = WorldToLocalInt(worldPos, matrixInfo);
+		var value = matrixInfo.Matrix.IsPassableAtOneMatrixOneTile(localPos, isServer, includingPlayers,
+			excludeLayers, excludeTiles, context, ignoreObjects, onlyExcludeLayerOnDestination);
+		return value;
+	}
+
+	///Cross-matrix edition of <see cref="Matrix.IsPassableAt(UnityEngine.Vector3Int,UnityEngine.Vector3Int,bool,GameObject)"/>
+	///<inheritdoc cref="Matrix.IsPassableAt(UnityEngine.Vector3Int,UnityEngine.Vector3Int,bool,GameObject)"/>
+	public static bool IsPassableAtAllMatrices(Vector3Int worldOrigin, Vector3Int worldTarget, bool isServer,
+		CollisionType collisionType = CollisionType.Player, bool includingPlayers = true, GameObject context = null,
+		MatrixInfo excludeMatrix = null, List<LayerType> excludeLayers = null, bool isReach = false,
+		bool onlyExcludeLayerOnDestination = false)
+	{
+		var matrixOrigin = AtPoint(worldOrigin, isServer);
+		var matrixTarget = AtPoint(worldTarget, isServer);
+		if (excludeMatrix != null)
 		{
-			if (condition(matrixInfos[i]) == false)
+			if (excludeMatrix == matrixOrigin)
+			{
+				matrixOrigin = Instance.spaceMatrix.MatrixInfo;
+			}
+			if (excludeMatrix == matrixTarget)
+			{
+				matrixTarget = Instance.spaceMatrix.MatrixInfo;
+			}
+		}
+
+		var localPosOrigin = WorldToLocalInt(worldOrigin, matrixOrigin);
+		var localPosTarget = WorldToLocalInt(worldTarget, matrixOrigin);
+
+		var value = matrixOrigin.Matrix.IsPassableAtOneMatrix(localPosOrigin, localPosTarget, isServer,
+			collisionType, includingPlayers, context, excludeLayers, isReach: isReach,
+			onlyExcludeLayerOnDestination: onlyExcludeLayerOnDestination);
+		if (value == false)
+		{
+			return false;
+		}
+
+		if (matrixOrigin != matrixTarget)
+		{
+			localPosOrigin = WorldToLocalInt(worldOrigin, matrixTarget);
+			localPosTarget = WorldToLocalInt(worldTarget, matrixTarget);
+
+			value = matrixTarget.Matrix.IsPassableAtOneMatrix(localPosOrigin, localPosTarget, isServer,
+				collisionType, includingPlayers, context, excludeLayers, isReach: isReach,
+				onlyExcludeLayerOnDestination: onlyExcludeLayerOnDestination);
+			if (value == false)
 			{
 				return false;
 			}
@@ -1058,51 +990,114 @@ public partial class MatrixManager : SingletonManager<MatrixManager>
 		return true;
 	}
 
-	// By default will just check every Matrix
-	private static bool AllMatchInternal(Func<MatrixInfo, bool> condition)
+	public static bool IsTableAt(Vector3Int worldPos, bool isServer)
 	{
-		return AllMatchInternal(condition, Instance.ActiveMatricesList.ToArray());
+		var matrixInfo = AtPoint(worldPos, isServer);
+		var localPos = WorldToLocalInt(worldPos, matrixInfo);
+		var value = matrixInfo.Matrix.IsTableAt(localPos, isServer);
+		return value;
 	}
 
-	private static bool AnyMatchInternal(Func<MatrixInfo, bool> condition, MatrixInfo[] matrixInfos)
+	public static bool IsWallAt(Vector3Int worldPos, bool isServer)
 	{
-		for (var i = 0; i < matrixInfos.Length; i++)
-		{
-			if (condition(matrixInfos[i]))
-			{
-				return true;
-			}
-		}
-
-		return false;
+		var matrixInfo = AtPoint(worldPos, isServer);
+		var localPos = WorldToLocalInt(worldPos, matrixInfo);
+		var value = matrixInfo.Matrix.IsWallAt(localPos, isServer);
+		return value;
 	}
 
-	private static bool AnyMatchInternal(Func<MatrixInfo, bool> condition)
+	public static bool IsWindowAt(Vector3Int worldPos, bool isServer)
 	{
-		return AnyMatchInternal(condition, Instance.ActiveMatricesList.ToArray());
+		var matrixInfo = AtPoint(worldPos, isServer);
+		var localPos = WorldToLocalInt(worldPos, matrixInfo);
+		var value = matrixInfo.Matrix.IsWindowAt(localPos, isServer);
+		return value;
 	}
 
-	public static bool IsTableAtAnyMatrix(Vector3Int worldTarget, bool isServer)
+	public static bool IsGrillAt(Vector3Int worldPos, bool isServer)
 	{
-		return AnyMatchInternal(mat =>
-			mat != null && mat.Matrix.IsTableAt(WorldToLocalInt(worldTarget, mat), isServer));
+		var matrixInfo = AtPoint(worldPos, isServer);
+		var localPos = WorldToLocalInt(worldPos, matrixInfo);
+		var value = matrixInfo.Matrix.IsGrillAt(localPos, isServer);
+		return value;
 	}
 
-	public static bool IsWallAtAnyMatrix(Vector3Int worldTarget, bool isServer)
+	/// <summary>
+	/// Serverside only: checks if tile is slippery
+	/// </summary>
+	[Server]
+	public static bool IsSlipperyAt(Vector3Int worldPos)
 	{
-		return AnyMatchInternal(mat => mat != null && mat.Matrix.IsWallAt(WorldToLocalInt(worldTarget, mat), isServer));
+		var matrixInfo = AtPoint(worldPos, true);
+		var localPos = WorldToLocalInt(worldPos, matrixInfo);
+		var value = matrixInfo.MetaDataLayer.IsSlipperyAt(localPos);
+		return value;
 	}
 
-	public static bool IsWindowAtAnyMatrix(Vector3Int worldTarget, bool isServer)
+	/// <inheritdoc cref="ObjectLayer.HasAnyDepartureBlockedByRegisterTile(Vector3Int, bool, RegisterTile)"/>
+	public static bool HasAnyDepartureBlockedAt(Vector3Int worldPos, bool isServer, RegisterTile context)
 	{
-		return AnyMatchInternal(
-			mat => mat != null && mat.Matrix.IsWindowAt(WorldToLocalInt(worldTarget, mat), isServer));
+		var matrixInfo = AtPoint(worldPos, isServer);
+		var localPos = WorldToLocalInt(worldPos, matrixInfo);
+		var value = matrixInfo.Matrix.HasAnyDepartureBlockedOneMatrix(localPos, isServer, context);
+		return value;
 	}
 
-	public static bool IsGrillAtAnyMatrix(Vector3Int worldTarget, bool isServer)
+	///Cross-matrix edition of <see cref="Matrix.IsFloatingAt(UnityEngine.Vector3Int,bool)"/>
+	///<inheritdoc cref="Matrix.IsFloatingAt(UnityEngine.Vector3Int,bool)"/>
+	public static bool IsNonStickyAt(Vector3Int worldPos, bool isServer)
 	{
-		return AnyMatchInternal(mat =>
-			mat != null && mat.Matrix.IsGrillAt(WorldToLocalInt(worldTarget, mat), isServer));
+		var matrixInfo = AtPoint(worldPos, isServer);
+		var localPos = WorldToLocalInt(worldPos, matrixInfo);
+		var value = matrixInfo.Matrix.IsNonStickyAt(localPos, isServer);
+		return value;
+	}
+
+	///Cross-matrix edition of <see cref="Matrix.IsNoGravityAt"/>
+	///<inheritdoc cref="Matrix.IsNoGravityAt"/>
+	public static bool IsNoGravityAt(Vector3Int worldPos, bool isServer)
+	{
+		var matrixInfo = AtPoint(worldPos, isServer);
+		var localPos = WorldToLocalInt(worldPos, matrixInfo);
+		var value = matrixInfo.Matrix.IsNoGravityAt(localPos, isServer);
+		return value;
+	}
+
+	/// <summary>
+	/// Server only.
+	/// Returns true if it's slippery or no gravity at provided position.
+	/// </summary>
+	[Server]
+	public static bool IsSlipperyOrNoGravityAt(Vector3Int worldPos)
+	{
+		return IsSlipperyAt(worldPos) || IsNoGravityAt(worldPos, true);
+	}
+
+	///Cross-matrix edition of <see cref="Matrix.IsFloatingAt(GameObject[],UnityEngine.Vector3Int,bool)"/>
+	///<inheritdoc cref="Matrix.IsFloatingAt(GameObject[],UnityEngine.Vector3Int,bool)"/>
+	public static bool IsFloatingAt(GameObject context, Vector3Int worldPos, bool isServer)
+	{
+		return IsFloatingAt(new[] {context}, worldPos, isServer);
+	}
+
+	///Cross-matrix edition of <see cref="Matrix.IsFloatingAt(GameObject[],UnityEngine.Vector3Int)"/>
+	///<inheritdoc cref="Matrix.IsFloatingAt(GameObject[],UnityEngine.Vector3Int)"/>
+	public static bool IsFloatingAt(GameObject[] context, Vector3Int worldPos, bool isServer)
+	{
+		var matrixInfo = AtPoint(worldPos, isServer);
+		var localPos = WorldToLocalInt(worldPos, matrixInfo);
+		var value = matrixInfo.Matrix.IsFloatingAt(context, localPos, isServer);
+		return value;
+	}
+
+	///Cross-matrix edition of <see cref="Matrix.IsAtmosPassableAt(UnityEngine.Vector3Int,bool)"/>
+	///<inheritdoc cref="Matrix.IsAtmosPassableAt(UnityEngine.Vector3Int,bool)"/>
+	public static bool IsAtmosPassableAt(Vector3Int worldPos, bool isServer)
+	{
+		var matrixInfo = AtPoint(worldPos, isServer);
+		var localPos = WorldToLocalInt(worldPos, matrixInfo);
+		var value = matrixInfo.Matrix.IsAtmosPassableAt(localPos, isServer);
+		return value;
 	}
 
 	/// <Summary>
@@ -1168,32 +1163,6 @@ public partial class MatrixManager : SingletonManager<MatrixManager>
 		}
 
 		return MatrixInfo.Invalid;
-	}
-
-	public static MatrixInfo[] ExcludeFromAllMatrixes(int[] excludeIDs)
-	{
-		var matrixList = new MatrixInfo[Instance.ActiveMatrices.Count - excludeIDs.Length];
-		var index = 0;
-		foreach (var matrixInfo in Instance.ActiveMatricesList)
-		{
-			var addMe = true;
-			foreach (var excludeID in excludeIDs)
-			{
-				if (matrixInfo.Id == excludeID)
-				{
-					addMe = false;
-					break;
-				}
-			}
-
-			if (addMe)
-			{
-				matrixList[index] = matrixInfo;
-				index++;
-			}
-		}
-
-		return matrixList;
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/NPC/AI/MobMeleeAttack.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobMeleeAttack.cs
@@ -122,7 +122,7 @@ namespace Systems.MobAIs
 				{
 					dir = new Vector3(isX ? normalised.x : 0, isX ? 0 : normalised.y , 0);
 
-					if (MatrixManager.IsWindowAtAnyMatrix(posShift, true) || MatrixManager.IsGrillAtAnyMatrix(posShift, true))
+					if (MatrixManager.IsWindowAt(posShift, true) || MatrixManager.IsGrillAt(posShift, true))
 					{
 						worldPos = posShift;
 						return true;

--- a/UnityProject/Assets/Scripts/Objects/PushPull.cs
+++ b/UnityProject/Assets/Scripts/Objects/PushPull.cs
@@ -1015,7 +1015,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 		{
 			// orthogonal movement
 			if (registerTile.IsPassableFromInside(-dir, serverSide) == false
-				&& MatrixManager.HasAnyDepartureBlockedAnyMatrix(from - dir, serverSide, registerTile))
+				&& MatrixManager.HasAnyDepartureBlockedAt(from - dir, serverSide, registerTile))
 			{
 				return true;
 			}
@@ -1028,8 +1028,8 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 
 			if (registerTile.IsPassableFromInside(-horizontalDir, serverSide) == false
 				&& registerTile.IsPassableFromInside(-verticalDir, serverSide) == false
-				&& MatrixManager.HasAnyDepartureBlockedAnyMatrix(from-horizontalDir, serverSide, registerTile)
-				&& MatrixManager.HasAnyDepartureBlockedAnyMatrix(from - verticalDir, serverSide, registerTile))
+				&& MatrixManager.HasAnyDepartureBlockedAt(from-horizontalDir, serverSide, registerTile)
+				&& MatrixManager.HasAnyDepartureBlockedAt(from - verticalDir, serverSide, registerTile))
 			{
 				return true;
 			}

--- a/UnityProject/Assets/Scripts/Objects/RolledPoster.cs
+++ b/UnityProject/Assets/Scripts/Objects/RolledPoster.cs
@@ -70,7 +70,7 @@ namespace Items
 				return false;
 			}
 
-			if (!MatrixManager.IsWallAtAnyMatrix(interaction.WorldPositionTarget.RoundToInt(), side == NetworkSide.Server))
+			if (!MatrixManager.IsWallAt(interaction.WorldPositionTarget.RoundToInt(), side == NetworkSide.Server))
 			{
 				return false;
 			}

--- a/UnityProject/Assets/Scripts/Shuttles/MatrixMove.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/MatrixMove.cs
@@ -763,10 +763,8 @@ public class MatrixMove : ManagedBehaviour
 			var sensor = SensorPositions[i];
 			Vector3Int sensorPos = MatrixManager.LocalToWorldInt(sensor, MatrixInfo, serverTargetState);
 
-			// Exclude the moving matrix, we shouldn't be able to collide with ourselves
-			int[] excludeList = { MatrixInfo.Id };
 			if (!MatrixManager.IsPassableAtAllMatrices(sensorPos, sensorPos + dir.RoundToInt(), isServer: true,
-											collisionType: matrixColliderType, excludeList: excludeList))
+											collisionType: matrixColliderType, excludeMatrix: MatrixInfo))
 			{
 				Logger.LogTrace(
 					$"Can't pass {serverTargetState.Position}->{serverTargetState.Position + dir} (because {sensorPos}->{sensorPos + dir})!",
@@ -795,10 +793,8 @@ public class MatrixMove : ManagedBehaviour
 			Vector3 localSensorAggrigateVector = (rotationSensorContainerTransform.localRotation * sensor.transform.localPosition) + rotationSensorContainerTransform.localPosition;
 			Vector3Int sensorPos = MatrixManager.LocalToWorldInt(localSensorAggrigateVector, MatrixInfo, serverTargetState);
 
-			// Exclude the rotating matrix, we shouldn't be able to collide with ourselves
-			int[] excludeList = { MatrixInfo.Id };
 			if (!MatrixManager.IsPassableAtAllMatrices(sensorPos, sensorPos, isServer: true,
-											collisionType: matrixColliderType, includingPlayers: true, excludeList: excludeList))
+											collisionType: matrixColliderType, includingPlayers: true, excludeMatrix: MatrixInfo))
 			{
 				Logger.LogTrace(
 					$"Can't rotate at {serverTargetState.Position}->{serverTargetState.Position } (because {sensorPos} is occupied)!",

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobStarter.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobStarter.cs
@@ -264,7 +264,7 @@ namespace Blob
 				.magnitude > 600f) || MatrixManager.IsSpaceAt(gameObject.GetComponent<PlayerSync>().ServerPosition, true) || on != MatrixManager.MainStationMatrix)
 			{
 				Vector3 position = new Vector3(Random.Range(bound.xMin, bound.xMax), Random.Range(bound.yMin, bound.yMax), 0);
-				while (MatrixManager.IsSpaceAt(Vector3Int.FloorToInt(position), true) || MatrixManager.IsWallAtAnyMatrix(Vector3Int.FloorToInt(position), true))
+				while (MatrixManager.IsSpaceAt(Vector3Int.FloorToInt(position), true) || MatrixManager.IsWallAt(Vector3Int.FloorToInt(position), true))
 				{
 					position = new Vector3(Random.Range(bound.xMin, bound.xMax), Random.Range(bound.yMin, bound.yMax), 0);
 				}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
@@ -448,7 +448,7 @@ public class InteractableTiles : MonoBehaviour, IClientInteractable<PositionalHa
 			OrientationEnum orientation = OrientationEnum.Down;
 			Vector3Int PlaceDirection = PlayerManager.LocalPlayerScript.WorldPos - tilePos;
 			bool isWallBlocked = false;
-			if (PlaceDirection.x != 0 && !MatrixManager.IsWallAtAnyMatrix(tilePos + new Vector3Int(PlaceDirection.x > 0 ? 1 : -1, 0, 0), true))
+			if (PlaceDirection.x != 0 && !MatrixManager.IsWallAt(tilePos + new Vector3Int(PlaceDirection.x > 0 ? 1 : -1, 0, 0), true))
 			{
 				if (PlaceDirection.x > 0)
 				{
@@ -461,7 +461,7 @@ public class InteractableTiles : MonoBehaviour, IClientInteractable<PositionalHa
 			}
 			else
 			{
-				if (PlaceDirection.y != 0 && !MatrixManager.IsWallAtAnyMatrix(tilePos + new Vector3Int(0, PlaceDirection.y > 0 ? 1 : -1, 0), true))
+				if (PlaceDirection.y != 0 && !MatrixManager.IsWallAt(tilePos + new Vector3Int(0, PlaceDirection.y > 0 ? 1 : -1, 0), true))
 				{
 					if (PlaceDirection.y > 0)
 					{
@@ -478,7 +478,7 @@ public class InteractableTiles : MonoBehaviour, IClientInteractable<PositionalHa
 				}
 			}
 
-			if (!MatrixManager.IsWallAtAnyMatrix(tilePos, false) || isWallBlocked)
+			if (!MatrixManager.IsWallAt(tilePos, false) || isWallBlocked)
 			{
 				if (instanceActive)
 				{


### PR DESCRIPTION
### Purpose
Increases performance in MatrixManager helpers
Removes the trycatch in AtPoint()
Removes AllMatchInternal(), MatrixManager helpers will now use AtPoint() to get the proper matrix.
Renames some helpers in MatrixManager to shorter versions of themselves.

And, in simpler terms, it cuts by half the cpu usage of player and mobs movement

CL: [Fix] Increases performance in MatrixManager helpers. 50% CPU usage reduction for player and mob movement.