### PR TITLE
Antag preferences on by default

### DIFF
--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/AntagonistPreferences.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/AntagonistPreferences.prefab
@@ -447,7 +447,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: No
+  m_text: Yes
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -709,7 +709,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.56299996, g: 0.12091272, b: 0.086906016, a: 1}
+  m_Color: {r: 0.18815999, g: 0.49, b: 0.11270001, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1

--- a/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
+++ b/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
@@ -293,15 +293,23 @@ namespace GameModes
 
 		/// <summary>
 		/// Checks if the antag preferences have at least one of the possible antags enabled.
-		/// Assume the antag is enabled by default if it doesn't appear in the preferences.
+		/// Assume the antag is enabled by default if it doesn't appear in the preferences or was never set up.
 		/// </summary>
 		/// <param name="antagPrefs"></param>
 		/// <param name="antag"></param>
 		/// <returns></returns>
 		protected bool HasAntagEnabled(ref AntagPrefsDict antagPrefs, Antagonist antag)
 		{
-			return !antag.ShowInPreferences ||
-			       (antagPrefs.ContainsKey(antag.AntagName) && antagPrefs[antag.AntagName]);
+			if (antag.ShowInPreferences == false)
+			{
+				return true;
+			}
+			if (antagPrefs.ContainsKey(antag.AntagName) && antagPrefs[antag.AntagName] == false)
+			{
+				//manually set to false by the player
+				return false;
+			}
+			return true;
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/UI/Systems/CharacterCreator/AntagEntry.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/CharacterCreator/AntagEntry.cs
@@ -24,7 +24,7 @@ namespace UI.CharacterCreator
 		private AntagonistPreferences antagPrefsUI = null;
 
 		// Internal values
-		private bool antagEnabled;
+		private bool antagEnabled = true;
 		private Antagonist antag = null;
 
 		/// <summary>


### PR DESCRIPTION
### Purpose
CL: [Balance] From now players will have all antag preferences on by default.
Updates the antag preferences to reflect this change.
