### PR TITLE
Shortcut to QuickLoad

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Editor/CheckmarkMenuItems/CheckmarkMenuItems.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/CheckmarkMenuItems/CheckmarkMenuItems.cs
@@ -1,27 +1,82 @@
 ﻿using UnityEditor;
 
-
 namespace Core.Editor
 {
-	[InitializeOnLoad]
-	public static class HideIrrelevantFields
+	/// Courtesy of <c>JanWosnitzaSAS</c>
+	/// from <see cref="https://answers.unity.com/questions/775869/editor-how-to-add-checkmarks-to-menuitems.html"/>.
+
+	public static class QuickLoad
 	{
-		private const string MenuPathName = "Tools/Inspector/Hide Irrelevant Fields";
+		private const string MenuName = "Tools/Quick Load";
+		private const string SettingName = "QuickLoad";
 
-		public static bool IsEnabled { get; private set; } = true;
-
-		static HideIrrelevantFields()
+		/// <summary>
+		/// If checked, prevents nonessential scenes from loading, in addition to removing the roundstart countdown.
+		/// </summary>
+		public static bool IsEnabled
 		{
-			IsEnabled = EditorPrefs.GetBool(MenuPathName, IsEnabled);
+			get => EditorPrefs.GetBool(SettingName, true);
+			set => EditorPrefs.SetBool(SettingName, value);
 		}
 
-		[MenuItem(MenuPathName)]
-		private static void ToggleItem()
+		[MenuItem(MenuName, priority = 1)]
+		public static void Toggle()
 		{
 			IsEnabled = !IsEnabled;
+			UpdateGameManager(IsEnabled);
+		}
 
-			Menu.SetChecked(MenuPathName, IsEnabled);
-			EditorPrefs.SetBool(MenuPathName, IsEnabled);
+		[MenuItem(MenuName, true, 1)]
+		private static bool ToggleValidate()
+		{
+			Menu.SetChecked(MenuName, IsEnabled);
+			return true;
+		}
+
+		private static void UpdateGameManager(bool isQuickLoad)
+		{
+			var gameManager = AssetDatabase.LoadAssetAtPath<GameManager>
+					("Assets/Prefabs/SceneConstruction/NestedManagers/GameManager.prefab");
+			if (gameManager == null)
+			{
+				Logger.LogWarning($"{nameof(GameManager)} not found! Cannot set {nameof(GameManager.QuickLoad)} property.");
+				return;
+			}
+
+			if (gameManager.QuickLoad != isQuickLoad)
+			{
+				gameManager.QuickLoad = isQuickLoad;
+				EditorUtility.SetDirty(gameManager);
+				AssetDatabase.SaveAssets();
+			}
+		}
+	}
+
+	/// <summary>
+	/// If checked, hides prefab-related fields from scene mode, and mapping-related fields from prefab mode.
+	/// </summary>
+	public static class HideIrrelevantFields
+	{
+		private const string MenuName = "Tools/Inspector/Hide Irrelevant Fields";
+		private const string SettingName = "HideIrrelevantFields";
+
+		public static bool IsEnabled
+		{
+			get => EditorPrefs.GetBool(SettingName, true);
+			set => EditorPrefs.SetBool(SettingName, value);
+		}
+
+		[MenuItem(MenuName)]
+		private static void Toggle()
+		{
+			IsEnabled = !IsEnabled;
+		}
+
+		[MenuItem(MenuName, true)]
+		private static bool ToggleValidate()
+		{
+			Menu.SetChecked(MenuName, IsEnabled);
+			return true;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Core/Editor/Tools/Mapping/DeviceLinker.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/Tools/Mapping/DeviceLinker.cs
@@ -22,7 +22,7 @@ namespace Core.Editor.Tools.Mapping
 
 		private WindowTab Tab => tabs[activeWindowTab];
 
-		[MenuItem("Tools/Mapping/Device Linker", priority = 120)]
+		[MenuItem("Tools/Mapping/Device Linker", priority = 1)]
 		public static void ShowWindow()
 		{
 			GetWindow<DeviceLinkerWindow>().Show();

--- a/UnityProject/Assets/Scripts/Core/Editor/Tools/Mapping/ObjectNameValidator.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/Tools/Mapping/ObjectNameValidator.cs
@@ -87,7 +87,7 @@ namespace Core.Editor.Tools.Mapping
 			}
 		}
 
-		[MenuItem("Tools/Mapping/Name Validator", priority = 120)]
+		[MenuItem("Tools/Mapping/Name Validator", priority = 2)]
 		public static void ShowWindow()
 		{
 			GetWindow<ObjectNameValidator>().Show();

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -2,12 +2,10 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Text;
 using Systems;
 using UnityEngine;
-using UnityEngine.Rendering;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using DatabaseAPI;
@@ -15,7 +13,6 @@ using DiscordWebhook;
 using Mirror;
 using GameConfig;
 using Initialisation;
-using AddressableReferences;
 using Audio.Containers;
 using Managers;
 using Messages.Server;
@@ -23,7 +20,6 @@ using Tilemaps.Behaviours.Layers;
 
 public partial class GameManager : MonoBehaviour, IInitialise
 {
-
 	public static GameManager Instance;
 	public bool counting;
 	/// <summary>
@@ -129,9 +125,13 @@ public partial class GameManager : MonoBehaviour, IInitialise
 	[SerializeField]
 	private AudioClipsArray endOfRoundSounds = null;
 
+	[NonSerialized]
 	public int ServerCurrentFPS;
+	[NonSerialized]
 	public int ServerAverageFPS;
+	[NonSerialized]
 	public int errorCounter;
+	[NonSerialized]
 	public int uniqueErrorCounter;
 
 	void IInitialise.Initialise()


### PR DESCRIPTION
- Add checkmark shortcut to GameManager prefab's QuickLoad: `Tools/Quick Load`.
- Fix HideIrrelevantFields not correctly setting checkbox state after reopening editor.

> Splits changes from #7745.