### PR TITLE
Fix BodyPartTraumaDamage NRE, refactor it a little

### DIFF
--- a/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPart.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPart.cs
@@ -322,12 +322,10 @@ namespace HealthV2
 				organ.BodyPartRemoveHealthMaster();
 			}
 
-
 			RemoveSprites(playerSprites, HealthMaster);
 			HealthMaster.rootBodyPartController.UpdateClients();
 			HealthMaster.BodyPartList.Remove(this);
 			HealthMaster = null;
-
 		}
 
 		/// <summary>
@@ -459,8 +457,6 @@ namespace HealthV2
 			{
 				Organ.SetUpSystems();
 			}
-
-
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartDamage.cs
@@ -240,7 +240,7 @@ namespace HealthV2
 						TraumaticDamageTypes selectedType = typeToSelectFrom[random.Next(1, typeToSelectFrom.Length)];
 						ApplyTraumaDamage(selectedType);
 					}
-					CheckBodyPartIntigrity();
+					CheckBodyPartIntegrity();
 				}
 			}
 

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs
@@ -224,10 +224,9 @@ namespace HealthV2
 			{
 				//Add 1 bleedstack every 10 seconds until the wound is closed
 				yield return WaitFor.Seconds(10f);
-				if (IsBleeding)
-				{
-					HealthMaster.OrNull()?.ChangeBleedStacks(1f);
-				}
+				if (IsBleeding == false) continue;
+
+				HealthMaster.OrNull()?.ChangeBleedStacks(1f);
 			}
 		}
 


### PR DESCRIPTION
Fixes:

NullReferenceException: Object reference not set to an instance of an object
HealthV2.BodyPart+<Bleedout>d__212.MoveNext () (at /root/UnityProject/Assets/Scripts/HealthV2/Living/Damage/BodyPartTraumaDamage.cs:225)
UnityEngine.SetupCoroutine.InvokeMoveNext (System.Collections.IEnumerator enumerator, System.IntPtr returnValueAddress) (at /home/bokken/buildslave/unity/build/Runtime/Export/Scripting/Coroutines.cs:17)

Is null due to coroutine persisting after removal from body