### PR TITLE
added coordinates to objects that fail PowerLightsRelatedTests

### DIFF
--- a/UnityProject/Assets/Tests/PowerLightsRelatedTests.cs
+++ b/UnityProject/Assets/Tests/PowerLightsRelatedTests.cs
@@ -302,10 +302,11 @@ namespace Tests
 			    var device = objectDevice;
 			    if (device.listOfLights.Count == 0)
 			    {
+					var objectCoords = $"({device.transform.position.x}, {device.transform.position.y})";
 				    count++;
 				    var obStr = objectDevice.name;
 				    devicesWithoutAPC.Add(obStr);
-				    Logger.Log(obStr, Category.Tests);
+				    Logger.Log(obStr, Category.Tests, objectCoords);
 				    report.AppendLine(obStr);
 			    }
 		    }
@@ -323,9 +324,9 @@ namespace Tests
 	    public void CheckAllScenes_ForAPCs_ConnectedDevicesInTheList()
 	    {
 		    var buildScenes = EditorBuildSettings.scenes.Where(s => s.enabled);
-		    var listAPCsWrongDevices = new List<(string, string, string, string)>();
-		    var listAPCsWithNulls = new List<(string, string, string)>();
-		    var listAPCWithEmptyList = new List<(string, string, string)>();
+		    var listAPCsWrongDevices = new List<(string, string, string)>();
+		    var listAPCsWithNulls = new List<(string, string)>();
+		    var listAPCWithEmptyList = new List<(string, string)>();
 
 		    int countAPCsWithEmptyLists = 0;
 		    int countAPCsWithNullDevices = 0;
@@ -343,8 +344,7 @@ namespace Tests
 				    countAll++;
 				    if (device.ConnectedDevices.Count == 0)
 				    {
-						var objectCoords = $"({device.transform.position.x}, {device.transform.position.y})";
-					    listAPCWithEmptyList.Add((currentSceneName,device.name, objectCoords));
+					    listAPCWithEmptyList.Add((currentSceneName,device.name));
 					    countAPCsWithEmptyLists++;
 					    continue;
 				    }
@@ -352,15 +352,13 @@ namespace Tests
 				    {
 					    if (connectedDevice == null)
 					    {
-							var objectCoords = $"({connectedDevice.transform.position.x}, {connectedDevice.transform.position.y})";
-						    listAPCsWithNulls.Add((currentSceneName,device.name, objectCoords));
+						    listAPCsWithNulls.Add((currentSceneName,device.name));
 						    countAPCsWithNullDevices++;
 					    }
 					    else
 					    if (connectedDevice.RelatedAPC != device)
 					    {
-							var objectCoords = $"({device.transform.position.x}, {device.transform.position.y})";
-						    listAPCsWrongDevices.Add((currentSceneName,device.name,connectedDevice.name, objectCoords));
+						    listAPCsWrongDevices.Add((currentSceneName,device.name,connectedDevice.name));
 						    countAPCsWithBadlyAssignedDevices++;
 					    }
 				    }
@@ -371,17 +369,17 @@ namespace Tests
 		    var report = new StringBuilder();
 		    foreach (var s in listAPCWithEmptyList)
 		    {
-			    var missingComponentMsg = $"{s.Item1}: \"{s.Item2}\" {s.Item3} has an empty list of devices.";
+			    var missingComponentMsg = $"{s.Item1}: \"{s.Item2}\" has an empty list of devices.";
 			    report.AppendLine(missingComponentMsg);
 		    }
 		    foreach (var s in listAPCsWithNulls)
 		    {
-			    var missingComponentMsg = $"{s.Item1}: \"{s.Item2}\" {s.Item3} has a null value in the list.";
+			    var missingComponentMsg = $"{s.Item1}: \"{s.Item2}\" has a null value in the list.";
 			    report.AppendLine(missingComponentMsg);
 		    }
 		    foreach (var s in listAPCsWrongDevices)
 		    {
-			    var missingComponentMsg = $"{s.Item1}: \"{s.Item3}\" {s.Item4} is not assigned to \"{s.Item2}\"";
+			    var missingComponentMsg = $"{s.Item1}: \"{s.Item3}\" is not assigned to \"{s.Item2}\"";
 			    report.AppendLine(missingComponentMsg);
 		    }
 

--- a/UnityProject/Assets/Tests/PowerLightsRelatedTests.cs
+++ b/UnityProject/Assets/Tests/PowerLightsRelatedTests.cs
@@ -323,9 +323,9 @@ namespace Tests
 	    public void CheckAllScenes_ForAPCs_ConnectedDevicesInTheList()
 	    {
 		    var buildScenes = EditorBuildSettings.scenes.Where(s => s.enabled);
-		    var listAPCsWrongDevices = new List<(string, string, string)>();
-		    var listAPCsWithNulls = new List<(string, string)>();
-		    var listAPCWithEmptyList = new List<(string, string)>();
+		    var listAPCsWrongDevices = new List<(string, string, string, string)>();
+		    var listAPCsWithNulls = new List<(string, string, string)>();
+		    var listAPCWithEmptyList = new List<(string, string, string)>();
 
 		    int countAPCsWithEmptyLists = 0;
 		    int countAPCsWithNullDevices = 0;
@@ -343,7 +343,8 @@ namespace Tests
 				    countAll++;
 				    if (device.ConnectedDevices.Count == 0)
 				    {
-					    listAPCWithEmptyList.Add((currentSceneName,device.name));
+						var objectCoords = $"({device.transform.position.x}, {device.transform.position.y})";
+					    listAPCWithEmptyList.Add((currentSceneName,device.name, objectCoords));
 					    countAPCsWithEmptyLists++;
 					    continue;
 				    }
@@ -351,13 +352,15 @@ namespace Tests
 				    {
 					    if (connectedDevice == null)
 					    {
-						    listAPCsWithNulls.Add((currentSceneName,device.name));
+							var objectCoords = $"({connectedDevice.transform.position.x}, {connectedDevice.transform.position.y})";
+						    listAPCsWithNulls.Add((currentSceneName,device.name, objectCoords));
 						    countAPCsWithNullDevices++;
 					    }
 					    else
 					    if (connectedDevice.RelatedAPC != device)
 					    {
-						    listAPCsWrongDevices.Add((currentSceneName,device.name,connectedDevice.name));
+							var objectCoords = $"({device.transform.position.x}, {device.transform.position.y})";
+						    listAPCsWrongDevices.Add((currentSceneName,device.name,connectedDevice.name, objectCoords));
 						    countAPCsWithBadlyAssignedDevices++;
 					    }
 				    }
@@ -368,17 +371,17 @@ namespace Tests
 		    var report = new StringBuilder();
 		    foreach (var s in listAPCWithEmptyList)
 		    {
-			    var missingComponentMsg = $"{s.Item1}: \"{s.Item2}\" has an empty list of devices.";
+			    var missingComponentMsg = $"{s.Item1}: \"{s.Item2}\" {s.Item3} has an empty list of devices.";
 			    report.AppendLine(missingComponentMsg);
 		    }
 		    foreach (var s in listAPCsWithNulls)
 		    {
-			    var missingComponentMsg = $"{s.Item1}: \"{s.Item2}\" has a null value in the list.";
+			    var missingComponentMsg = $"{s.Item1}: \"{s.Item2}\" {s.Item3} has a null value in the list.";
 			    report.AppendLine(missingComponentMsg);
 		    }
 		    foreach (var s in listAPCsWrongDevices)
 		    {
-			    var missingComponentMsg = $"{s.Item1}: \"{s.Item3}\" is not assigned to \"{s.Item2}\"";
+			    var missingComponentMsg = $"{s.Item1}: \"{s.Item3}\" {s.Item4} is not assigned to \"{s.Item2}\"";
 			    report.AppendLine(missingComponentMsg);
 		    }
 
@@ -428,8 +431,9 @@ namespace Tests
 			    {
 				    if (connectedDevice == null)
 				    {
+						var objectCoords = $"({device.transform.position.x}, {device.transform.position.y})";
 					    devicesAPC.Add(device.name);
-					    Logger.Log($"ConnectedDevice is null in \"{device.name}\"", Category.Tests);
+					    Logger.Log($"ConnectedDevice is null in \"{device.name}\"" , objectCoords, Category.Tests);
 					    report.AppendLine(device.name);
 					    count++;
 				    }

--- a/UnityProject/Assets/Tests/PowerLightsRelatedTests.cs
+++ b/UnityProject/Assets/Tests/PowerLightsRelatedTests.cs
@@ -306,7 +306,8 @@ namespace Tests
 				    count++;
 				    var obStr = objectDevice.name;
 				    devicesWithoutAPC.Add(obStr);
-				    Logger.Log(obStr, Category.Tests, objectCoords);
+				    Logger.Log(obStr, Category.Tests);
+					Logger.Log(objectCoords);
 				    report.AppendLine(obStr);
 			    }
 		    }
@@ -431,7 +432,8 @@ namespace Tests
 				    {
 						var objectCoords = $"({device.transform.position.x}, {device.transform.position.y})";
 					    devicesAPC.Add(device.name);
-					    Logger.Log($"ConnectedDevice is null in \"{device.name}\"" , objectCoords, Category.Tests);
+					    Logger.Log($"ConnectedDevice is null in \"{device.name}\"" , Category.Tests);
+						Logger.Log(objectCoords);
 					    report.AppendLine(device.name);
 					    count++;
 				    }

--- a/UnityProject/Assets/Tests/PowerLightsRelatedTests.cs
+++ b/UnityProject/Assets/Tests/PowerLightsRelatedTests.cs
@@ -302,11 +302,10 @@ namespace Tests
 			    var device = objectDevice;
 			    if (device.listOfLights.Count == 0)
 			    {
-					var objectCoords = $"({device.transform.position.x}, {device.transform.position.y})";
 				    count++;
 				    var obStr = objectDevice.name;
 				    devicesWithoutAPC.Add(obStr);
-				    Logger.Log(obStr, Category.Tests, objectCoords);
+				    Logger.Log(obStr, Category.Tests);
 				    report.AppendLine(obStr);
 			    }
 		    }
@@ -429,9 +428,8 @@ namespace Tests
 			    {
 				    if (connectedDevice == null)
 				    {
-						var objectCoords = $"({device.transform.position.x}, {device.transform.position.y})";
 					    devicesAPC.Add(device.name);
-					    Logger.Log($"ConnectedDevice is null in \"{device.name}\"" , objectCoords, Category.Tests);
+					    Logger.Log($"ConnectedDevice is null in \"{device.name}\"" , Category.Tests);
 					    report.AppendLine(device.name);
 					    count++;
 				    }

--- a/UnityProject/Assets/Tests/PowerLightsRelatedTests.cs
+++ b/UnityProject/Assets/Tests/PowerLightsRelatedTests.cs
@@ -56,7 +56,7 @@ namespace Tests
 	    public void CheckAllScenes_ForAPCPoweredDevices_WhichMissRelatedAPCs()
 	    {
 		    var buildScenes = EditorBuildSettings.scenes.Where(s => s.enabled);
-		    var missingAPCinDeviceReport = new List<(string, string)>();
+		    var missingAPCinDeviceReport = new List<(string, string, string)>();
 		    int countMissingAPC = 0;
 		    int countSelfPowered = 0;
 		    int countAll = 0;
@@ -78,8 +78,9 @@ namespace Tests
 				    }
 				    if (device.RelatedAPC == null && device.IsSelfPowered == false)
 				    {
+						var objectCoords = $"({objectDevice.transform.position.x}, {objectDevice.transform.position.y})";
 					    countMissingAPC++;
-					    missingAPCinDeviceReport.Add((currentSceneName,objectDevice.name));
+					    missingAPCinDeviceReport.Add((currentSceneName,objectDevice.name, objectCoords));
 				    }
 			    }
 		    }
@@ -88,7 +89,7 @@ namespace Tests
 		    var report = new StringBuilder();
 		    foreach (var s in missingAPCinDeviceReport)
 		    {
-			    var missingComponentMsg = $"{s.Item1}: \"{s.Item2}\" miss APC reference.";
+			    var missingComponentMsg = $"{s.Item1}: \"{s.Item2}\" {s.Item3} miss APC reference.";
 			    report.AppendLine(missingComponentMsg);
 		    }
 
@@ -146,7 +147,7 @@ namespace Tests
 	    public void CheckAllScenes_ForLightSources_WhichMissRelatedSwitches()
 	    {
 		    var buildScenes = EditorBuildSettings.scenes.Where(s => s.enabled);
-		    var missingAPCinDeviceReport = new List<(string, string)>();
+		    var missingAPCinDeviceReport = new List<(string, string, string)>();
 		    int countMissingSwitch = 0;
 		    int countWithoutSwitches = 0;
 		    int countAll = 0;
@@ -168,8 +169,9 @@ namespace Tests
 				    }
 				    if (device.relatedLightSwitch == null)
 				    {
+						var objectCoords = $"({objectDevice.transform.position.x}, {objectDevice.transform.position.y})";
 					    countMissingSwitch++;
-					    missingAPCinDeviceReport.Add((currentSceneName,objectDevice.name));
+					    missingAPCinDeviceReport.Add((currentSceneName,objectDevice.name, objectCoords));
 				    }
 			    }
 		    }
@@ -178,7 +180,7 @@ namespace Tests
 		    var report = new StringBuilder();
 		    foreach (var s in missingAPCinDeviceReport)
 		    {
-			    var missingComponentMsg = $"{s.Item1}: \"{s.Item2}\" miss switch reference.";
+			    var missingComponentMsg = $"{s.Item1}: \"{s.Item2}\" {s.Item3} miss switch reference.";
 			    report.AppendLine(missingComponentMsg);
 		    }
 
@@ -236,7 +238,7 @@ namespace Tests
 	    public void CheckAllScenes_ForLightSwitchesLists_WhichMissLightSources()
 	    {
 		    var buildScenes = EditorBuildSettings.scenes.Where(s => s.enabled);
-		    var missingAPCinDeviceReport = new List<(string, string)>();
+		    var missingAPCinDeviceReport = new List<(string, string, string)>();
 		    int countSwitchesWithoutLights = 0;
 		    int countAll = 0;
 
@@ -252,8 +254,9 @@ namespace Tests
 				    var device = objectDevice;
 				    if (device.listOfLights.Count == 0)
 				    {
+						var objectCoords = $"({objectDevice.transform.position.x}, {objectDevice.transform.position.y})";
 					    countSwitchesWithoutLights++;
-					    missingAPCinDeviceReport.Add((currentSceneName,objectDevice.name));
+					    missingAPCinDeviceReport.Add((currentSceneName,objectDevice.name, objectCoords));
 				    }
 			    }
 		    }
@@ -262,7 +265,7 @@ namespace Tests
 		    var report = new StringBuilder();
 		    foreach (var s in missingAPCinDeviceReport)
 		    {
-			    var missingComponentMsg = $"{s.Item1}: \"{s.Item2}\" miss switch reference.";
+			    var missingComponentMsg = $"{s.Item1}: \"{s.Item2}\" {s.Item3} miss switch reference.";
 			    report.AppendLine(missingComponentMsg);
 		    }
 
@@ -320,7 +323,7 @@ namespace Tests
 	    public void CheckAllScenes_ForAPCs_ConnectedDevicesInTheList()
 	    {
 		    var buildScenes = EditorBuildSettings.scenes.Where(s => s.enabled);
-		    var listAPCsWrongDevices = new List<(string, string,string)>();
+		    var listAPCsWrongDevices = new List<(string, string, string)>();
 		    var listAPCsWithNulls = new List<(string, string)>();
 		    var listAPCWithEmptyList = new List<(string, string)>();
 
@@ -354,7 +357,7 @@ namespace Tests
 					    else
 					    if (connectedDevice.RelatedAPC != device)
 					    {
-						    listAPCsWrongDevices.Add((currentSceneName,device.name, connectedDevice.name));
+						    listAPCsWrongDevices.Add((currentSceneName,device.name,connectedDevice.name));
 						    countAPCsWithBadlyAssignedDevices++;
 					    }
 				    }


### PR DESCRIPTION
Adds the (x , y) local transform values of lights and switches to the console.
fixes #7092
hoorah?