### PR TITLE
Expandable matrixes

### DIFF
--- a/UnityProject/Assets/Scripts/Items/PlaceableTile.cs
+++ b/UnityProject/Assets/Scripts/Items/PlaceableTile.cs
@@ -63,7 +63,7 @@ public class PlaceableTile : MonoBehaviour, ICheckedInteractable<PositionalHandA
 	public void ServerPerformInteraction(PositionalHandApply interaction)
 	{
 		//which matrix are we clicking on
-		var interactableTiles = InteractableTiles.GetAt(interaction.WorldPositionTarget, true);
+		var interactableTiles = InteractableTiles.TryGetNonSpaceMatrix(interaction.WorldPositionTarget.RoundToInt(), true);
 		Vector3Int cellPos = interactableTiles.WorldToCell(interaction.WorldPositionTarget);
 		var tileAtPosition = interactableTiles.LayerTileAt(interaction.WorldPositionTarget,layerTypeSelection);
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
@@ -86,9 +86,33 @@ public class InteractableTiles : MonoBehaviour, IClientInteractable<PositionalHa
 	public static InteractableTiles GetAt(Vector2 worldPos, bool isServer)
 	{
 		var matrixInfo = MatrixManager.AtPoint(worldPos.RoundToInt(), isServer);
-		var matrix = matrixInfo.Matrix;
-		var tileChangeManager = matrix.GetComponentInParent<TileChangeManager>();
-		return tileChangeManager.GetComponent<InteractableTiles>();
+		return matrixInfo.TileChangeManager.InteractableTiles;
+	}
+
+	/// <summary>
+	/// Gets the interactable tiles for the matrix at the indicated world position. Unless there's only space!
+	/// in that case tries to fetch an adjacent matrix, in the case of none, it returns the space matrix
+	/// </summary>
+	public static InteractableTiles TryGetNonSpaceMatrix(Vector3Int worldPos, bool isServer)
+	{
+		var matrixInfo = MatrixManager.AtPoint(worldPos, isServer);
+		if (matrixInfo.Matrix.IsSpaceMatrix == false)
+		{
+			return matrixInfo.TileChangeManager.InteractableTiles;
+		}
+
+		//This is just space! Lets try getting an adjacent matrix
+		foreach (var pos in worldPos.BoundsAround().allPositionsWithin)
+		{
+			matrixInfo = MatrixManager.AtPoint(pos, isServer);
+			if (matrixInfo.Matrix.IsSpaceMatrix == false)
+			{
+				return matrixInfo.TileChangeManager.InteractableTiles;
+			}
+		}
+
+		//we're in space and theres nothing but space all around us, we tried.
+		return MatrixManager.Instance.spaceMatrix.TileChangeManager.InteractableTiles;
 	}
 
 	/// <summary>


### PR DESCRIPTION
### Purpose
Building lattices on space will now try to fetch an adjacent matrix to build on it.
Fixes #7791
As a consequence, shuttles can now be expanded

CL: [New] shuttle matrixes can now be expanded.