### PR TITLE
Blocks mimes from force opening closed doors

### DIFF
--- a/UnityProject/Assets/Scripts/Systems/Spells/Spell.cs
+++ b/UnityProject/Assets/Scripts/Systems/Spells/Spell.cs
@@ -169,6 +169,7 @@ namespace Systems.Spells
 
 					if (matrixInfo.Matrix.Get<DoorMasterController>(localPos, true).Any(door => door.IsClosed))
 					{
+						//This stops tile based spells from being cast ontop of closed doors
 						Chat.AddExamineMsg(caster.GameObject, "You cannot cast this spell while a door is in the way.");
 						return false;
 					}

--- a/UnityProject/Assets/Scripts/Systems/Spells/Spell.cs
+++ b/UnityProject/Assets/Scripts/Systems/Spells/Spell.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+using Doors;
 using UnityEngine;
 using Mirror;
 using ScriptableObjects.Systems.Spells;
@@ -165,6 +167,10 @@ namespace Systems.Spells
 					var matrixInfo = MatrixManager.AtPoint(castPosition, true);
 					var localPos = MatrixManager.WorldToLocalInt(castPosition, matrixInfo);
 
+					if (matrixInfo.Matrix.Get<DoorMasterController>(localPos, true).Any())
+					{
+						return false;
+					}
 					if (matrixInfo.MetaTileMap.HasTile(localPos, tileToSummon.LayerType)
 					&& !SpellData.ReplaceExisting)
 					{

--- a/UnityProject/Assets/Scripts/Systems/Spells/Spell.cs
+++ b/UnityProject/Assets/Scripts/Systems/Spells/Spell.cs
@@ -167,8 +167,9 @@ namespace Systems.Spells
 					var matrixInfo = MatrixManager.AtPoint(castPosition, true);
 					var localPos = MatrixManager.WorldToLocalInt(castPosition, matrixInfo);
 
-					if (matrixInfo.Matrix.Get<DoorMasterController>(localPos, true).Any())
+					if (matrixInfo.Matrix.Get<DoorMasterController>(localPos, true).Any(door => door.IsClosed))
 					{
+						Chat.AddExamineMsg(caster.GameObject, "You cannot cast this spell while a door is in the way.");
 						return false;
 					}
 					if (matrixInfo.MetaTileMap.HasTile(localPos, tileToSummon.LayerType)


### PR DESCRIPTION
fixes #7286

CL: [Fix] fixed an exploit that allowed mimes to force open closed doors with the invisible wall spell.