### PR TITLE
Add RCON stuff to docker compose

### DIFF
--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -6,7 +6,9 @@ services:
     ports:
       - 7777:7777/udp
       - 7777:7777/tcp
+      - 7778:7778/tcp
     environment:
+      RCON_PASSWORD: $RCON_PASSWORD
       HUB_USERNAME: $HUB_USERNAME
       HUB_PASSWORD: $HUB_PASSWORD
       SERVER_NAME: Unitystation - EU02 Staging


### PR DESCRIPTION
<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->

### Purpose
Exposes the RCON port 7778 and adds the RCON_PASSWORD environment variable for configuration

### Changelog:
Does not change game code.
