### PR TITLE
Fix Syndie Shuttle so it flies again

### DIFF
--- a/UnityProject/Assets/Scenes/AdditionalScenes/Fallstation Syndicate.unity
+++ b/UnityProject/Assets/Scenes/AdditionalScenes/Fallstation Syndicate.unity
@@ -359,7 +359,7 @@ MonoBehaviour:
   SafetyProtocolsOn: 1
   initialPosition: {x: 0, y: 0, z: 0}
   pivot: {x: 0, y: 0, z: 0}
-  matrix: {fileID: 0}
+  matrix: {fileID: 636193986}
   IsForceStopped: 0
   RequiresFuel: 0
   rcsModeActive: 0
@@ -27112,11 +27112,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4335463542504290, guid: 4ce92eb606dc8b34a8b7718dd975fcaa, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 10
+      value: 9.96
       objectReference: {fileID: 0}
     - target: {fileID: 4335463542504290, guid: 4ce92eb606dc8b34a8b7718dd975fcaa, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -24
+      value: -23.31
       objectReference: {fileID: 0}
     - target: {fileID: 4335463542504290, guid: 4ce92eb606dc8b34a8b7718dd975fcaa, type: 3}
       propertyPath: m_LocalPosition.z


### PR DESCRIPTION
### Purpose
Sets the Matrix Move to the Syndie Shuttle Matrix on the Fallstation Syndicate scene so that you can use the engines and not just rely on RCS.

### Changelog:
CL: [Fix] Fixes Syndie Matrix on Fallstation Syndicate so it can be piloted by the engines again.
