### PR TITLE
Cached world bounds

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Others/NukeDiskScript.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/NukeDiskScript.cs
@@ -41,7 +41,7 @@ namespace Items.Command
 
 		public void OnSpawnServer(SpawnInfo info)
 		{
-			bound = MatrixManager.MainStationMatrix.Bounds;
+			bound = MatrixManager.MainStationMatrix.LocalBounds;
 			escapeShuttle = FindObjectOfType<EscapeShuttle>();
 			boundsConfigured = true;
 		}
@@ -81,7 +81,7 @@ namespace Items.Command
 			if (escapeShuttle != null && escapeShuttle.Status != EscapeShuttleStatus.DockedCentcom)
 			{
 				var matrixInfo = escapeShuttle.MatrixInfo;
-				if (matrixInfo == null || matrixInfo.Bounds.Contains(registerTile.WorldPositionServer))
+				if (matrixInfo == null || BoundsExtensions.Contains(matrixInfo.LocalBounds, registerTile.WorldPositionServer))
 				{
 					return false;
 				}

--- a/UnityProject/Assets/Scripts/Managers/GameManager.Escape.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.Escape.cs
@@ -74,11 +74,11 @@ public partial class GameManager
 
 		if (orientation == Orientation.Up || orientation == Orientation.Down)
 		{
-			width = PrimaryEscapeShuttle.MatrixInfo.Bounds.size.x;
+			width = PrimaryEscapeShuttle.MatrixInfo.LocalBounds.size.x;
 		}
 		else
 		{
-			width = PrimaryEscapeShuttle.MatrixInfo.Bounds.size.y;
+			width = PrimaryEscapeShuttle.MatrixInfo.LocalBounds.size.y;
 		}
 
 		Vector3 newPos;

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/BoundsExtensions.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/BoundsExtensions.cs
@@ -5,44 +5,44 @@ using UnityEngine;
 /// </summary>
 public static class BoundsExtensions
 {
-	public static bool BoundsIntersect( this MatrixInfo matrix, MatrixInfo otherMatrix )
+	public static bool BoundsIntersect(this MatrixInfo matrix, MatrixInfo otherMatrix)
 	{
-		if ( matrix == null || otherMatrix == null || matrix == otherMatrix )
+		if (matrix == null || otherMatrix == null || matrix == otherMatrix)
 		{
 			return false;
 		}
 
-		var rect = matrix.WorldBounds.Extend( 1 ).ToRect();
+		var rect = matrix.WorldBounds.Extend(1).ToRect();
 
-		return rect.Overlaps( otherMatrix.WorldBounds.Extend( 1 ).ToRect() );
+		return rect.Overlaps(otherMatrix.WorldBounds.Extend(1).ToRect());
 	}
 
-	public static bool BoundsIntersect( this MatrixInfo matrix, MatrixInfo otherMatrix, out Rect intersection )
+	public static bool BoundsIntersect(this MatrixInfo matrix, MatrixInfo otherMatrix, out Rect intersection)
 	{
 		intersection = Rect.zero;
-		if ( matrix == null || otherMatrix == null || matrix == otherMatrix )
+		if (matrix == null || otherMatrix == null || matrix == otherMatrix)
 		{
 			return false;
 		}
 
-		var rect = matrix.WorldBounds.Extend( 1 ).ToRect();
+		var rect = matrix.WorldBounds.Extend(1).ToRect();
 
-		return rect.Intersects( otherMatrix.WorldBounds.Extend( 1 ).ToRect(), out intersection );
+		return rect.Intersects(otherMatrix.WorldBounds.Extend(1).ToRect(), out intersection);
 	}
 
-	public static Rect ToRect( this BoundsInt bounds )
+	public static Rect ToRect(this Bounds bounds)
 	{
-		return new Rect( (Vector3)bounds.position, (Vector3)bounds.size );
+		return new Rect(bounds.min, bounds.size);
 	}
-	public static RectInt ToRectInt( this BoundsInt bounds )
+	public static RectInt ToRectInt(this Bounds bounds)
 	{
-		return new RectInt( bounds.position.To2Int(), bounds.size.To2Int() );
+		return new RectInt(bounds.min.To2Int(), bounds.size.To2Int());
 	}
 
 	private static readonly Vector3Int ZOneVector3Int = new Vector3Int(0,0,1);
 	private static readonly Vector3Int Vector3IntOneCut = new Vector3Int(1,1,0);
 
-	public static BoundsInt ToBoundsInt( this Rect rect )
+	public static BoundsInt ToBoundsInt(this Rect rect)
 	{ //Bounds are 3d and require Z of at least 1 to work, so it's Z 0 -> 1 here
 		return new BoundsInt(rect.min.RoundToInt(), rect.size.RoundToInt() + ZOneVector3Int);
 	}
@@ -50,11 +50,11 @@ public static class BoundsExtensions
 	/// <summary>
 	/// Extend/shrink bounds on x,y sides by integer amount
 	/// </summary>
-	public static BoundsInt Extend( this BoundsInt bounds, int amount )
+	public static Bounds Extend(this Bounds bounds, int amount)
 	{
-		var min = bounds.min - ( Vector3IntOneCut * amount );
-		var max = bounds.max + ( Vector3IntOneCut * amount );
-		return new BoundsInt(min, max - min);
+		var min = bounds.min - (Vector3IntOneCut * amount);
+		var max = bounds.max + (Vector3IntOneCut * amount);
+		return new Bounds(min, max - min);
 	}
 
 	public static bool Intersects(this Rect r1, Rect r2, out Rect area)
@@ -78,4 +78,25 @@ public static class BoundsExtensions
 
 		return false;
 	}
+
+	public static bool Contains(BoundsInt bounds, Vector3Int position)
+	{
+		if (position.x >= bounds.xMin && position.y >= bounds.yMin &&
+		    position.x <= bounds.xMax && position.y <= bounds.yMax)
+		{
+			return true;
+		}
+		return false;
+	}
+
+	public static bool Contains(Bounds bounds, Vector3Int position)
+	{
+		if (position.x >= bounds.min.x && position.y >= bounds.min.y &&
+		    position.x <= bounds.max.x && position.y <= bounds.max.y)
+		{
+			return true;
+		}
+		return false;
+	}
+
 }

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixInfo.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixInfo.cs
@@ -28,10 +28,10 @@ public class MatrixInfo : IEquatable<MatrixInfo>
 	private Vector3Int initialOffset;
 	private uint netId;
 
-	public BoundsInt Bounds => MetaTileMap.GetBounds();
+	public BoundsInt LocalBounds => MetaTileMap.GetLocalBounds();
 
 	//Warning slow
-	public BoundsInt WorldBounds => MetaTileMap.GetWorldBounds();
+	public Bounds WorldBounds => MetaTileMap.GetWorldBounds();
 
 	public Transform ObjectParent => MetaTileMap.ObjectLayer.transform;
 
@@ -42,7 +42,7 @@ public class MatrixInfo : IEquatable<MatrixInfo>
 	public string Name => Matrix.gameObject.name;
 
 	//todo: placeholder, should depend on solid tiles count instead (and use caching)
-	public float Mass => Bounds.size.sqrMagnitude/1000f;
+	public float Mass => LocalBounds.size.sqrMagnitude/1000f;
 
 	public bool IsMovable => MatrixMove != null;
 

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
@@ -11,7 +11,6 @@ using Systems.Atmospherics;
 using Managers;
 using Messages.Client.NewPlayer;
 using Messages.Client.SpriteMessages;
-using Objects.Construction;
 using Player.Movement;
 using Mirror;
 
@@ -298,17 +297,15 @@ public partial class MatrixManager : SingletonManager<MatrixManager>
 
 	private static bool IsInMatrix(Vector3Int worldPos, bool isServer, MatrixInfo matrixInfo)
 	{
-		var LocalPos = WorldToLocalInt(worldPos, matrixInfo);
-
-		if (matrixInfo.Bounds.Contains(LocalPos) == false)
+		if (BoundsExtensions.Contains(matrixInfo.WorldBounds, worldPos) == false)
 			return false;
+
 		if (matrixInfo.Matrix == Instance.spaceMatrix)
 			return false;
 
-		if (matrixInfo.Matrix.IsEmptyAt(LocalPos, isServer) == false)
-		{
+		var localPos = WorldToLocalInt(worldPos, matrixInfo);
+		if (matrixInfo.Matrix.IsEmptyAt(localPos, isServer) == false)
 			return true;
-		}
 
 		return false;
 	}
@@ -353,7 +350,7 @@ public partial class MatrixManager : SingletonManager<MatrixManager>
 				var Localorigin = Worldorigin.ToLocal(matrixInfo.Matrix);
 				var LocalTo = WorldTo.Value.ToLocal(matrixInfo.Matrix);
 
-				if (LineIntersectsRect(Localorigin, LocalTo, matrixInfo.Bounds))
+				if (LineIntersectsRect(Localorigin, LocalTo, matrixInfo.LocalBounds))
 				{
 					Checkhit = matrixInfo.MetaTileMap.Raycast(Localorigin, Vector2.zero,
 						distance,

--- a/UnityProject/Assets/Scripts/Shuttles/MatrixMove.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/MatrixMove.cs
@@ -102,7 +102,7 @@ public class MatrixMove : ManagedBehaviour
 	public bool rcsModeActive;
 
 	private bool ServerPositionsMatch => serverTargetState.Position == serverState.Position;
-	private bool IsRotatingServer => NeedsRotationClient; //todo: calculate rotation time on server instead
+	public bool IsRotatingServer => NeedsRotationClient; //todo: calculate rotation time on server instead
 	private bool IsAutopilotEngaged => Target != TransformState.HiddenPos;
 	private bool IsMovingClient => clientState.IsMoving && clientState.Speed > 0f;
 
@@ -826,6 +826,7 @@ public class MatrixMove : ManagedBehaviour
 		var oldState = clientState;
 
 		clientState = newState;
+		matrix.MetaTileMap.GlobalCachedBounds = null;
 		Logger.LogTraceFormat("{0} setting client / client target state from message {1}", Category.Shuttles, this, newState);
 
 
@@ -911,6 +912,7 @@ public class MatrixMove : ManagedBehaviour
 			//				When serverState reaches its planned destination,
 			//				embrace all other updates like changed speed and rotation
 			serverState = serverTargetState;
+			matrix.MetaTileMap.GlobalCachedBounds = null;
 			Logger.LogTraceFormat("{0} setting server state from target state {1}", Category.Shuttles, this, serverState);
 			NotifyPlayers();
 		}
@@ -985,7 +987,6 @@ public class MatrixMove : ManagedBehaviour
 			Logger.LogTraceFormat("{0} server target facing / flying {1}", Category.Shuttles, this, desiredOrientation);
 
 			MatrixMoveEvents.OnRotate.Invoke(new MatrixRotationInfo(this, serverState.FacingDirection.OffsetTo(desiredOrientation), NetworkSide.Server, RotationEvent.Start));
-
 			RequestNotify();
 			return true;
 		}

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobStarter.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobStarter.cs
@@ -254,7 +254,7 @@ namespace Blob
 
 			var playerScript = gameObject.GetComponent<PlayerScript>();
 
-			var bound = MatrixManager.MainStationMatrix.Bounds;
+			var bound = MatrixManager.MainStationMatrix.LocalBounds;
 
 			//To ensure that it has to be station matrix
 			var matrixInfo = GetComponent<RegisterTile>().Matrix.MatrixInfo;

--- a/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventAsteroids.cs
+++ b/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventAsteroids.cs
@@ -72,7 +72,7 @@ namespace InGameEvents
 
 			for (var i = 1; i <= asteroidAmount; i++)
 			{
-				Vector3 position = new Vector3(UnityEngine.Random.Range(stationMatrix.WorldBounds.xMin, stationMatrix.WorldBounds.xMax), UnityEngine.Random.Range(stationMatrix.WorldBounds.yMin, stationMatrix.WorldBounds.yMax), 0);
+				Vector3 position = new Vector3(UnityEngine.Random.Range(stationMatrix.WorldBounds.min.x, stationMatrix.WorldBounds.max.x), UnityEngine.Random.Range(stationMatrix.WorldBounds.min.y, stationMatrix.WorldBounds.max.y), 0);
 				impactCoords.Enqueue(position);
 			}
 

--- a/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventElectricalStorm.cs
+++ b/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventElectricalStorm.cs
@@ -24,7 +24,7 @@ namespace InGameEvents
 
 		public override void OnEventStartTimed()
 		{
-			var stationBounds = MatrixManager.MainStationMatrix.Bounds;
+			var stationBounds = MatrixManager.MainStationMatrix.LocalBounds;
 
 			float width = 0.35f * (stationBounds.xMax - stationBounds.xMin);
 			float height = 0.35f * (stationBounds.yMax - stationBounds.yMin);
@@ -36,7 +36,7 @@ namespace InGameEvents
 
 			foreach (var light in FindObjectsOfType<LightSource>())
 			{
-				if (region.Contains(light.gameObject.RegisterTile().WorldPositionServer))
+				if (BoundsExtensions.Contains(region, light.gameObject.RegisterTile().WorldPositionServer))
 				{
 					StartCoroutine(BreakLight(light));
 				}

--- a/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventImmovableRod.cs
+++ b/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventImmovableRod.cs
@@ -56,9 +56,9 @@ namespace InGameEvents
 		{
 			if (IsMatrixInvalid()) return;
 
-			var MaxCoord = new Vector2() { x = stationMatrix.WorldBounds.xMax , y = stationMatrix.WorldBounds.yMax };
+			var MaxCoord = new Vector2() { x = stationMatrix.WorldBounds.max.x , y = stationMatrix.WorldBounds.max.y };
 
-			var MinCoord = new Vector2() { x = stationMatrix.WorldBounds.xMin, y = stationMatrix.WorldBounds.yMin };
+			var MinCoord = new Vector2() { x = stationMatrix.WorldBounds.min.x, y = stationMatrix.WorldBounds.min.y };
 
 			var biggestDistancePosible = (int)Vector2.Distance(MaxCoord, MinCoord);
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
@@ -230,7 +230,7 @@ public class Matrix : MonoBehaviour
 	{
 		return MetaTileMap.IsAtmosPassableAt(position, isServer);
 	}
-	
+
 	public bool IsSpaceAt(Vector3Int position, bool isServer)
 	{
 		return MetaTileMap.IsSpaceAt(position, isServer);
@@ -541,7 +541,7 @@ public class Matrix : MonoBehaviour
 			metaTileMap = GetComponent<MetaTileMap>();
 		}
 
-		BoundsInt bounds = MetaTileMap.GetWorldBounds();
+		var bounds = MetaTileMap.GetWorldBounds();
 		DebugGizmoUtils.DrawText(gameObject.name, bounds.max, 11, 5);
 		DebugGizmoUtils.DrawRect(bounds);
 	}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
@@ -70,6 +70,9 @@ namespace TileManagement
 
 		public Matrix PresentMatrix => presentMatrix;
 
+		private BoundsInt? LocalCachedBounds;
+		private Bounds? GlobalCachedBounds;
+
 		public float Resistance(Vector3Int cellPos, bool includeObjects = true)
 		{
 			float resistance = 0;
@@ -236,11 +239,12 @@ namespace TileManagement
 					QueueTileChange.PresentlyOn.SetTile(QueueTileChange.TileCoordinates, QueueTileChange.Tile,
 						QueueTileChange.TransformMatrix, QueueTileChange.Colour);
 
-					if (CashedBoundsInt != null)
+					if (LocalCachedBounds != null)
 					{
-						if (CashedBoundsInt.Value.Contains(QueueTileChange.TileCoordinates) == false)
+						if (BoundsExtensions.Contains(LocalCachedBounds.Value, QueueTileChange.TileCoordinates) == false)
 						{
-							CashedBoundsInt = null;
+							LocalCachedBounds = null;
+							GlobalCachedBounds = null;
 						}
 					}
 				}
@@ -1581,33 +1585,6 @@ namespace TileManagement
 		public Vector3 CellToWorld(Vector3Int cellPos) => LayersValues[0].CellToWorld(cellPos);
 		public Vector3 WorldToLocal(Vector3 worldPos) => LayersValues[0].WorldToLocal(worldPos);
 
-
-		public BoundsInt GetWorldBounds()
-		{
-			var bounds = GetBounds();
-			//???
-			var min = CellToWorld(bounds.min);
-			var max = CellToWorld(bounds.max);
-			if (presentMatrix?.MatrixMove?.inProgressRotation != null)
-			{
-				Vector3Int TopRightMax = bounds.max;
-				Vector3Int BottomLeftMin = bounds.min;
-				Vector3Int BottomRight = new Vector3Int(TopRightMax.x, BottomLeftMin.y, 0);
-				Vector3Int TopLeft = new Vector3Int(BottomLeftMin.x, TopRightMax.y, 0);
-				var TopRightMaxI = CellToWorld(TopRightMax);
-				var BottomLeftMinI = CellToWorld(BottomLeftMin);
-				var BottomRightI = CellToWorld(BottomRight);
-				var TopLeftI = CellToWorld(TopLeft);
-				MaxMinCheck(ref min, ref max, TopRightMaxI);
-				MaxMinCheck(ref min, ref max, BottomLeftMinI);
-				MaxMinCheck(ref min, ref max, BottomRightI);
-				MaxMinCheck(ref min, ref max, TopLeftI);
-			}
-
-
-			return new BoundsInt(min.RoundToInt(), (max - min).RoundToInt());
-		}
-
 		public void MaxMinCheck(ref Vector3 min, ref Vector3 max, Vector3 ToCompare)
 		{
 			if (ToCompare.x > max.x)
@@ -1629,16 +1606,26 @@ namespace TileManagement
 			}
 		}
 
-
-		public BoundsInt? CashedBoundsInt;
-
-		public BoundsInt GetBounds()
+		public BoundsInt GetLocalBounds()
 		{
-			if (CashedBoundsInt != null)
+			if (LocalCachedBounds == null)
 			{
-				return CashedBoundsInt.Value;
+				CacheLocalBound();
 			}
+			return LocalCachedBounds.Value;
+		}
 
+		public Bounds GetWorldBounds()
+		{
+			if (GlobalCachedBounds == null)
+			{
+				CacheGlobalBound();
+			}
+			return GlobalCachedBounds.Value;
+		}
+
+		public void CacheLocalBound()
+		{
 			Vector3Int minPosition = Vector3Int.one * int.MaxValue;
 			Vector3Int maxPosition = Vector3Int.one * int.MinValue;
 
@@ -1649,13 +1636,38 @@ namespace TileManagement
 				{
 					continue; // Has no tiles
 				}
-
 				minPosition = Vector3Int.Min(layerBounds.min, minPosition);
 				maxPosition = Vector3Int.Max(layerBounds.max, maxPosition);
 			}
+			LocalCachedBounds = new BoundsInt(minPosition, maxPosition - minPosition);
+		}
 
-			CashedBoundsInt = new BoundsInt(minPosition, maxPosition - minPosition);
-			return CashedBoundsInt.Value;
+		public void CacheGlobalBound()
+		{
+			var localBound = GetLocalBounds();
+
+			var bottomLeft = transform.TransformPoint(localBound.min);
+			var bottomRight = transform.TransformPoint(new Vector3(localBound.xMax, localBound.min.y, 0));
+			var topLeft = transform.TransformPoint(new Vector3(localBound.min.x, localBound.yMax, 0));
+			var topRight = transform.TransformPoint(localBound.max);
+
+			var globalPoints = new Vector3[4]{bottomLeft, bottomRight, topLeft, topRight};
+			var minPosition = bottomLeft;
+			var maxPosition = bottomLeft;
+			foreach (var point in globalPoints)
+			{
+				if (point.x < minPosition.x || point.y < minPosition.y)
+				{
+					minPosition = point;
+				}
+				if (point.x > maxPosition.x || point.y > maxPosition.y)
+				{
+					maxPosition = point;
+				}
+			}
+
+			var middlePoint = minPosition + (maxPosition - minPosition) / 2;
+			GlobalCachedBounds = new Bounds(middlePoint, maxPosition - minPosition);
 		}
 
 		public Vector3Int WorldToCell(Vector3 worldPosition)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
@@ -4,8 +4,6 @@ using System.Diagnostics;
 using System.Linq;
 using Objects.Atmospherics;
 using UnityEngine;
-using UnityEngine.Events;
-using Debug = UnityEngine.Debug;
 
 namespace TileManagement
 {
@@ -71,7 +69,7 @@ namespace TileManagement
 		public Matrix PresentMatrix => presentMatrix;
 
 		private BoundsInt? LocalCachedBounds;
-		private Bounds? GlobalCachedBounds;
+		public Bounds? GlobalCachedBounds;
 
 		public float Resistance(Vector3Int cellPos, bool includeObjects = true)
 		{
@@ -1619,7 +1617,7 @@ namespace TileManagement
 		{
 			if (GlobalCachedBounds == null)
 			{
-				CacheGlobalBound();
+				return CacheGlobalBound();
 			}
 			return GlobalCachedBounds.Value;
 		}
@@ -1642,7 +1640,7 @@ namespace TileManagement
 			LocalCachedBounds = new BoundsInt(minPosition, maxPosition - minPosition);
 		}
 
-		public void CacheGlobalBound()
+		public Bounds CacheGlobalBound()
 		{
 			var localBound = GetLocalBounds();
 
@@ -1665,9 +1663,14 @@ namespace TileManagement
 					maxPosition = point;
 				}
 			}
-
 			var middlePoint = minPosition + (maxPosition - minPosition) / 2;
-			GlobalCachedBounds = new Bounds(middlePoint, maxPosition - minPosition);
+			var newGlobalBounds = new Bounds(middlePoint, maxPosition - minPosition);
+			if (presentMatrix.MatrixMove == null || (presentMatrix.MatrixMove.IsMovingServer == false && presentMatrix.MatrixMove.IsRotatingServer == false))
+			{
+				GlobalCachedBounds = newGlobalBounds;
+			}
+
+			return newGlobalBounds;
 		}
 
 		public Vector3Int WorldToCell(Vector3 worldPosition)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSystem.cs
@@ -25,7 +25,7 @@ namespace Systems.Atmospherics
 				gasSetter.SetUp();
 			}
 
-			BoundsInt bounds = metaTileMap.GetBounds();
+			BoundsInt bounds = metaTileMap.GetLocalBounds();
 
 			foreach (Vector3Int position in bounds.allPositionsWithin)
 			{
@@ -96,7 +96,7 @@ namespace Systems.Atmospherics
 		/// <param name="gasMixToUse">GasMix to fill room with</param>
 		public void SetRoomGas(int roomNumber, GasMix gasMixToUse)
 		{
-			BoundsInt bounds = metaTileMap.GetBounds();
+			BoundsInt bounds = metaTileMap.GetLocalBounds();
 
 			foreach (Vector3Int position in bounds.allPositionsWithin)
 			{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
@@ -122,7 +122,7 @@ public class MetaDataSystem : SubsystemBehaviour
 
 	private void LocateRooms()
 	{
-		BoundsInt bounds = metaTileMap.GetBounds();
+		BoundsInt bounds = metaTileMap.GetLocalBounds();
 
 		var watch = new Stopwatch();
 		watch.Start();

--- a/UnityProject/Assets/Scripts/UI/Objects/Shuttles/GUI_ShuttleControl.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Shuttles/GUI_ShuttleControl.cs
@@ -132,7 +132,7 @@ namespace UI.Objects.Shuttles
 			));
 
 			EntryList.AddItems(MapIconType.Asteroids, GetObjectsOf<Asteroid>());
-			var stationBounds = MatrixManager.MainStationMatrix.MetaTileMap.GetBounds();
+			var stationBounds = MatrixManager.MainStationMatrix.MetaTileMap.GetLocalBounds();
 			int stationRadius = (int) Mathf.Abs(stationBounds.center.x - stationBounds.xMin);
 			EntryList.AddStaticItem(MapIconType.Station, stationBounds.center, stationRadius);
 

--- a/UnityProject/Assets/Scripts/Util/RandomUtils.cs
+++ b/UnityProject/Assets/Scripts/Util/RandomUtils.cs
@@ -30,7 +30,7 @@ public static class RandomUtils
 	public static Vector3Int GetRandomPointOnStation(bool avoidSpace = false, bool avoidImpassable = false)
 	{
 		var stationMatrix = MatrixManager.MainStationMatrix;
-		var stationBounds = stationMatrix.Bounds;
+		var stationBounds = stationMatrix.LocalBounds;
 
 		Vector3Int point = default;
 		for (int i = 0; i < 10; i++)


### PR DESCRIPTION
### Purpose
World bounds will now be cached.
Creates a new bounds contains function to resolve it failing when the Z max and min point was equal.
AtPoint will now check for world bounds, avoiding the WorldToLocal call.
CL: [Fix] Fixed matrixes world bounds from being incorrect.

![image](https://user-images.githubusercontent.com/701959/142092215-ecde99f3-72ce-4f1a-8054-88cc7b91ba16.png)
performance difference with humans floating in space and in the station

CL: [Fix] world bounds will now be caches. Improves performance for player movement between matrixes by approximately 75%