### PR TITLE
Reagent code linq removal

### DIFF
--- a/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs
+++ b/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using HealthV2;
 using Items;
 using Items.Others;
@@ -199,13 +198,16 @@ namespace Chemistry.Components
 			{
 				lock (addition.reagents)
 				{
-					if (!addition.reagents.m_dict.All(r => reagentWhitelist.Contains(r.Key)))
+					foreach (var reagent in addition.reagents.m_dict.Keys)
 					{
-						return new TransferResult
+						if (reagentWhitelist.Contains(reagent) == false)
 						{
-							Success = false,
-							Message = "You can't transfer this into " + FancyContainerName
-						};
+							return new TransferResult
+							{
+								Success = false,
+								Message = "You can't transfer this into " + FancyContainerName
+							};
+						}
 					}
 				}
 			}
@@ -220,7 +222,7 @@ namespace Chemistry.Components
 				};
 			}
 
-			// save total ammount before mixing
+			// save total amount before mixing
 			var transferAmount = addition.Total;
 			var beforeMixTotal = CurrentReagentMix.Total;
 			var afterMixTotal = beforeMixTotal + transferAmount;

--- a/UnityProject/Assets/Scripts/HealthV2/Living/MedicalChemistry/MetabolismReaction.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/MedicalChemistry/MetabolismReaction.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using Chemistry;
 using HealthV2;
 using UnityEngine;
@@ -14,128 +13,55 @@ public class MetabolismReaction : Reaction
 	public float ReagentMetabolismMultiplier = 1;
 	public override bool Apply(MonoBehaviour sender, ReagentMix reagentMix)
 	{
-		tempMin = hasMinTemp ? (float?)serializableTempMin : null;
-		tempMax = hasMaxTemp ? (float?)serializableTempMax : null;
-
-		if (tempMin != null && reagentMix.Temperature <= tempMin ||
-		    tempMax != null && reagentMix.Temperature >= tempMax)
+		if (HasIngredients(reagentMix) == false)
+		{
+			return false;
+		}
+		if (CanReactionHappen(reagentMix) == false)
+		{
+			return false;
+		}
+		var bodyPart = sender.GetComponent<BodyPart>();
+		if (bodyPart == null)
 		{
 			return false;
 		}
 
-		if (!ingredients.m_dict.All(reagent => reagentMix[reagent.Key] > 0))
-		{
-			return false;
-		}
-
-		if (!ingredients.m_dict.Any())
-		{
-			return false;
-		}
-
-		if (!catalysts.m_dict.All(catalyst =>
-			reagentMix[catalyst.Key] >= catalyst.Value))
-		{
-			return false;
-		}
-
-		if (inhibitors.m_dict.Count > 0)
-		{
-			if (inhibitors.m_dict.All(inhibitor => reagentMix[inhibitor.Key] > inhibitor.Value))
-			{
-				return false;
-			}
-		}
-
-
-		var BodyPart = sender.GetComponent<BodyPart>();
-		if (BodyPart == null)
-		{
-			return false;
-		}
-
-		BodyPart.MetabolismReactions.Add(this);
-
+		bodyPart.MetabolismReactions.Add(this);
 		return false;
 	}
 
-	public void React(BodyPart sender, ReagentMix reagentMix, float INreactionAmount)
+	public void React(BodyPart sender, ReagentMix reagentMix, float inReactionAmount)
 	{
-
-		if (tempMin != null && reagentMix.Temperature <= tempMin ||
-		    tempMax != null && reagentMix.Temperature >= tempMax)
+		if (HasIngredients(reagentMix) == false)
 		{
 			return;
 		}
-
-		bool HasValidIngredient = false;
-
-		foreach (var Ingredients in ingredients.m_dict)
-		{
-			if (reagentMix.reagents.m_dict.ContainsKey(Ingredients.Key))
-			{
-				if (reagentMix.reagents.m_dict[Ingredients.Key] > 0)
-				{
-					HasValidIngredient = true;
-					break;
-				}
-			}
-		}
-
-		if (HasValidIngredient == false) return;
-
-		if (!ingredients.m_dict.All(reagent => reagentMix.reagents.m_dict[reagent.Key] > 0))
+		var reactionAmount = GetReactionAmount(reagentMix);
+		reactionAmount = Mathf.Min(reactionAmount, inReactionAmount * ReagentMetabolismMultiplier);
+		if (CanReactionHappen(reagentMix, reactionAmount) == false)
 		{
 			return;
 		}
-
-		if (!ingredients.m_dict.Any())
-		{
-			return;
-		}
-
-		var OptimalAmount = ingredients.m_dict.Min(i => reagentMix.reagents.m_dict[i.Key] / i.Value);
-
-		if (OptimalAmount < MinimumThreshold)
-		{
-			return;
-		}
-
-		var reactionAmount = Mathf.Min(OptimalAmount, INreactionAmount*ReagentMetabolismMultiplier);
-
-		if (!catalysts.m_dict.All(catalyst =>
-			reagentMix.reagents.m_dict[catalyst.Key] >= catalyst.Value * reactionAmount))
-		{
-			return;
-		}
-
-		if (inhibitors.m_dict.Count > 0)
-		{
-			if (inhibitors.m_dict.All(inhibitor => reagentMix.reagents.m_dict[inhibitor.Key] > inhibitor.Value * reactionAmount))
-			{
-				return;
-			}
-		}
-
 		PossibleReaction(sender, reagentMix, reactionAmount);
 	}
 
-	public virtual void PossibleReaction(BodyPart sender, ReagentMix reagentMix, float LimitedreactionAmount)
+	public virtual void PossibleReaction(BodyPart sender, ReagentMix reagentMix, float limitedreactionAmount)
 	{
 		foreach (var ingredient in ingredients.m_dict)
 		{
-			reagentMix.Subtract(ingredient.Key, LimitedreactionAmount * ingredient.Value);
+			reagentMix.Subtract(ingredient.Key, limitedreactionAmount * ingredient.Value);
 		}
 
 		foreach (var result in results.m_dict)
 		{
-			var reactionResult = LimitedreactionAmount * result.Value;
+			var reactionResult = limitedreactionAmount * result.Value;
 			reagentMix.Add(result.Key, reactionResult);
 		}
 
 		foreach (var effect in effects)
 		{
-			effect.Apply(sender, LimitedreactionAmount);
+			effect.Apply(sender, limitedreactionAmount);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Systems/Chemistry/Reaction.cs
+++ b/UnityProject/Assets/Scripts/Systems/Chemistry/Reaction.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using UnityEngine;
 using System;
-using System.Linq;
 
 namespace Chemistry
 {
@@ -29,28 +28,14 @@ namespace Chemistry
 
 		public virtual bool Apply(MonoBehaviour sender, ReagentMix reagentMix)
 		{
-            tempMin = hasMinTemp ? (float?)serializableTempMin : null;
-			tempMax = hasMaxTemp ? (float?)serializableTempMax : null;
-
-			if (tempMin != null && reagentMix.Temperature <= tempMin ||
-			    tempMax != null && reagentMix.Temperature >= tempMax)
+			if (HasIngredients(reagentMix) == false)
 			{
 				return false;
 			}
 
-			if (!ingredients.m_dict.All(reagent => reagentMix[reagent.Key] > 0))
-			{
-				return false;
-			}
+			var reactionAmount = GetReactionAmount(reagentMix);
 
-			if (!ingredients.m_dict.Any())
-			{
-				return false;
-			}
-
-			var reactionAmount = ingredients.m_dict.Min(i => reagentMix[i.Key] / i.Value);
-
-			if (useExactAmounts == true)
+			if (useExactAmounts)
 			{
 				reactionAmount = (float) Math.Floor(reactionAmount);
 				if (reactionAmount == 0)
@@ -59,20 +44,10 @@ namespace Chemistry
 				}
 			}
 
-			if (!catalysts.m_dict.All(catalyst =>
-				reagentMix[catalyst.Key] >= catalyst.Value * reactionAmount))
+			if (CanReactionHappen(reagentMix, reactionAmount) == false)
 			{
 				return false;
 			}
-
-			if (inhibitors.m_dict.Count > 0)
-			{
-				if (inhibitors.m_dict.All(inhibitor => reagentMix[inhibitor.Key] > inhibitor.Value * reactionAmount))
-				{
-					return false;
-				}
-			}
-
 
 			foreach (var ingredient in ingredients.m_dict)
 			{
@@ -93,5 +68,74 @@ namespace Chemistry
 
 			return true;
 		}
+
+		public float GetReactionAmount(ReagentMix reagentMix)
+		{
+			var reactionAmount = 0f;
+			foreach (var ingredient in ingredients.m_dict)
+			{
+				var asd = reagentMix.reagents.m_dict[ingredient.Key] / ingredient.Value;
+				if (asd < reactionAmount)
+				{
+					reactionAmount = asd;
+				}
+			}
+			return reactionAmount;
+		}
+
+		public bool HasIngredients(ReagentMix reagentMix)
+		{
+
+			//has all ingredients?
+			if (ingredients.m_dict.Count == 0)
+			{
+				return false;
+			}
+
+			foreach (var ingredient in ingredients.m_dict)
+			{
+				if (reagentMix.reagents.m_dict.ContainsKey(ingredient.Key) == false)
+				{
+					return false;
+				}
+				if (ingredient.Value <= 0)
+				{
+					return false;
+				}
+			}
+			return true;
+		}
+
+		public bool CanReactionHappen(ReagentMix reagentMix, float reactionAmount = 1)
+		{
+			//correct temperature?
+			tempMin = hasMinTemp ? (float?)serializableTempMin : null;
+			tempMax = hasMaxTemp ? (float?)serializableTempMax : null;
+			if (tempMin != null && reagentMix.Temperature <= tempMin ||
+			    tempMax != null && reagentMix.Temperature >= tempMax)
+			{
+				return false;
+			}
+
+			//are all catalysts present?
+			foreach (var catalyst in catalysts.m_dict)
+			{
+				if (reagentMix[catalyst.Key] < catalyst.Value * reactionAmount)
+				{
+					return false;
+				}
+			}
+
+			//is a single inhibitor present?
+			foreach (var inhibitor in inhibitors.m_dict)
+			{
+				if (reagentMix[inhibitor.Key] > inhibitor.Value * reactionAmount)
+				{
+					return false;
+				}
+			}
+			return true;
+		}
+
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Chemistry/Reaction.cs
+++ b/UnityProject/Assets/Scripts/Systems/Chemistry/Reaction.cs
@@ -71,13 +71,13 @@ namespace Chemistry
 
 		public float GetReactionAmount(ReagentMix reagentMix)
 		{
-			var reactionAmount = 0f;
+			var reactionAmount = Mathf.Infinity;
 			foreach (var ingredient in ingredients.m_dict)
 			{
-				var asd = reagentMix.reagents.m_dict[ingredient.Key] / ingredient.Value;
-				if (asd < reactionAmount)
+				var value = reagentMix.reagents.m_dict[ingredient.Key] / ingredient.Value;
+				if (value < reactionAmount)
 				{
-					reactionAmount = asd;
+					reactionAmount = value;
 				}
 			}
 			return reactionAmount;

--- a/UnityProject/Assets/Tests/Chemistry/ReagentContainerTests.cs
+++ b/UnityProject/Assets/Tests/Chemistry/ReagentContainerTests.cs
@@ -4,9 +4,7 @@ using System.Linq;
 using Chemistry;
 using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.TestTools;
 using Chemistry.Components;
-/*
 namespace Tests.Chemistry
 {
 	public class ReagentContainerTests
@@ -238,4 +236,3 @@ namespace Tests.Chemistry
 		}
 	}
 }
-*/


### PR DESCRIPTION
### Purpose
Removes some linq usage from reaction and metabolism code to increase performance and reduce GC.
Removes some copypasted code with reagent application.

![image](https://user-images.githubusercontent.com/701959/142460747-f27a623d-3b7f-4326-a041-96ca968aba4a.png)
the difference with 21 humans heartbeats on this frame, 1.1mb of GC gone and performance increased by 20%

![image](https://user-images.githubusercontent.com/701959/142461472-9fc00590-eed2-4287-84da-2833a9bca023.png)
this happens twice since thats how hmans work, so, another example with 27 humans but this time the old way was removed entirely. Just to get a rough idea of the difference

CL: [Fix] substantial improvement to how player bodies handle internal reagents. 20% performance gain and it consumes less memory