### PR TITLE
Better Inventory feedback

### DIFF
--- a/UnityProject/Assets/Scripts/Clothing/BackPack/InteractableStorage.cs
+++ b/UnityProject/Assets/Scripts/Clothing/BackPack/InteractableStorage.cs
@@ -115,6 +115,17 @@ public class InteractableStorage : MonoBehaviour, IClientInteractable<HandActiva
 		allowedToInteract = true;
 	}
 
+	private bool IsFull(GameObject usedObject, GameObject player)
+	{
+		if(itemStorage.GetNextFreeIndexedSlot() == null && usedObject != null)
+		{
+			Chat.AddExamineMsg(player,
+				$"<color=red>The {usedObject.ExpensiveName()} won't fit in the {itemStorage.gameObject.ExpensiveName()}, Make some space!</color>");
+			return true;
+		}
+		return false;
+	}
+
 	public bool Interact(InventoryApply interaction)
 	{
 		// client-side inventory apply interaction is just for opening / closing the backpack
@@ -143,12 +154,7 @@ public class InteractableStorage : MonoBehaviour, IClientInteractable<HandActiva
 		// we need to be the target - something is put inside us
 		if (interaction.TargetObject != gameObject) return false;
 		if (DefaultWillInteract.Default(interaction, side) == false) return false;
-		if (itemStorage.GetItemSlots().All(slot => slot.IsOccupied) && interaction.UsedObject != null)
-		{
-			Chat.AddExamineMsg(interaction.Performer,
-				$"<color=red>The {interaction.UsedObject.ExpensiveName()} won't fit in the {itemStorage.gameObject.ExpensiveName()}, Make some space!</color>");
-			return false;
-		}
+		if (IsFull(interaction.UsedObject, interaction.Performer)) return false;
 		// item must be able to fit
 		// note: since this is in local player's inventory, we are safe to check this stuff on client side
 		if (!Validations.CanPutItemToStorage(interaction.Performer.GetComponent<PlayerScript>(),
@@ -178,13 +184,7 @@ public class InteractableStorage : MonoBehaviour, IClientInteractable<HandActiva
 		if (allowedToInteract == false) return false;
 		// Use default interaction checks
 		if (DefaultWillInteract.Default(interaction, side) == false) return false;
-		if (itemStorage.GetItemSlots().All(slot => slot.IsOccupied) && interaction.HandObject != null)
-		{
-			Chat.AddExamineMsg(interaction.Performer,
-				$"<color=red>The {interaction.HandObject.ExpensiveName()} won't fit in the {interaction.HandObject.ExpensiveName()}, Make some space!</color>");
-			return false;
-		}
-
+		if (IsFull(interaction.UsedObject, interaction.Performer)) return false;
 		// See which item needs to be stored
 		if (Validations.IsTarget(gameObject, interaction))
 		{

--- a/UnityProject/Assets/Scripts/Clothing/BackPack/InteractableStorage.cs
+++ b/UnityProject/Assets/Scripts/Clothing/BackPack/InteractableStorage.cs
@@ -120,7 +120,7 @@ public class InteractableStorage : MonoBehaviour, IClientInteractable<HandActiva
 		if(itemStorage.GetNextFreeIndexedSlot() == null && usedObject != null)
 		{
 			Chat.AddExamineMsg(player,
-				$"<color=red>The {usedObject.ExpensiveName()} won't fit in the {itemStorage.gameObject.ExpensiveName()}, Make some space!</color>");
+				$"<color=red>The {usedObject.ExpensiveName()} won't fit in the {itemStorage.gameObject.ExpensiveName()}. Make some space!</color>");
 			return true;
 		}
 		return false;

--- a/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
@@ -147,6 +147,11 @@ namespace Items
 			set => hitSound = value;
 		}
 
+		[Tooltip("Sound to be played when object gets added to storage.")]
+		[SerializeField]
+		private AddressableAudioSource inventoryMoveSound = null;
+		public AddressableAudioSource InventoryMoveSound => inventoryMoveSound;
+
 		//TODO: tank / eva fields should probably be migrated to a different component as they are very specific to clothing, particularly
 		//suits and masks. Probably belong in the Clothing component.
 		[Tooltip("Is this a mask that can connect to a tank?")]

--- a/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
@@ -152,6 +152,11 @@ namespace Items
 		private AddressableAudioSource inventoryMoveSound = null;
 		public AddressableAudioSource InventoryMoveSound => inventoryMoveSound;
 
+		[Tooltip("Sound to be played when object gets added to storage.")]
+		[SerializeField]
+		private AddressableAudioSource inventoryRemoveSound = null;
+		public AddressableAudioSource InventoryRemoveSound => inventoryRemoveSound;
+
 		//TODO: tank / eva fields should probably be migrated to a different component as they are very specific to clothing, particularly
 		//suits and masks. Probably belong in the Clothing component.
 		[Tooltip("Is this a mask that can connect to a tank?")]

--- a/UnityProject/Assets/Scripts/Systems/Inventory/Inventory.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/Inventory.cs
@@ -223,7 +223,19 @@ public static class Inventory
 				Category.Inventory, toPerform.InventoryMoveType);
 		}
 
+		PlayInventorySound(toPerform.FromSlot, toPerform.MovedObject.gameObject.Item());
+
 		return true;
+	}
+
+	private static void PlayInventorySound(ItemSlot slot, Items.ItemAttributesV2 item)
+	{
+		if (slot == null || item == null) return;
+
+		if (item.InventoryRemoveSound != null)
+		{
+			_ = SoundManager.PlayNetworkedAtPosAsync(item.InventoryRemoveSound, slot.ItemStorage.gameObject.AssumedWorldPosServer());
+		}
 	}
 
 	private static bool ServerPerformTransfer(InventoryMove toPerform, Pickupable pickupable)

--- a/UnityProject/Assets/Scripts/Systems/Inventory/ItemSlot.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/ItemSlot.cs
@@ -320,7 +320,8 @@ public class ItemSlot
 					Logger.LogTrace($"Cannot fit {toStore} in slot {ToString()}, item was blacklisted.", Category.Inventory);
 					if (examineRecipient)
 					{
-						Chat.AddExamineMsg(examineRecipient, $"{toStore.gameObject.ExpensiveName()} can't be placed there!");
+						Chat.AddExamineMsg(examineRecipient,
+							$"<color=red>The {storageToCheck.gameObject.ExpensiveName()} cannot hold the {toStore.gameObject.ExpensiveName()}!</color>");
 					}
 
 					return false;
@@ -398,7 +399,7 @@ public class ItemSlot
 			if (targetPlayerScript != null)
 			{
 				//going into a top-level inventory slot of a player
-				Chat.AddExamineMsg(examineRecipient, $"{toStore.gameObject.ExpensiveName()} can't go in that slot.");
+				Chat.AddExamineMsg(examineRecipient, $"<color=red>{toStore.gameObject.ExpensiveName()} is too big for the {ItemStorage.gameObject.ExpensiveName()}!</color>");
 			}
 			else
 			{


### PR DESCRIPTION
fixes #7792 

CL: [Improvement] Improves player feedback for when items can't go into an inventory slot/when the storage is full

also adds in the functionality to play audio when moving an object into storage so we can play audio when we add stuff to backpacks just like in SS13 instead of just silently moving things though no sounds are applied yet.