### PR TITLE
Changes how TryUpdateServerTarget treats movement rejects

### DIFF
--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -458,9 +458,8 @@ public partial class PlayerSync
 		if (consideredFloatingServer || !serverState.Active || CanNotSpaceMoveServer || (pushPull && pushPull.IsBeingPulled))
 		{
 			Logger.LogWarning("Server ignored queued move while player isn't supposed to move", Category.Movement);
-			serverPendingActions.Dequeue();
-
-			TryUpdateServerTarget();
+			ClearQueueServer();
+			RollbackPosition();
 			return;
 		}
 


### PR DESCRIPTION
### Purpose
TryUpdateServerTarget() will no longer recursively call itself when the movement queue is rejected, it'll just clear it and rollback the client