### PR TITLE
Fixes clients being unable to move inside moving shuttles

### DIFF
--- a/UnityProject/Assets/Scripts/Shuttles/MatrixMove.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/MatrixMove.cs
@@ -104,7 +104,7 @@ public class MatrixMove : ManagedBehaviour
 	private bool ServerPositionsMatch => serverTargetState.Position == serverState.Position;
 	public bool IsRotatingServer => NeedsRotationClient; //todo: calculate rotation time on server instead
 	private bool IsAutopilotEngaged => Target != TransformState.HiddenPos;
-	private bool IsMovingClient => clientState.IsMoving && clientState.Speed > 0f;
+	public bool IsMovingClient => clientState.IsMoving && clientState.Speed > 0f;
 
 	/// <summary>
 	/// Dictionary containing lists of RCS thrusters.

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
@@ -1564,8 +1564,12 @@ namespace TileManagement
 			}
 			var middlePoint = minPosition + (maxPosition - minPosition) / 2;
 			var newGlobalBounds = new Bounds(middlePoint, maxPosition - minPosition);
-			if (matrix.MatrixMove == null || (matrix.MatrixMove.IsMovingServer == false && matrix.MatrixMove.IsRotatingServer == false))
+
+			if (matrix.MatrixMove == null ||
+			    (CustomNetworkManager.IsServer && matrix.MatrixMove.IsMovingServer == false && matrix.MatrixMove.IsRotatingServer == false) ||
+				(CustomNetworkManager.IsServer == false && matrix.MatrixMove.IsMovingClient == false && matrix.MatrixMove.IsRotatingServer == false))
 			{
+				//Only save the cache if the shuttle is static!
 				GlobalCachedBounds = newGlobalBounds;
 			}
 


### PR DESCRIPTION
### Purpose
CL: [Fix] Fixes clients being unable to move inside moving shuttles.
CL: [Fix] Fixes GlobalCachedBounds being cache'd by mistake on clients when the matrix was moving.