### PR TITLE
C4 Improvements

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/C4.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/C4.prefab
@@ -283,12 +283,8 @@ MonoBehaviour:
   minimumTimeToDetonate: 10
   explosionPrefab: {fileID: 2540564744460004555, guid: 311ad0ee31c0a654487179079dd48cdd,
     type: 3}
-  spriteHandler: {fileID: 5258580723283386321}
   activeSpriteSO: {fileID: 11400000, guid: 60942022f971e0440a63456ee27fc478, type: 2}
-  registerItem: {fileID: 4084437145900613279}
-  objectBehaviour: {fileID: 5809642687452026922}
-  pickupable: {fileID: 6536533875639940645}
-  explosiveGUI: {fileID: 5745720402341052027}
+  spriteHandler: {fileID: 5258580723283386321}
   GUI: {fileID: 0}
 --- !u!210 &-7063633880587810702
 SortingGroup:

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/X4.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/X4.prefab
@@ -282,12 +282,9 @@ MonoBehaviour:
   minimumTimeToDetonate: 1
   explosionPrefab: {fileID: 2540564744460004555, guid: 8fb8560e73de12548838a05b8ffcfcb1,
     type: 3}
-  spriteHandler: {fileID: 5258580723283386321}
   activeSpriteSO: {fileID: 11400000, guid: 6eedd99a9dc83864f808d929d4e9bd36, type: 2}
-  registerItem: {fileID: 4084437145900613279}
-  objectBehaviour: {fileID: 5809642687452026922}
-  pickupable: {fileID: 6536533875639940645}
-  explosiveGUI: {fileID: 5745720402341052027}
+  progressTime: 3
+  spriteHandler: {fileID: 5258580723283386321}
   GUI: {fileID: 0}
 --- !u!210 &-7063633880587810702
 SortingGroup:

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabExplosive.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabExplosive.prefab
@@ -1141,8 +1141,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4280887807
-  m_fontColor: {r: 1, g: 0.16078432, b: 0.16078432, a: 1}
+    rgba: 4278234101
+  m_fontColor: {r: 0.9622642, g: 0.6686306, b: 0, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:

--- a/UnityProject/Assets/Scripts/UI/Objects/GUI_Explosive.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/GUI_Explosive.cs
@@ -45,12 +45,13 @@ namespace UI
 			explosiveDevice = Provider.GetComponent<Explosive>();
 			if (explosiveDevice.DetonateImmediatelyOnSignal == false)
 			{
-				timer.Value = explosiveDevice.TimeToDetonate.ToString();
+				timerCount = explosiveDevice.TimeToDetonate;
+				DisplayTime();
 			}
 			else
 			{
 				timer.Value = "Waiting signal..";
-				status.Value = dangerColor.ToString();
+				status.ElementTMP.color = dangerColor;
 			}
 
 			switch (explosiveDevice.ExplosiveType)


### PR DESCRIPTION
- Improved some text related stuff
CL: [Fix] Fixed an error where the status text in C4 would print out `dangerColor` instead of the actual status of the C4 when someone checks it for the first time.
CL: [Fix] Timer Text is now much more readable on the X4 GUI.
CL: [Fix] When putting an explosive on a surface that it can't support it will now refer to it as "Explosive" rather than "C4" all the time.
- Attempting to fix an issue where headless servers don't get the sprite handler on Awake for some reason
CL: [Fix] Fixed an issue where people can just drag bombs off walls once they're armed (lol)
- Made interactions a lil bit better.

Note :
I still have no idea how to fix that issue where mirror throws an error when explosives spawn on a headless server
`The server tried to add a disconnected player to the list of X4 NetworkIdentity observers`