### PR TITLE
Fixes pulled items spazzing out

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.cs
+++ b/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.cs
@@ -147,6 +147,7 @@ public partial class CustomNetTransform : NetworkBehaviour, IPushable
 		registerTile = GetComponent<RegisterTile>();
 		itemAttributes = GetComponent<ItemAttributesV2>();
 		occupiableDirectionalSprite = GetComponent<OccupiableDirectionalSprite>();
+		pushPull = GetComponent<PushPull>();
 		syncInterval = 0f;
 	}
 


### PR DESCRIPTION
### Purpose
CL: [Fix] Fixes items being pulled accepting server positions while at the same time predicting its position. Pulling items should be less laggy, now.
Fixes #7388