### PR TITLE
Fixes clients failing access checks when the ID is inside a PDA

### DIFF
--- a/UnityProject/Assets/Scripts/Player/ExaminablePlayer.cs
+++ b/UnityProject/Assets/Scripts/Player/ExaminablePlayer.cs
@@ -110,12 +110,12 @@ namespace Player
 
 					// if item is PDA and IDCard is not null
 					if (itemSlot.ItemObject.TryGetComponent<PDALogic>(out var pdaLogic) == false ||
-					    pdaLogic.IDCard == null)
+					    pdaLogic.GetIDCard() == null)
 					{
 						continue;
 					}
 
-					idCard = pdaLogic.IDCard;
+					idCard = pdaLogic.GetIDCard();
 					return true;
 				}
 			}

--- a/UnityProject/Assets/Scripts/Systems/Occupations/AccessRestrictions.cs
+++ b/UnityProject/Assets/Scripts/Systems/Occupations/AccessRestrictions.cs
@@ -61,7 +61,7 @@ public class AccessRestrictions : MonoBehaviour
 
 		if (idCardObj.TryGetComponent<PDALogic>(out var pda))
 		{
-			return pda.IDCard;
+			return pda.GetIDCard();
 		}
 
 		return null;

--- a/UnityProject/Assets/Scripts/UI/Items/PDA/GUI_PDAMainMenu.cs
+++ b/UnityProject/Assets/Scripts/UI/Items/PDA/GUI_PDAMainMenu.cs
@@ -9,7 +9,7 @@ namespace UI.Items.PDA
 		[SerializeField] private NetLabel idLabel = null;
 		[SerializeField] private NetLabel lightLabel = null;
 
-		private IDCard IDCard => controller.PDA.IDCard;
+		private IDCard IDCard => controller.PDA.GetIDCard();
 
 		private void Start()
 		{


### PR DESCRIPTION
### Purpose
CL: [Fix] Fixes clients failing access checks when the ID is inside a PDA.
CL: [Fix] Fixes ID-locked guns projectiles being invisible for the shooter.
Fixes #7612
