### PR TITLE
Fixes a runtime when the InfiniteLoopTracker log directory didn't exist

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/InfiniteLoopTracker.cs
+++ b/UnityProject/Assets/Scripts/Managers/InfiniteLoopTracker.cs
@@ -21,6 +21,7 @@ namespace Managers
         {
 	        thread = new Thread (OverwatchMainThread);
 	        thread.Start();
+	        Directory.CreateDirectory("Logs");
 	        streamWriter = File.AppendText("Logs/InfiniteLoopTracker.txt");
         }
 


### PR DESCRIPTION
### Purpose
Fixes a runtime when the InfiniteLoopTracker log directory didn't exist