### PR TITLE
Fixes RCS getting players stuck

### DIFF
--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabShuttleControl.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabShuttleControl.prefab
@@ -715,7 +715,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 114343398355056170}
-        m_TargetAssemblyTypeName: 
+        m_TargetAssemblyTypeName: UI.Objects.Shuttles.GUI_ShuttleControl, Assets
         m_MethodName: TurnRight
         m_Mode: 1
         m_Arguments:
@@ -1270,10 +1270,9 @@ MonoBehaviour:
   OnTabOpened:
     m_PersistentCalls:
       m_Calls: []
-  rcsLight: {fileID: 4045547224110564359}
+  rcsLight: {fileID: 6023538412421918743}
   rcsLightOn: {fileID: 21300002, guid: 549fbecefe555964a8444a4cd42275a3, type: 3}
   rcsLightOff: {fileID: 21300000, guid: 549fbecefe555964a8444a4cd42275a3, type: 3}
-  rcsToggleButton: {fileID: 2180316960823425740}
   CoordReadout: {fileID: 1286891109983827235}
 --- !u!1 &1608340126526448
 GameObject:
@@ -1479,8 +1478,8 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 114343398355056170}
-        m_TargetAssemblyTypeName: 
-        m_MethodName: TurnOnOff
+        m_TargetAssemblyTypeName: UI.Objects.Shuttles.GUI_ShuttleControl, Assets
+        m_MethodName: ToggleEngine
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1799,8 +1798,8 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 114343398355056170}
-        m_TargetAssemblyTypeName: 
-        m_MethodName: SetAutopilot
+        m_TargetAssemblyTypeName: UI.Objects.Shuttles.GUI_ShuttleControl, Assets
+        m_MethodName: ToggleAutopilot
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2039,7 +2038,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 114343398355056170}
-        m_TargetAssemblyTypeName: 
+        m_TargetAssemblyTypeName: UI.Objects.Shuttles.GUI_ShuttleControl, Assets
         m_MethodName: TurnLeft
         m_Mode: 1
         m_Arguments:
@@ -3024,6 +3023,7 @@ GameObject:
   - component: {fileID: 1071522742833516225}
   - component: {fileID: 2606091136585971533}
   - component: {fileID: 4045547224110564359}
+  - component: {fileID: 6023538412421918743}
   m_Layer: 5
   m_Name: LightRed
   m_TagString: Untagged
@@ -3088,6 +3088,21 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &6023538412421918743
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2629233224449148803}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1bd4b313639849d2bad90a2330df0214, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sprites:
+  - {fileID: 21300000, guid: 549fbecefe555964a8444a4cd42275a3, type: 3}
+  - {fileID: 21300002, guid: 549fbecefe555964a8444a4cd42275a3, type: 3}
 --- !u!1 &3204274401632699804
 GameObject:
   m_ObjectHideFlags: 0
@@ -4285,8 +4300,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3673428243094180962}
-  - component: {fileID: 2180316960823425740}
-  - component: {fileID: 4369270839533957215}
+  - component: {fileID: 7550405390306932029}
+  - component: {fileID: 903792251565305510}
   m_Layer: 5
   m_Name: RcsToggle
   m_TagString: Untagged
@@ -4314,7 +4329,7 @@ RectTransform:
   m_AnchoredPosition: {x: -0.6, y: -7.3}
   m_SizeDelta: {x: 70, y: 45}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &2180316960823425740
+--- !u!114 &7550405390306932029
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4323,11 +4338,11 @@ MonoBehaviour:
   m_GameObject: {fileID: 7955098448894449466}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 220c42e66d2547fcbcb8aa6748e5d421, type: 3}
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
-    m_Mode: 0
+    m_Mode: 3
     m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
@@ -4351,18 +4366,15 @@ MonoBehaviour:
     m_NormalTrigger: Normal
     m_HighlightedTrigger: Highlighted
     m_PressedTrigger: Pressed
-    m_SelectedTrigger: Highlighted
+    m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 0}
-  toggleTransition: 0
-  graphic: {fileID: 5149656961688951475}
-  m_Group: {fileID: 0}
-  onValueChanged:
+  m_TargetGraphic: {fileID: 5149656961688951475}
+  m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 4369270839533957215}
-        m_TargetAssemblyTypeName: NetToggle, Assets
+      - m_Target: {fileID: 903792251565305510}
+        m_TargetAssemblyTypeName: NetUIElement`1[[System.String, mscorlib
         m_MethodName: ExecuteClient
         m_Mode: 1
         m_Arguments:
@@ -4373,8 +4385,7 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  m_IsOn: 0
---- !u!114 &4369270839533957215
+--- !u!114 &903792251565305510
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4383,19 +4394,15 @@ MonoBehaviour:
   m_GameObject: {fileID: 7955098448894449466}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c469783ba5934436896cc7b30fe5978b, type: 3}
+  m_Script: {fileID: 11500000, guid: f41ce54e3adddc243a63e91303c43614, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  enableWorkaround: 0
   ServerMethod:
-    m_PersistentCalls:
-      m_Calls: []
-  ServerMethodWithSubject:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 114343398355056170}
-        m_TargetAssemblyTypeName: 
-        m_MethodName: ServerToggleRcs
+        m_TargetAssemblyTypeName: UI.Objects.Shuttles.GUI_ShuttleControl, Assets
+        m_MethodName: ToggleRcsButton
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/UnityProject/Assets/Scripts/Messages/Server/ShuttleRcsMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/ShuttleRcsMessage.cs
@@ -1,0 +1,32 @@
+﻿using Mirror;
+using Objects.Shuttles;
+namespace Messages.Server
+{
+	public class ShuttleRcsMessage : ServerMessage<ShuttleRcsMessage.NetMessage>
+	{
+		public struct NetMessage : NetworkMessage
+		{
+			public uint shuttleConsoleUINT;
+			public bool State;
+		}
+
+		public override void Process(NetMessage msg)
+		{
+			LoadNetworkObject(msg.shuttleConsoleUINT);
+			var shuttleConsole = NetworkObject.GetComponent<ShuttleConsole>();
+			shuttleConsole.ChangeRcsPlayer(msg.State, PlayerManager.LocalPlayerScript);
+		}
+
+		public static NetMessage SendTo(ShuttleConsole shuttleConsole, bool state, ConnectedPlayer connectedPlayer)
+		{
+			NetMessage msg = new NetMessage
+			{
+				shuttleConsoleUINT = shuttleConsole.netId,
+				State = state
+			};
+
+			SendTo(connectedPlayer, msg);
+			return msg;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Messages/Server/ShuttleRcsMessage.cs.meta
+++ b/UnityProject/Assets/Scripts/Messages/Server/ShuttleRcsMessage.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f9313ad34d49480988fbf9e96a8e522a
+timeCreated: 1638717674

--- a/UnityProject/Assets/Scripts/Player/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerScript.cs
@@ -46,8 +46,7 @@ public class PlayerScript : NetworkBehaviour, IMatrixRotation, IAdminInfo, IActi
 
 	public Directional playerDirectional { get; set; }
 
-	private PlayerSync _playerSync; //Example of good on-demand reference init
-	public PlayerSync PlayerSync => _playerSync ? _playerSync : (_playerSync = GetComponent<PlayerSync>());
+	public PlayerSync PlayerSync;
 
 	public Equipment Equipment { get; private set; }
 
@@ -91,9 +90,9 @@ public class PlayerScript : NetworkBehaviour, IMatrixRotation, IAdminInfo, IActi
 	public float RTT;
 
 	[HideInInspector]
-	[SyncVar]
 	public bool RcsMode;
-	public MatrixMove RcsMatrixMove { get; set; }
+	[HideInInspector]
+	public MatrixMove RcsMatrixMove;
 
 	private bool isUpdateRTT;
 	private float waitTimeForRTTUpdate = 0f;
@@ -145,6 +144,7 @@ public class PlayerScript : NetworkBehaviour, IMatrixRotation, IAdminInfo, IActi
 		Cooldowns = GetComponent<HasCooldowns>();
 		PlayerOnlySyncValues = GetComponent<PlayerOnlySyncValues>();
 		playerCrafting = GetComponent<PlayerCrafting>();
+		PlayerSync = GetComponent<PlayerSync>();
 	}
 
 	public override void OnStartClient()

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -432,7 +432,7 @@ public partial class PlayerSync
 	/// Clear all queues and
 	/// inform players of true serverState
 	[Server]
-	private void RollbackPosition()
+	public void RollbackPosition()
 	{
 		foreach (var questionablePushable in questionablePushables)
 		{

--- a/UnityProject/Assets/Scripts/Shuttles/MatrixMove.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/MatrixMove.cs
@@ -88,7 +88,7 @@ public class MatrixMove : ManagedBehaviour
 	/// <summary>
 	/// If it is currently fuelled
 	/// </summary>
-	[NonSerialized]
+
 	public bool IsFueled;
 
 	public bool IsForceStopped;
@@ -96,10 +96,10 @@ public class MatrixMove : ManagedBehaviour
 	[Tooltip("Does it require fuel in order to fly?")]
 	public bool RequiresFuel;
 
-	//[SyncVar(hook = nameof(OnRcsActivated))]
-	//This is sync'd by the MatrixSync component
-	[HideInInspector]
+	[NonSerialized]
 	public bool rcsModeActive;
+	[NonSerialized]
+	public PlayerScript playerControllingRcs;
 
 	private bool ServerPositionsMatch => serverTargetState.Position == serverState.Position;
 	public bool IsRotatingServer => NeedsRotationClient; //todo: calculate rotation time on server instead
@@ -124,7 +124,6 @@ public class MatrixMove : ManagedBehaviour
 	private Vector2Int rcsMovementStartPosition;
 
 	/// <summary>
-	/// position on which player should be after the start of RCS
 	/// position on which shuttle should be located at the end of RCS movement
 	/// </summary>
 	private Vector2Int rcsMovementTargetPosition;
@@ -392,19 +391,6 @@ public class MatrixMove : ManagedBehaviour
 				pendingInitialRotation = false;
 			}
 		}
-
-		if (CustomNetworkManager.IsHeadless == false)
-		{
-			if (coordReadoutScript != null) coordReadoutScript.SetCoords(clientState.Position);
-			if (shuttleControlGUI != null && rcsModeActive != shuttleControlGUI.RcsMode)
-			{
-				shuttleControlGUI.ClientToggleRcs(rcsModeActive);
-
-				// int.MaxValue instead of zero to avoid bugs when shuttle is on position (0, 0)
-				rcsMovementStartPosition = new Vector2Int(int.MaxValue, int.MaxValue);
-				rcsMovementTargetPosition = new Vector2Int(int.MaxValue, int.MaxValue);
-			}
-		}
 	}
 
 	[Server]
@@ -418,15 +404,6 @@ public class MatrixMove : ManagedBehaviour
 		{
 			StartMovement();
 		}
-	}
-
-	[Server]
-	public void ToggleRcs(bool on)
-	{
-		networkedMatrix.MatrixSync.OnRcsActivated(rcsModeActive, on);
-		rcsModeActive = on;
-
-
 	}
 
 	/// Start moving. If speed was zero, it'll be set to 1
@@ -482,19 +459,6 @@ public class MatrixMove : ManagedBehaviour
 		clientState.IsMoving = true;
 
 		MatrixMoveEvents.OnStartMovementClient.Invoke();
-	}
-
-	public void OnRcsActivated(bool oldValue, bool newValue)
-	{
-		if (newValue)
-		{
-			CacheRcs();
-			rcsModeActive = true;
-		}
-		else
-		{
-			rcsModeActive = false;
-		}
 	}
 
 	/// Stop movement

--- a/UnityProject/Assets/Scripts/Shuttles/MatrixSync.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/MatrixSync.cs
@@ -22,10 +22,6 @@ namespace Shuttles
 			[SyncVar(hook = nameof(SyncPivot))]
 			private Vector3 pivot;
 
-			[SyncVar(hook = nameof(OnRcsActivated))]
-			[HideInInspector]
-			public bool rcsModeActive;
-
 			[SyncVar(hook = nameof(SyncMatrixID))]
 			[HideInInspector]
 			public int matrixID;
@@ -92,12 +88,6 @@ namespace Shuttles
 			{
 				pivot = newPivot;
 				matrixMove.pivot = pivot.RoundToInt();
-			}
-
-			public void OnRcsActivated(bool oldState, bool newState)
-			{
-				rcsModeActive = newState;
-				matrixMove.OnRcsActivated(oldState, newState);
 			}
 
 			public void SyncMatrixID(int oldID, int newID)

--- a/UnityProject/Assets/Scripts/Shuttles/ShuttleConsole.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/ShuttleConsole.cs
@@ -75,17 +75,17 @@ namespace Objects.Shuttles
 		public void ServerPerformInteraction(HandApply interaction)
 		{
 			//apply emag
-			switch (shuttleConsoleState)
+			if (shuttleConsoleState == ShuttleConsoleState.Normal)
 			{
-				case ShuttleConsoleState.Normal:
-					shuttleConsoleState = ShuttleConsoleState.Emagged;
-					break;
-				case ShuttleConsoleState.Emagged:
-					shuttleConsoleState = ShuttleConsoleState.Off;
-					break;
-				case ShuttleConsoleState.Off:
-					shuttleConsoleState = ShuttleConsoleState.Normal;
-					break;
+				shuttleConsoleState = ShuttleConsoleState.Emagged;
+			}
+			else if (shuttleConsoleState == ShuttleConsoleState.Emagged)
+			{
+				shuttleConsoleState = ShuttleConsoleState.Off;
+			}
+			else if (shuttleConsoleState == ShuttleConsoleState.Off)
+			{
+				shuttleConsoleState = ShuttleConsoleState.Normal;
 			}
 			if (GUItab)
 			{

--- a/UnityProject/Assets/Scripts/UI/Objects/Shuttles/GUI_ShuttleControl.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Shuttles/GUI_ShuttleControl.cs
@@ -8,41 +8,16 @@ using Objects.Command;
 using Systems.MobAIs;
 using Systems.Shuttles;
 using Map;
+using Messages.Server;
 
 namespace UI.Objects.Shuttles
 {
-	/// Server only stuff
 	public class GUI_ShuttleControl : NetTab
 	{
+		private RadarList radarList;
+		public MatrixMove matrixMove { get; private set; }
 
-		private RadarList entryList;
-		private RadarList EntryList {
-			get {
-				if (!entryList)
-				{
-					entryList = this["EntryList"] as RadarList;
-				}
-				return entryList;
-			}
-		}
-		private MatrixMove matrixMove;
-
-		public MatrixMove MatrixMove {
-			get {
-				if (!matrixMove)
-				{
-					matrixMove = Provider.GetComponent<ShuttleConsole>().ShuttleMatrixMove;
-				}
-
-				return matrixMove;
-			}
-		}
-
-		[SerializeField] private Image rcsLight = null;
-		[SerializeField] private Sprite rcsLightOn = null;
-		[SerializeField] private Sprite rcsLightOff = null;
-		[SerializeField] private ToggleButton rcsToggleButton = null;
-		private ConnectedPlayer playerControllingRcs;
+		[SerializeField] private NetSpriteImage rcsLight = null;
 
 		public GUI_CoordReadout CoordReadout;
 
@@ -51,9 +26,6 @@ namespace UI.Objects.Shuttles
 		Color rayColor;
 		Color crosshairColor;
 
-		public bool RcsMode { get; private set; }
-
-
 		private NetUIElement<string> SafetyText => (NetUIElement<string>)this[nameof(SafetyText)];
 		private NetUIElement<string> StartButton => (NetUIElement<string>)this[nameof(StartButton)];
 		private NetColorChanger Crosshair => (NetColorChanger)this[nameof(Crosshair)];
@@ -61,17 +33,16 @@ namespace UI.Objects.Shuttles
 		private NetColorChanger OffOverlay => (NetColorChanger)this[nameof(OffOverlay)];
 		private NetColorChanger Rulers => (NetColorChanger)this[nameof(Rulers)];
 
-		private ShuttleFuelSystem FuelSystemReference;
+		private ShuttleFuelSystem shuttleFuelSystem;
+
+		private ShuttleConsole shuttleConsole;
+
+		private bool Autopilot = true;
 
 		public override void OnEnable()
 		{
 			base.OnEnable();
 			StartCoroutine(WaitForProvider());
-		}
-
-		private void OnDisable()
-		{
-			RcsMode = false;
 		}
 
 		private IEnumerator WaitForProvider()
@@ -80,35 +51,29 @@ namespace UI.Objects.Shuttles
 			{
 				yield return WaitFor.EndOfFrame;
 			}
-			Trigger = Provider.GetComponent<ShuttleConsole>();
-			Trigger.OnStateChange.AddListener(OnStateChange);
 
-			MatrixMove.RegisterCoordReadoutScript(CoordReadout);
-			MatrixMove.RegisterShuttleGuiScript(this);
-			FuelSystemReference = matrixMove.ShuttleFuelSystem;
+			shuttleConsole = Provider.GetComponent<ShuttleConsole>();
+			matrixMove = shuttleConsole.ShuttleMatrixMove;
+			matrixMove.RegisterCoordReadoutScript(CoordReadout);
+			matrixMove.RegisterShuttleGuiScript(this);
+			shuttleFuelSystem = matrixMove.ShuttleFuelSystem;
+			radarList = this["EntryList"] as RadarList;
 
 			//Not doing this for clients
 			if (IsServer)
 			{
-				EntryList.Origin = MatrixMove;
+				shuttleConsole.GUItab = this;
+
+				radarList.Origin = matrixMove;
+				StartButton.SetValueServer("1");
+
 				//Init listeners
-				string temp = "1";
-				StartButton.SetValueServer(temp);
-				MatrixMove.MatrixMoveEvents.OnStartMovementServer.AddListener(() =>
-				{
-				// dont enable button when moving with RCS
-				if (!matrixMove.rcsModeActive)
-						StartButton.SetValueServer("1");
-				});
-				MatrixMove.MatrixMoveEvents.OnStopMovementServer.AddListener(() =>
-			   {
-				   StartButton.SetValueServer("0");
-				   HideWaypoint();
-			   });
+				matrixMove.MatrixMoveEvents.OnStartMovementServer.AddListener(OnStartMovementServer);
+				matrixMove.MatrixMoveEvents.OnStopMovementServer.AddListener(OnStopMovementServer);
 
 				if (!Waypoint)
 				{
-					Waypoint = new GameObject($"{MatrixMove.gameObject.name}Waypoint");
+					Waypoint = new GameObject($"{matrixMove.gameObject.name}Waypoint");
 				}
 				HideWaypoint(false);
 
@@ -116,48 +81,137 @@ namespace UI.Objects.Shuttles
 				rayColor = RadarScanRay.Value;
 				crosshairColor = Crosshair.Value;
 
-				OnStateChange(State);
-			}
-			else
-			{
-				ClientToggleRcs(matrixMove.rcsModeActive);
+				OnStateChange(shuttleConsole.shuttleConsoleState);
 			}
 		}
 
-		private void StartNormalOperation()
+		private void UpdateMe()
 		{
-			EntryList.AddItems(MapIconType.Ship, GetObjectsOf<MatrixMove>(
-				mm => mm != MatrixMove //ignore current ship
-					  && (mm.HasWorkingThrusters || mm.gameObject.name.Equals("Escape Pod")) //until pod gets engines
+			radarList.RefreshTrackedPos();
+
+			var fuelGauge = (NetUIElement<string>)this["FuelGauge"];
+			if (shuttleFuelSystem == null)
+			{
+				if (fuelGauge.Value != "0")
+				{
+					fuelGauge.SetValueServer((0).ToString());
+				}
+			}
+			else if(shuttleFuelSystem.Connector?.canister?.GasContainer != null)
+			{
+				var value = $"{(shuttleFuelSystem.FuelLevel * 100f)}";
+				fuelGauge.SetValueServer(value);
+			}
+
+			if (matrixMove.rcsModeActive)
+			{
+				if (Validations.CanApply(matrixMove.playerControllingRcs, Provider, NetworkSide.Server) == false)
+				{
+					shuttleConsole.ChangeRcsPlayer(false, matrixMove.playerControllingRcs);
+				}
+			}
+		}
+
+		public void OnStateChange(ShuttleConsoleState newState)
+		{
+			if (newState == ShuttleConsoleState.Off)
+			{
+				SetSafetyProtocols(true);
+				UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, UpdateMe);
+				ClearScreen();
+				return;
+			}
+			if (newState == ShuttleConsoleState.Normal)
+			{
+				AddRadarItems();
+				//Important: set values from server using SetValue and not Value
+				Rulers.SetValueServer(rulersColor);
+				RadarScanRay.SetValueServer(rayColor);
+				Crosshair.SetValueServer(crosshairColor);
+				SetSafetyProtocols(true);
+			}
+			else if (newState == ShuttleConsoleState.Emagged)
+			{
+				AddRadarItems(true);
+				//Repaint radar to evil colours
+				Rulers.SetValueServer(HSVUtil.ChangeColorHue(rulersColor, -80));
+				RadarScanRay.SetValueServer(HSVUtil.ChangeColorHue(rayColor, -80));
+				Crosshair.SetValueServer(HSVUtil.ChangeColorHue(crosshairColor, -80));
+				SetSafetyProtocols(false);
+			}
+			UpdateManager.Add(UpdateMe, 1f);
+			OffOverlay.SetValueServer(Color.clear);
+		}
+
+		private void ClearScreen()
+		{
+			//Black screen overlay
+			OffOverlay.SetValueServer(Color.black);
+			radarList.Clear();
+			ToggleEngine(false);
+			shuttleConsole.ChangeRcsPlayer(false, matrixMove.playerControllingRcs);
+		}
+
+		private void AddRadarItems(bool emagged = false)
+		{
+			radarList.AddItems(MapIconType.Ship, GetObjectsOf<MatrixMove>(
+				mm => mm != matrixMove //ignore current ship
+				      && (mm.HasWorkingThrusters || mm.gameObject.name.Equals("Escape Pod")) //until pod gets engines
 			));
 
-			EntryList.AddItems(MapIconType.Asteroids, GetObjectsOf<Asteroid>());
+			radarList.AddItems(MapIconType.Asteroids, GetObjectsOf<Asteroid>());
 			var stationBounds = MatrixManager.MainStationMatrix.MetaTileMap.GetLocalBounds();
-			int stationRadius = (int) Mathf.Abs(stationBounds.center.x - stationBounds.xMin);
-			EntryList.AddStaticItem(MapIconType.Station, stationBounds.center, stationRadius);
+			var stationRadius = (int) Mathf.Abs(stationBounds.center.x - stationBounds.xMin);
+			radarList.AddStaticItem(MapIconType.Station, stationBounds.center, stationRadius);
+			radarList.AddItems(MapIconType.Waypoint, new List<GameObject>(new[] {Waypoint}));
 
-			EntryList.AddItems(MapIconType.Waypoint, new List<GameObject>(new[] {Waypoint}));
-
-			RescanElements();
-
-			StartRefresh();
+			if (emagged)
+			{
+				radarList.AddItems(MapIconType.Human, GetObjectsOf<PlayerScript>(player => !player.IsDeadOrGhost));
+				radarList.AddItems(MapIconType.Ian, GetObjectsOf<CorgiAI>());
+				radarList.AddItems(MapIconType.Nuke, GetObjectsOf<Nuke>());
+			}
 		}
-		/// <summary>
-		/// Add secret emag functionality to radar
-		/// </summary>
-		private void AddEmagItems()
+
+		/// Get a list of positions for objects of given type within certain range from provided origin
+		/// todo: move, make it an util method
+		public static List<GameObject> GetObjectsOf<T>(Func<T, bool> condition = null) where T : Behaviour
 		{
-			EntryList.AddItems(MapIconType.Human, GetObjectsOf<PlayerScript>(player => !player.IsDeadOrGhost));
-			EntryList.AddItems(MapIconType.Ian, GetObjectsOf<CorgiAI>());
-			EntryList.AddItems(MapIconType.Nuke, GetObjectsOf<Nuke>());
-
-			RescanElements();
-
-			StartRefresh();
+			var foundBehaviours = FindObjectsOfType<T>();
+			var foundObjects = new List<GameObject>();
+			foreach (var foundBehaviour in foundBehaviours)
+			{
+				if (condition != null && !condition(foundBehaviour))
+				{
+					continue;
+				}
+				foundObjects.Add(foundBehaviour.gameObject);
+			}
+			return foundObjects;
 		}
 
-		private bool Autopilot = true;
-		public void SetAutopilot(bool on)
+		private void SetSafetyProtocols(bool state)
+		{
+			matrixMove.SafetyProtocolsOn = state;
+			SafetyText.SetValueServer(state ? "ON" : "OFF");
+		}
+
+		private void OnStopMovementServer()
+		{
+			StartButton.SetValueServer("0");
+			HideWaypoint();
+		}
+
+		private void OnStartMovementServer()
+		{
+			// dont enable button when moving with RCS
+			if (!matrixMove.rcsModeActive)
+			{
+				StartButton.SetValueServer("1");
+			}
+		}
+
+		public void ToggleAutopilot(bool on)
 		{
 			Autopilot = on;
 			if (on)
@@ -168,65 +222,31 @@ namespace UI.Objects.Shuttles
 			{
 				//touchscreen off, hide waypoint, invalidate MM target
 				HideWaypoint();
-				MatrixMove.DisableAutopilotTarget();
+				matrixMove.DisableAutopilotTarget();
 			}
 		}
 
-		public void ServerToggleRcs(bool on, ConnectedPlayer subject)
+		public void ToggleRcsButton(ConnectedPlayer connectedPlayer)
 		{
-			if (playerControllingRcs != null && playerControllingRcs != subject)
+			if (matrixMove.playerControllingRcs != null && matrixMove.playerControllingRcs != connectedPlayer.Script)
 			{
-				playerControllingRcs.Script.RcsMode = false;
-				playerControllingRcs.Script.RcsMatrixMove = null;
+				shuttleConsole.ChangeRcsPlayer(false, matrixMove.playerControllingRcs);
 			}
+			var newState = !matrixMove.rcsModeActive;
+			shuttleConsole.ChangeRcsPlayer(newState, connectedPlayer.Script);
+		}
 
-			if (subject != null)
+		public void SetRcsLight(bool state)
+		{
+			if (state)
 			{
-				subject.Script.RcsMode = on;
-				subject.Script.RcsMatrixMove = on ? MatrixMove : null;
-			}
-
-			RcsMode = on;
-			MatrixMove.ToggleRcs(on);
-			SetRcsLight(on);
-
-			if (on)
-			{
-				playerControllingRcs = subject;
+				rcsLight.SetSprite(1);
 			}
 			else
 			{
-				playerControllingRcs = null;
+				rcsLight.SetSprite(0);
 			}
 		}
-
-		public void ClientToggleRcs(bool on)
-		{
-			PlayerManager.LocalPlayerScript.RcsMatrixMove = on ? MatrixMove : null;
-
-			MatrixMove.CacheRcs();
-
-			RcsMode = on;
-			SetRcsLight(on);
-			rcsToggleButton.isOn = on;
-		}
-
-		private void SetRcsLight(bool on)
-		{
-			if (on)
-			{
-				rcsLight.sprite = rcsLightOn;
-				return;
-			}
-			rcsLight.sprite = rcsLightOff;
-		}
-
-		public void SetSafetyProtocols(bool on)
-		{
-			MatrixMove.SafetyProtocolsOn = on;
-			SafetyText.SetValueServer(@on ? "ON" : "OFF");
-		}
-
 
 		public void SetWaypoint(string position)
 		{
@@ -241,168 +261,24 @@ namespace UI.Objects.Shuttles
 			}
 
 			//Ignoring requests to set waypoint outside intended radar window
-			if (RadarList.ProjectionMagnitude(proposedPos) > EntryList.Range)
+			if (RadarList.ProjectionMagnitude(proposedPos) > radarList.Range)
 			{
 				return;
 			}
 			//Mind the ship's actual position
-			Waypoint.transform.position = (Vector2)proposedPos + Vector2Int.RoundToInt(MatrixMove.ServerState.Position);
+			Waypoint.transform.position = (Vector2)proposedPos + Vector2Int.RoundToInt(matrixMove.ServerState.Position);
 
-			EntryList.UpdateExclusive(Waypoint);
+			radarList.UpdateExclusive(Waypoint);
 
-			//		Logger.Log( $"Ordering travel to {Waypoint.transform.position}" );
-			MatrixMove.AutopilotTo(Waypoint.transform.position);
+			matrixMove.AutopilotTo(Waypoint.transform.position);
 		}
 
-		public void HideWaypoint(bool updateImmediately = true)
+		private void HideWaypoint(bool updateImmediately = true)
 		{
 			Waypoint.transform.position = TransformState.HiddenPos;
 			if (updateImmediately)
 			{
-				EntryList.UpdateExclusive(Waypoint);
-			}
-		}
-
-		private bool RefreshRadar = false;
-		private ShuttleConsole Trigger;
-		private TabState State => Trigger.State;
-
-		private void StartRefresh()
-		{
-			RefreshRadar = true;
-			//		Logger.Log( "Starting radar refresh" );
-			StartCoroutine(Refresh());
-		}
-
-		public void RefreshOnce()
-		{
-			RefreshRadar = false;
-			StartCoroutine(Refresh());
-		}
-
-		private void StopRefresh()
-		{
-			//		Logger.Log( "Stopping radar refresh" );
-			RefreshRadar = false;
-		}
-
-		/// <summary>
-		/// Shut it down as if it has no power. Controls won't react and screen will be empty
-		/// </summary>
-		private void PowerOff()
-		{
-			EntryList.Clear();
-			StopRefresh();
-			TurnOnOff(false);
-			RescanElements();
-		}
-
-		private IEnumerator Refresh()
-		{
-			if (State == TabState.Off)
-			{
-				yield break;
-			}
-			EntryList.RefreshTrackedPos();
-			//Logger.Log((MatrixMove.shuttleFuelSystem.FuelLevel * 100).ToString());
-			var fuelGauge = (NetUIElement<string>)this["FuelGauge"];
-			if (FuelSystemReference == null)
-			{
-				if (fuelGauge.Value != "0")
-				{
-					fuelGauge.SetValueServer((0).ToString());
-				}
-
-			}
-			else if(FuelSystemReference.Connector != null && FuelSystemReference.Connector.canister != null
-			&& FuelSystemReference.Connector.canister.GasContainer != null)
-			{
-				string value = $"{(FuelSystemReference.FuelLevel * 100f)}";
-				fuelGauge.SetValueServer(value);
-			}
-			yield return WaitFor.Seconds(1f);
-
-			//validate Player using Rcs
-			if (playerControllingRcs != null)
-			{
-				bool validate = playerControllingRcs.Script && Validations.CanApply(playerControllingRcs.Script, Provider, NetworkSide.Server);
-				if (!validate)
-				{
-					ServerToggleRcs(false, null);
-				}
-			}
-
-			if (RefreshRadar)
-			{
-				StartCoroutine(Refresh());
-			}
-		}
-
-		/// Get a list of positions for objects of given type within certain range from provided origin
-		/// todo: move, make it an util method
-		public static List<GameObject> GetObjectsOf<T>(Func<T, bool> condition = null)
-			where T : Behaviour
-		{
-			T[] foundBehaviours = FindObjectsOfType<T>();
-			var foundObjects = new List<GameObject>();
-
-			foreach (var foundBehaviour in foundBehaviours)
-			{
-				if (condition != null && !condition(foundBehaviour))
-				{
-					continue;
-				}
-
-				foundObjects.Add(foundBehaviour.gameObject);
-			}
-
-			return foundObjects;
-		}
-
-
-		private void OnStateChange(TabState newState)
-		{
-			//Important: if you get NREs out of nowhere, make sure your server code doesn't accidentally run on client as well
-			if (!IsServer)
-			{
-				return;
-			}
-
-			switch (newState)
-			{
-				case TabState.Normal:
-					PowerOff();
-					StartNormalOperation();
-					//Important: set values from server using SetValue and not Value
-					OffOverlay.SetValueServer(Color.clear);
-					Rulers.SetValueServer(rulersColor);
-					RadarScanRay.SetValueServer(rayColor);
-					Crosshair.SetValueServer(crosshairColor);
-					SetSafetyProtocols(true);
-
-					break;
-				case TabState.Emagged:
-					PowerOff();
-					StartNormalOperation();
-					//Remove overlay
-					OffOverlay.SetValueServer(Color.clear);
-					//Repaint radar to evil colours
-					Rulers.SetValueServer(HSVUtil.ChangeColorHue(rulersColor, -80));
-					RadarScanRay.SetValueServer(HSVUtil.ChangeColorHue(rayColor, -80));
-					Crosshair.SetValueServer(HSVUtil.ChangeColorHue(crosshairColor, -80));
-					AddEmagItems();
-					SetSafetyProtocols(false);
-
-					break;
-				case TabState.Off:
-					PowerOff();
-					//Black screen overlay
-					OffOverlay.SetValueServer(Color.black);
-					SetSafetyProtocols(true);
-
-					break;
-				default:
-					return;
+				radarList.UpdateExclusive(Waypoint);
 			}
 		}
 
@@ -410,15 +286,15 @@ namespace UI.Objects.Shuttles
 		/// Starts or stops the shuttle.
 		/// </summary>
 		/// <param name="off">Toggle parameter</param>
-		public void TurnOnOff(bool on)
+		public void ToggleEngine(bool engineState)
 		{
-			if (on && State != TabState.Off && !matrixMove.rcsModeActive)
+			if (engineState && shuttleConsole.shuttleConsoleState != ShuttleConsoleState.Off && !matrixMove.rcsModeActive)
 			{
-				MatrixMove.StartMovement();
+				matrixMove.StartMovement();
 			}
 			else
 			{
-				MatrixMove.StopMovement();
+				matrixMove.StopMovement();
 			}
 		}
 
@@ -427,11 +303,11 @@ namespace UI.Objects.Shuttles
 		/// </summary>
 		public void TurnRight()
 		{
-			if (State == TabState.Off)
+			if (shuttleConsole.shuttleConsoleState == ShuttleConsoleState.Off)
 			{
 				return;
 			}
-			MatrixMove.TryRotate(true);
+			matrixMove.TryRotate(true);
 		}
 
 		/// <summary>
@@ -439,11 +315,11 @@ namespace UI.Objects.Shuttles
 		/// </summary>
 		public void TurnLeft()
 		{
-			if (State == TabState.Off)
+			if (shuttleConsole.shuttleConsoleState == ShuttleConsoleState.Off)
 			{
 				return;
 			}
-			MatrixMove.TryRotate(false);
+			matrixMove.TryRotate(false);
 		}
 
 		/// <summary>
@@ -452,20 +328,13 @@ namespace UI.Objects.Shuttles
 		/// <param name="speedMultiplier"></param>
 		public void SetSpeed(float speedMultiplier)
 		{
-			if (MatrixMove == null)
-			{
-				Logger.LogWarning("Matrix move is missing for some reason on this shuttle", Category.Shuttles);
-				return;
-			}
-			float speed = speedMultiplier * (MatrixMove.MaxSpeed - 1) + 1;
-			//		Logger.Log( $"Multiplier={speedMultiplier}, setting speed to {speed}" );
-			MatrixMove.SetSpeed(speed);
+			var speed = speedMultiplier * (matrixMove.MaxSpeed - 1) + 1;
+			matrixMove.SetSpeed(speed);
 		}
 
 		public void PlayRadarDetectionSound()
 		{
-			if(Trigger == null) return;
-			Trigger.PlayRadarDetectionSound();
+			shuttleConsole.PlayRadarDetectionSound();
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Objects/Shuttles/GUI_TextSwap.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Shuttles/GUI_TextSwap.cs
@@ -29,7 +29,7 @@ namespace UI.Objects.Shuttles
 				return;
 			}
 
-			UIType keyToCheck = shuttleControlScript.MatrixMove.uiType;
+			UIType keyToCheck = shuttleControlScript.matrixMove.uiType;
 			if (textSetupDict.ContainsKey(keyToCheck))
 			{
 				textToSet.text = textSetupDict[keyToCheck].Replace("\\n", "\n");


### PR DESCRIPTION
### Purpose
Fixes #6992
CL: [Fix] Fixed RCS getting players stuck in position.
Removes the syncvars related to the RCS, it will now use a ServerMessage.
RCS status will now be tracked by the MatrixMove and the player's PlayerScript.
Adds the ShuttleRcsMessage to alert the players they are controlling or not a shuttle.
Cleans up GUI_ShuttleControl.cs, simplifying and making everything more linear.
The red led sprite of the shuttle GUI RCS will now use a NetSpriteImage.
PlayerScript will now load PlayerSync on Awake().