### PR TITLE
Fixes projectiles and status effects

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Camera/Camera2DFollow.cs
+++ b/UnityProject/Assets/Scripts/Core/Camera/Camera2DFollow.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using UnityEngine;
 using Random = UnityEngine.Random;
@@ -66,12 +67,16 @@ public class Camera2DFollow : MonoBehaviour
 			followControl = this;
 			cam = GetComponent<Camera>();
 			lightingSystem = GetComponent<LightingSystem>();
-			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 		}
 		else
 		{
 			Destroy(gameObject);
 		}
+	}
+
+	private void OnEnable()
+	{
+		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 
 	private void Start()

--- a/UnityProject/Assets/Scripts/Core/Camera/InteractCamera.cs
+++ b/UnityProject/Assets/Scripts/Core/Camera/InteractCamera.cs
@@ -17,6 +17,10 @@ public class InteractCamera : MonoBehaviour
 	private void Start()
 	{
 		interactCam.orthographicSize = mainCam.orthographicSize;
+	}
+
+	private void OnEnable()
+	{
 		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 

--- a/UnityProject/Assets/Scripts/Core/Camera/ParallaxController.cs
+++ b/UnityProject/Assets/Scripts/Core/Camera/ParallaxController.cs
@@ -16,6 +16,10 @@ public class ParallaxController : MonoBehaviour
 		centerColumn = backgroundTiles.Count / 2;
 		centerRow = backgroundTiles[0].rows.Count / 2;
 		RealignTiles();
+	}
+
+	private void OnEnable()
+	{
 		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 

--- a/UnityProject/Assets/Scripts/Core/Camera/UseMainCameraSize.cs
+++ b/UnityProject/Assets/Scripts/Core/Camera/UseMainCameraSize.cs
@@ -10,6 +10,10 @@ public class UseMainCameraSize : MonoBehaviour
 	{
 		Camera = GetComponent<Camera>();
 		MainCamera = Camera.main;
+	}
+
+	private void OnEnable()
+	{
 		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 

--- a/UnityProject/Assets/Scripts/Core/Chat/ChatScrollRect/ChatScroll.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/ChatScrollRect/ChatScroll.cs
@@ -46,6 +46,10 @@ public class ChatScroll : MonoBehaviour
 	{
 		InitPool();
 		contentWidth = chatContentParent.GetComponent<RectTransform>().rect.width;
+	}
+
+	private void OnEnable()
+	{
 		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 

--- a/UnityProject/Assets/Scripts/Core/Chat/ChatTypingSync.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/ChatTypingSync.cs
@@ -19,6 +19,10 @@ public class ChatTypingSync : MonoBehaviour
 	{
 		ChatUI.Instance.OnChatInputChanged += OnChatInputChanged;
 		ChatUI.Instance.OnChatWindowClosed += OnChatWindowClosed;
+	}
+
+	private void OnEnable()
+	{
 		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 

--- a/UnityProject/Assets/Scripts/Core/Chat/ChatUI.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/ChatUI.cs
@@ -140,6 +140,10 @@ namespace UI.Chat_UI
 			//channelPanel.gameObject.SetActive(false);
 			EventManager.AddHandler(Event.UpdateChatChannels, OnUpdateChatChannels);
 			chatFilter = Chat.Instance.GetComponent<ChatFilter>();
+		}
+
+		private void OnEnable()
+		{
 			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 		}
 

--- a/UnityProject/Assets/Scripts/Core/Input System/CablePlacementVisualisation.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/CablePlacementVisualisation.cs
@@ -76,6 +76,10 @@ public class CablePlacementVisualisation : MonoBehaviour
 		defaultPointColor = connectionPointRenderers[Connection.Overlap].color;
 		// get line renderer
 		lineRenderer = cablePlacementVisualisation.GetComponent<LineRenderer>();
+	}
+
+	private void OnEnable()
+	{
 		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 

--- a/UnityProject/Assets/Scripts/Core/Transform/RotateAroundTransform.cs
+++ b/UnityProject/Assets/Scripts/Core/Transform/RotateAroundTransform.cs
@@ -12,6 +12,10 @@
 		{
 			ourTransform = transform;
 			time = Random.Range(50, 100);
+		}
+
+		private void OnEnable()
+		{
 			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 		}
 

--- a/UnityProject/Assets/Scripts/Items/Weapons/Projectiles/Behaviours/LocalTrailRenderer.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Projectiles/Behaviours/LocalTrailRenderer.cs
@@ -75,6 +75,10 @@ namespace Weapons.Projectiles.Behaviours
 				objToFollow = transform.GetComponentInChildren<MovingProjectile>().transform;
 			}
 			Reset();
+		}
+
+		private void OnEnable()
+		{
 			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 		}
 

--- a/UnityProject/Assets/Scripts/Items/Weapons/Projectiles/Behaviours/TimeLimitedDecal.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Projectiles/Behaviours/TimeLimitedDecal.cs
@@ -15,6 +15,10 @@ namespace Weapons.Projectiles.Behaviours
 		{
 			spriteHandler = GetComponentInChildren<SpriteHandler>();
 			lightSprite = GetComponentInChildren<LightSprite>();
+		}
+
+		private void OnEnable()
+		{
 			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 		}
 

--- a/UnityProject/Assets/Scripts/Items/Weapons/Projectiles/MovingProjectile.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Projectiles/MovingProjectile.cs
@@ -1,4 +1,5 @@
-﻿using ScriptableObjects.Gun;
+﻿using System;
+using ScriptableObjects.Gun;
 using UnityEngine;
 
 namespace Weapons.Projectiles
@@ -20,10 +21,13 @@ namespace Weapons.Projectiles
 
 		private void Awake()
 		{
-
 			projectile = GetComponentInParent<Bullet>();
 			maskData = projectile.MaskData;
 			thisTransform = transform;
+		}
+
+		private void OnEnable()
+		{
 			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 		}
 

--- a/UnityProject/Assets/Scripts/Managers/InfiniteLoopTracker.cs
+++ b/UnityProject/Assets/Scripts/Managers/InfiniteLoopTracker.cs
@@ -28,6 +28,10 @@ namespace Managers
 	        thread.Start();
 	        Directory.CreateDirectory("Logs");
 	        streamWriter = File.AppendText("Logs/InfiniteLoopTracker.txt");
+        }
+
+        private void OnEnable()
+        {
 	        UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
         }
 

--- a/UnityProject/Assets/Scripts/Managers/LobbyManager/SpriteStretch.cs
+++ b/UnityProject/Assets/Scripts/Managers/LobbyManager/SpriteStretch.cs
@@ -12,6 +12,10 @@ public class SpriteStretch : MonoBehaviour
 	void Start()
 	{
 		image = gameObject.GetComponent<Image>();
+	}
+
+	private void OnEnable()
+	{
 		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 

--- a/UnityProject/Assets/Scripts/Managers/SettingsManager/DisplaySettings.cs
+++ b/UnityProject/Assets/Scripts/Managers/SettingsManager/DisplaySettings.cs
@@ -410,6 +410,10 @@ namespace Managers.SettingsManager
 			base.Awake();
 			IsFullScreen = Screen.fullScreen;
 			SetupPrefs();
+		}
+
+		private void OnEnable()
+		{
 			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 		}
 

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.cs
@@ -32,12 +32,16 @@ public partial class SubSceneManager : NetworkBehaviour
 		if (Instance == null)
 		{
 			Instance = this;
-			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 		}
 		else
 		{
 			Destroy(gameObject);
 		}
+	}
+
+	private void OnEnable()
+	{
+		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 
 	private void OnDisable()

--- a/UnityProject/Assets/Scripts/Objects/Research/Artifacts/Artifact.cs
+++ b/UnityProject/Assets/Scripts/Objects/Research/Artifacts/Artifact.cs
@@ -47,6 +47,10 @@ public class Artifact : MonoBehaviour, IServerSpawn, IServerDespawn,
 	private void Awake()
 	{
 		currentEffect = GetComponent<ArtifactEffect>();
+	}
+
+	private void OnEnable()
+	{
 		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 

--- a/UnityProject/Assets/Scripts/RCON/RconManager.cs
+++ b/UnityProject/Assets/Scripts/RCON/RconManager.cs
@@ -25,6 +25,10 @@ public class RconManager : SingletonManager<RconManager>
 	void Start()
 	{
 		Instance.Init();
+	}
+
+	private void OnEnable()
+	{
 		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 

--- a/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventsManager.cs
+++ b/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventsManager.cs
@@ -47,6 +47,10 @@ namespace InGameEvents
 		public void Start()
 		{
 			RandomEventsAllowed = GameConfigManager.GameConfig.RandomEventsAllowed;
+		}
+
+		private void OnEnable()
+		{
 			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 		}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosManager.cs
@@ -43,7 +43,6 @@ namespace Systems.Atmospherics
 			if (Instance == null)
 			{
 				Instance = this;
-				UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 			}
 			else
 			{
@@ -98,6 +97,7 @@ namespace Systems.Atmospherics
 			EventManager.AddHandler(Event.PostRoundStarted, OnPostRoundStart);
 			EventManager.AddHandler(Event.RoundEnded, OnRoundEnd);
 			SceneManager.activeSceneChanged += OnSceneChange;
+			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 		}
 
 		private void OnDisable()

--- a/UnityProject/Assets/Scripts/UI/Core/CanvasResolution.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/CanvasResolution.cs
@@ -9,10 +9,14 @@ public class CanvasResolution : MonoBehaviour
     {
         aspectCache = Camera.main.aspect;
         AdjustReferenceResolution();
-        if (Application.isPlaying)
-        {
-	        UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
-        }
+    }
+
+    private void OnEnable()
+    {
+	    if (Application.isPlaying)
+	    {
+		    UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
+	    }
     }
 
     private void OnDisable()

--- a/UnityProject/Assets/Scripts/UI/Core/DragAndDrop/UIDragAndDrop.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/DragAndDrop/UIDragAndDrop.cs
@@ -38,6 +38,10 @@ namespace UI
 			dragDummy.enabled = false;
 			scaleCache = dragDummy.transform.localScale;
 			interactableScale = scaleCache * 1.1f;
+		}
+
+		private void OnEnable()
+		{
 			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 		}
 

--- a/UnityProject/Assets/Scripts/UI/Core/GUI/Components/GUI_TabNext.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/GUI/Components/GUI_TabNext.cs
@@ -13,6 +13,10 @@ public class GUI_TabNext : GUI_Component
 	void Start()
 	{
 		thisField = GetComponent<InputField>();
+	}
+
+	private void OnEnable()
+	{
 		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 

--- a/UnityProject/Assets/Scripts/UI/Core/GUI/Components/GUI_TextInput.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/GUI/Components/GUI_TextInput.cs
@@ -23,6 +23,10 @@ using UnityEngine.UI;
 			{
 				initialTextColor = inputFieldText.color;
 			}
+		}
+
+		private void OnEnable()
+		{
 			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 		}
 

--- a/UnityProject/Assets/Scripts/UI/Core/Info/FPSCounter.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/Info/FPSCounter.cs
@@ -13,6 +13,10 @@ public class FPSCounter : MonoBehaviour
 	{
 		timeA = Time.timeSinceLevelLoad;
 		DontDestroyOnLoad(this);
+	}
+
+	private void OnEnable()
+	{
 		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 

--- a/UnityProject/Assets/Scripts/UI/Core/Radial/RadialScroll.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/Radial/RadialScroll.cs
@@ -56,6 +56,10 @@ namespace UI.Core.Radial
 		public void Awake()
 		{
 			RadialUI = GetComponent<IRadial>();
+		}
+
+		private void OnEnable()
+		{
 			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 		}
 

--- a/UnityProject/Assets/Scripts/UI/Core/Tooltip.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/Tooltip.cs
@@ -21,7 +21,11 @@ public class Tooltip : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
         // While the tooltip exists, we place it under the canvas so it'll be in the top layer
         tooltipObject.transform.SetParent(this.GetComponentInParent<Canvas>().transform);
         tooltipObject.SetActive(false);
-        UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
+    }
+
+    private void OnEnable()
+    {
+	    UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
     }
 
     private void OnDisable()

--- a/UnityProject/Assets/Scripts/UI/Core/WindowDrag.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/WindowDrag.cs
@@ -29,9 +29,12 @@ public class WindowDrag : MonoBehaviour
 									rectTransform.position.y / worldPointResolution.y);;
 
 		isReady = true;
-		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 
+	private void OnEnable()
+	{
+		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
+	}
 
 	public void UpdateMe()
 	{

--- a/UnityProject/Assets/Scripts/UI/Core/WindowFocus.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/WindowFocus.cs
@@ -22,6 +22,10 @@ public class WindowFocus : MonoBehaviour
 			Logger.LogError($"{nameof(TMP_InputField)} not found / assigned to {this}.");
 			enabled = false;
 		}
+	}
+
+	private void OnEnable()
+	{
 		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 

--- a/UnityProject/Assets/Scripts/UI/Core/Windows/TeleportWindow/TeleportButtonSearchBar.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/Windows/TeleportWindow/TeleportButtonSearchBar.cs
@@ -14,6 +14,10 @@ namespace UI.Core.Windows
 		private void Start()
 		{
 			Searchtext = GetComponent<InputField>();
+		}
+
+		private void OnEnable()
+		{
 			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 		}
 

--- a/UnityProject/Assets/Scripts/UI/Objects/Atmospherics/Canister/NumberSpinner.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Atmospherics/Canister/NumberSpinner.cs
@@ -84,6 +84,10 @@ namespace UI.Core
 			init = false;
 			// check if we are the server version (will not play sounds if that's the case)
 			muteSounds = GetComponentInParent<NetTab>().IsServer;
+		}
+
+		private void OnEnable()
+		{
 			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 		}
 

--- a/UnityProject/Assets/Scripts/UI/Objects/Atmospherics/Canister/Wheel.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Atmospherics/Canister/Wheel.cs
@@ -38,6 +38,10 @@ namespace UI.Core
 			base.Start();
 			windowDrag = GetComponentInParent<WindowDrag>();
 			shadow = GetComponent<Shadow>();
+		}
+
+		private void OnEnable()
+		{
 			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 		}
 

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/GUI_DevCloner.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/GUI_DevCloner.cs
@@ -49,6 +49,10 @@ public class GUI_DevCloner : MonoBehaviour
 		escapeKeyTarget = GetComponent<EscapeKeyTarget>();
 		lightingSystem = Camera.main.GetComponent<LightingSystem>();
 		ToState(State.SELECTING);
+	}
+
+	private void OnEnable()
+	{
 		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/GUI_DevSelectVVTile.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/GUI_DevSelectVVTile.cs
@@ -48,6 +48,10 @@ public class GUI_DevSelectVVTile : MonoBehaviour
 		escapeKeyTarget = GetComponent<EscapeKeyTarget>();
 		lightingSystem = Camera.main.GetComponent<LightingSystem>();
 		ToState(State.SELECTING);
+	}
+
+	private void OnEnable()
+	{
 		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/GUI_DevSpawner.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/GUI_DevSpawner.cs
@@ -29,7 +29,11 @@ public class GUI_DevSpawner : MonoBehaviour
 	void Start()
     {
 	    spawnerSearch = SpawnerSearch.ForPrefabs(Spawn.SpawnablePrefabs());
-	    UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
+    }
+
+	private void OnEnable()
+	{
+		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 
 	private void OnDisable()

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/GUI_LobbyDialogue.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/GUI_LobbyDialogue.cs
@@ -52,6 +52,10 @@ namespace Lobby
 			OnHostToggle();
 			// Init Lobby UI
 			InitPlayerName();
+		}
+
+		private void OnEnable()
+		{
 			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 		}
 

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/SongTracker.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/SongTracker.cs
@@ -52,6 +52,10 @@ namespace Audio.Containers
 		private void Start()
 		{
 			DetermineMuteState();
+		}
+
+		private void OnEnable()
+		{
 			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 		}
 

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/PlayerHealthUI.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/PlayerHealthUI.cs
@@ -31,6 +31,10 @@ public class PlayerHealthUI : MonoBehaviour
 	void Awake()
 	{
 		DisableAll();
+	}
+
+	private void OnEnable()
+	{
 		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 

--- a/UnityProject/Assets/Scripts/UI/Systems/PreRound/GUI_PreRoundWindow.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/PreRound/GUI_PreRoundWindow.cs
@@ -76,12 +76,16 @@ namespace UI
 			if (Instance == null)
 			{
 				Instance = this;
-				UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 			}
 			else
 			{
 				Destroy(gameObject);
 			}
+		}
+
+		private void OnEnable()
+		{
+			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 		}
 
 		private void OnDisable()

--- a/UnityProject/Assets/Standard Assets/HSVPicker/Other/TiltWindow.cs
+++ b/UnityProject/Assets/Standard Assets/HSVPicker/Other/TiltWindow.cs
@@ -13,6 +13,10 @@ public class TiltWindow : MonoBehaviour
 	{
 		mTrans = transform;
 		mStart = mTrans.localRotation;
+	}
+
+	private void OnEnable()
+	{
 		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 


### PR DESCRIPTION
### Purpose
Fixes pooled projectiles not moving, player warnings not appearing and many others UpdateMe related errors.
Fixes #7927
CL: [Fix] fixed status effects not showing for players

### Notes
projectiles are pooled so once they got re-enabled they didnt add themselves to the UpdateManager, something similar happens to the status effects where they are momentarely disabled.
briefly tested.