### PR TITLE
Singularity "Warp" Shader

### DIFF
--- a/UnityProject/Assets/Materials/PostProcess/Post-FloorFovGenerator Material.mat
+++ b/UnityProject/Assets/Materials/PostProcess/Post-FloorFovGenerator Material.mat
@@ -78,5 +78,5 @@ Material:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _OcclusionSpread: {r: 0, g: 0, b: 0, a: 0}
-    - _PositionOffset: {r: 0, g: 0.031577997, b: 0, a: 0}
+    - _PositionOffset: {r: 0, g: 0.024786765, b: 0, a: 0}
   m_BuildTextureStacks: []

--- a/UnityProject/Assets/Materials/PostProcess/Post-FovGenerator.mat
+++ b/UnityProject/Assets/Materials/PostProcess/Post-FovGenerator.mat
@@ -77,5 +77,5 @@ Material:
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _PositionOffset: {r: 0, g: 0.031577997, b: 0, a: 0}
+    - _PositionOffset: {r: 0, g: 0.024786765, b: 0, a: 0}
   m_BuildTextureStacks: []

--- a/UnityProject/Assets/Materials/WarpMaterial.mat
+++ b/UnityProject/Assets/Materials/WarpMaterial.mat
@@ -1,0 +1,115 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: WarpMaterial
+  m_Shader: {fileID: 4800000, guid: 115ad2634aa22c340a71b4dc55afb9b8, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 1
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 3000
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _FovExtendedMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _WallMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - PixelSnap: 0
+    - _BumpScale: 1
+    - _CosAmount: 0.05
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DistortionStrength: 1.02
+    - _DoubleVision: 0.01
+    - _DstBlend: 0
+    - _EffectAmount: 1
+    - _EffectAngle: 5.5
+    - _EffectRadius: 0.11
+    - _FovBlurSwitch: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.05
+    - _GlossyReflections: 1
+    - _HoleEdgeSmoothness: 0.0305
+    - _HoleSize: 0.588
+    - _Intensity: 5.5
+    - _IsPaletted: 0
+    - _LightAmount: 5
+    - _Magnitude: 0
+    - _Metallic: 0.727
+    - _Mode: 0
+    - _ObjectEdgeArtifactFix: 2.7
+    - _OcclusionStrength: 1
+    - _PaletteSize: 8
+    - _Parallax: 0.02
+    - _Pixelate: 5
+    - _Radius: 0.7
+    - _Scale: 0
+    - _Shape: 5.88
+    - _SinAmount: 0.05
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _Speed: 0.5
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _Waves: 0.25
+    - _ZWrite: 1
+    - _xPos: 0.5
+    - _yPos: 0.5
+    m_Colors:
+    - _Center: {r: 1.06, g: 0.77, b: -21.19, a: -55.9}
+    - _Color: {r: 1, g: 0, b: 0, a: 1}
+    - _Colour: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _PositionOffset: {r: 0, g: 0, b: 0, a: 0}
+  m_BuildTextureStacks: []

--- a/UnityProject/Assets/Materials/WarpMaterial.mat.meta
+++ b/UnityProject/Assets/Materials/WarpMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b76c67edad6fa1548a2790a6dd2af1ba
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Objects/Electricity/Engines/SingularityEngine/SingularityStages/Singularity.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Electricity/Engines/SingularityEngine/SingularityStages/Singularity.prefab
@@ -400,7 +400,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
-      objectReference: {fileID: 2100000, guid: c122dd7923e087c48bf08da9da455514, type: 2}
+      objectReference: {fileID: 2100000, guid: 4de36ea0be987c54d965ef5ee0f7b3bc, type: 2}
     - target: {fileID: 4197940402254186057, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
       propertyPath: m_Name

--- a/UnityProject/Assets/Prefabs/Objects/Electricity/Engines/SingularityEngine/SingularityStages/Singularity.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Electricity/Engines/SingularityEngine/SingularityStages/Singularity.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 3925721611769371617}
   - component: {fileID: 4738779574423242095}
   - component: {fileID: 1404268602364526087}
-  m_Layer: 2
+  m_Layer: 21
   m_Name: Light
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -86,7 +86,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 61930e16e81db5c43a4ecc22422a0953, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Color: {r: 0.57254905, g: 0.058823533, b: 0.24313727, a: 0.39215687}
+  Color: {r: 0.57254905, g: 0.058823533, b: 0.24313727, a: 0.5882353}
   Sprite: {fileID: 21300000, guid: 9e9f6c63bf3334c8791e01efff5c16fb, type: 3}
   SortingOrder: 0
   Material: {fileID: 2100000, guid: b7e7f24fa2e49cb48818dace424b5868, type: 2}

--- a/UnityProject/Assets/Prefabs/Objects/Electricity/Engines/SingularityEngine/SingularityStages/Singularity.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Electricity/Engines/SingularityEngine/SingularityStages/Singularity.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 3925721611769371617}
   - component: {fileID: 4738779574423242095}
   - component: {fileID: 1404268602364526087}
-  m_Layer: 21
+  m_Layer: 2
   m_Name: Light
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -92,6 +92,200 @@ MonoBehaviour:
   Material: {fileID: 2100000, guid: b7e7f24fa2e49cb48818dace424b5868, type: 2}
   LightOrigin: {x: 0, y: 0, z: 1}
   Shape: 0
+--- !u!1 &4225673206677485874
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5124450014596669819}
+  - component: {fileID: 6604085803539985251}
+  - component: {fileID: 5198684123758150572}
+  - component: {fileID: 6356715080128028321}
+  m_Layer: 1
+  m_Name: ForegroundWarpShader
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5124450014596669819
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4225673206677485874}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.5, y: 1.5, z: 1.5}
+  m_Children: []
+  m_Father: {fileID: 4692177491394706899}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!33 &6604085803539985251
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4225673206677485874}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &5198684123758150572
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4225673206677485874}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: b76c67edad6fa1548a2790a6dd2af1ba, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!64 &6356715080128028321
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4225673206677485874}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &8690972991113334663
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1917010104315098165}
+  - component: {fileID: 7405739772679748990}
+  - component: {fileID: 5759546546122504261}
+  - component: {fileID: 2967432370711235922}
+  m_Layer: 4
+  m_Name: BackgroundWarpShader
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1917010104315098165
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8690972991113334663}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.5, y: 1.5, z: 1.5}
+  m_Children: []
+  m_Father: {fileID: 4692177491394706899}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!33 &7405739772679748990
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8690972991113334663}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &5759546546122504261
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8690972991113334663}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: b76c67edad6fa1548a2790a6dd2af1ba, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!64 &2967432370711235922
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8690972991113334663}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!114 &-3154322499425992788
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -111,6 +305,8 @@ MonoBehaviour:
   maximumPoints: 3250
   pointLossRate: 4
   maxRadiation: 5000
+  WarpEffectFront: {fileID: 4225673206677485874}
+  WarpEffectBack: {fileID: 8690972991113334663}
   light: {fileID: 1404268602364526087}
   eatenSuperMatter: 0
   preventDowngrade: 0
@@ -162,7 +358,7 @@ PrefabInstance:
     - target: {fileID: 1481169419180323577, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
       propertyPath: m_SortingLayer
-      value: 12
+      value: 29
       objectReference: {fileID: 0}
     - target: {fileID: 1481169419180323577, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
@@ -172,7 +368,7 @@ PrefabInstance:
     - target: {fileID: 1481169419180323577, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
       propertyPath: m_SortingLayerID
-      value: 142874271
+      value: -2035547137
       objectReference: {fileID: 0}
     - target: {fileID: 4116897424394887774, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
@@ -182,13 +378,38 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 4116897424394887774, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
+      propertyPath: m_SortingLayer
+      value: 29
+      objectReference: {fileID: 0}
+    - target: {fileID: 4116897424394887774, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4116897424394887774, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_SortingLayerID
+      value: -2035547137
+      objectReference: {fileID: 0}
+    - target: {fileID: 4116897424394887774, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
       propertyPath: m_WasSpriteAssigned
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4116897424394887774, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: c122dd7923e087c48bf08da9da455514, type: 2}
     - target: {fileID: 4197940402254186057, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
       propertyPath: m_Name
       value: Singularity
+      objectReference: {fileID: 0}
+    - target: {fileID: 4197940402254186057, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_Layer
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4204006106222477459, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
@@ -282,6 +503,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4800765294880679425, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
+      propertyPath: customNetTransform
+      value: 
+      objectReference: {fileID: 7614721661653724171}
+    - target: {fileID: 4800765294880679425, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
       propertyPath: CurrentsortingGroup
       value: 
       objectReference: {fileID: 8053698836628426681}
@@ -289,6 +515,11 @@ PrefabInstance:
         type: 3}
       propertyPath: initialCrawlPassable
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5388634654466307187, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_Layer
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 5737521361753715499, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
@@ -382,6 +613,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 8884009795189538112}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &7614721661653724171 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1361981371736346955, guid: ebb08cf966efc084aa918bd8d9429604,
+    type: 3}
+  m_PrefabInstance: {fileID: 8884009795189538112}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4686069471335676681}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!210 &8053698836628426681 stripped
 SortingGroup:
   m_CorrespondingSourceObject: {fileID: 1481169419180323577, guid: ebb08cf966efc084aa918bd8d9429604,

--- a/UnityProject/Assets/Scripts/Core/Input System/MouseUtils.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/MouseUtils.cs
@@ -263,8 +263,7 @@ public static class MouseUtils
 		if (texPosX < 0 || texPosX < textureRect.x || texPosX >= Mathf.FloorToInt(textureRect.xMax)) return false;
 		if (texPosY < 0 || texPosY < textureRect.y || texPosY >= Mathf.FloorToInt(textureRect.yMax)) return false;
 
-		// Get pixel color
-
+		// Check to make sure texture is readable and get pixel color
 		if(texture.isReadable)
 			color = texture.GetPixel(texPosX, texPosY);
 

--- a/UnityProject/Assets/Scripts/Core/Input System/MouseUtils.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/MouseUtils.cs
@@ -264,7 +264,10 @@ public static class MouseUtils
 		if (texPosY < 0 || texPosY < textureRect.y || texPosY >= Mathf.FloorToInt(textureRect.yMax)) return false;
 
 		// Get pixel color
-		color = texture.GetPixel(texPosX, texPosY);
+
+		if(texture.isReadable)
+			color = texture.GetPixel(texPosX, texPosY);
+
 		return true;
 	}
 }

--- a/UnityProject/Assets/Scripts/Objects/Singularity.cs
+++ b/UnityProject/Assets/Scripts/Objects/Singularity.cs
@@ -58,7 +58,13 @@ namespace Objects
 		private float maxRadiation = 5000f;
 
 		[SerializeField]
-		private LightSprite light = null;
+		private GameObject WarpEffectFront;
+
+		[SerializeField]
+		private GameObject WarpEffectBack;
+
+		[SerializeField]
+		private new LightSprite light = null;
 
 		[SerializeField]
 		[Tooltip("Allows singularity to be stage 6")]
@@ -82,6 +88,9 @@ namespace Objects
 		private SpriteHandler spriteHandler;
 		private CustomNetTransform customNetTransform;
 		private int objectId;
+
+		private Material WarpEffectFrontMat;
+		private Material WarpEffectBackMat;
 
 		private int lockTimer;
 		private bool pointLock;
@@ -118,6 +127,11 @@ namespace Objects
 			spriteHandler = GetComponentInChildren<SpriteHandler>();
 			lightTransform = light.transform;
 			objectId = GetInstanceID();
+
+
+			WarpEffectFrontMat = WarpEffectFront.GetComponent<MeshRenderer>().materials[0];
+			WarpEffectBackMat = WarpEffectBack.GetComponent<MeshRenderer>().materials[0];
+
 		}
 
 		private void Start()
@@ -125,6 +139,7 @@ namespace Objects
 			if (CustomNetworkManager.IsServer == false) return;
 
 			CurrentStage = startingStage;
+		
 		}
 
 		private void OnEnable()
@@ -593,7 +608,11 @@ namespace Objects
 
 			int radius = GetRadius(newStage);
 
-			bool noObstructions = true;
+			bool noObstructions = true; 
+			Debug.Log("current stage =");
+			Debug.Log(newStage);
+
+			UpdateWarpFX(newStage);
 
 			//See whether we can move to that place, as we need to take into account our size
 			if (newStage != SingularityStages.Stage5 && newStage != SingularityStages.Stage4)
@@ -613,6 +632,54 @@ namespace Objects
 				CurrentStage = newStage;
 				UpdateVectors();
 				dynamicScale = Vector3.zero; // keyed value: don't tween; set it to 1x scale immediately
+			}
+		}
+		/// <summary>
+		/// Sets the warp effects in accordance with the correct sprite
+		/// </summary>
+		private void UpdateWarpFX(SingularityStages stage)
+		{
+			switch (stage)
+			{
+				case SingularityStages.Stage0:
+					WarpEffectFrontMat.SetFloat("_EffectRadius", 0.11f);
+					WarpEffectBackMat.SetFloat("_EffectRadius", 0.11f);
+					WarpEffectFrontMat.SetFloat("_EffectAngle", 5.5f);
+					WarpEffectBackMat.SetFloat("_EffectAngle", 5.5f);
+					break;
+				case SingularityStages.Stage1:
+					WarpEffectFrontMat.SetFloat("_EffectRadius", 0.2f);
+					WarpEffectBackMat.SetFloat("_EffectRadius", 0.2f);
+					WarpEffectFrontMat.SetFloat("_EffectAngle", 5.5f);
+					WarpEffectBackMat.SetFloat("_EffectAngle", 5.5f);
+					break;
+				case SingularityStages.Stage2:
+					WarpEffectFrontMat.SetFloat("_EffectRadius", 0.35f);
+					WarpEffectBackMat.SetFloat("_EffectRadius", 0.35f);
+					WarpEffectFrontMat.SetFloat("_EffectAngle", 6f);
+					WarpEffectBackMat.SetFloat("_EffectAngle", 6f);
+					break;
+				case SingularityStages.Stage3:
+					WarpEffectFrontMat.SetFloat("_EffectRadius", 0.55f);
+					WarpEffectBackMat.SetFloat("_EffectRadius", 0.55f);
+					WarpEffectFrontMat.SetFloat("_EffectAngle", 6.5f);
+					WarpEffectBackMat.SetFloat("_EffectAngle", 6.5f);
+					break;
+				case SingularityStages.Stage4:
+					WarpEffectFrontMat.SetFloat("_EffectRadius", 0.7f);
+					WarpEffectBackMat.SetFloat("_EffectRadius", 0.7f);
+					WarpEffectFrontMat.SetFloat("_EffectAngle", 7.0f);
+					WarpEffectBackMat.SetFloat("_EffectAngle", 7.0f);
+					break;
+				case SingularityStages.Stage5:
+					WarpEffectFrontMat.SetFloat("_EffectRadius", 0.78f);
+					WarpEffectBackMat.SetFloat("_EffectRadius", 0.78f);
+					WarpEffectFrontMat.SetFloat("_EffectAngle", 15.0f);
+					WarpEffectBackMat.SetFloat("_EffectAngle", 15.0f);
+					break;
+				default:
+					break;
+			
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/Singularity.cs
+++ b/UnityProject/Assets/Scripts/Objects/Singularity.cs
@@ -646,8 +646,8 @@ namespace Objects
 					WarpEffectBackMat.SetFloat("_EffectAngle", 6f);
 					break;
 				case SingularityStages.Stage1:
-					WarpEffectFrontMat.SetFloat("_EffectRadius", 0.08f);
-					WarpEffectBackMat.SetFloat("_EffectRadius", 0.08f);
+					WarpEffectFrontMat.SetFloat("_EffectRadius", 0.2f);
+					WarpEffectBackMat.SetFloat("_EffectRadius", 0.2f);
 					WarpEffectFrontMat.SetFloat("_EffectAngle", 7f);
 					WarpEffectBackMat.SetFloat("_EffectAngle", 7f);
 					break;

--- a/UnityProject/Assets/Scripts/Objects/Singularity.cs
+++ b/UnityProject/Assets/Scripts/Objects/Singularity.cs
@@ -637,48 +637,44 @@ namespace Objects
 		/// </summary>
 		private void UpdateWarpFX(SingularityStages stage)
 		{
+			float scaledRadius = 0f;
+			float scaledEffect = 0f;
+
 			switch (stage)
 			{
 				case SingularityStages.Stage0:
-					WarpEffectFrontMat.SetFloat("_EffectRadius", 0.06f);
-					WarpEffectBackMat.SetFloat("_EffectRadius", 0.06f);
-					WarpEffectFrontMat.SetFloat("_EffectAngle", 6f);
-					WarpEffectBackMat.SetFloat("_EffectAngle", 6f);
+					scaledRadius = 0.06f * gameObject.transform.localScale.x;
+					scaledEffect = 6f;
 					break;
 				case SingularityStages.Stage1:
-					WarpEffectFrontMat.SetFloat("_EffectRadius", 0.2f);
-					WarpEffectBackMat.SetFloat("_EffectRadius", 0.2f);
-					WarpEffectFrontMat.SetFloat("_EffectAngle", 7f);
-					WarpEffectBackMat.SetFloat("_EffectAngle", 7f);
+					scaledRadius = 0.08f * gameObject.transform.localScale.x;
+					scaledEffect = 8f;
 					break;
 				case SingularityStages.Stage2:
-					WarpEffectFrontMat.SetFloat("_EffectRadius", 0.25f);
-					WarpEffectBackMat.SetFloat("_EffectRadius", 0.25f);
-					WarpEffectFrontMat.SetFloat("_EffectAngle", 8f);
-					WarpEffectBackMat.SetFloat("_EffectAngle", 8f);
+					scaledRadius = 0.13f * gameObject.transform.localScale.x;
+					scaledEffect = 9f;
 					break;
 				case SingularityStages.Stage3:
-					WarpEffectFrontMat.SetFloat("_EffectRadius", 0.35f);
-					WarpEffectBackMat.SetFloat("_EffectRadius", 0.35f);
-					WarpEffectFrontMat.SetFloat("_EffectAngle", 8f);
-					WarpEffectBackMat.SetFloat("_EffectAngle", 8f);
+					scaledRadius = 0.25f * gameObject.transform.localScale.x;
+					scaledEffect = 10f;
 					break;
 				case SingularityStages.Stage4:
-					WarpEffectFrontMat.SetFloat("_EffectRadius", 0.7f);
-					WarpEffectBackMat.SetFloat("_EffectRadius", 0.7f);
-					WarpEffectFrontMat.SetFloat("_EffectAngle", 10f);
-					WarpEffectBackMat.SetFloat("_EffectAngle", 10f);
+					scaledRadius = 0.5f * gameObject.transform.localScale.x;
+					scaledEffect = 15f;
 					break;
 				case SingularityStages.Stage5:
-					WarpEffectFrontMat.SetFloat("_EffectRadius", 0.78f);
-					WarpEffectBackMat.SetFloat("_EffectRadius", 0.78f);
-					WarpEffectFrontMat.SetFloat("_EffectAngle", 15.0f);
-					WarpEffectBackMat.SetFloat("_EffectAngle", 15.0f);
+					scaledRadius = 0.6f * gameObject.transform.localScale.x;
+					scaledEffect = 20f;
 					break;
 				default:
 					break;
 			
 			}
+
+			WarpEffectFrontMat.SetFloat("_EffectRadius", scaledRadius);
+			WarpEffectBackMat.SetFloat("_EffectRadius", scaledRadius);
+			WarpEffectFrontMat.SetFloat("_EffectAngle", scaledEffect);
+			WarpEffectBackMat.SetFloat("_EffectAngle", scaledEffect);
 		}
 
 		private void UpdateVectors()

--- a/UnityProject/Assets/Scripts/Objects/Singularity.cs
+++ b/UnityProject/Assets/Scripts/Objects/Singularity.cs
@@ -174,6 +174,7 @@ namespace Objects
 		private void SyncCurrentStage(SingularityStages oldStage, SingularityStages newStage)
 		{
 			currentStage = newStage;
+			UpdateWarpFX(currentStage);
 		}
 
 		#endregion
@@ -229,8 +230,6 @@ namespace Objects
 
 			// will sync to clients
 			dynamicScale = GetDynamicScale();
-
-			UpdateWarpFX(CurrentStage);
 
 			//Radiation Pulse
 			var strength = Mathf.Max(((float) CurrentStage + 1) / 6 * maxRadiation, 0);

--- a/UnityProject/Assets/Scripts/Objects/Singularity.cs
+++ b/UnityProject/Assets/Scripts/Objects/Singularity.cs
@@ -608,9 +608,7 @@ namespace Objects
 
 			int radius = GetRadius(newStage);
 
-			bool noObstructions = true; 
-			Debug.Log("current stage =");
-			Debug.Log(newStage);
+			bool noObstructions = true;
 
 			UpdateWarpFX(newStage);
 
@@ -642,34 +640,34 @@ namespace Objects
 			switch (stage)
 			{
 				case SingularityStages.Stage0:
-					WarpEffectFrontMat.SetFloat("_EffectRadius", 0.11f);
-					WarpEffectBackMat.SetFloat("_EffectRadius", 0.11f);
-					WarpEffectFrontMat.SetFloat("_EffectAngle", 5.5f);
-					WarpEffectBackMat.SetFloat("_EffectAngle", 5.5f);
-					break;
-				case SingularityStages.Stage1:
-					WarpEffectFrontMat.SetFloat("_EffectRadius", 0.2f);
-					WarpEffectBackMat.SetFloat("_EffectRadius", 0.2f);
-					WarpEffectFrontMat.SetFloat("_EffectAngle", 5.5f);
-					WarpEffectBackMat.SetFloat("_EffectAngle", 5.5f);
-					break;
-				case SingularityStages.Stage2:
-					WarpEffectFrontMat.SetFloat("_EffectRadius", 0.35f);
-					WarpEffectBackMat.SetFloat("_EffectRadius", 0.35f);
+					WarpEffectFrontMat.SetFloat("_EffectRadius", 0.06f);
+					WarpEffectBackMat.SetFloat("_EffectRadius", 0.06f);
 					WarpEffectFrontMat.SetFloat("_EffectAngle", 6f);
 					WarpEffectBackMat.SetFloat("_EffectAngle", 6f);
 					break;
+				case SingularityStages.Stage1:
+					WarpEffectFrontMat.SetFloat("_EffectRadius", 0.08f);
+					WarpEffectBackMat.SetFloat("_EffectRadius", 0.08f);
+					WarpEffectFrontMat.SetFloat("_EffectAngle", 7f);
+					WarpEffectBackMat.SetFloat("_EffectAngle", 7f);
+					break;
+				case SingularityStages.Stage2:
+					WarpEffectFrontMat.SetFloat("_EffectRadius", 0.25f);
+					WarpEffectBackMat.SetFloat("_EffectRadius", 0.25f);
+					WarpEffectFrontMat.SetFloat("_EffectAngle", 8f);
+					WarpEffectBackMat.SetFloat("_EffectAngle", 8f);
+					break;
 				case SingularityStages.Stage3:
-					WarpEffectFrontMat.SetFloat("_EffectRadius", 0.55f);
-					WarpEffectBackMat.SetFloat("_EffectRadius", 0.55f);
-					WarpEffectFrontMat.SetFloat("_EffectAngle", 6.5f);
-					WarpEffectBackMat.SetFloat("_EffectAngle", 6.5f);
+					WarpEffectFrontMat.SetFloat("_EffectRadius", 0.35f);
+					WarpEffectBackMat.SetFloat("_EffectRadius", 0.35f);
+					WarpEffectFrontMat.SetFloat("_EffectAngle", 8f);
+					WarpEffectBackMat.SetFloat("_EffectAngle", 8f);
 					break;
 				case SingularityStages.Stage4:
 					WarpEffectFrontMat.SetFloat("_EffectRadius", 0.7f);
 					WarpEffectBackMat.SetFloat("_EffectRadius", 0.7f);
-					WarpEffectFrontMat.SetFloat("_EffectAngle", 7.0f);
-					WarpEffectBackMat.SetFloat("_EffectAngle", 7.0f);
+					WarpEffectFrontMat.SetFloat("_EffectAngle", 10f);
+					WarpEffectBackMat.SetFloat("_EffectAngle", 10f);
 					break;
 				case SingularityStages.Stage5:
 					WarpEffectFrontMat.SetFloat("_EffectRadius", 0.78f);

--- a/UnityProject/Assets/Scripts/Objects/Singularity.cs
+++ b/UnityProject/Assets/Scripts/Objects/Singularity.cs
@@ -168,6 +168,7 @@ namespace Objects
 			}
 
 			gameObject.transform.LeanScale(newScale, updateFrequency);
+			UpdateWarpFX(CurrentStage);
 		}
 
 		#endregion
@@ -610,7 +611,7 @@ namespace Objects
 
 			bool noObstructions = true;
 
-			UpdateWarpFX(newStage);
+		
 
 			//See whether we can move to that place, as we need to take into account our size
 			if (newStage != SingularityStages.Stage5 && newStage != SingularityStages.Stage4)
@@ -642,20 +643,20 @@ namespace Objects
 
 			switch (stage)
 			{
-				case SingularityStages.Stage0:
-					scaledRadius = 0.06f * gameObject.transform.localScale.x;
+				case SingularityStages.Stage0: 
+					scaledRadius = Mathf.Clamp(0.06f * gameObject.transform.localScale.x,0f,1f);
 					scaledEffect = 6f;
 					break;
 				case SingularityStages.Stage1:
-					scaledRadius = 0.08f * gameObject.transform.localScale.x;
+					scaledRadius = Mathf.Clamp(0.12f * gameObject.transform.localScale.x,0.15f,2f);
 					scaledEffect = 8f;
 					break;
 				case SingularityStages.Stage2:
-					scaledRadius = 0.13f * gameObject.transform.localScale.x;
+					scaledRadius = 0.22f * gameObject.transform.localScale.x;
 					scaledEffect = 9f;
 					break;
 				case SingularityStages.Stage3:
-					scaledRadius = 0.25f * gameObject.transform.localScale.x;
+					scaledRadius = 0.3f * gameObject.transform.localScale.x;
 					scaledEffect = 10f;
 					break;
 				case SingularityStages.Stage4:
@@ -663,7 +664,7 @@ namespace Objects
 					scaledEffect = 15f;
 					break;
 				case SingularityStages.Stage5:
-					scaledRadius = 0.6f * gameObject.transform.localScale.x;
+					scaledRadius = 0.7f * gameObject.transform.localScale.x;
 					scaledEffect = 20f;
 					break;
 				default:

--- a/UnityProject/Assets/Scripts/Objects/Singularity.cs
+++ b/UnityProject/Assets/Scripts/Objects/Singularity.cs
@@ -15,6 +15,8 @@ namespace Objects
 {
 	public class Singularity : NetworkBehaviour, IOnHitDetect, IExaminable
 	{
+
+		[SyncVar(hook = nameof(SyncCurrentStage))]
 		private SingularityStages currentStage = SingularityStages.Stage0;
 
 		private readonly float updateFrequency = 0.5f;
@@ -128,7 +130,6 @@ namespace Objects
 			lightTransform = light.transform;
 			objectId = GetInstanceID();
 
-
 			WarpEffectFrontMat = WarpEffectFront.GetComponent<MeshRenderer>().materials[0];
 			WarpEffectBackMat = WarpEffectBack.GetComponent<MeshRenderer>().materials[0];
 
@@ -139,7 +140,6 @@ namespace Objects
 			if (CustomNetworkManager.IsServer == false) return;
 
 			CurrentStage = startingStage;
-		
 		}
 
 		private void OnEnable()
@@ -168,7 +168,12 @@ namespace Objects
 			}
 
 			gameObject.transform.LeanScale(newScale, updateFrequency);
-			UpdateWarpFX(CurrentStage);
+			
+		}
+
+		private void SyncCurrentStage(SingularityStages oldStage, SingularityStages newStage)
+		{
+			currentStage = newStage;
 		}
 
 		#endregion
@@ -224,6 +229,8 @@ namespace Objects
 
 			// will sync to clients
 			dynamicScale = GetDynamicScale();
+
+			UpdateWarpFX(CurrentStage);
 
 			//Radiation Pulse
 			var strength = Mathf.Max(((float) CurrentStage + 1) / 6 * maxRadiation, 0);
@@ -611,8 +618,6 @@ namespace Objects
 
 			bool noObstructions = true;
 
-		
-
 			//See whether we can move to that place, as we need to take into account our size
 			if (newStage != SingularityStages.Stage5 && newStage != SingularityStages.Stage4)
 			{
@@ -632,6 +637,7 @@ namespace Objects
 				UpdateVectors();
 				dynamicScale = Vector3.zero; // keyed value: don't tween; set it to 1x scale immediately
 			}
+
 		}
 		/// <summary>
 		/// Sets the warp effects in accordance with the correct sprite
@@ -644,32 +650,31 @@ namespace Objects
 			switch (stage)
 			{
 				case SingularityStages.Stage0: 
-					scaledRadius = Mathf.Clamp(0.06f * gameObject.transform.localScale.x,0f,1f);
-					scaledEffect = 6f;
+					scaledRadius = Mathf.Clamp(0.08f * gameObject.transform.localScale.x, 0.08f,0.15f);
+					scaledEffect = 7f;
 					break;
 				case SingularityStages.Stage1:
-					scaledRadius = Mathf.Clamp(0.12f * gameObject.transform.localScale.x,0.15f,2f);
-					scaledEffect = 8f;
-					break;
-				case SingularityStages.Stage2:
-					scaledRadius = 0.22f * gameObject.transform.localScale.x;
+					scaledRadius = Mathf.Clamp(0.26f * gameObject.transform.localScale.x, 0.26f,0.35f);
 					scaledEffect = 9f;
 					break;
-				case SingularityStages.Stage3:
-					scaledRadius = 0.3f * gameObject.transform.localScale.x;
+				case SingularityStages.Stage2:
+					scaledRadius = Mathf.Clamp(0.35f * gameObject.transform.localScale.x, 0.35f, 0.6f);
 					scaledEffect = 10f;
 					break;
+				case SingularityStages.Stage3:
+					scaledRadius = Mathf.Clamp(0.55f * gameObject.transform.localScale.x, 0.55f, 0.75f);
+					scaledEffect = 12f;
+					break;
 				case SingularityStages.Stage4:
-					scaledRadius = 0.5f * gameObject.transform.localScale.x;
+					scaledRadius = Mathf.Clamp(0.75f * gameObject.transform.localScale.x, 0.75f, 0.8f);
 					scaledEffect = 15f;
 					break;
 				case SingularityStages.Stage5:
-					scaledRadius = 0.7f * gameObject.transform.localScale.x;
+					scaledRadius = Mathf.Clamp(0.8f * gameObject.transform.localScale.x, 0.8f, 1f);
 					scaledEffect = 20f;
 					break;
 				default:
 					break;
-			
 			}
 
 			WarpEffectFrontMat.SetFloat("_EffectRadius", scaledRadius);

--- a/UnityProject/Assets/Shaders/Experimental.meta
+++ b/UnityProject/Assets/Shaders/Experimental.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 15ab4fd04decdca4aa47947bf6bc3673
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Shaders/Experimental/BlackHolePrefab.prefab
+++ b/UnityProject/Assets/Shaders/Experimental/BlackHolePrefab.prefab
@@ -1,0 +1,129 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &993808236989696458
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1024663961923311431}
+  m_Layer: 0
+  m_Name: BlackHolePrefab
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1024663961923311431
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 993808236989696458}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 9059012912873960632}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7193153523012050039
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9059012912873960632}
+  - component: {fileID: 2672327121765608362}
+  - component: {fileID: 7881233886306979793}
+  - component: {fileID: 2017763758284195619}
+  m_Layer: 0
+  m_Name: Sphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9059012912873960632
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7193153523012050039}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.72734946, y: 0.32460907, z: -0.29519472}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1024663961923311431}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &2672327121765608362
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7193153523012050039}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &7881233886306979793
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7193153523012050039}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e58f1b9da440dc945bc59570380102fb, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &2017763758284195619
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7193153523012050039}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}

--- a/UnityProject/Assets/Shaders/Experimental/BlackHolePrefab.prefab.meta
+++ b/UnityProject/Assets/Shaders/Experimental/BlackHolePrefab.prefab.meta
@@ -1,7 +1,6 @@
 fileFormatVersion: 2
-guid: 2e6bf78634bc9304a879d2acc78fd6ad
-folderAsset: yes
-DefaultImporter:
+guid: d332d3cba3dc1f541a9d22b067ad7823
+PrefabImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/UnityProject/Assets/Shaders/Experimental/Blackhole.mat
+++ b/UnityProject/Assets/Shaders/Experimental/Blackhole.mat
@@ -1,0 +1,48 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Blackhole
+  m_Shader: {fileID: 4800000, guid: 3efb3c53cdc8c2f49984c35e6ea605e8, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 1
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _AlphaTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - PixelSnap: 0
+    - _DistortionStrength: 0.4
+    - _EffectAngle: 2
+    - _EffectRadius: 0.66
+    - _EnableExternalAlpha: 0
+    - _HoleEdgeSmoothness: 0.0276
+    - _HoleSize: 0.421
+    - _IsPaletted: 0
+    - _ObjectEdgeArtifactFix: 1
+    - _PaletteSize: 8
+    - _xPos: 0.5
+    - _yPos: 0.462
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _Flip: {r: 1, g: 1, b: 1, a: 1}
+    - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
+  m_BuildTextureStacks: []

--- a/UnityProject/Assets/Shaders/Experimental/Blackhole.mat.meta
+++ b/UnityProject/Assets/Shaders/Experimental/Blackhole.mat.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: e58f1b9da440dc945bc59570380102fb
+timeCreated: 1513058247
+licenseType: Pro
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Shaders/Experimental/Blackhole.shader
+++ b/UnityProject/Assets/Shaders/Experimental/Blackhole.shader
@@ -1,0 +1,77 @@
+// Shader created with Shader Forge v1.38 
+// Shader Forge (c) Neat Corporation / Joachim Holmer - http://www.acegikmo.com/shaderforge/
+// Note: Manually altering this data may prevent you from opening it in Shader Forge
+/*SF_DATA;ver:1.38;sub:START;pass:START;ps:flbk:,iptp:0,cusa:False,bamd:0,cgin:,lico:1,lgpr:1,limd:0,spmd:1,trmd:0,grmd:0,uamb:True,mssp:True,bkdf:False,hqlp:False,rprd:False,enco:False,rmgx:True,imps:True,rpth:0,vtps:0,hqsc:True,nrmq:1,nrsp:0,vomd:0,spxs:False,tesm:0,olmd:1,culm:0,bsrc:0,bdst:1,dpts:2,wrdp:False,dith:0,atcv:False,rfrpo:True,rfrpn:Refraction,coma:15,ufog:False,aust:True,igpj:True,qofs:0,qpre:3,rntp:2,fgom:False,fgoc:False,fgod:False,fgor:False,fgmd:0,fgcr:0.5,fgcg:0.5,fgcb:0.5,fgca:1,fgde:0.01,fgrn:0,fgrf:300,stcl:False,atwp:False,stva:128,stmr:255,stmw:255,stcp:6,stps:0,stfa:0,stfz:0,ofsf:0,ofsu:0,f2p0:False,fnsp:False,fnfb:False,fsmp:False;n:type:ShaderForge.SFN_Final,id:3138,x:33108,y:32711,varname:node_3138,prsc:2|emission-7854-OUT;n:type:ShaderForge.SFN_Fresnel,id:7089,x:32186,y:32534,varname:node_7089,prsc:2|EXP-8836-OUT;n:type:ShaderForge.SFN_SceneColor,id:3723,x:32755,y:32845,varname:node_3723,prsc:2|UVIN-7447-OUT;n:type:ShaderForge.SFN_ScreenPos,id:1467,x:31994,y:32845,varname:node_1467,prsc:2,sctp:2;n:type:ShaderForge.SFN_RemapRange,id:1704,x:32183,y:32845,cmnt:Distortion UVs,varname:node_1704,prsc:2,frmn:0,frmx:1,tomn:1,tomx:-1|IN-1467-UVOUT;n:type:ShaderForge.SFN_NormalVector,id:1295,x:31511,y:32684,cmnt:Old way of calculating distortion.,prsc:2,pt:False;n:type:ShaderForge.SFN_Negate,id:2161,x:31683,y:32684,varname:node_2161,prsc:2|IN-1295-OUT;n:type:ShaderForge.SFN_Transform,id:241,x:31850,y:32684,varname:node_241,prsc:2,tffrom:1,tfto:3|IN-2161-OUT;n:type:ShaderForge.SFN_ComponentMask,id:6330,x:32014,y:32684,varname:node_6330,prsc:2,cc1:0,cc2:1,cc3:-1,cc4:-1|IN-241-XYZ;n:type:ShaderForge.SFN_Add,id:7447,x:32533,y:32845,cmnt:Distort original UVs,varname:node_7447,prsc:2|A-9003-OUT,B-1579-OUT;n:type:ShaderForge.SFN_Multiply,id:9003,x:32350,y:32845,cmnt:Distortion Amount,varname:node_9003,prsc:2|A-4918-OUT,B-1704-OUT;n:type:ShaderForge.SFN_Slider,id:8836,x:31791,y:32529,ptovrint:False,ptlb:Distortion Strength,ptin:_DistortionStrength,varname:node_8836,prsc:2,glob:False,taghide:False,taghdr:False,tagprd:False,tagnsco:False,tagnrm:False,min:0,cur:3.020896,max:10;n:type:ShaderForge.SFN_OneMinus,id:3969,x:32360,y:32534,varname:node_3969,prsc:2|IN-7089-OUT;n:type:ShaderForge.SFN_Power,id:4918,x:32535,y:32534,varname:node_4918,prsc:2|VAL-3969-OUT,EXP-4038-OUT;n:type:ShaderForge.SFN_Vector1,id:4038,x:32535,y:32458,cmnt:This is an arbitrary value. You can modify it if you want.,varname:node_4038,prsc:2,v1:6;n:type:ShaderForge.SFN_Smoothstep,id:1841,x:32437,y:32133,cmnt:Create the hole mask,varname:node_1841,prsc:2|A-8502-OUT,B-8424-OUT,V-2665-OUT;n:type:ShaderForge.SFN_Slider,id:1077,x:31531,y:32109,ptovrint:False,ptlb:Hole Size,ptin:_HoleSize,varname:node_1077,prsc:2,glob:False,taghide:False,taghdr:False,tagprd:False,tagnsco:False,tagnrm:False,min:0,cur:0.7030833,max:1;n:type:ShaderForge.SFN_Add,id:8502,x:32054,y:32250,varname:node_8502,prsc:2|A-9892-OUT,B-9958-OUT;n:type:ShaderForge.SFN_Multiply,id:7854,x:32851,y:32666,cmnt:Combine the mask and distortion,varname:node_7854,prsc:2|A-1841-OUT,B-3723-RGB;n:type:ShaderForge.SFN_Relay,id:1579,x:32429,y:33001,varname:node_1579,prsc:2|IN-3973-OUT;n:type:ShaderForge.SFN_Relay,id:3973,x:32183,y:33001,varname:node_3973,prsc:2|IN-1467-UVOUT;n:type:ShaderForge.SFN_RemapRange,id:9892,x:31872,y:32107,varname:node_9892,prsc:2,frmn:0,frmx:1,tomn:1,tomx:0|IN-1077-OUT;n:type:ShaderForge.SFN_Slider,id:9958,x:31531,y:32332,ptovrint:False,ptlb:Hole Edge Smoothness,ptin:_HoleEdgeSmoothness,cmnt:Maybe this can be controlled by distance?,varname:node_9958,prsc:2,glob:False,taghide:False,taghdr:False,tagprd:False,tagnsco:False,tagnrm:False,min:0.001,cur:0.007289694,max:0.05;n:type:ShaderForge.SFN_Subtract,id:8424,x:32054,y:32107,varname:node_8424,prsc:2|A-9892-OUT,B-9958-OUT;n:type:ShaderForge.SFN_Fresnel,id:7652,x:32256,y:32281,varname:node_7652,prsc:2|EXP-7073-OUT;n:type:ShaderForge.SFN_OneMinus,id:2665,x:32437,y:32281,varname:node_2665,prsc:2|IN-7652-OUT;n:type:ShaderForge.SFN_Vector1,id:7073,x:32256,y:32407,varname:node_7073,prsc:2,v1:0.15;proporder:8836-1077-9958;pass:END;sub:END;*/
+
+Shader "MAG/Blackhole" {
+    Properties {
+        _DistortionStrength ("Distortion Strength", Range(0, 10)) = 3.020896
+        _HoleSize ("Hole Size", Range(0, 1)) = 0.7030833
+        _HoleEdgeSmoothness ("Hole Edge Smoothness", Range(0.001, 0.05)) = 0.007289694
+    }
+    SubShader {
+        Tags {
+            "IgnoreProjector"="True"
+            "Queue"="Transparent"
+            "RenderType"="Transparent"
+        }
+        GrabPass{ }
+        Pass {
+            Name "FORWARD"
+            Tags {
+                "LightMode"="ForwardBase"
+            }
+            ZWrite Off
+            
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #define UNITY_PASS_FORWARDBASE
+            #include "UnityCG.cginc"
+            #pragma multi_compile_fwdbase
+            #pragma only_renderers d3d9 d3d11 glcore gles 
+            #pragma target 3.0
+            uniform sampler2D _GrabTexture;
+            uniform float _DistortionStrength;
+            uniform float _HoleSize;
+            uniform float _HoleEdgeSmoothness;
+            struct VertexInput {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+            };
+            struct VertexOutput {
+                float4 pos : SV_POSITION;
+                float4 posWorld : TEXCOORD0;
+                float3 normalDir : TEXCOORD1;
+                float4 projPos : TEXCOORD2;
+            };
+            VertexOutput vert (VertexInput v) {
+                VertexOutput o = (VertexOutput)0;
+                o.normalDir = UnityObjectToWorldNormal(v.normal);
+                o.posWorld = mul(unity_ObjectToWorld, v.vertex);
+                o.pos = UnityObjectToClipPos( v.vertex );
+                o.projPos = ComputeScreenPos (o.pos);
+                COMPUTE_EYEDEPTH(o.projPos.z);
+                return o;
+            }
+            float4 frag(VertexOutput i) : COLOR {
+                i.normalDir = normalize(i.normalDir);
+                float3 viewDirection = normalize(_WorldSpaceCameraPos.xyz - i.posWorld.xyz);
+                float3 normalDirection = i.normalDir;
+                float2 sceneUVs = (i.projPos.xy);
+                float4 sceneColor = tex2D(_GrabTexture, sceneUVs);
+////// Lighting:
+////// Emissive:
+                float node_9892 = (_HoleSize*-1.0+1.0);
+                float node_1841 = smoothstep( (node_9892+_HoleEdgeSmoothness), (node_9892-_HoleEdgeSmoothness), (1.0 - pow(1.0-max(0,dot(normalDirection, viewDirection)),0.15)) ); // Create the hole mask
+                float node_3969 = (1.0 - pow(1.0-max(0,dot(normalDirection, viewDirection)),_DistortionStrength));
+                float3 emissive = (node_1841*tex2D( _GrabTexture, ((pow(node_3969,6.0)*(sceneUVs.rg*-2.0+1.0))+sceneUVs.rg)).rgb);
+                float3 finalColor = emissive;
+                return fixed4(finalColor,1);
+            }
+            ENDCG
+        }
+    }
+    FallBack "Diffuse"
+    CustomEditor "ShaderForgeMaterialInspector"
+}

--- a/UnityProject/Assets/Shaders/Experimental/Blackhole.shader.meta
+++ b/UnityProject/Assets/Shaders/Experimental/Blackhole.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: b520c790b2896e247a035478484001cc
+timeCreated: 1513058234
+licenseType: Pro
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Shaders/Experimental/Blackhole_GradientSmoothing.mat
+++ b/UnityProject/Assets/Shaders/Experimental/Blackhole_GradientSmoothing.mat
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Blackhole_GradientSmoothing
+  m_Shader: {fileID: 4800000, guid: 33e9bde0f3bf9284997647ac8baa44d2, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs: []
+    m_Ints: []
+    m_Floats:
+    - _DistortionStrength: 2.12
+    - _HoleEdgeSmoothness: 2.92
+    - _HoleSize: 0
+    - _ObjectEdgeArtifactFix: 8.04
+    m_Colors: []
+  m_BuildTextureStacks: []

--- a/UnityProject/Assets/Shaders/Experimental/Blackhole_GradientSmoothing.mat.meta
+++ b/UnityProject/Assets/Shaders/Experimental/Blackhole_GradientSmoothing.mat.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 4d34bcb2343ffc240b6db76ac48eb104
+timeCreated: 1513057546
+licenseType: Pro
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Shaders/Experimental/Blackhole_GradientSmoothing.shader
+++ b/UnityProject/Assets/Shaders/Experimental/Blackhole_GradientSmoothing.shader
@@ -1,0 +1,86 @@
+// Shader created with Shader Forge v1.38 
+// Shader Forge (c) Neat Corporation / Joachim Holmer - http://www.acegikmo.com/shaderforge/
+// Note: Manually altering this data may prevent you from opening it in Shader Forge
+/*SF_DATA;ver:1.38;sub:START;pass:START;ps:flbk:,iptp:0,cusa:False,bamd:0,cgin:,lico:1,lgpr:1,limd:0,spmd:1,trmd:0,grmd:0,uamb:True,mssp:True,bkdf:False,hqlp:False,rprd:False,enco:False,rmgx:True,imps:True,rpth:0,vtps:0,hqsc:True,nrmq:1,nrsp:0,vomd:0,spxs:False,tesm:0,olmd:1,culm:0,bsrc:0,bdst:1,dpts:2,wrdp:False,dith:0,atcv:False,rfrpo:True,rfrpn:Refraction,coma:15,ufog:False,aust:True,igpj:True,qofs:0,qpre:3,rntp:2,fgom:False,fgoc:False,fgod:False,fgor:False,fgmd:0,fgcr:0.5,fgcg:0.5,fgcb:0.5,fgca:1,fgde:0.01,fgrn:0,fgrf:300,stcl:False,atwp:False,stva:128,stmr:255,stmw:255,stcp:6,stps:0,stfa:0,stfz:0,ofsf:0,ofsu:0,f2p0:False,fnsp:False,fnfb:False,fsmp:False;n:type:ShaderForge.SFN_Final,id:3138,x:33108,y:32711,varname:node_3138,prsc:2|emission-7854-OUT;n:type:ShaderForge.SFN_Fresnel,id:7089,x:32186,y:32534,varname:node_7089,prsc:2|EXP-8836-OUT;n:type:ShaderForge.SFN_SceneColor,id:3723,x:32755,y:32845,varname:node_3723,prsc:2|UVIN-7447-OUT;n:type:ShaderForge.SFN_ScreenPos,id:1467,x:31994,y:32845,varname:node_1467,prsc:2,sctp:2;n:type:ShaderForge.SFN_RemapRange,id:1704,x:32183,y:32845,cmnt:Distortion UVs,varname:node_1704,prsc:2,frmn:0,frmx:1,tomn:1,tomx:-1|IN-1467-UVOUT;n:type:ShaderForge.SFN_NormalVector,id:1295,x:31511,y:32684,cmnt:Old way of calculating distortion.,prsc:2,pt:False;n:type:ShaderForge.SFN_Negate,id:2161,x:31683,y:32684,varname:node_2161,prsc:2|IN-1295-OUT;n:type:ShaderForge.SFN_Transform,id:241,x:31850,y:32684,varname:node_241,prsc:2,tffrom:1,tfto:3|IN-2161-OUT;n:type:ShaderForge.SFN_ComponentMask,id:6330,x:32014,y:32684,varname:node_6330,prsc:2,cc1:0,cc2:1,cc3:-1,cc4:-1|IN-241-XYZ;n:type:ShaderForge.SFN_Add,id:7447,x:32533,y:32845,cmnt:Distort original UVs,varname:node_7447,prsc:2|A-9003-OUT,B-1579-OUT;n:type:ShaderForge.SFN_Multiply,id:9003,x:32350,y:32845,cmnt:Distortion Amount,varname:node_9003,prsc:2|A-4918-OUT,B-1704-OUT;n:type:ShaderForge.SFN_Slider,id:8836,x:31791,y:32529,ptovrint:False,ptlb:Distortion Strength,ptin:_DistortionStrength,varname:node_8836,prsc:2,glob:False,taghide:False,taghdr:False,tagprd:False,tagnsco:False,tagnrm:False,min:0,cur:2.23301,max:10;n:type:ShaderForge.SFN_OneMinus,id:3969,x:32360,y:32534,varname:node_3969,prsc:2|IN-7089-OUT;n:type:ShaderForge.SFN_Power,id:4918,x:32535,y:32534,varname:node_4918,prsc:2|VAL-3969-OUT,EXP-4038-OUT;n:type:ShaderForge.SFN_Vector1,id:4038,x:32535,y:32458,cmnt:This is an arbitrary value. You can modify it if you want.,varname:node_4038,prsc:2,v1:6;n:type:ShaderForge.SFN_Smoothstep,id:1841,x:32055,y:32084,cmnt:Create the hole mask,varname:node_1841,prsc:2|A-8424-OUT,B-8502-OUT,V-4918-OUT;n:type:ShaderForge.SFN_Slider,id:1077,x:31336,y:31867,ptovrint:False,ptlb:Hole Size,ptin:_HoleSize,varname:node_1077,prsc:2,glob:False,taghide:False,taghdr:False,tagprd:False,tagnsco:False,tagnrm:False,min:0,cur:0.1736101,max:1;n:type:ShaderForge.SFN_Add,id:8502,x:31874,y:32084,varname:node_8502,prsc:2|A-9892-OUT,B-9136-OUT;n:type:ShaderForge.SFN_DDX,id:904,x:31346,y:32128,cmnt:This fancy stuff just ensures a smooth edge of the hole.,varname:node_904,prsc:2|IN-3969-OUT;n:type:ShaderForge.SFN_DDY,id:7995,x:31346,y:32252,varname:node_7995,prsc:2|IN-3969-OUT;n:type:ShaderForge.SFN_Append,id:3380,x:31525,y:32128,varname:node_3380,prsc:2|A-904-OUT,B-7995-OUT;n:type:ShaderForge.SFN_Length,id:2285,x:31525,y:32252,varname:node_2285,prsc:2|IN-3380-OUT;n:type:ShaderForge.SFN_Multiply,id:7854,x:32851,y:32666,cmnt:Combine the mask and distortion,varname:node_7854,prsc:2|A-4209-OUT,B-3723-RGB;n:type:ShaderForge.SFN_Relay,id:1579,x:32429,y:33001,varname:node_1579,prsc:2|IN-3973-OUT;n:type:ShaderForge.SFN_Relay,id:3973,x:32183,y:33001,varname:node_3973,prsc:2|IN-1467-UVOUT;n:type:ShaderForge.SFN_RemapRange,id:9892,x:31666,y:31867,varname:node_9892,prsc:2,frmn:0,frmx:1,tomn:1,tomx:0|IN-1077-OUT;n:type:ShaderForge.SFN_Multiply,id:9136,x:31709,y:32252,varname:node_9136,prsc:2|A-2285-OUT,B-9958-OUT;n:type:ShaderForge.SFN_Slider,id:9958,x:31555,y:32411,ptovrint:False,ptlb:Hole Edge Smoothness,ptin:_HoleEdgeSmoothness,varname:node_9958,prsc:2,glob:False,taghide:False,taghdr:False,tagprd:False,tagnsco:False,tagnrm:False,min:1,cur:4,max:4;n:type:ShaderForge.SFN_Lerp,id:4209,x:32524,y:32065,cmnt:The gradient trick also causes some artifacts around the object.,varname:node_4209,prsc:2|A-1920-OUT,B-6378-OUT,T-4539-OUT;n:type:ShaderForge.SFN_Vector4,id:6378,x:32524,y:31954,varname:node_6378,prsc:2,v1:1,v2:1,v3:1,v4:1;n:type:ShaderForge.SFN_Power,id:4539,x:32524,y:32204,cmnt:Blending them out does the trick.,varname:node_4539,prsc:2|VAL-3482-OUT,EXP-6392-OUT;n:type:ShaderForge.SFN_Fresnel,id:3482,x:32348,y:32204,varname:node_3482,prsc:2|EXP-5234-OUT;n:type:ShaderForge.SFN_Vector1,id:5234,x:32180,y:32224,varname:node_5234,prsc:2,v1:1;n:type:ShaderForge.SFN_Subtract,id:8424,x:31874,y:31956,varname:node_8424,prsc:2|A-9892-OUT,B-9136-OUT;n:type:ShaderForge.SFN_OneMinus,id:1920,x:32222,y:32084,varname:node_1920,prsc:2|IN-1841-OUT;n:type:ShaderForge.SFN_Slider,id:6392,x:32639,y:32291,ptovrint:False,ptlb:Object Edge Artifact Fix,ptin:_ObjectEdgeArtifactFix,varname:node_6392,prsc:2,glob:False,taghide:False,taghdr:False,tagprd:False,tagnsco:False,tagnrm:False,min:1,cur:1,max:10;proporder:8836-1077-9958-6392;pass:END;sub:END;*/
+
+Shader "MAG/Blackhole_GradientSmoothing" {
+    Properties {
+        _DistortionStrength ("Distortion Strength", Range(0, 10)) = 2.23301
+        _HoleSize ("Hole Size", Range(0, 1)) = 0.1736101
+        _HoleEdgeSmoothness ("Hole Edge Smoothness", Range(1, 4)) = 4
+        _ObjectEdgeArtifactFix ("Object Edge Artifact Fix", Range(1, 10)) = 1
+    }
+    SubShader {
+        Tags {
+            "IgnoreProjector"="True"
+            "Queue"="Transparent"
+            "RenderType"="Transparent"
+        }
+        GrabPass{ }
+        Pass {
+            Name "FORWARD"
+            Tags {
+                "LightMode"="ForwardBase"
+            }
+            ZWrite Off
+            
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #define UNITY_PASS_FORWARDBASE
+            #include "UnityCG.cginc"
+            #pragma multi_compile_fwdbase
+            #pragma only_renderers d3d9 d3d11 glcore gles 
+            #pragma target 3.0
+            uniform sampler2D _GrabTexture;
+            uniform float _DistortionStrength;
+            uniform float _HoleSize;
+            uniform float _HoleEdgeSmoothness;
+            uniform float _ObjectEdgeArtifactFix;
+            struct VertexInput {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+            };
+            struct VertexOutput {
+                float4 pos : SV_POSITION;
+                float4 posWorld : TEXCOORD0;
+                float3 normalDir : TEXCOORD1;
+                float4 projPos : TEXCOORD2;
+            };
+            VertexOutput vert (VertexInput v) {
+                VertexOutput o = (VertexOutput)0;
+                o.normalDir = UnityObjectToWorldNormal(v.normal);
+                o.posWorld = mul(unity_CameraInvProjection, v.vertex);
+                o.pos = UnityObjectToClipPos( v.vertex );
+                o.projPos = ComputeScreenPos (o.pos);
+                COMPUTE_EYEDEPTH(o.projPos.z);
+                return o;
+            }
+            float4 frag(VertexOutput i) : COLOR {
+                i.normalDir = normalize(i.normalDir);
+                float3 viewDirection = normalize(_WorldSpaceCameraPos.xyz - i.posWorld.xyz);
+                float3 normalDirection = i.normalDir;
+                float2 sceneUVs = (i.projPos.xy / i.projPos.w);
+                float4 sceneColor = tex2D(_GrabTexture, sceneUVs);
+////// Lighting:
+////// Emissive:
+                float node_9892 = (_HoleSize*-1.0+1.0);
+                float node_3969 = (1.0 - pow(1.0-max(0,dot(normalDirection, viewDirection)),_DistortionStrength));
+                float node_9136 = (length(float2(ddx(node_3969),ddy(node_3969)))*_HoleEdgeSmoothness);
+                float node_4918 = pow(node_3969,6.0);
+                float node_1920 = (1.0 - smoothstep( (node_9892-node_9136), (node_9892+node_9136), node_4918 ));
+                float3 emissive = (lerp(float4(node_1920,node_1920,node_1920,node_1920),
+					float4(1,1,1,1),
+					pow(pow(1.0-max(0,dot(normalDirection, viewDirection)),1.0),
+						_ObjectEdgeArtifactFix))
+					*tex2D( _GrabTexture, 
+					((node_4918*(sceneUVs.rg*-2.0+1.0))+sceneUVs.rg)).rgb).rgb;
+                float3 finalColor = emissive;
+                return fixed4(finalColor,1);
+            }
+            ENDCG
+        }
+    }
+    FallBack "Diffuse"
+    CustomEditor "ShaderForgeMaterialInspector"
+}

--- a/UnityProject/Assets/Shaders/Experimental/Blackhole_GradientSmoothing.shader.meta
+++ b/UnityProject/Assets/Shaders/Experimental/Blackhole_GradientSmoothing.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 33e9bde0f3bf9284997647ac8baa44d2
+timeCreated: 1513057758
+licenseType: Pro
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Shaders/Experimental/DisplaceShader.shader
+++ b/UnityProject/Assets/Shaders/Experimental/DisplaceShader.shader
@@ -1,0 +1,71 @@
+Shader "Unlit/DistortionParticle"
+{
+	Properties
+	{
+		_MainTex("Texture", 2D) = "white" {}
+		_Magnitude("Magnitude", Float) = 1
+	}
+		SubShader
+		{
+			Tags
+			{
+				"RenderType" = "Transparent"
+				"Queue" = "Transparent"
+			}
+			Pass
+			{
+				Blend One One
+				Cull Off
+				ZWrite Off
+				ZTest Always
+
+				CGPROGRAM
+				#pragma vertex vert
+				#pragma fragment frag			
+				#include "UnityCG.cginc"
+
+				struct appdata
+				{
+					float4 vertex : POSITION;
+					float2 uv : TEXCOORD0;
+					float4 color : COLOR;
+				};
+
+				struct v2f
+				{
+					float4 vertex : SV_POSITION;
+					float2 uv : TEXCOORD0;
+					float alpha : TEXCOORD1;
+					float4 projPos : TEXCOORD2;
+				};
+
+				sampler2D _MainTex;
+				sampler2D_float _CameraDepthTexture;
+				float4 _MainTex_ST;
+				float _Magnitude;
+
+				v2f vert(appdata v)
+				{
+					v2f o;
+
+					o.vertex = UnityObjectToClipPos(v.vertex);
+					o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+					o.alpha = v.color.a;
+					o.projPos = ComputeScreenPos(o.vertex);
+					COMPUTE_EYEDEPTH(o.projPos.z);
+
+					return o;
+				}
+
+				float2 frag(v2f i) : SV_Target
+				{
+					float sceneEyeDepth = DECODE_EYEDEPTH(tex2D(_CameraDepthTexture, i.projPos.xy / i.projPos.w));
+					float zCull = sceneEyeDepth > i.projPos.z;
+					float3 data = UnpackNormal(tex2D(_MainTex, i.uv)).xyz;
+					float scale = data.b * i.alpha * _Magnitude;
+					return data.rg * scale;// *zCull;
+				}
+				ENDCG
+			}
+		}
+}

--- a/UnityProject/Assets/Shaders/Experimental/DisplaceShader.shader.meta
+++ b/UnityProject/Assets/Shaders/Experimental/DisplaceShader.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 301bee1c3dfd5ae4cbe3f2d30570dfe6
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Shaders/Experimental/DistortingShader.shader
+++ b/UnityProject/Assets/Shaders/Experimental/DistortingShader.shader
@@ -1,0 +1,42 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
+Shader "Custom/DistortingGrabPass" {
+	Properties{
+		_Intensity("Intensity", Range(0, 50)) = 0
+	}
+		SubShader{
+		Tags { "Queue" = "Transparent" }
+			GrabPass { "_BackgroundTexture" }
+
+			Pass {
+
+				CGPROGRAM
+				#pragma vertex vert
+				#pragma fragment frag
+				#include "UnityCG.cginc"
+
+				struct v2f {
+					float4 pos : SV_POSITION;
+					float4 grabPos : TEXCOORD0;
+				};
+
+
+				half _Intensity;
+
+				v2f vert(appdata_base v) {
+					v2f o;
+					o.pos = UnityObjectToClipPos(v.vertex);
+					o.grabPos = ComputeGrabScreenPos(o.pos);
+					return o;
+				}
+				sampler2D _BackgroundTexture;
+				half4 frag(v2f i) : SV_Target{
+					i.grabPos.x += sin((_Time.y + i.grabPos.y) * _Intensity) / 20;
+					half4 color = tex2Dproj(_BackgroundTexture, UNITY_PROJ_COORD(i.grabPos));
+					return color;
+				}
+				ENDCG
+			}
+	}
+		FallBack "Diffuse"
+}

--- a/UnityProject/Assets/Shaders/Experimental/DistortingShader.shader.meta
+++ b/UnityProject/Assets/Shaders/Experimental/DistortingShader.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 22ea65839b29b8844bce3fb89255eae8
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Shaders/Experimental/NewSurfaceShader.shader
+++ b/UnityProject/Assets/Shaders/Experimental/NewSurfaceShader.shader
@@ -1,0 +1,92 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
+Shader "Custom/WaterGrab"
+{
+	Properties
+	{
+		_Colour("Colour", Color) = (1,1,1,1)
+		_MainTex("Noise text", 2D) = "bump" {}
+		_Magnitude("Magnitude", Range(0,1)) = 0.05
+	}
+
+		SubShader
+		{
+			Tags {"Queue" = "Transparent" "IgnoreProjector" = "True" "RenderType" = "Opaque"}
+			ZWrite On Lighting Off Cull Off Fog { Mode Off } Blend One Zero
+
+			GrabPass { "_GrabTexture" }
+
+			Pass
+			{
+				CGPROGRAM
+				#pragma vertex vert
+				#pragma fragment frag
+				#include "UnityCG.cginc"
+
+				sampler2D _GrabTexture;
+				fixed4 _Colour;
+				sampler2D _MainTex;
+				float  _Magnitude;
+
+				struct vin
+				{
+					float4 vertex : POSITION;
+					float4 color : COLOR;
+					float2 texcoord : TEXCOORD0;
+
+				};
+
+				struct v2f
+				{
+					float4 vertex : POSITION;
+					fixed4 color : COLOR;
+					float2 texcoord : TEXCOORD0;
+					float4 uvgrab : TEXCOORD1;
+
+				};
+
+				float4 _MainTex_ST;
+
+				// Vertex function 
+				v2f vert(vin v)
+				{
+					v2f o;
+					o.vertex = UnityObjectToClipPos(v.vertex);
+					o.color = v.color;
+					o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
+
+
+				#if UNITY_UV_STARTS_AT_TOP
+					float scale = -1.0;
+				#else
+					float scale = 1.0;
+				#endif            
+
+					o.uvgrab.xy = (float2(o.vertex.x, (o.vertex.y)* scale) + o.vertex.w) * 0.5;
+					o.uvgrab.zw = o.vertex.zw;
+
+					float4 top = UnityObjectToClipPos(float4(0, 0.5, 0, 1));
+					top.xy /= top.w;
+
+					o.uvgrab.y = 1 - (o.uvgrab.y + top.y);
+
+					return o;
+				}
+
+				// Fragment function
+				half4 frag(v2f i) : COLOR
+				{
+
+					half4 bump = tex2D(_MainTex, i.texcoord);
+					half2 distortion = UnpackNormal(bump).rg;
+
+
+					i.uvgrab.xy += distortion * _Magnitude;
+					fixed4 col = tex2D(_GrabTexture, i.uvgrab);
+					return col * _Colour;
+				}
+
+				ENDCG
+			}
+		}
+}

--- a/UnityProject/Assets/Shaders/Experimental/NewSurfaceShader.shader.meta
+++ b/UnityProject/Assets/Shaders/Experimental/NewSurfaceShader.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 43e4a6c44edce6f48b51514bfce37369
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Shaders/Experimental/PassGrabWarpShader.shader
+++ b/UnityProject/Assets/Shaders/Experimental/PassGrabWarpShader.shader
@@ -1,0 +1,93 @@
+﻿
+Shader "Custom/WarpShaderPassGrab" {
+	Properties{
+		//_MainTex("MainTex",2D) = "white"{}
+		_EffectRadius("EffectRadius", Range(0, 1)) = 0.1
+		_EffectAngle("EffectAngle", Range(0 , 4.)) = 2.0
+
+		_xPos("xPos", Range(0, 1)) = 0.5
+		_yPos("yPos", Range(0 , 1)) = .5
+	}
+	SubShader
+	{
+		Tags 
+		{
+			
+			"Queue" = "Transparent" 
+		}
+		GrabPass { "_BackgroundTexture" }
+		Pass {
+			ZWrite Off
+			//Blend SrcAlpha OneMinusSrcAlpha
+		
+			//Cull Off
+
+			CGPROGRAM
+			#pragma vertex vert
+			#pragma fragment frag
+			#include "UnityCG.cginc"
+
+
+			float2 vec2(float x,float y) { return float2(x,y); }
+
+
+			float vec(float x) { return float(x); }
+
+
+			struct v2f {
+				float4 pos : SV_POSITION;
+				//float2 uv : TEXCOORD0; //grabPos
+				float4 grabPos : TEXCOORD0;
+				//float4 uvgrab : TEXCOORD1;
+				float4 projPos : TEXCOORD2;
+			};
+
+			sampler2D _BackgroundTexture;
+
+			uniform float _EffectRadius;
+			uniform float _EffectAngle;
+
+			uniform float _xPos;
+			uniform float _yPos;
+
+			uniform half4 _MainTex_ST;
+
+			v2f vert(appdata_base v) {
+				v2f o;
+				o.pos = UnityObjectToClipPos(v.vertex);
+				//o.uv = v.uv;
+				//o.uvgrab = ComputeGrabScreenPos(v.vertex);
+				o.grabPos = ComputeGrabScreenPos(o.pos);
+
+				//o.position_uv = _MainTex_ST.xy * v.texCoord + _MainTex_ST.zw;
+
+				//o.worldPos = mul(unity_ObjectToWorld, float4(v.vertex.xyz, 1.0)).xyz;
+
+				return o;
+			}
+
+			#define PI 3.14159
+
+			half4 frag(v2f i) : SV_Target
+			{
+				float effectRadius = _EffectRadius;
+				float effectAngle = _EffectAngle * PI;
+				float2 center = vec2(_yPos, _xPos);
+				center = center == vec2(0., 0.) ? vec2(.5, .5) : center;
+
+				float2 uv = i.grabPos.xy / 1 - center;
+
+				float len = length(uv * vec2(_ScreenParams.xy.x / _ScreenParams.xy.y,1.0));
+				float angle = atan2(uv.y,uv.x) + effectAngle * smoothstep(effectRadius, 0., len);
+				float radius = length(uv);
+
+				i.grabPos.x += radius * cos(angle) + center;//i.grabpos
+				i.grabPos.y += radius * sin(angle) + center;
+				half4 color = tex2Dproj(_BackgroundTexture, UNITY_PROJ_COORD(i.grabPos));
+				//half4 splash = tex2D(_BackgroundTexture, UNITY_PROJ_COORD(i.grabPos));
+				return color ;
+			}
+			ENDCG
+		}
+	}
+}

--- a/UnityProject/Assets/Shaders/Experimental/PassGrabWarpShader.shader.meta
+++ b/UnityProject/Assets/Shaders/Experimental/PassGrabWarpShader.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 3efb3c53cdc8c2f49984c35e6ea605e8
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Shaders/Experimental/ShieldShader.shader
+++ b/UnityProject/Assets/Shaders/Experimental/ShieldShader.shader
@@ -1,0 +1,53 @@
+Shader "Custom/ShieldShader"
+{
+    Properties
+    {
+        _Color ("Color", Color) = (1,1,1,1)
+        _MainTex ("Albedo (RGB)", 2D) = "white" {}
+        _Glossiness ("Smoothness", Range(0,1)) = 0.5
+        _Metallic ("Metallic", Range(0,1)) = 0.0
+    }
+    SubShader
+    {
+        Tags { "RenderType"="Opaque" }
+        LOD 200
+
+        CGPROGRAM
+        // Physically based Standard lighting model, and enable shadows on all light types
+        #pragma surface surf Standard fullforwardshadows
+
+        // Use shader model 3.0 target, to get nicer looking lighting
+        #pragma target 3.0
+
+        sampler2D _MainTex;
+
+        struct Input
+        {
+            float2 uv_MainTex;
+        };
+
+        half _Glossiness;
+        half _Metallic;
+        fixed4 _Color;
+
+        // Add instancing support for this shader. You need to check 'Enable Instancing' on materials that use the shader.
+        // See https://docs.unity3d.com/Manual/GPUInstancing.html for more information about instancing.
+        // #pragma instancing_options assumeuniformscaling
+        UNITY_INSTANCING_BUFFER_START(Props)
+            // put more per-instance properties here
+        UNITY_INSTANCING_BUFFER_END(Props)
+
+        void surf (Input IN, inout SurfaceOutputStandard o)
+        {
+            // Albedo comes from a texture tinted by color
+            fixed4 c = tex2D (_MainTex, IN.uv_MainTex) * _Color;
+            o.Albedo = c.rgb;
+            // Metallic and smoothness come from slider variables
+            o.Metallic = _Metallic;
+            o.Smoothness = _Glossiness;
+            o.Alpha = c.a;
+        }
+        ENDCG
+    }
+    FallBack "Diffuse"
+}

--- a/UnityProject/Assets/Shaders/Experimental/ShieldShader.shader.meta
+++ b/UnityProject/Assets/Shaders/Experimental/ShieldShader.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 9421a14975e1ec2418225c259fd054e4
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Shaders/Experimental/Warp Render Texture.renderTexture
+++ b/UnityProject/Assets/Shaders/Experimental/Warp Render Texture.renderTexture
@@ -1,0 +1,38 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!84 &8400000
+RenderTexture:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Warp Render Texture
+  m_ImageContentsHash:
+    serializedVersion: 2
+    Hash: 00000000000000000000000000000000
+  m_ForcedFallbackFormat: 4
+  m_DownscaleFallback: 0
+  m_IsAlphaChannelOptional: 0
+  serializedVersion: 3
+  m_Width: 256
+  m_Height: 256
+  m_AntiAliasing: 1
+  m_MipCount: -1
+  m_DepthFormat: 2
+  m_ColorFormat: 8
+  m_MipMap: 0
+  m_GenerateMips: 1
+  m_SRGB: 0
+  m_UseDynamicScale: 0
+  m_BindMS: 0
+  m_EnableCompatibleFormat: 1
+  m_TextureSettings:
+    serializedVersion: 2
+    m_FilterMode: 1
+    m_Aniso: 0
+    m_MipBias: 0
+    m_WrapU: 1
+    m_WrapV: 1
+    m_WrapW: 1
+  m_Dimension: 2
+  m_VolumeDepth: 1

--- a/UnityProject/Assets/Shaders/Experimental/Warp Render Texture.renderTexture.meta
+++ b/UnityProject/Assets/Shaders/Experimental/Warp Render Texture.renderTexture.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2701dc3ff72dd2a42bd4e2ff98a9fbd7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 8400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Shaders/InvertShader.shader
+++ b/UnityProject/Assets/Shaders/InvertShader.shader
@@ -1,0 +1,51 @@
+Shader "Custom/GrabPassInvert"
+{
+	SubShader
+	{
+		// Draw after all opaque geometry
+		Tags { "Queue" = "Transparent" }
+
+		// Grab the screen behind the object into _BackgroundTexture
+		GrabPass
+		{
+			"_BackgroundTexture"
+		}
+
+		// Render the object with the texture generated above, and invert the colors
+		Pass
+		{
+			CGPROGRAM
+			#pragma vertex vert
+			#pragma fragment frag
+			#include "UnityCG.cginc"
+
+			struct v2f
+			{
+				float4 grabPos : TEXCOORD0;
+				float4 pos : SV_POSITION;
+			};
+
+			v2f vert(appdata_base v) {
+				v2f o;
+				// use UnityObjectToClipPos from UnityCG.cginc to calculate 
+				// the clip-space of the vertex
+				o.pos = UnityObjectToClipPos(v.vertex);
+
+				// use ComputeGrabScreenPos function from UnityCG.cginc
+				// to get the correct texture coordinate
+				o.grabPos = ComputeGrabScreenPos(o.pos);
+				return o;
+			}
+
+			sampler2D _BackgroundTexture;
+
+			half4 frag(v2f i) : SV_Target
+			{
+				half4 bgcolor = tex2Dproj(_BackgroundTexture, i.grabPos);
+				return 1 - bgcolor;
+			}
+			ENDCG
+		}
+
+	}
+}

--- a/UnityProject/Assets/Shaders/InvertShader.shader.meta
+++ b/UnityProject/Assets/Shaders/InvertShader.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 336eb822e56bde44ab5ee7f5a201851c
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Shaders/Materials.meta
+++ b/UnityProject/Assets/Shaders/Materials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2e6bf78634bc9304a879d2acc78fd6ad
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Shaders/WarpShader.shader
+++ b/UnityProject/Assets/Shaders/WarpShader.shader
@@ -1,0 +1,100 @@
+﻿// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
+
+Shader "Custom/WarpShader"
+{
+	Properties{
+		_MainTex("MainTex",2D) = "white"{}
+		_EffectRadius("EffectRadius", Range(0, 2)) = 0.11
+		_EffectAngle("EffectAngle", Range(0 , 32.)) = 5.5
+	}
+		SubShader
+		{
+		Tags
+		{
+			"IgnoreProjector" = "True"
+			"RenderType" = "Transparent"
+			"Queue" = "Transparent"
+		}
+		GrabPass { "_BackgroundTexture" }
+		Pass
+		{
+			Name "UNITY_PASS_FORWARDBASE"
+            Tags {
+                "LightMode"="ForwardBase"
+            }
+			ZWrite Off
+			ZTest Off
+			Blend SrcAlpha OneMinusSrcAlpha
+			Cull Off
+
+			CGPROGRAM
+			#pragma vertex vert
+			#pragma fragment frag
+			#define UNITY_PASS_FORWARDBASE
+			#include "UnityCG.cginc"
+			#pragma multi_compile_fwdbase
+
+			float2 vec2(float x,float y) { return float2(x,y); }
+			float2 vec2(float x) { return float2(x,x); }
+
+			float vec(float x) { return float(x); }
+
+			uniform sampler2D _BackgroundTexture;
+
+			struct VertexInput
+			{
+				float4 vertex : POSITION;
+				float2 uv:TEXCOORD0;
+				float4 tangent : TANGENT;
+				float3 normal : NORMAL;
+			};
+			struct VertexOutput
+			{
+				float4 pos : SV_POSITION;
+				float2 uv:TEXCOORD0;
+				float4 projPos : TEXCOORD2;
+			};
+			sampler2D _MainTex;
+
+			uniform float _EffectRadius;
+			uniform float _EffectAngle;
+
+			VertexOutput vert(VertexInput v)
+			{
+				VertexOutput o;
+				o.pos = UnityObjectToClipPos(v.vertex);
+				o.projPos = ComputeGrabScreenPos(o.pos);
+				o.uv = v.uv;
+
+				return o;
+			}
+
+			#define PI 3.14159
+
+			fixed4 frag(VertexOutput i) : SV_Target
+			{
+				float effectRadius = _EffectRadius;
+				float effectAngle = _EffectAngle * PI;
+
+				float2 center = vec2(0.5,0.5);
+				center = center == vec2(0., 0.) ? vec2(.5, .5) : center;
+
+				float2 uv = i.uv.xy - center;
+
+				float len = length(uv * vec2(_ScreenParams.xy.x / _ScreenParams.xy.y, _ScreenParams.xy.x / _ScreenParams.xy.y));
+				float angle = atan2(uv.y,uv.x) + (effectAngle / unity_OrthoParams.xy) * smoothstep(effectRadius, 0., len) ;
+				float radius = length(uv);
+				float2 spiralboy = vec2(radius * cos(angle), radius * sin(angle));
+				i.projPos.xy = i.projPos.xy - uv.xy;
+				i.projPos.xy += spiralboy;
+
+				fixed4 output = tex2Dproj(_BackgroundTexture, UNITY_PROJ_COORD(i.projPos) );
+		
+				return output;
+				  
+			}
+			ENDCG
+			}
+		}
+}

--- a/UnityProject/Assets/Shaders/WarpShader.shader
+++ b/UnityProject/Assets/Shaders/WarpShader.shader
@@ -1,14 +1,13 @@
-﻿// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
-
+﻿
 
 Shader "Custom/WarpShader"
 {
-	Properties{
-		_MainTex("MainTex",2D) = "white"{}
+	Properties
+	{
 		_EffectRadius("EffectRadius", Range(0, 2)) = 0.11
 		_EffectAngle("EffectAngle", Range(0 , 32.)) = 5.5
 	}
-		SubShader
+	SubShader
 		{
 		Tags
 		{
@@ -55,8 +54,6 @@ Shader "Custom/WarpShader"
 				float2 uv:TEXCOORD0;
 				float4 projPos : TEXCOORD2;
 			};
-			sampler2D _MainTex;
-
 			uniform float _EffectRadius;
 			uniform float _EffectAngle;
 
@@ -76,8 +73,8 @@ Shader "Custom/WarpShader"
 			{
 				float effectRadius = _EffectRadius;
 				float effectAngle = _EffectAngle * PI;
-
 				float2 center = vec2(0.5,0.5);
+
 				center = center == vec2(0., 0.) ? vec2(.5, .5) : center;
 
 				float2 uv = i.uv.xy - center;
@@ -85,14 +82,13 @@ Shader "Custom/WarpShader"
 				float len = length(uv * vec2(_ScreenParams.xy.x / _ScreenParams.xy.y, _ScreenParams.xy.x / _ScreenParams.xy.y));
 				float angle = atan2(uv.y,uv.x) + (effectAngle / unity_OrthoParams.xy) * smoothstep(effectRadius, 0., len) ;
 				float radius = length(uv);
-				float2 spiralboy = vec2(radius * cos(angle), radius * sin(angle));
+				float2 spiral = vec2(radius * cos(angle), radius * sin(angle));
 				i.projPos.xy = i.projPos.xy - uv.xy;
-				i.projPos.xy += spiralboy;
+				i.projPos.xy += spiral;
 
 				fixed4 output = tex2Dproj(_BackgroundTexture, UNITY_PROJ_COORD(i.projPos) );
 		
 				return output;
-				  
 			}
 			ENDCG
 			}

--- a/UnityProject/Assets/Shaders/WarpShader.shader.meta
+++ b/UnityProject/Assets/Shaders/WarpShader.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 115ad2634aa22c340a71b4dc55afb9b8
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
This adds a "warp" effect around the singularity using a grabpass shader on the prefab. This is to make the singularity look like its really beanding space time and has the nice effect of objects getting sucked in! 
![image](https://user-images.githubusercontent.com/4888377/144867018-1da7c1df-e2b7-4ca1-9170-915117516b4a.png)


### Notes:
The Singularity has 2 shaders on it. One applies to the "lit" layers and the other only applies on the water or stars layer.
Added a check to mouse utils to make sure the texture can be read. 
Added some other WIP shaders under shaders/experimental. These are not used anywhere but are being worked on. 
Effects may need to be tweaked as we get some user feedback.

### Changelog:
CL: [Improvement] Singularity now looks like its bending space time using shaders! 
