### PR TITLE
Fixes admin chat disconnecting admins

### DIFF
--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/AdminToAdminChat.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/AdminToAdminChat.cs
@@ -66,11 +66,15 @@ namespace AdminTools
 				return;
 			}
 
-			AdminChatUpdate update = new AdminChatUpdate
+			foreach (var adminChatChunk in serverAdminChatLogs.ToList().Chunk(100))
 			{
-				messages = serverAdminChatLogs
-			};
-			AdminChatUpdateMessage.SendLogUpdateToAdmin(requestee, update);
+				AdminChatUpdate update = new AdminChatUpdate
+				{
+					messages = adminChatChunk.ToList()
+				};
+				AdminChatUpdateMessage.SendLogUpdateToAdmin(requestee, update);
+			}
+
 		}
 
 		private void ClientGetUnreadAdminPlayerMessages()


### PR DESCRIPTION
### Purpose
Fixes #7885
CL: [Fix] Fixes admin panel disconnecting players
Large updates of admin chat will now be sent through different messages to avoid overloading mirror.
