### PR TITLE
Fixes eating after surgery

### DIFF
--- a/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPartSurgery.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPartSurgery.cs
@@ -11,12 +11,12 @@ namespace HealthV2
 		public List<SurgeryProcedureBase> SurgeryProcedureBase = new List<SurgeryProcedureBase>();
 
 
-		public virtual void SuccessfulProcedure(PositionalHandApply interaction, Dissectible.PresentProcedure PresentProcedure)
+		public virtual void SuccessfulProcedure(HandApply interaction, Dissectible.PresentProcedure PresentProcedure)
 		{
 			//Do you whatever you would like
 		}
 
-		public virtual void UnsuccessfulStep(PositionalHandApply interaction, Dissectible.PresentProcedure PresentProcedure)
+		public virtual void UnsuccessfulStep(HandApply interaction, Dissectible.PresentProcedure PresentProcedure)
 		{
 			//DO dmg
 			//Do you whatever you would like

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Dissectible.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Dissectible.cs
@@ -5,8 +5,8 @@ using UnityEngine;
 
 namespace HealthV2
 {
-	public class Dissectible : NetworkBehaviour, IClientInteractable<PositionalHandApply>,
-		ICheckedInteractable<PositionalHandApply>
+	public class Dissectible : NetworkBehaviour, IClientInteractable<HandApply>,
+		ICheckedInteractable<HandApply>
 	{
 		public LivingHealthMasterBase LivingHealthMasterBase;
 
@@ -61,7 +61,7 @@ namespace HealthV2
 			InitiateSurgeryItemTraits = new List<ItemTrait>(); //Make sure to include implantable stuff
 
 
-		public bool WillInteract(PositionalHandApply interaction, NetworkSide side)
+		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
 			if (interaction.Intent != Intent.Help) return false; //TODO problem with surgery in Progress and Trying to use something on help content on them
 			if (DefaultWillInteract.Default(interaction, side) == false) return false;
@@ -74,7 +74,7 @@ namespace HealthV2
 		}
 
 
-		public void ServerPerformInteraction(PositionalHandApply interaction)
+		public void ServerPerformInteraction(HandApply interaction)
 		{
 			if (ProcedureInProgress)
 			{
@@ -82,7 +82,7 @@ namespace HealthV2
 			}
 		}
 
-		public bool Interact(PositionalHandApply interaction)
+		public bool Interact(HandApply interaction)
 		{
 			if (DefaultWillInteract.Default(interaction, NetworkSide.Client) == false) return false;
 			//**Client**
@@ -327,11 +327,11 @@ namespace HealthV2
 			public BodyPart PreviousBodyPart;
 
 
-			public PositionalHandApply Stored;
+			public HandApply Stored;
 			public SurgeryStep ThisSurgeryStep;
 
 
-			public void TryTool(PositionalHandApply interaction)
+			public void TryTool(HandApply interaction)
 			{
 				Stored = interaction;
 				ThisSurgeryStep = null;

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Procedures/AffectHealthProcedure.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Procedures/AffectHealthProcedure.cs
@@ -15,7 +15,7 @@ namespace HealthV2
 
 		public AttackType FailAttackType = AttackType.Melee;
 
-		public override void FinnishSurgeryProcedure(BodyPart OnBodyPart, PositionalHandApply interaction,
+		public override void FinnishSurgeryProcedure(BodyPart OnBodyPart, HandApply interaction,
 			Dissectible.PresentProcedure PresentProcedure)
 		{
 			if (interaction.HandSlot.Item != null && interaction.HandSlot.Item.GetComponent<ItemAttributesV2>().HasTrait(RequiredTrait))
@@ -33,7 +33,7 @@ namespace HealthV2
 			}
 		}
 
-		public override void UnsuccessfulStep(BodyPart OnBodyPart, PositionalHandApply interaction,
+		public override void UnsuccessfulStep(BodyPart OnBodyPart, HandApply interaction,
 			Dissectible.PresentProcedure PresentProcedure)
 		{
 			OnBodyPart.TakeDamage(interaction.UsedObject,HeelStrength*0.1f,FailAttackType,Affects);

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Procedures/CloseProcedure.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Procedures/CloseProcedure.cs
@@ -7,7 +7,7 @@ namespace HealthV2
 	[CreateAssetMenu(fileName = "CloseProcedure", menuName = "ScriptableObjects/Surgery/CloseProcedure")]
 	public class CloseProcedure : SurgeryProcedureBase
 	{
-		public override void FinnishSurgeryProcedure(BodyPart OnBodyPart, PositionalHandApply interaction,
+		public override void FinnishSurgeryProcedure(BodyPart OnBodyPart, HandApply interaction,
 			Dissectible.PresentProcedure PresentProcedure)
 		{
 			base.FinnishSurgeryProcedure(OnBodyPart, interaction, PresentProcedure);
@@ -24,7 +24,7 @@ namespace HealthV2
 			}
 		}
 
-		public override void UnsuccessfulStep(BodyPart OnBodyPart, PositionalHandApply interaction,
+		public override void UnsuccessfulStep(BodyPart OnBodyPart, HandApply interaction,
 			Dissectible.PresentProcedure PresentProcedure)
 		{
 			base.UnsuccessfulStep(OnBodyPart, interaction,PresentProcedure );

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Procedures/ImplantProcedure.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Procedures/ImplantProcedure.cs
@@ -12,7 +12,7 @@ namespace HealthV2
 		public ItemTrait RequiredImplantTrait;
 
 
-		public override void FinnishSurgeryProcedure(BodyPart OnBodyPart, PositionalHandApply interaction,
+		public override void FinnishSurgeryProcedure(BodyPart OnBodyPart, HandApply interaction,
 			Dissectible.PresentProcedure PresentProcedure)
 		{
 			base.FinnishSurgeryProcedure(OnBodyPart, interaction, PresentProcedure);

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Procedures/OpenProcedure.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Procedures/OpenProcedure.cs
@@ -7,7 +7,7 @@ namespace HealthV2
 	[CreateAssetMenu(fileName = "OpenProcedure", menuName = "ScriptableObjects/Surgery/OpenProcedure")]
 	public class OpenProcedure : SurgeryProcedureBase
 	{
-		public override void FinnishSurgeryProcedure(BodyPart OnBodyPart, PositionalHandApply interaction,
+		public override void FinnishSurgeryProcedure(BodyPart OnBodyPart, HandApply interaction,
 			Dissectible.PresentProcedure PresentProcedure)
 		{
 			base.FinnishSurgeryProcedure(OnBodyPart, interaction, PresentProcedure);
@@ -15,7 +15,7 @@ namespace HealthV2
 
 		}
 
-		public override void UnsuccessfulStep(BodyPart OnBodyPart, PositionalHandApply interaction,
+		public override void UnsuccessfulStep(BodyPart OnBodyPart, HandApply interaction,
 			Dissectible.PresentProcedure PresentProcedure)
 		{
 			base.UnsuccessfulStep(OnBodyPart, interaction,PresentProcedure );

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Procedures/RemovalProcedure.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Procedures/RemovalProcedure.cs
@@ -7,7 +7,7 @@ namespace HealthV2
 	[CreateAssetMenu(fileName = "RemovalProcedure", menuName = "ScriptableObjects/Surgery/RemovalProcedure")]
 	public class RemovalProcedure : SurgeryProcedureBase
 	{
-		public override void FinnishSurgeryProcedure(BodyPart OnBodyPart, PositionalHandApply interaction,
+		public override void FinnishSurgeryProcedure(BodyPart OnBodyPart, HandApply interaction,
 			Dissectible.PresentProcedure PresentProcedure)
 		{
 			base.FinnishSurgeryProcedure(OnBodyPart, interaction, PresentProcedure);

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/SurgeryProcedureBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/SurgeryProcedureBase.cs
@@ -13,12 +13,12 @@ namespace HealthV2
 
 		public List<SurgeryStep> SurgerySteps = new List<SurgeryStep>();
 
-		public virtual void FinnishSurgeryProcedure(BodyPart OnBodyPart, PositionalHandApply interaction,
+		public virtual void FinnishSurgeryProcedure(BodyPart OnBodyPart, HandApply interaction,
 			Dissectible.PresentProcedure PresentProcedure)
 		{
 		}
 
-		public virtual void UnsuccessfulStep(BodyPart OnBodyPart, PositionalHandApply interaction,
+		public virtual void UnsuccessfulStep(BodyPart OnBodyPart, HandApply interaction,
 			Dissectible.PresentProcedure PresentProcedure)
 		{
 		}

--- a/UnityProject/Assets/Scripts/Items/Food/Consumable.cs
+++ b/UnityProject/Assets/Scripts/Items/Food/Consumable.cs
@@ -36,7 +36,7 @@ public abstract class Consumable : MonoBehaviour, ICheckedInteractable<HandApply
 		var Dissectible = interaction?.TargetObject.OrNull()?.GetComponent<Dissectible>();
 		if (Dissectible != null)
 		{
-			if (Dissectible.GetBodyPartIsopen)
+			if (Dissectible.GetBodyPartIsopen && Dissectible.WillInteract(interaction, side))
 			{
 				return false;
 			}


### PR DESCRIPTION
### Purpose
Fixes #7742
CL: [Fix] Fixes food not being able to be consumed by players who went under surgery
Changes the surgery interaction from PositionalHandApply to HandApply