### PR TITLE
#7258 Fix

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -368,7 +368,7 @@ public partial class GameManager : MonoBehaviour, IInitialise
 		else if (counting)
 		{
 			stationTime = stationTime.AddSeconds(Time.deltaTime);
-			roundTimer.text = stationTime.ToString("HH:mm");
+			roundTimer.text = stationTime.ToString("HH:mm:ss");
 		}
 
 		if(CustomNetworkManager.Instance._isServer == false) return;

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/EventsManagerPage.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/EventsManagerPage.cs
@@ -84,13 +84,15 @@ public class EventsManagerPage : AdminPage
 			}
 
 			AdminCommandsManager.Instance.CmdTriggerGameEvent(index, isFakeToggle.isOn, announceToggle.isOn, eventType, null);
-			
 		}
-		else 
-		{
-			// Tells all admins to wait X seconds, this is based on round time so if the server stutters loading an event it will take it into account effectivly stopping any sort of spam.
-			Chat.AddExamineMsgToClient($"Please wait {Mathf.Round((float)stationTimeSnapshot.Subtract(stationTimeHolder).TotalSeconds)} seconds before trying to generate another event.");
-		}
+
+		if (stationTimeHolder < (stationTimeSnapshot))
+   		{
+            // Tells all admins to wait X seconds, this is based on round time so if the server stutters loading an event it 
+            // will take it into account effectivly stopping any sort of spam.
+			Chat.AddExamineMsgToClient($"Please wait{Mathf.Round((float)stationTimeSnapshot.Subtract(stationTimeHolder).TotalSeconds)} seconds before trying to generate another event.");
+            return;
+    	}
 	}
 
 	public void ToggleRandomEvents()

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/EventsManagerPage.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/EventsManagerPage.cs
@@ -90,7 +90,7 @@ public class EventsManagerPage : AdminPage
    		{
             // Tells all admins to wait X seconds, this is based on round time so if the server stutters loading an event it 
             // will take it into account effectivly stopping any sort of spam.
-			Chat.AddExamineMsgToClient($"Please wait{Mathf.Round((float)stationTimeSnapshot.Subtract(stationTimeHolder).TotalSeconds)} seconds before trying to generate another event.");
+			Chat.AddExamineMsgToClient($"Please wait {Mathf.Round((float)stationTimeSnapshot.Subtract(stationTimeHolder).TotalSeconds)} seconds before trying to generate another event.");
             return;
     	}
 	}

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/EventsManagerPage.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/EventsManagerPage.cs
@@ -49,43 +49,6 @@ public class EventsManagerPage : AdminPage
 		
 		stationTimeHolder = GameManager.Instance.stationTime;
 
-		if (stationTimeHolder >= (stationTimeSnapshot))
-		{
-			stationTimeSnapshot = stationTimeHolder.AddSeconds(5);
-
-			if (!InGameEventType.TryParse(eventTypeDropDown.options[eventTypeDropDown.value].text,
-				out InGameEventType eventType)) return;
-
-			var index = nextDropDown.value;
-
-			if (eventType == InGameEventType.Random)
-			{
-				index = 0;
-			}
-
-			if (index != 0) // Index 0 (Random Event) will never have a parameter page
-			{
-				// Instead of triggering the event right away, if we have an extra parameter page, we show it
-				List<EventScriptBase> listEvents = InGameEventsManager.Instance.GetListFromEnum(eventType);
-				if (listEvents[index - 1].parametersPageType != ParametersPageType.None)
-				{
-					GameObject parameterPage = eventsParametersPages.eventParameterPages
-						.FirstOrDefault(p => p.ParametersPageType == listEvents[index - 1].parametersPageType)
-						.ParameterPage;
-
-					if (parameterPage)
-					{
-						parameterPage.SetActive(true);
-						parameterPage.GetComponent<SicknessParametersPage>().SetBasicEventParameters(index,
-							isFakeToggle.isOn, announceToggle.isOn, InGameEventType.Fun);
-						return;
-					}
-				}
-			}
-
-			AdminCommandsManager.Instance.CmdTriggerGameEvent(index, isFakeToggle.isOn, announceToggle.isOn, eventType, null);
-		}
-
 		if (stationTimeHolder < (stationTimeSnapshot))
    		{
             // Tells all admins to wait X seconds, this is based on round time so if the server stutters loading an event it 
@@ -93,6 +56,39 @@ public class EventsManagerPage : AdminPage
 			Chat.AddExamineMsgToClient($"Please wait {Mathf.Round((float)stationTimeSnapshot.Subtract(stationTimeHolder).TotalSeconds)} seconds before trying to generate another event.");
             return;
     	}
+
+		stationTimeSnapshot = stationTimeHolder.AddSeconds(5);
+
+		if (!InGameEventType.TryParse(eventTypeDropDown.options[eventTypeDropDown.value].text,
+			out InGameEventType eventType)) return;
+
+		var index = nextDropDown.value;
+
+		if (eventType == InGameEventType.Random)
+		{
+			index = 0;
+		}
+
+		if (index != 0) // Index 0 (Random Event) will never have a parameter page
+		{
+				// Instead of triggering the event right away, if we have an extra parameter page, we show it
+			List<EventScriptBase> listEvents = InGameEventsManager.Instance.GetListFromEnum(eventType);
+			if (listEvents[index - 1].parametersPageType != ParametersPageType.None)
+			{
+				GameObject parameterPage = eventsParametersPages.eventParameterPages
+					.FirstOrDefault(p => p.ParametersPageType == listEvents[index - 1].parametersPageType)
+					.ParameterPage;
+				if (parameterPage)
+				{
+					parameterPage.SetActive(true);
+					parameterPage.GetComponent<SicknessParametersPage>().SetBasicEventParameters(index,
+						isFakeToggle.isOn, announceToggle.isOn, InGameEventType.Fun);
+					return;
+				}
+			}
+		}
+
+		AdminCommandsManager.Instance.CmdTriggerGameEvent(index, isFakeToggle.isOn, announceToggle.isOn, eventType, null);
 	}
 
 	public void ToggleRandomEvents()


### PR DESCRIPTION
Added Timer to stop spam on event creation.

Also Added Seconds to GameManager Timer, This would allow Players to properly time bombs and allows for finer tuning of functions.

### Notes:
closes #7258

CL: [Fix] added 5 second cooldown to admin trigger event button