### PR TITLE
Bunch of fixes and QoL changes for bombs, mousetraps, and SBRs

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/C4.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/C4.prefab
@@ -98,6 +98,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   soundDelayTime: 0
   soundMinimumPitchVariance: 1
   soundMaximumPitchVariance: 1
@@ -174,6 +175,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   damageDeflection: 0
   Armor:
     Melee: 0
@@ -239,6 +241,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   hitSoundSettings: 0
   inventoryMoveSound:
     SetLoadSetting: 0
@@ -247,6 +250,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   inventoryRemoveSound:
     SetLoadSetting: 0
     AssetAddress: null
@@ -254,6 +258,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
@@ -292,12 +297,12 @@ MonoBehaviour:
   Emitter: {fileID: 0}
   DelayTime: 3
   EncryptionData: {fileID: 0}
+  ListenToEncryptedData: 0
   explosiveType: 0
   detonateImmediatelyOnSignal: 0
   timeToDetonate: 10
   minimumTimeToDetonate: 10
-  explosionPrefab: {fileID: 2540564744460004555, guid: 311ad0ee31c0a654487179079dd48cdd,
-    type: 3}
+  explosiveStrength: 1000
   activeSpriteSO: {fileID: 11400000, guid: 60942022f971e0440a63456ee27fc478, type: 2}
   progressTime: 3
   spriteHandler: {fileID: 5258580723283386321}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/X4.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/X4.prefab
@@ -20,6 +20,7 @@ GameObject:
   - component: {fileID: 1944057801525881069}
   - component: {fileID: -7063633880587810702}
   - component: {fileID: 5745720402341052027}
+  - component: {fileID: 53286352597045704}
   m_Layer: 0
   m_Name: X4
   m_TagString: Untagged
@@ -305,7 +306,7 @@ MonoBehaviour:
   activeSpriteSO: {fileID: 11400000, guid: 6eedd99a9dc83864f808d929d4e9bd36, type: 2}
   progressTime: 3
   spriteHandler: {fileID: 5258580723283386321}
-  scaleSync: {fileID: 229608321056612877}
+  scaleSync: {fileID: 53286352597045704}
   GUI: {fileID: 0}
 --- !u!210 &-7063633880587810702
 SortingGroup:
@@ -331,6 +332,20 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   NetTabType: 46
+--- !u!114 &53286352597045704
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 896716891640034833}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 14a67aad38c961f45ad1cb44ac3b1f07, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
 --- !u!1 &3204498178074362964
 GameObject:
   m_ObjectHideFlags: 0
@@ -342,8 +357,6 @@ GameObject:
   - component: {fileID: 3977958541996598942}
   - component: {fileID: 5258580723283386321}
   - component: {fileID: 1244029867708952306}
-  - component: {fileID: 3542653989710191825}
-  - component: {fileID: 229608321056612877}
   m_Layer: 0
   m_Name: SpriteHandler
   m_TagString: Untagged
@@ -441,34 +454,3 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!114 &3542653989710191825
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3204498178074362964}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  sceneId: 0
-  serverOnly: 0
-  visible: 0
-  m_AssetId: 9ca978c567f2e5c4bb8a6be3190717f7
-  hasSpawned: 0
---- !u!114 &229608321056612877
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3204498178074362964}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 14a67aad38c961f45ad1cb44ac3b1f07, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/X4.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/X4.prefab
@@ -98,6 +98,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   soundDelayTime: 0
   soundMinimumPitchVariance: 1
   soundMaximumPitchVariance: 1
@@ -174,6 +175,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   damageDeflection: 0
   Armor:
     Melee: 0
@@ -238,7 +240,24 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   hitSoundSettings: 0
+  inventoryMoveSound:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
+  inventoryRemoveSound:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
@@ -276,12 +295,13 @@ MonoBehaviour:
   Frequency: 122
   Emitter: {fileID: 0}
   DelayTime: 3
+  EncryptionData: {fileID: 0}
+  ListenToEncryptedData: 0
   explosiveType: 1
   detonateImmediatelyOnSignal: 0
   timeToDetonate: 10
   minimumTimeToDetonate: 1
-  explosionPrefab: {fileID: 2540564744460004555, guid: 8fb8560e73de12548838a05b8ffcfcb1,
-    type: 3}
+  explosiveStrength: 7000
   activeSpriteSO: {fileID: 11400000, guid: 6eedd99a9dc83864f808d929d4e9bd36, type: 2}
   progressTime: 3
   spriteHandler: {fileID: 5258580723283386321}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/X4.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/X4.prefab
@@ -305,6 +305,7 @@ MonoBehaviour:
   activeSpriteSO: {fileID: 11400000, guid: 6eedd99a9dc83864f808d929d4e9bd36, type: 2}
   progressTime: 3
   spriteHandler: {fileID: 5258580723283386321}
+  scaleSync: {fileID: 229608321056612877}
   GUI: {fileID: 0}
 --- !u!210 &-7063633880587810702
 SortingGroup:
@@ -341,6 +342,8 @@ GameObject:
   - component: {fileID: 3977958541996598942}
   - component: {fileID: 5258580723283386321}
   - component: {fileID: 1244029867708952306}
+  - component: {fileID: 3542653989710191825}
+  - component: {fileID: 229608321056612877}
   m_Layer: 0
   m_Name: SpriteHandler
   m_TagString: Untagged
@@ -438,3 +441,34 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &3542653989710191825
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3204498178074362964}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sceneId: 0
+  serverOnly: 0
+  visible: 0
+  m_AssetId: 9ca978c567f2e5c4bb8a6be3190717f7
+  hasSpawned: 0
+--- !u!114 &229608321056612877
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3204498178074362964}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 14a67aad38c961f45ad1cb44ac3b1f07, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabExplosive.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabExplosive.prefab
@@ -286,7 +286,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Hidden: 0
-  isPopOut: 1
+  isPopOut: 0
   Type: 46
   OnTabClosed:
     m_PersistentCalls:

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabFrequencyChanger.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabFrequencyChanger.prefab
@@ -29,7 +29,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 2594141318911464363}
+  - {fileID: 7276524173429247799}
   - {fileID: 3576941210312781497}
   m_Father: {fileID: 5760683192651201408}
   m_RootOrder: 0
@@ -302,6 +302,162 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1473014961565763794
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7276524173429247799}
+  - component: {fileID: 4737123495008601157}
+  - component: {fileID: 6242177477219099651}
+  m_Layer: 5
+  m_Name: FreqTextInput
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7276524173429247799
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1473014961565763794}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7804043847194677182}
+  m_Father: {fileID: 6519134028964616534}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.4932, y: 14.9283}
+  m_SizeDelta: {x: 297.1824, y: 59.8567}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4737123495008601157
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1473014961565763794}
+  m_CullTransparentMesh: 1
+--- !u!114 &6242177477219099651
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1473014961565763794}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2da0c512f12947e489f739169773d7ca, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_TextViewport: {fileID: 7804043847194677182}
+  m_TextComponent: {fileID: 2653064686013590470}
+  m_Placeholder: {fileID: 5679093329978905707}
+  m_VerticalScrollbar: {fileID: 0}
+  m_VerticalScrollbarEventHandler: {fileID: 0}
+  m_LayoutGroup: {fileID: 0}
+  m_ScrollSensitivity: 1
+  m_ContentType: 0
+  m_InputType: 0
+  m_AsteriskChar: 42
+  m_KeyboardType: 0
+  m_LineType: 0
+  m_HideMobileInput: 0
+  m_HideSoftKeyboard: 0
+  m_CharacterValidation: 0
+  m_RegexValue: 
+  m_GlobalPointSize: 14
+  m_CharacterLimit: 0
+  m_OnEndEdit:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5071671375371874642}
+        m_TargetAssemblyTypeName: UI.Objects.Telecomms.GUI_FrequencyChanger, Assets
+        m_MethodName: UpdateFrequencyFromInput
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  m_OnSubmit:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnSelect:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnDeselect:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnTextSelection:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnEndTextSelection:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnTouchScreenKeyboardStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_CaretColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_CustomCaretColor: 0
+  m_SelectionColor: {r: 0.65882355, g: 0.80784315, b: 1, a: 0.7529412}
+  m_Text: 122.5
+  m_CaretBlinkRate: 0.85
+  m_CaretWidth: 1
+  m_ReadOnly: 0
+  m_RichText: 1
+  m_GlobalFontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_OnFocusSelectAll: 1
+  m_ResetOnDeActivation: 1
+  m_RestoreOriginalTextOnEscape: 1
+  m_isRichTextEditingAllowed: 0
+  m_LineLimit: 0
+  m_InputValidator: {fileID: 0}
 --- !u!1 &1867839732942193293
 GameObject:
   m_ObjectHideFlags: 0
@@ -748,6 +904,141 @@ RectTransform:
   m_AnchoredPosition: {x: -5, y: 0}
   m_SizeDelta: {x: -20, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &3820745854862398299
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3639707458692270146}
+  - component: {fileID: 6058045789710734622}
+  - component: {fileID: 2653064686013590470}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3639707458692270146
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3820745854862398299}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7804043847194677182}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 2.6369, y: -12.733}
+  m_SizeDelta: {x: 5.2738, y: -9.826}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6058045789710734622
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3820745854862398299}
+  m_CullTransparentMesh: 1
+--- !u!114 &2653064686013590470
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3820745854862398299}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "122.5\u200B"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ecdcc6f0b368fde97adf0f4fe5884058, type: 2}
+  m_sharedMaterial: {fileID: -7227450847074856521, guid: ecdcc6f0b368fde97adf0f4fe5884058,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 37
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 1
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &4066055820962452428
 GameObject:
   m_ObjectHideFlags: 0
@@ -1162,7 +1453,7 @@ MonoBehaviour:
   OnTabOpened:
     m_PersistentCalls:
       m_Calls: []
-  freuquencyLabel: {fileID: 872893966275547795}
+  freuquencyLabel: {fileID: 6242177477219099651}
   frequencySlider: {fileID: 2468975341211061643}
   radioPowerToggle: {fileID: 2119414084431017395}
   broadcastModeToggle: {fileID: 6371760926059458484}
@@ -1242,7 +1533,7 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!1 &9047008419074859406
+--- !u!1 &8901051738967536340
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1250,51 +1541,52 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2594141318911464363}
-  - component: {fileID: 1480498353876151014}
-  - component: {fileID: 872893966275547795}
+  - component: {fileID: 4830945601085343701}
+  - component: {fileID: 953858525106607335}
+  - component: {fileID: 5679093329978905707}
+  - component: {fileID: 626941126331541628}
   m_Layer: 5
-  m_Name: FrequancyText
+  m_Name: Placeholder
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &2594141318911464363
+--- !u!224 &4830945601085343701
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9047008419074859406}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_GameObject: {fileID: 8901051738967536340}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 6519134028964616534}
+  m_Father: {fileID: 7804043847194677182}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 6.201538, y: 0}
-  m_SizeDelta: {x: 475.0012, y: 40.22}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0.054901123, y: -3.9099998}
+  m_SizeDelta: {x: 10.438, y: 7.82}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &1480498353876151014
+--- !u!222 &953858525106607335
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9047008419074859406}
+  m_GameObject: {fileID: 8901051738967536340}
   m_CullTransparentMesh: 1
---- !u!114 &872893966275547795
+--- !u!114 &5679093329978905707
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9047008419074859406}
-  m_Enabled: 1
+  m_GameObject: {fileID: 8901051738967536340}
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
@@ -1307,18 +1599,17 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 122.3Hz
+  m_text: 
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: db7a4906cad9d92448547ae6ad6498d8, type: 2}
-  m_sharedMaterial: {fileID: 8513864515037932874, guid: db7a4906cad9d92448547ae6ad6498d8,
-    type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+    rgba: 2150773298
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 0.5}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -1335,15 +1626,15 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 36
-  m_fontSizeBase: 36
+  m_fontSize: 14
+  m_fontSizeBase: 14
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
   m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 2
-  m_VerticalAlignment: 512
+  m_fontStyle: 2
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0
@@ -1351,13 +1642,13 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_enableWordWrapping: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
-  m_enableExtraPadding: 0
+  m_enableExtraPadding: 1
   checkPaddingRequired: 0
   m_isRichText: 1
   m_parseCtrlCharacters: 1
@@ -1377,3 +1668,75 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &626941126331541628
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8901051738967536340}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 1
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!1 &9124928969435801136
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7804043847194677182}
+  - component: {fileID: 7441655682825137492}
+  m_Layer: 5
+  m_Name: Text Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7804043847194677182
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9124928969435801136}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4830945601085343701}
+  - {fileID: 3639707458692270146}
+  m_Father: {fileID: 7276524173429247799}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.5}
+  m_SizeDelta: {x: -20, y: -13}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &7441655682825137492
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9124928969435801136}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3312d7739989d2b4e91e6319e9a96d76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding: {x: -8, y: -5, z: -8, w: -5}
+  m_Softness: {x: 0, y: 0}

--- a/UnityProject/Assets/Scripts/Clothing/BackPack/InteractableStorage.cs
+++ b/UnityProject/Assets/Scripts/Clothing/BackPack/InteractableStorage.cs
@@ -71,6 +71,14 @@ public class InteractableStorage : MonoBehaviour, IClientInteractable<HandActiva
 	[SerializeField] private ActionData actionData = null;
 	public ActionData ActionData => actionData;
 
+	private bool preventUIShowingAfterTrapTrigger = false;
+
+	public bool PreventUIShowingAfterTrapTrigger
+	{
+		get => preventUIShowingAfterTrapTrigger;
+		set => preventUIShowingAfterTrapTrigger = value;
+	}
+
 	/// <summary>
 	/// Used on the server to switch the pickup mode of this InteractableStorage
 	/// </summary>
@@ -476,6 +484,11 @@ public class InteractableStorage : MonoBehaviour, IClientInteractable<HandActiva
 		}
 
 		interaction.PerformerPlayerScript.playerNetworkActions.CmdTriggerStorageTrap(gameObject);
+		if (PreventUIShowingAfterTrapTrigger)
+		{
+			preventUIShowingAfterTrapTrigger = false;
+			return false;
+		}
 
 		// open / close the backpack on activate
 		if (UIManager.StorageHandler.CurrentOpenStorage != itemStorage)

--- a/UnityProject/Assets/Scripts/Clothing/BackPack/InteractableStorage.cs
+++ b/UnityProject/Assets/Scripts/Clothing/BackPack/InteractableStorage.cs
@@ -483,11 +483,14 @@ public class InteractableStorage : MonoBehaviour, IClientInteractable<HandActiva
 			return true;
 		}
 
-		interaction.PerformerPlayerScript.playerNetworkActions.CmdTriggerStorageTrap(gameObject);
-		if (PreventUIShowingAfterTrapTrigger)
+		if (interaction.Intent != Intent.Disarm)
 		{
-			preventUIShowingAfterTrapTrigger = false;
-			return false;
+			interaction.PerformerPlayerScript.playerNetworkActions.CmdTriggerStorageTrap(gameObject);
+			if (PreventUIShowingAfterTrapTrigger)
+			{
+				preventUIShowingAfterTrapTrigger = false;
+				return false;
+			}
 		}
 
 		// open / close the backpack on activate

--- a/UnityProject/Assets/Scripts/Core/Transform/ScaleSync.cs
+++ b/UnityProject/Assets/Scripts/Core/Transform/ScaleSync.cs
@@ -1,0 +1,35 @@
+using System.Collections;
+using System.Collections.Generic;
+using Mirror;
+using UnityEngine;
+using UnityEngine.Networking;
+
+
+namespace Scripts.Core.Transform
+{
+
+    public class ScaleSync : NetworkBehaviour
+    {
+	    [SyncVar(hook = nameof(SyncScale))]
+	    private Vector3 scaleTransform;
+
+	    public override void OnStartClient()
+	    {
+		    SyncScale(transform.localScale, scaleTransform);
+		    base.OnStartClient();
+	    }
+
+
+	    public void SetScale(Vector3 newScale)
+	    {
+		    SyncScale(transform.localScale, newScale);
+	    }
+
+	    private void SyncScale(Vector3 oldVec, Vector3 newVec)
+	    {
+		    scaleTransform = newVec;
+		    transform.localScale = newVec;
+	    }
+    }
+}
+

--- a/UnityProject/Assets/Scripts/Core/Transform/ScaleSync.cs
+++ b/UnityProject/Assets/Scripts/Core/Transform/ScaleSync.cs
@@ -11,7 +11,7 @@ namespace Scripts.Core.Transform
     public class ScaleSync : NetworkBehaviour
     {
 	    [SyncVar(hook = nameof(SyncScale))]
-	    private Vector3 scaleTransform;
+	    private Vector3 scaleTransform = new Vector3(1f, 1f, 1f);
 
 	    public override void OnStartClient()
 	    {

--- a/UnityProject/Assets/Scripts/Core/Transform/ScaleSync.cs.meta
+++ b/UnityProject/Assets/Scripts/Core/Transform/ScaleSync.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 14a67aad38c961f45ad1cb44ac3b1f07
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Items/Weapons/Explosive.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Explosive.cs
@@ -108,12 +108,7 @@ namespace Items.Weapons
 
 				//TODO : Figure out why the position keeps getting offset to it's last position inside the parent's hierarchy (it doesn't want to 0,0)s
 				attachedObjectTile = target.RegisterTile();
-				netTransform.OnTileReached().AddListener(pos => {
-					if(attachedObjectTile != null)
-					{
-						registerItem.ServerSetLocalPosition(attachedObjectTile.customNetTransform.ServerLocalPosition);
-					}
-				});
+				netTransform.OnTileReached().AddListener(UpdateBombPosition);
 				if (spriteHandler != null) spriteHandler.transform.localScale = new Vector3(0.6f, 0.6f, 0.6f);
 				return;
 			}
@@ -121,6 +116,15 @@ namespace Items.Weapons
 			Inventory.ServerDrop(pickupable.ItemSlot, targetPostion);
 			//Visual feedback to indicate that it's been attached and not just dropped.
 			if (spriteHandler != null) spriteHandler.transform.localScale = new Vector3(0.6f, 0.6f, 0.6f);
+		}
+
+		public Vector3Int UpdateBombPosition(Vector3Int pos)
+		{
+			if(attachedObjectTile != null)
+			{
+				registerItem.ServerSetLocalPosition(attachedObjectTile.customNetTransform.ServerLocalPosition);
+			}
+			return registerItem.WorldPosition;
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/Items/Weapons/Explosive.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Explosive.cs
@@ -105,11 +105,9 @@ namespace Items.Weapons
 				Inventory.ServerDrop(pickupable.ItemSlot);
 
 				transform.SetParent(handler.transform);
-				//TODO : Figure out why the position keeps getting offset to it's last position inside the parent's hierarchy (it doesn't want to 0,0)
-				/*
+				//TODO : Figure out why the position keeps getting offset to it's last position inside the parent's hierarchy (it doesn't want to 0,0)s
 				transform.localPosition = new Vector3(0, 0, 0);
 				transform.position = new Vector3(0, 0, 0);
-				*/
 				return;
 			}
 

--- a/UnityProject/Assets/Scripts/Items/Weapons/Explosive.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Explosive.cs
@@ -97,7 +97,7 @@ namespace Items.Weapons
 
 		}
 
-		[Command]
+		[Server]
 		private void CmdAttachExplosive(GameObject target, Vector2 targetPostion)
 		{
 			if (target.TryGetComponent<PushPull>(out var handler))
@@ -112,6 +112,7 @@ namespace Items.Weapons
 				*/
 				return;
 			}
+
 			Inventory.ServerDrop(pickupable.ItemSlot, targetPostion);
 			//Visual feedback to indicate that it's been attached and not just dropped.
 			if (spriteHandler != null) spriteHandler.transform.localScale = new Vector3(0.6f, 0.6f, 0.6f);
@@ -197,7 +198,7 @@ namespace Items.Weapons
 					}
 				}
 
-				CmdAttachExplosive(interaction.TargetObject, interaction.TargetObject.AssumedWorldPosServer());
+				CmdAttachExplosive(interaction.TargetObject, interaction.TargetVector);
 				isOnObject = true;
 				pickupable.ServerSetCanPickup(false);
 				objectBehaviour.ServerSetPushable(false);

--- a/UnityProject/Assets/Scripts/Items/Weapons/Explosive.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Explosive.cs
@@ -32,7 +32,6 @@ namespace Items.Weapons
 		private ObjectBehaviour objectBehaviour;
 		private Pickupable pickupable;
 		private HasNetworkTabItem explosiveGUI;
-		private CustomNetTransform netTransform;
 		[HideInInspector] public GUI_Explosive GUI;
 
 		private bool hasExploded;
@@ -65,7 +64,6 @@ namespace Items.Weapons
 			objectBehaviour = GetComponent<ObjectBehaviour>();
 			pickupable = GetComponent<Pickupable>();
 			explosiveGUI = GetComponent<HasNetworkTabItem>();
-			netTransform = GetComponent<CustomNetTransform>();
 		}
 
 		public async void Countdown()

--- a/UnityProject/Assets/Scripts/Items/Weapons/Explosive.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Explosive.cs
@@ -23,7 +23,7 @@ namespace Items.Weapons
 		[SerializeField] private bool detonateImmediatelyOnSignal;
 		[SerializeField] private int timeToDetonate = 10;
 		[SerializeField] private int minimumTimeToDetonate = 10;
-		[SerializeField] private ExplosionComponent explosionPrefab;
+		[SerializeField] private float explosiveStrength = 150f;
 		[SerializeField] private SpriteDataSO activeSpriteSO;
 		[SerializeField] private float progressTime = 3f;
 		[Header("Explosive Components")]
@@ -88,20 +88,16 @@ namespace Items.Weapons
 			if (isServer)
 			{
 				// Get data before despawning
-				var explosionMatrix = registerItem.Matrix;
 				var worldPos = objectBehaviour.AssumedWorldPositionServer();
 
 				// Despawn the explosive
 				_ = Despawn.ServerSingle(gameObject);
-
-				// Explosion here
-				var explosionGO = Instantiate(explosionPrefab, explosionMatrix.transform);
-				explosionGO.transform.position = worldPos;
-				explosionGO.Explode(explosionMatrix);
+				Explosion.StartExplosion(worldPos, explosiveStrength);
 			}
+
 		}
 
-		[Command(requiresAuthority = false)]
+		[Command]
 		private void CmdAttachExplosive(GameObject target, Vector2 targetPostion)
 		{
 			if (target.TryGetComponent<PushPull>(out var handler))

--- a/UnityProject/Assets/Scripts/Items/Weapons/Explosive.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Explosive.cs
@@ -118,13 +118,12 @@ namespace Items.Weapons
 			if (spriteHandler != null) spriteHandler.transform.localScale = new Vector3(0.6f, 0.6f, 0.6f);
 		}
 
-		public Vector3Int UpdateBombPosition(Vector3Int pos)
+		public void UpdateBombPosition(Vector3Int pos)
 		{
-			if(attachedObjectTile != null)
+			if (attachedObjectTile != null)
 			{
 				registerItem.ServerSetLocalPosition(attachedObjectTile.customNetTransform.ServerLocalPosition);
 			}
-			return registerItem.WorldPosition;
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/Items/Weapons/Explosive.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Explosive.cs
@@ -221,6 +221,7 @@ namespace Items.Weapons
 			    interaction.HandObject.TryGetComponent<SignalEmitter>(out var emitter))
 			{
 				Emitter = emitter;
+				Frequency = emitter.Frequency;
 				Chat.AddExamineMsg(interaction.Performer, "You successfully pair the remote signal to the device.");
 				return;
 			}

--- a/UnityProject/Assets/Scripts/Items/Weapons/Explosive.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Explosive.cs
@@ -62,7 +62,7 @@ namespace Items.Weapons
 		private void Awake()
 		{
 			if(spriteHandler == null) spriteHandler = GetComponentInChildren<SpriteHandler>();
-			if(scaleSync == null) scaleSync = GetComponentInChildren<ScaleSync>();
+			if(scaleSync == null) scaleSync = GetComponent<ScaleSync>();
 			registerItem = GetComponent<RegisterItem>();
 			objectBehaviour = GetComponent<ObjectBehaviour>();
 			pickupable = GetComponent<Pickupable>();
@@ -85,8 +85,6 @@ namespace Items.Weapons
 
 		private void Detonate()
 		{
-			//We don't use Explosion.StartExplosion() because it doesn't look or work as
-			//Explosion prefabs do
 			if (hasExploded)
 			{
 				return;

--- a/UnityProject/Assets/Scripts/Items/Weapons/Explosive.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Explosive.cs
@@ -15,7 +15,8 @@ using UnityEngine;
 
 namespace Items.Weapons
 {
-	public class Explosive : SignalReceiver, ICheckedInteractable<PositionalHandApply>, ICheckedInteractable<MouseDrop>
+	public class Explosive : SignalReceiver, ICheckedInteractable<PositionalHandApply>,
+		ICheckedInteractable<MouseDrop>, IRightClickable
 	{
 		[Header("Explosive settings")]
 		[SerializeField] private ExplosiveType explosiveType;
@@ -129,6 +130,14 @@ namespace Items.Weapons
 			detonateImmediatelyOnSignal = mode;
 		}
 
+		private void DeAttachExplosive()
+		{
+			isOnObject = false;
+			pickupable.ServerSetCanPickup(true);
+			objectBehaviour.ServerSetPushable(true);
+			if (spriteHandler != null) spriteHandler.transform.localScale = new Vector3(1f, 1f, 1f);
+		}
+
 		public override void ReceiveSignal(SignalStrength strength, ISignalMessage message = null)
 		{
 			if(countDownActive == true || isArmed == false) return;
@@ -221,6 +230,13 @@ namespace Items.Weapons
 			bar.ServerStartProgress(interaction.Performer.RegisterTile(), progressTime, interaction.Performer);
 		}
 		#endregion
+
+		public RightClickableResult GenerateRightClickOptions()
+		{
+			RightClickableResult result = new RightClickableResult();
+			if (isOnObject == false) return result;
+			return result.AddElement("Deattach", DeAttachExplosive);
+		}
 	}
 
 	public enum ExplosiveType

--- a/UnityProject/Assets/Scripts/Items/Weapons/Explosive.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Explosive.cs
@@ -9,6 +9,7 @@ using Communications;
 using Managers;
 using Mirror;
 using Objects;
+using Scripts.Core.Transform;
 using UI;
 using UnityEngine;
 
@@ -28,6 +29,7 @@ namespace Items.Weapons
 		[SerializeField] private float progressTime = 3f;
 		[Header("Explosive Components")]
 		[SerializeField] private SpriteHandler spriteHandler;
+		[SerializeField] private ScaleSync scaleSync;
 		private RegisterItem registerItem;
 		private ObjectBehaviour objectBehaviour;
 		private Pickupable pickupable;
@@ -59,7 +61,8 @@ namespace Items.Weapons
 
 		private void Awake()
 		{
-			if(spriteHandler == null) spriteHandler = GetComponent<SpriteHandler>();
+			if(spriteHandler == null) spriteHandler = GetComponentInChildren<SpriteHandler>();
+			if(scaleSync == null) scaleSync = GetComponentInChildren<ScaleSync>();
 			registerItem = GetComponent<RegisterItem>();
 			objectBehaviour = GetComponent<ObjectBehaviour>();
 			pickupable = GetComponent<Pickupable>();
@@ -110,13 +113,13 @@ namespace Items.Weapons
 				Inventory.ServerDrop(pickupable.ItemSlot, targetPostion);
 				attachedToObject = target;
 				UpdateManager.Add(UpdateBombPosition, 0.1f);
-				if (spriteHandler != null) spriteHandler.transform.localScale = new Vector3(0.6f, 0.6f, 0.6f);
+				scaleSync.SetScale(new Vector3(0.6f, 0.6f, 0.6f));
 				return;
 			}
 
 			Inventory.ServerDrop(pickupable.ItemSlot, targetPostion);
 			//Visual feedback to indicate that it's been attached and not just dropped.
-			if (spriteHandler != null) spriteHandler.transform.localScale = new Vector3(0.6f, 0.6f, 0.6f);
+			scaleSync.SetScale(new Vector3(0.6f, 0.6f, 0.6f));
 		}
 
 		public void UpdateBombPosition()
@@ -140,7 +143,7 @@ namespace Items.Weapons
 			isOnObject = false;
 			pickupable.ServerSetCanPickup(true);
 			objectBehaviour.ServerSetPushable(true);
-			if (spriteHandler != null) spriteHandler.transform.localScale = new Vector3(1f, 1f, 1f);
+			scaleSync.SetScale(new Vector3(1f, 1f, 1f));
 			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, UpdateBombPosition);
 			attachedToObject = null;
 		}

--- a/UnityProject/Assets/Scripts/Items/Weapons/Explosive.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Explosive.cs
@@ -66,6 +66,11 @@ namespace Items.Weapons
 			explosiveGUI = GetComponent<HasNetworkTabItem>();
 		}
 
+		private void OnDisable()
+		{
+			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, UpdateBombPosition);
+		}
+
 		public async void Countdown()
 		{
 			countDownActive = true;
@@ -104,7 +109,7 @@ namespace Items.Weapons
 			{
 				Inventory.ServerDrop(pickupable.ItemSlot, targetPostion);
 				attachedToObject = target;
-				UpdateManager.Add(CallbackType.UPDATE,UpdateBombPosition);
+				UpdateManager.Add(UpdateBombPosition, 0.1f);
 				if (spriteHandler != null) spriteHandler.transform.localScale = new Vector3(0.6f, 0.6f, 0.6f);
 				return;
 			}
@@ -116,6 +121,8 @@ namespace Items.Weapons
 
 		public void UpdateBombPosition()
 		{
+			if(attachedToObject == null) return;
+			if(attachedToObject.WorldPosServer() == gameObject.WorldPosServer()) return;
 			registerItem.customNetTransform.SetPosition(attachedToObject.WorldPosServer());
 		}
 
@@ -134,7 +141,7 @@ namespace Items.Weapons
 			pickupable.ServerSetCanPickup(true);
 			objectBehaviour.ServerSetPushable(true);
 			if (spriteHandler != null) spriteHandler.transform.localScale = new Vector3(1f, 1f, 1f);
-			UpdateManager.Remove(CallbackType.UPDATE,UpdateBombPosition);
+			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, UpdateBombPosition);
 			attachedToObject = null;
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/Other/MouseTrap.cs
+++ b/UnityProject/Assets/Scripts/Objects/Other/MouseTrap.cs
@@ -60,6 +60,7 @@ namespace Objects.Other
 		/// <param name="health"></param>
 		public void TriggerTrap(LivingHealthMasterBase health = null)
 		{
+			isArmed = false;
 			if(health != null) HurtHand(health);
 			var slot = trapContent.GetTopOccupiedIndexedSlot();
 			if(slot == null) return;
@@ -69,7 +70,6 @@ namespace Objects.Other
 				component.TriggerTrap();
 			}
 			UpdateTrapVisual();
-			isArmed = false;
 		}
 
 		private bool HasTrapTrait(GameObject item)

--- a/UnityProject/Assets/Scripts/Objects/Telecomms/StationBouncedRadio.cs
+++ b/UnityProject/Assets/Scripts/Objects/Telecomms/StationBouncedRadio.cs
@@ -84,8 +84,8 @@ namespace Objects.Telecomms
 				}
 				messageContent = EncryptionUtils.Decrypt(messageContent, EncryptionData.EncryptionSecret);
 			}
-			return $"<b><color=#{ColorUtility.ToHtmlStringRGBA(Chat.Instance.commonColor)}><sprite=\"RadioIcon\" name=\"radio_walkietalkie\">" +
-			       $" -{messageSender} says \"{messageContent}\"</color></b>";
+			return $"<b><color=#{ColorUtility.ToHtmlStringRGBA(Chat.Instance.commonColor)}>[{Frequency}]" +
+			       $" - {messageSender} says \"{messageContent}\"</color></b>.";
 		}
 
 		public void AddEncryptionKey(EncryptionKey key)

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -999,7 +999,12 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 			if(slot.IsEmpty) continue;
 			if (slot.ItemObject.TryGetComponent<MouseTrap>(out var trap))
 			{
-				if(trap.IsArmed) trap.TriggerTrap(playerScript.playerHealth);
+				if (trap.IsArmed)
+				{
+					trap.TriggerTrap(playerScript.playerHealth);
+					interactableStorage.PreventUIShowingAfterTrapTrigger = true;
+					return;
+				}
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/UI/Objects/Telecomms/GUI_FrequencyChanger.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Telecomms/GUI_FrequencyChanger.cs
@@ -5,12 +5,13 @@ using System.Collections;
 using Communications;
 using Objects.Telecomms;
 using System;
+using System.Linq;
 
 namespace UI.Objects.Telecomms
 {
 	public class GUI_FrequencyChanger : NetTab
 	{
-		[SerializeField] private TMP_Text freuquencyLabel;
+		[SerializeField] private TMP_InputField freuquencyLabel;
 		[SerializeField] private Slider frequencySlider;
 		[SerializeField] private Toggle radioPowerToggle;
 		[SerializeField] private Toggle broadcastModeToggle;
@@ -57,6 +58,23 @@ namespace UI.Objects.Telecomms
 
 		private void UpdateFrequencyFromProvider()
 		{
+			freuquencyLabel.text = $"{emittingDevice.Frequency.ToString()}KHz";
+		}
+
+		public void UpdateFrequencyFromInput()
+		{
+			if (float.TryParse(freuquencyLabel.text, out var result) == false)
+			{
+				freuquencyLabel.text = $"{emittingDevice.Frequency.ToString()}KHz";
+				return;
+			}
+			if (result.IsBetween(emittingDevice.SignalData.MinMaxFrequancy.x,
+				emittingDevice.SignalData.MinMaxFrequancy.y))
+			{
+				emittingDevice.Frequency = result;
+				freuquencyLabel.text = $"{emittingDevice.Frequency.ToString()}KHz";
+				return;
+			}
 			freuquencyLabel.text = $"{emittingDevice.Frequency.ToString()}KHz";
 		}
 


### PR DESCRIPTION
CL: [Fix] - Fixed an issue with mousetrap not being set to be inactive after triggering due to a code step execution oversight ( fixes #7957 )
CL: [Fix] - Fixed an issue where I forgot to re-add the disarm intent logic for mousetraps (twice! whoops)
CL: [New] - Mousetraps will now prevent the UI slots from appearing when they are active ( closes #7958 )
CL: [New] -Added a text field to the frequency changer UI for more precise and quick channel changes ( closes #7960 )
CL: [Improvement] - Replaced the radio icon with frequency text ( closes #7959 )
CL: [Improvement] -  Pairing a bomb with an emitter now copies the emitter frequency.
CL: [New] - Added the ability to detach bombs from surfaces.
CL: [Improvement] - Replaced the old explosion method with the new one; resulting in smaller code and fixing an issue where bombs couldn't harm walls.
CL: [Balance] - C4s have been rebalanced to be less deadly, but they're still harmful enough to tear some limbs apart if placed directly ontop of a player.
CL: [Fix] - Fixed an issue where bombs couldn't follow moveable objects like players and lockers.
CL: [Improvement] - The explosive UI is now treated as a normal tab and will not be draggable around the screen.