### PR TITLE
Added SpillOnThrow item attribute to base Bottle and Can

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Food/Drinks/DrinkBottles/_DrinkBottleBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Drinks/DrinkBottles/_DrinkBottleBase.prefab
@@ -85,7 +85,7 @@ PrefabInstance:
     - target: {fileID: 7730239227723964622, guid: 46bb2fe95f4f66341aadfb4600751333,
         type: 3}
       propertyPath: initialTraits.Array.size
-      value: 4
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 7730239227723964622, guid: 46bb2fe95f4f66341aadfb4600751333,
         type: 3}
@@ -98,6 +98,12 @@ PrefabInstance:
       propertyPath: initialTraits.Array.data[3]
       value: 
       objectReference: {fileID: 11400000, guid: 80279049e516c294ca6bd71aaa2a31f2,
+        type: 2}
+    - target: {fileID: 7730239227723964622, guid: 46bb2fe95f4f66341aadfb4600751333,
+        type: 3}
+      propertyPath: initialTraits.Array.data[4]
+      value: 
+      objectReference: {fileID: 11400000, guid: 55917bb83c64bdc41acf0a60f284366c,
         type: 2}
     - target: {fileID: 7730239227723964622, guid: 46bb2fe95f4f66341aadfb4600751333,
         type: 3}
@@ -115,6 +121,16 @@ PrefabInstance:
       propertyPath: itemSprites.RightHand.Texture
       value: 
       objectReference: {fileID: 2800000, guid: 2de6c283d82f76148b3c3cb77cc62e2d, type: 3}
+    - target: {fileID: 7730239227723964622, guid: 46bb2fe95f4f66341aadfb4600751333,
+        type: 3}
+      propertyPath: inventoryMoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
+    - target: {fileID: 7730239227723964622, guid: 46bb2fe95f4f66341aadfb4600751333,
+        type: 3}
+      propertyPath: inventoryRemoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     - target: {fileID: 7730239227723964622, guid: 46bb2fe95f4f66341aadfb4600751333,
         type: 3}
       propertyPath: itemSprites.LeftHand.EquippedData

--- a/UnityProject/Assets/Prefabs/Items/Food/Drinks/SodaCans/_SodaCanBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Drinks/SodaCans/_SodaCanBase.prefab
@@ -17,6 +17,27 @@ PrefabInstance:
       propertyPath: initialName
       value: soda can
       objectReference: {fileID: 0}
+    - target: {fileID: 7730239227723964622, guid: 46bb2fe95f4f66341aadfb4600751333,
+        type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7730239227723964622, guid: 46bb2fe95f4f66341aadfb4600751333,
+        type: 3}
+      propertyPath: initialTraits.Array.data[3]
+      value: 
+      objectReference: {fileID: 11400000, guid: 55917bb83c64bdc41acf0a60f284366c,
+        type: 2}
+    - target: {fileID: 7730239227723964622, guid: 46bb2fe95f4f66341aadfb4600751333,
+        type: 3}
+      propertyPath: inventoryMoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
+    - target: {fileID: 7730239227723964622, guid: 46bb2fe95f4f66341aadfb4600751333,
+        type: 3}
+      propertyPath: inventoryRemoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     - target: {fileID: 7799949450078925336, guid: 46bb2fe95f4f66341aadfb4600751333,
         type: 3}
       propertyPath: m_AssetId


### PR DESCRIPTION
### Purpose
This is a very small add but makes a large difference, cans and bottles right now do nothing when you throw them (even bottles which break open on throw). This will make greytiders happy and keep janitors busy. 

![image](https://user-images.githubusercontent.com/4888377/145714197-4d4b2698-3f34-42ab-93d8-bc4787708e85.png)

### Notes:
Tested with quite a few items, I doubt this has any other larger ramifications.

### Changelog:
CL: [Improvement] Cans and Bottles will now spill their contents on the floor when thrown. 

