### PR TITLE
Removes thread sleeps from the sickness manager sickplayers lock

### DIFF
--- a/UnityProject/Assets/Scripts/Health/Sickness/SicknessManager.cs
+++ b/UnityProject/Assets/Scripts/Health/Sickness/SicknessManager.cs
@@ -87,11 +87,9 @@ namespace Health.Sickness
 									{
 										CheckSicknessProgression(sicknessAffliction);
 										CheckSymptomOccurence(sicknessAffliction, playerSickness.MobHealth);
-										Thread.Sleep(100);
 									}
 								}
 							}
-							Thread.Sleep(100);
 						}
 					}
 				}
@@ -328,7 +326,7 @@ namespace Health.Sickness
 		// Add this player as a sick player
 		public void RegisterSickPlayer(MobSickness mobSickness)
 		{
-			lock(sickPlayers)
+			lock (sickPlayers)
 			{
 				if (!sickPlayers.Contains(mobSickness))
 					sickPlayers.Add(mobSickness);


### PR DESCRIPTION
### Purpose
Removes thread sleeps from the sickness manager sickplayers lock

### Notes
I don't believe its significant enough to cause a huge issue, but it could freeze the main thread for a tiny bit