### PR TITLE
Fixed soap scrubbing on occupied tiles by adding checks.

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Tool/Soap.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/Soap.cs
@@ -38,15 +38,15 @@ namespace Items
             Vector3Int positionInt = Vector3Int.RoundToInt(position);
 
             // Check if there is an object in the way of scrubbing the tile
-			var atPosition = MatrixManager.GetAt<RegisterTile>(positionInt, true);
+			var atPosition = MatrixManager.GetAt<RegisterObject>(positionInt, true);
             if(atPosition.Count != 0) return false;
 
 
             // Check that the layer scrubbed is a floor, e.g. not a table
-            var metaTileMap = MatrixManager.AtPoint(positionInt, false).MetaTileMap;
+            var metaTileMap = MatrixManager.AtPoint(positionInt, side == NetworkSide.Server).MetaTileMap;
             var tile = metaTileMap.GetTile(metaTileMap.WorldToCell(positionInt), true);
 
-            if (tile != null && tile.LayerType != LayerType.Floors)
+            if (tile != null && tile.LayerType == LayerType.Tables)
             {
                 return false;
             }

--- a/UnityProject/Assets/Scripts/Items/Tool/Soap.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/Soap.cs
@@ -38,7 +38,7 @@ namespace Items
             Vector3Int positionInt = Vector3Int.RoundToInt(position);
 
             // Check if there is an object in the way of scrubbing the tile
-			var atPosition = MatrixManager.GetAt<RegisterObject>(positionInt, true);
+			var atPosition = MatrixManager.GetAt<RegisterObject>(positionInt, side == NetworkSide.Server);
             if(atPosition.Count != 0) return false;
 
 

--- a/UnityProject/Assets/Scripts/Items/Tool/Soap.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/Soap.cs
@@ -33,6 +33,24 @@ namespace Items
 			//can only scrub tiles, for now
 			if (!Validations.HasComponent<InteractableTiles>(interaction.TargetObject)) return false;
 
+            // Get position of interaction as Vector3Int
+            Vector3 position = interaction.WorldPositionTarget;
+            Vector3Int positionInt = Vector3Int.RoundToInt(position);
+
+            // Check if there is an object in the way of scrubbing the tile
+			var atPosition = MatrixManager.GetAt<RegisterTile>(positionInt, true);
+            if(atPosition.Count != 0) return false;
+
+
+            // Check that the layer scrubbed is a floor, e.g. not a table
+            var metaTileMap = MatrixManager.AtPoint(positionInt, false).MetaTileMap;
+            var tile = metaTileMap.GetTile(metaTileMap.WorldToCell(positionInt), true);
+
+            if (tile != null && tile.LayerType != LayerType.Floors)
+            {
+                return false;
+            }
+
 			return true;
 		}
 


### PR DESCRIPTION
<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->

### Purpose
<!-- Describe the problem the PR fixes or the feature it introduces. --> <br>
<!-- Don't forget to use "Fixes #issuenumber" to select issues and auto close them on merge. -->
Fixes #7411, that is soap being able to scrub through tables and other objects.

### Notes:
<!-- Please enter any other relevant information here -->
Edited the Soap.cs file, adding checks in the WillInteract function to determine when the soap could be used for scrubbing. Added checks to see if an object was in the way of scrubbing the tile, and added a check to see if the tile to interact with was actually a floor, as opposed to a table tile.

### Changelog:
<!-- Add here individual lines with all your remarkable changes using the prefix ``CL:`` -->
<!-- Mind that the changes meant to be logged in the in changelog are those that are remarkable for the end user, so things like new features and fixes of known bugs are perfect for this section -->

<!-- CL: [New] For new features, things that didn't exist before the PR. -->

<!-- CL: [Improvement] For any change on any existing feature. -->

<!-- CL: [Balance] For any change on an existing feature done in the sake of improving game balance. It's the only exception to the rule above. -->

<!-- CL: [Fix] For any change that fixes a bug. -->
CL: [Fix] Fixed where players could use soap to scrub through tables and other objects by implementing the appropriate checks.
