### PR TITLE
Stopped player from slipping on soap when crawling.

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
@@ -251,11 +251,13 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 			return;
 		}
 		// Don't slip while walking unless its enabled with "slipWhileWalking".
+        // Don't slip while crawling
 		// Don't slip while player's consious state is crit, soft crit, or dead.
 		// Don't slip while the players hunger state is Strarving
 		// Don't slip if you got no legs (HealthV2)
 		if (IsSlippingServer
 			|| !slipWhileWalking && playerScript.PlayerSync.SpeedServer <= playerScript.playerMove.WalkSpeed
+            || isLayingDown
 			|| playerScript.playerHealth.IsCrit
 			|| playerScript.playerHealth.IsSoftCrit
 			|| playerScript.playerHealth.IsDead


### PR DESCRIPTION
<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->

### Purpose
<!-- Describe the problem the PR fixes or the feature it introduces. --> <br>
<!-- Don't forget to use "Fixes #issuenumber" to select issues and auto close them on merge. -->
Fixes #7414, where crawling over soap makes the player slip.

### Notes:
<!-- Please enter any other relevant information here -->
Edited the RegisterPlayer.cs file, adding a check to the ServerSlip function so that the player doesn't slip while crawling to the rest of the checks present there.

### Changelog:
<!-- Add here individual lines with all your remarkable changes using the prefix ``CL:`` -->
<!-- Mind that the changes meant to be logged in the in changelog are those that are remarkable for the end user, so things like new features and fixes of known bugs are perfect for this section -->

<!-- CL: [New] For new features, things that didn't exist before the PR. -->

<!-- CL: [Improvement] For any change on any existing feature. -->

<!-- CL: [Balance] For any change on an existing feature done in the sake of improving game balance. It's the only exception to the rule above. -->

<!-- CL: [Fix] For any change that fixes a bug. -->
CL: [Fix] Fixed the issue where players would slip on soap when crawling.
