### PR TITLE
devops: another attempt at fixing changelog update action

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,6 +1,8 @@
 name: pr2changelog
 on:
     pull_request_target:
+        paths-ignore:
+            - 'CHANGELOG.md'
         branches:
             - develop
         types:
@@ -57,4 +59,4 @@ jobs:
                 uses: ad-m/github-push-action@master
                 with:
                     force: true
-                    github_token: ${{ secrets.GITHUB_TOKEN }}
+                    github_token: ${{ secrets.PR2CHANGELOG_TOKEN }}

--- a/.github/workflows/pr_helpers.yml
+++ b/.github/workflows/pr_helpers.yml
@@ -4,8 +4,7 @@ name: PR helpers
 on:
   push:
     branches: [develop]
-  pull_request_target:
-    branches: [develop]
+
   pull_request:
     types: [opened, synchronize]
     branches: [develop]
@@ -21,7 +20,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: auto labeler
-        if: ${{ github.event_name == 'pull_request_target' }}
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/labeler@v3-preview
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
### Purpose
By allowing administrators to bypass branch protections and give PR2CHANGELOG action a token with administrator permissions.

I also made PR Helper only trigger on PULL_REQUEST event instead of PULL_REQUEST_TARGET.
