### PR TITLE
Adds server rebooting to tackle memory crash issues

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/GameConfigManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameConfigManager.cs
@@ -59,5 +59,6 @@ namespace GameConfig
 		public bool AdminOnlyHtml;
 		public int MalfAIRecieveTheirIntendedObjectiveChance;
 		public int CharacterNameLimit;
+		public bool ServerShutsDownOnRoundEnd;
 	}
 }

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -770,7 +770,7 @@ public partial class GameManager : MonoBehaviour, IInitialise
 	{
 		string[] args = Environment.GetCommandLineArgs();
 		if ((ServerShutsDownOnRoundEnd == false || args.Contains("-NoReboot"))
-		    && (ServerAverageFPS >= 45 || GetMemeoryUsagePrecentage() <= 75f) || args.Contains("-AlwaysReboot"))
+		    && (ServerAverageFPS >= 45 || GetMemeoryUsagePrecentage() <= 75f) || args.Contains("-AlwaysReboot") == false)
 		{
 			Logger.Log("Server restarting round now.", Category.Round);
 			Chat.AddGameWideSystemMsgToChat("<b>The round is now restarting...</b>");

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -784,7 +784,7 @@ public partial class GameManager : MonoBehaviour, IInitialise
 			StopAllCoroutines();
 			yield break;
 		}
-		Logger.Log("Server is rebooting now. If you don't have a way to automatically restart the " +
+		Logger.LogError("Server is rebooting now. If you don't have a way to automatically restart the " +
 		           "Unitystation process such as systemctl the server won't be able to restart!", Category.Round);
 		Chat.AddGameWideSystemMsgToChat("<size=72><b>The server is now restarting!</b></size>");
 		yield return WaitFor.Seconds(2f);

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -763,7 +763,7 @@ public partial class GameManager : MonoBehaviour, IInitialise
 
 	private float GetMemeoryUsagePrecentage()
 	{
-		return (Profiler.GetTotalAllocatedMemory() / 1048576) / SystemInfo.systemMemorySize * 100;
+		return (Profiler.GetTotalAllocatedMemoryLong() / 1048576) / SystemInfo.systemMemorySize * 100;
 	}
 
 	IEnumerator ServerRoundRestart()

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -770,7 +770,7 @@ public partial class GameManager : MonoBehaviour, IInitialise
 	{
 		string[] args = Environment.GetCommandLineArgs();
 		if ((ServerShutsDownOnRoundEnd == false || args.Contains("-NoReboot"))
-		    && (ServerAverageFPS >= 45 || GetMemeoryUsagePrecentage() <= 75f))
+		    && (ServerAverageFPS >= 45 || GetMemeoryUsagePrecentage() <= 75f) || args.Contains("-AlwaysReboot"))
 		{
 			Logger.Log("Server restarting round now.", Category.Round);
 			Chat.AddGameWideSystemMsgToChat("<b>The round is now restarting...</b>");

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -17,6 +17,7 @@ using Audio.Containers;
 using Managers;
 using Messages.Server;
 using Tilemaps.Behaviours.Layers;
+using UnityEngine.Profiling;
 
 public partial class GameManager : MonoBehaviour, IInitialise
 {
@@ -75,6 +76,11 @@ public partial class GameManager : MonoBehaviour, IInitialise
 	/// How long are character names are allowed to be?
 	/// </summary>
 	public int CharacterNameLimit { get; set; }
+
+	/// <summary>
+	/// ENABLE ON SERVERS THAT SUPPORT AUTO-RESTARTING ONLY VIA A MANAGER!
+	/// </summary>
+	public bool ServerShutsDownOnRoundEnd { get; set; }
 
 	/// <summary>
 	/// If true, only admins who put http/https links in OOC will be allowed
@@ -181,6 +187,7 @@ public partial class GameManager : MonoBehaviour, IInitialise
 		CharacterNameLimit = GameConfigManager.GameConfig.CharacterNameLimit;
 		AdminOnlyHtml = GameConfigManager.GameConfig.AdminOnlyHtml;
 		MalfAIRecieveTheirIntendedObjectiveChance = GameConfigManager.GameConfig.MalfAIRecieveTheirIntendedObjectiveChance;
+		ServerShutsDownOnRoundEnd = GameConfigManager.GameConfig.ServerShutsDownOnRoundEnd;
 		Physics.autoSimulation = false;
 		Physics2D.simulationMode = SimulationMode2D.Update;
 	}
@@ -754,18 +761,33 @@ public partial class GameManager : MonoBehaviour, IInitialise
 		StartCoroutine(ServerRoundRestart());
 	}
 
+	private float GetMemeoryUsagePrecentage()
+	{
+		return (Profiler.GetTotalAllocatedMemory() / 1048576) / SystemInfo.systemMemorySize * 100;
+	}
+
 	IEnumerator ServerRoundRestart()
 	{
-		Logger.Log("Server restarting round now.", Category.Round);
-		Chat.AddGameWideSystemMsgToChat("<b>The round is now restarting...</b>");
+		string[] args = Environment.GetCommandLineArgs();
+		if ((ServerShutsDownOnRoundEnd == false || args.Contains("-NoReboot"))
+		    && (ServerAverageFPS >= 45 || GetMemeoryUsagePrecentage() <= 75f))
+		{
+			Logger.Log("Server restarting round now.", Category.Round);
+			Chat.AddGameWideSystemMsgToChat("<b>The round is now restarting...</b>");
+			// Notify all clients that the round has ended
+			EventManager.Broadcast(Event.RoundEnded, true);
 
-		// Notify all clients that the round has ended
-		EventManager.Broadcast(Event.RoundEnded, true);
+			yield return WaitFor.Seconds(0.2f);
 
-		yield return WaitFor.Seconds(0.2f);
+			CustomNetworkManager.Instance.ServerChangeScene("OnlineScene");
 
-		CustomNetworkManager.Instance.ServerChangeScene("OnlineScene");
-
-		StopAllCoroutines();
+			StopAllCoroutines();
+			yield break;
+		}
+		Logger.Log("Server is rebooting now. If you don't have a way to automatically restart the " +
+		           "Unitystation process such as systemctl the server won't be able to restart!", Category.Round);
+		Chat.AddGameWideSystemMsgToChat("<size=72><b>The server is now restarting!</b></size>");
+		yield return WaitFor.Seconds(2f);
+		Application.Quit();
 	}
 }

--- a/UnityProject/Assets/StreamingAssets/config/gameConfig.json
+++ b/UnityProject/Assets/StreamingAssets/config/gameConfig.json
@@ -25,5 +25,7 @@
 
 	"CharacterNameLimit": 32,
 	
-	"MalfAIRecieveTheirIntendedObjectiveChance": 35
+	"MalfAIRecieveTheirIntendedObjectiveChance": 35,
+	
+	"ServerShutsDownOnRoundEnd" : true
 }


### PR DESCRIPTION
Because of memory issues that happen after a few rounds of playing; this PR aims to add server restarting to the game.
For servers to restart they'll require `systemctl` like how staging currently has one to auto-restart the server.

Incase you as the server host don't have something similar installed; there are two ways to disable this. Either by changing it from the gameConfig on build or using a commandline argument called `-NoReboot` when starting a headless server.

Server restarting will trigger now when one of two conditions are met; server performance has been detected to be low OR the `-AlwaysReboot` argument has been passed to the server to always reboot every round.

