### PR TITLE
Fixes guns shooting The wrong direction on rotated matrices

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Interactions/AimApply.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Interactions/AimApply.cs
@@ -38,7 +38,7 @@ public class AimApply : BodyPartTargetedInteraction
 	public Vector2 WorldPositionTarget => (Vector2)targetPosition.To3().ToWorld(Performer.RegisterTile().Matrix);
 
 	/// <summary>Vector pointing from the performer's position to the target position.</summary>
-	public Vector2 TargetVector => targetPosition - Performer.transform.localPosition.To2();
+	public Vector2 TargetVector => WorldPositionTarget.To3() - Performer.RegisterTile().WorldPosition;
 
 	/// <summary>
 	/// Whether player is aiming at themselves.

--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Interactions/PositionalHandApply.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Interactions/PositionalHandApply.cs
@@ -15,7 +15,7 @@ public class PositionalHandApply : HandApply
 	public Vector2 TargetPosition { get; protected set; }
 
 	/// <summary>Vector pointing from the performer's position to the target position.</summary>
-	public Vector2 TargetVector => TargetPosition - Performer.transform.localPosition.To2();
+	public Vector2 TargetVector => WorldPositionTarget.To3() - Performer.RegisterTile().WorldPosition;
 
 	/// <summary>Target world position calculated from matrix local position.</summary>
 	public Vector2 WorldPositionTarget => (Vector2) TargetPosition.To3().ToWorld(Performer.RegisterTile().Matrix);

--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/TileApply.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/TileApply.cs
@@ -42,13 +42,13 @@ public class TileApply : Interaction
 
 
 	/// <summary>Target world position calculated from matrix local position.</summary>
-	public Vector2 WorldPositionTarget => TargetPosition.To3().ToWorld(Performer.RegisterTile().Matrix);
+	public Vector2 WorldPositionTarget =>  TargetPosition.To3().ToWorld(Performer.RegisterTile().Matrix);
 
 	/// <summary>Requested local position target.</summary>
 	public Vector2 TargetPosition => targetPosition;
 
 	/// <summary>Vector pointing from the performer's position to the target position.</summary>
-	public Vector2 TargetVector => targetPosition - Performer.transform.localPosition.To2();
+	public Vector2 TargetVector =>WorldPositionTarget.To3() - Performer.RegisterTile().WorldPosition;
 
 	public enum ApplyType
 	{


### PR DESCRIPTION
as it was using local position for the vector target

CL: [Fix] Fixed guns shooting in the wrong direction on rotated matrices