### PR TITLE
Quantum Pad Fix v.2

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Machines/QuantumPad.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/QuantumPad.cs
@@ -184,7 +184,7 @@ namespace Objects.Science
 									.Concat(Matrix.Get<ObjectBehaviour>(registerTileLocation, ObjectType.Item, true)))
 			{
 				//Don't teleport self lol
-				if(item == gameObject) continue;
+				if(item.gameObject == gameObject) continue;
 
 				if (item.gameObject.TryGetComponent(out IQuantumReaction reaction))
 				{


### PR DESCRIPTION
-Hopefully this fixes it now.

Fixes #8026

CL: [Fix] fixed quantum pads teleporting themselves attempt 2.