### PR TITLE
Fix for green text problem for antags hiding in closets

### DIFF
--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/EscapeObjectives/Escape.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/EscapeObjectives/Escape.cs
@@ -24,6 +24,12 @@ namespace Antagonists
 			ValidShuttles.Add(GameManager.Instance.PrimaryEscapeShuttle);
 		}
 
+		private bool CheckOnShip(RegisterTile antagTile, RegisterTile shuttleTile)
+		{
+			if (antagTile.Matrix.Id == shuttleTile.Matrix.MatrixInfo.Id) return true;
+			return shuttleTile.Matrix.HasTile(antagTile.WorldPositionServer, true);
+		}
+
 		/// <summary>
 		/// Complete if the player is alive and on one of the escape shuttles and shuttle has
 		/// at least one working engine
@@ -32,7 +38,7 @@ namespace Antagonists
 		{
 			return !Owner.body.playerHealth.IsDead &&
 				ValidShuttles.Any( shuttle => shuttle.MatrixInfo != null
-					&& Owner.body.registerTile.Matrix.Id == shuttle.MatrixInfo.Id && shuttle.HasWorkingThrusters);
+					&& (CheckOnShip(Owner.body.registerTile, shuttle.gameObject.RegisterTile())) && shuttle.HasWorkingThrusters);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/EscapeObjectives/Escape.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/EscapeObjectives/Escape.cs
@@ -27,7 +27,7 @@ namespace Antagonists
 		private bool CheckOnShip(RegisterTile antagTile, RegisterTile shuttleTile)
 		{
 			if (antagTile.Matrix.Id == shuttleTile.Matrix.MatrixInfo.Id) return true;
-			return shuttleTile.Matrix.HasTile(antagTile.WorldPositionServer, true);
+			return shuttleTile.Matrix.HasTile(antagTile.gameObject.AssumedWorldPosServer().RoundToInt(), true);
 		}
 
 		/// <summary>


### PR DESCRIPTION
part of #4658

The idea of this fix is that the game should check if the the shuttle has a tile that the antag is currently on when the matrix check fails

CL: [Fix] fixed antagonists not getting greentext for objectives if they were hiding in closets.