### PR TITLE
Fixes random item pools Mapped over lockers

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Others/RandomItemSpot.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/RandomItemSpot.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Mirror;
+using Objects;
 using UnityEngine;
 using Random = UnityEngine.Random;
 
@@ -64,6 +65,18 @@ namespace Items
 
 			if (UnrestrictedAndspawn)
 			{
+				if (RegisterTile.TryGetComponent<ObjectBehaviour>(out var ObjectBehaviour))
+				{
+					if (ObjectBehaviour.parentContainer != null)
+					{
+						//TODO Do item storage
+						if (ObjectBehaviour.parentContainer.TryGetComponent<ObjectContainer>(out var ObjectContainer))
+						{
+							ObjectContainer.RetrieveObject(this.gameObject);
+						}
+					}
+				}
+
 				RegisterTile.Matrix.MetaDataLayer.InitialObjects[this.gameObject] = this.transform.localPosition;
 				this.GetComponent<CustomNetTransform>().DisappearFromWorldServer(true);
 				this.GetComponent<RegisterTile>().UpdatePositionServer();

--- a/UnityProject/Assets/Scripts/Objects/ObjectContainer.cs
+++ b/UnityProject/Assets/Scripts/Objects/ObjectContainer.cs
@@ -166,6 +166,7 @@ namespace Objects
 			}
 		}
 
+		//Only use for items that are being destroyed TODO Probably should cleanup values for nice pooling
 		public void RemoveObject(GameObject obj)
 		{
 			storedObjects.Remove(obj);


### PR DESCRIPTION
makes it so it removes itself from the locker

CL: [Fix] fixed random item spawners not despawning correctly when placed inside lockers.