### PR TITLE
Atmos System Change

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSystem.cs
@@ -46,13 +46,19 @@ namespace Systems.Atmospherics
 					{
 						//We use ChangeGasMix here incase we need to add overlays, while the BaseAirMix and BaseSpaceMix can set directly since none of the gases in them do
 						//Does come with a performance penalty
-						node.ChangeGasMix(GasMix.NewGasMix(gasSetter.GasMixToSpawn));
+						//node.ChangeGasMix(GasMix.NewGasMix(gasSetter.GasMixToSpawn));
+						
+						//TODO: above commented out due to performance on load for lavaland, remove line below if solution is found
+						node.GasMix = GasMix.NewGasMix(gasSetter.GasMixToSpawn);
 					}
 					//See if the whole matrix has a custom mix
 					else if (hasCustomMix)
 					{
 						//ChangeGasMix here too for the same reason as above
-						node.ChangeGasMix(GasMix.NewGasMix(defaultRoomGasMixOverride.BaseGasMix));
+						//node.ChangeGasMix(GasMix.NewGasMix(defaultRoomGasMixOverride.BaseGasMix));
+						
+						//TODO: above commented out due to performance on load for lavaland, remove line below if solution is found
+						node.GasMix = GasMix.NewGasMix(defaultRoomGasMixOverride.BaseGasMix);
 					}
 					//Default to air mix otherwise
 					else


### PR DESCRIPTION
-Revert atmos system change for setting overlays when gas first put into room as it was too performance intensive during load for lavaland