### PR TITLE
Fixes sprite issues with Atmos device pipes. Fixes #7194

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Binary/GasPumpOff.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Binary/GasPumpOff.prefab
@@ -80,7 +80,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8615011672783284396}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: -0, y: -0.008726535, z: -0, w: 0.9999619}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
@@ -208,17 +208,17 @@ PrefabInstance:
     - target: {fileID: 1583787549853510187, guid: 40b91fa71481bb54cbec1e89fa1ff1d2,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1583787549853510187, guid: 40b91fa71481bb54cbec1e89fa1ff1d2,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1583787549853510187, guid: 40b91fa71481bb54cbec1e89fa1ff1d2,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1583787549853510187, guid: 40b91fa71481bb54cbec1e89fa1ff1d2,
         type: 3}
@@ -261,7 +261,7 @@ PrefabInstance:
         type: 3}
       propertyPath: PresentSpriteSet
       value: 
-      objectReference: {fileID: 11400000, guid: 4b9517bdeea788140abc850f18e4a32d,
+      objectReference: {fileID: 11400000, guid: c59c5e3dd182a7649a161ea1d0bbc672,
         type: 2}
     - target: {fileID: 6323048891065173547, guid: 40b91fa71481bb54cbec1e89fa1ff1d2,
         type: 3}
@@ -279,6 +279,12 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 7572042400133878058, guid: 40b91fa71481bb54cbec1e89fa1ff1d2,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300002, guid: 2217fe06c75376d41af4a23f9383b678,
+        type: 3}
     - target: {fileID: 8163608160046166977, guid: 40b91fa71481bb54cbec1e89fa1ff1d2,
         type: 3}
       propertyPath: initialName

--- a/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Binary/GasPumpOn.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Binary/GasPumpOn.prefab
@@ -88,13 +88,25 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300002, guid: 2217fe06c75376d41af4a23f9383b678,
+      objectReference: {fileID: 21300000, guid: 2217fe06c75376d41af4a23f9383b678,
         type: 3}
     - target: {fileID: 3534284792730017904, guid: d243343741d540446b159becf769231a,
         type: 3}
       propertyPath: foreverID
       value: a2807265d4ddfb346993a6e08f769100
       objectReference: {fileID: 0}
+    - target: {fileID: 6422120630321073190, guid: d243343741d540446b159becf769231a,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: c59c5e3dd182a7649a161ea1d0bbc672,
+        type: 2}
+    - target: {fileID: 7503433032394499574, guid: d243343741d540446b159becf769231a,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: dc27c82ed88a09d43ac8a5fc2a86bd49,
+        type: 2}
     - target: {fileID: 8331787558733261659, guid: d243343741d540446b159becf769231a,
         type: 3}
       propertyPath: m_AssetId

--- a/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Binary/_AtmosBinaryBase.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Binary/_AtmosBinaryBase.prefab
@@ -7,6 +7,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1195305884334883205, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2206299048531075066, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89,
         type: 3}
       propertyPath: variantIndex
@@ -14,9 +19,21 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2206299048531075066, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89,
         type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: c59c5e3dd182a7649a161ea1d0bbc672,
+        type: 2}
+    - target: {fileID: 2206299048531075066, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89,
+        type: 3}
       propertyPath: initialVariantIndex
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 3431779693841004074, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: dc27c82ed88a09d43ac8a5fc2a86bd49,
+        type: 2}
     - target: {fileID: 3756522434771318919, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89,
         type: 3}
       propertyPath: m_AssetId
@@ -98,10 +115,20 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300002, guid: a5831f8b6dd567b41936e6c9fe76e4a2,
         type: 3}
+    - target: {fileID: 8105506691123192018, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8542731111769846700, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89,
         type: 3}
       propertyPath: foreverID
       value: 40b91fa71481bb54cbec1e89fa1ff1d2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8834229393779328598, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89, type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterOff.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterOff.prefab
@@ -97,7 +97,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9022212187074110458}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: -0, y: -0.008726535, z: -0, w: 0.9999619}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
@@ -283,6 +283,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AssetId
       value: f04f1148822d6c949aaafb1e43e5d59b
+      objectReference: {fileID: 0}
+    - target: {fileID: 7367506849151009271, guid: 9a9e0975a92c4564094bbb26dd165002,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999619
+      objectReference: {fileID: 0}
+    - target: {fileID: 7367506849151009271, guid: 9a9e0975a92c4564094bbb26dd165002,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.008726535
       objectReference: {fileID: 0}
     - target: {fileID: 8163608160046166977, guid: 9a9e0975a92c4564094bbb26dd165002,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterOn.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterOn.prefab
@@ -50,17 +50,17 @@ PrefabInstance:
     - target: {fileID: 8586105927633606280, guid: f04f1148822d6c949aaafb1e43e5d59b,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8586105927633606280, guid: f04f1148822d6c949aaafb1e43e5d59b,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8586105927633606280, guid: f04f1148822d6c949aaafb1e43e5d59b,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8586105927633606280, guid: f04f1148822d6c949aaafb1e43e5d59b,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterOnFlipped.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterOnFlipped.prefab
@@ -77,10 +77,30 @@ PrefabInstance:
       propertyPath: foreverID
       value: f67cb958fecc4774bbd74f4177c118b9
       objectReference: {fileID: 0}
+    - target: {fileID: 4119768353039044280, guid: c27cb1a9c87d9c94abaaf3bd9df216df,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999619
+      objectReference: {fileID: 0}
+    - target: {fileID: 4119768353039044280, guid: c27cb1a9c87d9c94abaaf3bd9df216df,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.008726535
+      objectReference: {fileID: 0}
     - target: {fileID: 7762674456558837273, guid: c27cb1a9c87d9c94abaaf3bd9df216df,
         type: 3}
       propertyPath: m_AssetId
       value: f67cb958fecc4774bbd74f4177c118b9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7905771561945024125, guid: c27cb1a9c87d9c94abaaf3bd9df216df,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999619
+      objectReference: {fileID: 0}
+    - target: {fileID: 7905771561945024125, guid: c27cb1a9c87d9c94abaaf3bd9df216df,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.008726535
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c27cb1a9c87d9c94abaaf3bd9df216df, type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterVariants/GasFilterCarbonDioxide.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterVariants/GasFilterCarbonDioxide.prefab
@@ -12,6 +12,31 @@ PrefabInstance:
       propertyPath: foreverID
       value: a7e1d4bdf8f0da343aa6762003b186a1
       objectReference: {fileID: 0}
+    - target: {fileID: 720176264496485969, guid: b089e233e72be7a459003b454eac5407,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 720176264496485969, guid: b089e233e72be7a459003b454eac5407,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1572009001982277665, guid: b089e233e72be7a459003b454eac5407,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1572009001982277665, guid: b089e233e72be7a459003b454eac5407,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999619
+      objectReference: {fileID: 0}
+    - target: {fileID: 1572009001982277665, guid: b089e233e72be7a459003b454eac5407,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.008726535
+      objectReference: {fileID: 0}
     - target: {fileID: 3439427727143657490, guid: b089e233e72be7a459003b454eac5407,
         type: 3}
       propertyPath: initalFilterValue
@@ -45,17 +70,17 @@ PrefabInstance:
     - target: {fileID: 3642943623497653048, guid: b089e233e72be7a459003b454eac5407,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3642943623497653048, guid: b089e233e72be7a459003b454eac5407,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3642943623497653048, guid: b089e233e72be7a459003b454eac5407,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3642943623497653048, guid: b089e233e72be7a459003b454eac5407,
         type: 3}
@@ -76,6 +101,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: GasFilterCarbonDioxide
+      objectReference: {fileID: 0}
+    - target: {fileID: 4704660720800313572, guid: b089e233e72be7a459003b454eac5407,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999619
+      objectReference: {fileID: 0}
+    - target: {fileID: 4704660720800313572, guid: b089e233e72be7a459003b454eac5407,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.008726535
       objectReference: {fileID: 0}
     - target: {fileID: 5135847317549049984, guid: b089e233e72be7a459003b454eac5407,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterVariants/GasFilterCarbonDioxideFlipped.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterVariants/GasFilterCarbonDioxideFlipped.prefab
@@ -12,6 +12,16 @@ PrefabInstance:
       propertyPath: foreverID
       value: 6e3c338712d4b9f41b11b964be643b82
       objectReference: {fileID: 0}
+    - target: {fileID: 1189905908281561642, guid: c9ad1c0d7b699d8439b33158cdaa8d2c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999619
+      objectReference: {fileID: 0}
+    - target: {fileID: 1189905908281561642, guid: c9ad1c0d7b699d8439b33158cdaa8d2c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.008726535
+      objectReference: {fileID: 0}
     - target: {fileID: 3091947157223803417, guid: c9ad1c0d7b699d8439b33158cdaa8d2c,
         type: 3}
       propertyPath: initalFilterValue
@@ -81,6 +91,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AssetId
       value: 6e3c338712d4b9f41b11b964be643b82
+      objectReference: {fileID: 0}
+    - target: {fileID: 4907181119387294447, guid: c9ad1c0d7b699d8439b33158cdaa8d2c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999619
+      objectReference: {fileID: 0}
+    - target: {fileID: 4907181119387294447, guid: c9ad1c0d7b699d8439b33158cdaa8d2c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.008726535
       objectReference: {fileID: 0}
     - target: {fileID: 6011633791992998105, guid: c9ad1c0d7b699d8439b33158cdaa8d2c,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterVariants/GasFilterNitrogen.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterVariants/GasFilterNitrogen.prefab
@@ -12,6 +12,16 @@ PrefabInstance:
       propertyPath: foreverID
       value: 5e8b24c3d4ba53d418cf6708f3c7d680
       objectReference: {fileID: 0}
+    - target: {fileID: 1572009001982277665, guid: b089e233e72be7a459003b454eac5407,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999619
+      objectReference: {fileID: 0}
+    - target: {fileID: 1572009001982277665, guid: b089e233e72be7a459003b454eac5407,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.008726535
+      objectReference: {fileID: 0}
     - target: {fileID: 3439427727143657490, guid: b089e233e72be7a459003b454eac5407,
         type: 3}
       propertyPath: initalFilterValue
@@ -45,17 +55,17 @@ PrefabInstance:
     - target: {fileID: 3642943623497653048, guid: b089e233e72be7a459003b454eac5407,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3642943623497653048, guid: b089e233e72be7a459003b454eac5407,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3642943623497653048, guid: b089e233e72be7a459003b454eac5407,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3642943623497653048, guid: b089e233e72be7a459003b454eac5407,
         type: 3}
@@ -76,6 +86,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: GasFilterNitrogen
+      objectReference: {fileID: 0}
+    - target: {fileID: 4704660720800313572, guid: b089e233e72be7a459003b454eac5407,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999619
+      objectReference: {fileID: 0}
+    - target: {fileID: 4704660720800313572, guid: b089e233e72be7a459003b454eac5407,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.008726535
       objectReference: {fileID: 0}
     - target: {fileID: 5135847317549049984, guid: b089e233e72be7a459003b454eac5407,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterVariants/GasFilterNitrogenFlipped.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterVariants/GasFilterNitrogenFlipped.prefab
@@ -12,6 +12,16 @@ PrefabInstance:
       propertyPath: foreverID
       value: a02e1795c6c2a474488cd85c3fa21569
       objectReference: {fileID: 0}
+    - target: {fileID: 1189905908281561642, guid: c9ad1c0d7b699d8439b33158cdaa8d2c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999619
+      objectReference: {fileID: 0}
+    - target: {fileID: 1189905908281561642, guid: c9ad1c0d7b699d8439b33158cdaa8d2c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.008726535
+      objectReference: {fileID: 0}
     - target: {fileID: 3091947157223803417, guid: c9ad1c0d7b699d8439b33158cdaa8d2c,
         type: 3}
       propertyPath: initalFilterValue
@@ -81,6 +91,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AssetId
       value: a02e1795c6c2a474488cd85c3fa21569
+      objectReference: {fileID: 0}
+    - target: {fileID: 4907181119387294447, guid: c9ad1c0d7b699d8439b33158cdaa8d2c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999619
+      objectReference: {fileID: 0}
+    - target: {fileID: 4907181119387294447, guid: c9ad1c0d7b699d8439b33158cdaa8d2c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.008726535
       objectReference: {fileID: 0}
     - target: {fileID: 6011633791992998105, guid: c9ad1c0d7b699d8439b33158cdaa8d2c,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterVariants/GasFilterNitrousOxide.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterVariants/GasFilterNitrousOxide.prefab
@@ -12,6 +12,16 @@ PrefabInstance:
       propertyPath: foreverID
       value: 741681531f3666a47bfb561e6504aef7
       objectReference: {fileID: 0}
+    - target: {fileID: 1572009001982277665, guid: b089e233e72be7a459003b454eac5407,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999619
+      objectReference: {fileID: 0}
+    - target: {fileID: 1572009001982277665, guid: b089e233e72be7a459003b454eac5407,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.008726535
+      objectReference: {fileID: 0}
     - target: {fileID: 3439427727143657490, guid: b089e233e72be7a459003b454eac5407,
         type: 3}
       propertyPath: initalFilterValue
@@ -45,17 +55,17 @@ PrefabInstance:
     - target: {fileID: 3642943623497653048, guid: b089e233e72be7a459003b454eac5407,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3642943623497653048, guid: b089e233e72be7a459003b454eac5407,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3642943623497653048, guid: b089e233e72be7a459003b454eac5407,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3642943623497653048, guid: b089e233e72be7a459003b454eac5407,
         type: 3}
@@ -76,6 +86,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: GasFilterNitrousOxide
+      objectReference: {fileID: 0}
+    - target: {fileID: 4704660720800313572, guid: b089e233e72be7a459003b454eac5407,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999619
+      objectReference: {fileID: 0}
+    - target: {fileID: 4704660720800313572, guid: b089e233e72be7a459003b454eac5407,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.008726535
       objectReference: {fileID: 0}
     - target: {fileID: 5135847317549049984, guid: b089e233e72be7a459003b454eac5407,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterVariants/GasFilterNitrousOxideFlipped.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterVariants/GasFilterNitrousOxideFlipped.prefab
@@ -12,6 +12,16 @@ PrefabInstance:
       propertyPath: foreverID
       value: ad674eedc3e39be45b021708d87435dc
       objectReference: {fileID: 0}
+    - target: {fileID: 1189905908281561642, guid: c9ad1c0d7b699d8439b33158cdaa8d2c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999619
+      objectReference: {fileID: 0}
+    - target: {fileID: 1189905908281561642, guid: c9ad1c0d7b699d8439b33158cdaa8d2c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.008726535
+      objectReference: {fileID: 0}
     - target: {fileID: 3091947157223803417, guid: c9ad1c0d7b699d8439b33158cdaa8d2c,
         type: 3}
       propertyPath: initalFilterValue
@@ -81,6 +91,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AssetId
       value: ad674eedc3e39be45b021708d87435dc
+      objectReference: {fileID: 0}
+    - target: {fileID: 4907181119387294447, guid: c9ad1c0d7b699d8439b33158cdaa8d2c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999619
+      objectReference: {fileID: 0}
+    - target: {fileID: 4907181119387294447, guid: c9ad1c0d7b699d8439b33158cdaa8d2c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.008726535
       objectReference: {fileID: 0}
     - target: {fileID: 6011633791992998105, guid: c9ad1c0d7b699d8439b33158cdaa8d2c,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterVariants/GasFilterOxygen.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterVariants/GasFilterOxygen.prefab
@@ -45,17 +45,17 @@ PrefabInstance:
     - target: {fileID: 3642943623497653048, guid: b089e233e72be7a459003b454eac5407,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3642943623497653048, guid: b089e233e72be7a459003b454eac5407,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3642943623497653048, guid: b089e233e72be7a459003b454eac5407,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3642943623497653048, guid: b089e233e72be7a459003b454eac5407,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterVariants/GasFilterPlasma.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterVariants/GasFilterPlasma.prefab
@@ -45,17 +45,17 @@ PrefabInstance:
     - target: {fileID: 3642943623497653048, guid: b089e233e72be7a459003b454eac5407,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3642943623497653048, guid: b089e233e72be7a459003b454eac5407,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3642943623497653048, guid: b089e233e72be7a459003b454eac5407,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3642943623497653048, guid: b089e233e72be7a459003b454eac5407,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterVariants/_GasFilterAtmosBase.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterVariants/_GasFilterAtmosBase.prefab
@@ -12,10 +12,47 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: b089e233e72be7a459003b454eac5407
       objectReference: {fileID: 0}
+    - target: {fileID: 245935552815682260, guid: f04f1148822d6c949aaafb1e43e5d59b,
+        type: 3}
+      propertyPath: pushTextureOnStartUp
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1367751887141801738, guid: f04f1148822d6c949aaafb1e43e5d59b,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: dc27c82ed88a09d43ac8a5fc2a86bd49,
+        type: 2}
+    - target: {fileID: 1832514158404938653, guid: f04f1148822d6c949aaafb1e43e5d59b,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: e2d530446c392ab44ba1f5086d7b415e,
+        type: 2}
     - target: {fileID: 4630725396653616667, guid: f04f1148822d6c949aaafb1e43e5d59b,
         type: 3}
       propertyPath: foreverID
       value: b089e233e72be7a459003b454eac5407
+      objectReference: {fileID: 0}
+    - target: {fileID: 5500927360601103329, guid: f04f1148822d6c949aaafb1e43e5d59b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5500927360601103329, guid: f04f1148822d6c949aaafb1e43e5d59b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5798747285961487761, guid: f04f1148822d6c949aaafb1e43e5d59b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5798747285961487761, guid: f04f1148822d6c949aaafb1e43e5d59b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7643419451972840866, guid: f04f1148822d6c949aaafb1e43e5d59b,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterVariants/_GasFilterAtmosFlippedBase.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasFilterVariants/_GasFilterAtmosFlippedBase.prefab
@@ -77,10 +77,37 @@ PrefabInstance:
       propertyPath: foreverID
       value: c9ad1c0d7b699d8439b33158cdaa8d2c
       objectReference: {fileID: 0}
+    - target: {fileID: 4119768353039044280, guid: c27cb1a9c87d9c94abaaf3bd9df216df,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4119768353039044280, guid: c27cb1a9c87d9c94abaaf3bd9df216df,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7655186459384654333, guid: c27cb1a9c87d9c94abaaf3bd9df216df,
+        type: 3}
+      propertyPath: pushTextureOnStartUp
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 7762674456558837273, guid: c27cb1a9c87d9c94abaaf3bd9df216df,
         type: 3}
       propertyPath: m_AssetId
       value: c9ad1c0d7b699d8439b33158cdaa8d2c
       objectReference: {fileID: 0}
+    - target: {fileID: 8087188916101107892, guid: c27cb1a9c87d9c94abaaf3bd9df216df,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: e2d530446c392ab44ba1f5086d7b415e,
+        type: 2}
+    - target: {fileID: 8912106392068977699, guid: c27cb1a9c87d9c94abaaf3bd9df216df,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: dc27c82ed88a09d43ac8a5fc2a86bd49,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c27cb1a9c87d9c94abaaf3bd9df216df, type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasMixerOff.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasMixerOff.prefab
@@ -25,7 +25,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2920762993511851191}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: -0, y: -0.008726535, z: -0, w: 0.9999619}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []

--- a/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasMixerOn.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasMixerOn.prefab
@@ -12,10 +12,115 @@ PrefabInstance:
       propertyPath: IsOn
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 1950110695813343693, guid: 7a167eaa044fd7142ad12de730b62846,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999619
+      objectReference: {fileID: 0}
+    - target: {fileID: 1950110695813343693, guid: 7a167eaa044fd7142ad12de730b62846,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1950110695813343693, guid: 7a167eaa044fd7142ad12de730b62846,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.008726535
+      objectReference: {fileID: 0}
+    - target: {fileID: 1950110695813343693, guid: 7a167eaa044fd7142ad12de730b62846,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
     - target: {fileID: 2097640912963940777, guid: 7a167eaa044fd7142ad12de730b62846,
         type: 3}
       propertyPath: m_AssetId
       value: 6bdbff38e08513c4b84323e02a765184
+      objectReference: {fileID: 0}
+    - target: {fileID: 4155446236359018667, guid: 7a167eaa044fd7142ad12de730b62846,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999619
+      objectReference: {fileID: 0}
+    - target: {fileID: 4155446236359018667, guid: 7a167eaa044fd7142ad12de730b62846,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4155446236359018667, guid: 7a167eaa044fd7142ad12de730b62846,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.008726535
+      objectReference: {fileID: 0}
+    - target: {fileID: 4155446236359018667, guid: 7a167eaa044fd7142ad12de730b62846,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4277940505902847818, guid: 7a167eaa044fd7142ad12de730b62846,
+        type: 3}
+      propertyPath: InitialDirection
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4945872616854286763, guid: 7a167eaa044fd7142ad12de730b62846,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999619
+      objectReference: {fileID: 0}
+    - target: {fileID: 4945872616854286763, guid: 7a167eaa044fd7142ad12de730b62846,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4945872616854286763, guid: 7a167eaa044fd7142ad12de730b62846,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.008726535
+      objectReference: {fileID: 0}
+    - target: {fileID: 4945872616854286763, guid: 7a167eaa044fd7142ad12de730b62846,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6027211411897634680, guid: 7a167eaa044fd7142ad12de730b62846,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999619
+      objectReference: {fileID: 0}
+    - target: {fileID: 6027211411897634680, guid: 7a167eaa044fd7142ad12de730b62846,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6027211411897634680, guid: 7a167eaa044fd7142ad12de730b62846,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.008726535
+      objectReference: {fileID: 0}
+    - target: {fileID: 6027211411897634680, guid: 7a167eaa044fd7142ad12de730b62846,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6431425520288524796, guid: 7a167eaa044fd7142ad12de730b62846,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999619
+      objectReference: {fileID: 0}
+    - target: {fileID: 6431425520288524796, guid: 7a167eaa044fd7142ad12de730b62846,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6431425520288524796, guid: 7a167eaa044fd7142ad12de730b62846,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.008726535
+      objectReference: {fileID: 0}
+    - target: {fileID: 6431425520288524796, guid: 7a167eaa044fd7142ad12de730b62846,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 6895126086718782082, guid: 7a167eaa044fd7142ad12de730b62846,
         type: 3}
@@ -55,17 +160,17 @@ PrefabInstance:
     - target: {fileID: 7553721075204866577, guid: 7a167eaa044fd7142ad12de730b62846,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7553721075204866577, guid: 7a167eaa044fd7142ad12de730b62846,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7553721075204866577, guid: 7a167eaa044fd7142ad12de730b62846,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7553721075204866577, guid: 7a167eaa044fd7142ad12de730b62846,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasMixerOnFlipped.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/GasMixerOnFlipped.prefab
@@ -45,17 +45,17 @@ PrefabInstance:
     - target: {fileID: 5370147364975866674, guid: 4f17af44773940f48a8a804c27fb1ea1,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5370147364975866674, guid: 4f17af44773940f48a8a804c27fb1ea1,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5370147364975866674, guid: 4f17af44773940f48a8a804c27fb1ea1,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5370147364975866674, guid: 4f17af44773940f48a8a804c27fb1ea1,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/_AtmosTrinaryBase.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Trinary/_AtmosTrinaryBase.prefab
@@ -25,7 +25,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7694038972534018014}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: -0, y: -0.008726535, z: -0, w: 0.9999619}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
@@ -73,7 +73,7 @@ SpriteRenderer:
   m_SortingLayerID: 776718967
   m_SortingLayer: 1
   m_SortingOrder: 70
-  m_Sprite: {fileID: 21300006, guid: a5831f8b6dd567b41936e6c9fe76e4a2, type: 3}
+  m_Sprite: {fileID: 21300002, guid: b0acb51e1d67bac48a3d15a157fef8bb, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -98,7 +98,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   NetworkThis: 1
   SubCatalogue: []
-  PresentSpriteSet: {fileID: 11400000, guid: c59c5e3dd182a7649a161ea1d0bbc672, type: 2}
+  PresentSpriteSet: {fileID: 11400000, guid: dc27c82ed88a09d43ac8a5fc2a86bd49, type: 2}
   randomInitialSprite: 0
   pushTextureOnStartUp: 1
   initialVariantIndex: 3
@@ -115,11 +115,27 @@ PrefabInstance:
       propertyPath: m_RootOrder
       value: 2
       objectReference: {fileID: 0}
+    - target: {fileID: 1195305884334883205, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1195305884334883205, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3431779693841004074, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89,
         type: 3}
       propertyPath: variantIndex
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 3431779693841004074, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: e2d530446c392ab44ba1f5086d7b415e,
+        type: 2}
     - target: {fileID: 3431779693841004074, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89,
         type: 3}
       propertyPath: initialVariantIndex
@@ -134,7 +150,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300002, guid: 2217fe06c75376d41af4a23f9383b678,
+      objectReference: {fileID: 21300006, guid: 2217fe06c75376d41af4a23f9383b678,
         type: 3}
     - target: {fileID: 4749535366278089535, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89,
         type: 3}
@@ -164,17 +180,17 @@ PrefabInstance:
     - target: {fileID: 4749535366278089535, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4749535366278089535, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4749535366278089535, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4749535366278089535, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89,
         type: 3}
@@ -221,6 +237,21 @@ PrefabInstance:
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 8105506691123192018, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8105506691123192018, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8105506691123192018, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8119568663060751305, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89,
         type: 3}
       propertyPath: isSelfPowered
@@ -230,6 +261,16 @@ PrefabInstance:
         type: 3}
       propertyPath: foreverID
       value: 9a9e0975a92c4564094bbb26dd165002
+      objectReference: {fileID: 0}
+    - target: {fileID: 8834229393779328598, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8834229393779328598, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 6759082740083206500, guid: 48ba0ba8fbfe6f849ac4809f7dbfed89, type: 3}

--- a/UnityProject/Assets/Resources/ScriptableObjectsSingletons/SpriteCatalogueSingleton.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjectsSingletons/SpriteCatalogueSingleton.asset
@@ -23853,4 +23853,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 8766fc6ca8ee3374ab0c6e27466fa9af, type: 2}
   - {fileID: 11400000, guid: 2c6b6e8d71b258b4aa875482727840fe, type: 2}
   - {fileID: 11400000, guid: dc27c82ed88a09d43ac8a5fc2a86bd49, type: 2}
-  - {fileID: 0}
+  - {fileID: 11400000, guid: e2d530446c392ab44ba1f5086d7b415e, type: 2}

--- a/UnityProject/Assets/Resources/ScriptableObjectsSingletons/SpriteCatalogueSingleton.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjectsSingletons/SpriteCatalogueSingleton.asset
@@ -23851,3 +23851,6 @@ MonoBehaviour:
   - {fileID: 11400000, guid: e97fc470147d7a14db67e6576b36516b, type: 2}
   - {fileID: 11400000, guid: da640a76bea4cf342a3103e412c82e49, type: 2}
   - {fileID: 11400000, guid: 8766fc6ca8ee3374ab0c6e27466fa9af, type: 2}
+  - {fileID: 11400000, guid: 2c6b6e8d71b258b4aa875482727840fe, type: 2}
+  - {fileID: 11400000, guid: dc27c82ed88a09d43ac8a5fc2a86bd49, type: 2}
+  - {fileID: 0}

--- a/UnityProject/Assets/Textures/objects/atmospherics/components/binary_devices/binary_devices_pipe_intact-1.asset
+++ b/UnityProject/Assets/Textures/objects/atmospherics/components/binary_devices/binary_devices_pipe_intact-1.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
+  m_Name: binary_devices_pipe_intact-1
+  m_EditorClassIdentifier: 
+  Variance:
+  - Frames:
+    - sprite: {fileID: 21300002, guid: b0acb51e1d67bac48a3d15a157fef8bb, type: 3}
+      secondDelay: 0
+  - Frames:
+    - sprite: {fileID: 21300000, guid: b0acb51e1d67bac48a3d15a157fef8bb, type: 3}
+      secondDelay: 0
+  - Frames:
+    - sprite: {fileID: 21300006, guid: b0acb51e1d67bac48a3d15a157fef8bb, type: 3}
+      secondDelay: 0
+  - Frames:
+    - sprite: {fileID: 21300004, guid: b0acb51e1d67bac48a3d15a157fef8bb, type: 3}
+      secondDelay: 0
+  IsPalette: 0
+  setID: 23839
+  DisplayName: 

--- a/UnityProject/Assets/Textures/objects/atmospherics/components/binary_devices/binary_devices_pipe_intact-1.asset.meta
+++ b/UnityProject/Assets/Textures/objects/atmospherics/components/binary_devices/binary_devices_pipe_intact-1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dc27c82ed88a09d43ac8a5fc2a86bd49
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Textures/objects/atmospherics/components/binary_devices/binary_devices_pipe_intact-2.asset
+++ b/UnityProject/Assets/Textures/objects/atmospherics/components/binary_devices/binary_devices_pipe_intact-2.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
+  m_Name: binary_devices_pipe_intact-2
+  m_EditorClassIdentifier: 
+  Variance:
+  - Frames:
+    - sprite: {fileID: 21300006, guid: b0acb51e1d67bac48a3d15a157fef8bb, type: 3}
+      secondDelay: 0
+  - Frames:
+    - sprite: {fileID: 21300004, guid: b0acb51e1d67bac48a3d15a157fef8bb, type: 3}
+      secondDelay: 0
+  - Frames:
+    - sprite: {fileID: 21300000, guid: b0acb51e1d67bac48a3d15a157fef8bb, type: 3}
+      secondDelay: 0
+  - Frames:
+    - sprite: {fileID: 21300000, guid: b0acb51e1d67bac48a3d15a157fef8bb, type: 3}
+      secondDelay: 0
+  IsPalette: 0
+  setID: 23840
+  DisplayName: 

--- a/UnityProject/Assets/Textures/objects/atmospherics/components/binary_devices/binary_devices_pipe_intact-2.asset.meta
+++ b/UnityProject/Assets/Textures/objects/atmospherics/components/binary_devices/binary_devices_pipe_intact-2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e2d530446c392ab44ba1f5086d7b415e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Textures/under floors/manifold/manifold_pipe-4.asset
+++ b/UnityProject/Assets/Textures/under floors/manifold/manifold_pipe-4.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
+  m_Name: manifold_pipe-4
+  m_EditorClassIdentifier: 
+  Variance:
+  - Frames:
+    - sprite: {fileID: 21300002, guid: 2217fe06c75376d41af4a23f9383b678, type: 3}
+      secondDelay: 0
+  - Frames:
+    - sprite: {fileID: 21300000, guid: 2217fe06c75376d41af4a23f9383b678, type: 3}
+      secondDelay: 0
+  - Frames:
+    - sprite: {fileID: 21300006, guid: 2217fe06c75376d41af4a23f9383b678, type: 3}
+      secondDelay: 0
+  - Frames:
+    - sprite: {fileID: 21300004, guid: 2217fe06c75376d41af4a23f9383b678, type: 3}
+      secondDelay: 0
+  IsPalette: 0
+  setID: 23838
+  DisplayName: 

--- a/UnityProject/Assets/Textures/under floors/manifold/manifold_pipe-4.asset.meta
+++ b/UnityProject/Assets/Textures/under floors/manifold/manifold_pipe-4.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2c6b6e8d71b258b4aa875482727840fe
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
Fixes the issues where all pipe connections for an atmos device shared the same SpriteDataSO so they would always face the same direction. Fixes #7194

### Notes:
Also Square stations filter and mixer prefabs where outdated, so I updated those while I was at it.

### Changelog:
CL: [Fix] Fixes sprite issues with Atmos device pipes
CL: [Fix] Updates Sqaurestations mixer and filter prefabs.
