### PR TITLE
Showing objective reminder for traitors now show their uplink code

### DIFF
--- a/UnityProject/Assets/Scripts/Player/Mind.cs
+++ b/UnityProject/Assets/Scripts/Player/Mind.cs
@@ -6,6 +6,7 @@ using Mirror;
 using Antagonists;
 using Systems.Spells;
 using HealthV2;
+using Items.PDA;
 using Player;
 using ScriptableObjects.Audio;
 using UI.Action;
@@ -223,8 +224,20 @@ public class Mind
 	public void ShowObjectives()
 	{
 		if (IsAntag == false) return;
-
-		Chat.AddExamineMsgFromServer(GetCurrentMob(), antag.GetObjectivesForPlayer());
+		var playerMob = GetCurrentMob();
+		Chat.AddExamineMsgFromServer(playerMob, antag.GetObjectivesForPlayer());
+		if(playerMob.TryGetComponent<PlayerScript>(out var body) == false) return;
+		if (antag.Antagonist.AntagJobType == JobType.TRAITOR || antag.Antagonist.AntagJobType == JobType.SYNDICATE)
+        {
+        	var playerInventory = body.DynamicItemStorage.GetItemSlots();
+        	foreach (var item in playerInventory)
+        	{
+        		if(item.IsEmpty) continue;
+        		if (item.ItemObject.TryGetComponent<PDALogic>(out var PDA) == false) continue;
+        		if(PDA.IsUplinkCapable == false) continue;
+                Chat.AddExamineMsgFromServer(playerMob, antag.GetObjectivesForPlayer());
+	        }
+        }
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Player/Mind.cs
+++ b/UnityProject/Assets/Scripts/Player/Mind.cs
@@ -225,17 +225,22 @@ public class Mind
 	{
 		if (IsAntag == false) return;
 		var playerMob = GetCurrentMob();
+		
+		//Send Objectives
 		Chat.AddExamineMsgFromServer(playerMob, antag.GetObjectivesForPlayer());
-		if(playerMob.TryGetComponent<PlayerScript>(out var body) == false) return;
+		
+		if (playerMob.TryGetComponent<PlayerScript>(out var body) == false) return;
 		if (antag.Antagonist.AntagJobType == JobType.TRAITOR || antag.Antagonist.AntagJobType == JobType.SYNDICATE)
         {
         	var playerInventory = body.DynamicItemStorage.GetItemSlots();
         	foreach (var item in playerInventory)
         	{
-        		if(item.IsEmpty) continue;
+        		if (item.IsEmpty) continue;
         		if (item.ItemObject.TryGetComponent<PDALogic>(out var PDA) == false) continue;
         		if(PDA.IsUplinkCapable == false) continue;
-                Chat.AddExamineMsgFromServer(playerMob, antag.GetObjectivesForPlayer());
+        		
+        		//Send Uplink code
+                Chat.AddExamineMsgFromServer(playerMob, $"PDA uplink code retrieved: {PDA.UplinkUnlockCode}");
 	        }
         }
 	}

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/SpawnedAntag.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/SpawnedAntag.cs
@@ -76,6 +76,17 @@ namespace Antagonists
 			}
 			// Adding back italic tag so rich text doesn't break
 			objSB.AppendLine("<i>");
+			if (Antagonist.AntagJobType == JobType.TRAITOR || Antagonist.AntagJobType == JobType.SYNDICATE)
+			{
+				var playerInventory = Owner.body.DynamicItemStorage.GetItemSlots();
+				foreach (var item in playerInventory)
+				{
+					if(item.IsEmpty) continue;
+					if (item.ItemObject.TryGetComponent<PDALogic>(out var PDA) == false) continue;
+					if(PDA.IsUplinkCapable == false) continue;
+					objSB.AppendLine($"Your uplink code is {PDA.UplinkUnlockCode}");
+				}
+			}
 			return objSB.ToString();
 		}
 

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/SpawnedAntag.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/SpawnedAntag.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Items.PDA;
 using Strings;
 
 namespace Antagonists
@@ -77,17 +76,6 @@ namespace Antagonists
 			}
 			// Adding back italic tag so rich text doesn't break
 			objSB.AppendLine("<i>");
-			if (Antagonist.AntagJobType == JobType.TRAITOR || Antagonist.AntagJobType == JobType.SYNDICATE)
-			{
-				var playerInventory = Owner.body.DynamicItemStorage.GetItemSlots();
-				foreach (var item in playerInventory)
-				{
-					if(item.IsEmpty) continue;
-					if (item.ItemObject.TryGetComponent<PDALogic>(out var PDA) == false) continue;
-					if(PDA.IsUplinkCapable == false) continue;
-					objSB.AppendLine($"Your uplink code is {PDA.UplinkUnlockCode}");
-				}
-			}
 			return objSB.ToString();
 		}
 

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/SpawnedAntag.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/SpawnedAntag.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Items.PDA;
 using Strings;
 
 namespace Antagonists


### PR DESCRIPTION
closes #7971

CL: [Improvement] hitting the objective reminder action button now shows traitors and nuclear operatives their uplink codes.