### PR TITLE
Handles customisations on body parts better

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Implants/Implant.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Implant.prefab
@@ -122,6 +122,18 @@ SortingGroup:
     type: 3}
   m_PrefabInstance: {fileID: 1164032867585741730}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &4999823976648774815 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
+    type: 3}
+  m_PrefabInstance: {fileID: 1164032867585741730}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &2314801526373061764
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -148,7 +160,7 @@ MonoBehaviour:
   RelatedPresentSprites: []
   SpritePrefab: {fileID: 8495837738996047739, guid: 7f846789e62ac004499611e9c1417efa,
     type: 3}
-  BodyPartItemSprite: {fileID: 0}
+  BodyPartItemSprite: {fileID: 4999823976648774815}
   BodyPartItemInheritsSkinColor: 0
   BodySpriteSet: 0
   LobbyCustomisation: {fileID: 0}
@@ -157,7 +169,6 @@ MonoBehaviour:
   IsSurface: 0
   DeathOnRemoval: 0
   ClothingHide: 0
-  Tone: {r: 1, g: 1, b: 1, a: 1}
   SetCustomisationData: 
   TotalModified: 1
   SurgeryProcedureBase:
@@ -210,8 +221,6 @@ MonoBehaviour:
   maxHealth: 100
   Severity: 50
   BodyPartReadableName: '[Default Part Name]'
-  internalDamageDesc: This {readableName} is suffering from internal damage.
-  externalBleedingDesc: This {readableName} is bleeding due to an open wound.
   BoneFracturedLvlThreeDesc: This {readableName} is suffering Hairline Fracture.
   BoneFracturedLvlTwoDesc: This {readableName} is suffering Compound Fracture. It
     is completely snapped in half.

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/BodyPartSpriteAndColour Variant.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/BodyPartSpriteAndColour Variant.prefab
@@ -124,6 +124,11 @@ PrefabInstance:
       objectReference: {fileID: 344716720463008260}
     - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
         type: 3}
+      propertyPath: ColourAppliesToItemsSprite
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
+        type: 3}
       propertyPath: OptionalSprites.Array.size
       value: 174
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/BodyPartSpriteAndColourFacialHair.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/BodyPartSpriteAndColourFacialHair.prefab
@@ -119,6 +119,16 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
         type: 3}
+      propertyPath: AppliesToItemsSprite
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
+        type: 3}
+      propertyPath: ColourAppliesToItemsSprite
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
+        type: 3}
       propertyPath: OptionalSprites.Array.size
       value: 35
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/lizard/Frills.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/lizard/Frills.prefab
@@ -119,6 +119,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
         type: 3}
+      propertyPath: ColourAppliesToItemsSprite
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
+        type: 3}
       propertyPath: OptionalSprites.Array.size
       value: 3
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/lizard/Horns.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/lizard/Horns.prefab
@@ -119,6 +119,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
         type: 3}
+      propertyPath: ColourAppliesToItemsSprite
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
+        type: 3}
       propertyPath: OptionalSprites.Array.size
       value: 5
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/lizard/Snout.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/lizard/Snout.prefab
@@ -119,6 +119,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
         type: 3}
+      propertyPath: ColourAppliesToItemsSprite
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
+        type: 3}
       propertyPath: OptionalSprites.Array.size
       value: 4
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/lizard/Spikes.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/lizard/Spikes.prefab
@@ -119,6 +119,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
         type: 3}
+      propertyPath: ColourAppliesToItemsSprite
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
+        type: 3}
       propertyPath: OptionalSprites.Array.size
       value: 5
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/lizard/TailCustomisation.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/lizard/TailCustomisation.prefab
@@ -119,6 +119,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
         type: 3}
+      propertyPath: ColourAppliesToItemsSprite
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
+        type: 3}
       propertyPath: OptionalSprites.Array.size
       value: 4
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/moth/MothAntennae.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/moth/MothAntennae.prefab
@@ -124,6 +124,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
         type: 3}
+      propertyPath: ColourAppliesToItemsSprite
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
+        type: 3}
       propertyPath: OptionalSprites.Array.size
       value: 21
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/moth/MothMarkings.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/moth/MothMarkings.prefab
@@ -124,6 +124,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
         type: 3}
+      propertyPath: ColourAppliesToItemsSprite
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
+        type: 3}
       propertyPath: OptionalSprites.Array.size
       value: 14
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/moth/MothWings.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/moth/MothWings.prefab
@@ -124,6 +124,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
         type: 3}
+      propertyPath: ColourAppliesToItemsSprite
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
+        type: 3}
       propertyPath: OptionalSprites.Array.size
       value: 19
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/vulpkanin/TailCustomisation 1.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/vulpkanin/TailCustomisation 1.prefab
@@ -119,6 +119,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
         type: 3}
+      propertyPath: ColourAppliesToItemsSprite
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
+        type: 3}
       propertyPath: OptionalSprites.Array.size
       value: 3
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/vulpkanin/VulpkaninBodyMarkings.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/vulpkanin/VulpkaninBodyMarkings.prefab
@@ -124,6 +124,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
         type: 3}
+      propertyPath: ColourAppliesToItemsSprite
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
+        type: 3}
       propertyPath: OptionalSprites.Array.size
       value: 8
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/vulpkanin/VulpkaninFacialHair.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/vulpkanin/VulpkaninFacialHair.prefab
@@ -119,6 +119,16 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
         type: 3}
+      propertyPath: AppliesToItemsSprite
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
+        type: 3}
+      propertyPath: ColourAppliesToItemsSprite
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
+        type: 3}
       propertyPath: OptionalSprites.Array.size
       value: 12
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/vulpkanin/VulpkaninFacialMarkings.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/vulpkanin/VulpkaninFacialMarkings.prefab
@@ -124,6 +124,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
         type: 3}
+      propertyPath: ColourAppliesToItemsSprite
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
+        type: 3}
       propertyPath: OptionalSprites.Array.size
       value: 8
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/vulpkanin/VulpkaninHair.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/vulpkanin/VulpkaninHair.prefab
@@ -124,6 +124,11 @@ PrefabInstance:
       objectReference: {fileID: 344716720463008260}
     - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
         type: 3}
+      propertyPath: ColourAppliesToItemsSprite
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
+        type: 3}
       propertyPath: OptionalSprites.Array.size
       value: 196
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/vulpkanin/VulpkaninTailCustomisation.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/vulpkanin/VulpkaninTailCustomisation.prefab
@@ -134,6 +134,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
         type: 3}
+      propertyPath: ColourAppliesToItemsSprite
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
+        type: 3}
       propertyPath: OptionalSprites.Array.size
       value: 2
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/vulpkanin/VulpkaninTailMarkings.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/DropDownSprites/vulpkanin/VulpkaninTailMarkings.prefab
@@ -139,6 +139,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
         type: 3}
+      propertyPath: ColourAppliesToItemsSprite
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7055774701040658935, guid: 89855ce616f6fac4db5a551a6b8ace28,
+        type: 3}
       propertyPath: OptionalSprites.Array.size
       value: 2
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPart.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPart.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Mirror;
 using UnityEngine;
 using NaughtyAttributes;
 using Player;
@@ -135,7 +136,7 @@ namespace HealthV2
 		/// <summary>
 		/// What is this BodyPart's sprite's tone if it shared a skin tone with the player?
 		/// </summary>
-		[HideInInspector] public Color Tone = Color.white;
+		[HideInInspector] public Color? Tone;
 
 		public string SetCustomisationData;
 
@@ -439,13 +440,6 @@ namespace HealthV2
 		/// </summary>
 		private void SetRemovedColor()
 		{
-			if (IsSurface && BodyPartItemInheritsSkinColor && currentBurnDamageLevel != TraumaDamageLevel.CRITICAL)
-			{
-				CharacterSettings settings = HealthMaster.gameObject.Player().Script.characterSettings;
-				ColorUtility.TryParseHtmlString(settings.SkinTone, out Tone);
-				BodyPartItemSprite.OrNull()?.SetColor(Tone);
-			}
-
 			if (currentBurnDamageLevel == TraumaDamageLevel.CRITICAL)
 			{
 				BodyPartItemSprite.OrNull()?.SetColor(bodyPartColorWhenCharred);
@@ -458,13 +452,15 @@ namespace HealthV2
 			for (var i = RelatedPresentSprites.Count - 1; i >= 0; i--)
 			{
 				var bodyPartSprite = RelatedPresentSprites[i];
-				if (IsSurface)
+				if (IsSurface || BodyPartItemInheritsSkinColor)
 				{
 					sprites.SurfaceSprite.Remove(bodyPartSprite);
 				}
 
 				RelatedPresentSprites.Remove(bodyPartSprite);
 				sprites.Addedbodypart.Remove(bodyPartSprite);
+				SpriteHandlerManager.UnRegisterHandler(sprites.GetComponent<NetworkIdentity>(),
+					bodyPartSprite.baseSpriteHandler);
 				Destroy(bodyPartSprite.gameObject);
 			}
 

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -1244,7 +1244,7 @@ namespace HealthV2
 			CurrentSurfaceColour.a = 1;
 			newSprite.baseSpriteHandler.SetColor(CurrentSurfaceColour);
 			implant.Tone = CurrentSurfaceColour;
-
+			implant.BodyPartItemSprite.SetColor(CurrentSurfaceColour);
 		}
 
 		public List<BodyPartSprites> ClientSprites = new List<BodyPartSprites>();

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/SubCustomisation/BodyPartCustomisations/BodyPartColourSprite.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/SubCustomisation/BodyPartCustomisations/BodyPartColourSprite.cs
@@ -11,6 +11,8 @@ namespace UI.CharacterCreator
 		public Color BodyPartColour = Color.white;
 		public Image SelectionColourImage;
 
+		public bool AppliesToItemsSprite = false;
+
 		public override void Deserialise(string InData)
 		{
 			ColorUtility.TryParseHtmlString(InData, out BodyPartColour);
@@ -35,6 +37,11 @@ namespace UI.CharacterCreator
 			ColorUtility.TryParseHtmlString(InData, out BodyPartColour);
 			BodyPartColour.a = 1; //Force body part color to never be transparent.
 			Body_Part.RelatedPresentSprites[0].baseSpriteHandler.SetColor(BodyPartColour);
+			if (AppliesToItemsSprite)
+			{
+				Body_Part.BodyPartItemSprite.SetColor(BodyPartColour);
+			}
+
 		}
 
 		public override void RandomizeValues()

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/SubCustomisation/BodyPartCustomisations/BodyPartSpriteAndColour.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/SubCustomisation/BodyPartCustomisations/BodyPartSpriteAndColour.cs
@@ -14,7 +14,8 @@ namespace UI.CharacterCreator
 		public Image SelectionColourImage;
 		public Dropdown Dropdown;
 		public List<SpriteDataSO> OptionalSprites = new List<SpriteDataSO>();
-
+		public bool AppliesToItemsSprite = false;
+		public bool ColourAppliesToItemsSprite = false;
 		public struct ColourAndSelected
 		{
 			public string color;
@@ -105,6 +106,11 @@ namespace UI.CharacterCreator
 			ColorUtility.TryParseHtmlString(ColourAnd_Selected.color, out BodyPartColour);
 			BodyPartColour.a = 1;
 			Body_Part.RelatedPresentSprites[0].baseSpriteHandler.SetColor(BodyPartColour);
+			if (ColourAppliesToItemsSprite)
+			{
+				Body_Part.BodyPartItemSprite.SetColor(BodyPartColour);
+			}
+
 			OptionalSprites = OptionalSprites.OrderBy(pcd => pcd.DisplayName == "" ? pcd.name : pcd.DisplayName).ToList();
 			if (ColourAnd_Selected.Chosen != 0)
 			{
@@ -116,6 +122,10 @@ namespace UI.CharacterCreator
 
 				Body_Part.RelatedPresentSprites[0].baseSpriteHandler
 					.SetSpriteSO(OptionalSprites[ColourAnd_Selected.Chosen - 1]);
+				if (AppliesToItemsSprite)
+				{
+					Body_Part.BodyPartItemSprite.SetSpriteSO(OptionalSprites[ColourAnd_Selected.Chosen - 1]);
+				}
 			}
 			else
 			{


### PR DESCRIPTION
Re-does how body part surface sprites are handled
CL: [Fix] fixed issue where moving and then implanting same body part would lose its Surface customisation
CL: [Fix] fixes issue with sprites not being cleaned up properly
makes it so customisation colour and sprite can be specified to transfer to the item object