### PR TITLE
Caching optimisations on player Sync

### DIFF
--- a/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs
+++ b/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs
@@ -397,7 +397,7 @@ namespace Chemistry.Components
 		private void NotifyPlayersOfSpill(Vector3Int worldPos)
 		{
 			var mobs = MatrixManager.GetAt<LivingHealthMasterBase>(worldPos, true);
-			if (mobs.Count > 0)
+			if (mobs is List<LivingHealthMasterBase>)
 			{
 				foreach (var mob in mobs)
 				{

--- a/UnityProject/Assets/Scripts/Clothing/BackPack/InteractableStorage.cs
+++ b/UnityProject/Assets/Scripts/Clothing/BackPack/InteractableStorage.cs
@@ -379,7 +379,7 @@ public class InteractableStorage : MonoBehaviour, IClientInteractable<HandActiva
 					var itemsOnTileSame =
 						MatrixManager.GetAt<ItemAttributesV2>(interaction.WorldPositionTarget.To2Int().To3Int(), true);
 
-					if (itemsOnTileSame.Count == 0)
+					if (itemsOnTileSame is List<ItemAttributesV2> == false)
 					{
 						Chat.AddExamineMsgFromServer(interaction.Performer, "There's nothing to pickup!");
 						return;
@@ -416,7 +416,7 @@ public class InteractableStorage : MonoBehaviour, IClientInteractable<HandActiva
 					var itemsOnTileAll =
 						MatrixManager.GetAt<ItemAttributesV2>(interaction.WorldPositionTarget.To2Int().To3Int(), true);
 
-					if (itemsOnTileAll.Count == 0)
+					if (itemsOnTileAll is List<ItemAttributesV2> == false)
 					{
 						Chat.AddExamineMsgFromServer(interaction.Performer, "There's nothing to pickup!");
 						return;

--- a/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.cs
+++ b/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.cs
@@ -694,7 +694,7 @@ public partial class CustomNetTransform : NetworkBehaviour, IPushable
 		UpdateOccupant();
 
 		//Object IObjectEntersTile
-		List<IObjectEntersTile> objectEntersTiles = MatrixManager.GetAt<IObjectEntersTile>(reachedWorldPosition, isServer);
+		var objectEntersTiles = MatrixManager.GetAt<IObjectEntersTile>(reachedWorldPosition, isServer);
 
 		foreach (IObjectEntersTile objectEntersTile in objectEntersTiles)
 		{

--- a/UnityProject/Assets/Scripts/Items/Tool/Soap.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/Soap.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System.Collections.Generic;
+using UnityEngine;
 
 namespace Items
 {
@@ -38,8 +39,8 @@ namespace Items
             Vector3Int positionInt = Vector3Int.RoundToInt(position);
 
             // Check if there is an object in the way of scrubbing the tile
-			var atPosition = MatrixManager.GetAt<RegisterObject>(positionInt, side == NetworkSide.Server);
-            if(atPosition.Count != 0) return false;
+			var atPosition = MatrixManager.GetAt<RegisterObject>(positionInt, side == NetworkSide.Server) as List<RegisterObject>;
+            if(atPosition != null) return false;
 
 
             // Check that the layer scrubbed is a floor, e.g. not a table

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
@@ -886,7 +886,7 @@ public partial class MatrixManager : SingletonManager<MatrixManager>
 	}
 
 	/// <see cref="Matrix.Get{T}(UnityEngine.Vector3Int,bool)"/>
-	public static List<T> GetAt<T>(Vector3Int worldPos, bool isServer, MatrixInfo MatrixAt = null )
+	public static IEnumerable<T> GetAt<T>(Vector3Int worldPos, bool isServer, MatrixInfo MatrixAt = null )
 	{
 		if (MatrixAt == null)
 		{
@@ -897,7 +897,7 @@ public partial class MatrixManager : SingletonManager<MatrixManager>
 	}
 
 
-	public static List<T> GetAs<T>(Vector3Int worldPos, bool isServer, MatrixInfo matrixAt = null) where T : RegisterTile
+	public static IEnumerable<T> GetAs<T>(Vector3Int worldPos, bool isServer, MatrixInfo matrixAt = null) where T : RegisterTile
 	{
 		if (matrixAt == null)
 		{
@@ -908,21 +908,21 @@ public partial class MatrixManager : SingletonManager<MatrixManager>
 		return matrixAt.Matrix.GetAs<T>(position, isServer);
 	}
 
-	public static List<RegisterTile> GetRegisterTiles(Vector3Int worldPos, bool isServer)
+	public static IEnumerable<RegisterTile> GetRegisterTiles(Vector3Int worldPos, bool isServer)
 	{
 		var matrixInfo = AtPoint(worldPos, isServer);
 		var position = WorldToLocalInt(worldPos, matrixInfo);
 		return matrixInfo.Matrix.Get(position, isServer);
 	}
 
-	public static List<T> GetReachableAt<T>(Vector3Int fromPos, Vector3Int toPos, bool isServer) where T : MonoBehaviour
+	public static IEnumerable<T> GetReachableAt<T>(Vector3Int fromPos, Vector3Int toPos, bool isServer) where T : MonoBehaviour
 	{
 		if (Validations.IsReachableByPositions(fromPos, toPos, isServer))
 		{
 			return GetAt<T>(toPos, isServer);
 		}
 
-		return new List<T>();
+		return Enumerable.Empty<T>();
 	}
 
 	/// <summary>
@@ -974,7 +974,7 @@ public partial class MatrixManager : SingletonManager<MatrixManager>
 	}
 
 	//shorthand for calling GetAt at the targeted object's position
-	public static List<T> GetAt<T>(GameObject targetObject, NetworkSide side, MatrixInfo MatrixAt = null) where T : MonoBehaviour
+	public static IEnumerable<T> GetAt<T>(GameObject targetObject, NetworkSide side, MatrixInfo MatrixAt = null) where T : MonoBehaviour
 	{
 		return GetAt<T>((Vector3Int) targetObject.TileWorldPosition(), side == NetworkSide.Server, MatrixAt);
 	}

--- a/UnityProject/Assets/Scripts/Objects/Engineering/FieldGenerator.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/FieldGenerator.cs
@@ -263,24 +263,21 @@ namespace Objects.Engineering
 				{
 					var pos = registerTile.WorldPositionServer + GetCoordFromDirection((Direction)value) * i;
 
-					var objects = MatrixManager.GetAt<FieldGenerator>(pos, true);
+					var objects = MatrixManager.GetAt<FieldGenerator>(pos, true) as List<FieldGenerator>;
 
-					//If there isn't a field generator but it is impassable dont check further
-					if (objects is List<FieldGenerator> == false && !MatrixManager.IsPassableAtAllMatricesOneTile(pos, true, false))
+					//If there isn't a field generator or it is impassable dont check further
+					if (objects == null || !MatrixManager.IsPassableAtAllMatricesOneTile(pos, true, false))
 					{
 						break;
 					}
 
-					var objectsList = objects as List<FieldGenerator>;
+					if (objects.Count <= 0 || objects[0].isWelded == false) continue;
 
-					if (objectsList != null && objectsList.Count > 0 && objectsList[0].isWelded)
-					{
-						//Shouldn't be more than one, but just in case pick first
-						//Add to connected gen dictionary
-						connectedGenerator.Add((Direction)value, new Tuple<GameObject, bool>(objectsList[0].gameObject, false));
-						objectsList[0].integrity.OnWillDestroyServer.AddListener(OnConnectedDestroy);
-						break;
-					}
+					//Shouldn't be more than one, but just in case pick first
+					//Add to connected gen dictionary
+					connectedGenerator.Add((Direction)value, new Tuple<GameObject, bool>(objects[0].gameObject, false));
+					objects[0].integrity.OnWillDestroyServer.AddListener(OnConnectedDestroy);
+					break;
 				}
 			}
 		}

--- a/UnityProject/Assets/Scripts/Objects/Engineering/FieldGenerator.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/FieldGenerator.cs
@@ -266,17 +266,19 @@ namespace Objects.Engineering
 					var objects = MatrixManager.GetAt<FieldGenerator>(pos, true);
 
 					//If there isn't a field generator but it is impassable dont check further
-					if (objects.Count == 0 && !MatrixManager.IsPassableAtAllMatricesOneTile(pos, true, false))
+					if (objects is List<FieldGenerator> == false && !MatrixManager.IsPassableAtAllMatricesOneTile(pos, true, false))
 					{
 						break;
 					}
 
-					if (objects.Count > 0 && objects[0].isWelded)
+					var objectsList = objects as List<FieldGenerator>;
+
+					if (objectsList != null && objectsList.Count > 0 && objectsList[0].isWelded)
 					{
 						//Shouldn't be more than one, but just in case pick first
 						//Add to connected gen dictionary
-						connectedGenerator.Add((Direction)value, new Tuple<GameObject, bool>(objects[0].gameObject, false));
-						objects[0].integrity.OnWillDestroyServer.AddListener(OnConnectedDestroy);
+						connectedGenerator.Add((Direction)value, new Tuple<GameObject, bool>(objectsList[0].gameObject, false));
+						objectsList[0].integrity.OnWillDestroyServer.AddListener(OnConnectedDestroy);
 						break;
 					}
 				}

--- a/UnityProject/Assets/Scripts/Objects/Engineering/ParticleAcceleratorControl.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/ParticleAcceleratorControl.cs
@@ -182,9 +182,9 @@ namespace Objects.Engineering
 						coord = RotateVector90(coord).To2Int();
 					}
 
-					var objects = MatrixManager.GetAt<ParticleAcceleratorPart>(registerTile.WorldPositionServer + coord.To3Int() , true);
+					var objects = MatrixManager.GetAt<ParticleAcceleratorPart>(registerTile.WorldPositionServer + coord.To3Int() , true) as List<ParticleAcceleratorPart>;
 
-					if (objects.Count > 0 && section.Value == objects[0].ParticleAcceleratorType)
+					if (objects != null && objects.Count > 0 && section.Value == objects[0].ParticleAcceleratorType)
 					{
 						//Correct Part there woo but now check status
 						if (objects[0].CurrentState == ParticleAcceleratorState.Frame || objects[0].CurrentState == ParticleAcceleratorState.Wired

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -525,7 +525,7 @@ public partial class PlayerSync
 			if (serverBump == BumpType.Push || serverBump == BumpType.Blocked)
 			{
 				var worldTarget = state.WorldPosition.RoundToInt() + (Vector3Int)action.Direction();
-				var swapee = MatrixManager.GetAs<RegisterPlayer>(worldTarget, true);
+				var swapee = MatrixManager.GetAs<RegisterPlayer>(worldTarget, true) as List<RegisterPlayer>;
 				if (swapee != null && swapee.Count > 0)
 				{
 					swapee[0].PlayerScript.PlayerSync.RollbackPosition();

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -471,7 +471,7 @@ public partial class PlayerSync
 			TryUpdateServerTarget();
 			return;
 		}
-
+		
 		var newPos = nextState.WorldPosition;
 		var oldPos = serverState.WorldPosition;
 		lastDirectionServer = Vector2Int.RoundToInt(newPos - oldPos);
@@ -787,11 +787,14 @@ public partial class PlayerSync
 	private void InteractEnterable(Vector3Int targetPos)
 	{
 		//Object IPlayerEntersTile
-		List<IPlayerEntersTile> enterables = MatrixManager.GetAt<IPlayerEntersTile>(targetPos, isServer);
-		foreach (IPlayerEntersTile enterable in enterables)
+		var registerTiles = MatrixManager.GetRegisterTiles(targetPos, isServer);
+		foreach (var registerTile in registerTiles)
 		{
-			if (enterable.WillAffectPlayer(playerScript) == false) continue;
-			enterable.OnPlayerStep(playerScript);
+			foreach (var enterable in registerTile.IPlayerEntersTiles)
+			{
+				if (enterable.WillAffectPlayer(playerScript) == false) continue;
+				enterable.OnPlayerStep(playerScript);
+			}
 		}
 
 		//Tile IPlayerEntersTile

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.cs
@@ -310,14 +310,8 @@ public partial class PlayerSync : NetworkBehaviour, IPushable, IPlayerControllab
 	{
 		firstPushable = null;
 		var pushables = MatrixManager.GetAt<PushPull>(stateWorldPosition.CutToInt(), isServer);
-		if (pushables.Count == 0)
+		foreach (var pushable in pushables)
 		{
-			return false;
-		}
-
-		for (var i = 0; i < pushables.Count; i++)
-		{
-			var pushable = pushables[i];
 			if (pushable.gameObject == this.gameObject || except != null && pushable.gameObject == except)
 			{
 				continue;

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.cs
@@ -149,13 +149,19 @@ public partial class PlayerSync : NetworkBehaviour, IPushable, IPlayerControllab
 	/// <param name="state">current state to try to slide from</param>
 	/// <param name="action">current player action (which should have a diagonal movement). Will be modified if a slide is performed</param>
 	/// <returns>bumptype of the final direction of movement if action is modified. Null otherwise</returns>
-	private BumpType? TrySlide(PlayerState state, bool isServer, ref PlayerAction action)
+	private BumpType? TrySlide(PlayerState state, bool isServer, ref PlayerAction action, MatrixInfo MatrixAtOrigin = null)
 	{
+
 		Vector2Int direction = action.Direction();
 		if (Math.Abs(direction.x) + Math.Abs(direction.y) < 2)
 		{
 			//not diagonal, do nothing
 			return null;
+		}
+
+		if (MatrixAtOrigin == null)
+		{
+			MatrixAtOrigin = MatrixManager.AtPoint(state.WorldPosition.RoundToInt(), isServer);
 		}
 
 		var facingUpDown = playerDirectional.CurrentDirection == Orientation.Up ||
@@ -165,8 +171,8 @@ public partial class PlayerSync : NetworkBehaviour, IPushable, IPlayerControllab
 		//better diagonal movement logic without cutting corners)
 		Vector2Int dir1 = new Vector2Int(facingUpDown ? direction.x : 0, facingUpDown ? 0 : direction.y);
 		Vector2Int dir2 = new Vector2Int(facingUpDown ? 0 : direction.x, facingUpDown ? direction.y : 0);
-		BumpType bump1 = MatrixManager.GetBumpTypeAt(state.WorldPosition.RoundToInt(), dir1, playerMove, isServer);
-		BumpType bump2 = MatrixManager.GetBumpTypeAt(state.WorldPosition.RoundToInt(), dir2, playerMove, isServer);
+		BumpType bump1 = MatrixManager.GetBumpTypeAt(state.WorldPosition.RoundToInt(), dir1, playerMove, isServer, MatrixAtOrigin);
+		BumpType bump2 = MatrixManager.GetBumpTypeAt(state.WorldPosition.RoundToInt(), dir2, playerMove, isServer, MatrixAtOrigin);
 
 		MoveAction? newAction = null;
 		BumpType? newBump = null;
@@ -229,7 +235,9 @@ public partial class PlayerSync : NetworkBehaviour, IPushable, IPlayerControllab
 			return BumpType.None;
 		}
 
-		BumpType bump = MatrixManager.GetBumpTypeAt(playerState, playerAction, playerMove, isServer);
+		var MatrixAtPointOrigin = MatrixManager.AtPoint(playerState.WorldPosition.RoundToInt(), isServer);
+
+		BumpType bump = MatrixManager.GetBumpTypeAt(playerState, playerAction, playerMove, isServer, MatrixAtPointOrigin);
 		//on diagonal movement, don't allow cutting corners or pushing (check x and y tile passability)
 		var dir = playerAction.Direction();
 		if (dir.x != 0 && dir.y != 0)
@@ -240,9 +248,9 @@ public partial class PlayerSync : NetworkBehaviour, IPushable, IPlayerControllab
 			}
 
 			var xBump = MatrixManager.GetBumpTypeAt(playerState.WorldPosition.RoundToInt(), new Vector2Int(dir.x, 0),
-				playerMove, isServer);
+				playerMove, isServer, MatrixAtPointOrigin);
 			var yBump = MatrixManager.GetBumpTypeAt(playerState.WorldPosition.RoundToInt(), new Vector2Int(0, dir.y),
-				playerMove, isServer);
+				playerMove, isServer, MatrixAtPointOrigin);
 
 			//opening doors diagonally is allowed only if x or y are blocked (assumes we are sliding along a
 			//wall and we hit a door).
@@ -261,7 +269,7 @@ public partial class PlayerSync : NetworkBehaviour, IPushable, IPlayerControllab
 		// if movement is blocked, try to slide
 		if (bump == BumpType.Blocked)
 		{
-			return TrySlide(playerState, isServer, ref playerAction) ?? bump;
+			return TrySlide(playerState, isServer, ref playerAction, MatrixAtPointOrigin) ?? bump;
 		}
 
 		return bump;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
@@ -277,7 +277,7 @@ public class Matrix : MonoBehaviour
 	{
 		if (!(isServer ? ServerObjects : ClientObjects).HasObjects(localPosition))
 		{
-			return Enumerable.Empty<T>();; //?
+			return Enumerable.Empty<T>(); //Enumerable.Empty<T>() Does not GC while new List<T> does
 		}
 
 		var filtered = new List<T>();
@@ -298,7 +298,7 @@ public class Matrix : MonoBehaviour
 	{
 		if (!(isServer ? ServerObjects : ClientObjects).HasObjects(localPosition))
 		{
-			return Enumerable.Empty<RegisterTile>();; //?
+			return Enumerable.Empty<RegisterTile>(); //Enumerable.Empty<T>() Does not GC while new List<T> does
 		}
 
 		var filtered = new List<RegisterTile>();
@@ -311,7 +311,7 @@ public class Matrix : MonoBehaviour
 	{
 		if (!(isServer ? ServerObjects : ClientObjects).HasObjects(localPosition))
 		{
-			return Enumerable.Empty<T>(); //?
+			return Enumerable.Empty<T>(); //Enumerable.Empty<T>() Does not GC while new List<T> does
 		}
 
 		var filtered = new List<T>();
@@ -345,7 +345,7 @@ public class Matrix : MonoBehaviour
 	{
 		if (!(isServer ? ServerObjects : ClientObjects).HasObjects(localPosition))
 		{
-			return  Enumerable.Empty<T>(); //?
+			return  Enumerable.Empty<T>(); //Enumerable.Empty<T>() Does not GC while new List<T> does
 		}
 
 		var filtered = new List<T>();

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
@@ -267,17 +267,17 @@ public class Matrix : MonoBehaviour
 		return MetaTileMap.IsNoGravityAt(position, isServer);
 	}
 
-	public List<RegisterTile> GetRegisterTile(Vector3Int localPosition, bool isServer)
+	public IEnumerable<RegisterTile> GetRegisterTile(Vector3Int localPosition, bool isServer)
 	{
 		return (isServer ? ServerObjects : ClientObjects).Get(localPosition);
 	}
 
 	//Has to inherit from register tile
-	public List<T> GetAs<T>(Vector3Int localPosition, bool isServer) where T : RegisterTile
+	public IEnumerable<T> GetAs<T>(Vector3Int localPosition, bool isServer) where T : RegisterTile
 	{
 		if (!(isServer ? ServerObjects : ClientObjects).HasObjects(localPosition))
 		{
-			return new List<T>(); //?
+			return Enumerable.Empty<T>();; //?
 		}
 
 		var filtered = new List<T>();
@@ -294,11 +294,11 @@ public class Matrix : MonoBehaviour
 	}
 
 
-	public List<RegisterTile> Get(Vector3Int localPosition, bool isServer)
+	public IEnumerable<RegisterTile> Get(Vector3Int localPosition, bool isServer)
 	{
 		if (!(isServer ? ServerObjects : ClientObjects).HasObjects(localPosition))
 		{
-			return new List<RegisterTile>(); //?
+			return Enumerable.Empty<RegisterTile>();; //?
 		}
 
 		var filtered = new List<RegisterTile>();
@@ -307,11 +307,11 @@ public class Matrix : MonoBehaviour
 	}
 
 
-	public List<T> Get<T>(Vector3Int localPosition, bool isServer)
+	public IEnumerable<T> Get<T>(Vector3Int localPosition, bool isServer)
 	{
 		if (!(isServer ? ServerObjects : ClientObjects).HasObjects(localPosition))
 		{
-			return new List<T>(); //?
+			return Enumerable.Empty<T>(); //?
 		}
 
 		var filtered = new List<T>();
@@ -341,11 +341,11 @@ public class Matrix : MonoBehaviour
 
 		return null;
 	}
-	public List<T> Get<T>(Vector3Int localPosition, ObjectType type, bool isServer) where T : MonoBehaviour
+	public IEnumerable<T> Get<T>(Vector3Int localPosition, ObjectType type, bool isServer) where T : MonoBehaviour
 	{
 		if (!(isServer ? ServerObjects : ClientObjects).HasObjects(localPosition))
 		{
-			return new List<T>();
+			return  Enumerable.Empty<T>(); //?
 		}
 
 		var filtered = new List<T>();

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
@@ -267,17 +267,17 @@ public class Matrix : MonoBehaviour
 		return MetaTileMap.IsNoGravityAt(position, isServer);
 	}
 
-	public IEnumerable<RegisterTile> GetRegisterTile(Vector3Int localPosition, bool isServer)
+	public List<RegisterTile> GetRegisterTile(Vector3Int localPosition, bool isServer)
 	{
 		return (isServer ? ServerObjects : ClientObjects).Get(localPosition);
 	}
 
 	//Has to inherit from register tile
-	public IEnumerable<T> GetAs<T>(Vector3Int localPosition, bool isServer) where T : RegisterTile
+	public List<T> GetAs<T>(Vector3Int localPosition, bool isServer) where T : RegisterTile
 	{
 		if (!(isServer ? ServerObjects : ClientObjects).HasObjects(localPosition))
 		{
-			return Enumerable.Empty<T>(); //?
+			return new List<T>(); //?
 		}
 
 		var filtered = new List<T>();
@@ -294,11 +294,24 @@ public class Matrix : MonoBehaviour
 	}
 
 
-	public IEnumerable<T> Get<T>(Vector3Int localPosition, bool isServer)
+	public List<RegisterTile> Get(Vector3Int localPosition, bool isServer)
 	{
 		if (!(isServer ? ServerObjects : ClientObjects).HasObjects(localPosition))
 		{
-			return Enumerable.Empty<T>(); //?
+			return new List<RegisterTile>(); //?
+		}
+
+		var filtered = new List<RegisterTile>();
+		filtered.AddRange((isServer ? ServerObjects : ClientObjects).Get(localPosition));
+		return filtered;
+	}
+
+
+	public List<T> Get<T>(Vector3Int localPosition, bool isServer)
+	{
+		if (!(isServer ? ServerObjects : ClientObjects).HasObjects(localPosition))
+		{
+			return new List<T>(); //?
 		}
 
 		var filtered = new List<T>();
@@ -328,11 +341,11 @@ public class Matrix : MonoBehaviour
 
 		return null;
 	}
-	public IEnumerable<T> Get<T>(Vector3Int localPosition, ObjectType type, bool isServer) where T : MonoBehaviour
+	public List<T> Get<T>(Vector3Int localPosition, ObjectType type, bool isServer) where T : MonoBehaviour
 	{
 		if (!(isServer ? ServerObjects : ClientObjects).HasObjects(localPosition))
 		{
-			return Enumerable.Empty<T>();
+			return new List<T>();
 		}
 
 		var filtered = new List<T>();

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -119,11 +119,11 @@ public class MetaDataLayer : MonoBehaviour
 		var reagentContainer = MatrixManager.GetAt<ReagentContainer>(worldPosInt, true);
 		var existingSplats = MatrixManager.GetAt<FloorDecal>(worldPosInt, true);
 
-		for (var i = 0; i < existingSplats.Count; i++)
+		foreach (var _existingSplat in existingSplats)
 		{
-			if (existingSplats[i].GetComponent<ReagentContainer>())
+			if (_existingSplat.GetComponent<ReagentContainer>())
 			{
-				existingSplat = existingSplats[i];
+				existingSplat = _existingSplat;
 			}
 		}
 
@@ -235,9 +235,9 @@ public class MetaDataLayer : MonoBehaviour
 		Get(localPosInt).IsSlippery = false;
 		var floorDecals = MatrixManager.GetAt<FloorDecal>(worldPosInt, isServer: true);
 
-		for (var i = 0; i < floorDecals.Count; i++)
+		foreach (var floorDecal in floorDecals)
 		{
-			floorDecals[i].TryClean();
+			floorDecal.TryClean();
 		}
 
 		//check for any moppable overlays

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
@@ -6,6 +6,7 @@ using UnityEngine.Rendering;
 using UnityEngine.Serialization;
 using Mirror;
 using Core.Editor.Attributes;
+using Objects;
 using Tilemaps.Behaviours.Layers;
 using Systems.Electricity;
 using Systems.Pipes;
@@ -139,6 +140,10 @@ public class RegisterTile : NetworkBehaviour, IServerDespawn
 	//cached for fast fire exposure without gc
 	private IFireExposable[] fireExposables;
 
+	public IPlayerEntersTile[] IPlayerEntersTiles;
+
+	public IObjectEntersTile[] IObjectEntersTiles;
+
 	[SerializeField] private PrefabTracker prefabTracker;
 	public PrefabTracker PrefabTracker => prefabTracker;
 
@@ -166,6 +171,8 @@ public class RegisterTile : NetworkBehaviour, IServerDespawn
 		customNetTransform = GetComponent<CustomNetTransform>();
 		matrixRotationHooks = GetComponents<IMatrixRotation>();
 		fireExposables = GetComponents<IFireExposable>();
+		IPlayerEntersTiles = GetComponents<IPlayerEntersTile>();
+		IObjectEntersTiles = GetComponents<IObjectEntersTile>();
 		CurrentsortingGroup = GetComponent<SortingGroup>();
 		iPushable = GetComponent<IPushable>();
 	}

--- a/UnityProject/Packages/packages-lock.json
+++ b/UnityProject/Packages/packages-lock.json
@@ -119,7 +119,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.scriptablebuildpipeline": {
-      "version": "1.15.2",
+      "version": "1.19.2",
       "depth": 1,
       "source": "registry",
       "dependencies": {},


### PR DESCRIPTION
instead of calculating whatmatrix the player is on about a billion times, it should cash it now and reuse it,  
need to double check since target and origin might have got mixed up since from late-night coding, 
need to test with headless but tested with editor

Now tested in headless with client,Works