### PR TITLE
Prevent Tags in ChatBubbles and Comms Console

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Chat/Chat.Process.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/Chat.Process.cs
@@ -342,7 +342,7 @@ public partial class Chat
 		return output;
 	}
 
-	private static string StripTags(string input)
+	public static string StripTags(string input)
 	{
 		//Regex - find "<" followed by any number of not ">" and ending in ">". Matches any HTML tags.
 		Regex rx = new Regex("[<][^>]+[>]");

--- a/UnityProject/Assets/Scripts/Messages/Server/ShowChatBubbleMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/ShowChatBubbleMessage.cs
@@ -42,7 +42,7 @@ namespace Messages.Server
 		}
 
 		public static NetMessage SendToNearby(GameObject followTransform, string message, bool isPlayerChatBubble = false,
-			ChatModifier chatModifier = ChatModifier.None, bool allowTags = false;)
+			ChatModifier chatModifier = ChatModifier.None, bool allowTags = false)
 		{
 			NetMessage msg = new NetMessage
 			{

--- a/UnityProject/Assets/Scripts/Messages/Server/ShowChatBubbleMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/ShowChatBubbleMessage.cs
@@ -14,6 +14,7 @@ namespace Messages.Server
 			public string Message;
 			public uint FollowTransform;
 			public bool IsPlayerChatBubble;
+			public bool AllowTags;
 
 			//Special flag for finding the correct transform target on players
 			//You may have to do something like this if your target does not
@@ -29,19 +30,27 @@ namespace Messages.Server
 			{
 				target = target.GetComponent<PlayerNetworkActions>().chatBubbleTarget;
 			}
+			
+			var message = msg.Message;
+			
+			if(msg.AllowTags == false)
+			{
+				message = Chat.StripTags(message);
+			}
 
-			ChatBubbleManager.ShowAChatBubble(target, msg.Message, msg.ChatModifiers);
+			ChatBubbleManager.ShowAChatBubble(target, message, msg.ChatModifiers);
 		}
 
 		public static NetMessage SendToNearby(GameObject followTransform, string message, bool isPlayerChatBubble = false,
-			ChatModifier chatModifier = ChatModifier.None)
+			ChatModifier chatModifier = ChatModifier.None, bool allowTags = false;)
 		{
 			NetMessage msg = new NetMessage
 			{
 				ChatModifiers = chatModifier,
 				Message = message,
 				FollowTransform = followTransform.GetComponent<NetworkIdentity>().netId,
-				IsPlayerChatBubble = isPlayerChatBubble
+				IsPlayerChatBubble = isPlayerChatBubble,
+				AllowTags = allowTags
 			};
 
 			SendToVisiblePlayers(followTransform.transform.position, msg);

--- a/UnityProject/Assets/Scripts/Systems/Ai/AiPlayer.cs
+++ b/UnityProject/Assets/Scripts/Systems/Ai/AiPlayer.cs
@@ -1132,6 +1132,9 @@ namespace Systems.Ai
 				Chat.AddExamineMsgFromServer(gameObject, "You must specify a reason to call the shuttle");
 				return;
 			}
+			
+			//Remove tags
+			reason = Chat.StripTags(reason);
 
 			if (reason.Trim().Length < 10)
 			{

--- a/UnityProject/Assets/Scripts/UI/Objects/Command/CommsConsole/GUI_Comms.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Command/CommsConsole/GUI_Comms.cs
@@ -115,6 +115,8 @@ namespace UI.Objects.Command
 
 		public void CallOrRecallShuttle(string text)
 		{
+			text = Chat.StripTags(text);
+		
 			Logger.Log(nameof(CallOrRecallShuttle), Category.Shuttles);
 
 			bool isRecall = shuttle.Status == EscapeShuttleStatus.OnRouteStation;
@@ -174,6 +176,8 @@ namespace UI.Objects.Command
 
 		public void SetStatusDisplay(string text)
 		{
+			text = Chat.StripTags(text);
+			
 			Logger.Log(nameof(SetStatusDisplay), Category.Shuttles);
 			GameManager.Instance.CentComm.UpdateStatusDisplay(StatusDisplayChannel.Command, text.Substring(0, Mathf.Min(text.Length, 50)));
 			OpenMenu();
@@ -181,6 +185,8 @@ namespace UI.Objects.Command
 
 		public void MakeAnAnnouncement(string text)
 		{
+			text = Chat.StripTags(text);
+			
 			Logger.Log(nameof(MakeAnAnnouncement), Category.Shuttles);
 			if (text.Length > 200)
 			{


### PR DESCRIPTION
-Prevent Tags in ChatBubbles and Comms Console

Fixes #8112

CL: [Fix] fixed an issue with chat bubbles and the comms console not being fully sanitized of richtext tags.