### PR TITLE
Prevent Death being called when dead, miasma and ash walker ghost slot fixes.

### DIFF
--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -830,6 +830,9 @@ namespace HealthV2
 		///</Summary>
 		public void Death()
 		{
+			//Don't trigger if already dead
+			if(ConsciousState == ConsciousState.DEAD) return;
+
 			timeOfDeath = GameManager.Instance.stationTime;
 
 			var HV2 = (this as PlayerHealthV2);
@@ -913,6 +916,9 @@ namespace HealthV2
 			if (objectBehaviour.parentContainer != null) return;
 
 			//TODO: check for formaldehyde in body, prevent if more than 15u
+
+			//Don't continuously produce miasma, only produce max 4 moles on the tile
+			if(node.GasMix.GetMoles(Gas.Miasma) > 4) return;
 
 			node.GasMix.AddGas(Gas.Miasma, AtmosDefines.MIASMA_CORPSE_MOLES);
 		}

--- a/UnityProject/Assets/Scripts/Systems/GhostRoles/GhostRoleManager.cs
+++ b/UnityProject/Assets/Scripts/Systems/GhostRoles/GhostRoleManager.cs
@@ -275,12 +275,29 @@ namespace Systems.GhostRoles
 			GhostRoleResponseMessage.SendTo(player, key, responseCode);
 		}
 
+		/// <summary>
+		/// Remove player from waiting for a role
+		/// </summary>
 		public void ServerRemoveWaitingPlayer(uint key, ConnectedPlayer player)
 		{
 			var role = serverAvailableRoles[key];
 			role.WaitingPlayers.Remove(player);
 
 			GhostRoleResponseMessage.SendTo(player, key, GhostRoleResponseCode.ClearMessage);
+		}
+
+		/// <summary>
+		/// Remove player from all waiting roles
+		/// </summary>
+		public void ServerRemoveWaitingPlayer(ConnectedPlayer player)
+		{
+			foreach (var role in serverAvailableRoles)
+			{
+				if (role.Value.WaitingPlayers.Contains(player) == false) continue;
+
+				role.Value.WaitingPlayers.Remove(player);
+				GhostRoleResponseMessage.SendTo(player, role.Key, GhostRoleResponseCode.ClearMessage);
+			}
 		}
 	}
 }


### PR DESCRIPTION
-Prevent Death being called when dead
CL: [Fix] fixed an issue causing the death signal triggering on already dead bodies.

-Limit miasma to 4 moles on tile from bodies
CL: [Balance] limited the total amount of miasma released from bodies to 4 moles

-Fix issue with ashwalker role sticking around
CL: [Fix] fixed an issue with ashwalker ghost role staying in the ghost role menu past it's expiration.