### PR TITLE
Blob and Crafting fix

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.Client.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.Client.cs
@@ -56,7 +56,8 @@ public partial class SubSceneManager
 		{
 			if (SubsceneLoadTimer != null)
 			{
-				SubsceneLoadTimer.IncrementLoadBar($"Loading {sceneInfo.SceneName}");
+				SubsceneLoadTimer.IncrementLoadBar(sceneInfo.SceneType != SceneType.HiddenScene ?
+					$"Loading {sceneInfo.SceneName}" : "");
 			}
 
 			yield return StartCoroutine(LoadSubScene(sceneInfo.SceneName, HandlSynchronising  :HandlSynchronising ));

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.SceneList.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.SceneList.cs
@@ -256,7 +256,7 @@ public partial class SubSceneManager
 		loadedScenesList.Add(new SceneInfo
 		{
 			SceneName = pickedMap,
-			SceneType = SceneType.AdditionalScenes
+			SceneType = SceneType.HiddenScene
 		});
 		netIdentity.isDirty = true;
 
@@ -275,7 +275,7 @@ public partial class SubSceneManager
 		loadedScenesList.Add(new SceneInfo
 		{
 			SceneName = pickedScene,
-			SceneType = SceneType.AdditionalScenes
+			SceneType = SceneType.HiddenScene
 		});
 		netIdentity.isDirty = true;
 

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.cs
@@ -108,7 +108,8 @@ public enum SceneType
 	AwaySite,
 	Asteroid,
 	AdditionalScenes,
-	Space
+	Space,
+	HiddenScene
 }
 
 [System.Serializable]

--- a/UnityProject/Assets/Scripts/Player/PlayerCrafting.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerCrafting.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Systems.CraftingV2;
 using Systems.CraftingV2.ClientServerLogic;
+using Systems.CraftingV2.GUI;
 using Chemistry;
 using Chemistry.Components;
 using Items;
@@ -178,7 +179,14 @@ namespace Player
 			GetKnownRecipesInCategory(recipe.Category).Remove(recipe);
 
 			//Prevent message being sent twice when local host
-			if(playerScript == PlayerManager.LocalPlayerScript) return;
+			if (playerScript == PlayerManager.LocalPlayerScript)
+			{
+				if (CraftingMenu.Instance == null) return;
+
+				//Remove button from crafting Ui for local host
+				CraftingMenu.Instance.OnPlayerForgotRecipe(recipe);
+				return;
+			}
 
 			SendForgottenCraftingRecipe.SendTo(playerScript.connectedPlayer, recipe);
 		}
@@ -206,6 +214,15 @@ namespace Player
 			{
 				recipeCategory.Clear();
 			}
+
+			//Only run on client player, no need for headless to run
+			if (CustomNetworkManager.IsHeadless) return;
+
+			//Crafting menu might not be ready, will init correctly without recipes on first load instead
+			if (CraftingMenu.Instance == null) return;
+
+			//The crafting menu is already initiated, so it's safe to remove buttons from it
+			CraftingMenu.Instance.OnPlayerForgetAllRecipes();
 		}
 
 		#endregion

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobPlayer.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobPlayer.cs
@@ -1911,24 +1911,30 @@ namespace Blob
 
 		private void CheckConnections()
 		{
-			if (!pathSearch)
-			{
-				pathSearch = true;
-				StartCoroutine(CheckPaths());
-			}
+			if (pathSearch == false || blobTiles.Count <= 0) return;
+			pathSearch = true;
+
+			StartCoroutine(CheckPaths());
 		}
 
 		private IEnumerator CheckPaths()
 		{
-			Profiler.BeginSample("Blob Grid");
-			GenerateGrid();
-			Profiler.EndSample();
+			try
+			{
+				Profiler.BeginSample("Blob Grid");
+				GenerateGrid();
+				Profiler.EndSample();
 
-			Profiler.BeginSample("Blob paths");
-			NodePaths();
-			EcoPaths();
-			FactoryPaths();
-			Profiler.EndSample();
+				Profiler.BeginSample("Blob paths");
+				NodePaths();
+				EcoPaths();
+				FactoryPaths();
+				Profiler.EndSample();
+			}
+			catch (Exception e)
+			{
+				Logger.LogError(e.ToString());
+			}
 
 			pathSearch = false;
 			yield break;

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobStarter.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobStarter.cs
@@ -274,9 +274,17 @@ namespace Blob
 
 			var spawnResult = Spawn.ServerPrefab(AntagManager.Instance.blobPlayerViewer, gameObject.RegisterTile().WorldPositionServer, gameObject.transform.parent);
 
-			if (!spawnResult.Successful)
+			if (spawnResult.Successful == false)
 			{
 				Logger.LogError("Failed to spawn blob!", Category.Blob);
+				Destroy(this);
+				return;
+			}
+
+			if (playerScript.mind == null)
+			{
+				//If this is true, block blob spawning
+				_ = Despawn.ServerSingle(spawnResult.GameObject);
 				Destroy(this);
 				return;
 			}

--- a/UnityProject/Assets/Scripts/Systems/CraftingV2/GUI/CraftingMenu.cs
+++ b/UnityProject/Assets/Scripts/Systems/CraftingV2/GUI/CraftingMenu.cs
@@ -406,6 +406,12 @@ namespace Systems.CraftingV2.GUI
 		public void Open()
 		{
 			this.SetActive(true);
+
+			foreach (var categoryButtons in recipesInCategories)
+			{
+				categoryButtons.CategoryButtonScript.gameObject.SetActive(categoryButtons.RecipeButtonScripts.Count > 0);
+			}
+
 			RequestRefreshRecipes();
 		}
 
@@ -434,9 +440,10 @@ namespace Systems.CraftingV2.GUI
 				newRecipeButton.SetActive(false);
 			}
 
-			GetRecipesInCategory(craftingRecipe.Category)
-				.RecipeButtonScripts
-				.Add(newRecipeButton.GetComponent<RecipeButtonScript>());
+			var category = GetRecipesInCategory(craftingRecipe.Category);
+
+			category.RecipeButtonScripts.Add(newRecipeButton.GetComponent<RecipeButtonScript>());
+			category.CategoryButtonScript.gameObject.SetActive(true);
 		}
 
 		/// <summary>
@@ -445,16 +452,45 @@ namespace Systems.CraftingV2.GUI
 		/// <param name="craftingRecipe">The associated crafting recipe.</param>
 		public void OnPlayerForgotRecipe(CraftingRecipe craftingRecipe)
 		{
-			int recipeIndexToForgot = GetRecipesInCategory(craftingRecipe.Category).RecipeButtonScripts.FindIndex(
+			var category = GetRecipesInCategory(craftingRecipe.Category);
+
+			int recipeIndexToForgot = category.RecipeButtonScripts.FindIndex(
 				recipeButtonScript => recipeButtonScript.CraftingRecipe
 			);
+
 			if (chosenRecipe != null && craftingRecipe == chosenRecipe.CraftingRecipe)
 			{
 				DeselectRecipe(chosenRecipe);
 			}
 
-			Destroy(GetRecipesInCategory(craftingRecipe.Category).RecipeButtonScripts[recipeIndexToForgot]);
-			GetRecipesInCategory(craftingRecipe.Category).RecipeButtonScripts.RemoveAt(recipeIndexToForgot);
+			Destroy(category.RecipeButtonScripts[recipeIndexToForgot].gameObject);
+			category.RecipeButtonScripts.RemoveAt(recipeIndexToForgot);
+
+			category.CategoryButtonScript.gameObject.SetActive(category.RecipeButtonScripts.Count > 0);
+		}
+
+		/// <summary>
+		/// Removes all recipe buttons
+		/// </summary>
+		public void OnPlayerForgetAllRecipes()
+		{
+			foreach (var recipesInCategory in recipesInCategories)
+			{
+				foreach (var recipeButton in recipesInCategory.RecipeButtonScripts)
+				{
+					if (chosenRecipe != null && recipeButton.CraftingRecipe == chosenRecipe.CraftingRecipe)
+					{
+						DeselectRecipe(chosenRecipe);
+					}
+
+					Destroy(recipeButton.gameObject);
+				}
+			}
+
+			foreach (var recipesInCategory in recipesInCategories)
+			{
+				recipesInCategory.RecipeButtonScripts.Clear();
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
Check for mind for blob start
CL: [Fix] fixed an issue with blobs spawning properly.
CL: [Fix] fixed crafting issues with ashwalker.
CL: [Balance] wizard and syndicate scenes no longer show on the loading screen.
CL: [Improvement] crafting categories that are empty in the crafting menu do not show.
-Make wizard and syndicate scene names not show on load

Also fixes #8121