### PR TITLE
StimulumFormation Balance

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/Reaction.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/Reaction.cs
@@ -445,7 +445,7 @@ namespace Systems.Atmospherics
 						Gas.Plasma,
 						new GasReactionData()
 						{
-							minimumMolesToReact = 10
+							minimumMolesToReact = AtmosDefines.MINIMUM_MOLE_COUNT
 						}
 					},
 
@@ -466,13 +466,13 @@ namespace Systems.Atmospherics
 					}
 				},
 
-				minimumTileTemperature: AtmosDefines.STIMULUM_HEAT_SCALE / 2,
+				minimumTileTemperature: 1500,
 				maximumTileTemperature: 10000000000,
 				minimumTilePressure: 0,
 				maximumTilePressure: 10000000000,
 
 				//Tritium + Plasma + BZ + Nitryl
-				minimumTileMoles: 90,
+				minimumTileMoles: 80,
 				maximumTileMoles: 10000000000,
 				addToBaseReactions: true
 			);

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/StimulumFormation.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/StimulumFormation.cs
@@ -15,14 +15,15 @@ namespace Systems.Atmospherics
 		{
 			var oldHeatCap = gasMix.WholeHeatCapacity;
 
-			var heatScale = Mathf.Min(gasMix.Temperature/AtmosDefines.STIMULUM_HEAT_SCALE, gasMix.GetMoles(Gas.Tritium), gasMix.GetMoles(Gas.Plasma), gasMix.GetMoles(Gas.Nitryl));
+			var heatScale = Mathf.Min(gasMix.Temperature / AtmosDefines.STIMULUM_HEAT_SCALE, 
+			gasMix.GetMoles(Gas.Tritium), gasMix.GetMoles(Gas.Plasma), gasMix.GetMoles(Gas.Nitryl));
 
 			var stimEnergyChange = heatScale + AtmosDefines.STIMULUM_FIRST_RISE * Mathf.Pow(heatScale, 2) -
 			                       AtmosDefines.STIMULUM_FIRST_DROP * Mathf.Pow(heatScale, 3) +
 			                       AtmosDefines.STIMULUM_SECOND_RISE * Mathf.Pow(heatScale, 4) -
 			                       AtmosDefines.STIMULUM_ABSOLUTE_DROP * Mathf.Pow(heatScale, 5);
 
-			if (gasMix.GetMoles(Gas.Tritium) - heatScale < 0 || gasMix.GetMoles(Gas.Plasma) - heatScale < 0 || gasMix.GetMoles(Gas.Nitryl) - heatScale < 0)
+			if (gasMix.GetMoles(Gas.Tritium) - heatScale < 0 || gasMix.GetMoles(Gas.Nitryl) - heatScale < 0)
 			{
 				//No reaction
 				return;
@@ -31,7 +32,6 @@ namespace Systems.Atmospherics
 			gasMix.AddGas(Gas.Stimulum, heatScale / 10f);
 
 			gasMix.RemoveGas(Gas.Tritium, heatScale);
-			gasMix.RemoveGas(Gas.Plasma, heatScale);
 			gasMix.RemoveGas(Gas.Nitryl,  heatScale);
 
 			gasMix.SetTemperature(


### PR DESCRIPTION
-Temperature only needs to be 1500K instead of 50000K

-Plasma no longer gets consumed but must be present in at least 0.01 moles (instead of 10)

CL: [Balance] reduced stimulum formation's necessary temperature threshold from 50000K to 1500K
CL: [Balance] plasma is no longer consumed by stimulum formation, but still must be present in a quantity of at least 0.01 moles