### PR TITLE
Fixing issue #7874

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/GameConfigManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameConfigManager.cs
@@ -48,6 +48,7 @@ namespace GameConfig
 		public bool RandomEventsAllowed;
 		public bool SpawnLavaLand;
 		public int MinPlayersForCountdown;
+		public int MinReadyPlayersForCountdown;
 		public float PreRoundTime;
 		public float RoundEndTime;
 		public int RoundsPerMap;

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -380,9 +380,6 @@ public partial class GameManager : MonoBehaviour, IInitialise
 				{
 					StartRound();
 				}
-				else {
-					Logger.Log("More ready players needed for countdown!")
-				}
 			}
 		}
 		else if (counting)

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -30,6 +30,11 @@ public partial class GameManager : MonoBehaviour, IInitialise
 	public int MinPlayersForCountdown { get; set; } = 1;
 
 	/// <summary>
+	/// The minimum number of ready players needed to start the pre-round countdown
+	/// </summary>
+	public int MinReadyPlayersForCountdown { get; set; } = 1;
+
+	/// <summary>
 	/// How long the pre-round stage should last
 	/// </summary>
 	public float PreRoundTime { get; set; } = 120f;
@@ -370,7 +375,13 @@ public partial class GameManager : MonoBehaviour, IInitialise
 		{
 			if (NetworkTime.time >= CountdownEndTime)
 			{
-				StartRound();
+				if (PlayerList.Instance.ReadyPlayers.Count >= MinReadyPlayersForCountdown)
+				{
+					StartRound();
+				}
+				else {
+					Logger.Log("More ready players needed for countdown!")
+				}
 			}
 		}
 		else if (counting)

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -181,6 +181,7 @@ public partial class GameManager : MonoBehaviour, IInitialise
 	private void LoadConfig()
 	{
 		MinPlayersForCountdown = GameConfigManager.GameConfig.MinPlayersForCountdown;
+		MinReadyPlayersForCountdown = GameConfigManager.GameConfig.MinReadyPlayersForCountdown;
 		PreRoundTime = GameConfigManager.GameConfig.PreRoundTime;
 		RoundEndTime = GameConfigManager.GameConfig.RoundEndTime;
 		RoundsPerMap = GameConfigManager.GameConfig.RoundsPerMap;

--- a/UnityProject/Assets/StreamingAssets/config/gameConfig.json
+++ b/UnityProject/Assets/StreamingAssets/config/gameConfig.json
@@ -5,6 +5,8 @@
 
 	"MinPlayersForCountdown": 1,
 
+	"MinReadyPlayersForCountdown": 1,
+
 	"PreRoundTime": 120,
 
 	"RoundEndTime": 60,


### PR DESCRIPTION

### Purpose

Fixing #7874

CL: [Improvement] the round start countdown won't start until at least 1 player has readied.