### PR TITLE
Quick fix for prod cells

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Weapons/Melee/ToggleableEffect.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Melee/ToggleableEffect.cs
@@ -120,7 +120,7 @@ namespace Weapons
 			{
 				if (interaction.UsedObject.GetComponent<Battery>().MaxWatts >= meleeEffect.chargeUsage)
 				{
-					Inventory.ClientRequestTransfer(interaction.FromSlot, meleeEffect.batterySlot);
+					Inventory.ServerTransfer(interaction.FromSlot, meleeEffect.batterySlot);
 					TurnOff();
 				}
 				else


### PR DESCRIPTION
Something that slipped under the radar when I was testing the PR yesterday that I discovered today on staging. Clients can't put cells into prods or batons- so switching to Inventory.ServerTransfer instead of Inventory.ClientRequestTransfer, this seems to fix the issue.

CL: [Fix] fixed an issue preventing power cells from being placed inside stun prods and batons.
