### PR TITLE
Fixes players being unable to escape lockers and expanding Escapable Containers and Cremator logic

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Drawers/Cremator.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Drawers/Cremator.prefab
@@ -244,18 +244,6 @@ SortingGroup:
     type: 3}
   m_PrefabInstance: {fileID: 2326953878361258396}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &6366370698346894607 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8652228875761003667, guid: ebb08cf966efc084aa918bd8d9429604,
-    type: 3}
-  m_PrefabInstance: {fileID: 2326953878361258396}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &-6615711806714216801
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -400,9 +388,6 @@ MonoBehaviour:
       m_SubObjectName: 
       m_SubObjectType: 
       m_EditorAssetChanged: 0
-  crematorActiveSO: {fileID: 11400000, guid: b25d6302278ad144a844caff05ff46e2, type: 2}
-  crematorInactiveSO: {fileID: 11400000, guid: 09b63097663eb2f41b62690b448cf86b, type: 2}
-  crematorSprites: {fileID: 6366370698346894607}
   burningDamage: 23
 --- !u!114 &6751178667305699581
 MonoBehaviour:

--- a/UnityProject/Assets/Prefabs/Objects/Drawers/Cremator.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Drawers/Cremator.prefab
@@ -371,7 +371,7 @@ MonoBehaviour:
       m_SubObjectName: 
       m_SubObjectType: 
       m_EditorAssetChanged: 0
-  escapeTime: 8
+  escapeTime: 24
   trayPrefab: {fileID: 6276591062313578460, guid: cb335e9d7c8dce444a0ea88946edbfd8,
     type: 3}
   storePlayers: 1
@@ -383,7 +383,7 @@ MonoBehaviour:
       m_SubObjectName: 
       m_SubObjectType: 
       m_EditorAssetChanged: 0
-  burningDamage: 4
+  burningDamage: 25
 --- !u!114 &6751178667305699581
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Objects/Drawers/Cremator.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Drawers/Cremator.prefab
@@ -239,6 +239,18 @@ SortingGroup:
     type: 3}
   m_PrefabInstance: {fileID: 2326953878361258396}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &6366370698346894607 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8652228875761003667, guid: ebb08cf966efc084aa918bd8d9429604,
+    type: 3}
+  m_PrefabInstance: {fileID: 2326953878361258396}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &-6615711806714216801
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -385,6 +397,7 @@ MonoBehaviour:
       m_EditorAssetChanged: 0
   crematorActiveSO: {fileID: 11400000, guid: b25d6302278ad144a844caff05ff46e2, type: 2}
   crematorInactiveSO: {fileID: 11400000, guid: 09b63097663eb2f41b62690b448cf86b, type: 2}
+  crematorSprites: {fileID: 6366370698346894607}
   burningDamage: 25
 --- !u!114 &6751178667305699581
 MonoBehaviour:

--- a/UnityProject/Assets/Prefabs/Objects/Drawers/Cremator.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Drawers/Cremator.prefab
@@ -166,6 +166,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8652228875761003667, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
+      propertyPath: initialVariantIndex
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8652228875761003667, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
       propertyPath: SubCatalogue.Array.size
       value: 4
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Objects/Drawers/Cremator.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Drawers/Cremator.prefab
@@ -383,6 +383,8 @@ MonoBehaviour:
       m_SubObjectName: 
       m_SubObjectType: 
       m_EditorAssetChanged: 0
+  crematorActiveSO: {fileID: 11400000, guid: b25d6302278ad144a844caff05ff46e2, type: 2}
+  crematorInactiveSO: {fileID: 11400000, guid: 09b63097663eb2f41b62690b448cf86b, type: 2}
   burningDamage: 25
 --- !u!114 &6751178667305699581
 MonoBehaviour:

--- a/UnityProject/Assets/Prefabs/Objects/Drawers/Cremator.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Drawers/Cremator.prefab
@@ -398,7 +398,7 @@ MonoBehaviour:
   crematorActiveSO: {fileID: 11400000, guid: b25d6302278ad144a844caff05ff46e2, type: 2}
   crematorInactiveSO: {fileID: 11400000, guid: 09b63097663eb2f41b62690b448cf86b, type: 2}
   crematorSprites: {fileID: 6366370698346894607}
-  burningDamage: 25
+  burningDamage: 23
 --- !u!114 &6751178667305699581
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Objects/Drawers/Cremator.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Drawers/Cremator.prefab
@@ -371,6 +371,7 @@ MonoBehaviour:
       m_SubObjectName: 
       m_SubObjectType: 
       m_EditorAssetChanged: 0
+  escapeTime: 8
   trayPrefab: {fileID: 6276591062313578460, guid: cb335e9d7c8dce444a0ea88946edbfd8,
     type: 3}
   storePlayers: 1
@@ -382,6 +383,7 @@ MonoBehaviour:
       m_SubObjectName: 
       m_SubObjectType: 
       m_EditorAssetChanged: 0
+  burningDamage: 4
 --- !u!114 &6751178667305699581
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Objects/Drawers/Morgue.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Drawers/Morgue.prefab
@@ -375,6 +375,7 @@ MonoBehaviour:
       m_SubObjectName: 
       m_SubObjectType: 
       m_EditorAssetChanged: 0
+  escapeTime: 4
   trayPrefab: {fileID: 6276591062313578460, guid: ec878b229bc16bb43a22dfbe0068687a,
     type: 3}
   storePlayers: 1

--- a/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
@@ -36,7 +36,7 @@ namespace Objects
 		}
 
 		private static readonly StandardProgressActionConfig ProgressConfig =
-				new StandardProgressActionConfig(StandardProgressActionType.Escape);
+				new StandardProgressActionConfig(StandardProgressActionType.Escape, true, true, true, true);
 
 		#region Inspector
 

--- a/UnityProject/Assets/Scripts/Objects/Drawers/Cremator.cs
+++ b/UnityProject/Assets/Scripts/Objects/Drawers/Cremator.cs
@@ -43,7 +43,7 @@ namespace Objects.Drawers
 			base.Awake();
 			accessRestrictions = GetComponent<AccessRestrictions>();
 			clearanceCheckable = GetComponent<ClearanceCheckable>();
-			crematorSprites = GetComponentInChildren<SpriteHandler>();
+			if(crematorSprites == null) crematorSprites = GetComponentInChildren<SpriteHandler>();
 		}
 
 		// This region (Interaction-RightClick) shouldn't exist once TODO in class summary is done.
@@ -147,10 +147,10 @@ namespace Objects.Drawers
 		{
 			SoundManager.PlayNetworkedAtPos(CremationSound, DrawerWorldPosition, sourceObj: gameObject);
 			SetDrawerState((DrawerState)CrematorState.ShutAndActive);
-			crematorSprites.SetSpriteSO(crematorActiveSO);
 			UpdateCloseState();
 			OnStartPlayerCremation();
 			StartCoroutine(nameof(BurnContent));
+			crematorSprites.SetSpriteSO(crematorActiveSO);
 		}
 
 		private IEnumerator BurnContent()
@@ -175,7 +175,7 @@ namespace Objects.Drawers
 			var objectsInContainer = container.GetStoredObjects();
 			foreach (var player in objectsInContainer)
 			{
-				if (player.TryGetComponent<LivingHealthBehaviour>(out var healthBehaviour))
+				if (player.TryGetComponent<PlayerHealthV2>(out var healthBehaviour))
 				{
 					if(healthBehaviour.ConsciousState == ConsciousState.CONSCIOUS ||
 					   healthBehaviour.ConsciousState == ConsciousState.BARELY_CONSCIOUS)

--- a/UnityProject/Assets/Scripts/Objects/Drawers/Cremator.cs
+++ b/UnityProject/Assets/Scripts/Objects/Drawers/Cremator.cs
@@ -18,9 +18,6 @@ namespace Objects.Drawers
 	{
 		[Tooltip("Sound used for cremation.")]
 		[SerializeField] private AddressableAudioSource CremationSound = null;
-		[SerializeField] private SpriteDataSO crematorActiveSO;
-		[SerializeField] private SpriteDataSO crematorInactiveSO;
-		[SerializeField] private SpriteHandler crematorSprites;
 
 		// Extra states over the base DrawerState enum.
 		private enum CrematorState
@@ -43,7 +40,6 @@ namespace Objects.Drawers
 			base.Awake();
 			accessRestrictions = GetComponent<AccessRestrictions>();
 			clearanceCheckable = GetComponent<ClearanceCheckable>();
-			if(crematorSprites == null) crematorSprites = GetComponentInChildren<SpriteHandler>();
 		}
 
 		// This region (Interaction-RightClick) shouldn't exist once TODO in class summary is done.
@@ -129,12 +125,10 @@ namespace Objects.Drawers
 		{
 			base.OpenDrawer();
 			if(drawerState == (DrawerState)CrematorState.ShutAndActive) StopCoroutine(BurnContent());
-			crematorSprites.SetSpriteSO(crematorInactiveSO);
 		}
 
 		private void UpdateCloseState()
 		{
-			crematorSprites.SetSpriteSO(crematorInactiveSO);
 			if (container.IsEmpty == false)
 			{
 				SetDrawerState((DrawerState)CrematorState.ShutWithContents);
@@ -150,7 +144,6 @@ namespace Objects.Drawers
 			UpdateCloseState();
 			OnStartPlayerCremation();
 			StartCoroutine(nameof(BurnContent));
-			crematorSprites.SetSpriteSO(crematorActiveSO);
 		}
 
 		private IEnumerator BurnContent()

--- a/UnityProject/Assets/Scripts/Objects/Drawers/Cremator.cs
+++ b/UnityProject/Assets/Scripts/Objects/Drawers/Cremator.cs
@@ -137,17 +137,11 @@ namespace Objects.Drawers
 			SetDrawerState((DrawerState)CrematorState.ShutAndActive);
 			UpdateCloseState();
 			OnStartPlayerCremation();
-			StartCoroutine(BurnContent());
+			StartCoroutine(nameof(BurnContent));
 		}
 
 		private IEnumerator BurnContent()
 		{
-			var timer = 0f;
-			var timeBetweenBurns = 10f;
-			while (timer <= timeBetweenBurns)
-			{
-				timer++;
-			}
 
 			if (drawerState == (DrawerState)CrematorState.ShutAndActive)
 			{
@@ -158,10 +152,10 @@ namespace Objects.Drawers
 					if(obj.TryGetComponent<LivingHealthBehaviour>(out var healthBehaviour))
 						healthBehaviour.ApplyDamage(gameObject, burningDamage, AttackType.Fire, DamageType.Burn);
 				}
-				StartCoroutine(BurnContent());
+				StartCoroutine(nameof(BurnContent));
 			}
 
-			return null;
+			yield return WaitFor.Seconds(5f);
 		}
 
 		private void OnStartPlayerCremation()

--- a/UnityProject/Assets/Scripts/Objects/Drawers/Cremator.cs
+++ b/UnityProject/Assets/Scripts/Objects/Drawers/Cremator.cs
@@ -159,6 +159,8 @@ namespace Objects.Drawers
 			}
 
 			yield return WaitFor.Seconds(BURNING_DURATION);
+			//if it's just closed but not active don't start this again.
+			if (drawerState == DrawerState.Shut || drawerState == DrawerState.Open) yield break;
 			StartCoroutine(nameof(BurnContent));
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/Drawers/Drawer.cs
+++ b/UnityProject/Assets/Scripts/Objects/Drawers/Drawer.cs
@@ -18,6 +18,10 @@ namespace Objects.Drawers
 	{
 	[SerializeField] private AddressableAudioSource BinOpenSFX = null;
 	[SerializeField] private AddressableAudioSource BinCloseSFX = null;
+	/// <summary>
+	/// How long does it take before players can escape from this drawer? (Put it to 0 to disable it)
+	/// </summary>
+	[SerializeField] protected float escapeTime = 8f;
 
 		protected enum DrawerState
 		{
@@ -195,6 +199,7 @@ namespace Objects.Drawers
 
 		public virtual void OpenDrawer()
 		{
+			if(drawerState == DrawerState.Open) return;
 			trayBehaviour.parentContainer = null;
 			trayTransform.SetPosition(TrayWorldPosition);
 
@@ -231,10 +236,18 @@ namespace Objects.Drawers
 
 		public void EntityTryEscape(GameObject entity,Action ifCompleted)
 		{
-			if (entity.Player() != null)
+			if(entity.Player() == null) return;
+			if (escapeTime <= 0.1f)
 			{
 				OpenDrawer();
+				return;
 			}
+			var bar = StandardProgressAction.Create(new StandardProgressActionConfig(StandardProgressActionType.Escape,
+				true, false, true, true), OpenDrawer);
+			bar.ServerStartProgress(gameObject.RegisterTile(), escapeTime, entity);
+			Chat.AddActionMsgToChat(entity,
+				$"You begin breaking out of the {gameObject.ExpensiveName()}...",
+				$"You hear noises coming from the {gameObject.ExpensiveName()}... Something must be trying to break out!");
 		}
 
 		#endregion Server Only

--- a/UnityProject/Assets/Scripts/Objects/Drawers/Morgue.cs
+++ b/UnityProject/Assets/Scripts/Objects/Drawers/Morgue.cs
@@ -60,6 +60,12 @@ namespace Objects.Drawers
 
 		public override void ServerPerformInteraction(HandApply interaction)
 		{
+			if (container.GetStoredObjects().Contains(interaction.Performer))
+			{
+				Chat.AddExamineMsg(interaction.Performer, "<color=red>I can't reach the controls from the inside!</color>");
+				EntityTryEscape(interaction.Performer, null);
+				return;
+			}
 			if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Screwdriver)) UseScrewdriver(interaction);
 			else if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Emag)
 				&& interaction.HandObject.TryGetComponent<Emag>(out var emag)

--- a/UnityProject/Assets/Scripts/Objects/Drawers/Morgue.cs
+++ b/UnityProject/Assets/Scripts/Objects/Drawers/Morgue.cs
@@ -63,7 +63,6 @@ namespace Objects.Drawers
 			if (container.GetStoredObjects().Contains(interaction.Performer))
 			{
 				Chat.AddExamineMsg(interaction.Performer, "<color=red>I can't reach the controls from the inside!</color>");
-				EntityTryEscape(interaction.Performer, null);
 				return;
 			}
 			if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Screwdriver)) UseScrewdriver(interaction);

--- a/UnityProject/Assets/Scripts/Objects/ObjectContainer.cs
+++ b/UnityProject/Assets/Scripts/Objects/ObjectContainer.cs
@@ -197,7 +197,14 @@ namespace Objects
 				}
 				else if (obj.TryGetComponent<PlayerScript>(out var playerScript))
 				{
-					playerScript.PlayerSync.AppearAtPositionServer(registerTile.WorldPositionServer);
+					if (worldPosition != null)
+					{
+						playerScript.PlayerSync.AppearAtPositionServer(worldPosition.Value);
+					}
+					else
+					{
+						playerScript.PlayerSync.AppearAtPositionServer(registerTile.WorldPositionServer);
+					}
 					playerScript.playerMove.IsTrapped = false;
 					if (pushPullObject.Pushable.IsMovingServer)
 					{

--- a/UnityProject/Assets/Scripts/Objects/ObjectContainer.cs
+++ b/UnityProject/Assets/Scripts/Objects/ObjectContainer.cs
@@ -197,14 +197,7 @@ namespace Objects
 				}
 				else if (obj.TryGetComponent<PlayerScript>(out var playerScript))
 				{
-					if (worldPosition != null)
-					{
-						playerScript.PlayerSync.AppearAtPositionServer(worldPosition.Value);
-					}
-					else
-					{
-						playerScript.PlayerSync.AppearAtPositionServer(registerTile.WorldPositionServer);
-					}
+					playerScript.PlayerSync.AppearAtPositionServer(worldPosition.GetValueOrDefault(registerTile.WorldPositionServer));
 					playerScript.playerMove.IsTrapped = false;
 					if (pushPullObject.Pushable.IsMovingServer)
 					{

--- a/UnityProject/Assets/Scripts/UI/Core/ProgressBar/StandardProgressAction.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/ProgressBar/StandardProgressAction.cs
@@ -136,17 +136,22 @@ public class StandardProgressAction : IProgressAction
 			return false;
 		}
 
-		//is this cross matrix? if so, don't start progress if either matrix is moving
-		var performerMatrix = playerScript.registerTile.Matrix;
-		crossMatrix = performerMatrix != info.Target.TargetMatrixInfo.Matrix;
-		if (crossMatrix && (performerMatrix.IsMovingServer || info.Target.TargetMatrixInfo.Matrix.IsMovingServer))
+		//Can this progress bar be interrupted by movement?
+		if (progressActionConfig.AllowMovement == false)
 		{
-			//progress already started by this player at this position
-			Logger.LogTraceFormat("Server cancelling progress bar {0} start because it is cross matrix and one of" +
-			                      " the matrices is moving.",
-				Category.ProgressAction, info.ProgressBar.ID);
-			return false;
+			//is this cross matrix? if so, don't start progress if either matrix is moving
+			var performerMatrix = playerScript.registerTile.Matrix;
+			crossMatrix = performerMatrix != info.Target.TargetMatrixInfo.Matrix;
+			if (crossMatrix && (performerMatrix.IsMovingServer || info.Target.TargetMatrixInfo.Matrix.IsMovingServer))
+			{
+				//progress already started by this player at this position
+				Logger.LogTraceFormat("Server cancelling progress bar {0} start because it is cross matrix and one of" +
+				                      " the matrices is moving.",
+					Category.ProgressAction, info.ProgressBar.ID);
+				return false;
+			}
 		}
+
 
 		//we are going to start progress, so set up the hooks
 		RegisterHooks();
@@ -184,7 +189,10 @@ public class StandardProgressAction : IProgressAction
 		eventRegistry.Register(playerScript.playerHealth.OnConsciousStateChangeServer, OnConsciousStateChange);
 		initialConsciousState = playerScript.playerHealth.ConsciousState;
 		//interrupt if player moves at all
-		eventRegistry.Register(playerScript.registerTile.OnLocalPositionChangedServer, OnLocalPositionChanged);
+		if (progressActionConfig.AllowMovement == false)
+		{
+			eventRegistry.Register(playerScript.registerTile.OnLocalPositionChangedServer, OnLocalPositionChanged);
+		}
 		//interrupt if player turns away and turning is not allowed
 		eventRegistry.Register(playerScript.playerDirectional.OnDirectionChange, OnDirectionChanged);
 		initialDirection = playerScript.playerDirectional.CurrentDirection;
@@ -248,6 +256,7 @@ public class StandardProgressAction : IProgressAction
 
 	private void InterruptProgress(string reason)
 	{
+		if(progressActionConfig.AllowMovement == true) return;
 		Logger.LogTraceFormat("Server progress bar {0} interrupted: {1}.", Category.ProgressAction,
 			ProgressBar.ID, reason);
 		ProgressBar.ServerInterruptProgress();
@@ -255,6 +264,7 @@ public class StandardProgressAction : IProgressAction
 
 	private void OnMatrixRotate(MatrixRotationInfo arg0)
 	{
+		if(progressActionConfig.AllowMovement == true) return;
 		InterruptProgress("cross-matrix and target or performer matrix rotated");
 	}
 

--- a/UnityProject/Assets/Scripts/UI/Core/ProgressBar/StandardProgressActionConfig.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/ProgressBar/StandardProgressActionConfig.cs
@@ -34,6 +34,8 @@ public class StandardProgressActionConfig
 	/// </summary>
 	public readonly bool AllowTurning;
 
+	public readonly bool AllowMovement;
+
 	/// <summary>
 	/// Creates a new progress action config with the indicated settings
 	/// </summary>
@@ -44,11 +46,12 @@ public class StandardProgressActionConfig
 	/// completes the action, the other players progress will be interrupted.</param>
 	/// <param name="allowTurning">Whether turning is allowed during the action</param>
 	public StandardProgressActionConfig(StandardProgressActionType standardProgressActionType,
-		bool allowMultiple = false, bool interruptsOverlapping = true, bool allowTurning = true)
+		bool allowMultiple = false, bool interruptsOverlapping = true, bool allowTurning = true, bool allowMovement = false)
 	{
 		StandardProgressActionType = standardProgressActionType;
 		AllowMultiple = allowMultiple;
 		InterruptsOverlapping = interruptsOverlapping;
 		AllowTurning = allowTurning;
+		AllowMovement = allowMovement;
 	}
 }


### PR DESCRIPTION
CL: [Fix] - Fixed an issue where players were unable to escape lockers
CL: [Fix] - Fixed  #7705
CL: [New] - You can no longer open a cremator or morgue from the inside and can attempt an escape by moving.
CL: [New] - Cremators now have proper burning logic, all items and mobs caught inside will be burnt for a period of time until they turn to ash.
