### PR TITLE
Fixes re-logging on rotated matrices items being displaced

### DIFF
--- a/UnityProject/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/UnityProject/Assets/Mirror/Runtime/NetworkClient.cs
@@ -988,7 +988,7 @@ namespace Mirror
             ///CUSTOM UNITYSTATION CODE///
             //Mirror specifically says that they dont support NetworkIdentities nested in normal gameobjects.
             //But, we do it, so we have to override this and make sure we read and send world pos
-            identity.transform.position = message.position;
+            identity.transform.localPosition = message.position;
             ///CUSTOM UNITYSTATION CODE///
 
             if (message.isLocalPlayer)
@@ -1061,6 +1061,10 @@ namespace Mirror
             if (spawnHandlers.TryGetValue(message.assetId, out SpawnHandlerDelegate handler))
             {
                 GameObject obj = handler(message);
+                ///UNITYSTATION CODE///
+                ///so, When the client logs in, The objects that are part of the map get the correct local position, If they've moved
+                obj.transform.localPosition = message.position;
+
                 if (obj == null)
                 {
                     Debug.LogError($"Spawn Handler returned null, Handler assetId '{message.assetId}'");

--- a/UnityProject/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/UnityProject/Assets/Mirror/Runtime/NetworkClient.cs
@@ -987,7 +987,7 @@ namespace Mirror
 
             ///CUSTOM UNITYSTATION CODE///
             //Mirror specifically says that they dont support NetworkIdentities nested in normal gameobjects.
-            //But, we do it, so we have to override this and make sure we read and send world pos
+            //But, we do it, so we have to override this and make sure we read and send local pos
             identity.transform.localPosition = message.position;
             ///CUSTOM UNITYSTATION CODE///
 

--- a/UnityProject/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/UnityProject/Assets/Mirror/Runtime/NetworkServer.cs
@@ -938,7 +938,7 @@ namespace Mirror
                 ///CUSTOM UNITYSTATION CODE///
                 //Mirror specifically says that they dont support NetworkIdentities nested in normal gameobjects.
                 //But, we do it, so we have to override this and make sure we read and send world pos
-                message.position = identity.transform.position;
+                message.position = identity.transform.localPosition;
                 ///CUSTOM UNITYSTATION CODE///
 
                 conn.Send(message);

--- a/UnityProject/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/UnityProject/Assets/Mirror/Runtime/NetworkServer.cs
@@ -937,7 +937,7 @@ namespace Mirror
 
                 ///CUSTOM UNITYSTATION CODE///
                 //Mirror specifically says that they dont support NetworkIdentities nested in normal gameobjects.
-                //But, we do it, so we have to override this and make sure we read and send world pos
+                //But, we do it, so we have to override this and make sure we read and send local pos
                 message.position = identity.transform.localPosition;
                 ///CUSTOM UNITYSTATION CODE///
 

--- a/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.cs
+++ b/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.cs
@@ -175,21 +175,43 @@ public partial class CustomNetTransform : NetworkBehaviour, IPushable
 			transform.position = new Vector2(transform.position.x, transform.position.y);
 		}
 
-		var pos = transform.position;
-		if (snapToGridOnStart)
+		Vector3 pos = TransformState.HiddenPos;
+		if (transform.parent == null)
 		{
-			pos = pos.RoundToInt();
-		}
-		var matrixInfo = matrix.MatrixInfo;
+			pos = transform.position; //Local and position are the same because no parent
+			if (snapToGridOnStart)
+			{
+				pos = pos.RoundToInt();
+			}
+			var matrixInfo = matrix.MatrixInfo;
 
-		predictedState.MatrixId = matrixInfo.Id;
-		predictedState.WorldPosition = pos;
-		serverState.MatrixId = matrixInfo.Id;
-		serverState.WorldPosition = pos;
-		clientState.MatrixId = matrixInfo.Id;
-		clientState.WorldPosition = pos;
-		serverLerpState.MatrixId = matrixInfo.Id;
-		serverLerpState.WorldPosition = pos;
+			predictedState.MatrixId = matrixInfo.Id;
+			predictedState.LocalPosition = pos;
+			serverState.MatrixId = matrixInfo.Id;
+			serverState.LocalPosition = pos;
+			clientState.MatrixId = matrixInfo.Id;
+			clientState.LocalPosition = pos;
+			serverLerpState.MatrixId = matrixInfo.Id;
+			serverLerpState.LocalPosition = pos;
+		}
+		else
+		{
+			pos = transform.position;
+			if (snapToGridOnStart)
+			{
+				pos = pos.RoundToInt();
+			}
+			var matrixInfo = matrix.MatrixInfo;
+
+			predictedState.MatrixId = matrixInfo.Id;
+			predictedState.WorldPosition = pos;
+			serverState.MatrixId = matrixInfo.Id;
+			serverState.WorldPosition = pos;
+			clientState.MatrixId = matrixInfo.Id;
+			clientState.WorldPosition = pos;
+			serverLerpState.MatrixId = matrixInfo.Id;
+			serverLerpState.WorldPosition = pos;
+		}
 
 		if (CustomNetworkManager.IsServer)
 		{
@@ -675,7 +697,7 @@ public partial class CustomNetTransform : NetworkBehaviour, IPushable
 		//Don't lerp (instantly change pos) if active state was changed
 		if (predictedState.Active != newState.Active || newState.Active == false /*|| newState.Speed == 0*/)
 		{
-			transform.position = newState.WorldPosition;
+			transform.localPosition = newState.LocalPosition;
 		}
 		predictedState = newState;
 		UpdateActiveStatusClient();

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
@@ -1244,7 +1244,7 @@ public partial class MatrixManager : SingletonManager<MatrixManager>
 	/// </summary>
 	public static Vector3Int LocalToWorldInt(Vector3 localPos, Matrix matrix)
 	{
-		return LocalToWorldInt(localPos, Get(matrix));
+		return LocalToWorldInt(localPos, matrix?.MatrixInfo);
 	}
 
 	/// <inheritdoc cref="LocalToWorldInt(Vector3, Matrix)"/>
@@ -1259,7 +1259,7 @@ public partial class MatrixManager : SingletonManager<MatrixManager>
 	/// </summary>
 	public static Vector3 LocalToWorld(Vector3 localPos, Matrix matrix)
 	{
-		return LocalToWorld(localPos, Get(matrix));
+		return LocalToWorld(localPos, matrix?.MatrixInfo);
 	}
 
 	/// <inheritdoc cref="LocalToWorld(Vector3, Matrix)"/>

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
@@ -80,6 +80,8 @@ namespace TileManagement
 		public BetterBounds? GlobalCachedBounds;
 
 		[NonSerialized] public Matrix4x4 localToWorldMatrix = Matrix4x4.identity;
+		[NonSerialized] public Matrix4x4 worldToLocalMatrix = Matrix4x4.identity;
+
 
 		public float Resistance(Vector3Int cellPos, bool includeObjects = true)
 		{
@@ -210,7 +212,9 @@ namespace TileManagement
 
 		public void UpdateMe()
 		{
-			localToWorldMatrix = transform.localToWorldMatrix;
+			var transform1 = transform;
+			localToWorldMatrix = transform1.localToWorldMatrix;
+			worldToLocalMatrix = transform1.worldToLocalMatrix;
 			if (QueuedChanges.Count == 0)
 				return;
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
@@ -372,7 +372,7 @@ public class RegisterTile : NetworkBehaviour, IServerDespawn
 			objectLayer = newObjectLayer;
 		}
 
-		transform.SetParent(objectLayer.transform, true);
+		transform.SetParent(objectLayer.transform, transform.parent); //If it has no parent presumed it was spawned in my mirror that Used the local position
 
 		//preserve absolute rotation if there was spin rotation
 		if (hadSpinRotation)


### PR DESCRIPTION
yeah, 
I've noticed a few wishes but I'm not sure if they're in developed or caused by my changes

Issues + items like banana pie when you eat it and the plate, appears in your inventory if you drop that, it lerps over to you position, this is because it's technically never told to be hidden because it's getting confused between localPOS = hiddenPOS and worldPOS = hiddenPOS ( I think this is in the main repository and it needs to be standardised so it only checks hiddenPOS  for worldPOS )

CL: [Fix] fixed an issue with items appearing in the wrong place when rejoining a round.