### PR TITLE
Fixes Round start explosions

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Engineering/Reactor/ReactorGraphiteChamber.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/Reactor/ReactorGraphiteChamber.cs
@@ -77,11 +77,13 @@ namespace Objects.Engineering
 
 		public void OnEnable()
 		{
+			if (CustomNetworkManager.IsServer == false) return;
 			UpdateManager.Add(CycleUpdate, 1);
 		}
 
 		public void OnDisable()
 		{
+			if (CustomNetworkManager.IsServer == false) return;
 			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, CycleUpdate);
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/Engineering/Reactor/ReactorGraphiteChamber.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/Reactor/ReactorGraphiteChamber.cs
@@ -11,8 +11,7 @@ using Objects.Atmospherics;
 
 namespace Objects.Engineering
 {
-	public class ReactorGraphiteChamber : MonoBehaviour, IInteractable<HandApply>, IMultitoolMasterable, IServerDespawn,
-		IServerSpawn
+	public class ReactorGraphiteChamber : MonoBehaviour, IInteractable<HandApply>, IMultitoolMasterable, IServerDespawn
 	{
 		public float EditorPresentNeutrons;
 		public float EditorEnergyReleased;
@@ -76,10 +75,16 @@ namespace Objects.Engineering
 			ReactorPipe = this.GetComponent<ReactorPipe>();
 		}
 
-		public void OnSpawnServer(SpawnInfo info)
+		public void OnEnable()
 		{
 			UpdateManager.Add(CycleUpdate, 1);
 		}
+
+		public void OnDisable()
+		{
+			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, CycleUpdate);
+		}
+
 
 		/// <summary>
 		/// is the function to denote that it will be pooled or destroyed immediately after this function is finished, Used for cleaning up anything that needs to be cleaned up before this happens

--- a/UnityProject/Assets/Scripts/Systems/Explosions/Explosion.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/Explosion.cs
@@ -148,7 +148,6 @@ namespace Systems.Explosions
 
 		public static void StartExplosion(Vector3Int WorldPOS, float strength, bool isEmp = false)
 		{
-			Logger.LogError($"Explosion started, look at Trace log, Strength {strength} at World {WorldPOS} ");
 			int Radius = (int) Math.Round(strength / (Math.PI * 75));
 
 			if (Radius > 150)


### PR DESCRIPTION
the issue was that the reactor wasn't being removed from the update manager when the Round was ended

CL: [Fix] fixed an issue that was causing the reactor to endlessly explode after a rounded ended, even carrying over into the next round.