### PR TITLE
Left Handed People Can Write

### DIFF
--- a/UnityProject/Assets/Scripts/UI/Items/GUI_Paper.cs
+++ b/UnityProject/Assets/Scripts/UI/Items/GUI_Paper.cs
@@ -73,6 +73,7 @@ namespace UI.Items
 			{
 				if (itemSlot.ItemObject != null && itemSlot.ItemObject.TryGetComponent<Pen>(out pen))
 				{
+					break;
 				}
 			}
 


### PR DESCRIPTION
### Purpose
Left handed people may once again write with paper

### Changelog:
CL: [Fix] minor fix so you can write with a pen in your left hand
