### PR TITLE
Adds a light switch reference tool

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Editor/Tools/Tools.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/Tools/Tools.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Systems.CraftingV2;
 using Systems.Electricity;
+using Objects.Lighting;
 using Mirror;
 using Objects.Wallmounts;
 using UnityEditor;
@@ -151,6 +152,36 @@ namespace Core.Editor.Tools
 			}
 
 			Debug.Log($"{allNets.Length} apcPoweredDevice found in scene, {count} were not in APC list.");
+		}
+
+		/// <summary>
+		/// Fixes Light Switch references where the light source has a related switch, but the switch doesnt have the light source in the list
+		/// </summary>
+		[MenuItem("Mapping/Fix Light switch references (scene)")]
+		private static void FixLights()
+		{
+			var allNets = FindObjectsOfType<LightSource>();
+
+			var count = 0;
+
+			for (int i = allNets.Length - 1; i > 0; i--)
+			{
+				var lightSource = allNets[i];
+
+				if (lightSource.IsWithoutSwitch) continue;
+
+				if (lightSource.relatedLightSwitch == null) continue;
+
+				if (lightSource.relatedLightSwitch.listOfLights.Contains(lightSource)) continue;
+
+				EditorUtility.SetDirty(lightSource.relatedLightSwitch);
+
+				lightSource.relatedLightSwitch.listOfLights.Add(lightSource);
+
+				count++;
+			}
+
+			Debug.Log($"{allNets.Length} light sources found in scene, {count} were not in light switch list.");
 		}
 
 		/// <summary>


### PR DESCRIPTION
Adds a new mapping tool for fixing missing references between light sources and light switches, this works the exact same as the APC reference tool but for light switches- as switches have a tendency to not like linking to things. Also should just be nice to have in general.
