### PR TITLE
Fixes Spare AA cards missing accesses

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Cards/IDCards/IDCardCaptainsSpare.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Cards/IDCards/IDCardCaptainsSpare.prefab
@@ -80,7 +80,7 @@ PrefabInstance:
     - target: {fileID: 1079326846074143117, guid: da8e7a51ad26f8f48ac7cff66da55f3e,
         type: 3}
       propertyPath: manuallyAddedAccess.Array.size
-      value: 62
+      value: 64
       objectReference: {fileID: 0}
     - target: {fileID: 1079326846074143117, guid: da8e7a51ad26f8f48ac7cff66da55f3e,
         type: 3}
@@ -391,6 +391,16 @@ PrefabInstance:
         type: 3}
       propertyPath: manuallyAddedAccess.Array.data[61]
       value: 79
+      objectReference: {fileID: 0}
+    - target: {fileID: 1079326846074143117, guid: da8e7a51ad26f8f48ac7cff66da55f3e,
+        type: 3}
+      propertyPath: manuallyAddedAccess.Array.data[62]
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 1079326846074143117, guid: da8e7a51ad26f8f48ac7cff66da55f3e,
+        type: 3}
+      propertyPath: manuallyAddedAccess.Array.data[63]
+      value: 47
       objectReference: {fileID: 0}
     - target: {fileID: 1144162440554374824, guid: da8e7a51ad26f8f48ac7cff66da55f3e,
         type: 3}


### PR DESCRIPTION
Spare captain card is unable to go through Xenobiology or Library doors, this just adds them to the access list of the card.

CL: [Fix] added missing xenobiology and library access to the captain's spare ID