### PR TITLE
Fixes defib sound thread error

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Medical/DefibrillatorPaddles.cs
+++ b/UnityProject/Assets/Scripts/Items/Medical/DefibrillatorPaddles.cs
@@ -70,23 +70,24 @@ namespace Items.Medical
 		void Perform()
 		{
 			var livingHealthMaster = interaction.TargetObject.GetComponent<LivingHealthMasterBase>();
+			var objectPos = gameObject.AssumedWorldPosServer();
 			if (CanDefibrillate(livingHealthMaster, interaction.Performer) == false)
 			{
-				_ = SoundManager.PlayNetworkedAtPosAsync(soundFailed, gameObject.AssumedWorldPosServer());
-				Cooldown();
+				_ = SoundManager.PlayNetworkedAtPosAsync(soundFailed, objectPos);
+				Cooldown(objectPos);
 				return;
 			}
 			livingHealthMaster.RestartHeart();
-			_ = SoundManager.PlayNetworkedAtPosAsync(soundZap, gameObject.AssumedWorldPosServer());
+			_ = SoundManager.PlayNetworkedAtPosAsync(soundZap, objectPos);
 			if (livingHealthMaster.IsDead == false)
 			{
 				livingHealthMaster.playerScript.ReturnGhostToBody();
-				_ = SoundManager.PlayNetworkedAtPosAsync(soundSuccsuess, gameObject.AssumedWorldPosServer());
-				Cooldown();
+				_ = SoundManager.PlayNetworkedAtPosAsync(soundSuccsuess, objectPos);
+				Cooldown(objectPos);
 				return;
 			}
-			_ = SoundManager.PlayNetworkedAtPosAsync(soundFailed, gameObject.AssumedWorldPosServer());
-			Cooldown();
+			_ = SoundManager.PlayNetworkedAtPosAsync(soundFailed, objectPos);
+			Cooldown(objectPos);
 		}
 
 		if (isReady == false || onCooldown == true)
@@ -98,12 +99,12 @@ namespace Items.Medical
 		bar.ServerStartProgress(interaction.Performer.RegisterTile(), Time, interaction.Performer);
 	}
 
-	private async void Cooldown()
+	private async void Cooldown(Vector3 soundPos)
 	{
 		onCooldown = true;
 		await Task.Delay(cooldownMs).ConfigureAwait(false);
 		onCooldown = false;
-		SoundManager.PlayNetworkedAtPos(soundCharged, gameObject.AssumedWorldPosServer());
+		SoundManager.PlayNetworkedAtPos(soundCharged, soundPos);
 	}
 
 	public void ServerPerformInteraction(HandActivate interaction)

--- a/UnityProject/Assets/Scripts/Items/Medical/DefibrillatorPaddles.cs
+++ b/UnityProject/Assets/Scripts/Items/Medical/DefibrillatorPaddles.cs
@@ -74,7 +74,7 @@ namespace Items.Medical
 			if (CanDefibrillate(livingHealthMaster, interaction.Performer) == false)
 			{
 				_ = SoundManager.PlayNetworkedAtPosAsync(soundFailed, objectPos);
-				Cooldown(objectPos);
+				Cooldown(gameObject);
 				return;
 			}
 			livingHealthMaster.RestartHeart();
@@ -83,11 +83,11 @@ namespace Items.Medical
 			{
 				livingHealthMaster.playerScript.ReturnGhostToBody();
 				_ = SoundManager.PlayNetworkedAtPosAsync(soundSuccsuess, objectPos);
-				Cooldown(objectPos);
+				Cooldown(gameObject);
 				return;
 			}
 			_ = SoundManager.PlayNetworkedAtPosAsync(soundFailed, objectPos);
-			Cooldown(objectPos);
+			Cooldown(gameObject);
 		}
 
 		if (isReady == false || onCooldown == true)
@@ -99,12 +99,12 @@ namespace Items.Medical
 		bar.ServerStartProgress(interaction.Performer.RegisterTile(), Time, interaction.Performer);
 	}
 
-	private async void Cooldown(Vector3 soundPos)
+	private async void Cooldown(GameObject objectPos)
 	{
 		onCooldown = true;
 		await Task.Delay(cooldownMs).ConfigureAwait(false);
 		onCooldown = false;
-		SoundManager.PlayNetworkedAtPos(soundCharged, soundPos);
+		SoundManager.PlayNetworkedAtPos(soundCharged, objectPos.AssumedWorldPosServer());
 	}
 
 	public void ServerPerformInteraction(HandActivate interaction)

--- a/UnityProject/Assets/Scripts/Items/Medical/DefibrillatorPaddles.cs
+++ b/UnityProject/Assets/Scripts/Items/Medical/DefibrillatorPaddles.cs
@@ -74,7 +74,7 @@ namespace Items.Medical
 			if (CanDefibrillate(livingHealthMaster, interaction.Performer) == false)
 			{
 				_ = SoundManager.PlayNetworkedAtPosAsync(soundFailed, objectPos);
-				StartCoroutine(Cooldown(gameObject));
+				StartCoroutine(Cooldown());
 				return;
 			}
 			livingHealthMaster.RestartHeart();
@@ -83,11 +83,11 @@ namespace Items.Medical
 			{
 				livingHealthMaster.playerScript.ReturnGhostToBody();
 				_ = SoundManager.PlayNetworkedAtPosAsync(soundSuccsuess, objectPos);
-				StartCoroutine(Cooldown(gameObject));
+				StartCoroutine(Cooldown());
 				return;
 			}
 			_ = SoundManager.PlayNetworkedAtPosAsync(soundFailed, objectPos);
-			StartCoroutine(Cooldown(gameObject));
+			StartCoroutine(Cooldown());
 		}
 
 		if (isReady == false || onCooldown == true)
@@ -99,12 +99,12 @@ namespace Items.Medical
 		bar.ServerStartProgress(interaction.Performer.RegisterTile(), Time, interaction.Performer);
 	}
 
-	private IEnumerator Cooldown(GameObject objectPos)
+	private IEnumerator Cooldown()
 	{
 		onCooldown = true;
 		yield return WaitFor.Seconds(cooldown);
 		onCooldown = false;
-		SoundManager.PlayNetworkedAtPos(soundCharged, objectPos.AssumedWorldPosServer());
+		SoundManager.PlayNetworkedAtPos(soundCharged, gameObject.AssumedWorldPosServer());
 	}
 
 	public void ServerPerformInteraction(HandActivate interaction)

--- a/UnityProject/Assets/Scripts/Items/Medical/DefibrillatorPaddles.cs
+++ b/UnityProject/Assets/Scripts/Items/Medical/DefibrillatorPaddles.cs
@@ -74,7 +74,7 @@ namespace Items.Medical
 			if (CanDefibrillate(livingHealthMaster, interaction.Performer) == false)
 			{
 				_ = SoundManager.PlayNetworkedAtPosAsync(soundFailed, objectPos);
-				Cooldown(gameObject);
+				StartCoroutine(Cooldown(gameObject));
 				return;
 			}
 			livingHealthMaster.RestartHeart();
@@ -83,11 +83,11 @@ namespace Items.Medical
 			{
 				livingHealthMaster.playerScript.ReturnGhostToBody();
 				_ = SoundManager.PlayNetworkedAtPosAsync(soundSuccsuess, objectPos);
-				Cooldown(gameObject);
+				StartCoroutine(Cooldown(gameObject));
 				return;
 			}
 			_ = SoundManager.PlayNetworkedAtPosAsync(soundFailed, objectPos);
-			Cooldown(gameObject);
+			StartCoroutine(Cooldown(gameObject));
 		}
 
 		if (isReady == false || onCooldown == true)

--- a/UnityProject/Assets/Scripts/Items/Medical/DefibrillatorPaddles.cs
+++ b/UnityProject/Assets/Scripts/Items/Medical/DefibrillatorPaddles.cs
@@ -24,7 +24,7 @@ namespace Items.Medical
 
 	private bool isReady;
 	private bool onCooldown;
-	private readonly int cooldownMs = 5000;
+	private readonly float cooldown = 5;
 
 	public bool WillInteract(HandApply interaction, NetworkSide side)
 	{
@@ -99,10 +99,10 @@ namespace Items.Medical
 		bar.ServerStartProgress(interaction.Performer.RegisterTile(), Time, interaction.Performer);
 	}
 
-	private async void Cooldown(GameObject objectPos)
+	private IEnumerator Cooldown(GameObject objectPos)
 	{
 		onCooldown = true;
-		await Task.Delay(cooldownMs).ConfigureAwait(false);
+		yield return WaitFor.Seconds(cooldown);
 		onCooldown = false;
 		SoundManager.PlayNetworkedAtPos(soundCharged, objectPos.AssumedWorldPosServer());
 	}


### PR DESCRIPTION
functions run on other threads can't fetch gameobjects correctly
this fix changes the cooldown function to stop the sound manager from fetching the game object's position and instead the server will provide the position from the main thread to the function.

Fixes #8155

CL: [Fix] fix an error when defibrillators played their sfx.