### PR TITLE
Powered Consoles

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Consoles/ConsoleScreenAnimator.cs
+++ b/UnityProject/Assets/Scripts/Objects/Consoles/ConsoleScreenAnimator.cs
@@ -3,10 +3,11 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using Systems.Electricity;
+using Objects.Construction;
 
 namespace Objects
 {
-	public class ConsoleScreenAnimator : MonoBehaviour, IAPCPowerable
+	public class ConsoleScreenAnimator : MonoBehaviour
 	{
 		public SpriteHandler SpriteHandlerHere {
 			get {
@@ -25,7 +26,7 @@ namespace Objects
 		private SpriteHandler spriteHandler;
 		public GameObject ScreenGlow;
 
-		private void ToggleOn(bool turnOn)
+		public void ToggleOn(bool turnOn)
 		{
 			if (turnOn)
 			{
@@ -35,6 +36,7 @@ namespace Objects
 					return;
 				}
 				SpriteHandlerHere.PushTexture();
+				ScreenGlow.SetActive(true);
 			}
 			else
 			{
@@ -45,23 +47,5 @@ namespace Objects
 				}
 			}
 		}
-
-		#region IAPCPowerable
-
-		public void PowerNetworkUpdate(float voltage) { }
-
-		public void StateUpdate(PowerState state)
-		{
-			if (state == PowerState.Off || state == PowerState.LowVoltage)
-			{
-				ToggleOn(false);
-			}
-			else
-			{
-				ToggleOn(true);
-			}
-		}
-
-		#endregion
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Construction/Computer.cs
+++ b/UnityProject/Assets/Scripts/Systems/Construction/Computer.cs
@@ -2,13 +2,15 @@ using UnityEngine;
 using Systems.Hacking;
 using Messages.Server;
 using Messages.Server.SoundMessages;
+using Systems.Electricity;
+using UI.Core.Net;
 
 namespace Objects.Construction
 {
 	/// <summary>
 	/// Main behavior for computers. Allows them to be deconstructed to frames.
 	/// </summary>
-	public class Computer : MonoBehaviour, ICheckedInteractable<HandApply>
+	public class Computer : MonoBehaviour, ICheckedInteractable<HandApply>, IAPCPowerable, ICanOpenNetTab
 	{
 		[Tooltip("Frame prefab this computer should deconstruct into.")]
 		[SerializeField]
@@ -22,6 +24,8 @@ namespace Objects.Construction
 		/// Prefab of the circuit board that lives inside this computer.
 		/// </summary>
 		public GameObject CircuitBoardPrefab => circuitBoardPrefab;
+
+		public bool hasPower = false;
 
 		[Tooltip("Time taken to screwdrive to deconstruct this.")]
 		[SerializeField]
@@ -126,6 +130,31 @@ namespace Objects.Construction
 			_ = Despawn.ServerSingle(gameObject);
 
 			integrity.OnWillDestroyServer.RemoveListener(WhenDestroyed);
+		}
+
+		public void PowerNetworkUpdate(float voltage) {}
+
+		public void StateUpdate(PowerState state)
+		{
+			if (state == PowerState.Off || state == PowerState.LowVoltage)
+			{
+				hasPower = false;
+			}
+			else
+			{
+				hasPower = true;
+			}
+			GetComponent<ConsoleScreenAnimator>().ToggleOn(hasPower);
+		}
+
+		public bool CanOpenNetTab(GameObject playerObject, NetTabType netTabType)
+		{
+			if (!hasPower)
+			{
+				Chat.AddExamineMsgFromServer(playerObject, $"{gameObject.ExpensiveName()} is unpowered");
+				return false;
+			}
+			return true;
 		}
 	}
 }


### PR DESCRIPTION
<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->

### Purpose
<!-- Describe the problem the PR fixes or the feature it introduces. -->
<!-- Don't forget to use "Fixes #issuenumber" to select issues and auto close them on merge. -->
Fixes #8066
When there is no power in the APC's consoles stop working and their display turns off.

### Changelog:

CL: [Improvement] Added Power check for Consoles.
