### PR TITLE
Ashwalker Spawn When Lavaland QP First Used

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/EventManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/EventManager.cs
@@ -30,7 +30,8 @@ public enum Event
 	PreRoundStarted,
 	MatrixManagerInit,
 	BlobSpawned,
-	ScenesLoadedServer
+	ScenesLoadedServer,
+	LavalandFirstEntered
 } // + other events. Add them as you need them
 
 [ExecuteInEditMode]

--- a/UnityProject/Assets/Scripts/Managers/GameManager.Escape.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.Escape.cs
@@ -83,6 +83,12 @@ public partial class GameManager
 
 		Vector3 newPos;
 
+		if (LandingZoneManager.Instance.centcomDocking == null)
+		{
+			Logger.LogError("Centcom docking point is null, this should only happen if theres no centcom scene");
+			return;
+		}
+
 		switch (LandingZoneManager.Instance.centcomDocking.orientation)
 		{
 			case OrientationEnum.Right_By90:

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.SceneList.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.SceneList.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using Mirror;
 using UnityEditor;
 using UnityEngine.SceneManagement;
@@ -145,6 +146,8 @@ public partial class SubSceneManager
 		}
 
 		var pickedMap = additionalSceneList.defaultCentComScenes.PickRandom();
+
+		if (string.IsNullOrEmpty(pickedMap)) yield break;
 
 		//If no special CentCom load default.
 		yield return StartCoroutine(LoadSubScene(pickedMap, loadTimer));

--- a/UnityProject/Assets/Scripts/Objects/Lavaland/AshwalkerNest.cs
+++ b/UnityProject/Assets/Scripts/Objects/Lavaland/AshwalkerNest.cs
@@ -56,6 +56,8 @@ namespace Objects
 			new Vector3Int(-1, 1, 0)
 		};
 
+		private bool wasMapped;
+
 		#region Life Cycle
 
 		private void Awake()
@@ -69,14 +71,14 @@ namespace Objects
 		{
 			UpdateManager.Add(PeriodicUpdate, 1f);
 			integrity.OnWillDestroyServer.AddListener(OnDestruction);
-			EventManager.AddHandler(Event.RoundStarted, OnRoundRestart);
+			EventManager.AddHandler(Event.LavalandFirstEntered, OnRoundRestart);
 		}
 
 		private void OnDisable()
 		{
 			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, PeriodicUpdate);
 			integrity.OnWillDestroyServer.RemoveListener(OnDestruction);
-			EventManager.RemoveHandler(Event.RoundStarted, OnRoundRestart);
+			EventManager.RemoveHandler(Event.LavalandFirstEntered, OnRoundRestart);
 
 			//Just in case remove the role here too
 			GhostRoleManager.Instance.ServerRemoveRole(createdRoleKey);
@@ -190,7 +192,8 @@ namespace Objects
 		//Used for when admin or in round spawned
 		public void OnSpawnServer(SpawnInfo info)
 		{
-			if(GameManager.Instance.CurrentRoundState != RoundState.Started) return;
+			wasMapped = info.SpawnType == SpawnType.Mapped;
+			if(wasMapped) return;
 
 			OnRoundRestart();
 		}
@@ -211,6 +214,8 @@ namespace Objects
 			GhostRoleManager.Instance.ServerUpdateRole(createdRoleKey, 1, ashwalkerEggs, -1);
 
 			role.OnPlayerAdded += OnSpawnPlayer;
+
+			EventManager.RemoveHandler(Event.LavalandFirstEntered, OnRoundRestart);
 		}
 
 		private void OnSpawnPlayer(ConnectedPlayer player)

--- a/UnityProject/Assets/Scripts/Objects/Machines/QuantumPad.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/QuantumPad.cs
@@ -45,12 +45,12 @@ namespace Objects.Science
 		/// Temp until shuttle landings possible
 		/// </summary>
 		public bool IsLavaLandBase1;
-		private bool firstEnteredTriggered;
 
 		/// <summary>
 		/// Temp until shuttle landings possible
 		/// </summary>
 		public bool IsLavaLandBase1Connector;
+		private bool firstEnteredTriggered;
 
 		/// <summary>
 		/// Temp until shuttle landings possible
@@ -179,7 +179,7 @@ namespace Objects.Science
 				TransportUtility.TransportObjectAndPulled(player, travelCoord);
 				somethingTeleported = true;
 
-				if (IsLavaLandBase1 && firstEnteredTriggered == false)
+				if (IsLavaLandBase1Connector && firstEnteredTriggered == false)
 				{
 					//Trigger lavaland first entered event
 					EventManager.Broadcast(Event.LavalandFirstEntered);

--- a/UnityProject/Assets/Scripts/Objects/Machines/QuantumPad.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/QuantumPad.cs
@@ -45,6 +45,7 @@ namespace Objects.Science
 		/// Temp until shuttle landings possible
 		/// </summary>
 		public bool IsLavaLandBase1;
+		private bool firstEnteredTriggered;
 
 		/// <summary>
 		/// Temp until shuttle landings possible
@@ -102,8 +103,8 @@ namespace Objects.Science
 
 		public void OnSpawnServer(SpawnInfo info)
 		{
-			if (!passiveDetect)
-				return;
+			if (!passiveDetect) return;
+
 			UpdateManager.Add(ServerDetectObjectsOnTile, 1f);
 		}
 
@@ -177,6 +178,13 @@ namespace Objects.Science
 				SoundManager.PlayNetworkedForPlayer(player.gameObject, CommonSounds.Instance.StealthOff); //very weird, sometimes does the sound other times not.
 				TransportUtility.TransportObjectAndPulled(player, travelCoord);
 				somethingTeleported = true;
+
+				if (IsLavaLandBase1 && firstEnteredTriggered == false)
+				{
+					//Trigger lavaland first entered event
+					EventManager.Broadcast(Event.LavalandFirstEntered);
+					firstEnteredTriggered = true;
+				}
 			}
 
 			//detect objects and items


### PR DESCRIPTION
CL: [Improvement] Ashwalker ghost role will now only appear when lavaland has been visited

-Allow for no centcom scene

-In the future this might be a good way to trigger the mob spawn as well?
