### PR TITLE
Fix Dead Gasps

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
@@ -54,6 +54,9 @@ namespace HealthV2
 		public override void ImplantPeriodicUpdate()
 		{
 			base.ImplantPeriodicUpdate();
+			if(RelatedPart.HealthMaster.IsDead)
+				return;
+
 			Vector3Int position = RelatedPart.HealthMaster.ObjectBehaviour.AssumedWorldPositionServer();
 			MetaDataNode node = MatrixManager.GetMetaDataAt(position);
 			var TotalModified = 1f;
@@ -107,9 +110,9 @@ namespace HealthV2
 			{
 				return false;
 			}
-			if (RelatedPart.HealthMaster.CirculatorySystem.BloodPool[RelatedPart.bloodType] == 0 || RelatedPart.HealthMaster.IsDead)
+			if (RelatedPart.HealthMaster.CirculatorySystem.BloodPool[RelatedPart.bloodType] == 0)
 			{
-				return false; //No point breathing if we are dead or dont have blood.
+				return false; //No point breathing if we dont have blood.
 			}
 
 			// Try to get internal breathing if possible, otherwise get from the surroundings

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
@@ -54,7 +54,13 @@ namespace HealthV2
 		public override void ImplantPeriodicUpdate()
 		{
 			base.ImplantPeriodicUpdate();
-			if(RelatedPart.HealthMaster.IsDead)
+
+			// Disable breathing for dead and brain damaged players
+			if (RelatedPart.HealthMaster.IsDead)
+				return;
+
+			Brain brain = RelatedPart.HealthMaster.brain;
+			if (brain && brain.RelatedPart.TotalModified <= 0.2f)
 				return;
 
 			Vector3Int position = RelatedPart.HealthMaster.ObjectBehaviour.AssumedWorldPositionServer();

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
@@ -107,10 +107,9 @@ namespace HealthV2
 			{
 				return false;
 			}
-
-			if (RelatedPart.HealthMaster.CirculatorySystem.BloodPool[RelatedPart.bloodType] == 0)
+			if (RelatedPart.HealthMaster.CirculatorySystem.BloodPool[RelatedPart.bloodType] == 0 || RelatedPart.HealthMaster.IsDead)
 			{
-				return false; //No point breathing if we dont have blood.
+				return false; //No point breathing if we are dead or dont have blood.
 			}
 
 			// Try to get internal breathing if possible, otherwise get from the surroundings
@@ -284,13 +283,10 @@ namespace HealthV2
 			else if (bloodSaturation <= RelatedPart.HealthMaster.CirculatorySystem.BloodInfo.BLOOD_REAGENT_SATURATION_BAD)
 			{
 				RelatedPart.HealthMaster.HealthStateController.SetSuffocating(true);
-				if (efficiency < 0.5f)
+				if (DMMath.Prob(20))
 				{
-					if (DMMath.Prob(20))
-					{
-						Chat.AddActionMsgToChat(RelatedPart.HealthMaster.gameObject, "You gasp for breath!",
-							$"{RelatedPart.HealthMaster.playerScript.visibleName} gasps!");
-					}
+					Chat.AddActionMsgToChat(RelatedPart.HealthMaster.gameObject, "You gasp for breath!",
+						$"{RelatedPart.HealthMaster.playerScript.visibleName} gasps!");
 				}
 			}
 


### PR DESCRIPTION
<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->

### Purpose
Fixes #7730 

### Notes:
<!-- Please enter any other relevant information here -->
Disabled TryBreathing() by doing a death check, removed efficiency check while attempting to gasp.

### Changelog:
CL: [Fix] Dead Players Gasping
