### PR TITLE
The PR that shows stacks some love

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/StackableItemBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/StackableItemBase.prefab
@@ -1,22 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-6495101291114284292
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1791647728409730387}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e7c30ca55ffa4467a421abf7a832a6a1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  initialAmount: 1
-  maxAmount: 50
-  stacksWith: []
 --- !u!1001 &1792047792650166761
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -77,10 +60,25 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: c3138c3e8a46444199668b85070b1a39
       objectReference: {fileID: 0}
+    - target: {fileID: 114776788309089574, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: customNetTransform
+      value: 
+      objectReference: {fileID: 1821874675337654403}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: initialTraits.Array.size
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: inventoryMoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: inventoryRemoveSound.AssetAddress
+      value: null
       objectReference: {fileID: 0}
     - target: {fileID: 6393191727481188567, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
@@ -95,3 +93,37 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 1792047792650166761}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1821874675337654403 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 114341119007412586, guid: a7abba22164ce49f0bf9b9b219f39298,
+    type: 3}
+  m_PrefabInstance: {fileID: 1792047792650166761}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1791647728409730387}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &-6495101291114284292
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1791647728409730387}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e7c30ca55ffa4467a421abf7a832a6a1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  initialAmount: 1
+  maxAmount: 50
+  stacksWith: []
+  stackNames:
+  - Name: a stack of [item]
+    OverAmount: 1
+  - Name: a ton of [item]
+    OverAmount: 30

--- a/UnityProject/Assets/Scripts/Items/Attributes.cs
+++ b/UnityProject/Assets/Scripts/Items/Attributes.cs
@@ -190,7 +190,7 @@ public class Attributes : NetworkBehaviour, IRightClickable, IExaminable
 	{
 		if (gameObject.TryGetComponent<Stackable>(out var stack))
 		{
-			newName = newName + $" ({stack.Amount})";
+			newName = $"{newName} ({stack.Amount})";
 		}
 		newName = newName.Replace("[item]", $"{initialName}");
 		SyncArticleName(articleName, newName);

--- a/UnityProject/Assets/Scripts/Items/Attributes.cs
+++ b/UnityProject/Assets/Scripts/Items/Attributes.cs
@@ -188,6 +188,11 @@ public class Attributes : NetworkBehaviour, IRightClickable, IExaminable
 
 	public void ServerSetArticleName(string newName)
 	{
+		if (gameObject.TryGetComponent<Stackable>(out var stack))
+		{
+			newName = newName + $" ({stack.Amount})";
+		}
+		newName = newName.Replace("[item]", $"{initialName}");
 		SyncArticleName(articleName, newName);
 	}
 

--- a/UnityProject/Assets/Scripts/Items/Stackable.cs
+++ b/UnityProject/Assets/Scripts/Items/Stackable.cs
@@ -196,7 +196,6 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 		{
 			_ = Despawn.ServerSingle(gameObject);
 		}
-		UpdateStackName(gameObject.Item());
 		return true;
 	}
 

--- a/UnityProject/Assets/Scripts/Items/Stackable.cs
+++ b/UnityProject/Assets/Scripts/Items/Stackable.cs
@@ -10,7 +10,8 @@ using UI;
 /// <summary>
 /// Allows an item to be stacked, occupying a single inventory slot.
 /// </summary>
-public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractable<InventoryApply>, ICheckedInteractable<HandApply>, IExaminable
+public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractable<InventoryApply>,
+	ICheckedInteractable<HandApply>, IExaminable
 {
 	[Tooltip("Amount initially in the stack when this is spawned.")]
 	[SerializeField]
@@ -64,13 +65,6 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 			}
 		});
 	}
-
-	private void Start()
-	{
-		//When the item is enabled, try and stack with anything under it.
-		ServerStackOnGround(gameObject.RegisterTile().LocalPosition);
-	}
-
 	private void EnsureInit()
 	{
 		if (pickupable != null) return;
@@ -122,7 +116,7 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 		InitStacksWith();
 		SyncAmount(amount, initialAmount);
 		amountInit = true;
-		ServerStackOnGround(registerTile.LocalPositionServer);
+		ServerStackOnGround(gameObject.RegisterTile().LocalPosition);
 	}
 
 	public void OnDespawnServer(DespawnInfo info)

--- a/UnityProject/Assets/Scripts/Items/Stackable.cs
+++ b/UnityProject/Assets/Scripts/Items/Stackable.cs
@@ -173,12 +173,9 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 			}
 			attributes.ServerSetArticleName(correctName.Name);
 		}
-		else
+		else if(amount == 1 && stackNames.Any(item => item.Name == gameObject.ExpensiveName()))
 		{
-			if (amount == 1 && stackNames.Any(item => item.Name == gameObject.ExpensiveName()))
-			{
-				attributes.ServerSetArticleName(attributes.InitialName);
-			}
+			attributes.ServerSetArticleName(attributes.InitialName);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Items/Stackable.cs
+++ b/UnityProject/Assets/Scripts/Items/Stackable.cs
@@ -158,7 +158,10 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 		Logger.LogTraceFormat("Amount {0}->{1} for {2}", Category.Objects, amount, newAmount, GetInstanceID());
 		this.amount = newAmount;
 		pickupable.RefreshUISlotImage();
-		UpdateStackName(gameObject.Item());
+		if (CustomNetworkManager.Instance._isServer)
+		{
+			UpdateStackName(gameObject.Item());
+		}
 	}
 
 	public void UpdateStackName(Attributes attributes)

--- a/UnityProject/Assets/Scripts/Items/Stackable.cs
+++ b/UnityProject/Assets/Scripts/Items/Stackable.cs
@@ -50,6 +50,8 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 	private RegisterTile registerTile;
 	private GameObject prefab;
 
+	[SerializeField] private List<StackNames> stackNames = new List<StackNames>();
+
 
 	private void Awake()
 	{
@@ -61,6 +63,12 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 				registerTile.OnLocalPositionChangedServer.AddListener(OnLocalPositionChangedServer);
 			}
 		});
+	}
+
+	private void Start()
+	{
+		//When the item is enabled, try and stack with anything under it.
+		ServerStackOnGround(gameObject.RegisterTile().LocalPosition);
 	}
 
 	private void EnsureInit()
@@ -123,7 +131,7 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 		amountInit = false;
 	}
 
-	private void ServerStackOnGround(Vector3Int localPosition)
+	public void ServerStackOnGround(Vector3Int localPosition)
 	{
 		if (registerTile?.Matrix == null) return;
 		//stacks with things on the same tile
@@ -150,7 +158,28 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 		Logger.LogTraceFormat("Amount {0}->{1} for {2}", Category.Objects, amount, newAmount, GetInstanceID());
 		this.amount = newAmount;
 		pickupable.RefreshUISlotImage();
+		UpdateStackName(gameObject.Item());
+	}
 
+	public void UpdateStackName(Attributes attributes)
+	{
+		if (amount > 1 && stackNames.Count > 0)
+		{
+			var correctName = stackNames[0];
+			foreach (var name in stackNames)
+			{
+				if (amount < name.OverAmount) continue;
+				correctName = name;
+			}
+			attributes.ServerSetArticleName(correctName.Name);
+		}
+		else
+		{
+			if (amount == 1 && stackNames.Any(item => item.Name == gameObject.ExpensiveName()))
+			{
+				attributes.ServerSetArticleName(attributes.InitialName);
+			}
+		}
 	}
 
 	/// <summary>
@@ -162,6 +191,7 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 	[Server]
 	public bool ServerConsume(int consumed)
 	{
+
 		if (consumed > amount)
 		{
 			Logger.LogErrorFormat($"Consumed amount {consumed} is greater than amount in this stack {amount}, will not consume.", Category.Objects);
@@ -172,6 +202,7 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 		{
 			_ = Despawn.ServerSingle(gameObject);
 		}
+		UpdateStackName(gameObject.Item());
 		return true;
 	}
 
@@ -354,5 +385,12 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 	public string Examine(Vector3 worldPos)
 	{
 		return $"This {gameObject.ExpensiveName()} contains {Amount} stacks.";
+	}
+
+	[Serializable]
+	private struct StackNames
+	{
+		[SerializeField] public string Name;
+		[SerializeField] public int OverAmount;
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Stackable.cs
+++ b/UnityProject/Assets/Scripts/Items/Stackable.cs
@@ -116,7 +116,7 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 		InitStacksWith();
 		SyncAmount(amount, initialAmount);
 		amountInit = true;
-		ServerStackOnGround(gameObject.RegisterTile().LocalPosition);
+		ServerStackOnGround(registerTile.LocalPositionServer);
 	}
 
 	public void OnDespawnServer(DespawnInfo info)

--- a/UnityProject/Assets/Scripts/Systems/Inventory/Inventory.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/Inventory.cs
@@ -384,7 +384,6 @@ public static class Inventory
 				//vanish it and set its parent container
 				ServerVanish(fromSlot);
 				objectContainer.StoreObject(pickupable.gameObject);
-
 				return true;
 			}
 
@@ -432,6 +431,12 @@ public static class Inventory
 		foreach (var onMove in pickupable.GetComponents<IServerInventoryMove>())
 		{
 			onMove.OnInventoryMoveServer(toPerform);
+		}
+
+		if (pickupable.gameObject.TryGetComponent<Stackable>(out var stack))
+		{
+			var cnt = pickupable.GetComponent<CustomNetTransform>();
+			stack.ServerStackOnGround(cnt.ServerLocalPosition);
 		}
 
 		return true;


### PR DESCRIPTION
closes #7285
closes #7288

### Note : 
when #7288 is closed we will require someone to go through all stackable items and change their single stack name to something else or they'll just be something like "Plasma ore" instead of "Plasma Ore chunk" like how it's described.
But the tools to do change stack names for all items is here and we can make them unique based on how many items there are and what their name will be and right now all stackable items with more than one item will appear as "A stack of [item name]" until someone goes through all items and customize their names.

Also I added an item indicator to the name because I always found it annoying that I had to examine or pick up the item to see how much is in a stack.

CL: [Improvement] stackable items of the same type merge together when placed on the same tile.