### PR TITLE
Rotatable Mapping Fix and Performance

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawn.cs
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawn.cs
@@ -370,12 +370,15 @@ public static class PlayerSpawn
 			SpawnDestination.At(spawnPosition, parentTransform));
 		Spawn._ServerFireClientServerSpawnHooks(SpawnResult.Single(info, ghost));
 
-		if (PlayerList.Instance.IsAdmin(forMind.ghost.connectedPlayer))
+		var isAdmin = PlayerList.Instance.IsAdmin(forMind.ghost.connectedPlayer);
+		if (isAdmin)
 		{
 			var adminItemStorage = AdminManager.Instance.GetItemSlotStorage(forMind.ghost.connectedPlayer);
 			adminItemStorage.ServerAddObserverPlayer(ghost);
-			ghost.GetComponent<GhostSprites>().SetAdminGhost();
 		}
+
+		//Set ghost sprite
+		ghost.GetComponent<GhostSprites>().SetGhostSprite(isAdmin);
 	}
 
 	/// <summary>
@@ -395,10 +398,8 @@ public static class PlayerSpawn
 		Mind.Create(newPlayer);
 		ServerTransferPlayer(joinedViewer.connectionToClient, newPlayer, null, Event.GhostSpawned, characterSettings);
 
-		if (PlayerList.Instance.IsAdmin(PlayerList.Instance.Get(joinedViewer.connectionToClient)))
-		{
-			newPlayer.GetComponent<GhostSprites>().SetAdminGhost();
-		}
+		var isAdmin = PlayerList.Instance.IsAdmin(PlayerList.Instance.Get(joinedViewer.connectionToClient));
+		newPlayer.GetComponent<GhostSprites>().SetGhostSprite(isAdmin);
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPartSprites.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPartSprites.cs
@@ -101,6 +101,9 @@ public class BodyPartSprites : MonoBehaviour
 			}
 		}
 
+		//Not networked so don't run sprite change on headless
+		if (CustomNetworkManager.IsHeadless) return;
+
 		baseSpriteHandler.ChangeSpriteVariant(referenceOffset, false);
 	}
 

--- a/UnityProject/Assets/Scripts/Objects/Directionals/Rotatable.cs
+++ b/UnityProject/Assets/Scripts/Objects/Directionals/Rotatable.cs
@@ -52,7 +52,7 @@ public class Rotatable : NetworkBehaviour, IMatrixRotation
 	private void SetDirection(OrientationEnum dir)
 	{
 #if UNITY_EDITOR
-		if (Application.isPlaying == false)
+		if (Application.isPlaying)
 		{
 #endif
 			if (isServer == false && isLocalPlayer)

--- a/UnityProject/Assets/Scripts/Objects/Directionals/Rotatable.cs
+++ b/UnityProject/Assets/Scripts/Objects/Directionals/Rotatable.cs
@@ -51,11 +51,17 @@ public class Rotatable : NetworkBehaviour, IMatrixRotation
 
 	private void SetDirection(OrientationEnum dir)
 	{
-		if (isServer == false && isLocalPlayer)
+#if UNITY_EDITOR
+		if (Application.isPlaying == false)
 		{
-			CmdChangeDirection(dir);
+#endif
+			if (isServer == false && isLocalPlayer)
+			{
+				CmdChangeDirection(dir);
+			}
+#if UNITY_EDITOR
 		}
-
+#endif
 		if (SynchroniseCurrentLockAndDirection.Locked)
 		{
 			SyncServerDirection(SynchroniseCurrentDirection, SynchroniseCurrentLockAndDirection.LockedTo);

--- a/UnityProject/Assets/Scripts/Objects/Directionals/Rotatable.cs
+++ b/UnityProject/Assets/Scripts/Objects/Directionals/Rotatable.cs
@@ -96,6 +96,8 @@ public class Rotatable : NetworkBehaviour, IMatrixRotation
 
 	private void SyncServerDirection(OrientationEnum oldDir, OrientationEnum dir)
 	{
+		//Seems like headless is running the hook when it shouldn't be
+		//(Mirror bug or our custom code broke something?)
 		if(CustomNetworkManager.IsHeadless) return;
 
 		SetDirectionInternal(oldDir, dir);

--- a/UnityProject/Assets/Scripts/Objects/Directionals/Rotatable.cs
+++ b/UnityProject/Assets/Scripts/Objects/Directionals/Rotatable.cs
@@ -51,24 +51,13 @@ public class Rotatable : NetworkBehaviour, IMatrixRotation
 
 	private void SetDirection(OrientationEnum dir)
 	{
-#if UNITY_EDITOR
-		if (Application.isPlaying)
-		{
-#endif
-			if (isServer == false && isLocalPlayer)
-			{
-				CmdChangeDirection(dir);
-			}
-#if UNITY_EDITOR
-		}
-#endif
 		if (SynchroniseCurrentLockAndDirection.Locked)
 		{
-			SyncServerDirection(SynchroniseCurrentDirection, SynchroniseCurrentLockAndDirection.LockedTo);
+			SetDirectionInternal(SynchroniseCurrentDirection, SynchroniseCurrentLockAndDirection.LockedTo);
 		}
 		else
 		{
-			SyncServerDirection(SynchroniseCurrentDirection, dir);
+			SetDirectionInternal(SynchroniseCurrentDirection, dir);
 		}
 	}
 
@@ -84,15 +73,32 @@ public class Rotatable : NetworkBehaviour, IMatrixRotation
 		SetDirection(SynchroniseCurrentLockAndDirection.LockedTo);
 	}
 
-	private void SyncServerDirection(OrientationEnum oldDir, OrientationEnum dir)
+	private void SetDirectionInternal(OrientationEnum oldDir, OrientationEnum dir)
 	{
 		CurrentDirection = dir;
 		SynchroniseCurrentDirection = dir;
 		RotateObject(dir);
+
 		if (oldDir != dir)
 		{
+			if (
+				#if UNITY_EDITOR
+				Application.isPlaying &&
+				#endif
+				isServer == false && isLocalPlayer)
+			{
+				CmdChangeDirection(dir);
+			}
+
 			OnRotationChange.Invoke(dir);
 		}
+	}
+
+	private void SyncServerDirection(OrientationEnum oldDir, OrientationEnum dir)
+	{
+		if(CustomNetworkManager.IsHeadless) return;
+
+		SetDirectionInternal(oldDir, dir);
 	}
 
 	public void SetFaceDirectionRotationZ(float direction)

--- a/UnityProject/Assets/Scripts/Objects/Disposals/DisposalIntake.cs
+++ b/UnityProject/Assets/Scripts/Objects/Disposals/DisposalIntake.cs
@@ -30,13 +30,16 @@ namespace Objects.Disposals
 		protected override void Awake()
 		{
 			base.Awake();
-
-			if (TryGetComponent<Rotatable>(out var directional))
-			{
-				directional.OnRotationChange.AddListener(OnDirectionChanged);
-			}
 			directionalPassable = GetComponent<DirectionalPassable>();
 			DenyEntry();
+		}
+
+		private void OnEnable()
+		{
+			if (TryGetComponent<Rotatable>(out var rotatable))
+			{
+				rotatable.OnRotationChange.AddListener(OnDirectionChanged);
+			}
 		}
 
 		private void Start()
@@ -162,6 +165,11 @@ namespace Objects.Disposals
 		private void OnDisable()
 		{
 			UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);
+
+			if (TryGetComponent<Rotatable>(out var rotatable))
+			{
+				rotatable.OnRotationChange.AddListener(OnDirectionChanged);
+			}
 		}
 
 		protected override void SetMachineUninstalled()

--- a/UnityProject/Assets/Scripts/Objects/Disposals/DisposalIntake.cs
+++ b/UnityProject/Assets/Scripts/Objects/Disposals/DisposalIntake.cs
@@ -168,7 +168,7 @@ namespace Objects.Disposals
 
 			if (TryGetComponent<Rotatable>(out var rotatable))
 			{
-				rotatable.OnRotationChange.AddListener(OnDirectionChanged);
+				rotatable.OnRotationChange.RemoveListener(OnDirectionChanged);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/Disposals/DisposalOutlet.cs
+++ b/UnityProject/Assets/Scripts/Objects/Disposals/DisposalOutlet.cs
@@ -35,9 +35,18 @@ namespace Objects.Disposals
 			rotatable = GetComponent<Rotatable>();
 		}
 
-		private void Start()
+		private void OnEnable()
 		{
 			rotatable.OnRotationChange.AddListener(OnDirectionChanged);
+		}
+
+		private void OnDisable()
+		{
+			rotatable.OnRotationChange.RemoveListener(OnDirectionChanged);
+		}
+
+		private void Start()
+		{
 			UpdateSpriteState();
 			UpdateSpriteOrientation();
 		}

--- a/UnityProject/Assets/Scripts/Objects/Drawers/Drawer.cs
+++ b/UnityProject/Assets/Scripts/Objects/Drawers/Drawer.cs
@@ -81,6 +81,11 @@ namespace Objects.Drawers
 			rotatable.OnRotationChange.AddListener(OnDirectionChanged);
 		}
 
+		private void OnDisable()
+		{
+			rotatable.OnRotationChange.RemoveListener(OnDirectionChanged);
+		}
+
 		private void ServerInit()
 		{
 			SpawnResult traySpawn = Spawn.ServerPrefab(trayPrefab, DrawerWorldPosition);

--- a/UnityProject/Assets/Scripts/Objects/Furniture/OccupiableDirectionalSprite.cs
+++ b/UnityProject/Assets/Scripts/Objects/Furniture/OccupiableDirectionalSprite.cs
@@ -87,6 +87,11 @@ namespace Objects
 			GetComponent<Integrity>().OnWillDestroyServer.AddListener(OnWillDestroyServer);
 		}
 
+		private void OnDisable()
+		{
+			rotatable.OnRotationChange.RemoveListener(OnDirectionChanged);
+		}
+
 		private void OnWillDestroyServer(DestructionInfo info)
 		{
 			//release the player

--- a/UnityProject/Assets/Scripts/Objects/Machines/MassDriver.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/MassDriver.cs
@@ -35,6 +35,11 @@ namespace Objects
 			registerTile = GetComponent<RegisterTile>();
 			spriteHandler = GetComponentInChildren<SpriteHandler>();
 			switchController = GetComponent<GeneralSwitchController>();
+		}
+
+		private void OnEnable()
+		{
+			switchController.SwitchPressedDoAction.AddListener(DoAction);
 
 			if (directional != null)
 			{
@@ -42,14 +47,14 @@ namespace Objects
 			}
 		}
 
-		private void OnEnable()
-		{
-			switchController.SwitchPressedDoAction.AddListener(DoAction);
-		}
-
 		private void OnDisable()
 		{
 			switchController.SwitchPressedDoAction.RemoveListener(DoAction);
+
+			if (directional != null)
+			{
+				directional.OnRotationChange.RemoveListener(OnDirectionChanged);
+			}
 		}
 
 		#region Sync

--- a/UnityProject/Assets/Scripts/Player/GhostSprites.cs
+++ b/UnityProject/Assets/Scripts/Player/GhostSprites.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using Mirror;
@@ -7,7 +8,7 @@ using Mirror;
 /// Handles displaying the ghost sprites.
 /// </summary>
 [RequireComponent(typeof(Rotatable))]
-public class GhostSprites : MonoBehaviour, IServerSpawn
+public class GhostSprites : MonoBehaviour
 {
 	//sprite renderer showing the ghost
 	private SpriteHandler SpriteHandler;
@@ -18,18 +19,25 @@ public class GhostSprites : MonoBehaviour, IServerSpawn
 
 	private Rotatable rotatable;
 
-	private bool AdminGhost;
-
 	protected void Awake()
 	{
 		rotatable = GetComponent<Rotatable>();
-		rotatable.OnRotationChange.AddListener(OnDirectionChange);
 		SpriteHandler = GetComponentInChildren<SpriteHandler>();
 	}
 
-	public void OnSpawnServer(SpawnInfo info)
+	private void OnEnable()
 	{
-		if (AdminGhost)
+		rotatable.OnRotationChange.AddListener(OnDirectionChange);
+	}
+
+	private void OnDisable()
+	{
+		rotatable.OnRotationChange.RemoveListener(OnDirectionChange);
+	}
+
+	public void SetGhostSprite(bool isAdmin)
+	{
+		if (isAdmin)
 		{
 			SpriteHandler.SetSpriteSO(AdminGhostSpriteSOs.PickRandom());
 		}
@@ -37,11 +45,6 @@ public class GhostSprites : MonoBehaviour, IServerSpawn
 		{
 			SpriteHandler.SetSpriteSO(GhostSpritesSOs.PickRandom());
 		}
-	}
-
-	public void SetAdminGhost()
-	{
-		AdminGhost = true;
 	}
 
 	private void OnDirectionChange(OrientationEnum direction)

--- a/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
@@ -112,6 +112,7 @@ namespace Player
 		private void OnDestroy()
 		{
 			playerHealth.OnClientFireStacksChange.RemoveListener(OnClientFireStacksChange);
+			directional.OnRotationChange.RemoveListener(OnDirectionChange);
 		}
 
 		/// <summary>
@@ -362,7 +363,6 @@ namespace Player
 			{
 				bodypart.OnDirectionChange(direction);
 			}
-
 
 			//TODO: Reimplement player fire sprites.
 			UpdateBurningOverlays(playerHealth.FireStacks, direction);

--- a/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
@@ -102,14 +102,20 @@ namespace Player
 
 			AddOverlayGameObjects();
 
+
+		}
+
+		private void OnEnable()
+		{
 			directional.OnRotationChange.AddListener(OnDirectionChange);
+
 			//TODO: Need to reimplement fire stacks on players.
 			playerHealth.OnClientFireStacksChange.AddListener(OnClientFireStacksChange);
 			var healthStateController = GetComponent<HealthStateController>();
 			OnClientFireStacksChange(healthStateController.FireStacks);
 		}
 
-		private void OnDestroy()
+		private void OnDisable()
 		{
 			playerHealth.OnClientFireStacksChange.RemoveListener(OnClientFireStacksChange);
 			directional.OnRotationChange.RemoveListener(OnDirectionChange);

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/SubCustomisation/SpriteHandlerNorder.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/SubCustomisation/SpriteHandlerNorder.cs
@@ -73,6 +73,9 @@ public class SpriteHandlerNorder : MonoBehaviour
 			}
 		}
 
+		//Not networked so don't run sprite change on headless
+		if (CustomNetworkManager.IsHeadless) return;
+
 		SpriteHandler.ChangeSpriteVariant(referenceOffset, false);
 	}
 


### PR DESCRIPTION
-Was calling stuff which was null outside play mode for the mapping issue.

-I think we have a bug in mirror where the SyncHooks are being called on Headless, so it was invoking the event twice

-Stopped headless changing sprites for players as they are not networked.

-Cleaned up the listeners to the rotation event

![image](https://user-images.githubusercontent.com/56727168/151704046-0cc2f8b0-9238-4aa5-96f9-cbdb9b06fec9.png)

