### PR TITLE
Rearrange NetworkServer Broadcast

### DIFF
--- a/UnityProject/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/UnityProject/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1529,10 +1529,7 @@ namespace Mirror
             foreach (var identityPair in NetworkIdentity.spawned)
             {
 	            var identity = identityPair.Value;
-	            if (identity.isDirty == false)
-	            {
-		            continue;
-	            }
+	            if (identity.isDirty == false || identity.observers == null) continue;
 
 	            for (int j = 0; j < connectionsCount; j++)
 	            {
@@ -1540,6 +1537,8 @@ namespace Mirror
 
 		            //Connection disconnected
 		            if (connection.isReady == false) continue;
+
+		            if (identity.observers.ContainsKey(connection.connectionId) == false) continue;
 
 		            ////////////////////////////
 		            // get serialization for this entity viewed by this connection

--- a/UnityProject/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/UnityProject/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1523,7 +1523,7 @@ namespace Mirror
         static void BroadcastToConnections()
         {
 	        //CUSTOM UNITYSTATION CODE//
-	        //Currently all player observe EVERYTHING so we can just loop through all identities and then all connections
+	        //Currently all players observe EVERYTHING so we can just loop through all identities and then all connections
 	        //Old mirror code was loop through all connections and then identities which was very bad for performance
             var connectionsCount = connectionsCopy.Count;
             foreach (var identityPair in NetworkIdentity.spawned)
@@ -1595,7 +1595,7 @@ namespace Mirror
             connections.Values.CopyTo(connectionsCopy);
 
             //CUSTOM UNITYSTATION CODE//
-            //Currently all player observe EVERYTHING so we can just loop through all identities and then all connections
+            //Currently all players observe EVERYTHING so we can just loop through all identities and then all connections
             //Old mirror code was loop through all connections and then identities which was very bad for performance
 
             var connectionsCount = connectionsCopy.Count;

--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/NetworkSide.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/NetworkSide.cs
@@ -1,7 +1,7 @@
 /// <summary>
 /// Refers to a "side" of the network - client or server.
 /// </summary>
-public enum NetworkSide
+public enum NetworkSide : byte
 {
 	Client,
 	Server

--- a/UnityProject/Assets/Scripts/Core/Input System/KeybindManager.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/KeybindManager.cs
@@ -8,7 +8,7 @@ using System.Linq;
 /// <summary>
 /// Describes all possible actions which can be mapped to a key
 /// </summary>
-public enum KeyAction
+public enum KeyAction : byte
 {
 	// No action
 	None = 0,
@@ -75,7 +75,7 @@ public enum KeyAction
 	PocketOne,
 	PocketTwo,
 	PocketThree,
-	
+
 	//Interactions that only happen when this key is pressed
 	RadialScrollBackward,
 	RadialScrollForward,
@@ -84,7 +84,7 @@ public enum KeyAction
 /// <summary>
 /// A subset of KeyAction which only describes move actions
 /// </summary>
-public enum MoveAction
+public enum MoveAction : byte
 {
 	MoveUp = KeyAction.MoveUp,
 	MoveLeft = KeyAction.MoveLeft,

--- a/UnityProject/Assets/Scripts/Core/Transform/Orientation.cs
+++ b/UnityProject/Assets/Scripts/Core/Transform/Orientation.cs
@@ -264,9 +264,8 @@ public struct Orientation : IEquatable<Orientation>
 /// <summary>
 /// Only for allowing setting an orientation in editor
 /// </summary>
-public enum OrientationEnum
+public enum OrientationEnum : byte
 {
-	Default = -1,
 	Right_By270 = 0,
 	Up_By0 = 1,
 	Left_By90 = 2,

--- a/UnityProject/Assets/Scripts/Messages/Server/GhostRoles/GhostRoleResponseMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/GhostRoles/GhostRoleResponseMessage.cs
@@ -59,7 +59,7 @@ namespace Messages.Server.GhostRoles
 		}
 	}
 
-	public enum GhostRoleResponseCode
+	public enum GhostRoleResponseCode : byte
 	{
 		Success,
 		RoleNotFound,

--- a/UnityProject/Assets/Scripts/Messages/Server/SpritesMessages/SpriteUpdateMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/SpritesMessages/SpriteUpdateMessage.cs
@@ -166,7 +166,7 @@ namespace Messages.Server.SpritesMessages
 			public List<int> arg = new List<int>();
 		}
 
-		public enum SpriteOperation
+		public enum SpriteOperation : byte
 		{
 			PresentSpriteSet,
 			VariantIndex,


### PR DESCRIPTION
-Old mirror code was loop through all connections and then identities which is expensive

-Because all players currently observe everything we can just loop through all identities and then all connections

-Made some enums bytes
	        
Needs testing