### PR TITLE
IDCard Fix

### DIFF
--- a/UnityProject/Assets/Scripts/Items/IDCard.cs
+++ b/UnityProject/Assets/Scripts/Items/IDCard.cs
@@ -218,7 +218,13 @@ public class IDCard : NetworkBehaviour, IServerInventoryMove, IServerSpawn, IInt
 
 	public string GetJobTitle()
 	{
-		return jobTitle.IsNullOrEmpty() ? Occupation.DisplayName : jobTitle;
+		if (jobTitle.IsNullOrEmpty())
+		{
+			var occupation = Occupation;
+			return occupation != null ? occupation.DisplayName : "";
+		}
+
+		return jobTitle;
 	}
 
 	/// <summary>


### PR DESCRIPTION
-Turns out occupation was null

CL: [Fix] fixed captain's spare ID reading as NULL