### PR TITLE
Fixed Volume Slider

### DIFF
--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/SongTracker.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/SongTracker.cs
@@ -163,7 +163,18 @@ namespace Audio.Containers
 
 		public void OnVolumeSliderChange()
 		{
-			MusicManager.Instance.ChangeVolume(volumeSlider.value);
+			if (volumeSlider.value == 0)
+            {
+				ToggleMusicMute();
+			}
+			else
+			{
+				if (PlayerPrefs.GetInt(PlayerPrefKeys.MuteMusic) == 0)
+                {
+					ToggleMusicMute();
+				}
+				MusicManager.Instance.ChangeVolume(volumeSlider.value);
+			}
 		}
 
 		public void OnTrackButtonClick()


### PR DESCRIPTION
Mutes Music in the Main Menu when volume slider is 0


### Purpose

Fixes Bug where volume goes to 100% when the slider is a 0. Fixes it by muting the music. Mute Toggle button also reacts to change.
resolves #8302 

CL: [Fix] Fixed a bug where setting in game volume to 0 would cause it to jump to 100%
