### PR TITLE
Reverts changes to world to and to local and make shuttle collisions more airtight

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Editor/Matrix/Views/MetaDataView.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/Matrix/Views/MetaDataView.cs
@@ -72,10 +72,26 @@ public class MetaDataView : BasicView
 
 		public override void DrawGizmo(MetaDataLayer source, Vector3Int position)
 		{
-			if (source.ExistsAt(position) && source.IsSpaceAt(position))
+
+			if (Application.isPlaying == false)
 			{
-				GizmoUtils.DrawCube(position, Color.red);
+				if (source.ExistsAt(position) && source.IsSpaceAt(position))
+				{
+					GizmoUtils.DrawCube(position, Color.red);
+				}
+				return;
 			}
+
+			var INWorld = MatrixManager.LocalToWorld(position, source.Matrix.MatrixInfo);
+			if (MatrixManager.AtPoint(INWorld.RoundToInt(), true).Matrix == source.Matrix)
+			{
+				if (source.ExistsAt(position) && source.IsSpaceAt(position))
+				{
+					GizmoUtils.DrawCube(position, Color.red);
+				}
+			}
+
+
 		}
 	}
 
@@ -111,13 +127,32 @@ public class MetaDataView : BasicView
 
 		public override void DrawGizmo(MetaDataLayer source, Vector3Int position)
 		{
-			MetaDataNode node = source.Get(position, false);
 
-			if (node.Exists)
+			if (Application.isPlaying == false)
 			{
-				if (node.IsSpace || node.Neighbors.Any(n => n != null && n.IsSpace))
+				MetaDataNode node = source.Get(position, false);
+
+				if (node.Exists)
 				{
-					GizmoUtils.DrawCube(position,  Color.red);
+					if (node.IsSpace || node.Neighbors.Any(n => n != null && n.IsSpace))
+					{
+						GizmoUtils.DrawCube(position, Color.red);
+					}
+				}
+			}
+			else
+			{
+				var INWorld = MatrixManager.LocalToWorld(position, source.Matrix.MatrixInfo);
+				if (MatrixManager.AtPoint(INWorld.RoundToInt(), true).Matrix == source.Matrix)
+				{
+					MetaDataNode node = source.Get(position, false);
+					if (node.Exists)
+					{
+						if (node.IsSpace || node.Neighbors.Any(n => n != null && n.IsSpace))
+						{
+							GizmoUtils.DrawCube(position, Color.red);
+						}
+					}
 				}
 			}
 		}

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
@@ -1278,10 +1278,10 @@ public partial class MatrixManager : SingletonManager<MatrixManager>
 			return localPos + matrix.Offset;
 		}
 
-		if (matrix.MetaTileMap.localToWorldMatrix != null)
-		{
-			return matrix.MetaTileMap.localToWorldMatrix.Value.MultiplyPoint(localPos);
-		}
+		// if (matrix.MetaTileMap.localToWorldMatrix != null) //TODO After fixing Shuttle offset and Change movement to local
+		// {
+		// 	return matrix.MetaTileMap.localToWorldMatrix.Value.MultiplyPoint(localPos);
+		// }
 
 		if (state.Equals(default(MatrixState)))
 		{
@@ -1312,10 +1312,10 @@ public partial class MatrixManager : SingletonManager<MatrixManager>
 			return worldPos - matrix.Offset;
 		}
 
-		if (matrix.MetaTileMap.worldToLocalMatrix != null)
-		{
-			return matrix.MetaTileMap.worldToLocalMatrix.Value.MultiplyPoint(worldPos);
-		}
+		// if (matrix.MetaTileMap.worldToLocalMatrix != null) //TODO After fixing Shuttle offset and Change movement to local
+		// {
+		// 	return matrix.MetaTileMap.worldToLocalMatrix.Value.MultiplyPoint(worldPos);
+		// }
 
 
 		var state = matrix.MatrixMove.ClientState;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -17,9 +17,13 @@ public class MetaDataLayer : MonoBehaviour
 {
 	private SerializableDictionary<Vector3Int, MetaDataNode> nodes = new SerializableDictionary<Vector3Int, MetaDataNode>();
 
+
+	private MetaDataSystem MetaDataSystem;
+
 	private SubsystemManager subsystemManager;
 	private ReactionManager reactionManager;
 	private Matrix matrix;
+	public Matrix Matrix => matrix;
 	private FloorDecal existingSplat;
 
 	public Dictionary<GameObject, Vector3> InitialObjects = new Dictionary<GameObject, Vector3>();
@@ -29,6 +33,7 @@ public class MetaDataLayer : MonoBehaviour
 		subsystemManager = GetComponentInParent<SubsystemManager>();
 		reactionManager = GetComponentInParent<ReactionManager>();
 		matrix = GetComponent<Matrix>();
+		MetaDataSystem = subsystemManager.GetComponent<MetaDataSystem>();
 	}
 
 	private void OnDestroy()
@@ -45,7 +50,7 @@ public class MetaDataLayer : MonoBehaviour
 		{
 			if (createIfNotExists)
 			{
-				nodes[localPosition] = new MetaDataNode(localPosition, reactionManager, matrix);
+				nodes[localPosition] = new MetaDataNode(localPosition, reactionManager, matrix, MetaDataSystem);
 			}
 			else
 			{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataNode.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataNode.cs
@@ -20,6 +20,11 @@ public class MetaDataNode : IGasMixContainer
 	public static readonly MetaDataNode None;
 
 	/// <summary>
+	/// MetaDataSystem That is part of
+	/// </summary>
+	public MetaDataSystem MetaDataSystem;
+
+	/// <summary>
 	/// Contains the matrix of the current node
 	/// </summary>
 	public Matrix PositionMatrix = null;
@@ -164,8 +169,9 @@ public class MetaDataNode : IGasMixContainer
 	/// Create a new MetaDataNode on the specified local position (within the parent matrix)
 	/// </summary>
 	/// <param name="position">local position (within the matrix) the node exists on</param>
-	public MetaDataNode(Vector3Int position, ReactionManager reactionManager, Matrix matrix)
+	public MetaDataNode(Vector3Int position, ReactionManager reactionManager, Matrix matrix, MetaDataSystem InMetaDataSystem )
 	{
+		MetaDataSystem = InMetaDataSystem;
 		PositionMatrix = matrix;
 		Position = position;
 		neighborList = new List<MetaDataNode>(4);
@@ -179,7 +185,7 @@ public class MetaDataNode : IGasMixContainer
 
 	static MetaDataNode()
 	{
-		None = new MetaDataNode(Vector3Int.one * -1000000, null, null);
+		None = new MetaDataNode(Vector3Int.one * -1000000, null, null, null);
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
@@ -117,7 +117,14 @@ public class MetaDataSystem : SubsystemBehaviour
 		}
 
 		SetupNeighbors(node);
-		MetaUtils.AddToNeighbors(node);
+
+
+
+		if (MatrixManager.AtPoint(node.Position.ToWorld(node.PositionMatrix).RoundToInt(),
+			    CustomNetworkManager.IsServer) == node.PositionMatrix.MatrixInfo)
+		{
+			MetaUtils.AddToNeighbors(node);
+		}
 	}
 
 	private void LocateRooms()
@@ -250,11 +257,11 @@ public class MetaDataSystem : SubsystemBehaviour
 
 			if (metaTileMap.IsSpaceAt(neighbor, true))
 			{
-				// // if current node is a room, but the neighboring is a space tile, this node needs to be checked regularly for changes by other matrices
-				// if (node.IsRoom && !externalNodes.ContainsKey(node) && metaTileMap.IsSpaceAt(node.Position, true) == false)
-				// {
-				// 	externalNodes[node] = node;
-				// }
+				// if current node is a room, but the neighboring is a space tile, this node needs to be checked regularly for changes by other matrices
+				if (node.IsRoom && !externalNodes.ContainsKey(node) && metaTileMap.IsSpaceAt(node.Position, true) == false)
+				{
+					externalNodes[node] = node;
+				}
 
 				// If the node is not space, check other matrices if it has a tile next to this node.
 				if (!node.IsSpace)
@@ -272,8 +279,33 @@ public class MetaDataSystem : SubsystemBehaviour
 							// Check if atmos can pass to the neighboring position
 							Vector3Int neighborlocalPosition = MatrixManager.WorldToLocalInt(neighborWorldPosition, matrixInfo);
 
+							var OppositeNode = matrixInfo.MetaDataLayer.Get(neighborlocalPosition);
+
 							// add node of other matrix to the neighbors of the current node
-							node.AddNeighbor(matrixInfo.MetaDataLayer.Get(neighborlocalPosition), dir);
+							node.AddNeighbor(OppositeNode, dir);
+
+							if (dir == Vector3Int.up)
+							{
+								OppositeNode.AddNeighbor(node, Vector3Int.down);
+							}
+							else if (dir == Vector3Int.down)
+							{
+								OppositeNode.AddNeighbor(node, Vector3Int.up);
+							}
+							else if (dir == Vector3Int.right)
+							{
+								OppositeNode.AddNeighbor(node, Vector3Int.left);
+							}
+							else if (dir == Vector3Int.left)
+							{
+								OppositeNode.AddNeighbor(node, Vector3Int.right);
+							}
+
+							// if current node is a room, but the neighboring is a space tile, this node needs to be checked regularly for changes by other matrices
+							if (OppositeNode.IsRoom && !OppositeNode.MetaDataSystem.externalNodes.ContainsKey(node) && OppositeNode.MetaDataSystem.metaTileMap.IsSpaceAt(OppositeNode.Position, true) == false)
+							{
+								OppositeNode.MetaDataSystem.externalNodes[OppositeNode] = OppositeNode;
+							}
 
 							// skip other checks for neighboring tile on local tilemap, to prevent the space tile to be added as a neighbor
 							continue;


### PR DESCRIPTION
there's a lot of stupid stuff going on such as movement using World position, 
and as you can probably guess it it's absolute hell on shuttles idk how it was working before, but the changes in World to local have really highlighted how there's a lot of stuff that does funny things,  such as the shuttle's tile mass being offset to get the pivot right, 

action plan so, I'm going to work on redoing movement because, it's laggy spaghetti and for some reason Uses world pos, 
then going to code in a custom pivot point for shuttles then bring back the world to and to local  changes