### PR TITLE
Fix eating/drinking through helmets or masks + Limit to length of name and title on ID

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/AncientHelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/AncientHelmet.prefab
@@ -19,6 +19,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3568482238077595727, guid: d3d950d792abb79fba51d3166022f581,
         type: 3}
+      propertyPath: disallowConsume
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3568482238077595727, guid: d3d950d792abb79fba51d3166022f581,
+        type: 3}
       propertyPath: currentClothData
       value: 
       objectReference: {fileID: 0}
@@ -119,6 +124,16 @@ PrefabInstance:
         type: 3}
       propertyPath: initialDescription
       value: None may pass!
+      objectReference: {fileID: 0}
+    - target: {fileID: 8004422176852823208, guid: d3d950d792abb79fba51d3166022f581,
+        type: 3}
+      propertyPath: inventoryMoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
+    - target: {fileID: 8004422176852823208, guid: d3d950d792abb79fba51d3166022f581,
+        type: 3}
+      propertyPath: inventoryRemoveSound.AssetAddress
+      value: null
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d3d950d792abb79fba51d3166022f581, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/Beanies/ChristmasBeanie.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/Beanies/ChristmasBeanie.prefab
@@ -115,5 +115,15 @@ PrefabInstance:
       propertyPath: initialName
       value: christmas beanie
       objectReference: {fileID: 0}
+    - target: {fileID: 8004422176852823208, guid: 9542c9504316c3845bbb5f541ec22cfb,
+        type: 3}
+      propertyPath: inventoryMoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
+    - target: {fileID: 8004422176852823208, guid: 9542c9504316c3845bbb5f541ec22cfb,
+        type: 3}
+      propertyPath: inventoryRemoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9542c9504316c3845bbb5f541ec22cfb, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/BioHoods/BioHood.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/BioHoods/BioHood.prefab
@@ -28,6 +28,16 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: ba923436cf6803a4f99a5ed73f885d61,
         type: 2}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: inventoryMoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: inventoryRemoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite
@@ -237,6 +247,11 @@ PrefabInstance:
     - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: hidesIdentity
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: disallowConsume
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/BlackRedSpaceHelmetReplica.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/BlackRedSpaceHelmetReplica.prefab
@@ -19,6 +19,16 @@ PrefabInstance:
         like a real murderous Syndicate agent in this! This is a toy, it is not made
         for use in space!
       objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: inventoryMoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: inventoryRemoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite
@@ -118,6 +128,11 @@ PrefabInstance:
     - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: hidesIdentity
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: disallowConsume
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/BombHoods/BombHood.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/BombHoods/BombHood.prefab
@@ -17,6 +17,16 @@ PrefabInstance:
       propertyPath: initialDescription
       value: Use in case of bomb.
       objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: inventoryMoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: inventoryRemoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite
@@ -276,6 +286,11 @@ PrefabInstance:
     - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: hidesIdentity
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: disallowConsume
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/Cardborg Helmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/Cardborg Helmet.prefab
@@ -17,6 +17,16 @@ PrefabInstance:
       propertyPath: initialDescription
       value: A piece of headwear made in his holy corrugated image.
       objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: inventoryMoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: inventoryRemoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite
@@ -152,6 +162,11 @@ PrefabInstance:
         type: 3}
       propertyPath: armoredBodyParts.Array.data[2].armoringBodyPartType
       value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: disallowConsume
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/CorgiHood.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/CorgiHood.prefab
@@ -17,6 +17,16 @@ PrefabInstance:
       propertyPath: initialDescription
       value: A hood that looks just like a corgi's head, it won't guarantee dog biscuits.
       objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: inventoryMoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: inventoryRemoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite
@@ -102,6 +112,11 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: disallowConsume
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/CrusaderHelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/CrusaderHelmet.prefab
@@ -28,6 +28,16 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: ba923436cf6803a4f99a5ed73f885d61,
         type: 2}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: inventoryMoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: inventoryRemoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/GriffonHead.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/GriffonHead.prefab
@@ -17,6 +17,16 @@ PrefabInstance:
       propertyPath: initialDescription
       value: Why not 'eagle head'? Who knows.
       objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: inventoryMoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: inventoryRemoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite
@@ -122,6 +132,11 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: disallowConsume
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/MagusHelmBloodCult.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/MagusHelmBloodCult.prefab
@@ -17,6 +17,16 @@ PrefabInstance:
       propertyPath: initialDescription
       value: A helm worn by the followers of Nar'Sie.
       objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: inventoryMoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: inventoryRemoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite
@@ -272,6 +282,11 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: disallowConsume
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/RadiationHood.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/RadiationHood.prefab
@@ -29,6 +29,16 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 8d9bddcf38348465eb528212d15282b5,
         type: 2}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: inventoryMoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: inventoryRemoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite
@@ -218,6 +228,11 @@ PrefabInstance:
     - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: hidesIdentity
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: disallowConsume
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/EVAHelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/EVAHelmet.prefab
@@ -20,6 +20,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4548501816867735510, guid: 5269bbb43ef5a0b40a2676310664d6c6,
         type: 3}
+      propertyPath: disallowConsume
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4548501816867735510, guid: 5269bbb43ef5a0b40a2676310664d6c6,
+        type: 3}
       propertyPath: currentClothData
       value: 
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/HardsuitHelmets/EngineeringHardsuitHelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/HardsuitHelmets/EngineeringHardsuitHelmet.prefab
@@ -195,6 +195,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8704044746233661378, guid: c60440956ff96af4b84ba3e95e41c3e0,
         type: 3}
+      propertyPath: disallowConsume
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8704044746233661378, guid: c60440956ff96af4b84ba3e95e41c3e0,
+        type: 3}
       propertyPath: currentClothData
       value: 
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/SpaceHelmetBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/SpaceHelmetBase.prefab
@@ -29,6 +29,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3568482238077595727, guid: fceccba0296eb5b4983bdfe2fc9ccdd0,
         type: 3}
+      propertyPath: disallowConsume
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3568482238077595727, guid: fceccba0296eb5b4983bdfe2fc9ccdd0,
+        type: 3}
       propertyPath: currentClothData
       value: 
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/WeldingHelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/WeldingHelmet.prefab
@@ -29,6 +29,16 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: ba923436cf6803a4f99a5ed73f885d61,
         type: 2}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: inventoryMoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: inventoryRemoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite
@@ -278,6 +288,11 @@ PrefabInstance:
     - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: hidesIdentity
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: disallowConsume
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/WerewolfMask.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/WerewolfMask.prefab
@@ -17,6 +17,16 @@ PrefabInstance:
       propertyPath: initialDescription
       value: The mask of a wolfman getup.
       objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: inventoryMoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: inventoryRemoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite
@@ -122,6 +132,11 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: disallowConsume
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/XenosHelmet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/XenosHelmet.prefab
@@ -17,6 +17,16 @@ PrefabInstance:
       propertyPath: initialDescription
       value: A helmet made out of chitinous alien hide.
       objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: inventoryMoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: inventoryRemoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite
@@ -102,6 +112,11 @@ PrefabInstance:
         type: 3}
       propertyPath: armoredBodyParts.Array.data[2].armoringBodyPartType
       value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: disallowConsume
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Maskwear.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Maskwear.prefab
@@ -172,6 +172,16 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 3858899698cc1425f86b8b93032ca57d,
         type: 2}
+    - target: {fileID: 3387296074795883840, guid: 6b5f74a79e023479cb5b30a2879621da,
+        type: 3}
+      propertyPath: inventoryMoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
+    - target: {fileID: 3387296074795883840, guid: 6b5f74a79e023479cb5b30a2879621da,
+        type: 3}
+      propertyPath: inventoryRemoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     - target: {fileID: 8166491247120154191, guid: 6b5f74a79e023479cb5b30a2879621da,
         type: 3}
       propertyPath: foreverID
@@ -180,6 +190,11 @@ PrefabInstance:
     - target: {fileID: 8183805690938991015, guid: 6b5f74a79e023479cb5b30a2879621da,
         type: 3}
       propertyPath: hidesIdentity
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8183805690938991015, guid: 6b5f74a79e023479cb5b30a2879621da,
+        type: 3}
+      propertyPath: disallowConsume
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8982871833932450213, guid: 6b5f74a79e023479cb5b30a2879621da,

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Maskwear/BreathMask.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Maskwear/BreathMask.prefab
@@ -39,6 +39,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3532393564309681412, guid: 05a135eab68164d34bb02b82fff3cde0,
         type: 3}
+      propertyPath: disallowConsume
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3532393564309681412, guid: 05a135eab68164d34bb02b82fff3cde0,
+        type: 3}
       propertyPath: currentClothData
       value: 
       objectReference: {fileID: 0}
@@ -165,6 +170,16 @@ PrefabInstance:
         type: 3}
       propertyPath: initialDescription
       value: A close-fitting mask that can be connected to an air supply.
+      objectReference: {fileID: 0}
+    - target: {fileID: 8040391005062056419, guid: 05a135eab68164d34bb02b82fff3cde0,
+        type: 3}
+      propertyPath: inventoryMoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
+    - target: {fileID: 8040391005062056419, guid: 05a135eab68164d34bb02b82fff3cde0,
+        type: 3}
+      propertyPath: inventoryRemoveSound.AssetAddress
+      value: null
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 05a135eab68164d34bb02b82fff3cde0, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Maskwear/CarpMask.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Maskwear/CarpMask.prefab
@@ -140,5 +140,15 @@ PrefabInstance:
       propertyPath: initialTraits.Array.size
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 6776931286767099191, guid: 996d62bfe3bf26c4e95c2a77cadabbd2,
+        type: 3}
+      propertyPath: inventoryMoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
+    - target: {fileID: 6776931286767099191, guid: 996d62bfe3bf26c4e95c2a77cadabbd2,
+        type: 3}
+      propertyPath: inventoryRemoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 996d62bfe3bf26c4e95c2a77cadabbd2, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Maskwear/ClownMask.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Maskwear/ClownMask.prefab
@@ -171,6 +171,16 @@ PrefabInstance:
       value: A true prankster's facial attire. A clown is incomplete without his
         wig and mask.
       objectReference: {fileID: 0}
+    - target: {fileID: 8040391005062056419, guid: 05a135eab68164d34bb02b82fff3cde0,
+        type: 3}
+      propertyPath: inventoryMoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
+    - target: {fileID: 8040391005062056419, guid: 05a135eab68164d34bb02b82fff3cde0,
+        type: 3}
+      propertyPath: inventoryRemoveSound.AssetAddress
+      value: null
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 05a135eab68164d34bb02b82fff3cde0, type: 3}
 --- !u!1 &6404652678407139925 stripped

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Maskwear/FakeMoustache.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Maskwear/FakeMoustache.prefab
@@ -29,6 +29,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3532393564309681412, guid: 05a135eab68164d34bb02b82fff3cde0,
         type: 3}
+      propertyPath: disallowConsume
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3532393564309681412, guid: 05a135eab68164d34bb02b82fff3cde0,
+        type: 3}
       propertyPath: currentClothData
       value: 
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Scripts/Clothing/ClothingV2.cs
+++ b/UnityProject/Assets/Scripts/Clothing/ClothingV2.cs
@@ -39,6 +39,10 @@ namespace Systems.Clothing
 		[SerializeField, EnumFlag]
 		private ClothingHideFlags hideClothingFlags = ClothingHideFlags.HIDE_NONE;
 
+		[Tooltip("Determines if this article of clothing prevents consuming food or drink.")]
+		[SerializeField]
+		private bool disallowConsume = false;
+
 		private ItemAttributesV2 myItem;
 		private Pickupable pickupable;
 
@@ -63,6 +67,11 @@ namespace Systems.Clothing
 		/// Determine when a piece of clothing hides another
 		/// </summary>
 		public ClothingHideFlags HideClothingFlags => hideClothingFlags;
+
+		/// <summary>
+		/// Determines if this article of clothing prevents consuming food or drink.
+		/// </summary>
+		public bool DisallowConsume => disallowConsume;
 
 		private void Awake()
 		{

--- a/UnityProject/Assets/Scripts/Items/Food/DrinkableContainer.cs
+++ b/UnityProject/Assets/Scripts/Items/Food/DrinkableContainer.cs
@@ -49,6 +49,12 @@ public class DrinkableContainer : Consumable
 		if (eater == null || feeder == null)
 			return;
 
+		// Check if player is wearing clothing that prevents eating or drinking
+		if (eater.Equipment.CanConsume() == false)
+		{
+			Chat.AddExamineMsgFromServer(eater.gameObject, $"Remove items that cover your mouth first!");
+			return;
+		}
 		// Check if container is empty
 		var reagentUnits = container.ReagentMixTotal;
 		if (reagentUnits <= 0f)
@@ -61,6 +67,7 @@ public class DrinkableContainer : Consumable
 		var name = itemAttributes ? itemAttributes.ArticleName : gameObject.ExpensiveName();
 		// Generate message to player
 		ConsumableTextUtils.SendGenericConsumeMessage(feeder, eater, HungerState.Hungry, name, "drink");
+
 
 		if (feeder != eater)  //If you're feeding it to someone else.
 		{

--- a/UnityProject/Assets/Scripts/Items/Food/Edible.cs
+++ b/UnityProject/Assets/Scripts/Items/Food/Edible.cs
@@ -86,6 +86,13 @@ namespace Items.Food
 
 			var feeder = feederGO.GetComponent<PlayerScript>();
 
+			// Check if player is wearing clothing that prevents eating or drinking
+			if (eater.Equipment.CanConsume() == false)
+			{
+				Chat.AddExamineMsgFromServer(eater.gameObject, $"Remove items that cover your mouth first!");
+				return;
+			}
+
 			// Show eater message
 			var eaterHungerState = eater.playerHealth.HungerState;
 			ConsumableTextUtils.SendGenericConsumeMessage(feeder, eater, eaterHungerState, Name, "eat");

--- a/UnityProject/Assets/Scripts/Mobs/Equipment/Equipment.cs
+++ b/UnityProject/Assets/Scripts/Mobs/Equipment/Equipment.cs
@@ -439,16 +439,13 @@ public class Equipment : NetworkBehaviour
 	/// </summary>
 	public bool CanConsume()
 	{
-		if (IsOccupied(headSlot))
+		if (IsOccupied(headSlot) && PreventsConsume(headSlot))
 		{
-			if (PreventsConsume(headSlot))
-			{
-				return false;
-			}
-			else
-			{
-				return true;
-			}
+			return false;
+		}
+		else if (IsOccupied(maskSlot) && PreventsConsume(maskSlot))
+		{
+			return false;
 		}
 		return true;
 	}

--- a/UnityProject/Assets/Scripts/Mobs/Equipment/Equipment.cs
+++ b/UnityProject/Assets/Scripts/Mobs/Equipment/Equipment.cs
@@ -431,4 +431,46 @@ public class Equipment : NetworkBehaviour
 	}
 
 	#endregion Examination
+
+	#region Consume Check
+	/// <summary>
+	/// Determine whether the player is wearing an item that prevents eating or drinking
+	/// with the DisallowConsume function in ClothingV2.
+	/// </summary>
+	public bool CanConsume()
+	{
+		if (IsOccupied(headSlot))
+		{
+			if (PreventsConsume(headSlot))
+			{
+				return false;
+			}
+			else
+			{
+				return true;
+			}
+		}
+		return true;
+	}
+
+	public bool PreventsConsume(IEnumerable<ItemSlot> ToCheck)
+	{
+		foreach (var itemSlot in ToCheck)
+		{
+			if (itemSlot.Item.TryGetComponent<ClothingV2>(out var headwear))
+			{
+				if (headwear.DisallowConsume == false)
+				{
+					return false;
+				}
+			}
+			else
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	#endregion Consume Check
 }

--- a/UnityProject/Assets/Scripts/UI/Objects/Command/IDConsole/GUI_IDConsole.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Command/IDConsole/GUI_IDConsole.cs
@@ -147,14 +147,30 @@ namespace UI.Objects.Command
 
 		public void ServerChangeName(string newName)
 		{
-			console.TargetCard.ServerSetRegisteredName(newName);
-			ServerRefreshCardNames();
+			if (newName.Length <= 32)
+			{
+				console.TargetCard.ServerSetRegisteredName(newName);
+				ServerRefreshCardNames();
+			}
+			else
+			{
+				Chat.AddExamineMsgToClient($"Name cannot exceed 32 characters!");
+				return;
+			}
 		}
 
 		public void ServerChangeJobTitle(string newJobTitle)
 		{
-			console.TargetCard.ServerSetJobTitle(newJobTitle);
-			ServerRefreshCardNames();
+			if (newJobTitle.Length <= 32)
+			{
+				console.TargetCard.ServerSetJobTitle(newJobTitle);
+				ServerRefreshCardNames();
+			}
+			else
+			{
+				Chat.AddExamineMsgToClient($"Job title cannot exceed 32 characters!");
+				return;
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
### Purpose

Fixes #8278 
Fixes #8327 
### Notes:
This is accomplished by introducing a bool in ClothingV2.cs that is checked against in Equipment.cs, then the value is read by DrinkableContainer.cs and Edible.cs when attempting to consume the item. This bool has been set on the appropriate headwear. Masks, by default, will now prevent eating/drinking but an exception was made for the fake mustache item. 

Additionally, now when editing an ID through an ID console, name and title are limited to 32 characters.



### Changelog:
CL: [Fix] You can no longer eat or drink through helmets or masks that would usually prevent it.
CL: [Fix] When editing an ID through the ID console, name and job title are limited to 32 characters.
<!-- Add here individual lines with all your remarkable changes using the prefix ``CL:`` -->
<!-- Mind that the changes meant to be logged in the in changelog are those that are remarkable for the end user, so things like new features and fixes of known bugs are perfect for this section -->

<!-- CL: [New] For new features, things that didn't exist before the PR. -->

<!-- CL: [Improvement] For any change on any existing feature. -->

<!-- CL: [Balance] For any change on an existing feature done in the sake of improving game balance. It's the only exception to the rule above. -->

<!-- CL: [Fix] For any change that fixes a bug. -->
