### PR TITLE
Add SpaceScene to QuickBuild

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.cs
@@ -70,7 +70,9 @@ public partial class SubSceneManager : NetworkBehaviour
 	IEnumerator LoadSubScene(string sceneName, SubsceneLoadTimer loadTimer = null, bool HandlSynchronising = true)
 	{
 		AsyncOperation AO = SceneManager.LoadSceneAsync(sceneName, LoadSceneMode.Additive);
-		while (!AO.isDone)
+		if (AO == null) yield break; // Null if scene not found.
+
+		while (AO.isDone == false)
 		{
 			if (loadTimer != null) loadTimer.IncrementLoadBar();
 			yield return WaitFor.EndOfFrame;


### PR DESCRIPTION
- Adds SpaceScene to QuickBuild. Fixes the QuickBuild part of #8331.
- Removes old `Disable Scenes` tab from QuickBuild window.

> ~Test build in progress...~ All good, though looks like there's an unrelated issue for force-starting the round too early.