### PR TITLE
Interrupt ProgressActions

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Engineering/CableCoil.cs
+++ b/UnityProject/Assets/Scripts/Items/Engineering/CableCoil.cs
@@ -314,17 +314,24 @@ namespace Objects.Electrical
 			// Get the electrical cable tile with the wire connection direction.
 			ElectricalCableTile tile =
 				ElectricityFunctions.RetrieveElectricalTile(wireEndA, wireEndB, powerTypeCategory);
-			// Then, add an electrical node at the tile.
-			interaction.Performer.GetComponentInParent<Matrix>().AddElectricalNode(position.RoundToInt(), tile, true);
 
 			// We only want to consume the difference needed to build the new
 			// cable.
 			int newTileCost = tile.SpawnAmountOnDeconstruct;
 			int finalCost = newTileCost - oldTileCost;
 
-			// Finally, consume the cables in the hands using the final cost
+			// Attempt to consume the cables in the hands using the final cost
 			// we found.
-			Inventory.ServerConsume(interaction.HandSlot, finalCost);
+			if (Inventory.ServerConsume(interaction.HandSlot, finalCost))
+			{
+				// Then, add an electrical node at the tile.
+				interaction.Performer.GetComponentInParent<Matrix>().AddElectricalNode(position.RoundToInt(), tile, true);
+			}
+			else
+			{
+				Chat.AddExamineMsgFromServer(interaction.PerformerPlayerScript.connectedPlayer,
+					$"You don't have enough cable to place");
+			}
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Inventory/Inventory.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/Inventory.cs
@@ -82,8 +82,7 @@ public static class Inventory
 		var stackable = fromSlot.ItemObject.GetComponent<Stackable>();
 		if (stackable != null)
 		{
-			stackable.ServerConsume(amountToConsume);
-			return true;
+			return stackable.ServerConsume(amountToConsume);
 		}
 		else
 		{
@@ -431,6 +430,12 @@ public static class Inventory
 		foreach (var onMove in pickupable.GetComponents<IServerInventoryMove>())
 		{
 			onMove.OnInventoryMoveServer(toPerform);
+		}
+		
+		if (pickupable.gameObject.TryGetComponent<Stackable>(out var stack))
+		{
+			var cnt = pickupable.GetComponent<CustomNetTransform>();
+			stack.ServerStackOnGround(cnt.ServerLocalPosition);
 		}
 
 		if (pickupable.gameObject.TryGetComponent<Stackable>(out var stack))

--- a/UnityProject/Assets/Scripts/Systems/Inventory/Inventory.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/Inventory.cs
@@ -431,12 +431,6 @@ public static class Inventory
 		{
 			onMove.OnInventoryMoveServer(toPerform);
 		}
-		
-		if (pickupable.gameObject.TryGetComponent<Stackable>(out var stack))
-		{
-			var cnt = pickupable.GetComponent<CustomNetTransform>();
-			stack.ServerStackOnGround(cnt.ServerLocalPosition);
-		}
 
 		if (pickupable.gameObject.TryGetComponent<Stackable>(out var stack))
 		{

--- a/UnityProject/Assets/Scripts/UI/Core/ProgressBar/StandardProgressAction.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/ProgressBar/StandardProgressAction.cs
@@ -3,6 +3,20 @@ using System;
 using System.Linq;
 using UnityEngine;
 
+public enum ActionInterruptionType
+{
+	MatrixRotation,
+	MatrixMove,
+	TargetDespawn,
+	PerformerCuffed,
+	PerformerOrTargetMoved,
+	PerformerSlipped,
+	PerformerUnconscious,
+	PerformerDirection,
+	ChangeToPerformerActiveSlot,
+	WelderOff
+}
+
 /// <summary>
 /// Progress action which covers the majority of common progress action use cases.
 /// These should be used once per attempted progress action, don't reuse one for multiple
@@ -13,8 +27,12 @@ public class StandardProgressAction : IProgressAction
 
 	private readonly StandardProgressActionConfig progressActionConfig;
 
+
+
 	//invoked on successful completion
 	private readonly Action onCompletion;
+	//invoked on interruption
+	private readonly Action<ActionInterruptionType> onInterruption;
 
 	//slot being used to perform the action, will be interrupted if slot contents change
 	private ItemSlot usedSlot;
@@ -47,6 +65,14 @@ public class StandardProgressAction : IProgressAction
 		this.welder = welder;
 	}
 
+	private StandardProgressAction(StandardProgressActionConfig progressActionConfig, Action onCompletion,
+		Action<ActionInterruptionType> onInterruption)
+	{
+		this.progressActionConfig = progressActionConfig;
+		this.onCompletion = onCompletion;
+		this.onInterruption = onInterruption;
+	}
+
 	/// <summary>
 	/// Creates a new instance of a progress action with the indicated configuration and
 	/// completion action.
@@ -70,6 +96,20 @@ public class StandardProgressAction : IProgressAction
 		Action onCompletion, Welder welder)
 	{
 		return new StandardProgressAction(progressActionConfig, onCompletion, welder);
+	}
+
+	/// <summary>
+	/// Creates a new instance of a progress action with the indicated configuration and
+	/// completion action.
+	/// </summary>
+	/// <param name="progressActionConfig">config</param>
+	/// <param name="onCompletion">action to invoke server-side on successful completion (not invoked when interrupted)</param>
+	/// <param name="onInterrupted">action to invoke server-side when interrupted</param>
+	/// <returns></returns>
+	public static StandardProgressAction Create(StandardProgressActionConfig progressActionConfig,
+		Action onCompletion, Action<ActionInterruptionType> onInterrupted)
+	{
+		return new StandardProgressAction(progressActionConfig, onCompletion, onInterrupted);
 	}
 
 	public bool OnServerStartProgress(StartProgressInfo info)
@@ -254,18 +294,19 @@ public class StandardProgressAction : IProgressAction
 		}
 	}
 
-	private void InterruptProgress(string reason)
+	private void InterruptProgress(string reason, ActionInterruptionType interruptionType)
 	{
 		if(progressActionConfig.AllowMovement == true) return;
 		Logger.LogTraceFormat("Server progress bar {0} interrupted: {1}.", Category.ProgressAction,
 			ProgressBar.ID, reason);
 		ProgressBar.ServerInterruptProgress();
+		onInterruption?.Invoke(interruptionType);
 	}
 
 	private void OnMatrixRotate(MatrixRotationInfo arg0)
 	{
 		if(progressActionConfig.AllowMovement == true) return;
-		InterruptProgress("cross-matrix and target or performer matrix rotated");
+		InterruptProgress("cross-matrix and target or performer matrix rotated", ActionInterruptionType.MatrixRotation);
 	}
 
 	private bool CanPlayerStillProgress()
@@ -285,48 +326,54 @@ public class StandardProgressAction : IProgressAction
 
 	private void OnWelderOff()
 	{
-		InterruptProgress("welder off");
+		InterruptProgress("welder off", ActionInterruptionType.WelderOff);
 	}
 
 	private void OnSlotContentsChanged()
 	{
-		InterruptProgress("performer's active slot contents changed");
+		InterruptProgress("performer's active slot contents changed",
+			ActionInterruptionType.ChangeToPerformerActiveSlot);
 	}
 
 	private void OnMatrixStartMove()
 	{
-		InterruptProgress("cross-matrix and performer or target matrix started moving");
+		InterruptProgress("cross-matrix and performer or target matrix started moving",
+			ActionInterruptionType.MatrixMove);
 	}
 
 	private void OnLocalPositionChanged(Vector3Int arg0)
 	{
 		//if player or target moves at all, interrupt
-		InterruptProgress("performer or target moved");
+		InterruptProgress("performer or target moved",ActionInterruptionType.PerformerOrTargetMoved);
 	}
 
 	private void OnDespawned()
 	{
-		InterruptProgress("target was despawned");
+		InterruptProgress("target was despawned", ActionInterruptionType.TargetDespawn);
 	}
 
 	private void OnConsciousStateChange(ConsciousState oldState, ConsciousState newState)
 	{
-		if (!CanPlayerStillProgress()) InterruptProgress("performer not conscious enough");
+		if (!CanPlayerStillProgress()) InterruptProgress("performer not conscious enough",
+			ActionInterruptionType.PerformerUnconscious);
 	}
 
 	private void OnSlipChange(bool wasSlipped, bool nowSlipped)
 	{
-		if (!CanPlayerStillProgress()) InterruptProgress("performer slipped");
+		if (!CanPlayerStillProgress()) InterruptProgress("performer slipped",
+			ActionInterruptionType.PerformerSlipped);
 	}
 
 	private void OnCuffChange(bool wasCuffed, bool nowCuffed)
 	{
-		if (!CanPlayerStillProgress()) InterruptProgress("performer cuffed");
+		if (!CanPlayerStillProgress()) InterruptProgress("performer cuffed",
+			ActionInterruptionType.PerformerCuffed);
 	}
 
 
 	private void OnDirectionChanged(OrientationEnum arg0)
 	{
-		if (!CanPlayerStillProgress()) InterruptProgress("performer direction changed");
+		if (!CanPlayerStillProgress()) InterruptProgress("performer direction changed",
+			ActionInterruptionType.PerformerDirection);
 	}
 }


### PR DESCRIPTION
### Purpose:
Fix some small dupes and give players just a tad more feedback on gamestate

### Notes:
StandardProgressActions extended for interruptable actions

### Changelog:
CL: [Fix] Fixes #7802 
CL: [Fix] Construction can be interrupted by a lack of materials, fixing a dupe
CL: [New] Certain interrupted actions now have action text to clarify the current situation
