### PR TITLE
Fixes objects that were originally on the station being teleported to random coordinates when re-logging

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
@@ -350,9 +350,6 @@ public class RegisterTile : NetworkBehaviour, IServerDespawn
 	/// <param name="newNetworkedMatrixNetID">uint of the new parent</param>
 	private void SyncNetworkedMatrixNetId(uint oldNetworkMatrixId, uint newNetworkedMatrixNetID)
 	{
-		if (Initialized == false)
-			return;
-
 		networkedMatrixNetId = newNetworkedMatrixNetID;
 		NetworkedMatrix.InvokeWhenInitialized(networkedMatrixNetId, FinishNetworkedMatrixRegistration); //note: we dont actually wait for init here anymore
 	}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
@@ -356,6 +356,7 @@ public class RegisterTile : NetworkBehaviour, IServerDespawn
 
 	private void FinishNetworkedMatrixRegistration(NetworkedMatrix networkedMatrix)
 	{
+		if (networkedMatrix == null) return;
 		//if we had any spin rotation, preserve it,
 		//otherwise all objects should always have upright local rotation
 		var rotation = transform.rotation;


### PR DESCRIPTION

doesn't seem to give any errors will double check with a build, with the changes since I tested with a build with the old changes

CL: [Fix] Fixed objects that were originally on the station being teleported to random coordinates when re-logging