### PR TITLE
Stackable items now have different sprites based off their amount

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/MetalSheet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/MetalSheet.prefab
@@ -1,21 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-6552081043697107899
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5770283965274354279}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8688576ed720a4f40b3583f62adeeb23, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  groundReagents:
-    m_keys:
-    - {fileID: 11400000, guid: bb1b374d9154ed45ca903a8ace087e8d, type: 2}
-    m_values: 14000000
 --- !u!1001 &2682220686170747480
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -39,6 +23,44 @@ PrefabInstance:
         type: 3}
       propertyPath: foreverID
       value: b83b68cfa4a201748aeeece963a989c3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 4fac1629a6b652d46803215274a2c5dd,
+        type: 2}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 712b9587b2ea69c4395526703429266f,
+        type: 2}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 38e19a7c32cdc6d428a3f8b8571bcbc2,
+        type: 2}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].OverAmount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].OverAmount
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].OverAmount
+      value: 51
       objectReference: {fileID: 0}
     - target: {fileID: 8340835308478918493, guid: b56fec0300832ce48ade0ddf2e577ee7,
         type: 3}
@@ -187,3 +209,19 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 2682220686170747480}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &-6552081043697107899
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5770283965274354279}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8688576ed720a4f40b3583f62adeeb23, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  groundReagents:
+    m_keys:
+    - {fileID: 11400000, guid: bb1b374d9154ed45ca903a8ace087e8d, type: 2}
+    m_values: 14000000

--- a/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/MineralSheets/SolidPlasmaSheet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/MineralSheets/SolidPlasmaSheet.prefab
@@ -1,21 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &3226264520061043506
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9177804066296137559}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8688576ed720a4f40b3583f62adeeb23, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  groundReagents:
-    m_keys:
-    - {fileID: 11400000, guid: 3f8ba0db83a8157ae8fbb3c4115580e7, type: 2}
-    m_values: 14000000
 --- !u!1001 &3259288868005657216
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -207,9 +191,47 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
         type: 3}
+      propertyPath: stackSprites.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
       propertyPath: stacksWith.Array.data[0]
       value: 
       objectReference: {fileID: 9177804066296137559}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 4c94f09266fb5c840ac902fef267ae5c,
+        type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 9166e45caf3ab324ea6c27e4c875eeb0,
+        type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 9f1c32c52a5bb2a43b4afb4daaa65296,
+        type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].OverAmount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].OverAmount
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].OverAmount
+      value: 51
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8a023982b9ee4fd40b87f69c23492dd6, type: 3}
 --- !u!1 &9177804066296137559 stripped
@@ -218,3 +240,19 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 3259288868005657216}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &3226264520061043506
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9177804066296137559}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8688576ed720a4f40b3583f62adeeb23, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  groundReagents:
+    m_keys:
+    - {fileID: 11400000, guid: 3f8ba0db83a8157ae8fbb3c4115580e7, type: 2}
+    m_values: 14000000

--- a/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/PlasmaGlassSheet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/PlasmaGlassSheet.prefab
@@ -1,67 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-6588257826460687609
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1151981523841236988}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8688576ed720a4f40b3583f62adeeb23, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  groundReagents:
-    m_keys:
-    - {fileID: 11400000, guid: 0dbe4ccb54c65da5e88a73f36441a195, type: 2}
-    - {fileID: 11400000, guid: 3f8ba0db83a8157ae8fbb3c4115580e7, type: 2}
-    m_values: 140000000a000000
---- !u!114 &5890203577239317802
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1151981523841236988}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9a92be9a13622bf48a10f05367a474f1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  rods: 2
-  sheetsGlass: 1
-  sheetsReinforcedGlass: 1
-  sheetsReinforcedGlassType: {fileID: 77673353444578627, guid: b6a0d928019a24a4f9cee04a1d06b3b1,
-    type: 3}
---- !u!114 &7753296470096805340
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1151981523841236988}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0d95e80c8fc844f38a2d4a6f11bee3c6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  waysToPlace:
-  - layerTile: {fileID: 11400000, guid: ae105d9364e52524f854296e03bc894e, type: 2}
-    placeableOn: 5
-    placeableOnlyOnTile: {fileID: 11400000, guid: 3975642db6c52ed4fa2086247abc1f28,
-      type: 2}
-    itemCost: 2
-    timeToPlace: 1
-  placeSound:
-    SetLoadSetting: 0
-    AssetAddress: Assets/Prefabs/Effects/GlassHit.prefab
-    AssetReference:
-      m_AssetGUID: 
-      m_SubObjectName: 
-      m_SubObjectType: 
 --- !u!1001 &8850041826560229315
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -85,6 +23,44 @@ PrefabInstance:
         type: 3}
       propertyPath: foreverID
       value: dfe30ea3b0c7a1a48ab584f1f6776309
+      objectReference: {fileID: 0}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 60d48ace82878ad49a58a0d58bffba61,
+        type: 2}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 1f7368cf5aab61e489a768161ee811d0,
+        type: 2}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: dfec86c6d5a66eb4b8996956992d949e,
+        type: 2}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].OverAmount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].OverAmount
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].OverAmount
+      value: 51
       objectReference: {fileID: 0}
     - target: {fileID: 8340835308478918493, guid: b56fec0300832ce48ade0ddf2e577ee7,
         type: 3}
@@ -229,3 +205,65 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 8850041826560229315}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &-6588257826460687609
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1151981523841236988}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8688576ed720a4f40b3583f62adeeb23, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  groundReagents:
+    m_keys:
+    - {fileID: 11400000, guid: 0dbe4ccb54c65da5e88a73f36441a195, type: 2}
+    - {fileID: 11400000, guid: 3f8ba0db83a8157ae8fbb3c4115580e7, type: 2}
+    m_values: 140000000a000000
+--- !u!114 &5890203577239317802
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1151981523841236988}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9a92be9a13622bf48a10f05367a474f1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  rods: 2
+  sheetsGlass: 1
+  sheetsReinforcedGlass: 1
+  sheetsReinforcedGlassType: {fileID: 77673353444578627, guid: b6a0d928019a24a4f9cee04a1d06b3b1,
+    type: 3}
+--- !u!114 &7753296470096805340
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1151981523841236988}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0d95e80c8fc844f38a2d4a6f11bee3c6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  waysToPlace:
+  - layerTile: {fileID: 11400000, guid: ae105d9364e52524f854296e03bc894e, type: 2}
+    placeableOn: 5
+    placeableOnlyOnTile: {fileID: 11400000, guid: 3975642db6c52ed4fa2086247abc1f28,
+      type: 2}
+    itemCost: 2
+    timeToPlace: 1
+  placeSound:
+    SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/Effects/GlassHit.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 

--- a/UnityProject/Assets/Prefabs/Items/Medical/Basic Treatments/Bruise Pack.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Medical/Basic Treatments/Bruise Pack.prefab
@@ -63,7 +63,7 @@ PrefabInstance:
     - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: stackSprites.Array.data[2].OverAmount
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Medical/Basic Treatments/Bruise Pack.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Medical/Basic Treatments/Bruise Pack.prefab
@@ -1,22 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &4441490070594631954
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6748581008247049004}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 19988dde784f6ae4f874dcb496f6115d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  healType: 0
-  StopsExternalBleeding: 0
-  HealsTraumaDamage: 0
-  TraumaDamageToHeal: 20
-  TraumaTypeToHeal: 0
 --- !u!1001 &5006578600938051199
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -41,9 +24,47 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
+      propertyPath: stackSprites.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
       propertyPath: stacksWith.Array.data[0]
       value: 
       objectReference: {fileID: 6748581008247049004}
+    - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 34d930aba778be043bd97c633c196529,
+        type: 2}
+    - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: b787f445012f3b64b81d32c2ac8626db,
+        type: 2}
+    - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: d7f55acbef20fd74f9e511cbc45ce5b3,
+        type: 2}
+    - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].OverAmount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].OverAmount
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].OverAmount
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: m_RootOrder
@@ -193,3 +214,20 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 5006578600938051199}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &4441490070594631954
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6748581008247049004}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 19988dde784f6ae4f874dcb496f6115d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  healType: 0
+  StopsExternalBleeding: 0
+  HealsTraumaDamage: 0
+  TraumaDamageToHeal: 20
+  TraumaTypeToHeal: 0

--- a/UnityProject/Assets/Prefabs/Items/Medical/Trauma Treatment/Gauze.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Medical/Trauma Treatment/Gauze.prefab
@@ -1,39 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-6495101291114284292
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1791647728409730387}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e7c30ca55ffa4467a421abf7a832a6a1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  initialAmount: 6
-  maxAmount: 6
-  stacksWith: []
---- !u!114 &5444546479528737663
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1791647728409730387}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 63f87c1010d1c364fbec5fa3289f9e09, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  healType: 0
-  StopsExternalBleeding: 1
-  HealsTraumaDamage: 0
-  TraumaDamageToHeal: 20
-  TraumaTypeToHeal: 0
 --- !u!1001 &1792047792650166761
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -94,6 +60,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 3ce7c70f4f293004689a6e84fe5b861d
       objectReference: {fileID: 0}
+    - target: {fileID: 114776788309089574, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: customNetTransform
+      value: 
+      objectReference: {fileID: 1821874675337654403}
     - target: {fileID: 114776788309089574, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: CurrentsortingGroup
@@ -180,9 +151,70 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 1792047792650166761}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1821874675337654403 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 114341119007412586, guid: a7abba22164ce49f0bf9b9b219f39298,
+    type: 3}
+  m_PrefabInstance: {fileID: 1792047792650166761}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1791647728409730387}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!210 &5506006793603177245 stripped
 SortingGroup:
   m_CorrespondingSourceObject: {fileID: 6104600676241079028, guid: a7abba22164ce49f0bf9b9b219f39298,
     type: 3}
   m_PrefabInstance: {fileID: 1792047792650166761}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &-6495101291114284292
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1791647728409730387}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e7c30ca55ffa4467a421abf7a832a6a1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  initialAmount: 6
+  maxAmount: 6
+  stacksWith:
+  - {fileID: 1791647728409730387}
+  stackNames:
+  - Name: Gauze
+    OverAmount: 1
+  - Name: Half a bunch of Gauze
+    OverAmount: 3
+  - Name: A Full stack of Gauze
+    OverAmount: 5
+  stackSprites:
+  - SpriteSO: {fileID: 11400000, guid: 8a92d8c108f796e4699c6b4d8b80f262, type: 2}
+    OverAmount: 1
+  - SpriteSO: {fileID: 11400000, guid: 5de10a362fc65d3498f7a45f7c022502, type: 2}
+    OverAmount: 3
+  - SpriteSO: {fileID: 11400000, guid: 723888300227e1b4ca3e1a0d5351defc, type: 2}
+    OverAmount: 6
+--- !u!114 &5444546479528737663
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1791647728409730387}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 63f87c1010d1c364fbec5fa3289f9e09, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  healType: 0
+  StopsExternalBleeding: 1
+  HealsTraumaDamage: 0
+  TraumaDamageToHeal: 20
+  TraumaTypeToHeal: 0

--- a/UnityProject/Assets/Prefabs/Items/Medical/Trauma Treatment/Gauze.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Medical/Trauma Treatment/Gauze.prefab
@@ -200,7 +200,7 @@ MonoBehaviour:
   - SpriteSO: {fileID: 11400000, guid: 5de10a362fc65d3498f7a45f7c022502, type: 2}
     OverAmount: 3
   - SpriteSO: {fileID: 11400000, guid: 723888300227e1b4ca3e1a0d5351defc, type: 2}
-    OverAmount: 6
+    OverAmount: 7
 --- !u!114 &5444546479528737663
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Items/Stackable.cs
+++ b/UnityProject/Assets/Scripts/Items/Stackable.cs
@@ -50,8 +50,10 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 	private PushPull pushPull;
 	private RegisterTile registerTile;
 	private GameObject prefab;
+	private SpriteHandler spriteHandler;
 
 	[SerializeField] private List<StackNames> stackNames = new List<StackNames>();
+	[SerializeField] private List<StackSprites> stackSprites = new List<StackSprites>();
 
 
 	private void Awake()
@@ -72,6 +74,7 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 		amount = initialAmount;
 		pushPull = GetComponent<PushPull>();
 		registerTile = GetComponent<RegisterTile>();
+		spriteHandler = GetComponentInChildren<SpriteHandler>();
 	}
 
 	private void OnLocalPositionChangedServer(Vector3Int newLocalPos)
@@ -155,6 +158,25 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 		if (CustomNetworkManager.Instance._isServer)
 		{
 			UpdateStackName(gameObject.Item());
+			UpdateStackSprites();
+		}
+	}
+
+	private void UpdateStackSprites()
+	{
+		if (stackSprites.Count == 0 || spriteHandler == null) return;
+		if (amount > 1)
+		{
+			foreach (var sprite in stackSprites)
+			{
+				if (sprite.OverAmount <= amount) continue;
+				if (spriteHandler.GetCurrentSpriteSO() != sprite.SpriteSO) spriteHandler.SetSpriteSO(sprite.SpriteSO);
+				break;
+			}
+		}
+		else if(amount == 1)
+		{
+			spriteHandler.SetSpriteSO(stackSprites[0].SpriteSO);
 		}
 	}
 
@@ -384,6 +406,13 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 	private struct StackNames
 	{
 		[SerializeField] public string Name;
+		[SerializeField] public int OverAmount;
+	}
+
+	[Serializable]
+	private struct StackSprites
+	{
+		[SerializeField] public SpriteDataSO SpriteSO;
 		[SerializeField] public int OverAmount;
 	}
 }


### PR DESCRIPTION
closes #5075 
closes #2355

CL: [Fix] Item stacks now have the ability to change sprites based off their amount. 
Customizable just like the previous stacks PR.

Only changed a couple of items to test and preview this which include :

- The Bruise Pack
- The Gauze
- Plasma Glass Sheets
- Metal Sheets
- Solid Plasma Sheets 