### PR TITLE
Observer optimisation

### DIFF
--- a/UnityProject/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/UnityProject/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -13,9 +13,6 @@ namespace Mirror
         // TODO move to server's NetworkConnectionToClient?
         internal readonly HashSet<NetworkIdentity> observing = new HashSet<NetworkIdentity>();
 
-        //CUSTOM UNITYSTATION CODE// so, for i Performance improvement
-        internal readonly List<NetworkIdentity> observingList = new List<NetworkIdentity>();
-
         /// <summary>Unique identifier for this connection that is assigned by the transport layer.</summary>
         // assigned by transport, this id is unique for every connection on server.
         // clients don't know their own id and they don't know other client's ids.
@@ -229,12 +226,7 @@ namespace Mirror
         // TODO move to server's NetworkConnectionToClient?
         internal void AddToObserving(NetworkIdentity netIdentity)
         {
-	        //CUSTOM UNITYSTATION CODE// so, No duplicate entries in observingList + log
-	        if (observing.Contains(netIdentity) == false)
-	        {
-		        observing.Add(netIdentity);
-		        observingList.Add(netIdentity);
-	        }
+	        observing.Add(netIdentity);
 
 	        // spawn identity for this conn
             NetworkServer.ShowForConnection(netIdentity, this);
@@ -243,11 +235,7 @@ namespace Mirror
         // TODO move to server's NetworkConnectionToClient?
         internal void RemoveFromObserving(NetworkIdentity netIdentity, bool isDestroyed)
         {
-	        if (observing.Contains(netIdentity))
-	        {
-		        observing.Remove(netIdentity);
-		        observingList.Remove(netIdentity);
-	        }
+	        observing.Remove(netIdentity);
 
 	        if (!isDestroyed)
             {
@@ -260,12 +248,11 @@ namespace Mirror
         internal void RemoveFromObservingsObservers()
         {
 
-	        for (int i = 0; i < observingList.Count; i++)
+	        foreach (var observingList in observing)
 	        {
-		        observingList[i].RemoveObserverInternal(this);
+		        observingList.RemoveObserverInternal(this);
 	        }
             observing.Clear();
-            observingList.Clear();
         }
 
         /// <summary>Check if we received a message within the last 'timeout' seconds.</summary>

--- a/UnityProject/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/UnityProject/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1523,11 +1523,9 @@ namespace Mirror
         static void BroadcastToConnection(NetworkConnectionToClient connection)
         {
             // for each entity that this connection is seeing
-            //CUSTOM UNITYSTATION CODE// for i Faster
-            var ListCount = connection.observingList.Count;
-            for (int i = 0; i < ListCount; i++)
+            foreach (var identity in connection.observing)
             {
-	            var identity = connection.observingList[i];
+
             // foreach (NetworkIdentity identity in connection.observing)
             // {
                 // make sure it's not null or destroyed.

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
@@ -338,9 +338,12 @@ public class MetaDataSystem : SubsystemBehaviour
 
 	private void ServerUpdateMe()
 	{
-		foreach (MetaDataNode node in externalNodes.Keys)
+		if (matrix.MatrixMove != null && matrix.MatrixMove.IsMovingServer)
 		{
-			subsystemManager.UpdateAt(node.Position);
+			foreach (MetaDataNode node in externalNodes.Keys)
+			{
+				subsystemManager.UpdateAt(node.Position);
+			}
 		}
 	}
 }


### PR DESCRIPTION
fixes expensive Destroying drawing of network objects ( brings back Slower loop)
makes it so  external Nodes only get update if the matrix is moving