### PR TITLE
Fixes direction signs pointing in wrong direction

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Wallmounts/Signs/DirectionSigns/_SignDirectionsBase.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Wallmounts/Signs/DirectionSigns/_SignDirectionsBase.prefab
@@ -12,6 +12,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: d95c8124beb3ec54ab012b6142cf1977
       objectReference: {fileID: 0}
+    - target: {fileID: 5601900763622263661, guid: 2d5ef1e4279414f4798d5cf1542d9388,
+        type: 3}
+      propertyPath: ChangeSprites
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5657113146019560963, guid: 2d5ef1e4279414f4798d5cf1542d9388,
         type: 3}
       propertyPath: foreverID


### PR DESCRIPTION
After the rotation PR direction signs hadn't been made to change the sprite. Should fix the signs all pointing down on every map

CL: [Fix] Fixes direction signs pointing in wrong direction