### PR TITLE
Fix hostile mobs attack message always using default body part

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Chat/Chat.Process.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/Chat.Process.cs
@@ -565,7 +565,7 @@ public partial class Chat
 
 	private static string InTheZone(BodyPartType hitZone)
 	{
-		return hitZone == BodyPartType.None ? "" : $" in the {hitZone.ToString().ToLower().Replace("_", " ")}";
+		return hitZone == BodyPartType.None ? "" : $" in the {hitZone.GetDescription().ToLower().Replace("_", " ")}";
 	}
 
 	private static bool IsServer()

--- a/UnityProject/Assets/Scripts/HealthV2/HealthEnums.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/HealthEnums.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 
 public enum BodyPartType
 {
@@ -9,19 +10,19 @@ public enum BodyPartType
 	Eyes = 7,
 	Mouth = 8,
 	Chest = 1,
-	LeftArm = 3,
-	LeftHand = 9,
-	RightArm = 2,
-	RightHand = 10,
+	[Description("Left Arm")] LeftArm = 3,
+	[Description("Left Hand")] LeftHand = 9,
+	[Description("Right Arm")] RightArm = 2,
+	[Description("Right Hand")] RightHand = 10,
 
 	//    LEFT_HAND,
 	//    RIGHT_HAND,
 	Groin = 6,
-	LeftLeg = 5,
-	LeftFoot = 11,
+	[Description("Left Leg")] LeftLeg = 5,
+	[Description("Left Foot")] LeftFoot = 11,
 
-	RightLeg = 4,
-	RightFoot = 12,
+	[Description("Right Leg")] RightLeg = 4,
+	[Description("Right Foot")] RightFoot = 12,
 
 	//    LEFT_FOOT,
 	//    RIGHT_FOOT

--- a/UnityProject/Assets/Scripts/NPC/AI/MobMeleeAttack.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobMeleeAttack.cs
@@ -59,17 +59,18 @@ namespace Systems.MobAIs
 
 			if (Vector3.Distance(mobTile.WorldPositionServer, worldPos) < 1.5f)
 			{
+				var bodyPartTarget = defaultTarget.Randomize();
 				if(targetHealth != null)
 				{
 					targetHealth.ApplyDamageToBodyPart(gameObject, hitDamage, AttackType.Melee, DamageType.Brute,
-						defaultTarget.Randomize());
-					Chat.AddAttackMsgToChat(gameObject, targetHealth.gameObject, defaultTarget, null, attackVerb);
+						bodyPartTarget);
+					Chat.AddAttackMsgToChat(gameObject, targetHealth.gameObject, bodyPartTarget, null, attackVerb);
 				}
 				else
 				{
 					livingHealth.ApplyDamageToBodyPart(gameObject, hitDamage, AttackType.Melee, DamageType.Brute,
-						defaultTarget.Randomize());
-					Chat.AddAttackMsgToChat(gameObject, livingHealth.gameObject, defaultTarget, null, attackVerb);
+						bodyPartTarget);
+					Chat.AddAttackMsgToChat(gameObject, livingHealth.gameObject, bodyPartTarget, null, attackVerb);
 				}
 				SoundManager.PlayNetworkedAtPos(attackSound, mobTile.WorldPositionServer, sourceObj: gameObject);
 			}


### PR DESCRIPTION
Fixes #6695

The chat message after a mob attack was always being sent using the default body type target, despite the actual attack using a randomized value. Now the actual value chosen is used in the chat too.

In commit 57f043c9ac91bf644c448f70947cfc858f1fd96d I've added some human readable names for the BodyPartType enums (so that we don't print "RightHand" in chat for example) using Descriptions, if that's not the desired approach for this I can revert it.

CL: [Fix] fixed hostile mob attack messages always using default body part name.