### PR TITLE
makes wrapping paper wrap an object with alt-click

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappingPaper.cs
+++ b/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappingPaper.cs
@@ -30,6 +30,7 @@ namespace Items.Cargo.Wrapping
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
+			if (interaction.IsAltClick == false) return false;
 			return DefaultWillInteract.Default(interaction, side) &&
 			       CommonWillInteract(interaction, side);
 		}
@@ -45,6 +46,7 @@ namespace Items.Cargo.Wrapping
 
 		public bool WillInteract(InventoryApply interaction, NetworkSide side)
 		{
+			if (interaction.IsAltClick == false) return false;
 			return interaction.IsToHandSlot &&
 				   DefaultWillInteract.Default(interaction, side) &&
 			       CommonWillInteract(interaction, side);

--- a/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappingPaper.cs
+++ b/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappingPaper.cs
@@ -31,7 +31,7 @@ namespace Items.Cargo.Wrapping
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
 
-			return return interaction.IsAltClick == true && DefaultWillInteract.Default(interaction, side) &&
+			return interaction.IsAltClick && DefaultWillInteract.Default(interaction, side) &&
 			       CommonWillInteract(interaction, side);
 		}
 
@@ -46,7 +46,7 @@ namespace Items.Cargo.Wrapping
 
 		public bool WillInteract(InventoryApply interaction, NetworkSide side)
 		{
-			return interaction.IsAltClick == true && interaction.IsToHandSlot &&
+			return interaction.IsAltClick && interaction.IsToHandSlot &&
 				   DefaultWillInteract.Default(interaction, side) &&
 			       CommonWillInteract(interaction, side);
 		}

--- a/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappingPaper.cs
+++ b/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappingPaper.cs
@@ -30,8 +30,8 @@ namespace Items.Cargo.Wrapping
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
-			if (interaction.IsAltClick == false) return false;
-			return DefaultWillInteract.Default(interaction, side) &&
+
+			return return interaction.IsAltClick == true && DefaultWillInteract.Default(interaction, side) &&
 			       CommonWillInteract(interaction, side);
 		}
 
@@ -46,8 +46,7 @@ namespace Items.Cargo.Wrapping
 
 		public bool WillInteract(InventoryApply interaction, NetworkSide side)
 		{
-			if (interaction.IsAltClick == false) return false;
-			return interaction.IsToHandSlot &&
+			return interaction.IsAltClick == true && interaction.IsToHandSlot &&
 				   DefaultWillInteract.Default(interaction, side) &&
 			       CommonWillInteract(interaction, side);
 		}


### PR DESCRIPTION
Adds in the fix that was suggested in #6840

CL: [Fix] made wrapping paper wrap an object with alt-click to fix an interaction conflict with containers.