### PR TITLE
Adds the option for disabling autostacking for some items

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Medical/Trauma Treatment/Regen Mesh.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Medical/Trauma Treatment/Regen Mesh.prefab
@@ -1,39 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-6495101291114284292
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1791647728409730387}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e7c30ca55ffa4467a421abf7a832a6a1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  initialAmount: 15
-  maxAmount: 15
-  stacksWith: []
---- !u!114 &2710468740513023014
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1791647728409730387}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 19988dde784f6ae4f874dcb496f6115d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  healType: 1
-  StopsExternalBleeding: 1
-  HealsTraumaDamage: 1
-  TraumaDamageToHeal: 50
-  TraumaTypeToHeal: 3
 --- !u!1001 &1792047792650166761
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -203,3 +169,41 @@ SortingGroup:
     type: 3}
   m_PrefabInstance: {fileID: 1792047792650166761}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &-6495101291114284292
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1791647728409730387}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e7c30ca55ffa4467a421abf7a832a6a1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  initialAmount: 15
+  maxAmount: 15
+  stacksWith: []
+  stackNames: []
+  stackSprites: []
+  autoStackOnSpawn: 1
+  autoStackOnDrop: 0
+--- !u!114 &2710468740513023014
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1791647728409730387}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 19988dde784f6ae4f874dcb496f6115d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  healType: 1
+  StopsExternalBleeding: 1
+  HealsTraumaDamage: 1
+  TraumaDamageToHeal: 50
+  TraumaTypeToHeal: 3

--- a/UnityProject/Assets/Scripts/Items/Stackable.cs
+++ b/UnityProject/Assets/Scripts/Items/Stackable.cs
@@ -54,6 +54,8 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 
 	[SerializeField] private List<StackNames> stackNames = new List<StackNames>();
 	[SerializeField] private List<StackSprites> stackSprites = new List<StackSprites>();
+	[SerializeField] private bool autoStackOnSpawn = true;
+	[SerializeField] private bool autoStackOnDrop = true;
 
 
 	private void Awake()
@@ -119,7 +121,7 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 		InitStacksWith();
 		SyncAmount(amount, initialAmount);
 		amountInit = true;
-		ServerStackOnGround(registerTile.LocalPositionServer);
+		if(autoStackOnSpawn) ServerStackOnGround(registerTile.LocalPositionServer);
 	}
 
 	public void OnDespawnServer(DespawnInfo info)
@@ -130,7 +132,7 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 
 	public void ServerStackOnGround(Vector3Int localPosition)
 	{
-		if (registerTile?.Matrix == null) return;
+		if (autoStackOnDrop == false || registerTile?.Matrix == null) return;
 		//stacks with things on the same tile
 		foreach (var stackable in registerTile.Matrix.Get<Stackable>(localPosition, true))
 		{


### PR DESCRIPTION
Some items do not automatically stack when dropped on the floor or when spawning, this adds the option to disable this behavior.

closes #8361