### PR TITLE
Adds the ability for some consumables to be closed/wrapped

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Food/Drinks/SodaCans/SpaceColaCan.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Drinks/SodaCans/SpaceColaCan.prefab
@@ -108,6 +108,11 @@ PrefabInstance:
       propertyPath: m_WasSpriteAssigned
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 3342103684390452506, guid: b04d0f9770ef17c459a1af178889e3ba,
+        type: 3}
+      propertyPath: customNetTransform
+      value: 
+      objectReference: {fileID: 642140874673133880}
     - target: {fileID: 3342215226231398706, guid: b04d0f9770ef17c459a1af178889e3ba,
         type: 3}
       propertyPath: m_AssetId
@@ -173,6 +178,26 @@ PrefabInstance:
       propertyPath: m_Name
       value: SpaceColaCan
       objectReference: {fileID: 0}
+    - target: {fileID: 3568516159987528955, guid: b04d0f9770ef17c459a1af178889e3ba,
+        type: 3}
+      propertyPath: openingVerb
+      value: crack open a cold one to enjoy
+      objectReference: {fileID: 0}
+    - target: {fileID: 3568516159987528955, guid: b04d0f9770ef17c459a1af178889e3ba,
+        type: 3}
+      propertyPath: spriteHandler
+      value: 
+      objectReference: {fileID: 6645879072490295151}
+    - target: {fileID: 3568516159987528955, guid: b04d0f9770ef17c459a1af178889e3ba,
+        type: 3}
+      propertyPath: openingNoise.AssetAddress
+      value: Pop.prefab
+      objectReference: {fileID: 0}
+    - target: {fileID: 3568516159987528955, guid: b04d0f9770ef17c459a1af178889e3ba,
+        type: 3}
+      propertyPath: requiresOpeningBeforeConsumption
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4530569950825010222, guid: b04d0f9770ef17c459a1af178889e3ba,
         type: 3}
       propertyPath: initialReagentMix.reagents.m_keys.Array.size
@@ -207,3 +232,27 @@ PrefabInstance:
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b04d0f9770ef17c459a1af178889e3ba, type: 3}
+--- !u!114 &642140874673133880 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3341800471880413526, guid: b04d0f9770ef17c459a1af178889e3ba,
+    type: 3}
+  m_PrefabInstance: {fileID: 2776788492469708910}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &6645879072490295151 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8841627809843521281, guid: b04d0f9770ef17c459a1af178889e3ba,
+    type: 3}
+  m_PrefabInstance: {fileID: 2776788492469708910}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Scripts/Items/Food/Consumable.cs
+++ b/UnityProject/Assets/Scripts/Items/Food/Consumable.cs
@@ -1,17 +1,40 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using AddressableReferences;
 using HealthV2;
 using UnityEngine;
+using NaughtyAttributes;
+
 
 /// <summary>
 /// Item that can be drinked or eaten by player
 /// Also supports force feeding other player
 /// </summary>
-public abstract class Consumable : MonoBehaviour, ICheckedInteractable<HandApply>
+public abstract class Consumable : MonoBehaviour, ICheckedInteractable<HandApply>, IInteractable<HandActivate>, IRightClickable
 {
+	public bool requiresOpeningBeforeConsumption = false;
+	protected bool isOpenForConsumption = false;
+
+	[SerializeField, ShowIf(nameof(requiresOpeningBeforeConsumption))]
+	private AddressableAudioSource openingNoise;
+	[SerializeField, ShowIf(nameof(requiresOpeningBeforeConsumption))]
+	private SpriteDataSO openedSprite;
+	[SerializeField, ShowIf(nameof(requiresOpeningBeforeConsumption))]
+	private SpriteHandler spriteHandler;
+	[SerializeField, ShowIf(nameof(requiresOpeningBeforeConsumption))]
+	private string openingVerb = "open";
+
 	public void ServerPerformInteraction(HandApply interaction)
 	{
+		if (requiresOpeningBeforeConsumption)
+		{
+			if (isOpenForConsumption == false)
+			{
+				Chat.AddExamineMsg(interaction.Performer, $"You need to open {gameObject.ExpensiveName()} before consuming it!");
+				return;
+			}
+		}
 		var targetPlayer = interaction.TargetObject.GetComponent<PlayerScript>();
 		if (targetPlayer == null)
 		{
@@ -80,4 +103,46 @@ public abstract class Consumable : MonoBehaviour, ICheckedInteractable<HandApply
 	/// <param name="feeder">Player that feed eater. Can be same as eater.</param>
 	/// <param name="eater">Player that is going to eat item</param>
 	public abstract void TryConsume(GameObject feeder, GameObject eater);
+
+	/// <summary>
+	/// For opening a consumable. Can be overriden by other scripts to extend this functionality even further.
+	/// </summary>
+	protected virtual void TryOpen()
+	{
+		if(requiresOpeningBeforeConsumption == false || isOpenForConsumption) return;
+		isOpenForConsumption = true;
+		if (openingNoise != null) SoundManager.PlayNetworkedAtPos(openingNoise, gameObject.AssumedWorldPosServer());
+		if (openedSprite != null) spriteHandler.SetSpriteSO(openedSprite);
+	}
+
+	/// <summary>
+	/// For opening the consumable and to trigger text feedback to the person holding it.
+	/// </summary>
+	/// <param name="activate"></param>
+	protected virtual void TryOpen(HandActivate activate)
+	{
+		if(requiresOpeningBeforeConsumption == false || isOpenForConsumption) return;
+		isOpenForConsumption = true;
+		if (openingNoise != null) SoundManager.PlayNetworkedAtPos(openingNoise, gameObject.AssumedWorldPosServer());
+		if (openedSprite != null) spriteHandler.SetSpriteSO(openedSprite);
+		if (activate != null) Chat.AddExamineMsg(activate.Performer, $"You {openingVerb} the {gameObject.ExpensiveName()}");
+	}
+
+	public void ServerPerformInteraction(HandActivate interaction)
+	{
+		TryOpen(interaction);
+	}
+
+
+	/// <summary>
+	/// Generates a right click button for items like Space Cola where another script gets in the way of HandActivate
+	/// </summary>
+	/// <returns></returns>
+	public RightClickableResult GenerateRightClickOptions()
+	{
+		var rightClickResult = new RightClickableResult();
+		if (requiresOpeningBeforeConsumption == false) return rightClickResult;
+		rightClickResult.AddElement("Open This", TryOpen);
+		return rightClickResult;
+	}
 }

--- a/UnityProject/Assets/Scripts/Items/Food/Consumable.cs
+++ b/UnityProject/Assets/Scripts/Items/Food/Consumable.cs
@@ -141,7 +141,7 @@ public abstract class Consumable : MonoBehaviour, ICheckedInteractable<HandApply
 	public RightClickableResult GenerateRightClickOptions()
 	{
 		var rightClickResult = new RightClickableResult();
-		if (requiresOpeningBeforeConsumption == false) return rightClickResult;
+		if (requiresOpeningBeforeConsumption == false || isOpenForConsumption) return rightClickResult;
 		rightClickResult.AddElement("Open This", TryOpen);
 		return rightClickResult;
 	}


### PR DESCRIPTION
more work on #8362

Consumables now can be configured to require the player to open/unwrap them before consuming.
the opening verb for text feedback is customizable as well as an opening sound and the ability to change the sprite to a new one that reflects that the item is now opened/unwrapped for consumption immediately.

### Note

Some items like the space cola can has this issue where another handactive functions gets in the way of the new one that's on consumables, to mitigate this; I've created two TryOpen functions, one designed for HandActivate and the other is for RightClick.

CL: [New] some consumables such as regen meshes start wrapped and must be unwrapped to use them.