### PR TITLE
Server wont add or notify disconnected players anymore #6665

### DIFF
--- a/UnityProject/Assets/Scripts/Messages/Server/GhostRoles/GhostRoleUpdateMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/GhostRoles/GhostRoleUpdateMessage.cs
@@ -1,4 +1,5 @@
-﻿using Systems.GhostRoles;
+﻿using System.Net.Configuration;
+using Systems.GhostRoles;
 using Mirror;
 
 namespace Messages.Server.GhostRoles
@@ -39,6 +40,7 @@ namespace Messages.Server.GhostRoles
 
 				foreach (ConnectedPlayer player in PlayerList.Instance.InGamePlayers)
 				{
+					if(PlayerList.Instance.loggedOff.Contains(player)) continue;
 					if (player?.Script == null)
 					{
 						Logger.LogError("SendToDead, player?.Script == null", Category.Ghosts);
@@ -63,6 +65,7 @@ namespace Messages.Server.GhostRoles
 		public static NetMessage SendTo(ConnectedPlayer player, uint key, GhostRoleServer role)
 		{
 			NetMessage msg = GetMessage(key, role);
+			if (PlayerList.Instance.loggedOff.Contains(player)) return msg;
 
 			SendTo(player, msg);
 			return msg;

--- a/UnityProject/Assets/Scripts/Systems/GhostRoles/GhostRoleManager.cs
+++ b/UnityProject/Assets/Scripts/Systems/GhostRoles/GhostRoleManager.cs
@@ -206,6 +206,8 @@ namespace Systems.GhostRoles
 
 		private GhostRoleResponseCode VerifyPlayerCanQueue(ConnectedPlayer player, uint key)
 		{
+			if (PlayerList.Instance.loggedOff.Contains(player)) return GhostRoleResponseCode.Error;
+
 			if (player.Script.IsDeadOrGhost == false)
 			{
 				return GhostRoleResponseCode.Error;
@@ -255,7 +257,6 @@ namespace Systems.GhostRoles
 		private void ServerTryAddPlayerToRole(ConnectedPlayer player, uint key)
 		{
 			GhostRoleResponseCode responseCode = VerifyPlayerCanQueue(player, key);
-
 			if (responseCode == GhostRoleResponseCode.Success)
 			{
 				var role = serverAvailableRoles[key];
@@ -294,7 +295,6 @@ namespace Systems.GhostRoles
 			foreach (var role in serverAvailableRoles)
 			{
 				if (role.Value.WaitingPlayers.Contains(player) == false) continue;
-
 				role.Value.WaitingPlayers.Remove(player);
 				GhostRoleResponseMessage.SendTo(player, role.Key, GhostRoleResponseCode.ClearMessage);
 			}

--- a/UnityProject/Assets/Scripts/Systems/GhostRoles/GhostRoleManager.cs
+++ b/UnityProject/Assets/Scripts/Systems/GhostRoles/GhostRoleManager.cs
@@ -283,6 +283,13 @@ namespace Systems.GhostRoles
 		{
 			var role = serverAvailableRoles[key];
 			role.WaitingPlayers.Remove(player);
+			
+			foreach (var playerQueued in role.WaitingPlayers)
+			{
+				//(Max) : this should remove all queued up players who are offline but I don't think this is the best place to put it
+				if(PlayerList.Instance.loggedOff.Contains(playerQueued) == false) continue;
+				role.WaitingPlayers.Remove(playerQueued);
+			}
 
 			GhostRoleResponseMessage.SendTo(player, key, GhostRoleResponseCode.ClearMessage);
 		}


### PR DESCRIPTION
fixes #6665

~~Need @Bod9001 to confirm that it solves the issue 100% incase I missed another queue function or a more important area that needed this fix.~~

Edit : we talked, this seems like it does the trick by making sure all disconnected players are cleared from the list before doing anything + the server wont waste time sending stuff to offline players.