### PR TITLE
Flares and Glowsticks need to be sparked to light up now

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Tools/Lights/Flare.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/Lights/Flare.prefab
@@ -80,7 +80,7 @@ PrefabInstance:
     - target: {fileID: 3320711171919508498, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5295069687449651132, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
@@ -406,6 +406,7 @@ MonoBehaviour:
   openedSprite: {fileID: 11400000, guid: cc73178d517fe324b95168df570fa6f7, type: 2}
   openingVerb: spark
   openingRequirementText: You need to spark this first before using it!
+  glowHandler: {fileID: 0}
   runsOutOverTime: 1
   runsOutOverSeconds: 356
   actionButton: {fileID: 2755709628018005534}

--- a/UnityProject/Assets/Prefabs/Items/Tools/Lights/Flare.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/Lights/Flare.prefab
@@ -1,21 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-8188105322153847258
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4784655301099371187}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8688576ed720a4f40b3583f62adeeb23, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  groundReagents:
-    m_keys:
-    - {fileID: 11400000, guid: 5758bc33729d6b659a58df7a702e162e, type: 2}
-    m_values: 0f000000
 --- !u!1001 &1004520157929427565
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -212,7 +196,7 @@ PrefabInstance:
     - target: {fileID: 5334267868750357690, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
       propertyPath: IsOn
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5334267868750357690, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
@@ -265,6 +249,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: e12562cf43e036c4fbde5d16036bef95,
         type: 3}
+    - target: {fileID: 5621077696875497794, guid: 6f371050bff8b32438f91c7c680900bb,
+        type: 3}
+      propertyPath: customNetTransform
+      value: 
+      objectReference: {fileID: 4896307685547251555}
     - target: {fileID: 5621181726967715178, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
       propertyPath: m_AssetId
@@ -339,3 +328,84 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 1004520157929427565}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &4896307685547251555 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5621592014544258318, guid: 6f371050bff8b32438f91c7c680900bb,
+    type: 3}
+  m_PrefabInstance: {fileID: 1004520157929427565}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4784655301099371187}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2755709628018005534 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: -6066636166583991181, guid: 6f371050bff8b32438f91c7c680900bb,
+    type: 3}
+  m_PrefabInstance: {fileID: 1004520157929427565}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4784655301099371187}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1360d2b65a03cdf449035cd3c4cd0153, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1666505115895660852 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1932141341405303641, guid: 6f371050bff8b32438f91c7c680900bb,
+    type: 3}
+  m_PrefabInstance: {fileID: 1004520157929427565}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &-8188105322153847258
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4784655301099371187}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8688576ed720a4f40b3583f62adeeb23, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  groundReagents:
+    m_keys:
+    - {fileID: 11400000, guid: 5758bc33729d6b659a58df7a702e162e, type: 2}
+    m_values: 0f000000
+--- !u!114 &1149402479745122159
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4784655301099371187}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cc6687cf50be4f82a8559dd623f577bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  spriteHandler: {fileID: 1666505115895660852}
+  destroyThisComponentOnOpen: 1
+  openingNoise:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  openedSprite: {fileID: 11400000, guid: cc73178d517fe324b95168df570fa6f7, type: 2}
+  openingVerb: spark
+  openingRequirementText: You need to spark this first before using it!
+  runsOutOverTime: 1
+  runsOutOverSeconds: 356
+  actionButton: {fileID: 2755709628018005534}

--- a/UnityProject/Assets/Prefabs/Items/Tools/Lights/Flare.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/Lights/Flare.prefab
@@ -407,6 +407,7 @@ MonoBehaviour:
   openingVerb: spark
   openingRequirementText: You need to spark this first before using it!
   glowHandler: {fileID: 0}
+  sparkOnOpen: 1
   runsOutOverTime: 1
   runsOutOverSeconds: 356
   actionButton: {fileID: 2755709628018005534}

--- a/UnityProject/Assets/Prefabs/Items/Tools/Lights/Glowsticks/Glowstick.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/Lights/Glowsticks/Glowstick.prefab
@@ -1,23 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &1575976863986952211
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4784655301099371187}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8688576ed720a4f40b3583f62adeeb23, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  groundReagents:
-    m_keys:
-    - {fileID: 11400000, guid: e491e0411dc22a5e28ef4d7a4685a3c1, type: 2}
-    - {fileID: 11400000, guid: b96ae222601db3faca1e9f832716f776, type: 2}
-    - {fileID: 11400000, guid: 72991f100b5704f5fb63c9629fcdeb6c, type: 2}
-    m_values: 0f0000000a00000005000000
 --- !u!1 &6883558287719408465
 GameObject:
   m_ObjectHideFlags: 0
@@ -35,7 +17,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &4302792187778836755
 Transform:
   m_ObjectHideFlags: 0
@@ -118,6 +100,7 @@ MonoBehaviour:
   SubCatalogue: []
   PresentSpriteSet: {fileID: 11400000, guid: b17bebc68a303e341ad9ae325f44e7ce, type: 2}
   randomInitialSprite: 0
+  doReverseAnimation: 0
   pushTextureOnStartUp: 1
   initialVariantIndex: 0
   palette: []
@@ -308,7 +291,7 @@ PrefabInstance:
     - target: {fileID: 5334267868750357690, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
       propertyPath: IsOn
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5334267868750357690, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
@@ -361,6 +344,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: e3a3dacaa74cf2c458198e3a7584b736,
         type: 3}
+    - target: {fileID: 5621077696875497794, guid: 6f371050bff8b32438f91c7c680900bb,
+        type: 3}
+      propertyPath: customNetTransform
+      value: 
+      objectReference: {fileID: 4896307685547251555}
     - target: {fileID: 5621181726967715178, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
       propertyPath: m_AssetId
@@ -446,3 +434,87 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1004520157929427565}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &4896307685547251555 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5621592014544258318, guid: 6f371050bff8b32438f91c7c680900bb,
+    type: 3}
+  m_PrefabInstance: {fileID: 1004520157929427565}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4784655301099371187}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2755709628018005534 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: -6066636166583991181, guid: 6f371050bff8b32438f91c7c680900bb,
+    type: 3}
+  m_PrefabInstance: {fileID: 1004520157929427565}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4784655301099371187}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1360d2b65a03cdf449035cd3c4cd0153, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1666505115895660852 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1932141341405303641, guid: 6f371050bff8b32438f91c7c680900bb,
+    type: 3}
+  m_PrefabInstance: {fileID: 1004520157929427565}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1575976863986952211
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4784655301099371187}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8688576ed720a4f40b3583f62adeeb23, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  groundReagents:
+    m_keys:
+    - {fileID: 11400000, guid: e491e0411dc22a5e28ef4d7a4685a3c1, type: 2}
+    - {fileID: 11400000, guid: b96ae222601db3faca1e9f832716f776, type: 2}
+    - {fileID: 11400000, guid: 72991f100b5704f5fb63c9629fcdeb6c, type: 2}
+    m_values: 0f0000000a00000005000000
+--- !u!114 &8424038021775439129
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4784655301099371187}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cc6687cf50be4f82a8559dd623f577bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  spriteHandler: {fileID: 1666505115895660852}
+  destroyThisComponentOnOpen: 1
+  openingNoise:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  openedSprite: {fileID: 0}
+  openingVerb: spark
+  openingRequirementText: You need to spark this first before using it!
+  glowHandler: {fileID: 1093619615679929208}
+  runsOutOverTime: 1
+  runsOutOverSeconds: 128
+  actionButton: {fileID: 2755709628018005534}

--- a/UnityProject/Assets/Scripts/Items/HandPreparable.cs
+++ b/UnityProject/Assets/Scripts/Items/HandPreparable.cs
@@ -10,11 +10,11 @@ namespace Items
 		public bool IsPrepared => isPrepared;
 
 
-		[SerializeField] private SpriteHandler spriteHandler;
-		[SerializeField] private bool destroyThisComponentOnOpen = true;
+		[SerializeField] protected SpriteHandler spriteHandler;
+		[SerializeField] protected bool destroyThisComponentOnOpen = true;
 		[Header("Feedback")]
 		[SerializeField] private AddressableAudioSource openingNoise;
-		[SerializeField] private SpriteDataSO openedSprite;
+		[SerializeField] protected SpriteDataSO openedSprite;
 		[Header("Chat Stuff")]
 		[SerializeField] private string openingVerb = "open";
 		public string openingRequirementText = "You need to open this first before using it!";
@@ -25,7 +25,7 @@ namespace Items
 			Chat.AddExamineMsg(interaction.Performer, $"You {openingVerb} the {gameObject.ExpensiveName()}");
 		}
 
-		public void Open()
+		public virtual void Open()
 		{
 			isPrepared = true;
 			if (openingNoise != null) SoundManager.PlayNetworkedAtPos(openingNoise, gameObject.AssumedWorldPosServer());
@@ -37,7 +37,7 @@ namespace Items
 		{
 			var rightClickResult = new RightClickableResult();
 			if (isPrepared) return rightClickResult;
-			rightClickResult.AddElement("Open This", Open);
+			rightClickResult.AddElement($"{openingVerb}", Open);
 			return rightClickResult;
 		}
 

--- a/UnityProject/Assets/Scripts/Items/Others/LightPreparable.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/LightPreparable.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Threading.Tasks;
+using System.Collections;
 using NaughtyAttributes;
 using Systems.Explosions;
 using UI.Action;
@@ -36,19 +36,24 @@ namespace Items.Others
 			actionButton.ServerActionClicked += Open;
 		}
 
+		private void OnDisable()
+		{
+			StopCoroutine(LightsOutAfterTime(lightControl, spriteHandler));
+		}
+
 		public override void Open()
 		{
 			lightControl.Toggle(true);
 			if(sparkOnOpen) SparkUtil.TrySpark(gameObject);
-			if(runsOutOverTime) LightsOutAfterTime(lightControl, spriteHandler);
+			if(runsOutOverTime) StartCoroutine(LightsOutAfterTime(lightControl, spriteHandler));
 			if(glowHandler != null) glowHandler.SetActive(true);
 			actionButton.ServerActionClicked -= Open;
 			base.Open();
 		}
 
-		private async void LightsOutAfterTime(ItemLightControl lightController, SpriteHandler handler)
+		private IEnumerator LightsOutAfterTime(ItemLightControl lightController, SpriteHandler handler)
 		{
-			await Task.Delay((int)runsOutOverSeconds * 1000);
+			yield return WaitFor.Seconds(runsOutOverSeconds);
 			lightController.Toggle(false);
 			handler.SetSpriteSO(offSprite);
 		}

--- a/UnityProject/Assets/Scripts/Items/Others/LightPreparable.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/LightPreparable.cs
@@ -11,6 +11,8 @@ namespace Items.Others
 	{
 		private ItemLightControl lightControl;
 		private SpriteDataSO offSprite;
+		[SerializeField, Tooltip("GlowSprite's handlers cannot be automatically fetched from Awake()")]
+		private SpriteHandler glowHandler;
 		[SerializeField]
 		private bool runsOutOverTime = false;
 		[SerializeField, ShowIf(nameof(runsOutOverTime))]
@@ -26,6 +28,7 @@ namespace Items.Others
 				destroyThisComponentOnOpen = false;
 				offSprite = spriteHandler.GetCurrentSpriteSO();
 			}
+			if(glowHandler != null) glowHandler.SetActive(false);
 			if(actionButton == null) return;
 			actionButton.ServerActionClicked += Open;
 		}
@@ -34,6 +37,7 @@ namespace Items.Others
 		{
 			lightControl.Toggle(true);
 			if(runsOutOverTime) LightsOutAfterTime(lightControl, spriteHandler);
+			if(glowHandler != null) glowHandler.SetActive(true);
 			actionButton.ServerActionClicked -= Open;
 			base.Open();
 		}

--- a/UnityProject/Assets/Scripts/Items/Others/LightPreparable.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/LightPreparable.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using NaughtyAttributes;
+using Systems.Explosions;
 using UI.Action;
 using UnityEngine;
 
@@ -13,6 +14,8 @@ namespace Items.Others
 		private SpriteDataSO offSprite;
 		[SerializeField, Tooltip("GlowSprite's handlers cannot be automatically fetched from Awake()")]
 		private SpriteHandler glowHandler;
+		[SerializeField, Tooltip("Create a spark when activating this light source?")]
+		private bool sparkOnOpen = false;
 		[SerializeField]
 		private bool runsOutOverTime = false;
 		[SerializeField, ShowIf(nameof(runsOutOverTime))]
@@ -36,6 +39,7 @@ namespace Items.Others
 		public override void Open()
 		{
 			lightControl.Toggle(true);
+			if(sparkOnOpen) SparkUtil.TrySpark(gameObject);
 			if(runsOutOverTime) LightsOutAfterTime(lightControl, spriteHandler);
 			if(glowHandler != null) glowHandler.SetActive(true);
 			actionButton.ServerActionClicked -= Open;

--- a/UnityProject/Assets/Scripts/Items/Others/LightPreparable.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/LightPreparable.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Threading.Tasks;
+using NaughtyAttributes;
+using UI.Action;
+using UnityEngine;
+
+namespace Items.Others
+{
+	[RequireComponent(typeof(ItemLightControl))]
+	public class LightPreparable : HandPreparable
+	{
+		private ItemLightControl lightControl;
+		private SpriteDataSO offSprite;
+		[SerializeField]
+		private bool runsOutOverTime = false;
+		[SerializeField, ShowIf(nameof(runsOutOverTime))]
+		private float runsOutOverSeconds = 356;
+		[SerializeField] private ItemActionButton actionButton;
+
+
+		private void Awake()
+		{
+			lightControl = GetComponent<ItemLightControl>();
+			if (runsOutOverTime)
+			{
+				destroyThisComponentOnOpen = false;
+				offSprite = spriteHandler.GetCurrentSpriteSO();
+			}
+			if(actionButton == null) return;
+			actionButton.ServerActionClicked += Open;
+		}
+
+		public override void Open()
+		{
+			lightControl.Toggle(true);
+			if(runsOutOverTime) LightsOutAfterTime(lightControl, spriteHandler);
+			actionButton.ServerActionClicked -= Open;
+			base.Open();
+		}
+
+		private async void LightsOutAfterTime(ItemLightControl lightController, SpriteHandler handler)
+		{
+			await Task.Delay((int)runsOutOverSeconds * 1000);
+			lightController.Toggle(false);
+			handler.SetSpriteSO(offSprite);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Others/LightPreparable.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Others/LightPreparable.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cc6687cf50be4f82a8559dd623f577bd
+timeCreated: 1645393848


### PR DESCRIPTION
Flares and Glowsticks now need to be sparked before use and can go out over time.

### Changelog:
CL: [New] - Flares and glowsticks will no longer have an infinite duration of light time. (129s for glowsticks, 356s for flares)
CL: [New] - Flares and glowsticks now require you to active them to light up.
CL: [New] - The action button of flares and glowsticks actually have a functionality now.
CL: [New] - Lighting up a flare causes a spark, be careful when lighting it near plasma!
