### PR TITLE
Emote system minor improvements, Screaming in pain and silencing your victims

### DIFF
--- a/UnityProject/Assets/Prefabs/Chat/ChatSystem.prefab
+++ b/UnityProject/Assets/Prefabs/Chat/ChatSystem.prefab
@@ -285,39 +285,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac9bec248156f5049a8ec842e4e1ed1c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  emotes:
-  - {fileID: 11400000, guid: 3b36b8c1a120cf34892752e6cba06558, type: 2}
-  - {fileID: 11400000, guid: 35c060ad09014bf4690dd84514d19ba9, type: 2}
-  - {fileID: 11400000, guid: 2cff1736527c3894fbdd981f71cc3d1e, type: 2}
-  - {fileID: 11400000, guid: 4bb81994d958ca945954c16262de2ec5, type: 2}
-  - {fileID: 11400000, guid: 49d5db6253e00f841b34c5b5a18fecd3, type: 2}
-  - {fileID: 11400000, guid: 5c9ded2a35848bc47affeda0c86062eb, type: 2}
-  - {fileID: 11400000, guid: b006c1f2e8da3c240a204541f7050a17, type: 2}
-  - {fileID: 11400000, guid: dd98449149813e24bb29b171c4e2eead, type: 2}
-  - {fileID: 11400000, guid: 326dded195ee0854295ba3fcd0dd0606, type: 2}
-  - {fileID: 11400000, guid: d930b33c2fc8c444a9cc7aa8533491ac, type: 2}
-  - {fileID: 11400000, guid: a2057a2da8bb8e04991de39d67c9979f, type: 2}
-  - {fileID: 11400000, guid: c5a62d06ca7357e4185aa698ff299f90, type: 2}
-  - {fileID: 11400000, guid: ba36907d9303c224ab97ff89832da1a8, type: 2}
-  - {fileID: 11400000, guid: b9f45ae3a374b754f9345f3883dc97eb, type: 2}
-  - {fileID: 11400000, guid: 5f235a824ea0645448bfdf386d2f073d, type: 2}
-  - {fileID: 11400000, guid: 042246a1ce11bc844bf8ed52b2b743be, type: 2}
-  - {fileID: 11400000, guid: c330a7cbe2059774fafd4a32d2eabecc, type: 2}
-  - {fileID: 11400000, guid: c330a7cbe2059774fafd4a32d2eabecc, type: 2}
-  - {fileID: 11400000, guid: 5d61ca3eb68b81946b8226b482703158, type: 2}
-  - {fileID: 11400000, guid: 1e2b175c8a78ba14b906ea42d08bc95c, type: 2}
-  - {fileID: 11400000, guid: cbd54165afc94e74eacb864267c4b033, type: 2}
-  - {fileID: 11400000, guid: fc470e3dd8b0a624a80a7b83686364c4, type: 2}
-  - {fileID: 11400000, guid: 9429737f18b346a409431a348e18d56d, type: 2}
-  - {fileID: 11400000, guid: 5472288fc970f4746b2c56ad42d9b5d8, type: 2}
-  - {fileID: 11400000, guid: 22ecbf3fe05075d45a7cb1df2d445c9c, type: 2}
-  - {fileID: 11400000, guid: c167f7374cdcf604a82efb440115efe4, type: 2}
-  - {fileID: 11400000, guid: 342b62c84c4954948849be8c4cff4ab4, type: 2}
-  - {fileID: 11400000, guid: fb8b997c55238654087b9aa99d5be1a1, type: 2}
-  - {fileID: 11400000, guid: 3206515809289334b92fd3117abc6264, type: 2}
-  - {fileID: 11400000, guid: 27930c9d10ecc4d40adad31fe910fddb, type: 2}
-  - {fileID: 11400000, guid: 0e21ef31e555dfb48a51959c3589ed89, type: 2}
-  - {fileID: 11400000, guid: 95dd82f55e7525544b644da7671f0890, type: 2}
-  - {fileID: 11400000, guid: 46f3f1cab09fa684d85d1fe9f0db0b7f, type: 2}
-  - {fileID: 11400000, guid: 82ba56953f6e83747a59713094e84e70, type: 2}
-  - {fileID: 11400000, guid: 7d5995929c9a86e4784da6a2cd594b55, type: 2}
+  emoteList: {fileID: 11400000, guid: 1530b58206feb2949afb378698755a1b, type: 2}

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Maskwear/Muzzle.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Maskwear/Muzzle.prefab
@@ -44,6 +44,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 60f0164788806f0438c27bbf24e6381b
       objectReference: {fileID: 0}
+    - target: {fileID: 7560695730306467613, guid: 05a135eab68164d34bb02b82fff3cde0,
+        type: 3}
+      propertyPath: customNetTransform
+      value: 
+      objectReference: {fileID: 2757585009989508541}
     - target: {fileID: 7596215297033493493, guid: 05a135eab68164d34bb02b82fff3cde0,
         type: 3}
       propertyPath: m_RootOrder
@@ -125,5 +130,28 @@ PrefabInstance:
       propertyPath: initialDescription
       value: To stop that awful noise.
       objectReference: {fileID: 0}
+    - target: {fileID: 8040391005062056419, guid: 05a135eab68164d34bb02b82fff3cde0,
+        type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8040391005062056419, guid: 05a135eab68164d34bb02b82fff3cde0,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: ddd8c57e8631c3d46a4a2eb42bd4a5e3,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 05a135eab68164d34bb02b82fff3cde0, type: 3}
+--- !u!114 &2757585009989508541 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7560700382122150737, guid: 05a135eab68164d34bb02b82fff3cde0,
+    type: 3}
+  m_PrefabInstance: {fileID: 5668316713118127852}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
+++ b/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
@@ -1060,6 +1060,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  CanRotateIfNotMovable: 0
 --- !u!114 &7092917086790084979
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1095,6 +1096,9 @@ MonoBehaviour:
   SurfaceBodyParts: []
   BodyPartStorage: {fileID: 0}
   playerSprites: {fileID: 0}
+  painScreamDamage: 20
+  painScreamCooldown: 15
+  screamEmote: {fileID: 11400000, guid: c167f7374cdcf604a82efb440115efe4, type: 2}
   rootBodyPartController: {fileID: 0}
   playerScript: {fileID: 0}
   CHem: {fileID: 11400000, guid: 6c3a3878e8878972ea633a27c6d0ba12, type: 2}

--- a/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
+++ b/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
@@ -1096,7 +1096,7 @@ MonoBehaviour:
   SurfaceBodyParts: []
   BodyPartStorage: {fileID: 0}
   playerSprites: {fileID: 0}
-  painScreamDamage: 20
+  painScreamDamage: 18
   painScreamCooldown: 15
   screamEmote: {fileID: 11400000, guid: c167f7374cdcf604a82efb440115efe4, type: 2}
   rootBodyPartController: {fileID: 0}

--- a/UnityProject/Assets/ScriptableObjects/Emotes/EmoteListSO.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/EmoteListSO.asset
@@ -1,0 +1,50 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 92b8012b609d4a56a3d696639ffc3e29, type: 3}
+  m_Name: EmoteListSO
+  m_EditorClassIdentifier: 
+  Emotes:
+  - {fileID: 11400000, guid: 3b36b8c1a120cf34892752e6cba06558, type: 2}
+  - {fileID: 11400000, guid: 35c060ad09014bf4690dd84514d19ba9, type: 2}
+  - {fileID: 11400000, guid: 2cff1736527c3894fbdd981f71cc3d1e, type: 2}
+  - {fileID: 11400000, guid: 4bb81994d958ca945954c16262de2ec5, type: 2}
+  - {fileID: 11400000, guid: 49d5db6253e00f841b34c5b5a18fecd3, type: 2}
+  - {fileID: 11400000, guid: 5c9ded2a35848bc47affeda0c86062eb, type: 2}
+  - {fileID: 11400000, guid: b006c1f2e8da3c240a204541f7050a17, type: 2}
+  - {fileID: 11400000, guid: dd98449149813e24bb29b171c4e2eead, type: 2}
+  - {fileID: 11400000, guid: 326dded195ee0854295ba3fcd0dd0606, type: 2}
+  - {fileID: 11400000, guid: d930b33c2fc8c444a9cc7aa8533491ac, type: 2}
+  - {fileID: 11400000, guid: a2057a2da8bb8e04991de39d67c9979f, type: 2}
+  - {fileID: 11400000, guid: c5a62d06ca7357e4185aa698ff299f90, type: 2}
+  - {fileID: 11400000, guid: ba36907d9303c224ab97ff89832da1a8, type: 2}
+  - {fileID: 11400000, guid: b9f45ae3a374b754f9345f3883dc97eb, type: 2}
+  - {fileID: 11400000, guid: 5f235a824ea0645448bfdf386d2f073d, type: 2}
+  - {fileID: 11400000, guid: 042246a1ce11bc844bf8ed52b2b743be, type: 2}
+  - {fileID: 11400000, guid: c330a7cbe2059774fafd4a32d2eabecc, type: 2}
+  - {fileID: 11400000, guid: c330a7cbe2059774fafd4a32d2eabecc, type: 2}
+  - {fileID: 11400000, guid: 5d61ca3eb68b81946b8226b482703158, type: 2}
+  - {fileID: 11400000, guid: 1e2b175c8a78ba14b906ea42d08bc95c, type: 2}
+  - {fileID: 11400000, guid: cbd54165afc94e74eacb864267c4b033, type: 2}
+  - {fileID: 11400000, guid: fc470e3dd8b0a624a80a7b83686364c4, type: 2}
+  - {fileID: 11400000, guid: 9429737f18b346a409431a348e18d56d, type: 2}
+  - {fileID: 11400000, guid: 5472288fc970f4746b2c56ad42d9b5d8, type: 2}
+  - {fileID: 11400000, guid: 22ecbf3fe05075d45a7cb1df2d445c9c, type: 2}
+  - {fileID: 11400000, guid: c167f7374cdcf604a82efb440115efe4, type: 2}
+  - {fileID: 11400000, guid: 342b62c84c4954948849be8c4cff4ab4, type: 2}
+  - {fileID: 11400000, guid: fb8b997c55238654087b9aa99d5be1a1, type: 2}
+  - {fileID: 11400000, guid: 3206515809289334b92fd3117abc6264, type: 2}
+  - {fileID: 11400000, guid: 27930c9d10ecc4d40adad31fe910fddb, type: 2}
+  - {fileID: 11400000, guid: 0e21ef31e555dfb48a51959c3589ed89, type: 2}
+  - {fileID: 11400000, guid: 95dd82f55e7525544b644da7671f0890, type: 2}
+  - {fileID: 11400000, guid: 46f3f1cab09fa684d85d1fe9f0db0b7f, type: 2}
+  - {fileID: 11400000, guid: 82ba56953f6e83747a59713094e84e70, type: 2}
+  - {fileID: 11400000, guid: 7d5995929c9a86e4784da6a2cd594b55, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Emotes/EmoteListSO.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/EmoteListSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1530b58206feb2949afb378698755a1b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Emotes/basicGenderedEmotes/Scream.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/basicGenderedEmotes/Scream.asset
@@ -15,10 +15,12 @@ MonoBehaviour:
   emoteName: scream
   requiresHands: 0
   allowEmoteWhileInCrit: 1
+  isAudibleEmote: 1
   allowEmoteWhileCrawling: 1
   viewText: Screams!
   youText: You scream!
   failText: You cannot scream!
+  mouthBlockedText: You try to scream but are unable to make a sound!
   critViewText: screams in pain!
   defaultSounds: []
   maleSounds: []

--- a/UnityProject/Assets/ScriptableObjects/Traits/CommonTraitsSingleton.asset
+++ b/UnityProject/Assets/ScriptableObjects/Traits/CommonTraitsSingleton.asset
@@ -65,6 +65,7 @@ MonoBehaviour:
   CanisterFillable: {fileID: 11400000, guid: a88f1555ca8abf643aea180c637f5329, type: 2}
   Breakable: {fileID: 11400000, guid: 86782de91b339c1438d9f4e310d321f4, type: 2}
   EMPResistant: {fileID: 11400000, guid: 0d6975d5c3876ee4cbb276a81b059cfb, type: 2}
+  Gag: {fileID: 11400000, guid: ddd8c57e8631c3d46a4a2eb42bd4a5e3, type: 2}
   OreGeneral: {fileID: 11400000, guid: 3c430c1e9384ac647a81057064b1d664, type: 2}
   MetalSheet: {fileID: 11400000, guid: f27d5423a79d84fcab6199b0c5a47f4e, type: 2}
   GlassSheet: {fileID: 11400000, guid: ef95b18f5d8aa42d2b4241d48a97d81d, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Traits/Effect/Gag.asset
+++ b/UnityProject/Assets/ScriptableObjects/Traits/Effect/Gag.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ccfe138752d4b66bcb7c56a0c9769c7, type: 3}
+  m_Name: Gag
+  m_EditorClassIdentifier: 
+  traitDescription: Prevents the user from emitting vocal noise.

--- a/UnityProject/Assets/ScriptableObjects/Traits/Effect/Gag.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Traits/Effect/Gag.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ddd8c57e8631c3d46a4a2eb42bd4a5e3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Core/Chat/EmoteActionManager.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/EmoteActionManager.cs
@@ -7,14 +7,19 @@ namespace Core.Chat
 {
 	public class EmoteActionManager : MonoBehaviour
 	{
-		[SerializeField]
-		private List<EmoteSO> emotes;
+		public static EmoteActionManager Instance;
+		[SerializeField] private EmoteListSO emoteList;
+
+		private void Awake()
+		{
+			Instance = this;
+		}
 
 		public static bool HasEmote(string emote, EmoteActionManager instance)
 		{
 			string[] emoteArray = emote.Split(' ');
 
-			foreach (var e in instance.emotes)
+			foreach (var e in instance.emoteList.Emotes)
 			{
 				if(emoteArray[0].Equals(e.EmoteName, StringComparison.CurrentCultureIgnoreCase))
 				{
@@ -26,13 +31,22 @@ namespace Core.Chat
 
 		public static void DoEmote(string emote, GameObject player, EmoteActionManager instance)
 		{
-			foreach (var e in instance.emotes)
+			foreach (var e in instance.emoteList.Emotes)
 			{
 				if(emote.Equals(e.EmoteName, StringComparison.CurrentCultureIgnoreCase))
 				{
 					e.Do(player);
 					return;
 				}
+			}
+		}
+
+		public static void DoEmote(EmoteSO emoteSo, GameObject player)
+		{
+			foreach (var emote in Instance.emoteList.Emotes)
+			{
+				if(emote != emoteSo) continue;
+				emote.Do(player);
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Core/Chat/EmoteActionManager.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/EmoteActionManager.cs
@@ -5,15 +5,9 @@ using UnityEngine;
 
 namespace Core.Chat
 {
-	public class EmoteActionManager : MonoBehaviour
+	public class EmoteActionManager : Managers.SingletonManager<EmoteActionManager>
 	{
-		public static EmoteActionManager Instance;
 		[SerializeField] private EmoteListSO emoteList;
-
-		private void Awake()
-		{
-			Instance = this;
-		}
 
 		public static bool HasEmote(string emote, EmoteActionManager instance)
 		{

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -1400,7 +1400,8 @@ namespace HealthV2
 
 		public void IndicatePain(float dmgTaken = 0f)
 		{
-			if(EmoteActionManager.Instance == null || screamEmote == null || canScream == false) return;
+			if(EmoteActionManager.Instance == null || screamEmote == null || 
+			   canScream == false || ConsciousState == ConsciousState.UNCONSCIOUS || IsDead) return;
 			if(dmgTaken <= 0f || dmgTaken >= painScreamDamage) EmoteActionManager.DoEmote(screamEmote, playerScript.gameObject);
 			StartCoroutine(ScreamCooldown());
 		}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -1400,7 +1400,7 @@ namespace HealthV2
 
 		public void IndicatePain(float dmgTaken = 0f)
 		{
-			if(EmoteActionManager.Instance == null || screamEmote == null || 
+			if(EmoteActionManager.Instance == null || screamEmote == null ||
 			   canScream == false || ConsciousState == ConsciousState.UNCONSCIOUS || IsDead) return;
 			if(dmgTaken <= 0f || dmgTaken >= painScreamDamage) EmoteActionManager.DoEmote(screamEmote, playerScript.gameObject);
 			StartCoroutine(ScreamCooldown());

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -1400,10 +1400,9 @@ namespace HealthV2
 
 		public void IndicatePain(float dmgTaken = 0f)
 		{
-			if(EmoteActionManager.Instance == null || screamEmote == null) return;
+			if(EmoteActionManager.Instance == null || screamEmote == null || canScream == false) return;
 			if(dmgTaken <= 0f || dmgTaken >= painScreamDamage) EmoteActionManager.DoEmote(screamEmote, playerScript.gameObject);
 			StartCoroutine(ScreamCooldown());
-
 		}
 		private IEnumerator ScreamCooldown()
 		{

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -7,10 +8,13 @@ using UnityEngine.Events;
 using Mirror;
 using Systems.Atmospherics;
 using Chemistry;
+using Core.Chat;
 using Health.Sickness;
 using JetBrains.Annotations;
+using NaughtyAttributes;
 using Player;
 using Newtonsoft.Json;
+using ScriptableObjects.RP;
 
 namespace HealthV2
 {
@@ -151,6 +155,11 @@ namespace HealthV2
 
 		private float maxBleedStacks = 10f;
 
+		[SerializeField, BoxGroup("PainFeedback")] private float painScreamDamage = 20f;
+		[SerializeField, BoxGroup("PainFeedback")] private float painScreamCooldown = 15f;
+		[SerializeField, BoxGroup("PainFeedback")] private EmoteSO screamEmote;
+		private bool canScream = true;
+
 		private ObjectBehaviour objectBehaviour;
 		public ObjectBehaviour ObjectBehaviour => objectBehaviour;
 
@@ -288,6 +297,7 @@ namespace HealthV2
 			if (CustomNetworkManager.IsServer == false) return;
 
 			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, PeriodicUpdate);
+			StopCoroutine(ScreamCooldown());
 		}
 
 		public void Setbrain(Brain _brain)
@@ -632,6 +642,7 @@ namespace HealthV2
 				//TODO: Re - impliment this using the new reagent- first code introduced in PR #6810
 				//EffectsFactory.BloodSplat(RegisterTile.WorldPositionServer, BloodSplatSize.large, BloodSplatType.red);
 			}
+			IndicatePain(damage);
 		}
 
 		/// <summary>
@@ -686,6 +697,8 @@ namespace HealthV2
 						traumaDamageChance: traumaDamageChance, tramuticDamageType: tramuticDamageType);
 				}
 			}
+
+			IndicatePain(damage);
 		}
 
 		/// <summary>
@@ -1383,6 +1396,20 @@ namespace HealthV2
 			}
 
 			InternalNetIDs = NewInternalNetIDs;
+		}
+
+		public void IndicatePain(float dmgTaken = 0f)
+		{
+			if(EmoteActionManager.Instance == null || screamEmote == null) return;
+			if(dmgTaken <= 0f || dmgTaken >= painScreamDamage) EmoteActionManager.DoEmote(screamEmote, playerScript.gameObject);
+			StartCoroutine(ScreamCooldown());
+
+		}
+		private IEnumerator ScreamCooldown()
+		{
+			canScream = false;
+			yield return WaitFor.Seconds(painScreamCooldown);
+			canScream = true;
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -1398,11 +1398,11 @@ namespace HealthV2
 			InternalNetIDs = NewInternalNetIDs;
 		}
 
-		public void IndicatePain(float dmgTaken = 0f)
+		public void IndicatePain(float dmgTaken)
 		{
 			if(EmoteActionManager.Instance == null || screamEmote == null ||
 			   canScream == false || ConsciousState == ConsciousState.UNCONSCIOUS || IsDead) return;
-			if(dmgTaken <= 0f || dmgTaken >= painScreamDamage) EmoteActionManager.DoEmote(screamEmote, playerScript.gameObject);
+			if(dmgTaken >= painScreamDamage) EmoteActionManager.DoEmote(screamEmote, playerScript.gameObject);
 			StartCoroutine(ScreamCooldown());
 		}
 		private IEnumerator ScreamCooldown()

--- a/UnityProject/Assets/Scripts/Items/Traits/CommonTraits.cs
+++ b/UnityProject/Assets/Scripts/Items/Traits/CommonTraits.cs
@@ -67,6 +67,7 @@ public class CommonTraits : SingletonScriptableObject<CommonTraits>
 	[BoxGroup("Characteristics")] public ItemTrait CanisterFillable;
 	[BoxGroup("Characteristics")] public ItemTrait Breakable;
 	[BoxGroup("Characteristics")] public ItemTrait EMPResistant;
+	[BoxGroup("Characteristics")] public ItemTrait Gag;
 
 	[BoxGroup("Materials")] public ItemTrait OreGeneral;
 	[BoxGroup("Materials")] public ItemTrait MetalSheet;

--- a/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteListSO.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteListSO.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace ScriptableObjects.RP
+{
+	[CreateAssetMenu(fileName = "EmoteListSO", menuName = "ScriptableObjects/RP/Emotes/EmoteList")]
+	public class EmoteListSO : ScriptableObject
+	{
+		public List<EmoteSO> Emotes = new List<EmoteSO>();
+	}
+}

--- a/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteListSO.cs.meta
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteListSO.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 92b8012b609d4a56a3d696639ffc3e29
+timeCreated: 1645679045

--- a/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
@@ -85,12 +85,12 @@ namespace ScriptableObjects.RP
 				FailText(player, FailType.Normal);
 				return;
 			}
-			else if (requiresHands && CheckHandState(player) == false)
+			if (requiresHands && CheckHandState(player) == false)
 			{
 				FailText(player, FailType.Normal);
 				return;
 			}
-			else if (CheckIfPlayerIsGagged(player))
+			if (CheckIfPlayerIsGagged(player))
 			{
 				FailText(player, FailType.MouthBlocked);
 				return;
@@ -199,12 +199,13 @@ namespace ScriptableObjects.RP
 		{
 			//TODO : This sort of thing should be checked on the player script when reworking telecomms and adding a proper silencing system
 			player.TryGetComponent<PlayerScript>(out var script);
-			if (script.mind.occupation.JobType == JobType.MIME) return true;
+			if (script.mind.occupation.JobType == JobType.MIME) return true; //FIXME : Find a way to check if vow of silence is broken
 			var playerInventory = script.DynamicItemStorage;
 			var masks = playerInventory.GetNamedItemSlots(NamedSlot.mask);
 			foreach (var slot in masks)
 			{
 				if(slot.IsEmpty) continue;
+				Debug.Log(slot.Item.ItemAttributesV2.ArticleName);
 				if (slot.ItemAttributes.HasTrait(CommonTraits.Instance.Gag)) return true;
 			}
 			return false;

--- a/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
@@ -200,8 +200,9 @@ namespace ScriptableObjects.RP
 			//TODO : This sort of thing should be checked on the player script when reworking telecomms and adding a proper silencing system
 			player.TryGetComponent<PlayerScript>(out var script);
 			if (script.mind.occupation.JobType == JobType.MIME) return true; //FIXME : Find a way to check if vow of silence is broken
-			var playerInventory = script.DynamicItemStorage;
-			var masks = playerInventory.GetNamedItemSlots(NamedSlot.mask);
+			var playerInventory = script.Equipment;
+			var masks = playerInventory.ItemStorage.GetNamedItemSlots(NamedSlot.mask);
+			Debug.Log(masks);
 			foreach (var slot in masks)
 			{
 				if(slot.IsEmpty) continue;

--- a/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
@@ -182,7 +182,6 @@ namespace ScriptableObjects.RP
 			foreach (var slot in script.Equipment.ItemStorage.GetItemSlots())
 			{
 				if(slot.IsEmpty) continue;
-				Debug.Log(slot.Item.ItemAttributesV2.ArticleName);
 				if (slot.ItemAttributes.HasTrait(CommonTraits.Instance.Gag)) return true;
 			}
 			return false;

--- a/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
@@ -90,7 +90,7 @@ namespace ScriptableObjects.RP
 				FailText(player, FailType.Normal);
 				return;
 			}
-			if (isAudibleEmote &&CheckIfPlayerIsGagged(player))
+			if (isAudibleEmote && CheckIfPlayerIsGagged(player))
 			{
 				FailText(player, FailType.MouthBlocked);
 				return;

--- a/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
@@ -90,7 +90,7 @@ namespace ScriptableObjects.RP
 				FailText(player, FailType.Normal);
 				return;
 			}
-			if (CheckIfPlayerIsGagged(player))
+			if (isAudibleEmote &&CheckIfPlayerIsGagged(player))
 			{
 				FailText(player, FailType.MouthBlocked);
 				return;

--- a/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
@@ -74,26 +74,11 @@ namespace ScriptableObjects.RP
 
 		public virtual void Do(GameObject player)
 		{
-			if (allowEmoteWhileInCrit == false && CheckPlayerCritState(player))
-			{
-				FailText(player, FailType.Critical);
-				return;
-			}
-			if ((allowEmoteWhileCrawling == false && CheckIfPlayerIsCrawling(player))
-			         || (requiresHands && CheckHandState(player) == false))
-			{
-				FailText(player, FailType.Normal);
-				return;
-			}
-			if (isAudibleEmote && CheckIfPlayerIsGagged(player))
-			{
-				FailText(player, FailType.MouthBlocked);
-				return;
-			}
-
+			if(CheckAllBaseConditions(player) == false) return;
 			Chat.AddActionMsgToChat(player, $"{youText}", $"{player.ExpensiveName()} {viewText}.");
 			PlayAudio(defaultSounds, player);
 		}
+
 
 		/// <summary>
 		/// Use this instead of rewriting Chat.AddActionMsgToChat() when adding text to a failed conditon.
@@ -201,6 +186,28 @@ namespace ScriptableObjects.RP
 				if (slot.ItemAttributes.HasTrait(CommonTraits.Instance.Gag)) return true;
 			}
 			return false;
+		}
+
+		protected bool CheckAllBaseConditions(GameObject player)
+		{
+			if (allowEmoteWhileInCrit == false && CheckPlayerCritState(player))
+			{
+				FailText(player, FailType.Critical);
+				return false;
+			}
+			if ((allowEmoteWhileCrawling == false && CheckIfPlayerIsCrawling(player))
+			    || (requiresHands && CheckHandState(player) == false))
+			{
+				FailText(player, FailType.Normal);
+				return false;
+			}
+			if (isAudibleEmote && CheckIfPlayerIsGagged(player))
+			{
+				FailText(player, FailType.MouthBlocked);
+				return false;
+			}
+
+			return true;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/ScriptableObjects/RP/GenderedEmote.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/RP/GenderedEmote.cs
@@ -8,8 +8,12 @@ namespace ScriptableObjects.RP
 	{
 		private string viewTextFinal;
 
+		/// <summary>
+		/// Gendered Emote is designed for Players only and any NPC that uses HealthV2
+		/// </summary>
 		public override void Do(GameObject player)
 		{
+			if(CheckAllBaseConditions(player) == false) return;
 			HealthCheck(player);
 			Chat.AddActionMsgToChat(player, $"{youText}", $"{player.ExpensiveName()} {viewTextFinal}.");
 			PlayAudio(GetBodyTypeAudio(player), player);


### PR DESCRIPTION
Been a while since I touched this huh?
The new improvements should pave the way for #8328 to come a reality one day as the emote system is no longer just tied to text input, meaning that emotes can finally be called from wherever and whenever from now on.

Removed a check for nonbinary characters as the `default` check already does the same exact thing

Added something that we've wanted to add for a long while now but we've been so busy that me (and I think Gillies as well) haven't got around to adding and it's the ability for players to AAAAAAAAAAAAAAAAAAAAAAAAAAAA when getting attacked, players will automatically now call the scream emote when they've received over 18 damage and have a 20 second cooldown between each automatic scream.

Though sounds have still not been added yet, there will be a time where they will be and traitors and doctors will want to muffle their victims screams of pain so the pass-bying clown doesn't look for the source of the scream or report it. The "gag" trait on mask items like the muzzle will stop players from giving away their position by screaming loudly and disturbing the entire station.


### Changelog:
CL: [New] - Players will now automatically scream when receiving over 18 points of damage.
CL: [New] - The *Scream emote can now be muffled by a muzzle.
CL: [Fix] - Fixed issues where players can use specific emotes while being dead.