### PR TITLE
Fixes antags stealing objectives failing

### DIFF
--- a/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
+++ b/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
@@ -4,10 +4,8 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;
 using Systems.Atmospherics;
-using Systems.Cargo;
 using Random = UnityEngine.Random;
 using DatabaseAPI;
-using Items;
 using Messages.Client;
 using Messages.Server;
 using Messages.Server.HealthMessages;
@@ -20,6 +18,28 @@ namespace IngameDebugConsole
 	/// </summary>
 	public class DebugLogUnitystationCommands : MonoBehaviour
 	{
+		[ConsoleMethod("checkObjectivesStatus", "check the current status of your objectives")]
+		public static void CheckObjectivesStatus()
+		{
+			bool playerSpawned = PlayerManager.LocalPlayer != null;
+			if (playerSpawned == false)
+			{
+				Logger.LogError("Player has not spawned yet to be able to check for their objectives!");
+				return;
+			}
+			if (PlayerManager.LocalPlayerScript.mind.IsAntag == false)
+			{
+				Logger.LogError("Player is not an antagonist!");
+				return;
+			}
+
+			Logger.Log("Current player objectives :");
+			foreach (var objective in PlayerManager.LocalPlayerScript.mind.GetAntag().Objectives)
+			{
+				Logger.Log($"{objective.ObjectiveName} -> {objective.IsComplete()}");
+			}
+		}
+
 		[ConsoleMethod("suicide", "kill yo' self")]
 		public static void RunSuicide()
 		{
@@ -252,8 +272,8 @@ namespace IngameDebugConsole
 				PlayerSpawn.ServerSpawnDummy();
 			}
 		}
-		
-		
+
+
 #if UNITY_EDITOR
 		[MenuItem("Networking/Spawn 100 dummy players")]
 #endif

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objective.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objective.cs
@@ -111,10 +111,11 @@ namespace Antagonists
 		{
 			if (Owner.body.DynamicItemStorage == null)
 			{
+				Logger.LogError($"Unable to find dynamic storage for {Owner.body} / {Owner.body.connectedPlayer.Username}");
 				//If they have no storage then fail, as they can't have the item
 				return false;
 			}
-			
+
 			return CheckStorage(Owner.body.DynamicItemStorage, default, name) >= count;
 		}
 
@@ -127,11 +128,20 @@ namespace Antagonists
 		private int CheckStorage(DynamicItemStorage itemStorage, Type component, string name)
 		{
 			int count = 0;
-			foreach (var slot in itemStorage.GetItemSlots())
+			foreach (var slot in itemStorage.GetItemSlotTree())
 			{
 				count += CheckSlot(slot, component, name);
 			}
+			return count;
+		}
 
+		private int CheckStorage(ItemStorage itemStorage, Type component, string name)
+		{
+			int count = 0;
+			foreach (var slot in itemStorage.GetItemSlotTree())
+			{
+				count += CheckSlot(slot, component, name);
+			}
 			return count;
 		}
 
@@ -156,6 +166,11 @@ namespace Antagonists
 			if (slot.ItemObject.TryGetComponent<DynamicItemStorage>(out var itemStorage))
 			{
 				return CheckStorage(itemStorage, component, name);
+			}
+
+			if (slot.ItemObject.TryGetComponent<ItemStorage>(out var storage))
+			{
+				return CheckStorage(storage, component, name);
 			}
 
 			return 0;


### PR DESCRIPTION
fixes #7814

Also adds in a new console command for quick debugging without having to end the round every single time to test objectives.

CL: [Fix] fixes a bug causing steal objectives to fail.