### PR TITLE
Fixes Explosives not detonating because various issues

### DIFF
--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabExplosive.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabExplosive.prefab
@@ -1459,9 +1459,9 @@ MonoBehaviour:
   onValueChanged:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 6018750049248943481}
-        m_TargetAssemblyTypeName: UI.GUI_Explosive, Assets
-        m_MethodName: ToggleMode
+      - m_Target: {fileID: 3249521037430449339}
+        m_TargetAssemblyTypeName: UI.Core.NetUI.NetToggle, Assets
+        m_MethodName: ExecuteClient
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1748,9 +1748,9 @@ MonoBehaviour:
   onValueChanged:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 6018750049248943481}
-        m_TargetAssemblyTypeName: UI.GUI_Explosive, Assets
-        m_MethodName: ArmDevice
+      - m_Target: {fileID: 8769180498747938857}
+        m_TargetAssemblyTypeName: UI.Core.NetUI.NetToggle, Assets
+        m_MethodName: ExecuteClient
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabExplosive.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabExplosive.prefab
@@ -286,7 +286,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Hidden: 0
-  isPopOut: 0
+  isPopOut: 1
   Type: 46
   OnTabClosed:
     m_PersistentCalls:

--- a/UnityProject/Assets/Scripts/Items/Weapons/Explosive.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Explosive.cs
@@ -69,12 +69,6 @@ namespace Items.Weapons
 			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, UpdateBombPosition);
 		}
 
-		[Command(requiresAuthority = false)]
-		public void CmdTellServerToCountDown()
-		{
-			StartCoroutine(Countdown());
-		}
-
 		[Server]
 		public IEnumerator Countdown()
 		{
@@ -126,7 +120,7 @@ namespace Items.Weapons
 		{
 			detonateImmediatelyOnSignal = mode;
 		}
-
+		
 		[Command(requiresAuthority = false)]
 		private void CmdTellServerToDeattachExplosive()
 		{

--- a/UnityProject/Assets/Scripts/UI/Items/GUI_Explosive.cs
+++ b/UnityProject/Assets/Scripts/UI/Items/GUI_Explosive.cs
@@ -74,7 +74,7 @@ namespace UI.Items
 			{
 				modeToggleButton.enabled = false;
 				armToggleButton.enabled = true;
-				explosiveDevice.Countdown();
+				explosiveDevice.CmdTellServerToCountDown();
 				UpdateStatusText();
 				return;
 			}

--- a/UnityProject/Assets/Scripts/UI/Items/GUI_Explosive.cs
+++ b/UnityProject/Assets/Scripts/UI/Items/GUI_Explosive.cs
@@ -74,7 +74,7 @@ namespace UI.Items
 			{
 				modeToggleButton.enabled = false;
 				armToggleButton.enabled = true;
-				explosiveDevice.CmdTellServerToCountDown();
+				StartCoroutine(explosiveDevice.Countdown());
 				UpdateStatusText();
 				return;
 			}


### PR DESCRIPTION
Work on #6149 

This took a while to fix because my PC doesn't like it when I build the game even with quick build on, but I've finally had some patience today to actually sit through it to test these fixes.

C4s and X4s can now finally expload on headless servers.

### Changelog :  

CL: [Fix] - Fixed C4s and X4s failing to call functions because server/client and thread shenanigans. 
CL: [Improvement] - The X4/C4 UI is no longer a tab again as many people didn't seem to like that.