### PR TITLE
Teleporter menu will now have the correct mob position when they're inside storage

### DIFF
--- a/UnityProject/Assets/Scripts/Player/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerScript.cs
@@ -68,6 +68,8 @@ public class PlayerScript : NetworkBehaviour, IMatrixRotation, IAdminInfo, IActi
 	/// </summary>
 	public Vector3Int AssumedWorldPos => pushPull.AssumedWorldPositionServer();
 
+	[SyncVar] public Vector3Int SyncedWorldPos = new Vector3Int(0,0,0);
+
 	/// <summary>
 	/// World position of the player.
 	/// Returns InvalidPos if you're hidden (e.g. in a locker)
@@ -290,6 +292,18 @@ public class PlayerScript : NetworkBehaviour, IMatrixRotation, IAdminInfo, IActi
 		{
 			playerHealth.RTT = rtt;
 		}
+	}
+
+	[Command(requiresAuthority = false)]
+	public void UpdateLastSyncedPosition()
+	{
+		SetLastRecordedPosition();
+	}
+
+	[Server]
+	private void SetLastRecordedPosition()
+	{
+		SyncedWorldPos = AssumedWorldPos;
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Player/TeleportUtils.cs
+++ b/UnityProject/Assets/Scripts/Player/TeleportUtils.cs
@@ -62,7 +62,8 @@ namespace Systems.Teleport
 				}
 
 				//Gets Position of Player
-				var teleportInfo = new TeleportInfo(nameOfObject + "\n" + status, player.AssumedWorldPos, player.gameObject);
+				player.UpdateLastSyncedPosition();
+				var teleportInfo = new TeleportInfo(nameOfObject + "\n" + status, player.SyncedWorldPos, player.gameObject);
 
 				yield return teleportInfo;
 			}

--- a/UnityProject/Assets/Scripts/Player/TeleportUtils.cs
+++ b/UnityProject/Assets/Scripts/Player/TeleportUtils.cs
@@ -62,9 +62,7 @@ namespace Systems.Teleport
 				}
 
 				//Gets Position of Player
-				var tile = player.gameObject.GetComponent<RegisterTile>();
-
-				var teleportInfo = new TeleportInfo(nameOfObject + "\n" + status, tile.WorldPositionClient, player.gameObject);
+				var teleportInfo = new TeleportInfo(nameOfObject + "\n" + status, player.AssumedWorldPos, player.gameObject);
 
 				yield return teleportInfo;
 			}


### PR DESCRIPTION
Fixes #7004
CL: [Fix] Teleporter menu will now have the correct mob position when they're inside storage 