### PR TITLE
Restore radial menu look

### DIFF
--- a/UnityProject/Assets/Prefabs/UI/RightClick/RightClickActionRadial.prefab
+++ b/UnityProject/Assets/Prefabs/UI/RightClick/RightClickActionRadial.prefab
@@ -232,12 +232,12 @@ PrefabInstance:
     - target: {fileID: -8524424544509167813, guid: 355aa1c925725fb4fa05974e5e5d7241,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 450
+      value: 448
       objectReference: {fileID: 0}
     - target: {fileID: -8524424544509167813, guid: 355aa1c925725fb4fa05974e5e5d7241,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 450
+      value: 448
       objectReference: {fileID: 0}
     - target: {fileID: -6439170484653939460, guid: 355aa1c925725fb4fa05974e5e5d7241,
         type: 3}
@@ -377,22 +377,22 @@ PrefabInstance:
     - target: {fileID: -2304375700400688866, guid: 355aa1c925725fb4fa05974e5e5d7241,
         type: 3}
       propertyPath: m_Color.a
-      value: 0.2901961
+      value: 0.2509804
       objectReference: {fileID: 0}
     - target: {fileID: -2304375700400688866, guid: 355aa1c925725fb4fa05974e5e5d7241,
         type: 3}
       propertyPath: m_Color.b
-      value: 0.78431374
+      value: 0.38431373
       objectReference: {fileID: 0}
     - target: {fileID: -2304375700400688866, guid: 355aa1c925725fb4fa05974e5e5d7241,
         type: 3}
       propertyPath: m_Color.g
-      value: 0.5176471
+      value: 0.3254902
       objectReference: {fileID: 0}
     - target: {fileID: -2304375700400688866, guid: 355aa1c925725fb4fa05974e5e5d7241,
         type: 3}
       propertyPath: m_Color.r
-      value: 0.4627451
+      value: 0.25490198
       objectReference: {fileID: 0}
     - target: {fileID: -2304375700400688866, guid: 355aa1c925725fb4fa05974e5e5d7241,
         type: 3}
@@ -458,12 +458,12 @@ PrefabInstance:
     - target: {fileID: -8524424544509167813, guid: 6c693e934b75fbc438c8c5dcd34aa000,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 450
+      value: 325
       objectReference: {fileID: 0}
     - target: {fileID: -8524424544509167813, guid: 6c693e934b75fbc438c8c5dcd34aa000,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 450
+      value: 325
       objectReference: {fileID: 0}
     - target: {fileID: -2514867084737055250, guid: 6c693e934b75fbc438c8c5dcd34aa000,
         type: 3}
@@ -493,22 +493,22 @@ PrefabInstance:
     - target: {fileID: -2304375700400688866, guid: 6c693e934b75fbc438c8c5dcd34aa000,
         type: 3}
       propertyPath: m_Color.a
-      value: 0.2901961
+      value: 0.69803923
       objectReference: {fileID: 0}
     - target: {fileID: -2304375700400688866, guid: 6c693e934b75fbc438c8c5dcd34aa000,
         type: 3}
       propertyPath: m_Color.b
-      value: 0.78431374
+      value: 0.5137255
       objectReference: {fileID: 0}
     - target: {fileID: -2304375700400688866, guid: 6c693e934b75fbc438c8c5dcd34aa000,
         type: 3}
       propertyPath: m_Color.g
-      value: 0.5176471
+      value: 0.5137255
       objectReference: {fileID: 0}
     - target: {fileID: -2304375700400688866, guid: 6c693e934b75fbc438c8c5dcd34aa000,
         type: 3}
       propertyPath: m_Color.r
-      value: 0.4627451
+      value: 0.3019608
       objectReference: {fileID: 0}
     - target: {fileID: -2304375700400688866, guid: 6c693e934b75fbc438c8c5dcd34aa000,
         type: 3}

--- a/UnityProject/Assets/Prefabs/UI/RightClick/RightClickItemRadial.prefab
+++ b/UnityProject/Assets/Prefabs/UI/RightClick/RightClickItemRadial.prefab
@@ -689,7 +689,6 @@ MonoBehaviour:
   upperMask: {fileID: 7746989757741798222}
   previousArrow: {fileID: 2951742535600077843}
   nextArrow: {fileID: 1156100514673360259}
-  background: {fileID: 5530086014413178847}
   itemRing: {fileID: 540027771882249049}
   itemLabel: {fileID: 344888277810257935}
 --- !u!114 &7864490826961940268
@@ -751,12 +750,12 @@ PrefabInstance:
     - target: {fileID: -8524424544509167813, guid: 007faf8947d462844bba2845078d8d5c,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 320
+      value: 194
       objectReference: {fileID: 0}
     - target: {fileID: -8524424544509167813, guid: 007faf8947d462844bba2845078d8d5c,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 320
+      value: 194
       objectReference: {fileID: 0}
     - target: {fileID: -4802687162951226709, guid: 007faf8947d462844bba2845078d8d5c,
         type: 3}
@@ -766,22 +765,22 @@ PrefabInstance:
     - target: {fileID: -2304375700400688866, guid: 007faf8947d462844bba2845078d8d5c,
         type: 3}
       propertyPath: m_Color.a
-      value: 0.29803923
+      value: 0.69803923
       objectReference: {fileID: 0}
     - target: {fileID: -2304375700400688866, guid: 007faf8947d462844bba2845078d8d5c,
         type: 3}
       propertyPath: m_Color.b
-      value: 0.78431374
+      value: 0.5137255
       objectReference: {fileID: 0}
     - target: {fileID: -2304375700400688866, guid: 007faf8947d462844bba2845078d8d5c,
         type: 3}
       propertyPath: m_Color.g
-      value: 0.5176471
+      value: 0.5137255
       objectReference: {fileID: 0}
     - target: {fileID: -2304375700400688866, guid: 007faf8947d462844bba2845078d8d5c,
         type: 3}
       propertyPath: m_Color.r
-      value: 0.4627451
+      value: 0.3019608
       objectReference: {fileID: 0}
     - target: {fileID: 1725816765075911490, guid: 007faf8947d462844bba2845078d8d5c,
         type: 3}
@@ -952,22 +951,22 @@ PrefabInstance:
     - target: {fileID: -2304375700400688866, guid: 8d3571c5e4b6da94689066d472152d4b,
         type: 3}
       propertyPath: m_Color.a
-      value: 0.29803923
+      value: 0.2509804
       objectReference: {fileID: 0}
     - target: {fileID: -2304375700400688866, guid: 8d3571c5e4b6da94689066d472152d4b,
         type: 3}
       propertyPath: m_Color.b
-      value: 0.78431374
+      value: 0.38431373
       objectReference: {fileID: 0}
     - target: {fileID: -2304375700400688866, guid: 8d3571c5e4b6da94689066d472152d4b,
         type: 3}
       propertyPath: m_Color.g
-      value: 0.5176471
+      value: 0.3254902
       objectReference: {fileID: 0}
     - target: {fileID: -2304375700400688866, guid: 8d3571c5e4b6da94689066d472152d4b,
         type: 3}
       propertyPath: m_Color.r
-      value: 0.4627451
+      value: 0.25490198
       objectReference: {fileID: 0}
     - target: {fileID: -510883232049887997, guid: 8d3571c5e4b6da94689066d472152d4b,
         type: 3}

--- a/UnityProject/Assets/Scripts/UI/Core/Radial/Radial.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/Radial/Radial.cs
@@ -91,7 +91,7 @@ namespace UI.Core.Radial
 
 			var prefabName = gameObject.name.Replace("(Clone)", string.Empty);
 
-			Logger.LogError($"{prefabName} prefab is missing a reference for {missingReference}. Functionality may be hindered or outright broken.", Category.UI);
+			Logger.LogError($"{prefabName} prefab is missing a reference for {missingReference}. Functionality may be hindered or broken.", Category.UI);
 
 			return component;
 		}
@@ -102,17 +102,14 @@ namespace UI.Core.Radial
 
 			var prefabName = gameObject.name.Replace("(Clone)", string.Empty);
 
-			Logger.LogError($"{prefabName} prefab is missing a reference for {missingReference}. Check the prefab and add a reference to {objName}. Attempting to find the child object.", Category.UI);
 			component = gameObject.GetComponentsInChildren<V>(true).FirstOrDefault(c => c.name == objName);
+			var missingDescription = $"{prefabName} prefab is missing a reference for {missingReference}";
 
-			if (component == null)
-			{
-				Logger.LogError($"{prefabName} prefab is missing {objName} child. Functionality may be hindered or outright broken.", Category.UI);
-			}
-			else
-			{
-				Logger.LogTrace($"Found {objName} child in {prefabName} prefab. Please fix the missing reference in the prefab.", Category.UI);
-			}
+			Logger.LogError(
+				component == null
+					? $"{missingDescription}. Unable to find the object in the prefab. Functionality may be hindered or broken."
+					: $"{missingDescription}. Found {objName} in the prefab. Check the prefab and add a reference to {objName}.",
+				Category.UI);
 
 			return component;
 		}

--- a/UnityProject/Assets/Scripts/UI/Core/Radial/Radial.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/Radial/Radial.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UI.Core.Events;
@@ -83,6 +84,38 @@ namespace UI.Core.Radial
 		protected virtual float RaycastableArcMeasure => ArcMeasure;
 
 		public int ShownItemsCount => Math.Min(TotalItemCount, MaxShownItems);
+
+		public V VerifyNonChildReference<V>(V component, string missingReference) where V : UnityEngine.Object
+		{
+			if (component != null) return component;
+
+			var prefabName = gameObject.name.Replace("(Clone)", string.Empty);
+
+			Logger.LogError($"{prefabName} prefab is missing a reference for {missingReference}. Functionality may be hindered or outright broken.", Category.UI);
+
+			return component;
+		}
+
+		public V VerifyChildReference<V>(ref V component, string missingReference, string objName) where V : UnityEngine.Object
+		{
+			if (component != null) return component;
+
+			var prefabName = gameObject.name.Replace("(Clone)", string.Empty);
+
+			Logger.LogError($"{prefabName} prefab is missing a reference for {missingReference}. Check the prefab and add a reference to {objName}. Attempting to find the child object.", Category.UI);
+			component = gameObject.GetComponentsInChildren<V>(true).FirstOrDefault(c => c.name == objName);
+
+			if (component == null)
+			{
+				Logger.LogError($"{prefabName} prefab is missing {objName} child. Functionality may be hindered or outright broken.", Category.UI);
+			}
+			else
+			{
+				Logger.LogTrace($"Found {objName} child in {prefabName} prefab. Please fix the missing reference in the prefab.", Category.UI);
+			}
+
+			return component;
+		}
 
 		public virtual void Setup(int itemCount)
 		{

--- a/UnityProject/Assets/Scripts/UI/Core/Radial/ScrollableRadial.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/Radial/ScrollableRadial.cs
@@ -12,11 +12,13 @@ namespace UI.Core.Radial
 		[SerializeField]
 		protected RectTransform upperMask;
 
-		private T lowerMaskItem;
-
-		private T upperMaskItem;
-
 		private float totalRotation;
+
+		protected RectTransform LowerMask =>
+			VerifyChildReference(ref lowerMask, $"{nameof(LowerMask)} to a masked image object", "LowerMask");
+
+		protected RectTransform UpperMask =>
+			VerifyChildReference(ref upperMask, $"{nameof(UpperMask)} to a masked image object", "UpperMask");
 
 		protected float TotalRotation
 		{
@@ -49,15 +51,19 @@ namespace UI.Core.Radial
 		{
 			InitItem(index);
 			var maskItem = Items[index];
-			maskItem.transform.SetParent(parent);
+
+			if (parent)
+			{
+				maskItem.transform.SetParent(parent);
+			}
 
 			return maskItem;
 		}
 
 		public void Awake()
 		{
-			LowerMaskItem = InitMaskItem(lowerMask, 0);
-			UpperMaskItem = InitMaskItem(upperMask, 1);
+			LowerMaskItem = InitMaskItem(LowerMask, 0);
+			UpperMaskItem = InitMaskItem(UpperMask, 1);
 		}
 
 		public override void Setup(int itemCount)
@@ -67,7 +73,12 @@ namespace UI.Core.Radial
 			CurrentIndex = 0;
 
 			var isScrollable = itemCount > ShownItemsCount;
-			upperMask.localEulerAngles = new Vector3(0, 0, ArcMeasure - 360);
+
+			if (UpperMask)
+			{
+				UpperMask.localEulerAngles = new Vector3(0, 0, ArcMeasure - 360);
+			}
+
 			SetupItem(LowerMaskItem, 0, Vector3.zero, isScrollable);
 			SetupItem(UpperMaskItem, ShownItemsCount, Vector3.zero, isScrollable);
 			for (var i = 2; i < Math.Max(2 + ShownItemsCount, Count); i++)

--- a/UnityProject/Assets/Scripts/UI/Core/RightClick/ActionRadial.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/RightClick/ActionRadial.cs
@@ -28,7 +28,7 @@ namespace UI.Core.RightClick
 			VerifyNonChildReference(borderPrefab, nameof(BorderPrefab));
 
 		private Image RadialMask =>
-			VerifyChildReference(ref radialMask, $"{nameof(RadialMask)} to an masked image object", "BackgroundMask");
+			VerifyChildReference(ref radialMask, $"{nameof(RadialMask)} to a masked image object", "BackgroundMask");
 
 		private Transform Background =>
 			VerifyChildReference(ref background, $"{nameof(Background)} to a background image object", "RadialActionRing");

--- a/UnityProject/Assets/Scripts/UI/Core/RightClick/ActionRadial.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/RightClick/ActionRadial.cs
@@ -24,11 +24,20 @@ namespace UI.Core.RightClick
 
 		private ParentConstraint parentConstraint;
 
+		private RectTransform BorderPrefab =>
+			VerifyNonChildReference(borderPrefab, nameof(BorderPrefab));
+
+		private Image RadialMask =>
+			VerifyChildReference(ref radialMask, $"{nameof(RadialMask)} to an masked image object", "BackgroundMask");
+
+		private Transform Background =>
+			VerifyChildReference(ref background, $"{nameof(Background)} to a background image object", "RadialActionRing");
+
 		private ParentConstraint ParentConstraint => this.GetComponentByRef(ref parentConstraint);
 
 		private T InitOrGet<T>(ref T obj, T prefab) where T : Component
 		{
-			if (obj == null)
+			if (obj == null && prefab != null)
 			{
 				obj = Instantiate(prefab, transform);
 				obj.SetActive(true);
@@ -37,23 +46,15 @@ namespace UI.Core.RightClick
 			return obj;
 		}
 
-		private RectTransform StartBorder => InitOrGet(ref startBorder, borderPrefab);
+		private RectTransform StartBorder => InitOrGet(ref startBorder, BorderPrefab);
 
-		private RectTransform EndBorder => InitOrGet(ref endBorder, borderPrefab);
+		private RectTransform EndBorder => InitOrGet(ref endBorder, BorderPrefab);
 
 		public void LateUpdate()
 		{
-			try
+			if (Background)
 			{
-				background.rotation = Quaternion.identity;
-			}
-			catch (NullReferenceException exception)
-			{
-				Logger.LogError($"Caught a NRE in ItemRadial.LateUpdate() {exception.Message} \n {exception.StackTrace}", Category.UI);
-			}
-			catch (UnassignedReferenceException exception)
-			{
-				Logger.LogError($"Caught an Unassigned Reference Exception in ItemRadial.LateUpdate() {exception.Message} \n {exception.StackTrace}", Category.UI);
+				Background.rotation = Quaternion.identity;
 			}
 		}
 
@@ -61,10 +62,19 @@ namespace UI.Core.RightClick
 		{
 			ArcMeasure = itemCount * (360 / MaxShownItems);
 			base.Setup(itemCount);
-			radialMask.fillAmount = (1f / 360f) * ArcMeasure;
-			StartBorder.localPosition = new Vector3(0, -.5f, 0);
-			EndBorder.localEulerAngles = new Vector3(0f, 0f, ItemArcMeasure * itemCount);
-			EndBorder.localPosition = new Vector3(-0.5f, 0, 0);
+
+			if (RadialMask)
+			{
+				RadialMask.fillAmount = (1f / 360f) * ArcMeasure;
+			}
+
+			if (StartBorder != null && EndBorder != null)
+			{
+				StartBorder.localPosition = new Vector3(0, -.5f, 0);
+				EndBorder.localEulerAngles = new Vector3(0f, 0f, ItemArcMeasure * itemCount);
+				EndBorder.localPosition = new Vector3(-0.5f, 0, 0);
+			}
+
 			if (Items.Count > 0)
 			{
 				Items[0].SetDividerActive(false);

--- a/UnityProject/Assets/Scripts/UI/Core/RightClick/ItemRadial.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/RightClick/ItemRadial.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using TMPro;
 using UnityEngine;
 using UI.Core.Radial;
@@ -18,60 +19,11 @@ namespace UI.Core.RightClick
 		[SerializeField]
 		private ReversibleObjectScale nextArrow = default;
 
-		[SerializeField, FormerlySerializedAs("background")]
-		private RectTransform _background;
-
-
-		private RectTransform Background
-		{
-			get
-			{
-				if (_background == null)
-				{
-					Logger.LogError($"RadialItemInnerRing Had to use  GameObject.Find ", Category.UI);
-					_background = GameObject.Find("RadialItemInnerRing").GetComponent<RectTransform>();
-				}
-
-				return _background;
-			}
-		}
-
-		[SerializeField, FormerlySerializedAs("itemRing")]
-		private Graphic _itemRing;
+		[SerializeField]
+		private Graphic itemRing;
 
 		[SerializeField]
-		private Graphic ItemRing
-		{
-			get {
-				if (_itemRing == null)
-				{
-					Logger.LogError($"RadialItemRing Had to use  GameObject.Find ", Category.UI);
-					_itemRing = GameObject.Find("RadialItemRing").GetComponent<Graphic>();
-				}
-
-				return _itemRing;
-			}
-		}
-
-		[SerializeField]
-		private TMP_Text _itemLabel = default;
-
-		[SerializeField]
-		private TMP_Text itemLabel
-		{
-			get {
-				if (_itemLabel == null)
-				{
-					Logger.LogError($"itemLabel Had to use  GameObject.Find ", Category.UI);
-					_itemLabel = GameObject.Find("ItemLabel").GetComponent<TMP_Text>();
-				}
-
-				return _itemLabel;
-			}
-		}
-
-
-
+		private TMP_Text itemLabel = default;
 
 		private float raycastableArcMeasure;
 
@@ -80,6 +32,18 @@ namespace UI.Core.RightClick
 		private RadialDrag drag;
 
 		private AnimatedRadialRotation rotationAnimator;
+
+		private ReversibleObjectScale PreviousArrow =>
+			VerifyChildReference(ref previousArrow, $"{nameof(PreviousArrow)} to an image with ReversibleObjectScale object", "PreviousArrow");
+
+		private ReversibleObjectScale NextArrow =>
+			VerifyChildReference(ref nextArrow, $"{nameof(NextArrow)} to an image with ReversibleObjectScale object", "NextArrow");
+
+		private Graphic ItemRing =>
+			VerifyChildReference(ref itemRing, $"{nameof(ItemRing)} to a SVG graphic object", "RadialItemRing");
+
+		private TMP_Text ItemLabel =>
+			VerifyChildReference(ref itemLabel, $"{nameof(ItemLabel)} to a TMP text object", "ItemLabel");
 
 		protected override float RaycastableArcMeasure => raycastableArcMeasure;
 
@@ -116,9 +80,10 @@ namespace UI.Core.RightClick
 		public override void Setup(int itemCount)
 		{
 			base.Setup(itemCount);
-			itemLabel.SetText(string.Empty);
-			previousArrow.transform.SetAsLastSibling();
-			nextArrow.transform.SetAsLastSibling();
+
+			ItemLabel.OrNull()?.SetText(string.Empty);
+			PreviousArrow.OrNull()?.transform.SetAsLastSibling();
+			NextArrow.OrNull()?.transform.SetAsLastSibling();
 			UpdateArrows();
 		}
 
@@ -144,41 +109,28 @@ namespace UI.Core.RightClick
 
 		private void SetRadialScrollable(bool value)
 		{
-			try
-			{
-				Drag.enabled = value;
-				Scroll.enabled = value;
-				ItemRing.raycastTarget = value;
-				itemLabel.raycastTarget = value;
-			}
-			catch (NullReferenceException exception)
-			{
-				Logger.LogError($"Caught a NRE in ItemRadial.SetRadialScrollable() {exception.Message} \n {exception.StackTrace}", Category.UI);
-			}
+			Drag.enabled = value;
+			Scroll.enabled = value;
+
+			if (ItemRing == null || ItemLabel == null) return;
+
+			ItemRing.raycastTarget = value;
+			ItemLabel.raycastTarget = value;
 		}
 
 		public void UpdateArrows()
 		{
 			var roundedRotation = Mathf.Round(TotalRotation);
-			previousArrow.SetActive(roundedRotation > 0);
-			nextArrow.SetActive(roundedRotation < Mathf.Round(MaxIndex * ItemArcMeasure));
+			PreviousArrow.OrNull()?.SetActive(roundedRotation > 0);
+			NextArrow.OrNull()?.SetActive(roundedRotation < Mathf.Round(MaxIndex * ItemArcMeasure));
 		}
 
 		public void LateUpdate()
 		{
-			try
-			{
-				Background.rotation = Quaternion.identity;
-				itemLabel.transform.rotation = Quaternion.identity;
-			}
-			catch (NullReferenceException exception)
-			{
-				Logger.LogError($"Caught a NRE in ItemRadial.LateUpdate() {exception.Message} \n {exception.StackTrace}", Category.UI);
-			}
-			catch (UnassignedReferenceException exception)
-			{
-				Logger.LogError($"Caught an Unassigned Reference Exception in ItemRadial.LateUpdate() {exception.Message} \n {exception.StackTrace}", Category.UI);
-			}
+			if (ItemRing == null || ItemLabel == null) return;
+
+			ItemRing.transform.rotation = Quaternion.identity;
+			ItemLabel.transform.rotation = Quaternion.identity;
 		}
 
 		public override void RotateRadial(float rotation)
@@ -275,16 +227,16 @@ namespace UI.Core.RightClick
 
 		private void TweenArrows(bool forward)
 		{
-			nextArrow.TweenScale(forward);
-			previousArrow.TweenScale(!forward);
+			NextArrow.OrNull()?.TweenScale(forward);
+			PreviousArrow.OrNull()?.TweenScale(!forward);
 		}
 
 		private void TweenArrowsBack()
 		{
-			nextArrow.TweenScale(AnimationDirection.Backward);
-			previousArrow.TweenScale(AnimationDirection.Backward);
+			NextArrow.OrNull()?.TweenScale(AnimationDirection.Backward);
+			PreviousArrow.OrNull()?.TweenScale(AnimationDirection.Backward);
 		}
 
-		public void ChangeLabel(string text) => itemLabel.SetText(text);
+		public void ChangeLabel(string text) => ItemLabel.OrNull()?.SetText(text);
 	}
 }


### PR DESCRIPTION
It's been a long time since I've checked on UnityStation, hence why this was not out much, much sooner. It looks like the initial issues with the menu happened after the prefabs were moved around. Somehow the references in the prefabs were lost during the move, thanks unity? At some point in the patching process to fix the issue, the colours, sizes of the images, and references were set incorrectly.

Fixes the colours and the image sizes to reflect how the radial used to look.

Replaces a still missing reference.

Now verifies more references and logs what reference is missing and in which prefab/object. Attempts to find the missing component by searching the prefab's children if the reference isn't set.

Removed a couple obsolete/unused things.
