### PR TITLE
makes all soda cans openable, fixes adv regen mesh's incorrect sprite

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Food/Drinks/MagmAle.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Drinks/MagmAle.prefab
@@ -1,5 +1,31 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-3902251006499403688
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1094635065414597411}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86536f54b4694d5a98b2f4962a473b7e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  spriteHandler: {fileID: 0}
+  destroyThisComponentOnOpen: 1
+  openingNoise:
+    SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/Effects/GenHit.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  openedSprite: {fileID: 0}
+  openingVerb: pop open a cold one and enjoy the sound of the
+  openingRequirementText: You need to open this first before using it!
 --- !u!1001 &7105033006757328015
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -213,3 +239,9 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 46bb2fe95f4f66341aadfb4600751333, type: 3}
+--- !u!1 &1094635065414597411 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7902349682654515116, guid: 46bb2fe95f4f66341aadfb4600751333,
+    type: 3}
+  m_PrefabInstance: {fileID: 7105033006757328015}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Food/Drinks/SodaCans/SpaceColaCan.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Drinks/SodaCans/SpaceColaCan.prefab
@@ -232,19 +232,13 @@ PrefabInstance:
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b04d0f9770ef17c459a1af178889e3ba, type: 3}
---- !u!1 &683694994805896424 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3455908610919537798, guid: b04d0f9770ef17c459a1af178889e3ba,
-    type: 3}
-  m_PrefabInstance: {fileID: 2776788492469708910}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &642140874673133880 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3341800471880413526, guid: b04d0f9770ef17c459a1af178889e3ba,
     type: 3}
   m_PrefabInstance: {fileID: 2776788492469708910}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 683694994805896424}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
@@ -262,27 +256,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &4475979094345587770
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 683694994805896424}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 86536f54b4694d5a98b2f4962a473b7e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  spriteHandler: {fileID: 0}
-  openingNoise:
-    SetLoadSetting: 0
-    AssetAddress: GenHit.prefab
-    AssetReference:
-      m_AssetGUID: 
-      m_SubObjectName: 
-      m_SubObjectType: 
-      m_EditorAssetChanged: 0
-  openedSprite: {fileID: 0}
-  openingVerb: crack open a cold one and enjoy the sound of the
-  openingRequirementText: You need to open this first before using it!

--- a/UnityProject/Assets/Prefabs/Items/Food/Drinks/SodaCans/_SodaCanBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Drinks/SodaCans/_SodaCanBase.prefab
@@ -1,5 +1,31 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &932332720324389715
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3455908610919537798}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86536f54b4694d5a98b2f4962a473b7e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  spriteHandler: {fileID: 0}
+  destroyThisComponentOnOpen: 1
+  openingNoise:
+    SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/Effects/GenHit.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  openedSprite: {fileID: 0}
+  openingVerb: crack open a cold one and enjoy the sound of the
+  openingRequirementText: You need to open this first before using it!
 --- !u!1001 &4782563013365961514
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -106,3 +132,9 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 5747741185675137456, guid: 46bb2fe95f4f66341aadfb4600751333, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 46bb2fe95f4f66341aadfb4600751333, type: 3}
+--- !u!1 &3455908610919537798 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7902349682654515116, guid: 46bb2fe95f4f66341aadfb4600751333,
+    type: 3}
+  m_PrefabInstance: {fileID: 4782563013365961514}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Food/Drinks/SpaceBeer.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Drinks/SpaceBeer.prefab
@@ -1,5 +1,31 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-3608348479036750439
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4501053395374146654}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86536f54b4694d5a98b2f4962a473b7e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  spriteHandler: {fileID: 0}
+  destroyThisComponentOnOpen: 1
+  openingNoise:
+    SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/Effects/GenHit.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  openedSprite: {fileID: 0}
+  openingVerb: pop open a cold one and enjoy the sound of the
+  openingRequirementText: You need to open this first before using it!
 --- !u!1001 &6042771998409264114
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -218,3 +244,9 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 46bb2fe95f4f66341aadfb4600751333, type: 3}
+--- !u!1 &4501053395374146654 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7902349682654515116, guid: 46bb2fe95f4f66341aadfb4600751333,
+    type: 3}
+  m_PrefabInstance: {fileID: 6042771998409264114}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Medical/Trauma Treatment/Advanced Regen Mesh.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Medical/Trauma Treatment/Advanced Regen Mesh.prefab
@@ -99,6 +99,12 @@ PrefabInstance:
       propertyPath: TraumaDamageToHeal
       value: 80
       objectReference: {fileID: 0}
+    - target: {fileID: 4620297301374731262, guid: 7fcf9e27e01f78e48aad63996e91ff2f,
+        type: 3}
+      propertyPath: openedSprite
+      value: 
+      objectReference: {fileID: 11400000, guid: 3bac7398600817a48949e8a3bd1d75c5,
+        type: 2}
     - target: {fileID: 4640836244599001406, guid: 7fcf9e27e01f78e48aad63996e91ff2f,
         type: 3}
       propertyPath: foreverID

--- a/UnityProject/Assets/Prefabs/Items/Medical/Trauma Treatment/Regen Mesh.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Medical/Trauma Treatment/Regen Mesh.prefab
@@ -1,5 +1,77 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-6495101291114284292
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1791647728409730387}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e7c30ca55ffa4467a421abf7a832a6a1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  initialAmount: 15
+  maxAmount: 15
+  stacksWith: []
+  stackNames: []
+  stackSprites:
+  - SpriteSO: {fileID: 11400000, guid: 3cb6f2ed76d09d648bda958c4ccebead, type: 2}
+    OverAmount: 2
+  - SpriteSO: {fileID: 11400000, guid: 98d622dd10330c2429a0259832426185, type: 2}
+    OverAmount: 6
+  - SpriteSO: {fileID: 11400000, guid: 7ab2f0c44122e1246a8aa1b3bd3f7d6a, type: 2}
+    OverAmount: 15
+  - SpriteSO: {fileID: 11400000, guid: ee25f4a4194b23247b9b9dd029f2caec, type: 2}
+    OverAmount: 16
+  autoStackOnSpawn: 1
+  autoStackOnDrop: 0
+--- !u!114 &2710468740513023014
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1791647728409730387}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 19988dde784f6ae4f874dcb496f6115d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  healType: 1
+  StopsExternalBleeding: 1
+  HealsTraumaDamage: 1
+  TraumaDamageToHeal: 50
+  TraumaTypeToHeal: 3
+--- !u!114 &4620297301374731262
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1791647728409730387}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86536f54b4694d5a98b2f4962a473b7e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  spriteHandler: {fileID: 5592108624515032788}
+  destroyThisComponentOnOpen: 1
+  openingNoise:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  openedSprite: {fileID: 11400000, guid: 7ab2f0c44122e1246a8aa1b3bd3f7d6a, type: 2}
+  openingVerb: you tear open the anti-microbial wrapping on the
+  openingRequirementText: You need to open this first before using it!
 --- !u!1001 &1792047792650166761
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -181,73 +253,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &-6495101291114284292
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1791647728409730387}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e7c30ca55ffa4467a421abf7a832a6a1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  initialAmount: 15
-  maxAmount: 15
-  stacksWith: []
-  stackNames: []
-  stackSprites:
-  - SpriteSO: {fileID: 11400000, guid: 3cb6f2ed76d09d648bda958c4ccebead, type: 2}
-    OverAmount: 2
-  - SpriteSO: {fileID: 11400000, guid: 98d622dd10330c2429a0259832426185, type: 2}
-    OverAmount: 6
-  - SpriteSO: {fileID: 11400000, guid: 7ab2f0c44122e1246a8aa1b3bd3f7d6a, type: 2}
-    OverAmount: 15
-  - SpriteSO: {fileID: 11400000, guid: ee25f4a4194b23247b9b9dd029f2caec, type: 2}
-    OverAmount: 16
-  autoStackOnSpawn: 1
-  autoStackOnDrop: 0
---- !u!114 &2710468740513023014
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1791647728409730387}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 19988dde784f6ae4f874dcb496f6115d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  healType: 1
-  StopsExternalBleeding: 1
-  HealsTraumaDamage: 1
-  TraumaDamageToHeal: 50
-  TraumaTypeToHeal: 3
---- !u!114 &4620297301374731262
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1791647728409730387}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 86536f54b4694d5a98b2f4962a473b7e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  spriteHandler: {fileID: 5592108624515032788}
-  openingNoise:
-    SetLoadSetting: 0
-    AssetAddress: 
-    AssetReference:
-      m_AssetGUID: 
-      m_SubObjectName: 
-      m_SubObjectType: 
-      m_EditorAssetChanged: 0
-  openedSprite: {fileID: 11400000, guid: 7ab2f0c44122e1246a8aa1b3bd3f7d6a, type: 2}
-  openingVerb: open
-  openingRequirementText: You need to open this first before using it!


### PR DESCRIPTION

### Purpose

This PR fixes the parenting of the HandPreparable component on soda cans. It was originally on Space Cola when it needed to be on _SodaCanBase. This PR also fixes the adv regen mesh having the wrong opened sprite and gives a description for opening regen meshes.

### Changelog:

CL: [Fix] All soda cans and beer bottles are openable now instead of just space cola.
CL: [Fix] fixed the advanced regen mesh's incorrect opened sprite and adds a proper description for opening regen mesh packaging.
