### PR TITLE
Rebalances Syndicate bombs

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/SyndicateBomb.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/SyndicateBomb.prefab
@@ -276,7 +276,7 @@ MonoBehaviour:
   detonateImmediatelyOnSignal: 0
   timeToDetonate: 90
   minimumTimeToDetonate: 90
-  explosiveStrength: 1600
+  explosiveStrength: 12000
   activeSpriteSO: {fileID: 11400000, guid: 17eb29bb46caa9044adc12a3e0afcd77, type: 2}
   progressTime: 3
   spriteHandler: {fileID: 5680589113982627379}


### PR DESCRIPTION
Syndicate bombs were much weaker than X4s for some reason, this corrects by making it more threatening than them.

CL: [Balance] syndicate bomb explosion strength has been increased from 1600 to 12000