### PR TITLE
`currentCharge` was not synced for clients for powersinks

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Weapons/PowerSink.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/PowerSink.cs
@@ -28,7 +28,7 @@ namespace Items.Weapons
 
 		[SyncVar] private bool isAnchored;
 		[SyncVar] private bool isCharging;
-		private float currentCharge;
+		[SyncVar] private float currentCharge;
 
 		private void Awake()
 		{


### PR DESCRIPTION
Caused some minor issues when testing on staging today, this will fix it.
