### PR TITLE
Moves VerifyChildReference into extension methods

### DIFF
--- a/UnityProject/Assets/Scripts/UI/Core/Radial/Radial.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/Radial/Radial.cs
@@ -2,9 +2,11 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UI.Core.Events;
+using Util;
 
 namespace UI.Core.Radial
 {
@@ -85,34 +87,12 @@ namespace UI.Core.Radial
 
 		public int ShownItemsCount => Math.Min(TotalItemCount, MaxShownItems);
 
-		public V VerifyNonChildReference<V>(V component, string missingReference) where V : UnityEngine.Object
-		{
-			if (component != null) return component;
-
-			var prefabName = gameObject.name.Replace("(Clone)", string.Empty);
-
-			Logger.LogError($"{prefabName} prefab is missing a reference for {missingReference}. Functionality may be hindered or broken.", Category.UI);
-
-			return component;
-		}
-
-		public V VerifyChildReference<V>(ref V component, string missingReference, string objName) where V : UnityEngine.Object
-		{
-			if (component != null) return component;
-
-			var prefabName = gameObject.name.Replace("(Clone)", string.Empty);
-
-			component = gameObject.GetComponentsInChildren<V>(true).FirstOrDefault(c => c.name == objName);
-			var missingDescription = $"{prefabName} prefab is missing a reference for {missingReference}";
-
-			Logger.LogError(
-				component == null
-					? $"{missingDescription}. Unable to find the object in the prefab. Functionality may be hindered or broken."
-					: $"{missingDescription}. Found {objName} in the prefab. Check the prefab and add a reference to {objName}.",
-				Category.UI);
-
-			return component;
-		}
+		/// Convenience method for verifying radial references.
+		/// <see cref="ComponentExtensions.VerifyChildReference"/>
+		protected V VerifyChildReference<V>(ref V component, string refDescription,
+			string childName = null, [CallerMemberName] string refName = "")
+			where V : UnityEngine.Object =>
+			this.VerifyChildReference(ref component, refDescription, childName, refName, Category.UI);
 
 		public virtual void Setup(int itemCount)
 		{

--- a/UnityProject/Assets/Scripts/UI/Core/Radial/ScrollableRadial.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/Radial/ScrollableRadial.cs
@@ -14,11 +14,9 @@ namespace UI.Core.Radial
 
 		private float totalRotation;
 
-		protected RectTransform LowerMask =>
-			VerifyChildReference(ref lowerMask, $"{nameof(LowerMask)} to a masked image object", "LowerMask");
+		protected RectTransform LowerMask => VerifyChildReference(ref lowerMask, "a masked image");
 
-		protected RectTransform UpperMask =>
-			VerifyChildReference(ref upperMask, $"{nameof(UpperMask)} to a masked image object", "UpperMask");
+		protected RectTransform UpperMask => VerifyChildReference(ref upperMask, "a masked image");
 
 		protected float TotalRotation
 		{

--- a/UnityProject/Assets/Scripts/UI/Core/RightClick/ActionRadial.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/RightClick/ActionRadial.cs
@@ -1,9 +1,9 @@
-using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Animations;
 using UnityEngine.UI;
 using UI.Core.Radial;
+using Util;
 
 namespace UI.Core.RightClick
 {
@@ -25,13 +25,11 @@ namespace UI.Core.RightClick
 		private ParentConstraint parentConstraint;
 
 		private RectTransform BorderPrefab =>
-			VerifyNonChildReference(borderPrefab, nameof(BorderPrefab));
+			this.VerifyNonChildReference(borderPrefab, "a rectangular image prefab", category: Category.UI);
 
-		private Image RadialMask =>
-			VerifyChildReference(ref radialMask, $"{nameof(RadialMask)} to a masked image object", "BackgroundMask");
+		private Image RadialMask => VerifyChildReference(ref radialMask, "a masked image", "BackgroundMask");
 
-		private Transform Background =>
-			VerifyChildReference(ref background, $"{nameof(Background)} to a background image object", "RadialActionRing");
+		private Transform Background => VerifyChildReference(ref background, "a background image", "RadialActionRing");
 
 		private ParentConstraint ParentConstraint => this.GetComponentByRef(ref parentConstraint);
 

--- a/UnityProject/Assets/Scripts/UI/Core/RightClick/ItemRadial.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/RightClick/ItemRadial.cs
@@ -1,12 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using TMPro;
 using UnityEngine;
 using UI.Core.Radial;
 using UI.Core.Animations;
 using UnityEngine.EventSystems;
-using UnityEngine.Serialization;
 using UnityEngine.UI;
 
 namespace UI.Core.RightClick
@@ -33,17 +31,13 @@ namespace UI.Core.RightClick
 
 		private AnimatedRadialRotation rotationAnimator;
 
-		private ReversibleObjectScale PreviousArrow =>
-			VerifyChildReference(ref previousArrow, $"{nameof(PreviousArrow)} to an image with ReversibleObjectScale object", "PreviousArrow");
+		private ReversibleObjectScale PreviousArrow => VerifyChildReference(ref previousArrow, "an image");
 
-		private ReversibleObjectScale NextArrow =>
-			VerifyChildReference(ref nextArrow, $"{nameof(NextArrow)} to an image with ReversibleObjectScale object", "NextArrow");
+		private ReversibleObjectScale NextArrow => VerifyChildReference(ref nextArrow, "an image");
 
-		private Graphic ItemRing =>
-			VerifyChildReference(ref itemRing, $"{nameof(ItemRing)} to a SVG graphic object", "RadialItemRing");
+		private Graphic ItemRing => VerifyChildReference(ref itemRing, "a SVG graphic", "RadialItemRing");
 
-		private TMP_Text ItemLabel =>
-			VerifyChildReference(ref itemLabel, $"{nameof(ItemLabel)} to a TMP text object", "ItemLabel");
+		private TMP_Text ItemLabel => VerifyChildReference(ref itemLabel, "a label");
 
 		protected override float RaycastableArcMeasure => raycastableArcMeasure;
 

--- a/UnityProject/Assets/Scripts/Util/CodeUtilities.cs
+++ b/UnityProject/Assets/Scripts/Util/CodeUtilities.cs
@@ -5,6 +5,8 @@ using UnityEngine;
 
 public static class CodeUtilities
 {
+	public static string RemoveClone(this string text) => text?.Replace("(Clone)", string.Empty);
+
 	public static string GetUntilOrEmpty(this string text, string stopAt = "-")
 	{
 		if (!String.IsNullOrWhiteSpace(text))

--- a/UnityProject/Assets/Scripts/Util/ComponentExtensions.cs
+++ b/UnityProject/Assets/Scripts/Util/ComponentExtensions.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Util
+{
+	public static class ComponentExtensions
+	{
+		/// <summary>
+		/// Checks a component's reference to a non-child component to verify if it has been added properly. If a reference
+		/// is not set, it will log the object/prefab and the component that has the missing reference.
+		/// </summary>
+		/// <param name="parent">The container component with the reference to check.</param>
+		/// <param name="component">A reference to a component to verify.</param>
+		/// <param name="refDescription">A brief description of the missing reference.</param>
+		/// <param name="refName">The name of the reference that is checked.</param>
+		/// <param name="category">What to categorize the log as.</param>
+		/// <typeparam name="V">The component's type.</typeparam>
+		/// <returns>The component if the reference exists or it is found.</returns>
+		public static V VerifyNonChildReference<V>(this Component parent, V component, string refDescription,
+			[CallerMemberName] string refName = "", Category category = Category.Unknown) where V : Object
+		{
+			if (component != null) return component;
+
+			var go = parent.gameObject;
+			var objName = go.name.RemoveClone();
+			var description = MissingRefDescription(parent, objName, refName, refDescription, typeof(V));
+			Logger.LogError($"{description} Functionality may be hindered or broken.", category);
+
+			return component;
+		}
+
+		/// <summary>
+		/// Checks a component's reference to a child component to verify if it has been added properly. If a reference is
+		/// not set, it will log the object/prefab and the component that has the missing reference. This will attempt to
+		/// search the object's hierarchy for a given child name and add the reference. If a child name is not given, it
+		/// will search using the name of the calling method (case-insensitive). Lastly, if no child matches the given
+		/// name, it will attempt to add a reference to the first component with a matching type if no more than a
+		/// single component is found.
+		/// </summary>
+		/// <param name="parent">The container component with the reference to check.</param>
+		/// <param name="component">A reference to a component to verify.</param>
+		/// <param name="refDescription">A brief description of the missing reference.</param>
+		/// <param name="childName">The name of a child to search for if the reference is missing.</param>
+		/// <param name="refName">The name of the reference that is checked.</param>
+		/// <param name="category">What to categorize the log as.</param>
+		/// <typeparam name="V">The component's type.</typeparam>
+		/// <returns>The component if the reference exists or it is found.</returns>
+		public static V VerifyChildReference<V>(this Component parent, ref V component, string refDescription,
+			string childName = null, [CallerMemberName] string refName = "", Category category = Category.Unknown) where V : Object
+		{
+			if (component != null) return component;
+
+			childName ??= refName;
+			var go = parent.gameObject;
+			var objName = go.name.RemoveClone();
+			var description = MissingRefDescription(parent, objName, refName, refDescription, typeof(V));
+			var componentsFound = go.GetComponentsInChildren<V>(true);
+			component = componentsFound.FirstOrDefault(c => c.name.ToLower() == childName?.ToLower());
+			if (component == null && componentsFound.Length > 1)
+			{
+				Logger.LogError($"{description} Found multiple children with the required component. Check the object/prefab and add a reference to one of them.", category);
+			}
+			else
+			{
+				component ??= componentsFound.FirstOrDefault();
+
+				Logger.LogError(
+					component == null
+						? $"{description} Unable to find a child object with a '{typeof(V)}' component. Functionality may be hindered or broken."
+						: $"{description} Found '{component.name}' as a child in the object. Check the object/prefab and add a reference to '{component.name}'.",
+					category);
+			}
+
+			return component;
+		}
+
+		private static string MissingRefDescription(Component parent, string objName, string refName, string refDescription, Type compType) =>
+			$"Component '{parent.GetType()}' in object/prefab '{objName}' is missing a reference for '{refName}' to {refDescription} with '{compType}' component.";
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/ComponentExtensions.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/ComponentExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b5b64dfde880470bb66f51db692fcbc2
+timeCreated: 1647840824


### PR DESCRIPTION
Takes the VerifyChildReference created for the radial menu yesterday and turns it into component extension methods with a couple added ease of use features. Adds a summary to those methods.

If no reference is found, it will log the component it is missing from, the object the component is located on, the reference name, a brief description, and the component type needed.

It now checks for a child with a given name, a child with a name that matches the reference method/property name, or a component that matches the type if there is only one.