### PR TITLE
Megaphone cooldown text feedback

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Chat/Chat.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/Chat.cs
@@ -240,7 +240,7 @@ public partial class Chat : MonoBehaviour
 						{
 							if (slot.IsEmpty) continue;
 							if (slot.Item.TryGetComponent<IChatInfluencer>(out var listener)
-							    && listener.RunChecks() == true)
+							    && listener.WillInfluenceChat() == true)
 							{
 								chatEvent = listener.InfluenceChat(chatEvent);
 							}

--- a/UnityProject/Assets/Scripts/Core/Chat/ChatRelay.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/ChatRelay.cs
@@ -238,7 +238,7 @@ public class ChatRelay : NetworkBehaviour
 			radioCheckRadius, itemsMask))
 		{
 			if (chatEvent.originator == coll.gameObject) continue;
-			if (coll.gameObject.TryGetComponent<IChatInfluencer>(out var listener) == false || listener.RunChecks() == false) continue;
+			if (coll.gameObject.TryGetComponent<IChatInfluencer>(out var listener) == false || listener.WillInfluenceChat() == false) continue;
 			var radioPos = coll.gameObject.AssumedWorldPosServer();
 			if (MatrixManager.Linecast(chatEvent.position, LayerTypeSelection.Walls,
 				layerMask, radioPos).ItHit == false)

--- a/UnityProject/Assets/Scripts/Items/Bureaucracy/Megaphone.cs
+++ b/UnityProject/Assets/Scripts/Items/Bureaucracy/Megaphone.cs
@@ -10,7 +10,7 @@ namespace Items.Bureaucracy
 	{
 		[SyncVar] private bool isOnCooldown = false;
 		[SyncVar] private bool isOn = false;
-		[SyncVar] private bool isEmmaged = false;
+		[SyncVar] private bool isEmagged = false;
 		[SerializeField] private float cooldown = 10f;
 
 		private Pickupable pickupable;
@@ -34,34 +34,37 @@ namespace Items.Bureaucracy
 
 		public bool RunChecks()
 		{
-			return IsOnCooldown() && isOn == true && pickupable.ItemSlot != null;
+			return IsOnCooldown() == false && isOn == true && pickupable.ItemSlot != null;
 		}
 
 		private bool IsOnCooldown()
 		{
-			if (isEmmaged) return false;
-			if(isOnCooldown && pickupable.ItemSlot != null && pickupable.ItemSlot.Player != null) Chat.AddExamineMsg(pickupable.ItemSlot.Player.gameObject,"The megaphone is on cooldown..");
+			if (isEmagged) return false;
+			if (isOnCooldown && pickupable.ItemSlot != null && pickupable.ItemSlot.Player != null)
+			{
+				Chat.AddExamineMsg(pickupable.ItemSlot.Player.gameObject, "The megaphone's internal capacitor is still recharging...");
+			}
 			return isOnCooldown;
 		}
 
 		public ChatEvent InfluenceChat(ChatEvent chatToManipulate)
 		{
 			var modifiedMsg = chatToManipulate;
-			modifiedMsg.VoiceLevel = isEmmaged ? Loudness.EARRAPE : Loudness.MEGAPHONE;
+			modifiedMsg.VoiceLevel = isEmagged ? Loudness.EARRAPE : Loudness.MEGAPHONE;
 			StartCoroutine(Cooldown());
 			return modifiedMsg;
 		}
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
-			return isEmmaged == false && DefaultWillInteract.Default(interaction, side) && pickupable.ItemSlot != null;
+			return isEmagged == false && DefaultWillInteract.Default(interaction, side) && pickupable.ItemSlot != null;
 		}
 
 		public void ServerPerformInteraction(HandApply interaction)
 		{
 			if (interaction.TargetObject == null ||
 			    interaction.TargetObject.TryGetComponent<Emag>(out var mag) == false) return;
-			if (mag.UseCharge(interaction)) isEmmaged = true;
+			if (mag.UseCharge(interaction)) isEmagged = true;
 		}
 
 		public void ServerPerformInteraction(HandActivate interaction)

--- a/UnityProject/Assets/Scripts/Items/Bureaucracy/Megaphone.cs
+++ b/UnityProject/Assets/Scripts/Items/Bureaucracy/Megaphone.cs
@@ -34,7 +34,14 @@ namespace Items.Bureaucracy
 
 		public bool RunChecks()
 		{
-			return isOnCooldown == false && isOn == true && pickupable.ItemSlot != null;
+			return IsOnCooldown() && isOn == true && pickupable.ItemSlot != null;
+		}
+
+		private bool IsOnCooldown()
+		{
+			if (isEmmaged) return false;
+			if(isOnCooldown && pickupable.ItemSlot != null && pickupable.ItemSlot.Player != null) Chat.AddExamineMsg(pickupable.ItemSlot.Player.gameObject,"The megaphone is on cooldown..");
+			return isOnCooldown;
 		}
 
 		public ChatEvent InfluenceChat(ChatEvent chatToManipulate)

--- a/UnityProject/Assets/Scripts/Items/Bureaucracy/Megaphone.cs
+++ b/UnityProject/Assets/Scripts/Items/Bureaucracy/Megaphone.cs
@@ -32,7 +32,7 @@ namespace Items.Bureaucracy
 			isOnCooldown = false;
 		}
 
-		public bool RunChecks()
+		public bool WillInfluenceChat()
 		{
 			return IsOnCooldown() == false && isOn == true && pickupable.ItemSlot != null;
 		}

--- a/UnityProject/Assets/Scripts/Objects/Telecomms/LocalRadioListener.cs
+++ b/UnityProject/Assets/Scripts/Objects/Telecomms/LocalRadioListener.cs
@@ -42,7 +42,7 @@ namespace Objects.Telecomms
 			Chat.AddLocalMsgToChat("ksshhhk!", gameObject);
 		}
 
-		public bool RunChecks()
+		public bool WillInfluenceChat()
 		{
 			return true; //other checks such as being powered can be checked for later
 		}

--- a/UnityProject/Assets/Scripts/Systems/Communications/ChatInfluncer.cs
+++ b/UnityProject/Assets/Scripts/Systems/Communications/ChatInfluncer.cs
@@ -1,8 +1,8 @@
 ﻿namespace Systems.Communications
 {
-	public interface IChatInfluencer 
+	public interface IChatInfluencer
 	{
-		public bool RunChecks();
+		public bool WillInfluenceChat();
 		public ChatEvent InfluenceChat(ChatEvent chatToManipulate);
 	}
 }


### PR DESCRIPTION
stop bugging me about megaphones they're not broken or unreliable they're on god damn cooldown.

Also if they're emagged now there is no cooldown for them so they're extra annoying now, you asked for this.

CL: [Improvement] added text feedback to notify that a megaphone is on cooldown.
CL: [New] emagging a megaphone removes it's cooldown.