### PR TITLE
Ensure verification only happens once.

### DIFF
--- a/UnityProject/Assets/Scripts/Util/ComponentExtensions.cs
+++ b/UnityProject/Assets/Scripts/Util/ComponentExtensions.cs
@@ -59,16 +59,16 @@ namespace Util
 
 			var go = parent.gameObject;
 
-			if (go.TryGetComponent<VerifiedReferences>(out var verified) == false)
+			if (go.TryGetComponent<FailedReferences>(out var failures) == false)
 			{
-				verified = go.AddComponent<VerifiedReferences>();
+				failures = go.AddComponent<FailedReferences>();
 			}
-			else if (verified.Refs.Contains($"{parent.GetType()}-{refName}"))
+			else if (failures.Refs.Contains($"{parent.GetType()}-{refName}"))
 			{
 				return component;
 			}
 
-			verified.Refs.Add($"{parent.GetType()}-{refName}");
+			failures.Refs.Add($"{parent.GetType()}-{refName}");
 			childName ??= refName;
 			var objName = go.name.RemoveClone();
 			var description = MissingRefDescription(parent, objName, refName, refDescription, typeof(V));
@@ -98,7 +98,7 @@ namespace Util
 		/// <summary>
 		/// A simple helper component attached to a game object when reference verification fails.
 		/// </summary>
-		private class VerifiedReferences : MonoBehaviour
+		private class FailedReferences : MonoBehaviour
 		{
 			public readonly HashSet<string> Refs = new HashSet<string>();
 		}

--- a/UnityProject/Assets/Scripts/Util/ComponentExtensions.cs
+++ b/UnityProject/Assets/Scripts/Util/ComponentExtensions.cs
@@ -41,8 +41,8 @@ namespace Util
 		/// name, it will attempt to add a reference to the first component with a matching type if no more than a
 		/// single component is found.
 		///
-		/// In the event that no matching child is found, this will attach a small component to the object.
-		/// No further logging or attempts to find another child will occur afterward.
+		/// If a reference fails verification, a small component is attached to the object to track it and
+		/// other failures. No further logging or attempts to find another child will occur on subsequent calls.
 		/// </summary>
 		/// <param name="parent">The container component with the reference to check.</param>
 		/// <param name="component">A reference to a component to verify.</param>


### PR DESCRIPTION
If a reference is missing, a simple component is added to the offending object. This is to ensure that, in the event that a child component isn't found, accessing the component reference doesn't keep going through the hierarchy to find a component that doesn't exist. The helper component is only ever added or checked if a reference has failed verification. Verification will only log the event and try to find a valid child component once.