### PR TITLE
Fixes kick on opening orbit menu

### DIFF
--- a/UnityProject/Assets/Scripts/Player/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerScript.cs
@@ -294,7 +294,7 @@ public class PlayerScript : NetworkBehaviour, IMatrixRotation, IAdminInfo, IActi
 		}
 	}
 
-	[Command]
+	[Command(requiresAuthority = false)]
 	public void UpdateLastSyncedPosition()
 	{
 		SetLastRecordedPosition();
@@ -303,12 +303,7 @@ public class PlayerScript : NetworkBehaviour, IMatrixRotation, IAdminInfo, IActi
 	[Server]
 	private void SetLastRecordedPosition()
 	{
-		if (IsDeadOrGhost)
-		{
-			mind.body.gameObject.AssumedWorldPosServer();
-			return;
-		}
-		SyncedWorldPos = AssumedWorldPos;
+		SyncedWorldPos = gameObject.AssumedWorldPosServer().CutToInt();
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Player/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerScript.cs
@@ -294,7 +294,7 @@ public class PlayerScript : NetworkBehaviour, IMatrixRotation, IAdminInfo, IActi
 		}
 	}
 
-	[Command(requiresAuthority = false)]
+	[Command]
 	public void UpdateLastSyncedPosition()
 	{
 		SetLastRecordedPosition();
@@ -303,6 +303,11 @@ public class PlayerScript : NetworkBehaviour, IMatrixRotation, IAdminInfo, IActi
 	[Server]
 	private void SetLastRecordedPosition()
 	{
+		if (IsDeadOrGhost)
+		{
+			mind.body.gameObject.AssumedWorldPosServer();
+			return;
+		}
 		SyncedWorldPos = AssumedWorldPos;
 	}
 


### PR DESCRIPTION
PushPull was null for some reason, just get AssumedWorldPos() from the gameObject itself

CL: [Fix] Fixed a bug causing players to be kicked on opening orbit menu