### PR TITLE
Game window title will now change to reflect what server you are on

### DIFF
--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/GameData.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/GameData.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 8934140032923375002}
   - component: {fileID: 8824916536560241868}
   - component: {fileID: 839482601120855914}
+  - component: {fileID: 2960250731806234843}
   m_Layer: 0
   m_Name: GameData
   m_TagString: Untagged
@@ -57,5 +58,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5bd44a413d4f0e94a8207afc717efd94, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2960250731806234843
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8929341582706713524}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3940a3427ce046b8973d90f8b2772ba8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Scripts/UI/Systems/ServerInfoUI.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/ServerInfoUI.cs
@@ -12,7 +12,7 @@ using UI;
 
 namespace ServerInfo
 {
-	public class ServerInfoUI : MonoBehaviour, IInitialise
+	public class ServerInfoUI : Managers.SingletonManager<ServerInfoUI>, IInitialise
     {
     	public TMP_Text ServerName;
 

--- a/UnityProject/Assets/Scripts/Util/WindowNameChanger.cs
+++ b/UnityProject/Assets/Scripts/Util/WindowNameChanger.cs
@@ -33,7 +33,8 @@ namespace Util
 			//Get the window handle.
 			var windowPtr = FindWindow(null, Application.productName);
 			//Set the title text using the window handle.
-			SetWindowText(windowPtr, $"{Application.productName} Build v{Application.version} - {ServerInfoUI.Instance.ServerName.text} ||" +
+			var serverName = ServerInfoUI.Instance.ServerName.text != "" ? ServerInfoUI.Instance.ServerName.text : "Nameless Server";
+			SetWindowText(windowPtr, $"{Application.productName} Build v{Application.version} - {serverName} ||" +
 			                         $" {GameManager.Instance.GetGameModeName()} on {SubSceneManager.ServerChosenMainStation}");
 		}
 

--- a/UnityProject/Assets/Scripts/Util/WindowNameChanger.cs
+++ b/UnityProject/Assets/Scripts/Util/WindowNameChanger.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using DatabaseAPI;
+using ServerInfo;
+using UnityEngine;
+
+namespace Util
+{
+	/// <summary>
+	/// Changes the game's window title. Only works on windows sadly :(
+	/// </summary>
+	public class WindowNameChanger : MonoBehaviour
+	{
+#if UNITY_STANDALONE_WIN
+
+
+		//Import the following.
+		[DllImport("user32.dll", EntryPoint = "SetWindowText")]
+		public static extern bool SetWindowText(System.IntPtr hwnd, System.String lpString);
+		[DllImport("user32.dll", EntryPoint = "FindWindow")]
+		public static extern System.IntPtr FindWindow(System.String className, System.String windowName);
+
+
+		private void Awake()
+		{
+			if(EventManager.Instance == null) return;
+			EventManager.AddHandler(Event.PlayerRejoined, ChangeTile);
+			EventManager.AddHandler(Event.RoundStarted, ChangeTile);
+		}
+
+		private void ChangeTile()
+		{
+			//Get the window handle.
+			var windowPtr = FindWindow(null, Application.productName);
+			//Set the title text using the window handle.
+			SetWindowText(windowPtr, $"{Application.productName} Build v{Application.version} - {ServerInfoUI.Instance.ServerName.text} ||" +
+			                         $" {GameManager.Instance.GetGameModeName()} on {SubSceneManager.ServerChosenMainStation}");
+		}
+
+#endif
+
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/WindowNameChanger.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/WindowNameChanger.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3940a3427ce046b8973d90f8b2772ba8
+timeCreated: 1647958768


### PR DESCRIPTION
while browsing through older issues i found an issue saying that players can't know what server they are on, this is of course very old as you can see what server you are on when you join a server now with the MOTD window. 
However I've decided to add an extra thing to this so it can be more in parity with SS13 with how detailed some servers' make the game's window title be some times.

### Notes :
At some point we should make this method public and let admins change the title themselves like how admins can do on UnityStation
Works sadly only with windows because Unity is not as advanced as other cooler game engines like Godot.

closes #3292