### PR TITLE
Bomb signal pairing

### DIFF
--- a/UnityProject/Assets/Scripts/Communications/SignalReceiver.cs
+++ b/UnityProject/Assets/Scripts/Communications/SignalReceiver.cs
@@ -29,7 +29,7 @@ namespace Communications
 		/// <summary>
 		/// Logic to do when
 		/// </summary>
-		public abstract void ReceiveSignal(SignalStrength strength, ISignalMessage message = null);
+		public abstract void ReceiveSignal(SignalStrength strength, SignalEmitter responsibleEmitter, ISignalMessage message = null);
 
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/Items/Devices/ButtonSignalReceiver.cs
+++ b/UnityProject/Assets/Scripts/Items/Devices/ButtonSignalReceiver.cs
@@ -14,7 +14,7 @@ namespace Items
 	{
 		private DoorSwitch doorSwitch;
 
-		public override void ReceiveSignal(SignalStrength strength, ISignalMessage message = null)
+		public override void ReceiveSignal(SignalStrength strength, SignalEmitter responsibleEmitter, ISignalMessage message = null)
 		{
 			if (doorSwitch != null)
 			{

--- a/UnityProject/Assets/Scripts/Items/Storage/PizzaBox.cs
+++ b/UnityProject/Assets/Scripts/Items/Storage/PizzaBox.cs
@@ -204,7 +204,7 @@ namespace Items.Storage
 			return false;
 		}
 
-		public override void ReceiveSignal(SignalStrength strength, ISignalMessage message = null)
+		public override void ReceiveSignal(SignalStrength strength, SignalEmitter responsibleEmitter, ISignalMessage message = null)
 		{
 			if(isArmed == false) return;
 			if (detenationOnTimer)

--- a/UnityProject/Assets/Scripts/Items/Weapons/AttachableExplosive.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/AttachableExplosive.cs
@@ -83,6 +83,7 @@ namespace Items.Weapons
 
 		public void ServerPerformInteraction(PositionalHandApply interaction)
 		{
+			if(HackEmitter(interaction)) return;
 			void Perform()
 			{
 				if (interaction.TargetObject?.OrNull().RegisterTile()?.OrNull().Matrix?.OrNull() != null)

--- a/UnityProject/Assets/Scripts/Items/Weapons/AttachableExplosive.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/AttachableExplosive.cs
@@ -83,7 +83,6 @@ namespace Items.Weapons
 
 		public void ServerPerformInteraction(PositionalHandApply interaction)
 		{
-			if(HackEmitter(interaction)) return;
 			void Perform()
 			{
 				if (interaction.TargetObject?.OrNull().RegisterTile()?.OrNull().Matrix?.OrNull() != null)
@@ -150,6 +149,7 @@ namespace Items.Weapons
 
 		public void ServerPerformInteraction(HandApply interaction)
 		{
+			if(HackEmitter(interaction)) return;
 			explosiveGUI.ServerPerformInteraction(interaction);
 		}
 

--- a/UnityProject/Assets/Scripts/Items/Weapons/BulkyExplosive.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/BulkyExplosive.cs
@@ -55,6 +55,7 @@ namespace Items.Weapons
 
 		public void ServerPerformInteraction(HandApply interaction)
 		{
+			if(HackEmitter(interaction)) return;
 			if (interaction.HandObject != null && interaction.HandObject.Item().HasTrait(wrenchTrait))
 			{
 				objectBehaviour.ServerSetPushable(!objectBehaviour.IsPushable);

--- a/UnityProject/Assets/Scripts/Items/Weapons/ExplosiveBase.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/ExplosiveBase.cs
@@ -128,24 +128,6 @@ namespace Items.Weapons
 			                       $"{emitter.gameObject.ExpensiveName()} over the {gameObject.ExpensiveName()}", interaction.Performer);
 			return true;
 		}
-
-		protected bool HackEmitter(PositionalHandApply interaction)
-		{
-			if(interaction.UsedObject == null || interaction.UsedObject.TryGetComponent<SignalEmitter>(out var emitter) == false) return false;
-			void Hack()
-			{
-				Emitter = emitter;
-				Chat.AddLocalMsgToChat($"The {gameObject.ExpensiveName()} copies {Emitter.gameObject.ExpensiveName()}'s " +
-				                       $"codes from {interaction.PerformerPlayerScript.visibleName}'s hands!", interaction.Performer);
-			}
-			var bar = StandardProgressAction.Create(
-				new StandardProgressActionConfig(StandardProgressActionType.CPR, false, false), Hack);
-			bar.ServerStartProgress(interaction.Performer.RegisterTile(), progressTime, interaction.Performer);
-			SparkUtil.TrySpark(interaction.Performer);
-			Chat.AddLocalMsgToChat($"{interaction.PerformerPlayerScript.visibleName} hovers a " +
-			                       $"{emitter.gameObject.ExpensiveName()} over the {gameObject.ExpensiveName()}", interaction.Performer);
-			return true;
-		}
 	}
 
 	public enum ExplosiveType

--- a/UnityProject/Assets/Scripts/Items/Weapons/ExplosiveBase.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/ExplosiveBase.cs
@@ -113,6 +113,12 @@ namespace Items.Weapons
 
 		protected bool HackEmitter(HandApply interaction)
 		{
+			if (Emitter != null)
+			{
+				Chat.AddLocalMsgToChat($"<color=red>The {interaction.PerformerPlayerScript.visibleName} hovers the {interaction.HandObject.gameObject.ExpensiveName()} " +
+				                       $"in front of the {gameObject.ExpensiveName()} but nothing happens!</color>", interaction.Performer);
+				return false;
+			}
 			if(interaction.UsedObject == null || interaction.UsedObject.TryGetComponent<SignalEmitter>(out var emitter) == false) return false;
 			void Hack()
 			{

--- a/UnityProject/Assets/Scripts/Items/Weapons/ExplosiveBase.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/ExplosiveBase.cs
@@ -13,6 +13,7 @@ using Objects;
 using Systems.Explosions;
 using Scripts.Core.Transform;
 using UI.Items;
+using Random = UnityEngine.Random;
 
 namespace Items.Weapons
 {
@@ -68,6 +69,7 @@ namespace Items.Weapons
 			objectBehaviour = GetComponent<ObjectBehaviour>();
 			pickupable = GetComponent<Pickupable>();
 			explosiveGUI = GetComponent<HasNetworkTabItem>();
+			Frequency = Random.Range(120.00f, 122.99f);
 		}
 
 		[Server]
@@ -118,6 +120,7 @@ namespace Items.Weapons
 			void Hack()
 			{
 				emitters.Add(emitter);
+				emitter.Frequency = Frequency;
 				Chat.AddLocalMsgToChat($"The {gameObject.ExpensiveName()} copies {Emitter.gameObject.ExpensiveName()}'s " +
 				                       $"codes from {interaction.PerformerPlayerScript.visibleName}'s hands!", interaction.Performer);
 			}

--- a/UnityProject/Assets/Scripts/Items/Weapons/ExplosiveBase.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/ExplosiveBase.cs
@@ -120,7 +120,7 @@ namespace Items.Weapons
 			void Hack()
 			{
 				emitters.Add(emitter);
-				emitter.Frequency = Frequency;
+				Frequency = emitter.Frequency;
 				Chat.AddLocalMsgToChat($"The {gameObject.ExpensiveName()} copies {Emitter.gameObject.ExpensiveName()}'s " +
 				                       $"codes from {interaction.PerformerPlayerScript.visibleName}'s hands!", interaction.Performer);
 			}

--- a/UnityProject/Assets/Scripts/Items/Weapons/ExplosiveBase.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/ExplosiveBase.cs
@@ -41,6 +41,7 @@ namespace Items.Weapons
 		[HideInInspector] public GUI_Explosive GUI;
 		[SyncVar] protected bool isArmed;
 		[SyncVar] protected bool countDownActive = false;
+		protected List<SignalEmitter> emitters = new List<SignalEmitter>();
 
 		public int MinimumTimeToDetonate => minimumTimeToDetonate;
 		public bool DetonateImmediatelyOnSignal => detonateImmediatelyOnSignal;
@@ -102,7 +103,7 @@ namespace Items.Weapons
 		public override void ReceiveSignal(SignalStrength strength, SignalEmitter responsibleEmitter, ISignalMessage message = null)
 		{
 			if(gameObject == null || countDownActive == true) return;
-			if(Emitter != null && Emitter != responsibleEmitter) return;
+			if(emitters.Contains(responsibleEmitter)) return;
 			if (detonateImmediatelyOnSignal)
 			{
 				Detonate();
@@ -113,16 +114,10 @@ namespace Items.Weapons
 
 		protected bool HackEmitter(HandApply interaction)
 		{
-			if (Emitter != null)
-			{
-				Chat.AddLocalMsgToChat($"<color=red>{interaction.PerformerPlayerScript.visibleName} hovers the {interaction.HandObject.gameObject.ExpensiveName()} " +
-				                       $"in front of the {gameObject.ExpensiveName()} but nothing happens!</color>", interaction.Performer);
-				return false;
-			}
 			if(interaction.UsedObject == null || interaction.UsedObject.TryGetComponent<SignalEmitter>(out var emitter) == false) return false;
 			void Hack()
 			{
-				Emitter = emitter;
+				emitters.Add(emitter);
 				Chat.AddLocalMsgToChat($"The {gameObject.ExpensiveName()} copies {Emitter.gameObject.ExpensiveName()}'s " +
 				                       $"codes from {interaction.PerformerPlayerScript.visibleName}'s hands!", interaction.Performer);
 			}

--- a/UnityProject/Assets/Scripts/Items/Weapons/ExplosiveBase.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/ExplosiveBase.cs
@@ -99,15 +99,52 @@ namespace Items.Weapons
 			detonateImmediatelyOnSignal = mode;
 		}
 
-		public override void ReceiveSignal(SignalStrength strength, ISignalMessage message = null)
+		public override void ReceiveSignal(SignalStrength strength, SignalEmitter responsibleEmitter, ISignalMessage message = null)
 		{
 			if(gameObject == null || countDownActive == true) return;
+			if(Emitter != null && Emitter != responsibleEmitter) return;
 			if (detonateImmediatelyOnSignal)
 			{
 				Detonate();
 				return;
 			}
 			StartCoroutine(Countdown());
+		}
+
+		protected bool HackEmitter(HandApply interaction)
+		{
+			if(interaction.UsedObject == null || interaction.UsedObject.TryGetComponent<SignalEmitter>(out var emitter) == false) return false;
+			void Hack()
+			{
+				Emitter = emitter;
+				Chat.AddLocalMsgToChat($"The {gameObject.ExpensiveName()} copies {Emitter.gameObject.ExpensiveName()}'s " +
+				                       $"codes from {interaction.PerformerPlayerScript.visibleName}'s hands!", interaction.Performer);
+			}
+			var bar = StandardProgressAction.Create(
+				new StandardProgressActionConfig(StandardProgressActionType.CPR, false, false), Hack);
+			bar.ServerStartProgress(interaction.Performer.RegisterTile(), progressTime, interaction.Performer);
+			SparkUtil.TrySpark(interaction.Performer);
+			Chat.AddLocalMsgToChat($"{interaction.PerformerPlayerScript.visibleName} hovers a " +
+			                       $"{emitter.gameObject.ExpensiveName()} over the {gameObject.ExpensiveName()}", interaction.Performer);
+			return true;
+		}
+
+		protected bool HackEmitter(PositionalHandApply interaction)
+		{
+			if(interaction.UsedObject == null || interaction.UsedObject.TryGetComponent<SignalEmitter>(out var emitter) == false) return false;
+			void Hack()
+			{
+				Emitter = emitter;
+				Chat.AddLocalMsgToChat($"The {gameObject.ExpensiveName()} copies {Emitter.gameObject.ExpensiveName()}'s " +
+				                       $"codes from {interaction.PerformerPlayerScript.visibleName}'s hands!", interaction.Performer);
+			}
+			var bar = StandardProgressAction.Create(
+				new StandardProgressActionConfig(StandardProgressActionType.CPR, false, false), Hack);
+			bar.ServerStartProgress(interaction.Performer.RegisterTile(), progressTime, interaction.Performer);
+			SparkUtil.TrySpark(interaction.Performer);
+			Chat.AddLocalMsgToChat($"{interaction.PerformerPlayerScript.visibleName} hovers a " +
+			                       $"{emitter.gameObject.ExpensiveName()} over the {gameObject.ExpensiveName()}", interaction.Performer);
+			return true;
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Items/Weapons/ExplosiveBase.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/ExplosiveBase.cs
@@ -115,7 +115,7 @@ namespace Items.Weapons
 		{
 			if (Emitter != null)
 			{
-				Chat.AddLocalMsgToChat($"<color=red>The {interaction.PerformerPlayerScript.visibleName} hovers the {interaction.HandObject.gameObject.ExpensiveName()} " +
+				Chat.AddLocalMsgToChat($"<color=red>{interaction.PerformerPlayerScript.visibleName} hovers the {interaction.HandObject.gameObject.ExpensiveName()} " +
 				                       $"in front of the {gameObject.ExpensiveName()} but nothing happens!</color>", interaction.Performer);
 				return false;
 			}

--- a/UnityProject/Assets/Scripts/Items/Weapons/PowerSink.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/PowerSink.cs
@@ -157,7 +157,7 @@ namespace Items.Weapons
 			}
 		}
 
-		public override void ReceiveSignal(SignalStrength strength, ISignalMessage message = null)
+		public override void ReceiveSignal(SignalStrength strength, SignalEmitter responsibleEmitter, ISignalMessage message = null)
 		{
 			ToggleActivity();
 		}

--- a/UnityProject/Assets/Scripts/Managers/SignalsManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SignalsManager.cs
@@ -80,7 +80,7 @@ namespace Managers
 
 			if (strength == SignalStrength.DELAYED)
 			{
-				StartCoroutine(DelayedSignalRecevie(receiver.DelayTime, receiver, strength, signalMessage));
+				StartCoroutine(DelayedSignalRecevie(receiver.DelayTime, receiver, emitter, strength, signalMessage));
 				return;
 			}
 			if (strength == SignalStrength.WEAK)
@@ -88,13 +88,13 @@ namespace Managers
 				Random chance = new Random();
 				if (DMMath.Prob(chance.Next(0, 100)))
 				{
-					StartCoroutine(DelayedSignalRecevie(receiver.DelayTime, receiver, strength, signalMessage));
+					StartCoroutine(DelayedSignalRecevie(receiver.DelayTime, receiver, emitter, strength, signalMessage));
 				}
 				emitter.SignalFailed();
 			}
 		}
 
-		private IEnumerator DelayedSignalRecevie(float waitTime, SignalReceiver receiver, SignalStrength strength, ISignalMessage signalMessage = null)
+		private IEnumerator DelayedSignalRecevie(float waitTime, SignalReceiver receiver, SignalEmitter emitter, SignalStrength strength, ISignalMessage signalMessage = null)
 		{
 			yield return WaitFor.Seconds(waitTime);
 			if (receiver.gameObject == null)
@@ -102,7 +102,7 @@ namespace Managers
 				//In case the object despawns before the signal reaches it
 				yield break;
 			}
-			receiver.ReceiveSignal(strength, receiver.Emitter, signalMessage);
+			receiver.ReceiveSignal(strength, emitter, signalMessage);
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/Managers/SignalsManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SignalsManager.cs
@@ -21,7 +21,7 @@ namespace Managers
 		public void SendSignal(SignalEmitter emitter, SignalType type, SignalDataSO signalDataSo, ISignalMessage signalMessage = null)
 		{
 			Receivers.Remove(null);
-			
+
 			foreach (SignalReceiver receiver in Receivers)
 			{
 				if (receiver.SignalTypeToReceive != type) continue;
@@ -32,14 +32,14 @@ namespace Managers
 				if (receiver.SignalTypeToReceive == SignalType.PING && receiver.Emitter == emitter)
 				{
 					if (signalDataSo.UsesRange) { SignalStrengthHandler(receiver, emitter, signalDataSo); break; }
-					receiver.ReceiveSignal(SignalStrength.HEALTHY, signalMessage);
+					receiver.ReceiveSignal(SignalStrength.HEALTHY, emitter, signalMessage);
 					break;
 				}
 				//TODO (Max) : Radio signals should be sent to relays and servers.
 				if (receiver.SignalTypeToReceive == SignalType.RADIO && AreOnTheSameFrequancy(receiver, emitter))
 				{
 					if (signalDataSo.UsesRange) { SignalStrengthHandler(receiver, emitter, signalDataSo, signalMessage); continue; }
-					receiver.ReceiveSignal(SignalStrength.HEALTHY, signalMessage);
+					receiver.ReceiveSignal(SignalStrength.HEALTHY, emitter, signalMessage);
 					continue;
 				}
 				//Bounced radios always have a limited range.
@@ -74,7 +74,7 @@ namespace Managers
 		private void SignalStrengthHandler(SignalReceiver receiver, SignalEmitter emitter, SignalDataSO signalDataSo, ISignalMessage signalMessage = null)
 		{
 			SignalStrength strength = GetStrength(receiver, emitter, signalDataSo.SignalRange);
-			if (strength == SignalStrength.HEALTHY) receiver.ReceiveSignal(strength, signalMessage);
+			if (strength == SignalStrength.HEALTHY) receiver.ReceiveSignal(strength, emitter, signalMessage);
 			if (strength == SignalStrength.TOOFAR) emitter.SignalFailed();
 
 
@@ -102,7 +102,7 @@ namespace Managers
 				//In case the object despawns before the signal reaches it
 				yield break;
 			}
-			receiver.ReceiveSignal(strength, signalMessage);
+			receiver.ReceiveSignal(strength, receiver.Emitter, signalMessage);
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/Objects/Telecomms/SBRSignaller.cs
+++ b/UnityProject/Assets/Scripts/Objects/Telecomms/SBRSignaller.cs
@@ -8,7 +8,7 @@ namespace Objects.Telecomms
 	public class SBRSignaller : SignalReceiver, ICheckedInteractable<HandApply>
 	{
 		[SerializeField] private StationBouncedRadio radio;
-		public override void ReceiveSignal(SignalStrength strength, ISignalMessage message = null)
+		public override void ReceiveSignal(SignalStrength strength, SignalEmitter responsibleEmitter, ISignalMessage message = null)
 		{
 			radio.BroadcastToNearbyTiles = !radio.BroadcastToNearbyTiles;
 		}

--- a/UnityProject/Assets/Scripts/Objects/Telecomms/StationBouncedRadio.cs
+++ b/UnityProject/Assets/Scripts/Objects/Telecomms/StationBouncedRadio.cs
@@ -41,7 +41,7 @@ namespace Objects.Telecomms
 			Frequency = radioListener.Frequency;
 		}
 
-		public override void ReceiveSignal(SignalStrength strength, ISignalMessage message = null)
+		public override void ReceiveSignal(SignalStrength strength, SignalEmitter responsibleEmitter, ISignalMessage message = null)
 		{
 			if (message is RadioMessage msg)
 			{


### PR DESCRIPTION
work on #6149

Bombs by default can receive any bounced signal from remote signaling devices as of #8480 at the request of Jack. This PR aims to add the ability for antags to make bombs only accept a signal from a specific remote signaler(s).

CL: [Balance] Bombs have a random frequency on spawn now.
Bombs will only work with paired remote signalers, the bomb will automatically copy the remote's frequency on pair.

On the backend side a bit, the `ReceiveSignal()` function is now aware of the emitter regardless if it was a PING or BOUNCED signal.

~~Tip : If a traitor doesn't pair their bombs with their a remote, you can sabotage their bombs by pairing any kind of emitter to the bomb. However, you can't override any devices it was paired to.~~