### PR TITLE
Fix wooden logs somehow being able to be filled up with reagents.

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Botany/Produce/_GrownInedibleBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Botany/Produce/_GrownInedibleBase.prefab
@@ -1,89 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &6226849216177938727
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4353717592831911221}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 62eb19bca4bfc5c48be147510edfe6ed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  plantData:
-    ProduceObject: {fileID: 0}
-    PlantName: 
-    DeadSpriteSO: {fileID: 0}
-    FullyGrownSpriteSO: {fileID: 0}
-    GrowthSpritesSOs: []
-    WeedResistance: 50
-    WeedGrowthRate: 10
-    GrowthSpeed: 60
-    Potency: 10
-    Endurance: 15
-    Yield: 40
-    Lifespan: 25
-    PlantTrays: 
-    ReagentProduction: []
-    MutatesInToGameObject: []
-    plantEvolveStats:
-      WeedResistanceChange: 0
-      WeedGrowthRateChange: 0
-      GrowthSpeedChange: 0
-      PotencyChange: 0
-      EnduranceChange: 0
-      YieldChange: 0
-      LifespanChange: 0
-      PlantTrays: 
-      ReagentProduction: []
-      RemovePlantTrays: 
-      RemoveReagentProduction: []
-    Age: 0
-    NextGrowthStageProgress: 0
-    Health: 0
-  reagentContainer: {fileID: 7586176257189890726}
-  nutrient: {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237, type: 2}
-  seedPacket: {fileID: 0}
-  SpriteSizeAdjustment: {fileID: 4511048310713767529}
-  Sprite: {fileID: 7578885421250109106}
-  edible: {fileID: 0}
-  sizeScale: 1
---- !u!114 &7586176257189890726
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4353717592831911221}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  maxCapacity: 100
-  reactionSet: {fileID: 0}
-  AdditionalReactions: []
-  canPourOut: 1
-  initialReagentMix:
-    temperature: 273.15
-    reagents:
-      m_keys: []
-      m_values: []
-    reagentKeys: []
-  destroyOnEmpty: 0
-  ContentsSet: 0
-  UseStandardExamine: 1
-  ExamineAmount: 0
-  ExamineContent: 0
-  traitWhitelist: []
-  reagentWhitelist: []
-  transferMode: 0
-  possibleTransferAmounts: []
-  transferAmount: 20
 --- !u!1001 &4352752067959167375
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -209,3 +125,87 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &6226849216177938727
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4353717592831911221}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62eb19bca4bfc5c48be147510edfe6ed, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  plantData:
+    ProduceObject: {fileID: 0}
+    PlantName: 
+    DeadSpriteSO: {fileID: 0}
+    FullyGrownSpriteSO: {fileID: 0}
+    GrowthSpritesSOs: []
+    WeedResistance: 50
+    WeedGrowthRate: 10
+    GrowthSpeed: 60
+    Potency: 10
+    Endurance: 15
+    Yield: 40
+    Lifespan: 25
+    PlantTrays: 
+    ReagentProduction: []
+    MutatesInToGameObject: []
+    plantEvolveStats:
+      WeedResistanceChange: 0
+      WeedGrowthRateChange: 0
+      GrowthSpeedChange: 0
+      PotencyChange: 0
+      EnduranceChange: 0
+      YieldChange: 0
+      LifespanChange: 0
+      PlantTrays: 
+      ReagentProduction: []
+      RemovePlantTrays: 
+      RemoveReagentProduction: []
+    Age: 0
+    NextGrowthStageProgress: 0
+    Health: 0
+  reagentContainer: {fileID: 7586176257189890726}
+  nutrient: {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237, type: 2}
+  seedPacket: {fileID: 0}
+  SpriteSizeAdjustment: {fileID: 4511048310713767529}
+  Sprite: {fileID: 7578885421250109106}
+  edible: {fileID: 0}
+  sizeScale: 1
+--- !u!114 &7586176257189890726
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4353717592831911221}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxCapacity: 100
+  reactionSet: {fileID: 0}
+  AdditionalReactions: []
+  canPourOut: 0
+  initialReagentMix:
+    temperature: 273.15
+    reagents:
+      m_keys: []
+      m_values: []
+    reagentKeys: []
+  destroyOnEmpty: 0
+  ContentsSet: 0
+  UseStandardExamine: 1
+  ExamineAmount: 2
+  ExamineContent: 0
+  traitWhitelist: []
+  reagentWhitelist: []
+  transferMode: 4
+  possibleTransferAmounts: []
+  transferAmount: 20


### PR DESCRIPTION
<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->

### Purpose
- Title. You could somehow fill up wooden logs like beakers. This PR fixes that.

### Changelog:

CL: [Fix] Wooden logs can no longer be filled up like beakers.
