### PR TITLE
Put C4/X4s on walls only on harm intent

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Weapons/AttachableExplosive.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/AttachableExplosive.cs
@@ -77,7 +77,7 @@ namespace Items.Weapons
 		public bool WillInteract(PositionalHandApply interaction, NetworkSide side)
 		{
 			if (DefaultWillInteract.Default(interaction, side) == false
-			    || isArmed == true || pickupable.ItemSlot == null) return false;
+			    || isArmed == true || pickupable.ItemSlot == null || interaction.Intent != Intent.Harm) return false;
 			return true;
 		}
 


### PR DESCRIPTION
more work on #6149 
Done at Jack's request.
CL: [Improvement] C4/X4s will now only be put on walls when the user is on harm intent, allowing you to place them on tables without attaching them.