### PR TITLE
Fixes Mob attack cooldowns

### DIFF
--- a/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/Xenomorphs/Facehugger.prefab
+++ b/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Hostile/Xenomorphs/Facehugger.prefab
@@ -7,6 +7,21 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 941816724250882487, guid: cf769d410d94f0e47bab5eee03a3b07d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 941816724250882487, guid: cf769d410d94f0e47bab5eee03a3b07d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 941816724250882487, guid: cf769d410d94f0e47bab5eee03a3b07d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
     - target: {fileID: 3783638323905235520, guid: cf769d410d94f0e47bab5eee03a3b07d,
         type: 3}
       propertyPath: m_RootOrder
@@ -193,7 +208,6 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
-      m_EditorAssetChanged: 0
   randomSounds: []
   playRandomSoundTimer: 3
   randomSoundProbability: 20
@@ -220,7 +234,8 @@ MonoBehaviour:
   onlyActOnTarget: 0
   doLerpOnAction: 1
   spriteHolder: {fileID: 6655050449683268901}
-  actionCooldown: 1
+  actionCooldown: 3
+  isOnCooldown: 0
   maskObject: {fileID: 8320299039891337921, guid: 6fecf534029349145b17735e15c9498c,
     type: 3}
   bite:
@@ -230,4 +245,3 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
-      m_EditorAssetChanged: 0

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/GenericHostileAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/GenericHostileAI.cs
@@ -103,6 +103,7 @@ namespace Systems.MobAIs
 					HandleSearch();
 					break;
 				case MobStatus.Attacking:
+					if(mobMeleeAction.isOnCooldown) break;
 					MonitorIdleness();
 					break;
 				case MobStatus.None:

--- a/UnityProject/Assets/Scripts/NPC/AI/MobMeleeAction.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobMeleeAction.cs
@@ -39,7 +39,7 @@ namespace Systems.MobAIs
 		private float lerpProgress;
 		private bool lerping;
 		private bool isActing = false;
-		private bool isOnCooldown = false;
+		public bool isOnCooldown = false;
 
 		/// <summary>
 		/// Maximum range that the mob will continue to try to act on the target

--- a/UnityProject/Assets/Scripts/NPC/AI/MobMeleeAction.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobMeleeAction.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using HealthV2;
 using Messages.Server;
+using Mirror;
 using UnityEngine;
 using Random = UnityEngine.Random;
 
@@ -38,6 +39,7 @@ namespace Systems.MobAIs
 		private float lerpProgress;
 		private bool lerping;
 		private bool isActing = false;
+		private bool isOnCooldown = false;
 
 		/// <summary>
 		/// Maximum range that the mob will continue to try to act on the target
@@ -53,11 +55,23 @@ namespace Systems.MobAIs
 		}
 
 		/// <summary>
+		/// Cooldown that tells DoAction() to not hit the player. ServerDoLerpAnimation() only affects the animation!!
+		/// </summary>
+		/// <returns></returns>
+		private IEnumerator Cooldown()
+		{
+			isOnCooldown = true;
+			yield return WaitFor.Seconds(actionCooldown);
+			isOnCooldown = false;
+		}
+
+		/// <summary>
 		/// Determines if the target of the action can be acted upon and what kind of target it is.
 		/// Then performs the appropriate action. Action methods are individually overridable for flexibility.
 		/// </summary>
 		public override void DoAction()
 		{
+			if(isOnCooldown) return;
 			base.DoAction();
 			var hitInfo = ValidateTarget();
 			if (hitInfo.ItHit == false)
@@ -65,6 +79,7 @@ namespace Systems.MobAIs
 				return;
 			}
 
+			StartCoroutine(Cooldown());
 			var dir = (hitInfo.TileHitWorld - mobTile.WorldPositionServer).normalized;
 
 			if (hitInfo.CollisionHit.GameObject != null &&


### PR DESCRIPTION
Fixes #7830

this is the silliest coding mistake i've seen lol, Mobs had a cooldown variable but it was used on their animations.. not their actual actions.

This actually introduces a proper cooldown to their melee actions and will no longer hit you 10000000000 times a second.

CL: [Fix] fixed mob attack cooldowns.