### PR TITLE
Sugarcane and white beets can now be grinded for sugar.

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Botany/Produce/Roots/RedBeet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Botany/Produce/Roots/RedBeet.prefab
@@ -18,6 +18,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: f866b6c644819d54aa67d13c291864a2
       objectReference: {fileID: 0}
+    - target: {fileID: 3075618960723909792, guid: 65aa5598a8968404e9ca47e68a8d09b6,
+        type: 3}
+      propertyPath: customNetTransform
+      value: 
+      objectReference: {fileID: 2044653010848069422}
     - target: {fileID: 3110045621768978504, guid: 65aa5598a8968404e9ca47e68a8d09b6,
         type: 3}
       propertyPath: m_RootOrder
@@ -132,5 +137,18 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 366e429fce866944d8fda1a97b278048,
         type: 2}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: -5936286651745845230, guid: 65aa5598a8968404e9ca47e68a8d09b6, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 65aa5598a8968404e9ca47e68a8d09b6, type: 3}
+--- !u!114 &2044653010848069422 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3075737970608722156, guid: 65aa5598a8968404e9ca47e68a8d09b6,
+    type: 3}
+  m_PrefabInstance: {fileID: 3949417694945109954}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Prefabs/Items/Botany/Produce/Roots/WhiteBeet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Botany/Produce/Roots/WhiteBeet.prefab
@@ -128,3 +128,25 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 27208d0fc3f7c3544a8d1a7861253b52, type: 3}
+--- !u!1 &3114969372513860924 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1188401911067925580, guid: 27208d0fc3f7c3544a8d1a7861253b52,
+    type: 3}
+  m_PrefabInstance: {fileID: 4270702303430943088}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &-5936286651745845230
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3114969372513860924}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8688576ed720a4f40b3583f62adeeb23, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  groundReagents:
+    m_keys:
+    - {fileID: 11400000, guid: 911271db97b77da51889f97d6688a103, type: 2}
+    m_values: 05000000

--- a/UnityProject/Assets/Prefabs/Items/Botany/Produce/sugarcane.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Botany/Produce/sugarcane.prefab
@@ -1,22 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-595227118724416437
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5426168625685936815}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1468e3dc2ea50c647aea7b69f0986db9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  FermentTime: 10
-  fermentedReagents:
-    m_keys:
-    - {fileID: 11400000, guid: a42ee1808745235d6992c36a45c1f94b, type: 2}
-    m_values: 00000000
 --- !u!1001 &6571757499017881315
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -95,6 +78,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: f897271445a9a544683354068c060441
       objectReference: {fileID: 0}
+    - target: {fileID: 1290947839602867664, guid: 27208d0fc3f7c3544a8d1a7861253b52,
+        type: 3}
+      propertyPath: customNetTransform
+      value: 
+      objectReference: {fileID: 5393114280324863871}
     - target: {fileID: 1337560984964591376, guid: 27208d0fc3f7c3544a8d1a7861253b52,
         type: 3}
       propertyPath: m_Sprite
@@ -135,3 +123,48 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 6571757499017881315}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &5393114280324863871 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1291304377019134364, guid: 27208d0fc3f7c3544a8d1a7861253b52,
+    type: 3}
+  m_PrefabInstance: {fileID: 6571757499017881315}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5426168625685936815}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &-595227118724416437
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5426168625685936815}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1468e3dc2ea50c647aea7b69f0986db9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  FermentTime: 10
+  fermentedReagents:
+    m_keys:
+    - {fileID: 11400000, guid: a42ee1808745235d6992c36a45c1f94b, type: 2}
+    m_values: 00000000
+--- !u!114 &6110820142320645922
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5426168625685936815}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8688576ed720a4f40b3583f62adeeb23, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  groundReagents:
+    m_keys:
+    - {fileID: 11400000, guid: 911271db97b77da51889f97d6688a103, type: 2}
+    m_values: 05000000


### PR DESCRIPTION
<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->

### Purpose
- Title. Sugarcane and white beets can now be grinded for sugar. Red beets however cannot. Fixes #8517.

### Changelog:
<!-- Add here individual lines with all your remarkable changes using the prefix ``CL:`` -->
<!-- Mind that the changes meant to be logged in the in changelog are those that are remarkable for the end user, so things like new features and fixes of known bugs are perfect for this section -->

 CL: [New] Added ability to grind sugarcane and white beets (not red beets) for sugar.
