### PR TITLE
Fixes debug door signal item and improves it slightly

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Research/ButtonSignalEmitter.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Research/ButtonSignalEmitter.prefab
@@ -89,7 +89,8 @@ PrefabInstance:
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: initialDescription
-      value: Sends a signal to a paired receiver.
+      value: Sends a signal to a paired door button(s). Just click this on a door
+        button to add a signal receiver to it.
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Research/ButtonSignalReceiver.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Research/ButtonSignalReceiver.prefab
@@ -1,23 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &7760974441610081215
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3648832323169248661}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8e51546a99cdfed4e91d5b21638adf00, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  SignalTypeToReceive: 0
-  Frequency: 122
-  Emitter: {fileID: 0}
-  DelayTime: 3
 --- !u!1001 &3648151331491256623
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -161,3 +143,24 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &7760974441610081215
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3648832323169248661}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8e51546a99cdfed4e91d5b21638adf00, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  SignalTypeToReceive: 2
+  Frequency: 122
+  Emitter: {fileID: 0}
+  DelayTime: 3
+  EncryptionData: {fileID: 0}
+  ListenToEncryptedData: 0
+  doorSwitch: {fileID: 0}

--- a/UnityProject/Assets/ScriptableObjects/Communications/SignalData/RemoteDoorSignal.asset
+++ b/UnityProject/Assets/ScriptableObjects/Communications/SignalData/RemoteDoorSignal.asset
@@ -13,5 +13,6 @@ MonoBehaviour:
   m_Name: RemoteDoorSignal
   m_EditorClassIdentifier: 
   UsesRange: 1
-  SignalRange: 25
-  EmittedSignalType: 0
+  SignalRange: 30
+  EmittedSignalType: 2
+  MinMaxFrequancy: {x: 100, y: 144}

--- a/UnityProject/Assets/Scripts/Items/Devices/ButtonSignalEmitter.cs
+++ b/UnityProject/Assets/Scripts/Items/Devices/ButtonSignalEmitter.cs
@@ -1,6 +1,8 @@
 using System.Collections;
 using System.Collections.Generic;
 using Communications;
+using Managers;
+using Objects.Wallmounts;
 using UnityEngine;
 
 
@@ -8,20 +10,24 @@ using UnityEngine;
 ///PLEASE REMOVE THIS (OR POLISH IT AND ADD IT TO THE LIST OF THINGS SCIENCE CAN MAKE) ONCE WE MAKE THE MOVE TO FULLY USE THE SIGNAL MANAGER
 namespace Items
 {
-	public class ButtonSignalEmitter : SignalEmitter, ICheckedInteractable<HandApply>, ICheckedInteractable<HandActivate>
+	public class ButtonSignalEmitter : SignalEmitter, ICheckedInteractable<HandApply>, IInteractable<HandActivate>
 	{
 		public void ServerPerformInteraction(HandApply interaction)
 		{
-			if (interaction.TargetObject.TryGetComponent<ButtonSignalReceiver>(out var receiver))
+			if(interaction.TargetObject.TryGetComponent<DoorSwitch>(out var doorSwitch)
+			   && doorSwitch.TryGetComponent<ButtonSignalReceiver>(out var s) == false)
 			{
-				receiver.Emitter = this;
-				Chat.AddExamineMsg(interaction.Performer.gameObject, "You assign the receiver to this emitter.");
+				var switchSignal = doorSwitch.gameObject.AddComponent<ButtonSignalReceiver>();
+				switchSignal.doorSwitch = doorSwitch;
+				switchSignal.SignalTypeToReceive = SignalType.BOUNCED;
+				Chat.AddExamineMsg(interaction.Performer, "Added signal receiver successfully to the door switch");
+				return;
 			}
+			Chat.AddExamineMsg(interaction.Performer.gameObject, "You assign the receiver to this emitter.");
 		}
 
 		protected override bool SendSignalLogic()
 		{
-			if(signalData == null) return false;
 			return true;
 		}
 
@@ -37,15 +43,8 @@ namespace Items
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
-
-			if (!DefaultWillInteract.Default(interaction, side)) return false;
-			if (interaction.TargetObject.TryGetComponent<ButtonSignalReceiver>(out var _)) return true;
-			return false;
-		}
-
-		public bool WillInteract(HandActivate interaction, NetworkSide side)
-		{
-			if (!DefaultWillInteract.Default(interaction, side)) return false;
+			if (!DefaultWillInteract.Default(interaction, side)
+			    || interaction.TargetObject == null || gameObject.PickupableOrNull().ItemSlot == null) return false;
 			return true;
 		}
 	}

--- a/UnityProject/Assets/Scripts/Items/Devices/ButtonSignalReceiver.cs
+++ b/UnityProject/Assets/Scripts/Items/Devices/ButtonSignalReceiver.cs
@@ -12,7 +12,7 @@ namespace Items
 {
 	public class ButtonSignalReceiver : SignalReceiver, ICheckedInteractable<HandApply>
 	{
-		private DoorSwitch doorSwitch;
+		public DoorSwitch doorSwitch;
 
 		public override void ReceiveSignal(SignalStrength strength, SignalEmitter responsibleEmitter, ISignalMessage message = null)
 		{


### PR DESCRIPTION
At the request of .ᚲᚨᚲᛖ᛫ᛁᛋ᛫ᚡᛖᚱᛃ᛫ᛏᛁᚱᛖᛞ on discord
fixed and improved the debug item that opens doors remotely

you can now add a signal receiver to any door button by clicking the Button Signal Emitter item on them.
changed the range from 25 to 30.
you can now open trigger multiple door buttons at once.
improved interactions slightly
updated item desc to explain people how to use it.


Once again, this is a debug item. I understand when admins want to add it for events like the merchant event but dont expect it to be a regular item anytime soon. Its entirely intended for testing any major change I do to the signals system currently and will be like this for a while until i completely finish and polish the signals system.
Once it's done i promise I'll make this an official item that science can make and use.