### PR TITLE
Added option to not consume healing item on use + Fixes Door crowbar ( thought this branch was already merged oops )

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/Surgery/HealBruteProcedure.asset
+++ b/UnityProject/Assets/ScriptableObjects/Surgery/HealBruteProcedure.asset
@@ -28,3 +28,4 @@ MonoBehaviour:
   Affects: 0
   HeelStrength: 15
   FailAttackType: 0
+  UseUpItem: 1

--- a/UnityProject/Assets/ScriptableObjects/Surgery/HealBurnProcedure.asset
+++ b/UnityProject/Assets/ScriptableObjects/Surgery/HealBurnProcedure.asset
@@ -28,3 +28,4 @@ MonoBehaviour:
   Affects: 1
   HeelStrength: 15
   FailAttackType: 0
+  UseUpItem: 1

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Procedures/AffectHealthProcedure.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Procedures/AffectHealthProcedure.cs
@@ -15,20 +15,25 @@ namespace HealthV2
 
 		public AttackType FailAttackType = AttackType.Melee;
 
+		public bool UseUpItem = false;
+
 		public override void FinnishSurgeryProcedure(BodyPart OnBodyPart, HandApply interaction,
 			Dissectible.PresentProcedure PresentProcedure)
 		{
 			if (interaction.HandSlot.Item != null && interaction.HandSlot.Item.GetComponent<ItemAttributesV2>().HasTrait(RequiredTrait))
 			{
 				OnBodyPart.HealDamage(interaction.UsedObject,HeelStrength,Affects);
-				var stackable = interaction.UsedObject.GetComponent<Stackable>();
-				if (stackable != null)
+				if (UseUpItem)
 				{
-					stackable.ServerConsume(1);
-				}
-				else
-				{
-					_ = Despawn.ServerSingle(interaction.UsedObject);
+					var stackable = interaction.UsedObject.GetComponent<Stackable>();
+					if (stackable != null)
+					{
+						stackable.ServerConsume(1);
+					}
+					else
+					{
+						_ = Despawn.ServerSingle(interaction.UsedObject);
+					}
 				}
 			}
 		}

--- a/UnityProject/Assets/Scripts/Objects/Doors/ConstructibleDoor.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/ConstructibleDoor.cs
@@ -75,7 +75,7 @@ namespace Doors
 			}
 			else
 			{
-				return weldModule.CanDoorStateChange();
+				return weldModule.CanDoorStateChange() == false; //Door has to be welded to allow Deconstruction
 			}
 
 		}
@@ -122,7 +122,7 @@ namespace Doors
 					interaction.Performer.AssumedWorldPosServer(), audioSourceParameters, sourceObj: gameObject);
 			}
 
-			if (!weldModule.CanDoorStateChange() && boltsModule.CanDoorStateChange() && !doorMasterController.HasPower)
+			if (CheckWeld() && CheckBolts() && !doorMasterController.HasPower)
 			{
 				if (Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.Crowbar) && airlockAssemblyPrefab)
 				{


### PR DESCRIPTION
pretty self-explanatory title
Fixes Door crowbar 

CL: [Balance] organ treatment no longer consumes gauze or ointment when used.