### PR TITLE
Removes the character screen on joining a server from stationhub

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/GameData.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameData.cs
@@ -96,7 +96,7 @@ public class GameData : MonoBehaviour
 			forceOfflineMode = true;
 			return;
 		}
-		
+
 		forceOfflineMode = false;
 	}
 
@@ -305,7 +305,7 @@ public class GameData : MonoBehaviour
 					if (success)
 					{
 						Logger.Log("Signed in successfully with valid token", Category.DatabaseAPI);
-						LobbyManager.Instance.lobbyDialogue.ShowCharacterEditor(OnCharacterScreenCloseFromHubConnect);
+						OnCharacterScreenCloseFromHubConnect();
 					}
 					else
 					{
@@ -318,17 +318,17 @@ public class GameData : MonoBehaviour
 		{
 			if (FirebaseAuth.DefaultInstance.CurrentUser != null)
 			{
-				AttemptAutoJoin(OnHubConnectAutoJoinSuccess);
+				AttemptAutoJoin(OnCharacterScreenCloseFromHubConnect);
 			}
 		}
 	}
 
-	private void OnHubConnectAutoJoinSuccess(string msg)
+	private void OnCharacterScreenCloseFromHubConnect()
 	{
-		LobbyManager.Instance.lobbyDialogue.ShowCharacterEditor(OnCharacterScreenCloseFromHubConnect);
+		LobbyManager.Instance.lobbyDialogue.OnStartGameFromHub();
 	}
 
-	private void OnCharacterScreenCloseFromHubConnect()
+	private void OnCharacterScreenCloseFromHubConnect(string msg)
 	{
 		LobbyManager.Instance.lobbyDialogue.OnStartGameFromHub();
 	}

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/GUI_LobbyDialogue.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/GUI_LobbyDialogue.cs
@@ -365,7 +365,7 @@ namespace Lobby
 
 		public void OnStartGameFromHub()
 		{
-			PlayerPrefs.SetString(UserNamePlayerPref, PlayerManager.CurrentCharacterSettings.Name);
+			if (PlayerManager.CurrentCharacterSettings != null) PlayerPrefs.SetString(UserNamePlayerPref, PlayerManager.CurrentCharacterSettings.Name);
 			ConnectToServer();
 			gameObject.SetActive(false);
 		}


### PR DESCRIPTION
Makes the game join the server immediately after connecting to one from stationhub.

The idea behind this is that people should edit their characters *after* they have joined instead of *before* so players can get their correct character settings from the server's firebase/django database.
If you edit your characters offline or on another server the character menu in the pre-lobby screen actually loads your **offline** character sheets not the server's character sheets.

Also it makes joining a server now require less clicks on the user's part and they don't have to be forced to make a character to just join a server. (Though they cant join the round still until they have made a character)