### PR TITLE
Add Mirror doc (link to unitystation/Mirror contribution guide)

### DIFF
--- a/docs/development/Mirror.md
+++ b/docs/development/Mirror.md
@@ -1,0 +1,15 @@
+# Mirror (Networking library)
+
+## Packaged Mirror
+
+Mirror (or SpaceMirror) is now packaged in the [unitystation/Mirror](https://github.com/unitystation/Mirror) repository. Please see the [CONTRIBUTING.md](https://github.com/unitystation/Mirror/blob/master/CONTRIBUTING.md) document.
+
+## Mirror Upgrade Customization Notes
+
+See [Mirror-Upgrade-Customization-Notes](/docs/development/Mirror-Upgrade-Customization-Notes.md).
+
+## Working with Mirror
+
+ - [Networking](/docs/development/Networking-(Network-Messages).md)
+ - [Mirror sync notes](/docs/development/Notes-on-SyncObject-and-SyncList.md)
+ - [SyncVar - best practices](/docs/development/SyncVar-Best-Practices-for-Easy-Networking.md)


### PR DESCRIPTION
Adds a link to the unitystation/Mirror contribution document from the Unitystation docs.