### PR TITLE
File cabinets in Squarestation

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/RandomItemPools/AsteroidPools/nukiegearpool.asset
+++ b/UnityProject/Assets/ScriptableObjects/RandomItemPools/AsteroidPools/nukiegearpool.asset
@@ -96,3 +96,7 @@ MonoBehaviour:
       type: 3}
     maxAmount: 1
     probability: 100
+  - prefab: {fileID: 6081445882463156587, guid: 037968b5e32c4ea41b05e567fa5e0cdf,
+      type: 3}
+    maxAmount: 1
+    probability: 100

--- a/UnityProject/Assets/ScriptableObjects/RandomItemPools/RandomHat.asset
+++ b/UnityProject/Assets/ScriptableObjects/RandomItemPools/RandomHat.asset
@@ -85,3 +85,53 @@ MonoBehaviour:
       type: 3}
     maxAmount: 1
     probability: 100
+  - prefab: {fileID: 6980020022460415521, guid: 9c308081529a1fa43850db366eb71631,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 8849173994779109555, guid: d658c7db2b934fd36b6c93a517098ae5,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 616735813865956089, guid: c8f2cdc822ad0e543852e74c225f3b14, type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 616735813865956089, guid: 9dd23cd6632343f42a2e2ad869d97aa8, type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 7636118406116123594, guid: 9542c9504316c3845bbb5f541ec22cfb,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 7636118406116123594, guid: 59b6ec971c7da824b83117e8faa53db3,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 6804612781048497285, guid: 7783baf2677b3a844aff37585692717e,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 2850241452416116279, guid: 3961caf40305bd741b8c919afd07fca2,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 3116170454584013683, guid: db265d83fcf1bbb46aedc59510228a5d,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 1454153603153415932, guid: bcf175e4b2e739a47a94808c336aaa33,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 4040753959103249631, guid: ec0203c4cccabd440904f3733552e0d2,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 9131734980111636233, guid: 71a7c952a49de8042b89c9bbdf8df8fd,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 8823201312216209349, guid: b1298be73a51bd846a23547ed228e0ce,
+      type: 3}
+    maxAmount: 1
+    probability: 100


### PR DESCRIPTION
### Purpose

This PR adds file cabinets to Squarestation and remixes some of the loot like #8542 and #8543. Overall, the loot rebalance focused on filling out the southern and eastern maintenance areas which were very empty compared to the central and western areas.

### Notes:

- added syndicate jaws of life to the random syndicate item pool
- added ball caps, beanies, and the flower hat to the random hat pool

### Changelog:

CL: [Improvement] Squarestation has gained file cabinets.
CL: [Balance] Loot in Squarestation has been more randomized to vary up each round.
CL: [Fix] Command shuttle in squarestation no longer starts depressurized.
