### PR TITLE
Buffs and Nerfs for syndicate explosions

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/C4.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/C4.prefab
@@ -100,7 +100,6 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
-      m_EditorAssetChanged: 0
   soundDelayTime: 0
   soundMinimumPitchVariance: 1
   soundMaximumPitchVariance: 1
@@ -177,7 +176,6 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
-      m_EditorAssetChanged: 0
   damageDeflection: 0
   Armor:
     Melee: 0
@@ -244,7 +242,6 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
-      m_EditorAssetChanged: 0
   hitSoundSettings: 0
   inventoryMoveSound:
     SetLoadSetting: 0
@@ -253,7 +250,6 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
-      m_EditorAssetChanged: 0
   inventoryRemoveSound:
     SetLoadSetting: 0
     AssetAddress: null
@@ -261,7 +257,6 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
-      m_EditorAssetChanged: 0
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
@@ -306,7 +301,7 @@ MonoBehaviour:
   detonateImmediatelyOnSignal: 0
   timeToDetonate: 10
   minimumTimeToDetonate: 10
-  explosiveStrength: 1000
+  explosiveStrength: 1750
   activeSpriteSO: {fileID: 11400000, guid: 60942022f971e0440a63456ee27fc478, type: 2}
   beepSound:
     SetLoadSetting: 0

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/SyndicateBomb.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/SyndicateBomb.prefab
@@ -277,7 +277,7 @@ MonoBehaviour:
   detonateImmediatelyOnSignal: 0
   timeToDetonate: 90
   minimumTimeToDetonate: 90
-  explosiveStrength: 17500
+  explosiveStrength: 19500
   activeSpriteSO: {fileID: 11400000, guid: 17eb29bb46caa9044adc12a3e0afcd77, type: 2}
   beepSound:
     SetLoadSetting: 0

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/SyndicateBomb.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/SyndicateBomb.prefab
@@ -277,13 +277,8 @@ MonoBehaviour:
   detonateImmediatelyOnSignal: 0
   timeToDetonate: 90
   minimumTimeToDetonate: 90
-  explosiveStrength: 12000
+  explosiveStrength: 17500
   activeSpriteSO: {fileID: 11400000, guid: 17eb29bb46caa9044adc12a3e0afcd77, type: 2}
-  progressTime: 3
-  spriteHandler: {fileID: 5680589113982627379}
-  scaleSync: {fileID: 0}
-  GUI: {fileID: 0}
-  wrenchTrait: {fileID: 11400000, guid: 024541a41c4ab42a499f8e49374496d4, type: 2}
   beepSound:
     SetLoadSetting: 0
     AssetAddress: Assets/Prefabs/Machines/Beep.prefab
@@ -291,7 +286,11 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
-      m_EditorAssetChanged: 0
+  progressTime: 3
+  spriteHandler: {fileID: 5680589113982627379}
+  scaleSync: {fileID: 0}
+  GUI: {fileID: 0}
+  wrenchTrait: {fileID: 11400000, guid: 024541a41c4ab42a499f8e49374496d4, type: 2}
 --- !u!114 &4256679036758816722
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/ScriptableObjects/PDA/UplinkCategoryList.asset
+++ b/UnityProject/Assets/ScriptableObjects/PDA/UplinkCategoryList.asset
@@ -245,11 +245,11 @@ MonoBehaviour:
         type: 3}
       name: EMP grenade box
       isNukeOps: 0
-    - cost: 25
+    - cost: 15
       item: {fileID: 1011433845357754, guid: 2354313a50efe2543862cb92150a5388, type: 3}
       name: Power Sink
       isNukeOps: 0
-    - cost: 25
+    - cost: 20
       item: {fileID: 4761250752494374682, guid: 00265c28041a8b84f9012e430f772f08,
         type: 3}
       name: Syndicate Bomb


### PR DESCRIPTION
Based on latest feedback from playtest.

CL: [Balance] Nerfed prices for Syndicate bomb and Power sink. (20 and 15).
CL: [Balance] Increased damage for C4 and Syndicate bomb. C4s can now breach more stuff more easily and Syndicate bombs should hopefully be more threatening than X4s now so their price is justifiable.