### PR TITLE
fixes griddle not cooking properly

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Machines/Griddle.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/Griddle.cs
@@ -165,6 +165,7 @@ namespace Objects.Kitchen
 					{
 						// Swap item for its cooked version, if applicable.
 						if (slotCooked.CookedProduct == null) return;
+						Spawn.ServerPrefab(slotCooked.CookedProduct, slotCooked.gameObject.transform.position, transform.parent);
 						var stackable = slotCooked.GetComponent<Stackable>();
 						if (stackable != null && stackable.Amount > 1)
 						{
@@ -175,7 +176,7 @@ namespace Objects.Kitchen
 						{
 							_ = Despawn.ServerSingle(slotCooked.gameObject);
 						}
-						Spawn.ServerPrefab(slotCooked.CookedProduct, slotCooked.gameObject.transform.position, transform.parent);
+
 
 					}
 				}


### PR DESCRIPTION
looks like it was being hidden at hidden POS, and then using that coordinates To spawn in

CL: [Fix] fixed griddle not cooking properly 