### PR TITLE
Fully functional janitor cart

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Misc/JanitorialCart.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Misc/JanitorialCart.prefab
@@ -100,6 +100,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 39f11c8504eb6b7409e8dba3179a52ca
       objectReference: {fileID: 0}
+    - target: {fileID: 1140667517167752775, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
+      propertyPath: Meleeable
+      value: 
+      objectReference: {fileID: 7988589231758933372}
     - target: {fileID: 1197192003336439530, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
       propertyPath: initialName
@@ -241,6 +246,65 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 8248558368109462878}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &7988589231758933372 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2064319571996571682, guid: a7af28adb717b4c44b8b2002b27670bd,
+    type: 3}
+  m_PrefabInstance: {fileID: 8248558368109462878}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 450498622285847684}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &772111864290309540
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 450498622285847684}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fdce8a163088453ca593c0e98f2c5f07, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemStorageStructure: {fileID: 11400000, guid: 74bf3e872403e488695c17ecdde194ab,
+    type: 2}
+  itemStorageCapacity: {fileID: 11400000, guid: 411b6b7a74c524a91b9a38a0c692761b,
+    type: 2}
+  itemStoragePopulator: {fileID: 0}
+  forceSpawnContents: 1
+  dropItemsOnDespawn: 1
+  UesAddlistPopulater: 1
+  Populater:
+    SlotContents: []
+    DeprecatedContents:
+    - {fileID: 359432221073519209, guid: 4dddcb74ff9a3ee4ca69bc6d757dca03, type: 3}
+  ashPrefab: {fileID: 2957035178188790827, guid: 9ac6968a3f3ed54428662c9aae5a4b32,
+    type: 3}
+--- !u!114 &2827566681100547254
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 450498622285847684}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 819809cff2481914d883a6e1fefb4edd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  MethodRotation: 0
+  ChangeSprites: 1
+  isChangingSO: 0
+  CurrentDirection: 3
+  IgnoreServerUpdatesIfLocalPlayer: 0
+  IsAtmosphericDevice: 0
+  doNotResetOtherSpriteOptions: 0
 --- !u!114 &4320299406662285398
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -258,7 +322,7 @@ MonoBehaviour:
   fillSpriteRender: {fileID: 4758289030963813880}
   fillIcons:
   - {fileID: 21300002, guid: a5f4f4df60b0b9140bfbfcf452db0502, type: 3}
---- !u!114 &7030391235084296120
+--- !u!114 &7087012579486443808
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -267,13 +331,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 450498622285847684}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
+  m_Script: {fileID: 11500000, guid: d7a784e759cd4d83a10d616f9999dbf4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   maxCapacity: 100
   reactionSet: {fileID: 11400000, guid: 2d5f766d9268838aa8d819bee2a442a7, type: 2}
   AdditionalReactions: []
-  canPourOut: 1
+  canPourOut: 0
   initialReagentMix:
     temperature: 273.15
     reagents:
@@ -284,9 +348,19 @@ MonoBehaviour:
   ContentsSet: 0
   UseStandardExamine: 1
   ExamineAmount: 0
-  ExamineContent: 0
+  ExamineContent: 1
   traitWhitelist: []
   reagentWhitelist: []
   transferMode: 0
   possibleTransferAmounts: []
-  transferAmount: 5
+  transferAmount: 20
+  dippingSound:
+    SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/footsteps/water/FootstepWater1.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
+  mopTrait: {fileID: 11400000, guid: 20597800d3cec8f438706d926881018b, type: 2}
+  trashbagTrait: {fileID: 11400000, guid: 3bc88a6fd0eb5cd49a3295a04e1ca62d, type: 2}

--- a/UnityProject/Assets/Scripts/Objects/Other/JanitorCart.cs
+++ b/UnityProject/Assets/Scripts/Objects/Other/JanitorCart.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using AddressableReferences;
+using Chemistry.Components;
+using UnityEngine;
+
+namespace Objects.Other
+{
+	public class JanitorCart : ReagentContainer, ICheckedInteractable<HandApply>
+	{
+		[SerializeField] private AddressableAudioSource dippingSound;
+		[SerializeField] private ItemTrait mopTrait;
+		[SerializeField] private ItemTrait trashbagTrait;
+
+		private ReagentContainer liquds;
+		private ItemStorage jaintorToolsHolding;
+
+		private void Awake()
+		{
+			liquds = GetComponent<ReagentContainer>();
+			jaintorToolsHolding = GetComponent<ItemStorage>();
+		}
+
+		public new bool WillInteract(HandApply interaction, NetworkSide side)
+		{
+			return DefaultWillInteract.Default(interaction, side);
+		}
+
+		public new void ServerPerformInteraction(HandApply interaction)
+		{
+			if (interaction.IsAltClick || interaction.Intent == Intent.Disarm)
+			{
+				if (interaction.HandObject == null)
+				{
+					Inventory.ServerTransfer(jaintorToolsHolding.GetTopOccupiedIndexedSlot(), interaction.HandSlot);
+					return;
+				}
+				if (Inventory.ServerTransfer(interaction.HandObject.PickupableOrNull().ItemSlot,
+					    jaintorToolsHolding.GetNextFreeIndexedSlot()))
+				{
+					Chat.AddLocalMsgToChat($"{interaction.PerformerPlayerScript.visibleName} adds a {interaction.HandObject.ExpensiveName()} to the {gameObject.ExpensiveName()}", interaction.Performer);
+					return;
+				}
+				Chat.AddExamineMsg(interaction.Performer, $"The {gameObject.ExpensiveName()} has no space for the {interaction.HandObject.ExpensiveName()}");
+				Logger.Log("No space found in cart");
+				return;
+			}
+			if(interaction.HandObject == null) return;
+			Logger.Log("Player has item in his hand");
+			if (interaction.HandObject.Item().HasTrait(mopTrait))
+			{
+				base.ServerPerformInteraction(interaction);
+				if(dippingSound != null) _ = SoundManager.PlayNetworkedAtPosAsync(dippingSound, gameObject.AssumedWorldPosServer());
+				return;
+			}
+			foreach (var slot in jaintorToolsHolding.GetItemSlots())
+			{
+				if(slot.IsEmpty) continue;
+				if(slot.ItemAttributes.HasTrait(trashbagTrait) == false) continue;
+				if(slot.ItemObject.TryGetComponent<ItemStorage>(out var bag) == false) continue;
+				if (bag.ServerTryTransferFrom(interaction.HandSlot))
+				{
+					Chat.AddLocalMsgToChat($"{interaction.PerformerPlayerScript.visibleName} throws a {interaction.HandObject.ExpensiveName()} into the {gameObject.ExpensiveName()}", interaction.Performer);
+					return;
+				}
+				Chat.AddExamineMsg(interaction.Performer, "This wont fit into the trash bag that's on this cart!");
+			}
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Objects/Other/JanitorCart.cs
+++ b/UnityProject/Assets/Scripts/Objects/Other/JanitorCart.cs
@@ -11,7 +11,6 @@ namespace Objects.Other
 		[SerializeField] private ItemTrait mopTrait;
 		[SerializeField] private ItemTrait trashbagTrait;
 
-		private ReagentContainer liquds;
 		private ItemStorage jaintorToolsHolding;
 
 		private void Awake()

--- a/UnityProject/Assets/Scripts/Objects/Other/JanitorCart.cs
+++ b/UnityProject/Assets/Scripts/Objects/Other/JanitorCart.cs
@@ -15,7 +15,6 @@ namespace Objects.Other
 
 		private void Awake()
 		{
-			liquds = GetComponent<ReagentContainer>();
 			jaintorToolsHolding = GetComponent<ItemStorage>();
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/Other/JanitorCart.cs.meta
+++ b/UnityProject/Assets/Scripts/Objects/Other/JanitorCart.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d7a784e759cd4d83a10d616f9999dbf4
+timeCreated: 1649806010


### PR DESCRIPTION
closes #5098

Janitor cart now can hold janitor items and adds a single QoL feature into it that is not present on SS13.

No overlays added sadly.
use alt-click or disarm intent to add and remove items into the cart. disarm intent is for quick access to these items until we replace the intent system.
for the new QoL; you can now throw trash directly into the trash bag thats on the cart without taking it out of it.
there is code to play sounds when dipping the mop into water but there are none currently so it will just skip that.

### Changelog 

CL: [New] - Janitor carts can now hold janitor items like mops and trash bags
CL: [New] - if a trash bag is on the cart, clicking on the cart will cause the item in your hand to be thrown into the trash bag immediately.
CL: [New] - Janitor cart sprites are now rotatable
CL: [Fix] - You no longer can pour all reagent contents of the cart via the right click menu.