### PR TITLE
Enables multi-threaded imports

### DIFF
--- a/UnityProject/Assets/Textures/objects/machines/research/research_protolathe_m.png.meta
+++ b/UnityProject/Assets/Textures/objects/machines/research/research_protolathe_m.png.meta
@@ -51,6 +51,7 @@ TextureImporter:
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
+  ignoreMasterTextureLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -316,6 +317,16 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    nameFileIdTable:
+      research_protolathe_m_8: -156505894599014461
+      research_protolathe_m_4: -3302991386977554517
+      research_protolathe_m_5: 7659719883601063510
+      research_protolathe_m_7: -8706675271401879566
+      research_protolathe_m_6: 3909484710597134966
+      research_protolathe_m_3: -6567081437830198491
+      research_protolathe_m_2: -1644622625615953253
+      research_protolathe_m_1: 8424539439413526129
+      research_protolathe_m_0: 6202742127332999404
   spritePackingTag: 
   pSDRemoveMatte: 0
   pSDShowRemoveMatteOption: 0

--- a/UnityProject/Assets/UI/Research/connection.png.meta
+++ b/UnityProject/Assets/UI/Research/connection.png.meta
@@ -30,6 +30,7 @@ TextureImporter:
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
+  ignoreMasterTextureLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -148,6 +149,9 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    nameFileIdTable:
+      connection_0: -6676138422775949228
+      connection_1: 5919906950770870372
   spritePackingTag: 
   pSDRemoveMatte: 0
   pSDShowRemoveMatteOption: 0

--- a/UnityProject/ProjectSettings/EditorSettings.asset
+++ b/UnityProject/ProjectSettings/EditorSettings.asset
@@ -11,6 +11,7 @@ EditorSettings:
   m_PrefabUIEnvironment: {fileID: 0}
   m_SpritePackerMode: 3
   m_SpritePackerPaddingPower: 1
+  m_Bc7TextureCompressor: 0
   m_EtcTextureCompressorBehavior: 1
   m_EtcTextureFastCompressor: 1
   m_EtcTextureNormalCompressor: 2
@@ -31,6 +32,7 @@ EditorSettings:
   m_SerializeInlineMappingsOnOneLine: 0
   m_DisableCookiesInLightmapper: 1
   m_AssetPipelineMode: 1
+  m_RefreshImportMode: 1
   m_CacheServerMode: 0
   m_CacheServerEndpoint: 
   m_CacheServerNamespacePrefix: default


### PR DESCRIPTION
Enables multithreaded imports in the project settings with 4 desired workers and 2 standby workers.

Also updates some of the new assets that were imported from the recent research PR