### PR TITLE
Adds in handheld flashers and portable flashers

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Clothing/Eyewear/SecurityHUD/SecurityHUDSunglasses.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Eyewear/SecurityHUD/SecurityHUDSunglasses.prefab
@@ -56,7 +56,7 @@ PrefabInstance:
     - target: {fileID: 2987011942256334699, guid: a04a2ac5c1ef5a142b26e818b8dfa3fb,
         type: 3}
       propertyPath: initialTraits.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 2987011942256334699, guid: a04a2ac5c1ef5a142b26e818b8dfa3fb,
         type: 3}
@@ -67,7 +67,7 @@ PrefabInstance:
         type: 3}
       propertyPath: initialTraits.Array.data[1]
       value: 
-      objectReference: {fileID: 11400000, guid: 5beae98557a654ea6acad86c309950af,
+      objectReference: {fileID: 11400000, guid: 4f5b7ce1cca0a644cba934af14ea4b2c,
         type: 2}
     - target: {fileID: 3273994478765017941, guid: a04a2ac5c1ef5a142b26e818b8dfa3fb,
         type: 3}
@@ -75,6 +75,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 2d84281b35c440544ae36afd5ad05a70,
         type: 3}
+    - target: {fileID: 3317523692514924949, guid: a04a2ac5c1ef5a142b26e818b8dfa3fb,
+        type: 3}
+      propertyPath: customNetTransform
+      value: 
+      objectReference: {fileID: 3294689372906803577}
     - target: {fileID: 3317552745358689725, guid: a04a2ac5c1ef5a142b26e818b8dfa3fb,
         type: 3}
       propertyPath: m_AssetId
@@ -184,3 +189,15 @@ PrefabInstance:
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a04a2ac5c1ef5a142b26e818b8dfa3fb, type: 3}
+--- !u!114 &3294689372906803577 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3317968190863873497, guid: a04a2ac5c1ef5a142b26e818b8dfa3fb,
+    type: 3}
+  m_PrefabInstance: {fileID: 266518297843975328}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Eyewear/Sunglasses/BigSunglasses.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Eyewear/Sunglasses/BigSunglasses.prefab
@@ -18,6 +18,17 @@ PrefabInstance:
       value: Strangely ancient technology used to help provide rudimentary eye cover.
         Larger than average enhanced shielding blocks flashes.
       objectReference: {fileID: 0}
+    - target: {fileID: 2987011942256334699, guid: 0c3e7a0b25eff4d33a4f511cfc36b5d9,
+        type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2987011942256334699, guid: 0c3e7a0b25eff4d33a4f511cfc36b5d9,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 4f5b7ce1cca0a644cba934af14ea4b2c,
+        type: 2}
     - target: {fileID: 3273994478765017941, guid: 0c3e7a0b25eff4d33a4f511cfc36b5d9,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Eyewear/Sunglasses/Sunglasses.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Eyewear/Sunglasses/Sunglasses.prefab
@@ -94,11 +94,27 @@ PrefabInstance:
       propertyPath: hitSound.AssetAddress
       value: Assets/Prefabs/Effects/Tap.prefab
       objectReference: {fileID: 0}
+    - target: {fileID: 2546418124722880301, guid: 28c72054b1f484ed4a6253c4feee3eb4,
+        type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2546418124722880301, guid: 28c72054b1f484ed4a6253c4feee3eb4,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 4f5b7ce1cca0a644cba934af14ea4b2c,
+        type: 2}
     - target: {fileID: 2607336686439034363, guid: 28c72054b1f484ed4a6253c4feee3eb4,
         type: 3}
       propertyPath: m_AssetId
       value: 0c3e7a0b25eff4d33a4f511cfc36b5d9
       objectReference: {fileID: 0}
+    - target: {fileID: 2607435180188348883, guid: 28c72054b1f484ed4a6253c4feee3eb4,
+        type: 3}
+      propertyPath: customNetTransform
+      value: 
+      objectReference: {fileID: 3317968190863873497}
     - target: {fileID: 2713605000496459067, guid: 28c72054b1f484ed4a6253c4feee3eb4,
         type: 3}
       propertyPath: m_RootOrder
@@ -192,3 +208,15 @@ PrefabInstance:
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 28c72054b1f484ed4a6253c4feee3eb4, type: 3}
+--- !u!114 &3317968190863873497 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2607166637791280543, guid: 28c72054b1f484ed4a6253c4feee3eb4,
+    type: 3}
+  m_PrefabInstance: {fileID: 731076568007370822}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Prefabs/Items/Construction/Assemblies/FlashHandheld.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Construction/Assemblies/FlashHandheld.prefab
@@ -95,53 +95,19 @@ MonoBehaviour:
     type: 3}
   m_PrefabInstance: {fileID: 2176125562174552113}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7000420633856662113}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &7000420633856662113 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 9157326371999507024, guid: e77ad8336ea71364c9ec01faad07f5f4,
-    type: 3}
-  m_PrefabInstance: {fileID: 2176125562174552113}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1656610268748102239
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7000420633856662113}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 17e7a056918f4d81bf5394f635688745, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  flashRadius: 12
-  flashTime: 12
-  stunExtraTime: 3
-  flashCooldown: 24
-  sunglassesTrait: {fileID: 0}
-  flashSound:
-    SetLoadSetting: 0
-    AssetAddress: 
-    AssetReference:
-      m_AssetGUID: 
-      m_SubObjectName: 
-      m_SubObjectType: 
-      m_EditorAssetChanged: 0
-  stunsPlayers: 1
 --- !u!114 &7479326478255699203 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 8788987313818766642, guid: e77ad8336ea71364c9ec01faad07f5f4,
     type: 3}
   m_PrefabInstance: {fileID: 2176125562174552113}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7000420633856662113}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 99794c150ee14b21a829d6ed54d27a60, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Construction/Assemblies/FlashHandheld.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Construction/Assemblies/FlashHandheld.prefab
@@ -12,6 +12,16 @@ PrefabInstance:
       propertyPath: foreverID
       value: 7885c3ef269a1bb49870f7fb6d8f904d
       objectReference: {fileID: 0}
+    - target: {fileID: 9115576831223235532, guid: e77ad8336ea71364c9ec01faad07f5f4,
+        type: 3}
+      propertyPath: customNetTransform
+      value: 
+      objectReference: {fileID: 6968144197604865969}
+    - target: {fileID: 9115658328221961518, guid: e77ad8336ea71364c9ec01faad07f5f4,
+        type: 3}
+      propertyPath: ItemAttributesV2
+      value: 
+      objectReference: {fileID: 7479326478255699203}
     - target: {fileID: 9115688381779992548, guid: e77ad8336ea71364c9ec01faad07f5f4,
         type: 3}
       propertyPath: m_AssetId
@@ -79,3 +89,61 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e77ad8336ea71364c9ec01faad07f5f4, type: 3}
+--- !u!114 &6968144197604865969 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 9115554552792240000, guid: e77ad8336ea71364c9ec01faad07f5f4,
+    type: 3}
+  m_PrefabInstance: {fileID: 2176125562174552113}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7000420633856662113}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &7000420633856662113 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 9157326371999507024, guid: e77ad8336ea71364c9ec01faad07f5f4,
+    type: 3}
+  m_PrefabInstance: {fileID: 2176125562174552113}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1656610268748102239
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7000420633856662113}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 17e7a056918f4d81bf5394f635688745, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  flashRadius: 12
+  flashTime: 12
+  stunExtraTime: 3
+  flashCooldown: 24
+  sunglassesTrait: {fileID: 0}
+  flashSound:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
+  stunsPlayers: 1
+--- !u!114 &7479326478255699203 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8788987313818766642, guid: e77ad8336ea71364c9ec01faad07f5f4,
+    type: 3}
+  m_PrefabInstance: {fileID: 2176125562174552113}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7000420633856662113}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 99794c150ee14b21a829d6ed54d27a60, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Prefabs/Items/Construction/Assemblies/_FlashBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Construction/Assemblies/_FlashBase.prefab
@@ -170,7 +170,7 @@ MonoBehaviour:
   flashTime: 6
   stunExtraTime: 4
   flashCooldown: 12
-  sunglassesTrait: {fileID: 0}
+  sunglassesTrait: {fileID: 11400000, guid: 4f5b7ce1cca0a644cba934af14ea4b2c, type: 2}
   flashSound:
     SetLoadSetting: 0
     AssetAddress: 

--- a/UnityProject/Assets/Prefabs/Items/Construction/Assemblies/_FlashBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Construction/Assemblies/_FlashBase.prefab
@@ -116,6 +116,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: e77ad8336ea71364c9ec01faad07f5f4
       objectReference: {fileID: 0}
+    - target: {fileID: 4578568276478799971, guid: 201d4b5714989d64d86b11da761ecb15,
+        type: 3}
+      propertyPath: customNetTransform
+      value: 
+      objectReference: {fileID: 9115554552792240000}
     - target: {fileID: 7396244808014028178, guid: 201d4b5714989d64d86b11da761ecb15,
         type: 3}
       propertyPath: foreverID
@@ -129,3 +134,49 @@ PrefabInstance:
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 201d4b5714989d64d86b11da761ecb15, type: 3}
+--- !u!114 &9115554552792240000 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4578942373061721135, guid: 201d4b5714989d64d86b11da761ecb15,
+    type: 3}
+  m_PrefabInstance: {fileID: 4686944575098696623}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9157326371999507024}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &9157326371999507024 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4476020110803030527, guid: 201d4b5714989d64d86b11da761ecb15,
+    type: 3}
+  m_PrefabInstance: {fileID: 4686944575098696623}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &6031154819312805203
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9157326371999507024}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 17e7a056918f4d81bf5394f635688745, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  flashRadius: 12
+  flashTime: 6
+  stunExtraTime: 4
+  flashCooldown: 12
+  sunglassesTrait: {fileID: 0}
+  flashSound:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
+  stunsPlayers: 1

--- a/UnityProject/Assets/Prefabs/Objects/Machines/PortableFlasher.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Machines/PortableFlasher.prefab
@@ -110,6 +110,21 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8196760117574954170, guid: 3e02bb6440df3c34f88a1add858dfac8,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8196760117574954170, guid: 3e02bb6440df3c34f88a1add858dfac8,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8196760117574954170, guid: 3e02bb6440df3c34f88a1add858dfac8,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
     - target: {fileID: 9066908898016155968, guid: 3e02bb6440df3c34f88a1add858dfac8,
         type: 3}
       propertyPath: foreverID
@@ -119,3 +134,41 @@ PrefabInstance:
     - {fileID: 6990654033406033745, guid: 3e02bb6440df3c34f88a1add858dfac8, type: 3}
     - {fileID: 8954267026484833717, guid: 3e02bb6440df3c34f88a1add858dfac8, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 3e02bb6440df3c34f88a1add858dfac8, type: 3}
+--- !u!1 &1185562140364895280 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5378927155846326025, guid: 3e02bb6440df3c34f88a1add858dfac8,
+    type: 3}
+  m_PrefabInstance: {fileID: 6545489219064025913}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7076398014117559573
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1185562140364895280}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ab2c21a9da2642fda56e3a8b7edf5679, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  flashRadius: 12
+  flashTime: 12
+  stunExtraTime: 3
+  flashCooldown: 24
+  sunglassesTrait: {fileID: 11400000, guid: 4f5b7ce1cca0a644cba934af14ea4b2c, type: 2}
+  flashSound:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
+  stunsPlayers: 1
+  isWrenched: 0
+  isOn: 0
+  progressBarTime: 4
+  timeInBetweenFlashes: 12

--- a/UnityProject/Assets/Prefabs/Objects/Machines/PortableFlasher.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Machines/PortableFlasher.prefab
@@ -157,7 +157,7 @@ MonoBehaviour:
   flashRadius: 12
   flashTime: 12
   stunExtraTime: 3
-  flashCooldown: 24
+  flashCooldown: 16
   sunglassesTrait: {fileID: 11400000, guid: 4f5b7ce1cca0a644cba934af14ea4b2c, type: 2}
   flashSound:
     SetLoadSetting: 0

--- a/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
+++ b/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
@@ -29,6 +29,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4892080207053079231}
   m_RootOrder: 0
@@ -148,6 +149,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4892080207053079231}
   - {fileID: 6973244498870489173}
@@ -184,6 +186,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4892080207053079231}
   m_RootOrder: 13
@@ -306,6 +309,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4892080207053079231}
   m_RootOrder: 4
@@ -457,6 +461,7 @@ GameObject:
   - component: {fileID: 3160124018402396833}
   - component: {fileID: 5123748548063984441}
   - component: {fileID: 4951365732200208794}
+  - component: {fileID: 1594872346571213938}
   m_Layer: 8
   m_Name: Player_V4(uNet)
   m_TagString: Untagged
@@ -474,6 +479,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4027748146393864}
   - {fileID: 4304794156734570639}
@@ -526,6 +532,7 @@ MonoBehaviour:
   playerName: ' '
   visibleName: ' '
   PlayerSync: {fileID: 0}
+  SyncedWorldPos: {x: 0, y: 0, z: 0}
   RTT: 0
   RcsMode: 0
   RcsMatrixMove: {fileID: 0}
@@ -1014,8 +1021,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 62cc3ef7cd9082443aaf3c255851d15a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
 --- !u!114 &4174611152458090807
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1388,6 +1393,20 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   foreverID: oRKrJS26sGZ7QuMo1?Rh
+--- !u!114 &1594872346571213938
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1133514949248654}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 61d54d2e664e46eebfc8375e5a889f19, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
 --- !u!1 &1147423205297840
 GameObject:
   m_ObjectHideFlags: 0
@@ -1417,6 +1436,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4892080207053079231}
   m_RootOrder: 3
@@ -1539,6 +1559,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4892080207053079231}
   m_RootOrder: 7
@@ -1661,6 +1682,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4892080207053079231}
   m_RootOrder: 12
@@ -1783,6 +1805,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4892080207053079231}
   m_RootOrder: 10
@@ -1905,6 +1928,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4892080207053079231}
   m_RootOrder: 1
@@ -2027,6 +2051,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4892080207053079231}
   m_RootOrder: 14
@@ -2149,6 +2174,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4892080207053079231}
   m_RootOrder: 9
@@ -2271,6 +2297,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4892080207053079231}
   m_RootOrder: 11
@@ -2393,6 +2420,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4892080207053079231}
   m_RootOrder: 2
@@ -2515,6 +2543,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4892080207053079231}
   m_RootOrder: 6
@@ -2637,6 +2666,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: -0.08, z: 0}
   m_LocalScale: {x: 11.488002, y: 11.24355, z: 0.16779698}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4102488425209486}
   m_RootOrder: 0
@@ -2735,6 +2765,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 825323040080109227}
   m_Father: {fileID: 4102488425209486}
@@ -2766,6 +2797,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4962232741225816}
   m_RootOrder: 2
@@ -2796,6 +2828,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4435576251767608}
   - {fileID: 4813964138953014}
@@ -2842,6 +2875,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8006988482386011679}
   m_Father: {fileID: 4102488425209486}
@@ -2928,6 +2962,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6041869919515743495}
   m_RootOrder: 0
@@ -7882,6 +7917,7 @@ ParticleSystemRenderer:
   m_SortingLayer: 23
   m_SortingOrder: 0
   m_RenderMode: 0
+  m_MeshDistribution: 0
   m_SortMode: 0
   m_MinParticleSize: 0
   m_MaxParticleSize: 1
@@ -7905,6 +7941,10 @@ ParticleSystemRenderer:
   m_Mesh1: {fileID: 0}
   m_Mesh2: {fileID: 0}
   m_Mesh3: {fileID: 0}
+  m_MeshWeighting: 1
+  m_MeshWeighting1: 1
+  m_MeshWeighting2: 1
+  m_MeshWeighting3: 1
   m_MaskInteraction: 0
 --- !u!1 &2496504889366734254
 GameObject:
@@ -7932,6 +7972,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.27950388, y: 0.3687627, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6035216670950357378}
   m_Father: {fileID: 8022112743560827165}
@@ -7965,6 +8006,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0.738, y: 0.313, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8006988482386011679}
   m_RootOrder: 0
@@ -8075,6 +8117,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4892080207053079231}
   m_RootOrder: 8
@@ -8196,6 +8239,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4892080207053079231}
   m_RootOrder: 5
@@ -8302,6 +8346,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4962232741225816}
   m_RootOrder: 1
@@ -8379,18 +8424,6 @@ PrefabInstance:
         type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e2b1333de46384f95876864de1911fff, type: 3}
---- !u!1 &4299649681570296155 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1762630675659964, guid: e2b1333de46384f95876864de1911fff,
-    type: 3}
-  m_PrefabInstance: {fileID: 4300145449095171559}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &4304794156734570639 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4676201352523112, guid: e2b1333de46384f95876864de1911fff,
-    type: 3}
-  m_PrefabInstance: {fileID: 4300145449095171559}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &4196149980577959187 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 114445607401685236, guid: e2b1333de46384f95876864de1911fff,
@@ -8403,3 +8436,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 61930e16e81db5c43a4ecc22422a0953, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &4299649681570296155 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1762630675659964, guid: e2b1333de46384f95876864de1911fff,
+    type: 3}
+  m_PrefabInstance: {fileID: 4300145449095171559}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &4304794156734570639 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4676201352523112, guid: e2b1333de46384f95876864de1911fff,
+    type: 3}
+  m_PrefabInstance: {fileID: 4300145449095171559}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/ScriptableObjects/Traits/Effect/FlashProtection.asset
+++ b/UnityProject/Assets/ScriptableObjects/Traits/Effect/FlashProtection.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ccfe138752d4b66bcb7c56a0c9769c7, type: 3}
+  m_Name: FlashProtection
+  m_EditorClassIdentifier: 
+  traitDescription: Protects the eyes of a person from flashes.

--- a/UnityProject/Assets/ScriptableObjects/Traits/Effect/FlashProtection.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Traits/Effect/FlashProtection.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4f5b7ce1cca0a644cba934af14ea4b2c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Core/Camera/CameraEffectControlScript.cs
+++ b/UnityProject/Assets/Scripts/Core/Camera/CameraEffectControlScript.cs
@@ -10,17 +10,20 @@ namespace CameraEffects
 
 		public DrunkCamera drunkCamera;
 		public GreyscaleCamera greyscaleCamera;
+		public OverlayCrits greyscaleFlashCamera;
 		public GlitchEffect glitchEffect;
 		public NightVisionCamera nightVisionCamera;
 
 		[SerializeField]
 		private GameObject minimalVisibilitySprite;
 
-		[SerializeField]
-		private int maxDrunkTime = 120000;
+
+		[SerializeField] private int maxDrunkTime = 120000;
+		[SerializeField] private int maxFlashTime = 25;
 
 		private const float TIMER_INTERVAL = 1f;
 		private float drunkCameraTime = 0;
+		private float flashCameraTime = 0;
 
 		private void OnEnable()
 		{
@@ -48,6 +51,7 @@ namespace CameraEffects
 
 			if (drunkCamera.enabled == false)
 			{
+				ToggleDrunkEffectState(true);
 				drunkCamera.ModerateDrunk();
 				UpdateManager.Add(DoEffectTimeCheck, TIMER_INTERVAL);
 			}
@@ -55,7 +59,11 @@ namespace CameraEffects
 
 		public void FlashEyes(float flashTime)
 		{
-
+			flashCameraTime += flashTime;
+			flashCameraTime = Mathf.Min(flashCameraTime, maxFlashTime);
+			greyscaleFlashCamera.enabled = true;
+			greyscaleFlashCamera.expectedRadius = 0f;
+			if(greyscaleFlashCamera.Radius >= 5f) UpdateManager.Add(CallbackType.UPDATE, DoFlashTimeCheck);
 		}
 
 		public void ToggleDrunkEffectState(bool state)
@@ -83,8 +91,15 @@ namespace CameraEffects
 			else
 			{
 				drunkCamera.enabled = false;
-				UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, DoEffectTimeCheck);
+
 			}
+		}
+
+		private void DoFlashTimeCheck()
+		{
+			greyscaleFlashCamera.expectedRadius = Mathf.Lerp(greyscaleFlashCamera.expectedRadius,
+				greyscaleFlashCamera.Radius + 0.5f, Time.deltaTime);
+			if(greyscaleFlashCamera.Radius >= 5f) UpdateManager.Remove(CallbackType.UPDATE, DoFlashTimeCheck);
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/Core/Camera/CameraEffectControlScript.cs
+++ b/UnityProject/Assets/Scripts/Core/Camera/CameraEffectControlScript.cs
@@ -10,7 +10,7 @@ namespace CameraEffects
 
 		public DrunkCamera drunkCamera;
 		public GreyscaleCamera greyscaleCamera;
-		public OverlayCrits greyscaleFlashCamera;
+		public OverlayCrits overlayFlashCamera;
 		public GlitchEffect glitchEffect;
 		public NightVisionCamera nightVisionCamera;
 
@@ -61,9 +61,9 @@ namespace CameraEffects
 		{
 			flashCameraTime += flashTime;
 			flashCameraTime = Mathf.Min(flashCameraTime, maxFlashTime);
-			greyscaleFlashCamera.enabled = true;
-			greyscaleFlashCamera.expectedRadius = 0f;
-			if(greyscaleFlashCamera.Radius >= 5f) UpdateManager.Add(CallbackType.UPDATE, DoFlashTimeCheck);
+			overlayFlashCamera.enabled = true;
+			overlayFlashCamera.expectedRadius = 0f;
+			if(overlayFlashCamera.Radius >= 5f) UpdateManager.Add(CallbackType.UPDATE, DoFlashTimeCheck);
 		}
 
 		public void ToggleDrunkEffectState(bool state)
@@ -97,9 +97,9 @@ namespace CameraEffects
 
 		private void DoFlashTimeCheck()
 		{
-			greyscaleFlashCamera.expectedRadius = Mathf.Lerp(greyscaleFlashCamera.expectedRadius,
-				greyscaleFlashCamera.Radius + 0.5f, Time.deltaTime);
-			if(greyscaleFlashCamera.Radius >= 5f) UpdateManager.Remove(CallbackType.UPDATE, DoFlashTimeCheck);
+			overlayFlashCamera.expectedRadius = Mathf.Lerp(overlayFlashCamera.expectedRadius,
+				overlayFlashCamera.Radius + 0.5f, Time.deltaTime);
+			if(overlayFlashCamera.Radius >= 5f) UpdateManager.Remove(CallbackType.UPDATE, DoFlashTimeCheck);
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/Core/Camera/CameraEffectControlScript.cs
+++ b/UnityProject/Assets/Scripts/Core/Camera/CameraEffectControlScript.cs
@@ -10,7 +10,6 @@ namespace CameraEffects
 
 		public DrunkCamera drunkCamera;
 		public GreyscaleCamera greyscaleCamera;
-		public OverlayCrits overlayFlashCamera;
 		public GlitchEffect glitchEffect;
 		public NightVisionCamera nightVisionCamera;
 
@@ -23,7 +22,6 @@ namespace CameraEffects
 
 		private const float TIMER_INTERVAL = 1f;
 		private float drunkCameraTime = 0;
-		private float flashCameraTime = 0;
 
 		private void OnEnable()
 		{
@@ -59,11 +57,12 @@ namespace CameraEffects
 
 		public void FlashEyes(float flashTime)
 		{
-			flashCameraTime += flashTime;
-			flashCameraTime = Mathf.Min(flashCameraTime, maxFlashTime);
-			overlayFlashCamera.enabled = true;
-			overlayFlashCamera.expectedRadius = 0f;
-			if(overlayFlashCamera.Radius >= 5f) UpdateManager.Add(CallbackType.UPDATE, DoFlashTimeCheck);
+			StartCoroutine(FlashEyesCoroutine(flashTime));
+		}
+		private IEnumerator FlashEyesCoroutine(float flashTime)
+		{
+			//TODO : Add flash effects here later
+			yield break;
 		}
 
 		public void ToggleDrunkEffectState(bool state)
@@ -93,13 +92,6 @@ namespace CameraEffects
 				drunkCamera.enabled = false;
 
 			}
-		}
-
-		private void DoFlashTimeCheck()
-		{
-			overlayFlashCamera.expectedRadius = Mathf.Lerp(overlayFlashCamera.expectedRadius,
-				overlayFlashCamera.Radius + 0.5f, Time.deltaTime);
-			if(overlayFlashCamera.Radius >= 5f) UpdateManager.Remove(CallbackType.UPDATE, DoFlashTimeCheck);
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/Core/Camera/CameraEffectControlScript.cs
+++ b/UnityProject/Assets/Scripts/Core/Camera/CameraEffectControlScript.cs
@@ -53,6 +53,11 @@ namespace CameraEffects
 			}
 		}
 
+		public void FlashEyes(float flashTime)
+		{
+
+		}
+
 		public void ToggleDrunkEffectState(bool state)
 		{
 			drunkCamera.enabled = state;

--- a/UnityProject/Assets/Scripts/Items/Tool/FlasherItem.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/FlasherItem.cs
@@ -14,7 +14,7 @@ namespace Items.Tool
 		{
 			if (OnCooldown)
 			{
-				Chat.AddExamineMsg(interaction.Performer,"This flash seems to be on cooldown!");
+				Chat.AddExamineMsg(interaction.Performer,"This flash seems to be recharging!");
 				return;
 			}
 			if(interaction.TargetObject == null || interaction.TargetObject.TryGetComponent<RegisterPlayer>(out var player) == false) return;

--- a/UnityProject/Assets/Scripts/Items/Tool/FlasherItem.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/FlasherItem.cs
@@ -6,7 +6,8 @@ namespace Items.Tool
 	{
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
-			return DefaultWillInteract.Default(interaction, side);
+			if (DefaultWillInteract.Default(interaction, side) == false) return false;
+			return gameObject.PickupableOrNull().ItemSlot != null;
 		}
 
 		public void ServerPerformInteraction(HandApply interaction)

--- a/UnityProject/Assets/Scripts/Items/Tool/FlasherItem.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/FlasherItem.cs
@@ -1,0 +1,25 @@
+﻿using Objects;
+
+namespace Items.Tool
+{
+	public class FlasherItem : FlasherBase, ICheckedInteractable<HandApply>
+	{
+		public bool WillInteract(HandApply interaction, NetworkSide side)
+		{
+			return DefaultWillInteract.Default(interaction, side);
+		}
+
+		public void ServerPerformInteraction(HandApply interaction)
+		{
+			if (OnCooldown)
+			{
+				Chat.AddExamineMsg(interaction.Performer,"This flash seems to be on cooldown!");
+				return;
+			}
+			if(interaction.TargetObject == null || interaction.TargetObject.TryGetComponent<RegisterPlayer>(out var player) == false) return;
+			Chat.AddActionMsgToChat(interaction.Performer, $"You flash {player.PlayerScript.visibleName}",
+				$"{interaction.PerformerPlayerScript.visibleName} flashes {player.PlayerScript.visibleName}!");
+			FlashTarget(player.gameObject);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Tool/FlasherItem.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Tool/FlasherItem.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 17e7a056918f4d81bf5394f635688745
+timeCreated: 1650359958

--- a/UnityProject/Assets/Scripts/Objects/FlasherBase.cs
+++ b/UnityProject/Assets/Scripts/Objects/FlasherBase.cs
@@ -12,6 +12,7 @@ namespace Objects
 		[SerializeField, MinMaxSlider(3,20)] protected float flashStrength = 12f;
 		[SerializeField] protected float flashCooldown = 24f;
 		[SerializeField] protected ItemTrait sunglassesTrait;
+		[SerializeField] protected bool stunsPlayers = true;
 		[SyncVar] private bool onCooldown = false;
 		public bool OnCooldown => onCooldown;
 		private LayerMask pLayerMask;
@@ -31,8 +32,12 @@ namespace Objects
 					if(slots.Key != NamedSlot.eyes) continue;
 					foreach (var onSlots in slots.Value)
 					{
-						if(onSlots.IsEmpty) continue;
-						if(onSlots.ItemAttributes.HasTrait(sunglassesTrait) == false) continue;
+						if (onSlots.IsEmpty)
+						{
+							flashEffector.ServerSendMessageToClient(target.gameObject, flashStrength);
+							continue;
+						}
+						if(onSlots.ItemAttributes.HasTrait(sunglassesTrait)) continue;
 						flashEffector.ServerSendMessageToClient(target.gameObject, flashStrength);
 						break;
 					}

--- a/UnityProject/Assets/Scripts/Objects/FlasherBase.cs
+++ b/UnityProject/Assets/Scripts/Objects/FlasherBase.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections;
+using Mirror;
+using NaughtyAttributes;
+using Player;
+using UnityEngine;
+
+namespace Objects
+{
+	public class FlasherBase : NetworkBehaviour
+	{
+		[SerializeField] protected float flashRadius = 12f;
+		[SerializeField, MinMaxSlider(3,20)] protected float flashStrength = 12f;
+		[SerializeField] protected float flashCooldown = 24f;
+		[SerializeField] protected ItemTrait sunglassesTrait;
+		[SyncVar] private bool onCooldown = false;
+		public bool OnCooldown => onCooldown;
+		private LayerMask pLayerMask;
+
+		[Server]
+		public void Flash()
+		{
+			if(onCooldown) return;
+			var possibleTargets = Physics2D.OverlapCircleAll(gameObject.AssumedWorldPosServer(), flashRadius, pLayerMask);
+			foreach (var target in possibleTargets)
+			{
+				if(gameObject == target.gameObject) continue;
+				if(target.gameObject.TryGetComponent<PlayerFlashEffects>(out var flashEffector) == false) continue;
+				if(target.gameObject.TryGetComponent<DynamicItemStorage>(out var playerStorage) == false) continue;
+				foreach (var slots in playerStorage.ServerContents)
+				{
+					if(slots.Key != NamedSlot.eyes) continue;
+					foreach (var onSlots in slots.Value)
+					{
+						if(onSlots.IsEmpty) continue;
+						if(onSlots.ItemAttributes.HasTrait(sunglassesTrait) == false) continue;
+						flashEffector.ServerSendMessageToClient(target.gameObject, flashStrength);
+						break;
+					}
+				}
+			}
+			StartCoroutine(Cooldown());
+		}
+
+		[Server]
+		private IEnumerator Cooldown()
+		{
+			onCooldown = true;
+			yield return WaitFor.Seconds(flashCooldown);
+			onCooldown = false;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Objects/FlasherBase.cs
+++ b/UnityProject/Assets/Scripts/Objects/FlasherBase.cs
@@ -60,7 +60,7 @@ namespace Objects
 				}
 			}
 			StartCoroutine(Cooldown());
-			Chat.AddLocalMsgToChat($"The {gameObject.ExpensiveName()} flashes everyone in it's radius.", gameObject);
+			Chat.AddLocalMsgToChat($"The {gameObject.ExpensiveName()} flashes everyone in its radius.", gameObject);
 		}
 
 		[Server]

--- a/UnityProject/Assets/Scripts/Objects/FlasherBase.cs
+++ b/UnityProject/Assets/Scripts/Objects/FlasherBase.cs
@@ -11,7 +11,7 @@ namespace Objects
 	public class FlasherBase : NetworkBehaviour
 	{
 		[SerializeField] protected float flashRadius = 12f;
-		[SerializeField, MinMaxSlider(3,20)] protected float flashStrength = 12f;
+		[SerializeField, MinMaxSlider(3,20)] protected float flashTime = 12f;
 		[SerializeField, MinMaxSlider(3,6), ShowIf(nameof(stunsPlayers))] protected float stunExtraTime = 3f;
 		[SerializeField] protected float flashCooldown = 24f;
 		[SerializeField] protected ItemTrait sunglassesTrait;
@@ -87,8 +87,8 @@ namespace Objects
 		[Server]
 		private void TellClientThatTheyHaveBeenFlashed(PlayerFlashEffects effects, RegisterPlayer player)
 		{
-			effects.ServerSendMessageToClient(player.gameObject, flashStrength);
-			if(stunsPlayers) player.ServerStun(flashStrength + stunExtraTime);
+			effects.ServerSendMessageToClient(player.gameObject, flashTime);
+			if(stunsPlayers) player.ServerStun(flashTime + stunExtraTime);
 		}
 
 		[Server]

--- a/UnityProject/Assets/Scripts/Objects/FlasherBase.cs
+++ b/UnityProject/Assets/Scripts/Objects/FlasherBase.cs
@@ -20,11 +20,13 @@ namespace Objects
 		[SyncVar] private bool onCooldown = false;
 		public bool OnCooldown => onCooldown;
 		private LayerMask pLayerMask;
+		private LayerMask layerMask;
 
 		private void Start()
 		{
 			//(Max) : How would this work when we get to the mind rework? Will we force all objects that inherit from player to change their mask to "Players"? Or will we make a new one?
 			pLayerMask = LayerMask.GetMask("Players");
+			layerMask = LayerMask.GetMask("Door Closed"); //I copied this from ChatRelay.cs
 		}
 
 		[Server]
@@ -36,6 +38,8 @@ namespace Objects
 			foreach (var target in possibleTargets)
 			{
 				if(gameObject == target.gameObject) continue;
+				if (MatrixManager.Linecast(gameObject.AssumedWorldPosServer(), LayerTypeSelection.Walls,
+					    layerMask, target.gameObject.AssumedWorldPosServer()).ItHit == false) continue;
 				if(target.gameObject.TryGetComponent<RegisterPlayer>(out var player) == false) continue; //If it's not a player, check next
 				if(target.gameObject.TryGetComponent<PlayerFlashEffects>(out var flashEffector) == false) continue; //If the player doesn't have the ability to be flashed for whatever reason, check next
 				if(target.gameObject.TryGetComponent<DynamicItemStorage>(out var playerStorage) == false) continue; //If the player has no storage for whatever reason... would this be a bug?
@@ -56,6 +60,7 @@ namespace Objects
 				}
 			}
 			StartCoroutine(Cooldown());
+			Chat.AddLocalMsgToChat($"The {gameObject.ExpensiveName()} flashes everyone in it's radius.", gameObject);
 		}
 
 		[Server]

--- a/UnityProject/Assets/Scripts/Objects/FlasherBase.cs
+++ b/UnityProject/Assets/Scripts/Objects/FlasherBase.cs
@@ -39,7 +39,7 @@ namespace Objects
 			{
 				if(gameObject == target.gameObject) continue;
 				if (MatrixManager.Linecast(gameObject.AssumedWorldPosServer(), LayerTypeSelection.Walls,
-					    layerMask, target.gameObject.AssumedWorldPosServer()).ItHit == false) continue;
+					    layerMask, target.gameObject.AssumedWorldPosServer()).ItHit) continue;
 				if(target.gameObject.TryGetComponent<RegisterPlayer>(out var player) == false) continue; //If it's not a player, check next
 				if(target.gameObject.TryGetComponent<PlayerFlashEffects>(out var flashEffector) == false) continue; //If the player doesn't have the ability to be flashed for whatever reason, check next
 				if(target.gameObject.TryGetComponent<DynamicItemStorage>(out var playerStorage) == false) continue; //If the player has no storage for whatever reason... would this be a bug?

--- a/UnityProject/Assets/Scripts/Objects/FlasherBase.cs
+++ b/UnityProject/Assets/Scripts/Objects/FlasherBase.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
+using AddressableReferences;
 using Mirror;
 using NaughtyAttributes;
 using Player;
@@ -10,35 +12,44 @@ namespace Objects
 	{
 		[SerializeField] protected float flashRadius = 12f;
 		[SerializeField, MinMaxSlider(3,20)] protected float flashStrength = 12f;
+		[SerializeField, MinMaxSlider(3,6), ShowIf(nameof(stunsPlayers))] protected float stunExtraTime = 3f;
 		[SerializeField] protected float flashCooldown = 24f;
 		[SerializeField] protected ItemTrait sunglassesTrait;
+		[SerializeField] protected AddressableAudioSource flashSound;
 		[SerializeField] protected bool stunsPlayers = true;
 		[SyncVar] private bool onCooldown = false;
 		public bool OnCooldown => onCooldown;
 		private LayerMask pLayerMask;
 
-		[Server]
-		public void Flash()
+		private void Start()
 		{
-			if(onCooldown) return;
+			//(Max) : How would this work when we get to the mind rework? Will we force all objects that inherit from player to change their mask to "Players"? Or will we make a new one?
+			pLayerMask = LayerMask.GetMask("Players");
+		}
+
+		[Server]
+		public void FlashInRadius()
+		{
+			if (onCooldown) return;
+			if (flashSound != null) _ = SoundManager.PlayNetworkedAtPosAsync(flashSound, gameObject.AssumedWorldPosServer());
 			var possibleTargets = Physics2D.OverlapCircleAll(gameObject.AssumedWorldPosServer(), flashRadius, pLayerMask);
 			foreach (var target in possibleTargets)
 			{
 				if(gameObject == target.gameObject) continue;
-				if(target.gameObject.TryGetComponent<RegisterPlayer>(out var player) == false) continue;
-				if(target.gameObject.TryGetComponent<PlayerFlashEffects>(out var flashEffector) == false) continue;
-				if(target.gameObject.TryGetComponent<DynamicItemStorage>(out var playerStorage) == false) continue;
+				if(target.gameObject.TryGetComponent<RegisterPlayer>(out var player) == false) continue; //If it's not a player, check next
+				if(target.gameObject.TryGetComponent<PlayerFlashEffects>(out var flashEffector) == false) continue; //If the player doesn't have the ability to be flashed for whatever reason, check next
+				if(target.gameObject.TryGetComponent<DynamicItemStorage>(out var playerStorage) == false) continue; //If the player has no storage for whatever reason... would this be a bug?
 				foreach (var slots in playerStorage.ServerContents)
 				{
 					if(slots.Key != NamedSlot.eyes) continue;
 					foreach (var onSlots in slots.Value)
 					{
-						if (onSlots.IsEmpty)
+						if (onSlots.IsEmpty) //Nothing protecting the eye, flash immediately
 						{
 							TellClientThatTheyHaveBeenFlashed(flashEffector, player);
 							continue;
 						}
-						if(onSlots.ItemAttributes.HasTrait(sunglassesTrait)) continue;
+						if(onSlots.ItemAttributes.HasTrait(sunglassesTrait)) continue; //If the player is wearing protective glasses, check next.
 						TellClientThatTheyHaveBeenFlashed(flashEffector, player);
 						break;
 					}
@@ -47,10 +58,37 @@ namespace Objects
 			StartCoroutine(Cooldown());
 		}
 
+		[Server]
+		public void FlashTarget(GameObject target)
+		{
+			if (onCooldown) return;
+			if (flashSound != null) _ = SoundManager.PlayNetworkedAtPosAsync(flashSound, gameObject.AssumedWorldPosServer());
+			StartCoroutine(Cooldown());
+			if (target.TryGetComponent<RegisterPlayer>(out var player) == false) return;
+			if (target.gameObject.TryGetComponent<PlayerFlashEffects>(out var flashEffector) == false) return;
+			if (target.gameObject.TryGetComponent<DynamicItemStorage>(out var playerStorage) == false) return;
+			foreach (var slots in playerStorage.ServerContents)
+			{
+				if(slots.Key != NamedSlot.eyes) continue;
+				foreach (var onSlots in slots.Value)
+				{
+					if (onSlots.IsEmpty) //Nothing protecting the eye, flash immediately
+					{
+						TellClientThatTheyHaveBeenFlashed(flashEffector, player);
+						continue;
+					}
+					if(onSlots.ItemAttributes.HasTrait(sunglassesTrait)) continue; //If the player is wearing protective glasses, check next.
+					TellClientThatTheyHaveBeenFlashed(flashEffector, player);
+					break;
+				}
+			}
+		}
+
+		[Server]
 		private void TellClientThatTheyHaveBeenFlashed(PlayerFlashEffects effects, RegisterPlayer player)
 		{
 			effects.ServerSendMessageToClient(player.gameObject, flashStrength);
-			if(stunsPlayers) player.ServerStun(flashStrength + 3);
+			if(stunsPlayers) player.ServerStun(flashStrength + stunExtraTime);
 		}
 
 		[Server]

--- a/UnityProject/Assets/Scripts/Objects/FlasherBase.cs
+++ b/UnityProject/Assets/Scripts/Objects/FlasherBase.cs
@@ -11,8 +11,8 @@ namespace Objects
 	public class FlasherBase : NetworkBehaviour
 	{
 		[SerializeField] protected float flashRadius = 12f;
-		[SerializeField, MinMaxSlider(3,20)] protected float flashTime = 12f;
-		[SerializeField, MinMaxSlider(3,6), ShowIf(nameof(stunsPlayers))] protected float stunExtraTime = 3f;
+		[SerializeField] protected float flashTime = 12f;
+		[SerializeField, ShowIf(nameof(stunsPlayers))] protected float stunExtraTime = 3f;
 		[SerializeField] protected float flashCooldown = 24f;
 		[SerializeField] protected ItemTrait sunglassesTrait;
 		[SerializeField] protected AddressableAudioSource flashSound;

--- a/UnityProject/Assets/Scripts/Objects/FlasherBase.cs
+++ b/UnityProject/Assets/Scripts/Objects/FlasherBase.cs
@@ -25,6 +25,7 @@ namespace Objects
 			foreach (var target in possibleTargets)
 			{
 				if(gameObject == target.gameObject) continue;
+				if(target.gameObject.TryGetComponent<RegisterPlayer>(out var player) == false) continue;
 				if(target.gameObject.TryGetComponent<PlayerFlashEffects>(out var flashEffector) == false) continue;
 				if(target.gameObject.TryGetComponent<DynamicItemStorage>(out var playerStorage) == false) continue;
 				foreach (var slots in playerStorage.ServerContents)
@@ -34,16 +35,22 @@ namespace Objects
 					{
 						if (onSlots.IsEmpty)
 						{
-							flashEffector.ServerSendMessageToClient(target.gameObject, flashStrength);
+							TellClientThatTheyHaveBeenFlashed(flashEffector, player);
 							continue;
 						}
 						if(onSlots.ItemAttributes.HasTrait(sunglassesTrait)) continue;
-						flashEffector.ServerSendMessageToClient(target.gameObject, flashStrength);
+						TellClientThatTheyHaveBeenFlashed(flashEffector, player);
 						break;
 					}
 				}
 			}
 			StartCoroutine(Cooldown());
+		}
+
+		private void TellClientThatTheyHaveBeenFlashed(PlayerFlashEffects effects, RegisterPlayer player)
+		{
+			effects.ServerSendMessageToClient(player.gameObject, flashStrength);
+			if(stunsPlayers) player.ServerStun(flashStrength + 3);
 		}
 
 		[Server]

--- a/UnityProject/Assets/Scripts/Objects/FlasherBase.cs.meta
+++ b/UnityProject/Assets/Scripts/Objects/FlasherBase.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4260771755c043c3a258f5ae9f8371e1
+timeCreated: 1650352302

--- a/UnityProject/Assets/Scripts/Objects/FlasherBase.cs.meta
+++ b/UnityProject/Assets/Scripts/Objects/FlasherBase.cs.meta
@@ -1,3 +1,12 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: 4260771755c043c3a258f5ae9f8371e1
-timeCreated: 1650352302
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences:
+  - sunglassesTrait: {fileID: 11400000, guid: 4f5b7ce1cca0a644cba934af14ea4b2c, type: 2}
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Objects/Other/PortableFlasher.cs
+++ b/UnityProject/Assets/Scripts/Objects/Other/PortableFlasher.cs
@@ -1,0 +1,63 @@
+﻿using AddressableReferences;
+using Mirror;
+using UnityEngine;
+
+namespace Objects.Other
+{
+	public class PortableFlasher : FlasherBase, ICheckedInteractable<HandApply>
+	{
+		[SerializeField, SyncVar] private bool isWrenched = false;
+		[SerializeField, SyncVar] private bool isOn = false;
+		[SerializeField] private float progressBarTime;
+		[SerializeField] private float timeInBetweenFlashes = 12f;
+
+		private ObjectBehaviour objectBehaviour;
+
+
+		public bool WillInteract(HandApply interaction, NetworkSide side)
+		{
+			return DefaultWillInteract.Default(interaction, side);
+		}
+
+		public void ServerPerformInteraction(HandApply interaction)
+		{
+			if (interaction.HandObject == null)
+			{
+				SwitchOffOn(interaction.PerformerPlayerScript);
+				return;
+			}
+			if(interaction.HandObject.Item().HasTrait(CommonTraits.Instance.Wrench) == false) return;
+			var cfg = new StandardProgressActionConfig(StandardProgressActionType.Mop);
+			var bar = StandardProgressAction.Create(cfg, WrenchInteraction).ServerStartProgress(interaction.Performer.AssumedWorldPosServer(), progressBarTime, interaction.Performer);
+		}
+
+		private void WrenchInteraction()
+		{
+			isWrenched = !isWrenched;
+			//We inverse this to get the opposite of the wrench, so if its not wrenched; isPushable is true and vice versa
+			objectBehaviour.ServerSetPushable(!isWrenched);
+			SoundManager.PlayNetworkedAtPos(CommonSounds.Instance.Wrench, gameObject.AssumedWorldPosServer());
+		}
+
+		private void SwitchOffOn(PlayerScript switcher)
+		{
+			if (isWrenched == false && isOn == false)
+			{
+				Chat.AddExamineMsg(switcher.gameObject, "You need to wrench this first before you can turn it on!");
+				return;
+			}
+
+			isOn = !isOn;
+			if (isOn)
+			{
+				UpdateManager.Add(FlashInRadius, timeInBetweenFlashes);
+			}
+			else
+			{
+				UpdateManager.Remove(CallbackType.PERIODIC_UPDATE ,FlashInRadius);
+			}
+			var status = isOn ? "on" : "off";
+			Chat.AddLocalMsgToChat($"{switcher.visibleName} switches {status} the {gameObject.ExpensiveName()}", gameObject);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Objects/Other/PortableFlasher.cs
+++ b/UnityProject/Assets/Scripts/Objects/Other/PortableFlasher.cs
@@ -35,25 +35,31 @@ namespace Objects.Other
 				return;
 			}
 			if(interaction.HandObject.Item().HasTrait(CommonTraits.Instance.Wrench) == false) return;
+
+			void DoWrenchInteraction()
+			{
+				WrenchInteraction(interaction.PerformerPlayerScript);
+			}
 			var cfg = new StandardProgressActionConfig(StandardProgressActionType.Mop);
-			var bar = StandardProgressAction.Create(cfg, WrenchInteraction).ServerStartProgress(interaction.Performer.AssumedWorldPosServer(), progressBarTime, interaction.Performer);
+			var bar = StandardProgressAction.Create(cfg, DoWrenchInteraction).ServerStartProgress(interaction.Performer.AssumedWorldPosServer(), progressBarTime, interaction.Performer);
 		}
 
-		private void WrenchInteraction()
+		private void WrenchInteraction(PlayerScript wrenchHolder)
 		{
 			isWrenched = !isWrenched;
 			//We inverse this to get the opposite of the wrench, so if its not wrenched; isPushable is true and vice versa
 			objectBehaviour.ServerSetPushable(!isWrenched);
 			SoundManager.PlayNetworkedAtPos(CommonSounds.Instance.Wrench, gameObject.AssumedWorldPosServer());
 			var status = !isWrenched ? "immovable" : "movable";
-			Chat.AddLocalMsgToChat($"The {gameObject.ExpensiveName()} is now {status}", gameObject);
+			Chat.AddActionMsgToChat(wrenchHolder.gameObject, $"The {gameObject.ExpensiveName()} is now {status}",
+				$"{wrenchHolder.visibleName} uses the wrench on the {gameObject.ExpensiveName()}");
 		}
 
 		private void SwitchOffOn(PlayerScript switcher)
 		{
 			if (isWrenched == false && isOn == false)
 			{
-				Chat.AddExamineMsg(switcher.gameObject, "You need to wrench this first before you can turn it on!");
+				Chat.AddExamineMsg(switcher.gameObject, "You need to wrench this down first before you can turn it on!");
 				return;
 			}
 

--- a/UnityProject/Assets/Scripts/Objects/Other/PortableFlasher.cs
+++ b/UnityProject/Assets/Scripts/Objects/Other/PortableFlasher.cs
@@ -16,6 +16,7 @@ namespace Objects.Other
 
 		private void Awake()
 		{
+			objectBehaviour = GetComponent<ObjectBehaviour>();
 			if(CustomNetworkManager.IsServer == false) return;
 			//Incase mappers want the portable flashers to be active on the map without someone setting it up
 			if(isOn) UpdateManager.Add(FlashInRadius, timeInBetweenFlashes);
@@ -50,7 +51,7 @@ namespace Objects.Other
 			//We inverse this to get the opposite of the wrench, so if its not wrenched; isPushable is true and vice versa
 			objectBehaviour.ServerSetPushable(!isWrenched);
 			SoundManager.PlayNetworkedAtPos(CommonSounds.Instance.Wrench, gameObject.AssumedWorldPosServer());
-			var status = !isWrenched ? "immovable" : "movable";
+			var status = !isWrenched ? "movable" : "immovable";
 			Chat.AddActionMsgToChat(wrenchHolder.gameObject, $"The {gameObject.ExpensiveName()} is now {status}",
 				$"{wrenchHolder.visibleName} uses the wrench on the {gameObject.ExpensiveName()}");
 		}

--- a/UnityProject/Assets/Scripts/Objects/Other/PortableFlasher.cs.meta
+++ b/UnityProject/Assets/Scripts/Objects/Other/PortableFlasher.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ab2c21a9da2642fda56e3a8b7edf5679
+timeCreated: 1650383472

--- a/UnityProject/Assets/Scripts/Player/PlayerFlashEffects.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerFlashEffects.cs
@@ -1,0 +1,45 @@
+﻿using UnityEngine;
+using Mirror;
+using CameraEffects;
+using Messages.Server;
+
+namespace Player
+{
+	public class PlayerFlashEffects : NetworkBehaviour
+	{
+		[Server]
+		public void ServerSendMessageToClient(GameObject client, float newValue)
+		{
+			PlayerDrunkServerMessage.Send(client, newValue);
+		}
+	}
+
+	public class PlayerFlashEffectsMessage : ServerMessage<PlayerFlashEffectsMessage.NetMessage>
+	{
+		public struct NetMessage : NetworkMessage
+		{
+			public float flashValue;
+		}
+
+		public override void Process(NetMessage msg)
+		{
+			var camera = Camera.main;
+			if (camera == null) return;
+			camera.GetComponent<CameraEffectControlScript>().FlashEyes(msg.flashValue);
+		}
+
+		/// <summary>
+		/// Send full update to a client
+		/// </summary>
+		public static NetMessage Send(GameObject clientConn, float newflashValue)
+		{
+			NetMessage msg = new NetMessage
+			{
+				flashValue = newflashValue
+			};
+
+			SendTo(clientConn, msg);
+			return msg;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Player/PlayerFlashEffects.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerFlashEffects.cs
@@ -11,6 +11,7 @@ namespace Player
 		public void ServerSendMessageToClient(GameObject client, float newValue)
 		{
 			PlayerDrunkServerMessage.Send(client, newValue);
+			PlayerFlashEffectsMessage.Send(client, newValue);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Player/PlayerFlashEffects.cs.meta
+++ b/UnityProject/Assets/Scripts/Player/PlayerFlashEffects.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 61d54d2e664e46eebfc8375e5a889f19
+timeCreated: 1650353451

--- a/UnityProject/Assets/Scripts/UI/Systems/CameraOverlays/OverlayCrits.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/CameraOverlays/OverlayCrits.cs
@@ -22,7 +22,7 @@ using System.Collections;
 
 		public float Epow = 2;
 
-		public float expectedRadius;
+		private float expectedRadius;
 
 		void LateUpdate()
 		{

--- a/UnityProject/Assets/Scripts/UI/Systems/CameraOverlays/OverlayCrits.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/CameraOverlays/OverlayCrits.cs
@@ -22,7 +22,7 @@ using System.Collections;
 
 		public float Epow = 2;
 
-		private float expectedRadius;
+		public float expectedRadius;
 
 		void LateUpdate()
 		{

--- a/UnityProject/Assets/Textures/objects/machines/research/research_protolathe_m.png.meta
+++ b/UnityProject/Assets/Textures/objects/machines/research/research_protolathe_m.png.meta
@@ -51,6 +51,7 @@ TextureImporter:
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
+  ignoreMasterTextureLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -316,6 +317,16 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    nameFileIdTable:
+      research_protolathe_m_8: -156505894599014461
+      research_protolathe_m_4: -3302991386977554517
+      research_protolathe_m_5: 7659719883601063510
+      research_protolathe_m_7: -8706675271401879566
+      research_protolathe_m_6: 3909484710597134966
+      research_protolathe_m_3: -6567081437830198491
+      research_protolathe_m_2: -1644622625615953253
+      research_protolathe_m_1: 8424539439413526129
+      research_protolathe_m_0: 6202742127332999404
   spritePackingTag: 
   pSDRemoveMatte: 0
   pSDShowRemoveMatteOption: 0


### PR DESCRIPTION
Adds a new safe defense item for command and a new object for crowd control for security.

Flashers will blind* and can be configured to stun players for a set amount of time after getting flashed unless they are wearing glasses that have the FlashProtection trait on them. Security's sunglasses gain this trait by default.

-* : Blind effects has been half implemented because I have no idea how to get them working correctly.

Partially completes #5219.

### Changes
CL: [New] - Adds in portable flashers
CL: [New] - Adds in handheld flashers
CL: [Fix] - Fixes the drunk effect not getting toggled on.