### PR TITLE
Ragin' Mages

### DIFF
--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/InGameEventsManager.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/InGameEventsManager.prefab
@@ -27,6 +27,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 739026179657658727}
   m_RootOrder: 2
@@ -91,6 +92,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 739026179657658727}
   m_RootOrder: 3
@@ -155,6 +157,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6277872687871681347}
   m_RootOrder: 3
@@ -207,6 +210,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -5.2508955, y: 0.74306184, z: -0.91875}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6277872687871681347}
   m_RootOrder: 0
@@ -265,6 +269,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 5.2508955, y: -0.74306184, z: 0.91875}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 739026179657658727}
   m_RootOrder: 1
@@ -319,6 +324,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6277872687871681347}
   m_RootOrder: 9
@@ -393,6 +399,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6277872687871681347}
   m_RootOrder: 12
@@ -448,6 +455,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6277872687871681347}
   m_RootOrder: 4
@@ -509,6 +517,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -3.0673392, y: 0.73924786, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6277872687871681347}
   m_RootOrder: 1
@@ -624,6 +633,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6277872687871681347}
   m_RootOrder: 10
@@ -675,11 +685,13 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -5.2508955, y: 0.74306184, z: -0.91875}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6034400332780565072}
   - {fileID: 1318916917475401147}
   - {fileID: 1986124767922438636}
   - {fileID: 3219844687204394920}
+  - {fileID: 4276429877836597935}
   m_Father: {fileID: 8934140032923375002}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -709,6 +721,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4748508647246467756}
   - {fileID: 5866069805973481999}
@@ -754,6 +767,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6277872687871681347}
   m_RootOrder: 5
@@ -817,6 +831,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -3.8358982, y: 0.99273133, z: -0.09894371}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6277872687871681347}
   m_RootOrder: 2
@@ -898,6 +913,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6277872687871681347}
   m_RootOrder: 8
@@ -949,6 +965,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -3.8358982, y: 0.99273133, z: -0.09894371}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6475051549989528625}
   - {fileID: 6757691155947884009}
@@ -982,6 +999,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 5.2508955, y: -0.74306184, z: 0.91875}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 739026179657658727}
   m_RootOrder: 0
@@ -1009,6 +1027,62 @@ MonoBehaviour:
   AnnounceEvent: 1
   ghostRole: {fileID: 11400000, guid: e0bcf33d6a9ef0443960a18ba45b742e, type: 2}
   message: 
+--- !u!1 &5506525348332587342
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4276429877836597935}
+  - component: {fileID: 7742797128823571182}
+  m_Layer: 0
+  m_Name: Ragin' Mages
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4276429877836597935
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5506525348332587342}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 5.2508955, y: -0.74306184, z: 0.91875}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 739026179657658727}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7742797128823571182
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5506525348332587342}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9e60c8a1f7899e2408bce7cd56fb3d6b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  EventName: Ragin' Mages
+  StartTimer: 0
+  EndTimer: 0
+  EventType: 3
+  ChanceToHappen: 5
+  MinPlayersToTrigger: 20
+  parametersPageType: 0
+  FakeEvent: 0
+  AnnounceEvent: 1
+  ghostRole: {fileID: 11400000, guid: df31f525e37890241b61376d16ec3af3, type: 2}
+  message: GREETINGS. WE ARE WIZARDS OF THE WIZARD FEDERATION. WE HAVE DECIDED TO
+    CAUSE PROBLEMS ON PURPOSE TODAY.
 --- !u!1 &5514556414432881390
 GameObject:
   m_ObjectHideFlags: 0
@@ -1036,6 +1110,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6277872687871681347}
   m_RootOrder: 6
@@ -1128,6 +1203,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -5.2508955, y: 0.74306184, z: -0.91875}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6277872687871681347}
   m_RootOrder: 13
@@ -1185,6 +1261,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6277872687871681347}
   m_RootOrder: 11
@@ -1237,6 +1314,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -1.4149973, y: -0.24966949, z: -0.8198063}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8107851843940366990}
   m_RootOrder: 1
@@ -1292,6 +1370,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 1.4149973, y: 0.24966949, z: 0.8198063}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8619822432118796632}
   m_RootOrder: 0
@@ -1474,6 +1553,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -1.4149973, y: -0.24966949, z: -0.8198063}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8107851843940366990}
   m_RootOrder: 0
@@ -1529,6 +1609,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6277872687871681347}
   m_RootOrder: 7
@@ -1583,6 +1664,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6277872687871681347}
   - {fileID: 8619822432118796632}
@@ -1671,6 +1753,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -5.2508955, y: 0.74306184, z: -0.91875}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 534459490156450071}
   m_Father: {fileID: 8934140032923375002}

--- a/UnityProject/Assets/ScriptableObjects/Systems/GhostRoles/Antagonists/RaginMages.asset
+++ b/UnityProject/Assets/ScriptableObjects/Systems/GhostRoles/Antagonists/RaginMages.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d1bf4d5e2bd850949b9b9f6afe22de9b, type: 3}
+  m_Name: RaginMages
+  m_EditorClassIdentifier: 
+  name: Ragin' Mages
+  description: Make the station your playground.
+  sprite: {fileID: 11400000, guid: c251e51c37931a447966369525ec261e, type: 2}
+  respawnType: 1
+  targetOccupation: {fileID: 11400000, guid: 191fa13b4d14221479bf108a4c9628fa, type: 2}
+  targetAntagonist: {fileID: 11400000, guid: 7325a4893b19676439a5fdb39d2cc069, type: 2}
+  minPlayers: 1
+  maxPlayers: 3
+  timeout: 60
+  playerCountType: 1

--- a/UnityProject/Assets/ScriptableObjects/Systems/GhostRoles/Antagonists/RaginMages.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Systems/GhostRoles/Antagonists/RaginMages.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: df31f525e37890241b61376d16ec3af3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Systems/GhostRoles/GhostRoleList.asset
+++ b/UnityProject/Assets/ScriptableObjects/Systems/GhostRoles/GhostRoleList.asset
@@ -20,3 +20,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 7fbf96e6e42920b47b8eedec97e8b4ce, type: 2}
   - {fileID: 11400000, guid: ba4d90971ca72aba1861e17fb48e5e50, type: 2}
   - {fileID: 11400000, guid: 87ed037326d06fd458fe27837dfb4151, type: 2}
+  - {fileID: 11400000, guid: df31f525e37890241b61376d16ec3af3, type: 2}


### PR DESCRIPTION
### Purpose

This PR adds Ragin' Mages as a possible random event. The event requires a minimum of 20 players to trigger, and is the least likely random event to trigger in the pool, so it's very uncommon. When it does trigger, it spawns **3** wizards to cause chaos on the station together. Admins, don't trigger this event lightly. 

The arrival of the wizards is preempted by a threatening message to the station.

### Notes:

https://www.youtube.com/watch?v=jJDAV9vSmYc

### Changelog:

CL: [New] new rare random event: Ragin' Mages; 3 wizards are spawned to attack the station. requires minimum 20 players.

