### PR TITLE
electrical wire tile names

### DIFF
--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/EO-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/EO-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: EO-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 1
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/E_NE-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/E_NE-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: E_NE-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/E_NW-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/E_NW-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: E_NW-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/E_SE-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/E_SE-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: E_SE-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/E_SW-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/E_SW-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: E_SW-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/NE-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/NE-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NE-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/NE_NW-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/NE_NW-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NE_NW-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/NE_O-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/NE_O-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NE_O-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 1
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/NE_SE-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/NE_SE-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NE_SE-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/NE_SW-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/NE_SW-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NE_SW-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/NO-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/NO-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NO-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 1
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/NS-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/NS-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NS-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/NW-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/NW-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NW-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/NW_O-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/NW_O-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NW_O-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 1
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/NW_SE-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/NW_SE-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NW_SE-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/NW_SW-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/NW_SW-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NW_SW-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/N_NE-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/N_NE-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: N_NE-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/N_NW-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/N_NW-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: N_NW-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/N_SE-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/N_SE-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: N_SE-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/N_SW-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/N_SW-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: N_SW-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/SE-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/SE-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: SE-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/SE_O-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/SE_O-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: SE_O-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 1
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/SO-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/SO-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: SO-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 1
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/SW-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/SW-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: SW-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/SW_O-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/SW_O-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: SW_O-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 1
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/SW_SE-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/SW_SE-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: SW_SE-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/S_NE-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/S_NE-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: S_NE-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/S_NW-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/S_NW-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: S_NW-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/S_SE-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/S_SE-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: S_SE-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/S_SW-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/S_SW-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: S_SW-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/WE-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/WE-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: WE-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/WO-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/WO-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: WO-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 1
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/W_NE-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/W_NE-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: W_NE-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/W_NW-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/W_NW-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: W_NW-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/W_SE-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/W_SE-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: W_SE-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/W_SW-High_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/High voltage cable/W_SW-High_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: W_SW-High_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: high voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 75c463bff74ba104c83113bc4102735f, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4019383695740491213, guid: 930cb494644d9ed46b31e1ecf4222089,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0d000000050000000b0000000600000010000000120000001400000015000000
   PowerType: 11

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/EO-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/EO-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: EO-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 1
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/E_NE-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/E_NE-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: E_NE-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/E_NW-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/E_NW-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: E_NW-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/E_SE-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/E_SE-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: E_SE-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/E_SW-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/E_SW-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: E_SW-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/NE-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/NE-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NE-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/NE_NW-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/NE_NW-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NE_NW-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/NE_O-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/NE_O-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NE_O-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 1
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/NE_SE-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/NE_SE-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NE_SE-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/NE_SW-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/NE_SW-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NE_SW-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/NO-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/NO-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NO-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 1
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/NS-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/NS-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NS-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/NW-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/NW-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NW-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/NW_O-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/NW_O-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NW_O-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 1
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/NW_SE-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/NW_SE-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NW_SE-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/NW_SW-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/NW_SW-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NW_SW-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/N_NE-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/N_NE-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: N_NE-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/N_NW-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/N_NW-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: N_NW-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/N_SE-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/N_SE-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: N_SE-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/N_SW-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/N_SW-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: N_SW-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/SE-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/SE-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: SE-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/SE_O-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/SE_O-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: SE_O-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 1
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/SO-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/SO-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: SO-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 1
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/SW-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/SW-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: SW-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/SW_O-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/SW_O-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: SW_O-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 1
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/SW_SE-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/SW_SE-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: SW_SE-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/S_NE-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/S_NE-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: S_NE-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/S_NW-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/S_NW-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: S_NW-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/S_SE-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/S_SE-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: S_SE-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/S_SW-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/S_SW-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: S_SW-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/WE-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/WE-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: WE-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/WO-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/WO-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: WO-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 1
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/W_NE-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/W_NE-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: W_NE-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/W_NW-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/W_NW-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: W_NW-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/W_SE-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/W_SE-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: W_SE-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/W_SW-Low_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Low voltage cable/W_SW-Low_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: W_SW-Low_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: low voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: 162b6f27da2d03440bee7ac6b55830bb, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 09000000080000000f0000000e00000010000000140000000500000015000000
   PowerType: 8

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/EO-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/EO-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: EO-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 1
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/E_NE-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/E_NE-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: E_NE-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/E_NW-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/E_NW-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: E_NW-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/E_SE-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/E_SE-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: E_SE-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/E_SW-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/E_SW-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: E_SW-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/NE-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/NE-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NE-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/NE_NW-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/NE_NW-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NE_NW-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/NE_O-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/NE_O-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NE_O-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 1
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/NE_SE-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/NE_SE-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NE_SE-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/NE_SW-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/NE_SW-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NE_SW-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/NO-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/NO-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NO-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 1
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/NS-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/NS-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NS-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/NW-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/NW-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NW-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/NW_O-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/NW_O-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NW_O-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 1
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/NW_SE-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/NW_SE-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NW_SE-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/NW_SW-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/NW_SW-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: NW_SW-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/N_NE-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/N_NE-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: N_NE-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/N_NW-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/N_NW-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: N_NW-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/N_SE-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/N_SE-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: N_SE-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/N_SW-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/N_SW-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: N_SW-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/SE-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/SE-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: SE-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/SE_O-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/SE_O-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: SE_O-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 1
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/SO-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/SO-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: SO-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 1
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/SW-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/SW-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: SW-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/SW_O-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/SW_O-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: SW_O-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 1
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/SW_SE-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/SW_SE-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: SW_SE-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/S_NE-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/S_NE-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: S_NE-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/S_NW-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/S_NW-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: S_NW-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/S_SE-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/S_SE-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: S_SE-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/S_SW-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/S_SW-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: S_SW-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/WE-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/WE-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: WE-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/WO-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/WO-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: WO-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 1
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/W_NE-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/W_NE-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: W_NE-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/W_NW-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/W_NW-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: W_NW-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/W_SE-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/W_SE-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: W_SE-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/W_SW-Medium_Voltage_Cable.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Electrical/Medium voltage cable/W_SW-Medium_Voltage_Cable.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b1bfcb29a2677e48add641bd21c8ade, type: 3}
   m_Name: W_SW-Medium_Voltage_Cable
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: medium voltage cable
   LayerType: 8
   TileType: 11
   RequiredTiles: []
@@ -31,6 +31,7 @@ MonoBehaviour:
   doesReflectBullet: 0
   indestructible: 0
   ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
   passableException:
     m_keys: 
     m_values: 
@@ -50,6 +51,7 @@ MonoBehaviour:
     DismembermentProtectionChance: 0
   tileInteractions:
   - {fileID: 11400000, guid: a357998b2bd41c0489e7b22914e697e5, type: 2}
+  tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0,
     type: 3}
   spawnAmountOnDeconstruct: 2
@@ -64,6 +66,7 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+      m_EditorAssetChanged: 0
   SoundOnDestroy: []
   CanConnectTo: 0100000003000000020000000600000007000000040000000d00000010000000140000000500000015000000
   PowerType: 1


### PR DESCRIPTION
### Purpose

fixes #8556.

### Changelog:

CL: [Fix] laid electrical wires will name what type of cable they are when examined.
