### PR TITLE
Fix LightningBolt Spell

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
@@ -346,7 +346,6 @@ public partial class MatrixManager : SingletonManager<MatrixManager>
 		return RayCast(Worldorigin, Vector2.zero, 0, layerMask, Layermask2D, WorldTo);
 	}
 
-
 	public static CustomPhysicsHit RayCast(Vector3 Worldorigin,
 		Vector2 direction,
 		float distance,
@@ -366,12 +365,14 @@ public partial class MatrixManager : SingletonManager<MatrixManager>
 		{
 			WorldTo = Worldorigin + (Vector3) (direction.normalized * distance);
 		}
-
-		var Distance = (WorldTo - Worldorigin).Value.magnitude;
-
-		if (Distance > 30)
+		else
 		{
-			Logger.LogError($" Limit exceeded on raycast, Look at stack trace for What caused it at {Distance}"); //Meant to catch up stuff that's been naughty and doing stuff like 900 tile Ray casts
+			distance = (WorldTo - Worldorigin).Value.magnitude;
+		}
+
+		if (distance > 30)
+		{
+			Logger.LogError($" Limit exceeded on raycast, Look at stack trace for What caused it at {distance}"); //Meant to catch up stuff that's been naughty and doing stuff like 900 tile Ray casts
 			return new CustomPhysicsHit();
 		}
 

--- a/UnityProject/Assets/Scripts/Managers/UpdateManager/UpdateManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/UpdateManager/UpdateManager.cs
@@ -99,19 +99,23 @@ public class UpdateManager : MonoBehaviour
 		instance.threadSafeAddQueue.Enqueue(new Tuple<CallbackType, Action>(type, action));
 	}
 
-	public static void Add(Action action, float timeInterval)
+	public static void Add(Action action, float timeInterval, bool offsetUpdate = true)
 	{
 		if (Instance.periodicUpdateActions.Any(x => x.Action == action)) return;
 		TimedUpdate timedUpdate = Instance.GetTimedUpdates();
 		timedUpdate.SetUp(action, timeInterval);
-		timedUpdate.TimeTitleNext += NumberOfUpdatesAdded * 0.01f;
+		if (offsetUpdate)
+		{
+			timedUpdate.TimeTitleNext += NumberOfUpdatesAdded * 0.01f;
+		}
+
+		Instance.periodicUpdateActions.Add(timedUpdate);
+
 		NumberOfUpdatesAdded++;
 		if (NumberOfUpdatesAdded > 500)
 		{
 			NumberOfUpdatesAdded = 0; //So the delay can't be too big
 		}
-
-		Instance.periodicUpdateActions.Add(timedUpdate);
 	}
 
 	public static void SafeAdd(Action action, float timeInterval)

--- a/UnityProject/Assets/Scripts/Systems/Explosions/ElectricalArc.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/ElectricalArc.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -23,7 +23,7 @@ namespace Systems.ElectricalArcs
 
 		public ElectricalArcSettings Settings { get; private set; }
 
-		private List<LightningBoltScript> arcs = new List<LightningBoltScript>();
+		private readonly List<LightningBoltScript> arcs = new();
 
 		/// <summary>
 		/// Informs all clients and the server to create arcs with the given settings.
@@ -45,14 +45,13 @@ namespace Systems.ElectricalArcs
 
 			if (settings.reachCheck && CanReach() == false) return;
 
-			var newArcs = new LightningBoltScript[settings.arcCount];
+			arcs.Clear();
 			for (int i = 0; i < settings.arcCount; i++)
 			{
-				newArcs[i] = CreateSingleArc(settings);
+				arcs.Add(CreateSingleArc(settings));
 			}
-			arcs = newArcs.ToList();
 
-			UpdateManager.Add(TriggerArc, arcs[0].Duration);
+			UpdateManager.Add(TriggerArc, arcs[0].Duration, offsetUpdate: false);
 			UpdateManager.Add(DoPulse, PULSE_INTERVAL);
 			UpdateManager.Add(EndArcs, settings.duration);
 		}

--- a/UnityProject/Assets/Scripts/Systems/Spells/Wizard/LightningBolt.cs
+++ b/UnityProject/Assets/Scripts/Systems/Spells/Wizard/LightningBolt.cs
@@ -178,8 +178,6 @@ namespace Systems.Spells.Wizard
 			Collider2D[] entities = Physics2D.OverlapCircleAll(point, radius, mask);
 			foreach (Collider2D coll in entities)
 			{
-				Debug.Log(coll.gameObject.name);
-
 				if (ignored != null && ignored.Contains(coll.gameObject)) continue;
 
 				if (RaycastToTarget(point, coll.transform.position).ItHit == false)

--- a/UnityProject/Assets/Scripts/Systems/Spells/Wizard/LightningBolt.cs
+++ b/UnityProject/Assets/Scripts/Systems/Spells/Wizard/LightningBolt.cs
@@ -1,10 +1,10 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using Systems.ElectricalArcs;
 using Systems.Explosions;
-using Systems.Mob;
 using HealthV2;
 
 namespace Systems.Spells.Wizard
@@ -22,7 +22,7 @@ namespace Systems.Spells.Wizard
 		[SerializeField, Range(0.5f, 10)]
 		private float duration = 2;
 		[SerializeField, Range(0, 20)]
-		[Tooltip("How much damage should each electrical arc apply every arc pulse (0.5 seconds)")]
+		[Tooltip("How much damage each electrical arc should apply every arc pulse (0.5 seconds).")]
 		private float damage = 3;
 		[SerializeField, Range(3, 12)]
 		private int primaryRange = 8;
@@ -43,10 +43,7 @@ namespace Systems.Spells.Wizard
 			}
 
 			GameObject primaryTarget = ZapPrimaryTarget(caster, targetPosition);
-			if (primaryTarget != null)
-			{
-				ZapSecondaryTargets(primaryTarget, targetPosition);
-			}
+			StartCoroutine(ZapSecondaryTargets(primaryTarget, targetPosition));
 
 			return true;
 		}
@@ -65,46 +62,53 @@ namespace Systems.Spells.Wizard
 				targetObject = TryGetGameObjectAt(targetPosition);
 			}
 
-			Zap(caster.GameObject, targetObject, arcCount, targetObject == null ? targetPosition : default);
+			Zap(arcCount, caster.GameObject, targetObject, endPos: targetPosition);
 
 			return targetObject;
 		}
 
-		private void ZapSecondaryTargets(GameObject originatingObject, Vector3 centrepoint)
+		private IEnumerator ZapSecondaryTargets(GameObject originatingObject, Vector3 centrepoint)
 		{
 			var ignored = new GameObject[2] { caster.GameObject, originatingObject };
 			int i = 0;
 
-			var mobs = GetNearbyEntities(centrepoint, LayerMask.GetMask("Players", "NPC"), ignored);
+			var mobs = GetNearbyEntities(centrepoint, secondaryRange, LayerMask.GetMask("Players", "NPC"), ignored);
 			foreach (Collider2D entity in mobs)
 			{
-				if (i >= arcCount) return;
+				if (i >= arcCount) yield break;
 				if (entity.gameObject == originatingObject) continue;
 
-				Zap(originatingObject, entity.gameObject, 1);
+				yield return WaitFor.Seconds(0.2f);
+				Zap(1, originatingObject, entity.gameObject, startPos: centrepoint);
 				i++;
 			}
 
-			// Not enough mobs around, try zapping nearby machines.
-			var machines = GetNearbyEntities(centrepoint, LayerMask.GetMask("Machines", "WallMounts", "Objects"), ignored);
+			// Not enough mobs around, try zapping nearby machines
+			// "Unshootable Machines" are so bullets pass over them, which doesn't need to apply here, so we target them too.
+			var machines = GetNearbyEntities(centrepoint, secondaryRange,
+					LayerMask.GetMask("Machines", "Unshootable Machines", "WallMounts", "Objects", "Items"), ignored);
 			foreach (Collider2D entity in machines)
 			{
-				if (i >= arcCount) return;
+				if (i >= arcCount) yield break;
 				if (entity.gameObject == originatingObject) continue;
 
-				Zap(originatingObject, entity.gameObject, 1);
+				yield return WaitFor.Seconds(0.2f);
+				Zap(1, originatingObject, entity.gameObject, startPos: centrepoint);
 				i++;
 			}
 		}
 
-		private void Zap(GameObject originatingObject, GameObject targetObject, int arcs, Vector3 targetPosition = default)
+		private void Zap(int arcs, GameObject startObject, GameObject endObject, Vector3 startPos = default, Vector3 endPos = default)
 		{
-			ElectricalArcSettings arcSettings = new ElectricalArcSettings(
-					arcEffect, originatingObject, targetObject, default, targetPosition, arcs, duration);
+			ElectricalArcSettings arcSettings = new(
+					arcEffect, startObject, endObject,
+					startObject ? default : startPos,
+					endObject ? default : endPos,
+					arcs, duration);
 
-			if (targetObject != null)
+			if (endObject != null)
 			{
-				var interfaces = targetObject.GetComponents<IOnLightningHit>();
+				var interfaces = endObject.GetComponents<IOnLightningHit>();
 
 				foreach (var lightningHit in interfaces)
 				{
@@ -123,6 +127,10 @@ namespace Systems.Spells.Wizard
 			{
 				health.ApplyDamageAll(caster.GameObject, damage * arc.Settings.arcCount, AttackType.Magic, DamageType.Burn);
 			}
+			else if (arc.Settings.endObject.TryGetComponent<LivingHealthBehaviour>(out var healthOld))
+			{
+				healthOld.ApplyDamage(caster.GameObject, damage * arc.Settings.arcCount, AttackType.Magic, DamageType.Burn);
+			}
 			else if (arc.Settings.endObject.TryGetComponent<Integrity>(out var integrity))
 			{
 				integrity.ApplyDamage(damage * arc.Settings.arcCount, AttackType.Magic, DamageType.Burn);
@@ -131,17 +139,22 @@ namespace Systems.Spells.Wizard
 
 		#region Helpers
 
-		private T GetFirstAt<T>(Vector3Int position) where T : MonoBehaviour
+		private static T GetFirstAt<T>(Vector3Int position) where T : MonoBehaviour
 		{
 			return MatrixManager.GetAt<T>(position, true).FirstOrDefault();
 		}
 
-		private GameObject TryGetGameObjectAt(Vector3 targetPosition)
+		private static GameObject TryGetGameObjectAt(Vector3 targetPosition)
 		{
 			var mob = GetFirstAt<LivingHealthMasterBase>(targetPosition.CutToInt());
 			if (mob != null)
 			{
 				return mob.gameObject;
+			}
+			var mobOld = GetFirstAt<LivingHealthBehaviour>(targetPosition.CutToInt());
+			if (mobOld != null)
+			{
+				return mobOld.gameObject;
 			}
 
 			var integrity = GetFirstAt<Integrity>(targetPosition.CutToInt());
@@ -153,21 +166,23 @@ namespace Systems.Spells.Wizard
 			return default;
 		}
 
-		private MatrixManager.CustomPhysicsHit RaycastToTarget(Vector3 start, Vector3 end)
+		private static MatrixManager.CustomPhysicsHit RaycastToTarget(Vector3 start, Vector3 end)
 		{
-			return MatrixManager.RayCast(start, default, primaryRange,
+			return MatrixManager.RayCast(start, default, default,
 					LayerTypeSelection.Walls | LayerTypeSelection.Windows, LayerMask.GetMask("Door Closed"),
 					end);
 		}
 
-		private IEnumerable<Collider2D> GetNearbyEntities(Vector3 centrepoint, int mask, GameObject[] ignored = default)
+		private static IEnumerable<Collider2D> GetNearbyEntities(Vector3 point, float radius, int mask, GameObject[] ignored = default)
 		{
-			Collider2D[] entities = Physics2D.OverlapCircleAll(centrepoint, secondaryRange, mask);
+			Collider2D[] entities = Physics2D.OverlapCircleAll(point, radius, mask);
 			foreach (Collider2D coll in entities)
 			{
-				if (ignored.Contains(coll.gameObject)) continue;
+				Debug.Log(coll.gameObject.name);
 
-				if (RaycastToTarget(centrepoint, coll.transform.position).ItHit == false)
+				if (ignored != null && ignored.Contains(coll.gameObject)) continue;
+
+				if (RaycastToTarget(point, coll.transform.position).ItHit == false)
 				{
 					yield return coll;
 				}


### PR DESCRIPTION
- Fixes issue where the electrical arcs were no longer being spawned instantly.
- Old LHB mobs are now targetable.
- More secondary targets.
- Targeting the floor will now also spread to secondary targets.
CL: [Fix] Fixed issue where the electrical arcs of the lightning bolt spell were no longer being spawned instantly.
CL: [Fix] the wizard's lightning bolt spell will hot all kinds of NPC mobs, now.
CL: [Balance] the lightning bolt spell will arc to more targets now.
CL: [Improvement] targeting the floor with the lightning bolt spell will send it's arc's to nearby targets as if it hit a person.