### PR TITLE
Antags will no longer receive the steal objective with an item they have immediate access to in their job

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/Steal.asset
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/Steal.asset
@@ -19,10 +19,44 @@ MonoBehaviour:
   ItemPool:
     m_keys:
     - {fileID: 9177804066296137559, guid: 25108e21a69d52c46a538e66eb85db0a, type: 3}
+    - {fileID: 3469891026679729664, guid: b032e09c1bd8c5449b888c4353d665ba, type: 3}
+    - {fileID: 7781396554342910705, guid: 5215b03386bb16b47863b89009d46ba9, type: 3}
+    - {fileID: 4008869112228049984, guid: 14918809bba44684bb80ebb008610c5a, type: 3}
     m_values:
-    - amountToSteal: 3
-      blacklistedOccupations:
-      - {fileID: 11400000, guid: 6d7b61c950bf54e649c18adb64c9e36c, type: 2}
-      - {fileID: 11400000, guid: c9dec3badc798443c8ce07e7cd400d48, type: 2}
+    - AmountToSteal: 3
+      BlacklistedOccupations:
+      - {fileID: 11400000, guid: ffc6b873cd2cf4e4f81501fbc12385f0, type: 2}
+      - {fileID: 11400000, guid: 208f5eb5b3dd142f0a83a9cc628dc485, type: 2}
       - {fileID: 11400000, guid: d66123701b005402eae243fdc5236dff, type: 2}
+      - {fileID: 11400000, guid: c9dec3badc798443c8ce07e7cd400d48, type: 2}
       - {fileID: 11400000, guid: 1162c4c5057294689ae4e937930969d0, type: 2}
+      - {fileID: 11400000, guid: 6d7b61c950bf54e649c18adb64c9e36c, type: 2}
+    - AmountToSteal: 1
+      BlacklistedOccupations:
+      - {fileID: 11400000, guid: ffc6b873cd2cf4e4f81501fbc12385f0, type: 2}
+      - {fileID: 11400000, guid: 208f5eb5b3dd142f0a83a9cc628dc485, type: 2}
+      - {fileID: 11400000, guid: d66123701b005402eae243fdc5236dff, type: 2}
+      - {fileID: 11400000, guid: c9dec3badc798443c8ce07e7cd400d48, type: 2}
+      - {fileID: 11400000, guid: 1162c4c5057294689ae4e937930969d0, type: 2}
+      - {fileID: 11400000, guid: 6d7b61c950bf54e649c18adb64c9e36c, type: 2}
+      - {fileID: 11400000, guid: 91271c894925b4e89a46031cb7a50fe6, type: 2}
+      - {fileID: 11400000, guid: ea02bc3c4a28c430ea905db72a3630ec, type: 2}
+      - {fileID: 11400000, guid: 3df53a0fd5d684622b48ad9dce6fcf5b, type: 2}
+    - AmountToSteal: 1
+      BlacklistedOccupations:
+      - {fileID: 11400000, guid: ffc6b873cd2cf4e4f81501fbc12385f0, type: 2}
+      - {fileID: 11400000, guid: 91271c894925b4e89a46031cb7a50fe6, type: 2}
+      - {fileID: 11400000, guid: ea02bc3c4a28c430ea905db72a3630ec, type: 2}
+      - {fileID: 11400000, guid: 3df53a0fd5d684622b48ad9dce6fcf5b, type: 2}
+      - {fileID: 11400000, guid: 14ae2bbebc49841308668e7732024737, type: 2}
+      - {fileID: 11400000, guid: 2b58a814f2ab69e4b8a4781a15555222, type: 2}
+      - {fileID: 11400000, guid: 9548345f52bca334a8741ae407dc25e8, type: 2}
+    - AmountToSteal: 1
+      BlacklistedOccupations:
+      - {fileID: 11400000, guid: ffc6b873cd2cf4e4f81501fbc12385f0, type: 2}
+      - {fileID: 11400000, guid: 91271c894925b4e89a46031cb7a50fe6, type: 2}
+      - {fileID: 11400000, guid: ea02bc3c4a28c430ea905db72a3630ec, type: 2}
+      - {fileID: 11400000, guid: 3df53a0fd5d684622b48ad9dce6fcf5b, type: 2}
+      - {fileID: 11400000, guid: 14ae2bbebc49841308668e7732024737, type: 2}
+      - {fileID: 11400000, guid: 2b58a814f2ab69e4b8a4781a15555222, type: 2}
+      - {fileID: 11400000, guid: 9548345f52bca334a8741ae407dc25e8, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/Steal.asset
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/Steal.asset
@@ -19,13 +19,10 @@ MonoBehaviour:
   ItemPool:
     m_keys:
     - {fileID: 9177804066296137559, guid: 25108e21a69d52c46a538e66eb85db0a, type: 3}
-    - {fileID: 7781396554342910705, guid: 5215b03386bb16b47863b89009d46ba9, type: 3}
-    - {fileID: 1646905509486091719, guid: 6f2f89dc5b40b0340a7dcc57cc71dec7, type: 3}
-    - {fileID: 6398340229684661186, guid: 24461e841e57b3c499e6b3621dd50639, type: 3}
-    - {fileID: 100328150011014054, guid: b998cf4e42b95ec4fbbb893c889010e8, type: 3}
-    - {fileID: 3921521694364753778, guid: 3bce251232ebb5a49a7a932420df0027, type: 3}
-    - {fileID: 3469891026679729664, guid: b032e09c1bd8c5449b888c4353d665ba, type: 3}
-    - {fileID: 5374960043103273218, guid: 5653131fc0c7f0b46af145251ab061d4, type: 3}
-    - {fileID: 70068185008237990, guid: f2f44eb806b35ff40a64333b48771101, type: 3}
-    - {fileID: 6069169269836946088, guid: 16fa65d926209f949a7501fc381f882b, type: 3}
-    m_values: 03000000010000000100000001000000010000000100000001000000010000000100000001000000
+    m_values:
+    - amountToSteal: 3
+      blacklistedOccupations:
+      - {fileID: 11400000, guid: 6d7b61c950bf54e649c18adb64c9e36c, type: 2}
+      - {fileID: 11400000, guid: c9dec3badc798443c8ce07e7cd400d48, type: 2}
+      - {fileID: 11400000, guid: d66123701b005402eae243fdc5236dff, type: 2}
+      - {fileID: 11400000, guid: 1162c4c5057294689ae4e937930969d0, type: 2}

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/Steal.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/Steal.cs
@@ -50,7 +50,7 @@ namespace Antagonists
 
 			foreach (var item in possibleItems)
 			{
-				if(item.Value.blacklistedOccupations.Contains(Owner.occupation) == false) continue;
+				if(item.Value.BlacklistedOccupations.Contains(Owner.occupation) == false) continue;
 				possibleItems.Remove(item);
 			}
 
@@ -80,7 +80,7 @@ namespace Antagonists
 				                $"Item: {itemEntry.Key.Item().gameObject.name}", Category.Antags);
 				return;
 			}
-			Amount = itemEntry.Value.amountToSteal;
+			Amount = itemEntry.Value.AmountToSteal;
 			AntagManager.Instance.TargetedItems.Add(itemEntry.Key);
 			// TODO randomise amount based on range/weightings?
 			description = $"Steal {Amount} {ItemName}";
@@ -95,7 +95,7 @@ namespace Antagonists
 	[Serializable]
 	public struct StealData
 	{
-		public int amountToSteal;
-		public List<Occupation> blacklistedOccupations;
+		public int AmountToSteal;
+		public List<Occupation> BlacklistedOccupations;
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/Steal.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/Steal.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using System.Linq;
+using System;
 
 namespace Antagonists
 {
@@ -15,7 +16,7 @@ namespace Antagonists
 		/// The pool of possible items to steal
 		/// </summary>
 		[SerializeField]
-		private SerializableDictionary<GameObject, int> ItemPool = null;
+		private SerializableDictionary<GameObject, StealData> ItemPool = null;
 
 		/// <summary>
 		/// The item to steal
@@ -47,6 +48,12 @@ namespace Antagonists
 			var possibleItems = ItemPool.Where( itemDict =>
 				!AntagManager.Instance.TargetedItems.Contains(itemDict.Key)).ToList();
 
+			foreach (var item in possibleItems)
+			{
+				if(item.Value.blacklistedOccupations.Contains(Owner.occupation) == false) continue;
+				possibleItems.Remove(item);
+			}
+
 			if (possibleItems.Count == 0)
 			{
 				Logger.LogWarning("Unable to find any suitable items to steal! Giving free objective", Category.Antags);
@@ -63,6 +70,7 @@ namespace Antagonists
 				                " Definitely a programming bug. ", Category.Antags);
 				return;
 			}
+
 			ItemName = itemEntry.Key.Item().InitialName;
 
 			if (string.IsNullOrEmpty(ItemName))
@@ -72,7 +80,7 @@ namespace Antagonists
 				                $"Item: {itemEntry.Key.Item().gameObject.name}", Category.Antags);
 				return;
 			}
-			Amount = itemEntry.Value;
+			Amount = itemEntry.Value.amountToSteal;
 			AntagManager.Instance.TargetedItems.Add(itemEntry.Key);
 			// TODO randomise amount based on range/weightings?
 			description = $"Steal {Amount} {ItemName}";
@@ -82,5 +90,12 @@ namespace Antagonists
 		{
 			return CheckStorageFor(ItemName, Amount);
 		}
+	}
+
+	[Serializable]
+	public struct StealData
+	{
+		public int amountToSteal;
+		public List<Occupation> blacklistedOccupations;
 	}
 }


### PR DESCRIPTION
Fixes #4857

Adds the ability to blacklist occupations from receiving the steal objective that have immediate access to their objective

![image](https://user-images.githubusercontent.com/34368774/165656744-a4bee3d7-00a3-4db1-9e94-3483cdd97420.png)


### Changelog


CL: [Fix] - Antags will no longer receive the steal objective with an item they have immediate access to in their job