### PR TITLE
Small fixes: ensure username on new character, resilient addressables, fixes kick on round restart

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/AddressableManager/AddressableCatalogueManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/AddressableManager/AddressableCatalogueManager.cs
@@ -243,10 +243,10 @@ public class AddressableCatalogueManager : MonoBehaviour, IInitialise
 	public static List<string> GetCataloguePathStreamingAssets()
 	{
 		var pathss = Application.streamingAssetsPath + "/AddressableCatalogues";
-		var Directories = System.IO.Directory.GetDirectories(pathss);
-		var Catalogues = new List<string>();
-		var MultiCatalogues = new List<string>();
-		foreach (var Directorie in Directories)
+		var directories = System.IO.Directory.GetDirectories(pathss);
+		var catalogues = new List<string>();
+		var multiCatalogues = new List<string>();
+		foreach (var Directorie in directories)
 		{
 			var newpaths = Directorie.Replace(@"\", "/");
 			var newDirectories = System.IO.Directory.GetFiles(newpaths);
@@ -255,16 +255,16 @@ public class AddressableCatalogueManager : MonoBehaviour, IInitialise
 			{
 				if (pathST.Contains(".json"))
 				{
-					MultiCatalogues.Add(pathST);
+					multiCatalogues.Add(pathST);
 				}
 
 			}
 
 
 			string Newest = "";
-			if (MultiCatalogues.Count > 1)
+			if (multiCatalogues.Count > 1)
 			{
-				foreach (var Catalogue in MultiCatalogues)
+				foreach (var Catalogue in multiCatalogues)
 				{
 					var intCatalogue = Catalogue.Replace(".json", "");
 					intCatalogue =	intCatalogue.Substring(intCatalogue.IndexOf("\\", StringComparison.Ordinal) + 1).Trim();
@@ -283,14 +283,14 @@ public class AddressableCatalogueManager : MonoBehaviour, IInitialise
 						}
 					}
 				}
-				Catalogues.Add(Newest);
+				catalogues.Add(Newest);
 			}
 			else
 			{
-				Catalogues.Add(MultiCatalogues[0]);
+				catalogues.Add(multiCatalogues[0]);
 			}
 		}
 
-		return Catalogues;
+		return catalogues;
 	}
 }

--- a/UnityProject/Assets/Scripts/Managers/AddressableManager/AddressableCatalogueManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/AddressableManager/AddressableCatalogueManager.cs
@@ -246,10 +246,10 @@ public class AddressableCatalogueManager : MonoBehaviour, IInitialise
 		var directories = System.IO.Directory.GetDirectories(pathss);
 		var catalogues = new List<string>();
 		var multiCatalogues = new List<string>();
-		foreach (var directorie in directories)
+		foreach (var directory in directories)
 		{
-			var newpaths = directorie.Replace(@"\", "/");
-			var newDirectories = System.IO.Directory.GetFiles(newpaths);
+			var newPath = directory.Replace(@"\", "/");
+			var newDirectories = System.IO.Directory.GetFiles(newPath);
 
 			foreach (var pathST in newDirectories)
 			{

--- a/UnityProject/Assets/Scripts/Managers/AddressableManager/AddressableCatalogueManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/AddressableManager/AddressableCatalogueManager.cs
@@ -246,9 +246,9 @@ public class AddressableCatalogueManager : MonoBehaviour, IInitialise
 		var directories = System.IO.Directory.GetDirectories(pathss);
 		var catalogues = new List<string>();
 		var multiCatalogues = new List<string>();
-		foreach (var Directorie in directories)
+		foreach (var directorie in directories)
 		{
-			var newpaths = Directorie.Replace(@"\", "/");
+			var newpaths = directorie.Replace(@"\", "/");
 			var newDirectories = System.IO.Directory.GetFiles(newpaths);
 
 			foreach (var pathST in newDirectories)
@@ -264,13 +264,13 @@ public class AddressableCatalogueManager : MonoBehaviour, IInitialise
 			string Newest = "";
 			if (multiCatalogues.Count > 1)
 			{
-				foreach (var Catalogue in multiCatalogues)
+				foreach (var catalogue in multiCatalogues)
 				{
-					var intCatalogue = Catalogue.Replace(".json", "");
+					var intCatalogue = catalogue.Replace(".json", "");
 					intCatalogue =	intCatalogue.Substring(intCatalogue.IndexOf("\\", StringComparison.Ordinal) + 1).Trim();
 					if (string.IsNullOrEmpty(Newest))
 					{
-						Newest = Catalogue;
+						Newest = catalogue;
 					}
 					else
 					{
@@ -279,7 +279,7 @@ public class AddressableCatalogueManager : MonoBehaviour, IInitialise
 
 						if (double.Parse(intCatalogue) > double.Parse(intNewest))
 						{
-							Newest = Catalogue;
+							Newest = catalogue;
 						}
 					}
 				}

--- a/UnityProject/Assets/Scripts/Managers/AddressableManager/AddressableCatalogueManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/AddressableManager/AddressableCatalogueManager.cs
@@ -245,6 +245,7 @@ public class AddressableCatalogueManager : MonoBehaviour, IInitialise
 		var pathss = Application.streamingAssetsPath + "/AddressableCatalogues";
 		var Directories = System.IO.Directory.GetDirectories(pathss);
 		var Catalogues = new List<string>();
+		var MultiCatalogues = new List<string>();
 		foreach (var Directorie in Directories)
 		{
 			var newpaths = Directorie.Replace(@"\", "/");
@@ -254,9 +255,39 @@ public class AddressableCatalogueManager : MonoBehaviour, IInitialise
 			{
 				if (pathST.Contains(".json"))
 				{
-					Catalogues.Add(pathST);
+					MultiCatalogues.Add(pathST);
 				}
 
+			}
+
+
+			string Newest = "";
+			if (MultiCatalogues.Count > 1)
+			{
+				foreach (var Catalogue in MultiCatalogues)
+				{
+					var intCatalogue = Catalogue.Replace(".json", "");
+					intCatalogue =	intCatalogue.Substring(intCatalogue.IndexOf("\\", StringComparison.Ordinal) + 1).Trim();
+					if (string.IsNullOrEmpty(Newest))
+					{
+						Newest = Catalogue;
+					}
+					else
+					{
+						var intNewest = Newest.Replace(".json", "");
+						intNewest =	intNewest.Substring(intNewest.IndexOf("\\", StringComparison.Ordinal) + 1).Trim();
+
+						if (double.Parse(intCatalogue) > double.Parse(intNewest))
+						{
+							Newest = Catalogue;
+						}
+					}
+				}
+				Catalogues.Add(Newest);
+			}
+			else
+			{
+				Catalogues.Add(MultiCatalogues[0]);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -43,29 +43,31 @@ namespace Player
 			{
 				CmdServerSetupPlayer(GetNetworkInfo(),
 					PlayerManager.CurrentCharacterSettings.Username, DatabaseAPI.ServerData.UserID, GameData.BuildNumber,
-					DatabaseAPI.ServerData.IdToken);
-				CmdServerRequestLoadedScenes(SceneManager.GetActiveScene().name);
+					DatabaseAPI.ServerData.IdToken, SceneManager.GetActiveScene().name);
+
 			}
 		}
+
+
 
 		private async void HandleServerConnection()
 		{
 			await ServerSetUpPlayer(GetNetworkInfo(),
 				PlayerManager.CurrentCharacterSettings.Username, DatabaseAPI.ServerData.UserID, GameData.BuildNumber,
-				DatabaseAPI.ServerData.IdToken);
+				DatabaseAPI.ServerData.IdToken, "");
 			ClientFinishLoading();
 		}
 
 		[Command]
 		private void CmdServerSetupPlayer(string unverifiedClientId, string unverifiedUsername,
-			string unverifiedUserid, int unverifiedClientVersion, string unverifiedToken)
+			string unverifiedUserid, int unverifiedClientVersion, string unverifiedToken, string clientCurrentScene)
 		{
 			ClearCache();
-			_ = ServerSetUpPlayer(unverifiedClientId, unverifiedUsername, unverifiedUserid, unverifiedClientVersion, unverifiedToken);
+			_ = ServerSetUpPlayer(unverifiedClientId, unverifiedUsername, unverifiedUserid, unverifiedClientVersion, unverifiedToken,clientCurrentScene);
 		}
 
-		[Command]
-		private void CmdServerRequestLoadedScenes(string AlreadyLoaded)
+
+		private void ServerRequestLoadedScenes(string AlreadyLoaded)
 		{
 			List<SceneInfo> SceneS = new List<SceneInfo>();
 
@@ -95,7 +97,8 @@ namespace Player
 			string unverifiedUsername,
 			string unverifiedUserid,
 			int unverifiedClientVersion,
-			string unverifiedToken)
+			string unverifiedToken,
+			string clientCurrentScene)
 		{
 			Logger.LogFormat("A joinedviewer called CmdServerSetupPlayer on this server, Unverified ClientId: {0} Unverified Username: {1}",
 				Category.Connections,
@@ -144,6 +147,10 @@ namespace Player
 			STUnverifiedClientId = unverifiedClientId;
 			STVerifiedUserid = unverifiedUserid; //Is validated within  PlayerList.Instance.ValidatePlayer(
 			STVerifiedConnPlayer = unverifiedConnPlayer;
+			if (string.IsNullOrEmpty(clientCurrentScene) == false)
+			{
+				ServerRequestLoadedScenes(clientCurrentScene );
+			}
 		}
 
 		[Command]

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -66,7 +66,7 @@ namespace Player
 			_ = ServerSetUpPlayer(unverifiedClientId, unverifiedUsername, unverifiedUserid, unverifiedClientVersion, unverifiedToken,clientCurrentScene);
 		}
 
-
+		[Server]
 		private void ServerRequestLoadedScenes(string AlreadyLoaded)
 		{
 			List<SceneInfo> SceneS = new List<SceneInfo>();

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -235,6 +235,7 @@ namespace UI.CharacterCreator
 			currentCharacterIndex = PlayerCharacters.Count() - 1;
 			LoadSettings(PlayerCharacters[currentCharacterIndex]);
 			currentCharacter.Species = Race.Human.ToString();
+			currentCharacter.Username = ServerData.Auth.CurrentUser.DisplayName;
 			ShowCharacterCreator();
 			ReturnCharacterPreviewFromTheCharacterSelector();
 			_ = SoundManager.Play(CommonSounds.Instance.Click01);


### PR DESCRIPTION

Makes addressable more resilient to Multiple  dev catalogues Being included
and
Sets up the joint viewer  login process to Hopefully fix the issue with clients being Kicked on a round restart
and
Ensure username is set when making a new character
