### PR TITLE
remove some unity complaining also fixes rotatable not updating

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandler.cs
+++ b/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandler.cs
@@ -6,6 +6,7 @@ using Mirror;
 using UnityEngine.Serialization;
 #if UNITY_EDITOR
 using Unity.EditorCoroutines.Editor;
+using UnityEditor;
 #endif
 using UnityEngine.UI;
 
@@ -938,11 +939,17 @@ public class SpriteHandler : MonoBehaviour
 		}
 		if (this.gameObject.scene.path == null || this.gameObject.scene.path.Contains("Scenes") == false)
 		{
-			variantIndex = initialVariantIndex;
-			PushTexture();
+#if UNITY_EDITOR
+			EditorApplication.delayCall += ValidateLate;
+#endif
+
 		}
 	}
-
+	public void ValidateLate()
+	{
+		variantIndex = initialVariantIndex;
+		PushTexture();
+	}
 
 	private bool EditorTryToggleAnimationState(bool turnOn)
 	{

--- a/UnityProject/Assets/Scripts/Objects/Cargo/ConveyorBelts/ConveyorBelt.cs
+++ b/UnityProject/Assets/Scripts/Objects/Cargo/ConveyorBelts/ConveyorBelt.cs
@@ -4,7 +4,9 @@ using UnityEngine;
 using Mirror;
 using ScriptableObjects;
 using Systems.ObjectConnection;
-
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 
 namespace Construction.Conveyors
 {
@@ -47,7 +49,10 @@ namespace Construction.Conveyors
 		private void OnValidate()
 		{
 			if (Application.isPlaying) return;
-			RefreshSprites();
+#if UNITY_EDITOR
+			EditorApplication.delayCall += RefreshSprites;
+#endif
+
 		}
 
 		#endregion Lifecycle

--- a/UnityProject/Assets/Scripts/Objects/Directionals/Rotatable.cs
+++ b/UnityProject/Assets/Scripts/Objects/Directionals/Rotatable.cs
@@ -99,10 +99,6 @@ public class Rotatable : NetworkBehaviour, IMatrixRotation
 		}
 	}
 
-	// private bool HasSetEditor = false;
-	//
-	// private OrientationEnum Cashed = OrientationEnum.Default;
-
 	public void OnValidate()
 	{
 		if (Application.isPlaying) return;

--- a/UnityProject/Assets/Scripts/Objects/Directionals/Rotatable.cs
+++ b/UnityProject/Assets/Scripts/Objects/Directionals/Rotatable.cs
@@ -99,6 +99,27 @@ public class Rotatable : NetworkBehaviour, IMatrixRotation
 		}
 	}
 
+	// private bool HasSetEditor = false;
+	//
+	// private OrientationEnum Cashed = OrientationEnum.Default;
+
+	public void OnValidate()
+	{
+		if (Application.isPlaying) return;
+#if UNITY_EDITOR
+		EditorApplication.delayCall += ValidateLate;
+#endif
+
+	}
+
+	public void ValidateLate()
+	{
+		Awake();
+		CurrentDirection = CurrentDirection;
+		RotateObject(CurrentDirection);
+		ResitOthers();
+	}
+
 	private void SyncServerDirection(OrientationEnum oldDir, OrientationEnum dir)
 	{
 		if (IgnoreServerUpdatesIfLocalPlayer && isLocalPlayer)
@@ -187,6 +208,7 @@ public class Rotatable : NetworkBehaviour, IMatrixRotation
 	[NaughtyAttributes.Button()]
 	public void Refresh()
 	{
+		Awake();
 		SetDirection(CurrentDirection);
 		ResitOthers();
 	}
@@ -203,12 +225,12 @@ public class Rotatable : NetworkBehaviour, IMatrixRotation
 
 	private void Awake()
 	{
-		if (spriteRenderers == null)
+		if (spriteRenderers == null || spriteRenderers.Length == 0 )
 		{
 			spriteRenderers = GetComponentsInChildren<SpriteRenderer>();
 		}
 
-		if (spriteHandlers == null)
+		if (spriteHandlers == null || spriteHandlers.Length == 0)
 		{
 			spriteHandlers = GetComponentsInChildren<SpriteHandler>();
 		}
@@ -297,7 +319,7 @@ public class Rotatable : NetworkBehaviour, IMatrixRotation
 		public bool Locked;
 		public OrientationEnum LockedTo;
 	}
-	
+
 	public void ResitOthers()
 	{
 		if (doNotResetOtherSpriteOptions) return;
@@ -352,6 +374,7 @@ public class Rotatable : NetworkBehaviour, IMatrixRotation
 
 				var localRotation = serializedObject.FindProperty("m_LocalRotation");
 				PrefabUtility.RevertPropertyOverride(localRotation, InteractionMode.AutomatedAction);
+				EditorUtility.SetDirty(this);
 			}
 
 			if (MethodRotation != RotationMethod.Sprites)
@@ -361,6 +384,7 @@ public class Rotatable : NetworkBehaviour, IMatrixRotation
 					SerializedObject serializedObject = new UnityEditor.SerializedObject(spriteRenderer.transform);
 					var localRotation = serializedObject.FindProperty("m_LocalRotation");
 					PrefabUtility.RevertPropertyOverride(localRotation, InteractionMode.AutomatedAction);
+					EditorUtility.SetDirty(this);
 				}
 			}
 
@@ -379,6 +403,7 @@ public class Rotatable : NetworkBehaviour, IMatrixRotation
 					SerializedObject serializedSpriteRenderer = new UnityEditor.SerializedObject(SpriteRenderer);
 					var sprite = serializedSpriteRenderer.FindProperty("m_Sprite");
 					PrefabUtility.RevertPropertyOverride(sprite, InteractionMode.AutomatedAction);
+					EditorUtility.SetDirty(this);
 				}
 			}
 		}

--- a/UnityProject/Assets/Scripts/Objects/Engineering/Reflector.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/Reflector.cs
@@ -3,6 +3,9 @@ using Messages.Server;
 using Mirror;
 using ScriptableObjects;
 using ScriptableObjects.Gun;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 using UnityEngine;
 using Weapons;
 using Weapons.Projectiles;
@@ -61,7 +64,14 @@ namespace Objects.Engineering
 		private void OnValidate()
 		{
 			if (Application.isPlaying) return;
+#if UNITY_EDITOR
+			EditorApplication.delayCall += ValidateLate;
+#endif
 
+		}
+
+		public void ValidateLate()
+		{
 			spriteHandler = GetComponentInChildren<SpriteHandler>();
 			currentState = startingState;
 			spriteHandler.ChangeSprite((int)startingState);
@@ -69,6 +79,7 @@ namespace Objects.Engineering
 			transform.localEulerAngles = new Vector3(0, 0, rotation);
 			spriteTransform.localEulerAngles = Vector3.zero;
 		}
+
 
 		private void Start()
 		{


### PR DESCRIPTION
SendMessage cannot be called during Awake, CheckConsistency, or OnValidate (Sprite: OnSpriteTilingPropertyChange)


should hopefully stop this appearing In tests, reducing size 