### PR TITLE
Adds a purchasable traitor crate for emagged supply consoles + fixes missing sound

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Consoles/SupplyConsole.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Consoles/SupplyConsole.prefab
@@ -1,30 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &2832537527261000937
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9063439616851718856}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 064528c52a5b48c7f8912a3b6914eb79, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  CorrectID: 0
-  Emagged: 0
-  cargoGUI: {fileID: 0}
-  allowedTypes: 0000000006000000070000001600000001000000100000001d000000
-  creditArrivalSound:
-    SetLoadSetting: 0
-    AssetAddress: null
-    AssetReference:
-      m_AssetGUID: 
-      m_SubObjectName: 
-      m_SubObjectType: 
 --- !u!1001 &1614618359472984753
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -272,12 +247,6 @@ PrefabInstance:
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b46887a995abc224aab70e21b9e53697, type: 3}
---- !u!1 &9063439616851718856 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7759570870767460473, guid: b46887a995abc224aab70e21b9e53697,
-    type: 3}
-  m_PrefabInstance: {fileID: 1614618359472984753}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &6152867160171636170 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4830997643641780091, guid: b46887a995abc224aab70e21b9e53697,
@@ -290,3 +259,35 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &9063439616851718856 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7759570870767460473, guid: b46887a995abc224aab70e21b9e53697,
+    type: 3}
+  m_PrefabInstance: {fileID: 1614618359472984753}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2832537527261000937
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9063439616851718856}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 064528c52a5b48c7f8912a3b6914eb79, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  CorrectID: 0
+  Emagged: 0
+  cargoGUI: {fileID: 0}
+  allowedTypes: 0000000006000000070000001600000001000000100000001d000000
+  creditArrivalSound:
+    SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/Machines/TerminalAlert.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0

--- a/UnityProject/Assets/ScriptableObjects/Cargo/Categories/Armory.asset
+++ b/UnityProject/Assets/ScriptableObjects/Cargo/Categories/Armory.asset
@@ -24,3 +24,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 0ba70e8f4573013458945e8575189a89, type: 2}
   - {fileID: 11400000, guid: 2f8d748ec4206634bb5293eec27828e2, type: 2}
   - {fileID: 11400000, guid: d7ec83a17e215c345af3200f52f35d8d, type: 2}
+  - {fileID: 11400000, guid: 6c61db1dc4fb5e345b6295d170f38c5c, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Cargo/Orders/ScottishWeaponryCrateSO.asset
+++ b/UnityProject/Assets/ScriptableObjects/Cargo/Orders/ScottishWeaponryCrateSO.asset
@@ -1,0 +1,26 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c0c8fd537387459c95edf35f9c5dd2c3, type: 3}
+  m_Name: ScottishWeaponryCrateSO
+  m_EditorClassIdentifier: 
+  OrderName: Scottish Weapons
+  CreditCost: 1500
+  Crate: {fileID: 6829341300379324721, guid: 6ecb8b1a0d8d9184fa74bdd3c7ded42d, type: 3}
+  Items:
+  - {fileID: 6941869242834729591, guid: b8abdef0ab4ea4b4da3cb3ef1e47f065, type: 3}
+  - {fileID: 6941869242834729591, guid: b8abdef0ab4ea4b4da3cb3ef1e47f065, type: 3}
+  - {fileID: 896716891640034833, guid: 9ca978c567f2e5c4bb8a6be3190717f7, type: 3}
+  - {fileID: 896716891640034833, guid: 9ca978c567f2e5c4bb8a6be3190717f7, type: 3}
+  - {fileID: 896716891640034833, guid: 9ca978c567f2e5c4bb8a6be3190717f7, type: 3}
+  - {fileID: 896716891640034833, guid: 9ca978c567f2e5c4bb8a6be3190717f7, type: 3}
+  ContentSellPrice: 70
+  EmagOnly: 1

--- a/UnityProject/Assets/ScriptableObjects/Cargo/Orders/ScottishWeaponryCrateSO.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Cargo/Orders/ScottishWeaponryCrateSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6c61db1dc4fb5e345b6295d170f38c5c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
CL: [New] Adds a traitor crate in the armory category of an emagged console shuttle titled "Scottish weaponry." Contains 4 X4s and two claymores.

Fixes missing sound for when budget updates.

part of #6150.