### PR TITLE
Re-adds some steal objectives, updates blacklist on others.

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/Steal.asset
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/Steal.asset
@@ -22,41 +22,76 @@ MonoBehaviour:
     - {fileID: 3469891026679729664, guid: b032e09c1bd8c5449b888c4353d665ba, type: 3}
     - {fileID: 7781396554342910705, guid: 5215b03386bb16b47863b89009d46ba9, type: 3}
     - {fileID: 4008869112228049984, guid: 14918809bba44684bb80ebb008610c5a, type: 3}
+    - {fileID: 6069169269836946088, guid: 16fa65d926209f949a7501fc381f882b, type: 3}
+    - {fileID: 100328150011014054, guid: b998cf4e42b95ec4fbbb893c889010e8, type: 3}
+    - {fileID: 1646905509486091719, guid: 6f2f89dc5b40b0340a7dcc57cc71dec7, type: 3}
+    - {fileID: 6398340229684661186, guid: 24461e841e57b3c499e6b3621dd50639, type: 3}
+    - {fileID: 5374960043103273218, guid: 5653131fc0c7f0b46af145251ab061d4, type: 3}
+    - {fileID: 3921521694364753778, guid: 3bce251232ebb5a49a7a932420df0027, type: 3}
     m_values:
     - AmountToSteal: 3
       BlacklistedOccupations:
       - {fileID: 11400000, guid: ffc6b873cd2cf4e4f81501fbc12385f0, type: 2}
       - {fileID: 11400000, guid: 208f5eb5b3dd142f0a83a9cc628dc485, type: 2}
+      - {fileID: 11400000, guid: 6d7b61c950bf54e649c18adb64c9e36c, type: 2}
+      - {fileID: 11400000, guid: 1162c4c5057294689ae4e937930969d0, type: 2}
       - {fileID: 11400000, guid: d66123701b005402eae243fdc5236dff, type: 2}
       - {fileID: 11400000, guid: c9dec3badc798443c8ce07e7cd400d48, type: 2}
-      - {fileID: 11400000, guid: 1162c4c5057294689ae4e937930969d0, type: 2}
-      - {fileID: 11400000, guid: 6d7b61c950bf54e649c18adb64c9e36c, type: 2}
     - AmountToSteal: 1
       BlacklistedOccupations:
       - {fileID: 11400000, guid: ffc6b873cd2cf4e4f81501fbc12385f0, type: 2}
-      - {fileID: 11400000, guid: 208f5eb5b3dd142f0a83a9cc628dc485, type: 2}
-      - {fileID: 11400000, guid: d66123701b005402eae243fdc5236dff, type: 2}
-      - {fileID: 11400000, guid: c9dec3badc798443c8ce07e7cd400d48, type: 2}
-      - {fileID: 11400000, guid: 1162c4c5057294689ae4e937930969d0, type: 2}
-      - {fileID: 11400000, guid: 6d7b61c950bf54e649c18adb64c9e36c, type: 2}
-      - {fileID: 11400000, guid: 91271c894925b4e89a46031cb7a50fe6, type: 2}
-      - {fileID: 11400000, guid: ea02bc3c4a28c430ea905db72a3630ec, type: 2}
-      - {fileID: 11400000, guid: 3df53a0fd5d684622b48ad9dce6fcf5b, type: 2}
     - AmountToSteal: 1
       BlacklistedOccupations:
-      - {fileID: 11400000, guid: ffc6b873cd2cf4e4f81501fbc12385f0, type: 2}
       - {fileID: 11400000, guid: 91271c894925b4e89a46031cb7a50fe6, type: 2}
-      - {fileID: 11400000, guid: ea02bc3c4a28c430ea905db72a3630ec, type: 2}
-      - {fileID: 11400000, guid: 3df53a0fd5d684622b48ad9dce6fcf5b, type: 2}
       - {fileID: 11400000, guid: 14ae2bbebc49841308668e7732024737, type: 2}
-      - {fileID: 11400000, guid: 2b58a814f2ab69e4b8a4781a15555222, type: 2}
+      - {fileID: 11400000, guid: 3df53a0fd5d684622b48ad9dce6fcf5b, type: 2}
+      - {fileID: 11400000, guid: ffc6b873cd2cf4e4f81501fbc12385f0, type: 2}
+      - {fileID: 11400000, guid: ea02bc3c4a28c430ea905db72a3630ec, type: 2}
+      - {fileID: 11400000, guid: 639b047743b074fb29d97a08deaf93f8, type: 2}
       - {fileID: 11400000, guid: 9548345f52bca334a8741ae407dc25e8, type: 2}
+      - {fileID: 11400000, guid: d780e69b0affab948aff96be1b193ec8, type: 2}
     - AmountToSteal: 1
       BlacklistedOccupations:
-      - {fileID: 11400000, guid: ffc6b873cd2cf4e4f81501fbc12385f0, type: 2}
       - {fileID: 11400000, guid: 91271c894925b4e89a46031cb7a50fe6, type: 2}
-      - {fileID: 11400000, guid: ea02bc3c4a28c430ea905db72a3630ec, type: 2}
-      - {fileID: 11400000, guid: 3df53a0fd5d684622b48ad9dce6fcf5b, type: 2}
       - {fileID: 11400000, guid: 14ae2bbebc49841308668e7732024737, type: 2}
-      - {fileID: 11400000, guid: 2b58a814f2ab69e4b8a4781a15555222, type: 2}
+      - {fileID: 11400000, guid: 3df53a0fd5d684622b48ad9dce6fcf5b, type: 2}
+      - {fileID: 11400000, guid: ffc6b873cd2cf4e4f81501fbc12385f0, type: 2}
+      - {fileID: 11400000, guid: ea02bc3c4a28c430ea905db72a3630ec, type: 2}
+      - {fileID: 11400000, guid: 639b047743b074fb29d97a08deaf93f8, type: 2}
       - {fileID: 11400000, guid: 9548345f52bca334a8741ae407dc25e8, type: 2}
+      - {fileID: 11400000, guid: d780e69b0affab948aff96be1b193ec8, type: 2}
+    - AmountToSteal: 1
+      BlacklistedOccupations:
+      - {fileID: 11400000, guid: 91271c894925b4e89a46031cb7a50fe6, type: 2}
+      - {fileID: 11400000, guid: 14ae2bbebc49841308668e7732024737, type: 2}
+      - {fileID: 11400000, guid: 3df53a0fd5d684622b48ad9dce6fcf5b, type: 2}
+      - {fileID: 11400000, guid: ffc6b873cd2cf4e4f81501fbc12385f0, type: 2}
+      - {fileID: 11400000, guid: ea02bc3c4a28c430ea905db72a3630ec, type: 2}
+      - {fileID: 11400000, guid: 639b047743b074fb29d97a08deaf93f8, type: 2}
+      - {fileID: 11400000, guid: 9548345f52bca334a8741ae407dc25e8, type: 2}
+      - {fileID: 11400000, guid: d780e69b0affab948aff96be1b193ec8, type: 2}
+    - AmountToSteal: 1
+      BlacklistedOccupations:
+      - {fileID: 11400000, guid: 91271c894925b4e89a46031cb7a50fe6, type: 2}
+      - {fileID: 11400000, guid: 14ae2bbebc49841308668e7732024737, type: 2}
+      - {fileID: 11400000, guid: 3df53a0fd5d684622b48ad9dce6fcf5b, type: 2}
+      - {fileID: 11400000, guid: ffc6b873cd2cf4e4f81501fbc12385f0, type: 2}
+      - {fileID: 11400000, guid: ea02bc3c4a28c430ea905db72a3630ec, type: 2}
+      - {fileID: 11400000, guid: 639b047743b074fb29d97a08deaf93f8, type: 2}
+      - {fileID: 11400000, guid: 9548345f52bca334a8741ae407dc25e8, type: 2}
+      - {fileID: 11400000, guid: d780e69b0affab948aff96be1b193ec8, type: 2}
+    - AmountToSteal: 1
+      BlacklistedOccupations:
+      - {fileID: 11400000, guid: 3df53a0fd5d684622b48ad9dce6fcf5b, type: 2}
+    - AmountToSteal: 1
+      BlacklistedOccupations:
+      - {fileID: 11400000, guid: 91271c894925b4e89a46031cb7a50fe6, type: 2}
+    - AmountToSteal: 1
+      BlacklistedOccupations:
+      - {fileID: 11400000, guid: 639b047743b074fb29d97a08deaf93f8, type: 2}
+    - AmountToSteal: 1
+      BlacklistedOccupations:
+      - {fileID: 11400000, guid: 3df53a0fd5d684622b48ad9dce6fcf5b, type: 2}
+      - {fileID: 11400000, guid: 3d8b17fd7b70945e19b1bb25504461c0, type: 2}
+      - {fileID: 11400000, guid: e54df7e9d577f4d6da43439e4a949ad4, type: 2}
+      - {fileID: 11400000, guid: 2fa29e9d68e1547c4b009c1515de2372, type: 2}


### PR DESCRIPTION

### Purpose

This re-adds the ablative trenchcoat, hypospray, secret docs, imperator, and justitia steal objectives that were removed in #8619 and trims the blacklists for the ones that remained.

### Notes:

- cut almost all jobs from the advanced magboots and captain's jetpack blacklists, as they are only possessed by a single person (CE and Captain, respectively) so they don't need to be very restrictive.

### Changelog:

CL: [Fix] Re-added the ablative trenchcoat, hypospray, secret docs, imperator, and justitia steal objectives
