### PR TITLE
ReagentContainer inspector options for right click menu.

### DIFF
--- a/UnityProject/Assets/Prefabs/Decal/Resources/ChemSplat.prefab
+++ b/UnityProject/Assets/Prefabs/Decal/Resources/ChemSplat.prefab
@@ -194,6 +194,7 @@ MonoBehaviour:
     reagentKeys: []
   destroyOnEmpty: 0
   ContentsSet: 0
+  menuOptions: 0
   UseStandardExamine: 1
   ExamineAmount: 2
   ExamineContent: 1

--- a/UnityProject/Assets/Prefabs/Decal/Resources/LargeBloodSplat.prefab
+++ b/UnityProject/Assets/Prefabs/Decal/Resources/LargeBloodSplat.prefab
@@ -200,6 +200,7 @@ MonoBehaviour:
     reagentKeys: []
   destroyOnEmpty: 0
   ContentsSet: 0
+  menuOptions: 0
   UseStandardExamine: 1
   ExamineAmount: 2
   ExamineContent: 0

--- a/UnityProject/Assets/Prefabs/Decal/Resources/MediumBloodSplat.prefab
+++ b/UnityProject/Assets/Prefabs/Decal/Resources/MediumBloodSplat.prefab
@@ -198,6 +198,7 @@ MonoBehaviour:
     reagentKeys: []
   destroyOnEmpty: 0
   ContentsSet: 0
+  menuOptions: 0
   UseStandardExamine: 1
   ExamineAmount: 2
   ExamineContent: 0

--- a/UnityProject/Assets/Prefabs/Decal/Resources/PowderSplat.prefab
+++ b/UnityProject/Assets/Prefabs/Decal/Resources/PowderSplat.prefab
@@ -194,6 +194,7 @@ MonoBehaviour:
     reagentKeys: []
   destroyOnEmpty: 0
   ContentsSet: 0
+  menuOptions: 0
   UseStandardExamine: 1
   ExamineAmount: 2
   ExamineContent: 1

--- a/UnityProject/Assets/Prefabs/Decal/Resources/SmallBloodSplat.prefab
+++ b/UnityProject/Assets/Prefabs/Decal/Resources/SmallBloodSplat.prefab
@@ -198,6 +198,7 @@ MonoBehaviour:
     reagentKeys: []
   destroyOnEmpty: 0
   ContentsSet: 0
+  menuOptions: 0
   UseStandardExamine: 1
   ExamineAmount: 2
   ExamineContent: 0

--- a/UnityProject/Assets/Prefabs/Decal/Resources/VomitSplat.prefab
+++ b/UnityProject/Assets/Prefabs/Decal/Resources/VomitSplat.prefab
@@ -197,6 +197,7 @@ MonoBehaviour:
     reagentKeys: []
   destroyOnEmpty: 0
   ContentsSet: 0
+  menuOptions: 0
   UseStandardExamine: 1
   ExamineAmount: 0
   ExamineContent: 0

--- a/UnityProject/Assets/Prefabs/Items/Botany/Produce/_GrownInedibleBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Botany/Produce/_GrownInedibleBase.prefab
@@ -188,6 +188,7 @@ MonoBehaviour:
     reagentKeys: []
   destroyOnEmpty: 0
   ContentsSet: 0
+  menuOptions: 0
   UseStandardExamine: 1
   ExamineAmount: 2
   ExamineContent: 0

--- a/UnityProject/Assets/Prefabs/Items/Food/Drinks/_DrinkBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Drinks/_DrinkBase.prefab
@@ -116,6 +116,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2002631705224524847, guid: 6eb9748e1eaf8dc4598a50e5b09df3b3,
         type: 3}
+      propertyPath: menuOptions
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2002631705224524847, guid: 6eb9748e1eaf8dc4598a50e5b09df3b3,
+        type: 3}
       propertyPath: ExamineContent
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Food/_FoodBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/_FoodBase.prefab
@@ -94,6 +94,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9018167180428263240, guid: f866b44bcdd7d734885f7c49999d85c9,
         type: 3}
+      propertyPath: menuOptions
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9018167180428263240, guid: f866b44bcdd7d734885f7c49999d85c9,
+        type: 3}
       propertyPath: ExamineContent
       value: 0
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Other/CigarettesAndLighters/Smokeables/CigaretteBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/CigarettesAndLighters/Smokeables/CigaretteBase.prefab
@@ -291,6 +291,7 @@ MonoBehaviour:
     reagentKeys: []
   destroyOnEmpty: 0
   ContentsSet: 0
+  menuOptions: 0
   UseStandardExamine: 0
   ExamineAmount: 0
   ExamineContent: 0

--- a/UnityProject/Assets/Prefabs/Items/Tools/ArtSupplies/Crayons/_CrayonBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/ArtSupplies/Crayons/_CrayonBase.prefab
@@ -199,6 +199,7 @@ MonoBehaviour:
     reagentKeys: []
   destroyOnEmpty: 0
   ContentsSet: 0
+  menuOptions: 0
   UseStandardExamine: 0
   ExamineAmount: 0
   ExamineContent: 0

--- a/UnityProject/Assets/Prefabs/Items/Tools/WeldingTools/WeldingTool.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/WeldingTools/WeldingTool.prefab
@@ -548,6 +548,7 @@ MonoBehaviour:
     reagentKeys: []
   destroyOnEmpty: 0
   ContentsSet: 0
+  menuOptions: 0
   UseStandardExamine: 1
   ExamineAmount: 1
   ExamineContent: 0

--- a/UnityProject/Assets/Prefabs/Objects/Kitchen/Griddle.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Kitchen/Griddle.prefab
@@ -296,6 +296,7 @@ MonoBehaviour:
     reagentKeys: []
   destroyOnEmpty: 0
   ContentsSet: 0
+  menuOptions: 1
   UseStandardExamine: 1
   ExamineAmount: 2
   ExamineContent: 0

--- a/UnityProject/Assets/Prefabs/Objects/Misc/JanitorialCart.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Misc/JanitorialCart.prefab
@@ -320,7 +320,6 @@ MonoBehaviour:
   maxCapacity: 100
   reactionSet: {fileID: 11400000, guid: 2d5f766d9268838aa8d819bee2a442a7, type: 2}
   AdditionalReactions: []
-  canPourOut: 0
   initialReagentMix:
     temperature: 273.15
     reagents:
@@ -329,6 +328,7 @@ MonoBehaviour:
     reagentKeys: []
   destroyOnEmpty: 0
   ContentsSet: 0
+  menuOptions: 0
   UseStandardExamine: 1
   ExamineAmount: 0
   ExamineContent: 1

--- a/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs
+++ b/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs
@@ -76,9 +76,6 @@ namespace Chemistry.Components
 			}
 		}
 
-		[Tooltip("Can you empty out its contents?")]
-		public bool canPourOut = true;
-
 		[Tooltip("Initial mix of reagent inside container")]
 		[FormerlySerializedAs("reagentMix")]
 		[SerializeField] private ReagentMix initialReagentMix = new ReagentMix();
@@ -496,7 +493,7 @@ namespace Chemistry.Components
 
 			var pourOutContext = ContextMenuApply.ByLocalPlayer(gameObject, "PourOut");
 			//Pour / add can only be done if in reach
-			if (WillInteract(pourOutContext, NetworkSide.Client) && canPourOut && menuOptions.HasFlag(ShowMenuOptions.PourOut))
+			if (WillInteract(pourOutContext, NetworkSide.Client) && menuOptions.HasFlag(ShowMenuOptions.PourOut))
 			{
 				result.AddElement("PourOut", OnPourOutClicked);
 			}

--- a/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs
+++ b/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs
@@ -18,6 +18,15 @@ namespace Chemistry.Components
 	public partial class ReagentContainer : MonoBehaviour, IServerSpawn, IRightClickable, ICheckedInteractable<ContextMenuApply>,
 		IEnumerable<KeyValuePair<Reagent, float>>
 	{
+		[Flags]
+		private enum ShowMenuOptions
+		{
+			None = 0,
+			ShowContents = 1 << 0,
+			PourOut = 1 << 1,
+			All = ~None
+		}
+
 		[Header("Container Parameters")]
 
 		[Tooltip("Max container capacity in units")]
@@ -82,6 +91,10 @@ namespace Chemistry.Components
 
 
 		public bool ContentsSet = false;
+
+		[Tooltip("What options should appear on the right click menu.")]
+		[SerializeField]
+		private ShowMenuOptions menuOptions = ShowMenuOptions.All;
 
 		/// <summary>
 		/// Invoked server side when regent container spills all of its contents
@@ -476,9 +489,14 @@ namespace Chemistry.Components
 		public RightClickableResult GenerateRightClickOptions()
 		{
 			var result = RightClickableResult.Create();
-			result.AddElement("Contents", OnExamineContentsClicked);
+			if (menuOptions.HasFlag(ShowMenuOptions.ShowContents))
+			{
+				result.AddElement("Contents", OnExamineContentsClicked);
+			}
+
+			var pourOutContext = ContextMenuApply.ByLocalPlayer(gameObject, "PourOut");
 			//Pour / add can only be done if in reach
-			if (WillInteract(ContextMenuApply.ByLocalPlayer(gameObject, "PourOut"), NetworkSide.Client) && canPourOut)
+			if (WillInteract(pourOutContext, NetworkSide.Client) && canPourOut && menuOptions.HasFlag(ShowMenuOptions.PourOut))
 			{
 				result.AddElement("PourOut", OnPourOutClicked);
 			}


### PR DESCRIPTION
Adds option to ReagentContainer inspector to choose what to show on the right click menu. Default is to show "Show Contents" and "Pour Out" options.

Food base and welding tool variants will show neither option on the menu.

I don't know if you are supposed to be able to "pour out" the fuel in a welder via right click options, so I just set it to none.