### PR TITLE
fix docker builds failing

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:20.04
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     jq \


### PR DESCRIPTION
since the version wasn't specified, it started downloading a way too new version that just made builds fail
