### PR TITLE
Fixes machine connectors getting duplicated

### DIFF
--- a/UnityProject/Assets/Scripts/Systems/Electricity/Wire/CableCategories/LowVoltageMachineConnector.cs
+++ b/UnityProject/Assets/Scripts/Systems/Electricity/Wire/CableCategories/LowVoltageMachineConnector.cs
@@ -6,7 +6,7 @@ using Systems.Electricity;
 
 namespace Objects.Engineering
 {
-	public class LowVoltageMachineConnector : NetworkBehaviour, ICheckedInteractable<PositionalHandApply>
+	public class LowVoltageMachineConnector : NetworkBehaviour, ICheckedInteractable<PositionalHandApply>, IServerSpawn
 	{
 		[Tooltip("The machine connector prefab to spawn on interaction.")]
 		[SerializeField]
@@ -32,9 +32,14 @@ namespace Objects.Engineering
 			RelatedWire.InData.WireEndB = Connection.SurroundingTiles;
 		}
 
+
+		public void OnSpawnServer(SpawnInfo info)
+		{
+			removedOnce = false; //(Max) : Bod said this was important for object pooling.
+		}
+
 		public bool WillInteract(PositionalHandApply interaction, NetworkSide side)
 		{
-			if(removedOnce) return false; //Counter measure for desynced clients that somehow can get to spawn multiple of these
 			if (DefaultWillInteract.Default(interaction, side) == false) return false;
 			if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Wirecutter) == false) return false;
 			if (interaction.TargetObject != gameObject) return false;

--- a/UnityProject/Assets/Scripts/Systems/Electricity/Wire/CableCategories/LowVoltageMachineConnector.cs
+++ b/UnityProject/Assets/Scripts/Systems/Electricity/Wire/CableCategories/LowVoltageMachineConnector.cs
@@ -46,12 +46,11 @@ namespace Objects.Engineering
 		{
 			void Remove()
 			{
-				if (removedOnce) return;
-				removedOnce = true;
-				Spawn.ServerPrefab(
+				if (removedOnce == false) Spawn.ServerPrefab(
 					machineConnectorPrefab, gameObject.AssumedWorldPosServer(),
 					// Random positioning to make it clear this is disassembled
 					scatterRadius: 0.35f, localRotation: RandomUtils.RandomRotation2D());
+				removedOnce = true; //Counter measure incase the gameobject doesn't despawn for whatever reason.
 				_ = Despawn.ServerSingle(gameObject);
 			}
 


### PR DESCRIPTION
Fixes #7554

## Changelog : 

CL: [Fix] - Fixed machine connectors getting duplicated.
CL: [Improvement] - Adds a 1 second progress bar to remove machine connectors.