### PR TITLE
balance: Milking numbers tweak to make it easier

### DIFF
--- a/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Friendly/Cows/Cow.prefab
+++ b/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Friendly/Cows/Cow.prefab
@@ -251,10 +251,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   milkReagent: {fileID: 11400000, guid: a1724b1210d8177c097a28325415c0b1, type: 2}
   milkAmount: 25
-  milkTick: 200
-  milkProducePerTick: 10
+  milkTick: 120
+  milkProducePerTick: 25
   maxMilk: 100
-  requiredMood: 60
+  requiredMood: 40
   moodPenalty: 10
   milkMessageYou: You milk {0}.
   milkMessageOthers: '{1} milks {0}'

--- a/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Friendly/Cows/CowWisdom.prefab
+++ b/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Friendly/Cows/CowWisdom.prefab
@@ -77,5 +77,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: CowWisdom
       objectReference: {fileID: 0}
+    - target: {fileID: 3597321348955184804, guid: 738fd5d21d2b347498cb8cafcdc1d43f,
+        type: 3}
+      propertyPath: milkReagent
+      value: 
+      objectReference: {fileID: 11400000, guid: a1724b1210d8177c097a28325415c0b1,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 738fd5d21d2b347498cb8cafcdc1d43f, type: 3}

--- a/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Friendly/Goats/GoatPete.prefab
+++ b/UnityProject/Assets/Prefabs/Mobs/Living/SimpleAnimals/Friendly/Goats/GoatPete.prefab
@@ -124,10 +124,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   milkReagent: {fileID: 11400000, guid: a1724b1210d8177c097a28325415c0b1, type: 2}
   milkAmount: 25
-  milkTick: 200
-  milkProducePerTick: 10
+  milkTick: 120
+  milkProducePerTick: 25
   maxMilk: 100
-  requiredMood: 60
+  requiredMood: 40
   moodPenalty: 10
   milkMessageYou: You milk {0}.
   milkMessageOthers: '{1} milks {0}'

--- a/UnityProject/Assets/Scripts/NPC/Mood/MilkableMob.cs
+++ b/UnityProject/Assets/Scripts/NPC/Mood/MilkableMob.cs
@@ -4,7 +4,6 @@ using Chemistry.Components;
 using NaughtyAttributes;
 using UnityEngine;
 using UnityEngine.Events;
-using UnityEngine.EventSystems;
 
 namespace NPC.Mood
 {
@@ -25,12 +24,12 @@ namespace NPC.Mood
 		[BoxGroup("Reagent")]
 		[SerializeField]
 		[Tooltip("The update frequency this mob will use for milk production.")]
-		private float milkTick = 200;
+		private float milkTick = 120;
 
 		[BoxGroup("Reagent")]
 		[SerializeField]
 		[Tooltip("The amount of milk the mob can produce each update period.")]
-		private float milkProducePerTick = 10;
+		private float milkProducePerTick = 25;
 
 		[BoxGroup("Reagent")]
 		[SerializeField]
@@ -40,7 +39,7 @@ namespace NPC.Mood
 		[BoxGroup("Mood")]
 		[SerializeField]
 		[Tooltip("Amount of mood required to produce milk")]
-		private int requiredMood = 60;
+		private int requiredMood = 40;
 
 		[BoxGroup("Mood")]
 		[SerializeField]

--- a/UnityProject/Assets/Textures/items/device/caravan_multitool.png.meta
+++ b/UnityProject/Assets/Textures/items/device/caravan_multitool.png.meta
@@ -36,6 +36,7 @@ TextureImporter:
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
+  ignoreMasterTextureLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -196,6 +197,11 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    nameFileIdTable:
+      caravan_multitool_3: -3645589962466789108
+      caravan_multitool_1: -4955024086358360757
+      caravan_multitool_2: 4402132735088504499
+      caravan_multitool_0: 8356564091196892284
   spritePackingTag: 
   pSDRemoveMatte: 0
   pSDShowRemoveMatteOption: 0

--- a/UnityProject/Assets/Textures/items/device/caravan_multitool_red.png.meta
+++ b/UnityProject/Assets/Textures/items/device/caravan_multitool_red.png.meta
@@ -36,6 +36,7 @@ TextureImporter:
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
+  ignoreMasterTextureLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -196,6 +197,11 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    nameFileIdTable:
+      caravan_multitool_red_3: -4201445167779231239
+      caravan_multitool_red_2: -2171563409955308419
+      caravan_multitool_red_0: 2650199487706923488
+      caravan_multitool_red_1: 7236781422286584174
   spritePackingTag: 
   pSDRemoveMatte: 0
   pSDShowRemoveMatteOption: 0

--- a/UnityProject/Assets/Textures/items/device/caravan_multitool_yellow.png.meta
+++ b/UnityProject/Assets/Textures/items/device/caravan_multitool_yellow.png.meta
@@ -30,6 +30,7 @@ TextureImporter:
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
+  ignoreMasterTextureLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -148,6 +149,9 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    nameFileIdTable:
+      caravan_multitool_yellow_1: 8859059741604430277
+      caravan_multitool_yellow_0: 941147588301312978
   spritePackingTag: 
   pSDRemoveMatte: 0
   pSDShowRemoveMatteOption: 0

--- a/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_lefthand/caravan crowbar lefthand.png.meta
+++ b/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_lefthand/caravan crowbar lefthand.png.meta
@@ -36,6 +36,7 @@ TextureImporter:
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
+  ignoreMasterTextureLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -196,6 +197,11 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    nameFileIdTable:
+      caravan crowbar lefthand_0: 6530505255261814144
+      caravan crowbar lefthand_3: 5482706423096379202
+      caravan crowbar lefthand_2: 7862241848475747220
+      caravan crowbar lefthand_1: -3563487569206572557
   spritePackingTag: 
   pSDRemoveMatte: 0
   pSDShowRemoveMatteOption: 0

--- a/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_lefthand/caravan cutters lefthand.png.meta
+++ b/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_lefthand/caravan cutters lefthand.png.meta
@@ -36,6 +36,7 @@ TextureImporter:
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
+  ignoreMasterTextureLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -196,6 +197,11 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    nameFileIdTable:
+      caravan cutters lefthand_1: 48245953341424263
+      caravan cutters lefthand_2: 7185179353520438155
+      caravan cutters lefthand_0: 9134600540919912726
+      caravan cutters lefthand_3: -2735891397435750850
   spritePackingTag: 
   pSDRemoveMatte: 0
   pSDShowRemoveMatteOption: 0

--- a/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_lefthand/caravan ind welder lefthand lit.png.meta
+++ b/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_lefthand/caravan ind welder lefthand lit.png.meta
@@ -36,6 +36,7 @@ TextureImporter:
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
+  ignoreMasterTextureLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -196,6 +197,11 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    nameFileIdTable:
+      caravan ind welder lefthand lit_0: -3903167393634619478
+      caravan ind welder lefthand lit_3: 4691869149222480953
+      caravan ind welder lefthand lit_2: -8891837226575101044
+      caravan ind welder lefthand lit_1: -4165695229851278212
   spritePackingTag: 
   pSDRemoveMatte: 0
   pSDShowRemoveMatteOption: 0

--- a/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_lefthand/caravan ind welder lefthand.png.meta
+++ b/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_lefthand/caravan ind welder lefthand.png.meta
@@ -36,6 +36,7 @@ TextureImporter:
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
+  ignoreMasterTextureLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -196,6 +197,11 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    nameFileIdTable:
+      caravan ind welder lefthand_2: 1786464981909030834
+      caravan ind welder lefthand_3: 4142464606634592501
+      caravan ind welder lefthand_0: -8667124324689954510
+      caravan ind welder lefthand_1: 4264897271462602971
   spritePackingTag: 
   pSDRemoveMatte: 0
   pSDShowRemoveMatteOption: 0

--- a/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_lefthand/caravan multitool lefthand.png.meta
+++ b/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_lefthand/caravan multitool lefthand.png.meta
@@ -36,6 +36,7 @@ TextureImporter:
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
+  ignoreMasterTextureLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -196,6 +197,11 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    nameFileIdTable:
+      caravan multitool lefthand_0: -555466669310351812
+      caravan multitool lefthand_3: 3860635633879372425
+      caravan multitool lefthand_2: 6176498318322387541
+      caravan multitool lefthand_1: -9216323928398721868
   spritePackingTag: 
   pSDRemoveMatte: 0
   pSDShowRemoveMatteOption: 0

--- a/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_lefthand/caravan screwdriver lefthand.png.meta
+++ b/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_lefthand/caravan screwdriver lefthand.png.meta
@@ -36,6 +36,7 @@ TextureImporter:
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
+  ignoreMasterTextureLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -196,6 +197,11 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    nameFileIdTable:
+      caravan screwdriver lefthand_3: -2555058567298970120
+      caravan screwdriver lefthand_1: 380561250423621741
+      caravan screwdriver lefthand_2: -2540319465734864225
+      caravan screwdriver lefthand_0: -4771421879966997724
   spritePackingTag: 
   pSDRemoveMatte: 0
   pSDShowRemoveMatteOption: 0

--- a/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_lefthand/caravan wrench lefthand.png.meta
+++ b/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_lefthand/caravan wrench lefthand.png.meta
@@ -36,6 +36,7 @@ TextureImporter:
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
+  ignoreMasterTextureLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -196,6 +197,11 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    nameFileIdTable:
+      caravan wrench lefthand_1: -8449824396792440149
+      caravan wrench lefthand_2: -2495682792716727183
+      caravan wrench lefthand_3: -5873953262807394004
+      caravan wrench lefthand_0: 935538883564227871
   spritePackingTag: 
   pSDRemoveMatte: 0
   pSDShowRemoveMatteOption: 0

--- a/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_righthand/caravan crowbar righthand.png.meta
+++ b/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_righthand/caravan crowbar righthand.png.meta
@@ -36,6 +36,7 @@ TextureImporter:
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
+  ignoreMasterTextureLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -196,6 +197,11 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    nameFileIdTable:
+      caravan crowbar righthand_0: 2669385004200254374
+      caravan crowbar righthand_1: -1564662514468137091
+      caravan crowbar righthand_2: 1755678535903930367
+      caravan crowbar righthand_3: -3118574479943586138
   spritePackingTag: 
   pSDRemoveMatte: 0
   pSDShowRemoveMatteOption: 0

--- a/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_righthand/caravan cutters righthand.png.meta
+++ b/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_righthand/caravan cutters righthand.png.meta
@@ -36,6 +36,7 @@ TextureImporter:
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
+  ignoreMasterTextureLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -196,6 +197,11 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    nameFileIdTable:
+      caravan cutters righthand_0: 7409943777057409539
+      caravan cutters righthand_3: 2263526505762709956
+      caravan cutters righthand_2: 1424481004549696448
+      caravan cutters righthand_1: 6804492651557470779
   spritePackingTag: 
   pSDRemoveMatte: 0
   pSDShowRemoveMatteOption: 0

--- a/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_righthand/caravan ind welder righthand lit.png.meta
+++ b/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_righthand/caravan ind welder righthand lit.png.meta
@@ -36,6 +36,7 @@ TextureImporter:
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
+  ignoreMasterTextureLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -196,6 +197,11 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    nameFileIdTable:
+      caravan ind welder righthand lit_1: -2651191942791208732
+      caravan ind welder righthand lit_3: -5935950624754678004
+      caravan ind welder righthand lit_0: -4621092746920084057
+      caravan ind welder righthand lit_2: -3569673383299027887
   spritePackingTag: 
   pSDRemoveMatte: 0
   pSDShowRemoveMatteOption: 0

--- a/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_righthand/caravan ind welder righthand.png.meta
+++ b/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_righthand/caravan ind welder righthand.png.meta
@@ -36,6 +36,7 @@ TextureImporter:
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
+  ignoreMasterTextureLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -196,6 +197,11 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    nameFileIdTable:
+      caravan ind welder righthand_3: -4642570898557571358
+      caravan ind welder righthand_2: 445283714164219799
+      caravan ind welder righthand_1: 3595050020831489161
+      caravan ind welder righthand_0: 4085008703507443911
   spritePackingTag: 
   pSDRemoveMatte: 0
   pSDShowRemoveMatteOption: 0

--- a/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_righthand/caravan multitool righthand.png.meta
+++ b/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_righthand/caravan multitool righthand.png.meta
@@ -36,6 +36,7 @@ TextureImporter:
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
+  ignoreMasterTextureLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -196,6 +197,11 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    nameFileIdTable:
+      caravan multitool righthand_1: -6750588038402127793
+      caravan multitool righthand_0: -1734044444567757545
+      caravan multitool righthand_3: 387675938774731191
+      caravan multitool righthand_2: -2663440506985493608
   spritePackingTag: 
   pSDRemoveMatte: 0
   pSDShowRemoveMatteOption: 0

--- a/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_righthand/caravan screwdriver righthand.png.meta
+++ b/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_righthand/caravan screwdriver righthand.png.meta
@@ -36,6 +36,7 @@ TextureImporter:
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
+  ignoreMasterTextureLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -196,6 +197,11 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    nameFileIdTable:
+      caravan screwdriver righthand_2: 7656900263192313616
+      caravan screwdriver righthand_1: -6673832017182060863
+      caravan screwdriver righthand_3: 7909273528379013738
+      caravan screwdriver righthand_0: 7507750429365148269
   spritePackingTag: 
   pSDRemoveMatte: 0
   pSDShowRemoveMatteOption: 0

--- a/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_righthand/caravan wrench righthand.png.meta
+++ b/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/tools_righthand/caravan wrench righthand.png.meta
@@ -36,6 +36,7 @@ TextureImporter:
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
+  ignoreMasterTextureLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -196,6 +197,11 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    nameFileIdTable:
+      caravan wrench righthand_2: -8979710964332875816
+      caravan wrench righthand_0: -3618533180148493268
+      caravan wrench righthand_1: 8144964584412588012
+      caravan wrench righthand_3: -3324438712618157674
   spritePackingTag: 
   pSDRemoveMatte: 0
   pSDShowRemoveMatteOption: 0


### PR DESCRIPTION
### Purpose
So I wanted to do this quick and easy thing to get my feet wet again with the repo. Someone asked today how to milk cows and I joined them to find out it is actually quite hard thing to do, so I tweaked the numbers to make it easier.

### Notes:
- Production time improved from 200 seconds to 120, so you now have to keep the cow happy for a little less time before you get milk.
- Amount of milk per production tick improved from 10 to 25, this makes it so you can milk the cow the very first tick of production which wasn't possible before.
- Required mood decreased from 60 to 40, so the cow can produce milk as long as it is in *normal* mood, which is around 40 points of mood.
- I also included some meta files that seemed to be lost.

### Changelog:
CL: [Balance] Tweaked numbers in milking system to make it easier to produce milk.
