### PR TITLE
NRE fixes for protips

### DIFF
--- a/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
+++ b/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
@@ -1437,7 +1437,7 @@ MonoBehaviour:
   - GameObjectToCheck: {fileID: 2515425442973781969, guid: 8df46e8f4633f9e43ab5993c9075028e,
       type: 3}
     AssoicatedSo: {fileID: 11400000, guid: eb646ca04872733468148685a9a74fc0, type: 2}
-  SearchRadius: 9
+  SearchRadius: 8
   SearchCooldown: 6
   MaskToCheck:
     serializedVersion: 2

--- a/UnityProject/Assets/Scripts/Learning/ProtipObject.cs
+++ b/UnityProject/Assets/Scripts/Learning/ProtipObject.cs
@@ -56,6 +56,11 @@ namespace Learning
 		public void TriggerTip(ProtipSO protipSo)
 		{
 			if(TriggerConditions() == false) return;
+			if(protipSo == null) 
+			{
+				Logger.LogError("Passed ProtipSO is null. Cannot trigger tip.");
+				return;
+			}
 			ProtipManager.Instance.ShowTip(protipSo.TipData.Tip, protipSo.TipData.ShowDuration, protipSo.TipData.TipIcon, protipSo.TipData.ShowAnimation);
 			if (triggerOnce)
 			{

--- a/UnityProject/Assets/Scripts/Learning/ProtipObjectTypes/ProtipObjectOnEnterRadius.cs
+++ b/UnityProject/Assets/Scripts/Learning/ProtipObjectTypes/ProtipObjectOnEnterRadius.cs
@@ -8,13 +8,13 @@ namespace Learning.ProtipObjectTypes
 	public class ProtipObjectOnEnterRadius : ProtipObject
 	{
 		public List<ObjectCheckData> ObjectsToCheck = new List<ObjectCheckData>();
-		public float SearchRadius = 25f;
+		public float SearchRadius = 12f;
 		public float SearchCooldown = 6f;
 		public LayerMask MaskToCheck;
 
 		private void Start()
 		{
-			if(CustomNetworkManager.IsServer && Application.isEditor == false) return;
+			if(CustomNetworkManager.IsHeadless) return;
 			if(ProtipManager.Instance.PlayerExperienceLevel == ProtipManager.ExperienceLevel.Robust) return;
 			UpdateManager.Add(CheckForNearbyItems, SearchCooldown);
 		}
@@ -24,10 +24,6 @@ namespace Learning.ProtipObjectTypes
 			var possibleTargets = Physics2D.OverlapCircleAll(gameObject.AssumedWorldPosServer(), SearchRadius, MaskToCheck);
 			foreach (var target in possibleTargets)
 			{
-				if (Application.isEditor)
-				{
-					Debug.DrawLine(gameObject.AssumedWorldPosServer(), target.gameObject.AssumedWorldPosServer(), Color.green, 8f);
-				}
 				if(gameObject == target.gameObject) continue;
 				if (MatrixManager.Linecast(gameObject.AssumedWorldPosServer(), LayerTypeSelection.Walls,
 					    MaskToCheck, target.gameObject.AssumedWorldPosServer()).ItHit) continue;


### PR DESCRIPTION
Protips should not work on headless at all and should be entirely client-sided. Part of #5316.

## Changelog 

CL: [Fix] - Fixes NREs on headless servers because they should only be client sided.
CL: [Fix] - Made search radius for protips even smaller.