### PR TITLE
changes and improvements for cargo offline interactions

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Consoles/SupplyConsole.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Consoles/SupplyConsole.prefab
@@ -285,9 +285,11 @@ MonoBehaviour:
   allowedTypes: 0000000006000000070000001600000001000000100000001d000000
   creditArrivalSound:
     SetLoadSetting: 0
-    AssetAddress: Assets/Prefabs/Machines/TerminalAlert.prefab
+    AssetAddress: Assets/Prefabs/UI/Select.prefab
     AssetReference:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
       m_EditorAssetChanged: 0
+  offlineMessage: The console flashes red as an error message appears and says that
+    access is denied.

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/AdminTools/AdminTools.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/AdminTools/AdminTools.prefab
@@ -23495,7 +23495,7 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  m_IsOn: 1
+  m_IsOn: 0
 --- !u!1 &4129518432101702432
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabCargo.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabCargo.prefab
@@ -1156,6 +1156,43 @@ RectTransform:
   m_AnchoredPosition: {x: 93.38, y: -40.829998}
   m_SizeDelta: {x: 186.76, y: 27.22}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &554546792109795053
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3519184594870294653}
+  m_Layer: 5
+  m_Name: OfflinePage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &3519184594870294653
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 554546792109795053}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1106630327657020749}
+  m_Father: {fileID: 8278237228466518704}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 5.3387, y: -39.1578}
+  m_SizeDelta: {x: 689.927, y: 635.6356}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &565771500631554775
 GameObject:
   m_ObjectHideFlags: 0
@@ -4610,6 +4647,87 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &5389434907912382404
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1106630327657020749}
+  - component: {fileID: 7746583782868215131}
+  - component: {fileID: 1977844361548214529}
+  m_Layer: 5
+  m_Name: Text (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1106630327657020749
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5389434907912382404}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3519184594870294653}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.00027466, y: 0.00059509}
+  m_SizeDelta: {x: 689.93, y: 635.64}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7746583782868215131
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5389434907912382404}
+  m_CullTransparentMesh: 0
+--- !u!114 &1977844361548214529
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5389434907912382404}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.6901961, b: 0, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: b8471550233548f5a8aecb61061a2263, type: 3}
+    m_FontSize: 32
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 65
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "Cannot establish communication with Central Command. \n\nSorry for the
+    inconvenience."
 --- !u!1 &5422094107623980648
 GameObject:
   m_ObjectHideFlags: 0
@@ -5755,6 +5873,7 @@ RectTransform:
   - {fileID: 1037072251229652399}
   - {fileID: 2846010541325572902}
   - {fileID: 4000760067452735997}
+  - {fileID: 3519184594870294653}
   m_Father: {fileID: 224663602153563088}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabCargo.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabCargo.prefab
@@ -319,6 +319,7 @@ MonoBehaviour:
   cargoConsole: {fileID: 0}
   pageCart: {fileID: 6294078452491510302}
   pageSupplies: {fileID: 2086902534434124868}
+  OfflinePage: {fileID: 0}
 --- !u!1 &1571967781877764
 GameObject:
   m_ObjectHideFlags: 0
@@ -1165,6 +1166,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3519184594870294653}
+  - component: {fileID: 3457916164249116016}
   m_Layer: 5
   m_Name: OfflinePage
   m_TagString: Untagged
@@ -1193,6 +1195,21 @@ RectTransform:
   m_AnchoredPosition: {x: 5.3387, y: -39.1578}
   m_SizeDelta: {x: 689.927, y: 635.6356}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &3457916164249116016
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 554546792109795053}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 471c40d3ce8365a4eba1df5a2f9f25b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  DirectoryName: /.../
+  cargoGUI: {fileID: 5799221400677952107}
+  errorText: {fileID: 1977844361548214529}
 --- !u!1 &565771500631554775
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabCargo.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabCargo.prefab
@@ -319,7 +319,7 @@ MonoBehaviour:
   cargoConsole: {fileID: 0}
   pageCart: {fileID: 6294078452491510302}
   pageSupplies: {fileID: 2086902534434124868}
-  OfflinePage: {fileID: 0}
+  OfflinePage: {fileID: 3457916164249116016}
 --- !u!1 &1571967781877764
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
@@ -564,6 +564,7 @@ namespace AdminCommands
 		{
 			if (IsAdmin(sender, out var admin) == false) return;
 			CargoManager.Instance.CargoOffline = online;
+			CargoManager.Instance.OnConnectionChangeToCentComm?.Invoke();
 		}
 
 		#endregion

--- a/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
@@ -565,6 +565,7 @@ namespace AdminCommands
 			if (IsAdmin(sender, out var admin) == false) return;
 			CargoManager.Instance.CargoOffline = online;
 			CargoManager.Instance.OnConnectionChangeToCentComm?.Invoke();
+			LogAdminAction($"{admin.Username} has changed the cargo online status to -> {online}");
 		}
 
 		#endregion

--- a/UnityProject/Assets/Scripts/Managers/CargoManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/CargoManager.cs
@@ -35,6 +35,7 @@ namespace Systems.Cargo
 		public CargoUpdateEvent OnCreditsUpdate = new CargoUpdateEvent();
 		public CargoUpdateEvent OnTimerUpdate = new CargoUpdateEvent();
 		public CargoUpdateEvent OnBountiesUpdate = new CargoUpdateEvent();
+		public CargoUpdateEvent OnConnectionChangeToCentComm = new CargoUpdateEvent();
 
 		[SerializeField]
 		private CargoData cargoData;
@@ -47,7 +48,7 @@ namespace Systems.Cargo
 		public Dictionary<ItemTrait, int> SoldHistory = new Dictionary<ItemTrait, int>();
 
 		public bool CargoOffline = false;
-    
+
     private int lastTimeRecorded = 0;
 		private int randomBountyTimeCheck = 0;
 
@@ -531,7 +532,7 @@ namespace Systems.Cargo
 			if(announce) AnnounceNewBounty();
 		}
 
-		private void AnnounceNewBounty() 
+		private void AnnounceNewBounty()
 		{
 			CentComm.MakeAnnouncement(ChatTemplates.CentcomAnnounce, "A bounty for cargo has been issued from central communications", CentComm.UpdateSound.Notice);
 		}

--- a/UnityProject/Assets/Scripts/Objects/Consoles/CargoConsole.cs
+++ b/UnityProject/Assets/Scripts/Objects/Consoles/CargoConsole.cs
@@ -89,6 +89,7 @@ namespace Objects.Cargo
 
 		public void PlayBudgetUpdateSound()
 		{
+			if(soundIsOnCooldown) return;
 			_ = SoundManager.PlayNetworkedAtPosAsync(creditArrivalSound, gameObject.WorldPosServer());
 			StartCoroutine(SoundCooldown());
 		}

--- a/UnityProject/Assets/Scripts/Objects/Consoles/CargoConsole.cs
+++ b/UnityProject/Assets/Scripts/Objects/Consoles/CargoConsole.cs
@@ -22,6 +22,7 @@ namespace Objects.Cargo
 		private List<JobType> allowedTypes = null;
 
 		[SerializeField] private AddressableAudioSource creditArrivalSound;
+		private bool soundIsOnCooldown = false;
 
 		[SerializeField] private string offlineMessage = "The console flashes red as an error message appears and says that access is denied.";
 
@@ -89,6 +90,7 @@ namespace Objects.Cargo
 		public void PlayBudgetUpdateSound()
 		{
 			_ = SoundManager.PlayNetworkedAtPosAsync(creditArrivalSound, gameObject.WorldPosServer());
+			StartCoroutine(SoundCooldown());
 		}
 
 		public bool CargoOfflineCheck()
@@ -100,6 +102,13 @@ namespace Objects.Cargo
 			}
 
 			return false;
+		}
+
+		private IEnumerator SoundCooldown()
+		{
+			soundIsOnCooldown = true;
+			yield return WaitFor.Seconds(2f);
+			soundIsOnCooldown = false;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Objects/Consoles/CargoConsole.cs
+++ b/UnityProject/Assets/Scripts/Objects/Consoles/CargoConsole.cs
@@ -47,6 +47,7 @@ namespace Objects.Cargo
 
 		public void ServerPerformInteraction(HandApply interaction)
 		{
+			if(CargoOfflineCheck()) return;
 			if (interaction.HandSlot.Item.TryGetComponent<IDCard>(out var id))
 			{
 
@@ -66,10 +67,8 @@ namespace Objects.Cargo
 		[Server]
 		private void CheckID(JobType usedID, GameObject playeref)
 		{
-			if (cargoGUI == null)
-				return;
+			if (cargoGUI == null) return;
 
-			if(CargoOfflineCheck()) return;
 			foreach (var aJob in allowedTypes.Where(aJob => usedID == aJob))
 			{
 				CorrectID = true;

--- a/UnityProject/Assets/Scripts/UI/Objects/Cargo/GUI_Cargo.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Cargo/GUI_Cargo.cs
@@ -16,10 +16,12 @@ namespace UI.Objects.Cargo
 
 		public GUI_CargoPageCart pageCart;
 		public GUI_CargoPageSupplies pageSupplies;
+		public GUI_CargoOfflinePage OfflinePage;
 
 		protected override void InitServer()
 		{
 			CargoManager.Instance.OnCreditsUpdate.AddListener(UpdateCreditsText);
+			CargoManager.Instance.OnConnectionChangeToCentComm.AddListener(SwitchToOfflinePage);
 			foreach (var page in NestedSwitcher.Pages)
 			{
 				page.GetComponent<GUI_CargoPage>().cargoGUI = this;
@@ -40,7 +42,7 @@ namespace UI.Objects.Cargo
 
 		public void OpenTab(NetPage pageToOpen)
 		{
-			NestedSwitcher.SetActivePage(pageToOpen);
+			NestedSwitcher.SetActivePage(CargoManager.Instance.CargoOffline ? OfflinePage : pageToOpen);
 			var cargopage = pageToOpen.GetComponent<GUI_CargoPage>();
 			cargopage.OpenTab();
 			cargopage.UpdateTab();
@@ -67,6 +69,13 @@ namespace UI.Objects.Cargo
 		public void ResetId()
 		{
 			cargoConsole.ResetID();
+		}
+
+		private void SwitchToOfflinePage()
+		{
+			if(CargoManager.Instance.CargoOffline == false) return;
+			OpenTab(OfflinePage);
+			ResetId();
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Objects/Cargo/GUI_Cargo.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Cargo/GUI_Cargo.cs
@@ -43,6 +43,9 @@ namespace UI.Objects.Cargo
 		public void OpenTab(NetPage pageToOpen)
 		{
 			NestedSwitcher.SetActivePage(CargoManager.Instance.CargoOffline ? OfflinePage : pageToOpen);
+			//(Max) : NetUI shinangins where pages would randomly be null and kick players on headless servers.
+			//This is a workaround to stop people from getting kicked. In-game reason would be this : Solar winds obstruct communications between CC and the station.
+			if (pageToOpen == null) pageToOpen = OfflinePage;
 			var cargopage = pageToOpen.GetComponent<GUI_CargoPage>();
 			cargopage.OpenTab();
 			cargopage.UpdateTab();
@@ -73,6 +76,7 @@ namespace UI.Objects.Cargo
 
 		private void SwitchToOfflinePage()
 		{
+			//If the event has been invoked and cargo is online, ignore.
 			if(CargoManager.Instance.CargoOffline == false) return;
 			OpenTab(OfflinePage);
 			ResetId();

--- a/UnityProject/Assets/Scripts/UI/Objects/Cargo/GUI_CargoOfflinePage.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Cargo/GUI_CargoOfflinePage.cs
@@ -22,11 +22,11 @@ namespace UI.Objects.Cargo
         {
             while(gameObject.activeSelf)
             {
-	            LeanTween.alpha(errorText.gameObject, 0, blinkTime);
+	            errorText.SetActive(false);
 	            yield return WaitFor.Seconds(blinkTime);
-	            LeanTween.alpha(errorText.gameObject, 1, blinkTime);
-	            yield return WaitFor.Seconds(blinkTime);
+	            errorText.SetActive(true);
             }
+            errorText.SetActive(true);
         }
     }
 }

--- a/UnityProject/Assets/Scripts/UI/Objects/Cargo/GUI_CargoOfflinePage.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Cargo/GUI_CargoOfflinePage.cs
@@ -1,10 +1,3 @@
-using System.Collections;
-using UnityEngine;
-using UnityEngine.UI;
-using UI.Core.NetUI;
-using UI.Objects.Cargo;
-
-
 namespace UI.Objects.Cargo
 {
     public class GUI_CargoOfflinePage : GUI_CargoPage { }

--- a/UnityProject/Assets/Scripts/UI/Objects/Cargo/GUI_CargoOfflinePage.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Cargo/GUI_CargoOfflinePage.cs
@@ -10,6 +10,7 @@ namespace UI.Objects.Cargo
     public class GUI_CargoOfflinePage : GUI_CargoPage
     {
         public Text errorText;
+        public float blinkTime = 0.3f;
 
         public override void OpenTab()
         {
@@ -21,10 +22,10 @@ namespace UI.Objects.Cargo
         {
             while(gameObject.activeSelf)
             {
-	            errorText.color = new Color(errorText.color.r, errorText.color.g, 0);
-	            yield return WaitFor.Seconds(0.2f);
-	            errorText.color = new Color(errorText.color.r, errorText.color.g, 1);
-	            yield return WaitFor.Seconds(0.3f);
+	            LeanTween.alpha(errorText.gameObject, 0, blinkTime);
+	            yield return WaitFor.Seconds(blinkTime);
+	            LeanTween.alpha(errorText.gameObject, 1, blinkTime);
+	            yield return WaitFor.Seconds(blinkTime);
             }
         }
     }

--- a/UnityProject/Assets/Scripts/UI/Objects/Cargo/GUI_CargoOfflinePage.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Cargo/GUI_CargoOfflinePage.cs
@@ -1,0 +1,31 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.UI;
+using UI.Core.NetUI;
+using UI.Objects.Cargo;
+
+
+namespace UI.Objects.Cargo
+{
+    public class GUI_CargoOfflinePage : GUI_CargoPage
+    {
+        public Text errorText;
+
+        public override void OpenTab()
+        {
+            base.OpenTab();
+            StartCoroutine(AnimateText());
+        }
+
+        private IEnumerator AnimateText()
+        {
+            while(gameObject.activeSelf)
+            {
+	            errorText.color = new Color(errorText.color.r, errorText.color.g, 0);
+	            yield return WaitFor.Seconds(0.2f);
+	            errorText.color = new Color(errorText.color.r, errorText.color.g, 1);
+	            yield return WaitFor.Seconds(0.3f);
+            }
+        }
+    }
+}

--- a/UnityProject/Assets/Scripts/UI/Objects/Cargo/GUI_CargoOfflinePage.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Cargo/GUI_CargoOfflinePage.cs
@@ -7,26 +7,5 @@ using UI.Objects.Cargo;
 
 namespace UI.Objects.Cargo
 {
-    public class GUI_CargoOfflinePage : GUI_CargoPage
-    {
-        public Text errorText;
-        public float blinkTime = 0.3f;
-
-        public override void OpenTab()
-        {
-            base.OpenTab();
-            StartCoroutine(AnimateText());
-        }
-
-        private IEnumerator AnimateText()
-        {
-            while(gameObject.activeSelf)
-            {
-	            errorText.SetActive(false);
-	            yield return WaitFor.Seconds(blinkTime);
-	            errorText.SetActive(true);
-            }
-            errorText.SetActive(true);
-        }
-    }
+    public class GUI_CargoOfflinePage : GUI_CargoPage { }
 }

--- a/UnityProject/Assets/Scripts/UI/Objects/Cargo/GUI_CargoOfflinePage.cs.meta
+++ b/UnityProject/Assets/Scripts/UI/Objects/Cargo/GUI_CargoOfflinePage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 471c40d3ce8365a4eba1df5a2f9f25b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
CL : [New] - Admin logs now tracks when an admin changes the state of cargo being offline or not.
CL : [New] - Added an offline message to the cargo ui.
CL : [Balance] - Emags no longer bypass cargo being offline
CL : [Improvement] - Changed budget update sound to something else.
CL: : [Fix] - Stopped budget sound spam
CL: : [Fix] - Fixed rare occasion where NetUI would freak out for unknown reasons and brick the cargo console and kick out players over an NRE on headless servers.