### PR TITLE
[Expermintal Draft] Loading custom lobby music

### DIFF
--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/MusicManager.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/MusicManager.prefab
@@ -11,6 +11,8 @@ GameObject:
   - component: {fileID: 9102338525819353079}
   - component: {fileID: 2511758383109350009}
   - component: {fileID: -431472425038679297}
+  - component: {fileID: 7942324314767868266}
+  - component: {fileID: 1477545378951660728}
   m_Layer: 0
   m_Name: MusicManager
   m_TagString: Untagged
@@ -147,3 +149,38 @@ MonoBehaviour:
   MusicVolume: 0.5
   musicAudioSource: {fileID: 0}
   audioClips: {fileID: 11400000, guid: 754bcabad708be8409022843f6c689f4, type: 2}
+--- !u!114 &7942324314767868266
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9104243219371999339}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sceneId: 0
+  serverOnly: 0
+  visible: 0
+  m_AssetId: 121687c1567e69043b22c5b48d721f82
+  hasSpawned: 0
+--- !u!114 &1477545378951660728
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9104243219371999339}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f566ddf1fd904df894dba46afb3af8d4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  AllowCustomMusicFromServer: 1
+  ServerDataPath: /Server/Music
+  ServerCachedMusicPaths: []
+  CustomPlayerMusicPaths: []

--- a/UnityProject/Assets/Scripts/Managers/GameConfigManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameConfigManager.cs
@@ -65,5 +65,6 @@ namespace GameConfig
 		public int LowPopLimit;
 		public int LowPopCheckTimeAfterRoundStart;
 		public int RebootOnAverageFPSOrLower;
+		public List<string> ServerCustomMusic;
 	}
 }

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -158,9 +158,11 @@ public partial class GameManager : MonoBehaviour, IInitialise
 
 	public int RebootOnAverageFPSOrLower = 35;
 
+	public List<string> ServerCustomMusic = new List<string>();
+
 	[NonSerialized]
 	public bool DisconnectExpected = false;
-	
+
 	void IInitialise.Initialise()
 	{
 		// Set up server defaults, needs to be loaded here to ensure gameConfigManager is load.
@@ -214,6 +216,7 @@ public partial class GameManager : MonoBehaviour, IInitialise
 		LowPopLimit = GameConfigManager.GameConfig.LowPopLimit;
 		LowPopCheckTimeAfterRoundStart = GameConfigManager.GameConfig.LowPopCheckTimeAfterRoundStart;
 		RebootOnAverageFPSOrLower = GameConfigManager.GameConfig.RebootOnAverageFPSOrLower;
+		ServerCustomMusic = GameConfigManager.GameConfig.ServerCustomMusic;
 
 		Physics.autoSimulation = false;
 		Physics2D.simulationMode = SimulationMode2D.Update;

--- a/UnityProject/Assets/Scripts/Managers/LobbyManager/CustomMusic.meta
+++ b/UnityProject/Assets/Scripts/Managers/LobbyManager/CustomMusic.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 01a68e960097467683dd3dc21698fdb9
+timeCreated: 1652423399

--- a/UnityProject/Assets/Scripts/Managers/LobbyManager/CustomMusic/CustomMusicManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/LobbyManager/CustomMusic/CustomMusicManager.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mirror;
+using UnityEngine;
+
+namespace Managers.LobbyManager.CustomMusic
+{
+	public class CustomMusicManager : NetworkBehaviour
+	{
+		public bool AllowCustomMusicFromServer = true;
+		public string ServerDataPath = "\\Server\\Music";
+		[HideInInspector] public List<string> ServerCachedMusicPaths = new List<string>();
+		[HideInInspector] public List<string> CustomPlayerMusicPaths = new List<string>();
+		private SyncList<string> AudioLinks = new SyncList<string>();
+		private string finalPath;
+
+		private AudioClip audioClip;
+
+		private void OnEnable()
+		{
+			finalPath = Path.Combine(Application.persistentDataPath, ServerDataPath);
+			if (CustomNetworkManager.IsServer)
+			{
+				ServerSetup();
+				return;
+			}
+			ServerCachedMusicPaths = GetAllMusicPaths();
+		}
+
+		private void ServerSetup()
+		{
+			AudioLinks.AddRange(GameManager.Instance.ServerCustomMusic);
+		}
+
+		private IEnumerator DownloadMusic()
+		{
+			foreach (var audioLink in AudioLinks)
+			{
+				if (IsMusicPathValid(audioLink))
+				{
+					continue;
+				}
+
+				var www = new WWW(audioLink);
+				yield return www;
+
+				if (www.error != null)
+				{
+					Logger.LogError("Error downloading music: " + www.error);
+					continue;
+				}
+
+
+				var fileName = Path.GetFileName(audioLink);
+				var filePath = Path.Combine(finalPath, fileName);
+				File.WriteAllBytes(filePath, www.bytes);
+				CustomPlayerMusicPaths.Add(filePath);
+			}
+		}
+
+		private bool IsMusicPathValid(string path)
+		{
+			if (File.Exists(finalPath + "\\" + path))
+			{
+				Logger.LogWarning($"Music path already exists.. Skipping : {path}");
+				return false;
+			}
+			if(path.Length > 254) //Windows character limit for filenames
+			{
+				Logger.LogWarning($"Music path is too long.. Skipping : {path}");
+				return false;
+			}
+			if (path.Contains(".wav") == false || path.Contains(".mp3") == false)
+			{
+				Logger.LogError($"Music files can only be .wav or .mp3.. Skipping : {path}");
+				return false;
+			}
+
+			return true;
+		}
+
+		private List<string> GetAllMusicPaths()
+		{
+			if (Directory.Exists(finalPath)) return Directory.GetFiles(finalPath).ToList();
+			Directory.CreateDirectory(finalPath);
+			return null;
+		}
+
+		public WWW GetAudioFromFile(string path, string filename)
+		{
+			string audioToLoad = string.Format(path + "{0}", filename);
+			WWW request = new WWW(audioToLoad);
+			return request;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Managers/LobbyManager/CustomMusic/CustomMusicManager.cs.meta
+++ b/UnityProject/Assets/Scripts/Managers/LobbyManager/CustomMusic/CustomMusicManager.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f566ddf1fd904df894dba46afb3af8d4
+timeCreated: 1652423430


### PR DESCRIPTION
This is a very very early WIP draft of loading custom lobby music.

The idea is to allow players and server hosts to add their own music to play when the game starts via the gameConfig using links that download the raw music files then cache it inside a folder where the game can load up these music files and play them.

Yes, you heard me right. You can add your own songs to a list by just referencing their filepath on your PC or via a downloadable link online and you can have custom music running on your game without having to download unity just to generate a custom bundle for yourself or your server.

### Why you should probably not be hyped about this draft just yet 

So far this is an experimental draft that is up here for future reference for anyone working on audio related stuff if this idea ever just gets killed due to the following reasons : 
 
- Our audio system currently uses addressables and `IResourceLoader` probably only supports unity prefabs only and does not allow us to load the files that we download ( [Addressable Docs](https://docs.unity3d.com/Packages/com.unity.addressables@1.20/manual/AddressableAssetsOverview.html) )
- Security concerns because of the lack of sandboxing and this feature might be abuse-able in the future when we allow community servers onto the official station hub OR a malicious third party having access to the staging server's config files and replacing the music links with "johncenatheme.mp3.exe"
- Linux/Mac OS memes that will make maintain this feature a pain because Windows decided to be quriky and use \ instead of / and WWW being deprecated by Unity at some point. 
