### PR TITLE
Adds the ability to toggle what a board can spawn using a screw driver.

### DIFF
--- a/UnityProject/Assets/Scripts/Systems/Construction/ComputerCircuitboard.cs
+++ b/UnityProject/Assets/Scripts/Systems/Construction/ComputerCircuitboard.cs
@@ -25,7 +25,7 @@ namespace Items.Construction
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
-			if (customTypes.Count == 0) return false;
+			if (customTypes.Count == 0 || screwdriver == null) return false;
 			if (DefaultWillInteract.Default(interaction, side) == false) return false;
 			return interaction.HandObject.Item().HasTrait(screwdriver);
 		}

--- a/UnityProject/Assets/Scripts/Systems/Construction/ComputerCircuitboard.cs
+++ b/UnityProject/Assets/Scripts/Systems/Construction/ComputerCircuitboard.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Items.Construction
@@ -6,15 +7,35 @@ namespace Items.Construction
 	/// Allows an object to function as a circuitboard for a computer, being placed into a computer frame and
 	/// causing a particular computer to be spawned on completion.
 	/// </summary>
-	public class ComputerCircuitboard : MonoBehaviour
+	public class ComputerCircuitboard : MonoBehaviour, ICheckedInteractable<HandApply>
 	{
 		[Tooltip("Computer which should be spawned when this circuitboard's frame is constructed.")]
 		[SerializeField]
 		private GameObject computerToSpawn = null;
 
+		[SerializeField] private ItemTrait screwdriver;
+		[SerializeField] private List<GameObject> customTypes = new List<GameObject>();
+
+		private int currentIndex = 0;
+
 		/// <summary>
 		/// Computer which should be spawned when this circuitboard's frame is constructed
 		/// </summary>
 		public GameObject ComputerToSpawn => computerToSpawn;
+
+		public bool WillInteract(HandApply interaction, NetworkSide side)
+		{
+			if (customTypes.Count == 0) return false;
+			if (DefaultWillInteract.Default(interaction, side) == false) return false;
+			return interaction.HandObject.Item().HasTrait(screwdriver);
+		}
+
+		public void ServerPerformInteraction(HandApply interaction)
+		{
+			currentIndex++;
+			if (currentIndex >= customTypes.Count) currentIndex = 0;
+			computerToSpawn = customTypes[currentIndex];
+			Chat.AddExamineMsg(interaction.Performer, $"The board will spawn a {customTypes[currentIndex].name}");
+		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Construction/ComputerCircuitboard.cs
+++ b/UnityProject/Assets/Scripts/Systems/Construction/ComputerCircuitboard.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -22,6 +23,12 @@ namespace Items.Construction
 		/// Computer which should be spawned when this circuitboard's frame is constructed
 		/// </summary>
 		public GameObject ComputerToSpawn => computerToSpawn;
+
+		private void Awake()
+		{
+			if(customTypes.Count == 0 || computerToSpawn != null) return;
+			computerToSpawn = customTypes[currentIndex];
+		}
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{

--- a/UnityProject/Assets/Scripts/Systems/Construction/ComputerCircuitboard.cs
+++ b/UnityProject/Assets/Scripts/Systems/Construction/ComputerCircuitboard.cs
@@ -35,7 +35,7 @@ namespace Items.Construction
 			currentIndex++;
 			if (currentIndex >= customTypes.Count) currentIndex = 0;
 			computerToSpawn = customTypes[currentIndex];
-			Chat.AddExamineMsg(interaction.Performer, $"The board will spawn a {customTypes[currentIndex].name}");
+			Chat.AddExamineMsg(interaction.Performer, $"You tune the board to create a {customTypes[currentIndex].name}");
 		}
 	}
 }


### PR DESCRIPTION
Work on #4763

No prefabs currently use this functionality because there's a lot to go through so I'm just going to leave this up to someone else who knows how these should be assigned/edited and what should be deleted and merged into one board.