### PR TITLE
Fixes issue where detention times were out of sync for bombs

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Weapons/ExplosiveBase.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/ExplosiveBase.cs
@@ -26,7 +26,7 @@ namespace Items.Weapons
 		[Header("Explosive settings")]
 		[SerializeField] protected ExplosiveType explosiveType;
 		[SerializeField] protected bool detonateImmediatelyOnSignal;
-		[SerializeField] protected int timeToDetonate = 10;
+		[SerializeField, SyncVar] protected int timeToDetonate = 10;
 		[SerializeField] protected int minimumTimeToDetonate = 10;
 		[SerializeField] protected float explosiveStrength = 150f;
 		[SerializeField] protected SpriteDataSO activeSpriteSO;


### PR DESCRIPTION
When you change the timer on a bomb you only changed the value client side so when you arm the bomb it would actually use the value on the server's not the one you adjusted. Part of #6149

## Changelog:

CL: [Fix] - Fixed bomb timers being out of sync when adjusting them.
