### PR TITLE
Wall descriptions and armor value fixes

### DIFF
--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/CatWalk.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/CatWalk.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: CatWalk
   m_EditorClassIdentifier: 
   displayName: catwalk
-  description: 
+  description: Flooring that shows its contents underneath. Engineers love it!
   LayerType: 4
   TileType: 7
   RequiredTiles: []
@@ -25,6 +25,7 @@ MonoBehaviour:
   passable: 1
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 1
   RadiationPassability: 1
   ThermalConductivity: 0.05
@@ -36,7 +37,7 @@ MonoBehaviour:
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 50
+  maxHealth: 75
   damageDeflection: 0
   armor:
     Melee: 50

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/Grass/FairyGrassBaseSmooth.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/Grass/FairyGrassBaseSmooth.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: FairyGrassBaseSmooth
   m_EditorClassIdentifier: 
-  displayName: fairygrass
-  description: 
+  displayName: fairy grass
+  description: A patch of grass.
   LayerType: 4
   TileType: 7
   RequiredTiles: []
@@ -25,6 +25,7 @@ MonoBehaviour:
   passable: 1
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 1
   RadiationPassability: 1
   ThermalConductivity: 0.05

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/Grass/GrassBase.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/Grass/GrassBase.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: GrassBase
   m_EditorClassIdentifier: 
   displayName: grass
-  description: 
+  description: A patch of grass.
   LayerType: 4
   TileType: 7
   RequiredTiles: []
@@ -25,6 +25,7 @@ MonoBehaviour:
   passable: 1
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 1
   RadiationPassability: 1
   ThermalConductivity: 0.05

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/Grass/GrassBaseSmooth.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/Grass/GrassBaseSmooth.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: GrassBaseSmooth
   m_EditorClassIdentifier: 
   displayName: grass
-  description: 
+  description: A patch of grass.
   LayerType: 4
   TileType: 7
   RequiredTiles: []
@@ -25,6 +25,7 @@ MonoBehaviour:
   passable: 1
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 1
   RadiationPassability: 1
   ThermalConductivity: 0.05

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/Grass/JungleGrassBaseSmooth.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/Grass/JungleGrassBaseSmooth.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: JungleGrassBaseSmooth
   m_EditorClassIdentifier: 
   displayName: jungle grass
-  description: 
+  description: A patch of grass.
   LayerType: 4
   TileType: 7
   RequiredTiles: []
@@ -25,6 +25,7 @@ MonoBehaviour:
   passable: 1
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 1
   RadiationPassability: 1
   ThermalConductivity: 0.05

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/NaturalBaseFloor/DirtBase.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/NaturalBaseFloor/DirtBase.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: DirtBase
   m_EditorClassIdentifier: 
   displayName: dirt
-  description: 
+  description: Upon closer examination, it's still dirt.
   LayerType: 4
   TileType: 7
   RequiredTiles: []
@@ -25,6 +25,7 @@ MonoBehaviour:
   passable: 1
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 1
   RadiationPassability: 1
   ThermalConductivity: 0.05

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/NaturalBaseFloor/DirtDarkBase.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/NaturalBaseFloor/DirtDarkBase.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: DirtDarkBase
   m_EditorClassIdentifier: 
   displayName: dirt
-  description: 
+  description: Upon closer examination, it's still dirt.
   LayerType: 4
   TileType: 7
   RequiredTiles: []
@@ -25,6 +25,7 @@ MonoBehaviour:
   passable: 1
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 1
   RadiationPassability: 1
   ThermalConductivity: 0.05

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/Plating.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/Plating.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: Plating
   m_EditorClassIdentifier: 
-  displayName: plating
+  displayName: base plating
   description: 
   LayerType: 4
   TileType: 7
@@ -25,6 +25,7 @@ MonoBehaviour:
   passable: 1
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 1
   RadiationPassability: 1
   ThermalConductivity: 0.05

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/AdminWall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/AdminWall.asset
@@ -26,8 +26,9 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
-  RadiationPassability: 0.75
+  RadiationPassability: 0
   ThermalConductivity: 0
   HeatCapacity: 312500
   doesReflectBullet: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallAnchorBolts.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallAnchorBolts.asset
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.6
   ThermalConductivity: 0
@@ -44,7 +45,7 @@ MonoBehaviour:
     Bullet: 90
     Laser: 90
     Energy: 90
-    Bomb: 90
+    Bomb: 65
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallCover.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallCover.asset
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.6
   ThermalConductivity: 0
@@ -44,7 +45,7 @@ MonoBehaviour:
     Bullet: 90
     Laser: 90
     Energy: 90
-    Bomb: 90
+    Bomb: 65
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallCutCover.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallCutCover.asset
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.6
   ThermalConductivity: 0
@@ -44,7 +45,7 @@ MonoBehaviour:
     Bullet: 90
     Laser: 90
     Energy: 90
-    Bomb: 90
+    Bomb: 65
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallSheath.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallSheath.asset
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.6
   ThermalConductivity: 0
@@ -44,7 +45,7 @@ MonoBehaviour:
     Bullet: 90
     Laser: 90
     Energy: 90
-    Bomb: 90
+    Bomb: 65
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallSupportLines.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallSupportLines.asset
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.6
   ThermalConductivity: 0
@@ -44,7 +45,7 @@ MonoBehaviour:
     Bullet: 90
     Laser: 90
     Energy: 90
-    Bomb: 90
+    Bomb: 65
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallSupportRods.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RWallSupportRods.asset
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.6
   ThermalConductivity: 0
@@ -44,7 +45,7 @@ MonoBehaviour:
     Bullet: 90
     Laser: 90
     Energy: 90
-    Bomb: 90
+    Bomb: 65
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/ReinforcedWall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/ReinforcedWall.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: ReinforcedWall
   m_EditorClassIdentifier: 
   displayName: reinforced wall
-  description: 
+  description: A strong, composite structure design to resist a good deal of punishment.
   LayerType: 0
   TileType: 1
   RequiredTiles:
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.6
   ThermalConductivity: 0
@@ -37,8 +38,8 @@ MonoBehaviour:
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 100
-  damageDeflection: 0
+  maxHealth: 400
+  damageDeflection: 21
   armor:
     Melee: 90
     Bullet: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RustyReinforcedWall/RustyRWallAnchorBolts.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RustyReinforcedWall/RustyRWallAnchorBolts.asset
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.7
   ThermalConductivity: 0
@@ -44,7 +45,7 @@ MonoBehaviour:
     Bullet: 90
     Laser: 90
     Energy: 90
-    Bomb: 90
+    Bomb: 65
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RustyReinforcedWall/RustyRWallCover.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RustyReinforcedWall/RustyRWallCover.asset
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.7
   ThermalConductivity: 0
@@ -44,7 +45,7 @@ MonoBehaviour:
     Bullet: 90
     Laser: 90
     Energy: 90
-    Bomb: 90
+    Bomb: 65
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RustyReinforcedWall/RustyRWallCutCover.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RustyReinforcedWall/RustyRWallCutCover.asset
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.7
   ThermalConductivity: 0
@@ -44,7 +45,7 @@ MonoBehaviour:
     Bullet: 90
     Laser: 90
     Energy: 90
-    Bomb: 90
+    Bomb: 65
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RustyReinforcedWall/RustyRWallSheath.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RustyReinforcedWall/RustyRWallSheath.asset
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.7
   ThermalConductivity: 0
@@ -44,7 +45,7 @@ MonoBehaviour:
     Bullet: 90
     Laser: 90
     Energy: 90
-    Bomb: 90
+    Bomb: 65
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RustyReinforcedWall/RustyRWallSupportLines.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RustyReinforcedWall/RustyRWallSupportLines.asset
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.7
   ThermalConductivity: 0
@@ -44,7 +45,7 @@ MonoBehaviour:
     Bullet: 90
     Laser: 90
     Energy: 90
-    Bomb: 90
+    Bomb: 65
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RustyReinforcedWall/RustyRWallSupportRods.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RustyReinforcedWall/RustyRWallSupportRods.asset
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.7
   ThermalConductivity: 0
@@ -44,7 +45,7 @@ MonoBehaviour:
     Bullet: 90
     Laser: 90
     Energy: 90
-    Bomb: 90
+    Bomb: 65
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RustyReinforcedWall/RustyReinforcedWall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RustyReinforcedWall/RustyReinforcedWall.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: RustyReinforcedWall
   m_EditorClassIdentifier: 
   displayName: rusted reinforced wall
-  description: 
+  description: A strong, composite structure design to resist a good deal of punishment.
   LayerType: 0
   TileType: 1
   RequiredTiles:
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.7
   ThermalConductivity: 0
@@ -37,14 +38,14 @@ MonoBehaviour:
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 100
-  damageDeflection: 0
+  maxHealth: 400
+  damageDeflection: 11
   armor:
     Melee: 90
     Bullet: 90
     Laser: 90
     Energy: 90
-    Bomb: 90
+    Bomb: 65
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/Wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/Wall.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: Wall
   m_EditorClassIdentifier: 
-  displayName: wall
-  description: 
+  displayName: metal wall
+  description: A sealed metal framework used to separate rooms.
   LayerType: 0
   TileType: 1
   RequiredTiles:
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.75
   ThermalConductivity: 0
@@ -38,12 +39,12 @@ MonoBehaviour:
     m_keys: 
     m_values: 
   maxHealth: 300
-  damageDeflection: 0
+  damageDeflection: 11
   armor:
     Melee: 90
     Bullet: 90
     Laser: 90
-    Energy: 90
+    Energy: 75
     Bomb: 45
     Rad: 100
     Fire: 100

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/bananium_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/bananium_wall.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: bananium_wall
   m_EditorClassIdentifier: 
-  displayName: 
-  description: 
+  displayName: bananium wall
+  description: A wall with bananium plating. Honk!
   LayerType: 0
   TileType: 1
   RequiredTiles:
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.75
   ThermalConductivity: 0
@@ -37,14 +38,14 @@ MonoBehaviour:
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 100
+  maxHealth: 200
   damageDeflection: 0
   armor:
     Melee: 90
     Bullet: 90
     Laser: 90
-    Energy: 90
-    Bomb: 90
+    Energy: 75
+    Bomb: 45
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/clockwork_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/clockwork_wall.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: clockwork_wall
   m_EditorClassIdentifier: 
-  displayName: 
-  description: 
+  displayName: clockwork wall
+  description: A huge chunk of bronze, decorated like gears and cogs.
   LayerType: 0
   TileType: 1
   RequiredTiles:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/clockwork_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/clockwork_wall.asset
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.75
   ThermalConductivity: 0
@@ -37,14 +38,14 @@ MonoBehaviour:
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 100
-  damageDeflection: 0
+  maxHealth: 300
+  damageDeflection: 11
   armor:
     Melee: 90
     Bullet: 90
     Laser: 90
-    Energy: 90
-    Bomb: 90
+    Energy: 75
+    Bomb: 45
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/cult_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/cult_wall.asset
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.75
   ThermalConductivity: 0
@@ -37,14 +38,14 @@ MonoBehaviour:
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 100
-  damageDeflection: 0
+  maxHealth: 300
+  damageDeflection: 11
   armor:
     Melee: 90
     Bullet: 90
     Laser: 90
-    Energy: 90
-    Bomb: 90
+    Energy: 75
+    Bomb: 45
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/cult_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/cult_wall.asset
@@ -12,8 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: cult_wall
   m_EditorClassIdentifier: 
-  displayName: 
-  description: 
+  displayName: runed metal wall
+  description: A cold metal wall engraved with indecipherable symbols. Studying them
+    causes your head to pound.
   LayerType: 0
   TileType: 1
   RequiredTiles:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/diamond_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/diamond_wall.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: diamond_wall
   m_EditorClassIdentifier: 
-  displayName: 
-  description: 
+  displayName: solid diamond wall
+  description: A wall with diamond plating. You monster.
   LayerType: 0
   TileType: 1
   RequiredTiles:
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.75
   ThermalConductivity: 0
@@ -37,10 +38,10 @@ MonoBehaviour:
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 100
-  damageDeflection: 0
+  maxHealth: 400
+  damageDeflection: 16
   armor:
-    Melee: 90
+    Melee: 100
     Bullet: 90
     Laser: 90
     Energy: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/gold_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/gold_wall.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: gold_wall
   m_EditorClassIdentifier: 
-  displayName: 
-  description: 
+  displayName: solid gold wall
+  description: A wall with gold plating. Swag!
   LayerType: 0
   TileType: 1
   RequiredTiles:
@@ -26,8 +26,9 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
-  RadiationPassability: 0.75
+  RadiationPassability: 0.5
   ThermalConductivity: 0
   HeatCapacity: 312500
   doesReflectBullet: 0
@@ -37,14 +38,14 @@ MonoBehaviour:
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 100
-  damageDeflection: 0
+  maxHealth: 200
+  damageDeflection: 11
   armor:
-    Melee: 90
-    Bullet: 90
-    Laser: 90
-    Energy: 90
-    Bomb: 90
+    Melee: 80
+    Bullet: 80
+    Laser: 80
+    Energy: 80
+    Bomb: 40
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/iron_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/iron_wall.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: iron_wall
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: solid iron wall
   description: 
   LayerType: 0
   TileType: 1
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.75
   ThermalConductivity: 0
@@ -37,8 +38,8 @@ MonoBehaviour:
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 100
-  damageDeflection: 0
+  maxHealth: 200
+  damageDeflection: 11
   armor:
     Melee: 90
     Bullet: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/plasma_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/plasma_wall.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: plasma_wall
   m_EditorClassIdentifier: 
-  displayName: 
-  description: 
+  displayName: solid plasma wall
+  description: A wall with plasma plating. This is definitely a bad idea.
   LayerType: 0
   TileType: 1
   RequiredTiles:
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.75
   ThermalConductivity: 0
@@ -37,8 +38,8 @@ MonoBehaviour:
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 100
-  damageDeflection: 0
+  maxHealth: 200
+  damageDeflection: 11
   armor:
     Melee: 90
     Bullet: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/plastitanium_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/plastitanium_wall.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: plastitanium_wall
   m_EditorClassIdentifier: 
-  displayName: 
-  description: 
+  displayName: plastitanium wall
+  description: A durable wall made of an alloy of plasma and titanium.
   LayerType: 0
   TileType: 1
   RequiredTiles:
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.75
   ThermalConductivity: 0
@@ -37,14 +38,14 @@ MonoBehaviour:
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 100
-  damageDeflection: 0
+  maxHealth: 400
+  damageDeflection: 11
   armor:
     Melee: 90
     Bullet: 90
     Laser: 90
     Energy: 90
-    Bomb: 90
+    Bomb: 45
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/plastitanium_wall_corner.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/plastitanium_wall_corner.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: plastitanium_wall_corner
   m_EditorClassIdentifier: 
-  displayName: 
-  description: 
+  displayName: plastitanium wall
+  description: A durable wall made of an alloy of plasma and titanium.
   LayerType: 0
   TileType: 1
   RequiredTiles: []
@@ -25,6 +25,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.75
   ThermalConductivity: 0
@@ -36,14 +37,14 @@ MonoBehaviour:
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 100
-  damageDeflection: 0
+  maxHealth: 400
+  damageDeflection: 11
   armor:
     Melee: 90
     Bullet: 90
     Laser: 90
     Energy: 90
-    Bomb: 90
+    Bomb: 45
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/rock_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/rock_wall.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: rock_wall
   m_EditorClassIdentifier: 
-  displayName: 
-  description: 
+  displayName: rock wall
+  description: This looks exceptionally easy to mine through.
   LayerType: 0
   TileType: 1
   RequiredTiles:
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 1
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.75
   ThermalConductivity: 0
@@ -40,11 +41,11 @@ MonoBehaviour:
   maxHealth: 100
   damageDeflection: 0
   armor:
-    Melee: 90
-    Bullet: 90
-    Laser: 90
-    Energy: 90
-    Bomb: 90
+    Melee: 80
+    Bullet: 80
+    Laser: 80
+    Energy: 80
+    Bomb: 45
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/rusty_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/rusty_wall.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: rusty_wall
   m_EditorClassIdentifier: 
   displayName: rusted wall
-  description: 
+  description: A sealed metal framework used to separate rooms. It has rusted over.
   LayerType: 0
   TileType: 1
   RequiredTiles:
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.75
   ThermalConductivity: 0
@@ -37,14 +38,14 @@ MonoBehaviour:
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 100
+  maxHealth: 300
   damageDeflection: 0
   armor:
-    Melee: 90
-    Bullet: 90
-    Laser: 90
-    Energy: 90
-    Bomb: 90
+    Melee: 80
+    Bullet: 80
+    Laser: 80
+    Energy: 75
+    Bomb: 40
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/sandstone_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/sandstone_wall.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: sandstone_wall
   m_EditorClassIdentifier: 
-  displayName: 
-  description: 
+  displayName: sandstone wall
+  description: A wall with sandstone plating. Rough.
   LayerType: 0
   TileType: 1
   RequiredTiles:
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.75
   ThermalConductivity: 0
@@ -40,11 +41,11 @@ MonoBehaviour:
   maxHealth: 100
   damageDeflection: 0
   armor:
-    Melee: 90
-    Bullet: 90
+    Melee: 75
+    Bullet: 45
     Laser: 90
     Energy: 90
-    Bomb: 90
+    Bomb: 45
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/shuttle_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/shuttle_wall.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: shuttle_wall
   m_EditorClassIdentifier: 
-  displayName: 
-  description: 
+  displayName: shuttle wall
+  description: A light-weight titanium wall used in shuttles.
   LayerType: 0
   TileType: 1
   RequiredTiles:
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.75
   ThermalConductivity: 0
@@ -37,14 +38,14 @@ MonoBehaviour:
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 100
-  damageDeflection: 0
+  maxHealth: 300
+  damageDeflection: 11
   armor:
     Melee: 90
     Bullet: 90
     Laser: 90
     Energy: 90
-    Bomb: 90
+    Bomb: 40
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/shuttle_wall_corner.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/shuttle_wall_corner.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: shuttle_wall_corner
   m_EditorClassIdentifier: 
-  displayName: 
-  description: 
+  displayName: shuttle wall
+  description: A light-weight titanium wall used in shuttles.
   LayerType: 0
   TileType: 1
   RequiredTiles: []
@@ -25,6 +25,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.75
   ThermalConductivity: 0
@@ -36,14 +37,14 @@ MonoBehaviour:
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 100
-  damageDeflection: 0
+  maxHealth: 300
+  damageDeflection: 11
   armor:
     Melee: 90
     Bullet: 90
     Laser: 90
     Energy: 90
-    Bomb: 90
+    Bomb: 40
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/silver_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/silver_wall.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: silver_wall
   m_EditorClassIdentifier: 
-  displayName: 
-  description: 
+  displayName: solid silver wall
+  description: A wall with silver plating. Shiny!
   LayerType: 0
   TileType: 1
   RequiredTiles:
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.75
   ThermalConductivity: 0
@@ -37,14 +38,14 @@ MonoBehaviour:
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 100
-  damageDeflection: 0
+  maxHealth: 200
+  damageDeflection: 11
   armor:
-    Melee: 90
-    Bullet: 90
-    Laser: 90
-    Energy: 90
-    Bomb: 90
+    Melee: 80
+    Bullet: 80
+    Laser: 80
+    Energy: 80
+    Bomb: 80
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/snow_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/snow_wall.asset
@@ -26,8 +26,9 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
-  RadiationPassability: 0.75
+  RadiationPassability: 1
   ThermalConductivity: 0
   HeatCapacity: 312500
   doesReflectBullet: 0
@@ -40,13 +41,13 @@ MonoBehaviour:
   maxHealth: 100
   damageDeflection: 0
   armor:
-    Melee: 90
-    Bullet: 90
-    Laser: 90
-    Energy: 90
-    Bomb: 90
+    Melee: 0
+    Bullet: 0
+    Laser: 0
+    Energy: 0
+    Bomb: 0
     Rad: 100
-    Fire: 100
+    Fire: -100
     Acid: 90
     Magic: 0
     Bio: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/survival_pod_walls.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/survival_pod_walls.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: survival_pod_walls
   m_EditorClassIdentifier: 
-  displayName: 
-  description: 
+  displayName: pod wall
+  description: An easily-compressable wall used for temporary shelter.
   LayerType: 0
   TileType: 1
   RequiredTiles:
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.75
   ThermalConductivity: 0
@@ -37,14 +38,14 @@ MonoBehaviour:
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 100
-  damageDeflection: 0
+  maxHealth: 300
+  damageDeflection: 11
   armor:
-    Melee: 90
-    Bullet: 90
-    Laser: 90
-    Energy: 90
-    Bomb: 90
+    Melee: 80
+    Bullet: 80
+    Laser: 80
+    Energy: 80
+    Bomb: 30
     Rad: 100
     Fire: 100
     Acid: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/uranium_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/uranium_wall.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: uranium_wall
   m_EditorClassIdentifier: 
-  displayName: 
-  description: 
+  displayName: uranium wall
+  description: A wall with uranium plating. This is probably a bad idea.
   LayerType: 0
   TileType: 1
   RequiredTiles:
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
   RadiationPassability: 0.75
   ThermalConductivity: 0
@@ -37,8 +38,8 @@ MonoBehaviour:
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 100
-  damageDeflection: 0
+  maxHealth: 200
+  damageDeflection: 11
   armor:
     Melee: 90
     Bullet: 90

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/wood_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/wood_wall.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: wood_wall
   m_EditorClassIdentifier: 
-  displayName: 
-  description: 
+  displayName: wood plank wall
+  description: a wall plated with wood planks. Looks pretty flammable.
   LayerType: 0
   TileType: 1
   RequiredTiles:
@@ -26,8 +26,9 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 0
-  RadiationPassability: 0.75
+  RadiationPassability: 0.95
   ThermalConductivity: 0
   HeatCapacity: 312500
   doesReflectBullet: 0
@@ -40,13 +41,13 @@ MonoBehaviour:
   maxHealth: 100
   damageDeflection: 0
   armor:
-    Melee: 90
-    Bullet: 90
-    Laser: 90
-    Energy: 90
-    Bomb: 90
+    Melee: 50
+    Bullet: 0
+    Laser: 0
+    Energy: 0
+    Bomb: 0
     Rad: 100
-    Fire: 100
+    Fire: -30
     Acid: 90
     Magic: 0
     Bio: 90


### PR DESCRIPTION

### Purpose

This PR adds descriptions to a number of tile types and corrects some inconsistencies with armor and integrity values for walls. The most critical change is reinforced walls now have damage deflection (they didn't before) and have an appropriate amount of integrity rather than just 100.

### Notes:

given that we handle tiles more closely to objects than ss13, this is sort of new territory, so I kept my changes conservative. I mainly made all of the different wall types mimic the standard wall.

### Changelog:

CL [Improvement] many wall and floor tiles now have descriptions when examined.
CL: [Balance] reinforced wall now has a damage deflection of 21.
CL: [Balance] reinforced wall integrity increased from 100 to 400.
CL: [Balance] armor values of the various construction states of reinforced walls are now the same as the complete version.
CL: [Balance] admin walls now do not let any radiation pass.
CL: [Balance] rusty versions of walls now have the same armor and integrity values as their non-rusty counterparts.
CL: [Balance] integrity of all mineral walls has been increased from 100 to 300.
CL: [Balance] armor on all mineral walls has been decreased by 10%
CL: [Balance] diamond walls now have 100 melee armor and 400 integrity.
CL: [Balance] catwalk integrity increased from 50 to 75.
CL: [Balance] plastitanium and all plasma-derived walls have a damage deflection of 11 and 400 integrity.
CL: [Balance] wood walls are now significantly less tough, having minimal armor and integrity and they take 30% bonus fire damage. They also pass significantly more radiation.
