### PR TITLE
Fixes Mac Builds

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Editor/Mac Ignorance Fix.meta
+++ b/UnityProject/Assets/Scripts/Core/Editor/Mac Ignorance Fix.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 14cf9235ada15ff4d8e879ca5774d20d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Core/Editor/Mac Ignorance Fix/SetUpENetMac.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/Mac Ignorance Fix/SetUpENetMac.cs
@@ -1,0 +1,23 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+using UnityEngine;
+
+
+public class SetUpENetMac : IPostprocessBuildWithReport
+{
+	public int callbackOrder { get { return 1; } }
+	public void OnPostprocessBuild(BuildReport report)
+	{
+		if (report.summary.platform == BuildTarget.StandaloneOSX)
+		{
+			var toCopyTo = report.summary.outputPath + "/Contents/PlugIns/libenet.dylib";
+			var toCopyFrom = Application.dataPath + "/Mirror/Runtime/Transports/Ignorance/Plugins/macOS/libenet.dylib";
+			var InFile = new FileInfo(toCopyFrom);
+			InFile.CopyTo(toCopyTo, true);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Core/Editor/Mac Ignorance Fix/SetUpENetMac.cs.meta
+++ b/UnityProject/Assets/Scripts/Core/Editor/Mac Ignorance Fix/SetUpENetMac.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 74e4e58a91f72ab438c1d7616c5fd258
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
so, it looks like the issue is that unity is not moving the Enet library into the bill on Mac for some reason, so manually copying it over should fix the issue

Note: 
need someone with a mac to test, might be targeting the wrong folder, I was just using the folder it was in previous Builds

### Changelog:

 CL: [Fix] Mac Builds now work hopefully. 
