### PR TITLE
Fixes two issues with action buttons

### DIFF
--- a/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
+++ b/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
@@ -6,10 +6,12 @@ using UnityEditor;
 using Systems.Atmospherics;
 using Random = UnityEngine.Random;
 using DatabaseAPI;
+using HealthV2;
 using Messages.Client;
 using Messages.Server;
 using Messages.Server.HealthMessages;
 using ScriptableObjects;
+using UI.Action;
 
 namespace IngameDebugConsole
 {
@@ -18,6 +20,21 @@ namespace IngameDebugConsole
 	/// </summary>
 	public class DebugLogUnitystationCommands : MonoBehaviour
 	{
+
+		[ConsoleMethod("CloneSelf", "Allows user to test cloning quickly.")]
+		public static void CloneSelf()
+		{
+			if (AdminCommands.AdminCommandsManager.IsAdmin(PlayerManager.PlayerScript.connectedPlayer.Connection, out var _) == false)
+			{
+				Logger.Log("This function can only be executed by admins.", Category.DebugConsole);
+				return;
+			}
+
+			var mind = PlayerManager.LocalPlayerScript.mind;
+			var playerBody = PlayerSpawn.ServerClonePlayer(mind, mind.body.gameObject.transform.position.CutToInt()).GetComponent<LivingHealthMasterBase>();
+			playerBody.ApplyDamageAll(null, 2, AttackType.Internal, DamageType.Clone, false);
+		}
+
 		[ConsoleMethod("checkObjectivesStatus", "check the current status of your objectives")]
 		public static void CheckObjectivesStatus()
 		{

--- a/UnityProject/Assets/Scripts/Messages/Server/ClearActionsMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/ClearActionsMessage.cs
@@ -1,0 +1,24 @@
+using Mirror;
+using UI.Action;
+using UnityEngine;
+
+namespace Messages.Server
+{
+	public class ClearActionsMessage : ServerMessage<ClearActionsMessage.NetMessage>
+	{
+		public struct NetMessage : NetworkMessage { }
+
+		public override void Process(NetMessage msg)
+		{
+			UIActionManager.ClearAllActions();
+		}
+
+		public static NetMessage SendTo(GameObject recipient)
+		{
+			NetMessage msg = new NetMessage {};
+
+			SendTo(recipient, msg);
+			return msg;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Messages/Server/ClearActionsMessage.cs.meta
+++ b/UnityProject/Assets/Scripts/Messages/Server/ClearActionsMessage.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 814ddade1fb04082a9f96a72fd3b53bd
+timeCreated: 1652704640

--- a/UnityProject/Assets/Scripts/Player/Mind.cs
+++ b/UnityProject/Assets/Scripts/Player/Mind.cs
@@ -22,7 +22,7 @@ public class Mind
 	public Occupation occupation;
 	public PlayerScript ghost;
 	public PlayerScript body;
-	public SpawnedAntag antag;
+	private SpawnedAntag antag;
 	public bool IsAntag => antag != null;
 	public bool IsGhosting;
 	public bool DenyCloning;

--- a/UnityProject/Assets/Scripts/Player/Mind.cs
+++ b/UnityProject/Assets/Scripts/Player/Mind.cs
@@ -7,6 +7,7 @@ using Antagonists;
 using Systems.Spells;
 using HealthV2;
 using Items.PDA;
+using Messages.Server;
 using Player;
 using ScriptableObjects.Audio;
 using UI.Action;
@@ -21,7 +22,7 @@ public class Mind
 	public Occupation occupation;
 	public PlayerScript ghost;
 	public PlayerScript body;
-	private SpawnedAntag antag;
+	public SpawnedAntag antag;
 	public bool IsAntag => antag != null;
 	public bool IsGhosting;
 	public bool DenyCloning;
@@ -108,6 +109,7 @@ public class Mind
 		ClearOldBody();
 		playerScript.mind = this;
 		body = playerScript;
+		if(antag != null) SetAntag(antag);
 
 		if (playerScript.TryGetComponent<LivingHealthMasterBase>(out var health))
 		{
@@ -134,6 +136,7 @@ public class Mind
 	{
 		if (body)
 		{
+			ClearActionsMessage.SendTo(body.gameObject);
 			body.mind = null;
 		}
 	}
@@ -234,10 +237,10 @@ public class Mind
 	{
 		if (IsAntag == false) return;
 		var playerMob = GetCurrentMob();
-		
+
 		//Send Objectives
 		Chat.AddExamineMsgFromServer(playerMob, antag.GetObjectivesForPlayer());
-		
+
 		if (playerMob.TryGetComponent<PlayerScript>(out var body) == false) return;
 		if (antag.Antagonist.AntagJobType == JobType.TRAITOR || antag.Antagonist.AntagJobType == JobType.SYNDICATE)
         {
@@ -247,7 +250,7 @@ public class Mind
         		if (item.IsEmpty) continue;
         		if (item.ItemObject.TryGetComponent<PDALogic>(out var PDA) == false) continue;
         		if(PDA.IsUplinkCapable == false) continue;
-        		
+
         		//Send Uplink code
                 Chat.AddExamineMsgFromServer(playerMob, $"PDA uplink code retrieved: {PDA.UplinkUnlockCode}");
 	        }

--- a/UnityProject/Assets/Scripts/UI/Core/Action/UIActionManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/Action/UIActionManager.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
 using Messages.Server;
 using UnityEngine;
@@ -188,8 +189,12 @@ namespace UI.Action
 		{
 			foreach (var actionButton in Instance.DicIActionGUI)
 			{
-				//If there is a duplicate of this button, don't spawn it!
-				if (actionButton.Value.ActionData == iActionGUI.ActionData) return;
+				//Remove old button from list. Don't spawn the same button if it already exists!
+				if (actionButton.Value.ActionData == iActionGUI.ActionData)
+				{
+					Hide(actionButton.Key);
+					break;
+				}
 			}
 			UIAction _UIAction;
 			if (Instance.PooledUIAction.Count > 0)
@@ -269,17 +274,12 @@ namespace UI.Action
 			CheckEvent(Event.PlayerRejoined);
 		}
 
-		public void CheckEvent(Event Event)
+		private void CheckEvent(Event Event)
 		{
 			var TOremove = new List<IActionGUI>();
 			foreach (var action in DicIActionGUI)
 			{
-				if (action.Key.ActionData == null)
-				{
-					Logger.LogWarningFormat("UIAction {0}: action data is null!", Category.UserInput, action.Key + ":" + action.Value);
-					continue;
-				}
-				if (action.Key.ActionData.DisableOnEvent.Contains(Event))
+				if (action.Key.ActionData != null && action.Key.ActionData.DisableOnEvent.Contains(Event))
 				{
 					action.Value.Pool();
 					TOremove.Add(action.Key);
@@ -288,6 +288,15 @@ namespace UI.Action
 			foreach (var Remove in TOremove)
 			{
 				DicIActionGUI.Remove(Remove);
+			}
+		}
+
+		public static void ClearAllActions()
+		{
+			if(Instance.DicIActionGUI.Count == 0) return;
+			for (int i = Instance.DicIActionGUI.Count - 1; i > -1; i--)
+			{
+				Hide(Instance.DicIActionGUI.ElementAt(i).Key);
 			}
 		}
 


### PR DESCRIPTION
Fixes #8509

## Changelog:

CL: [New] - Added an admin command to quickly test cloning.
CL: [Fix] - Fixed issue where antags getting cloned lost their ability to check their objectives
CL: [Improvement] - Duplicate actions now replace old buttons with the most recent change/addition to the player's inventory.

