### PR TITLE
Fixes new players being kicked for having an empty charactesheet

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/GameData.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameData.cs
@@ -304,6 +304,12 @@ public class GameData : MonoBehaviour
 					if (success)
 					{
 						Logger.Log("Signed in successfully with valid token", Category.DatabaseAPI);
+						var prefsCheck = PlayerPrefs.GetString("currentcharacter");
+						if (string.IsNullOrEmpty(prefsCheck))
+						{
+							LobbyManager.Instance.lobbyDialogue.ShowCharacterEditor(OnCharacterScreenCloseFromHubConnect);
+							return;
+						}
 						OnCharacterScreenCloseFromHubConnect();
 					}
 					else

--- a/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using DatabaseAPI;
 using Mirror;
@@ -433,10 +434,15 @@ public partial class PlayerList
 		//Must have non-null/empty username
 		if (string.IsNullOrEmpty(unverifiedConnPlayer.Username))
 		{
-			StartCoroutine(KickPlayer(unverifiedConnPlayer, $"Server Error: Account has invalid username (Null/Empty). To fix go to character creator then click Serialise and then load"));
-			Logger.LogError($"A user tried to connect with null/empty username" +
-			           $"Details: Username: {unverifiedConnPlayer.Username}, ClientID: {unverifiedConnPlayer.ClientId}, IP: {unverifiedConnPlayer.ConnectionIP}",
-				Category.Admin);
+			var prefsCheck = PlayerPrefs.GetString("currentcharacter");
+			if (string.IsNullOrEmpty(prefsCheck))
+			{
+				StartCoroutine(KickPlayer(unverifiedConnPlayer, $"Server Error: Account has invalid username (Null/Empty). To fix go to character creator then click Serialise and then load"));
+				Logger.LogError($"A user tried to connect with null/empty username" +
+				                $"Details: Username: {unverifiedConnPlayer.Username}, ClientID: {unverifiedConnPlayer.ClientId}, IP: {unverifiedConnPlayer.ConnectionIP}",
+					Category.Admin);
+			}
+			Logger.Log("First time player found. Skipping username checks.");
 		}
 
 		//Allow error response for local offline testing

--- a/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
@@ -339,6 +339,13 @@ public partial class PlayerList
 		File.WriteAllLines(mentorsPath, newContents);
 	}
 
+	[TargetRpc]
+	public void RpcShowCharacterCreatorScreenRemotely(NetworkConnection target)
+	{
+		LobbyManager.Instance.SetActive(true);
+		LobbyManager.Instance.characterCustomization.SetActive(true);
+	}
+
 	public async Task<bool> ValidatePlayer(int unverifiedClientVersion, ConnectedPlayer unverifiedConnPlayer,
 		string unverifiedToken)
 	{
@@ -443,7 +450,8 @@ public partial class PlayerList
 				                $"Details: Username: {unverifiedConnPlayer.Username}, ClientID: {unverifiedConnPlayer.ClientId}, IP: {unverifiedConnPlayer.ConnectionIP}",
 					Category.Admin);
 			}
-			LobbyManager.Instance.characterCustomization.SetActive(true);
+
+			RpcShowCharacterCreatorScreenRemotely(unverifiedConnPlayer.Connection);
 			Logger.Log("First time player found. Skipping username checks.");
 		}
 

--- a/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
@@ -10,6 +10,7 @@ using DatabaseAPI;
 using Mirror;
 using UnityEngine;
 using DiscordWebhook;
+using Lobby;
 using Messages.Client;
 using Messages.Server;
 using Messages.Server.AdminTools;
@@ -442,6 +443,7 @@ public partial class PlayerList
 				                $"Details: Username: {unverifiedConnPlayer.Username}, ClientID: {unverifiedConnPlayer.ClientId}, IP: {unverifiedConnPlayer.ConnectionIP}",
 					Category.Admin);
 			}
+			LobbyManager.Instance.characterCustomization.SetActive(true);
 			Logger.Log("First time player found. Skipping username checks.");
 		}
 

--- a/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
@@ -442,17 +442,11 @@ public partial class PlayerList
 		//Must have non-null/empty username
 		if (string.IsNullOrEmpty(unverifiedConnPlayer.Username))
 		{
-			var prefsCheck = PlayerPrefs.GetString("currentcharacter");
-			if (string.IsNullOrEmpty(prefsCheck))
-			{
-				StartCoroutine(KickPlayer(unverifiedConnPlayer, $"Server Error: Account has invalid username (Null/Empty). To fix go to character creator then click Serialise and then load"));
-				Logger.LogError($"A user tried to connect with null/empty username" +
-				                $"Details: Username: {unverifiedConnPlayer.Username}, ClientID: {unverifiedConnPlayer.ClientId}, IP: {unverifiedConnPlayer.ConnectionIP}",
-					Category.Admin);
-			}
-
 			RpcShowCharacterCreatorScreenRemotely(unverifiedConnPlayer.Connection);
-			Logger.Log("First time player found. Skipping username checks.");
+			StartCoroutine(KickPlayer(unverifiedConnPlayer, $"Server Error: Account has invalid username (Null/Empty). To fix go to character creator then click Serialise and then load"));
+			Logger.LogError($"A user tried to connect with null/empty username" +
+			                $"Details: Username: {unverifiedConnPlayer.Username}, ClientID: {unverifiedConnPlayer.ClientId}, IP: {unverifiedConnPlayer.ConnectionIP}",
+				Category.Admin);
 		}
 
 		//Allow error response for local offline testing


### PR DESCRIPTION
Fixes #8687

New players will now be automatically prompted to make a character when they join the server as well.

CL : [Fix] - Fixed new players being kicked due to the lack of a character sheet.
CL: [Improvement] - New players are automatically prompted to create a character sheet when first joining a server now.