### PR TITLE
Quick equipment change

### DIFF
--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -1035,4 +1035,14 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 
 		painter.CurrentPaintJobIndex = paintJobIndex;
 	}
+
+	[Command]
+	public void CmdServerReplaceItemInInventory(GameObject gameObject, uint id, NamedSlot namedSlot)
+	{
+		if (NetworkIdentity.spawned.ContainsKey(id) == false) return;
+		var Object = NetworkIdentity.spawned[id].gameObject;
+		var slot = itemStorage.GetNamedItemSlot(Object,namedSlot);
+		if (slot == null) return;
+		Inventory.ServerTransfer(gameObject.PickupableOrNull().ItemSlot, slot, ReplacementStrategy.DropOther);
+	}
 }

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemSlot.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemSlot.cs
@@ -2,15 +2,11 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using Items;
-using UnityEditor;
 using UnityEngine;
-using UnityEngine.EventSystems;
 using UnityEngine.SceneManagement;
 using UnityEngine.Serialization;
 using UnityEngine.UI;
-using AdminCommands;
 using HealthV2;
 using Managers;
 using UI;
@@ -356,23 +352,23 @@ public class UI_ItemSlot : TooltipMonoBehaviour
 		if (isValidPlayer())
 		{
 			var CurrentSlot = PlayerManager.LocalPlayerScript.DynamicItemStorage.GetActiveHandSlot();
-			if (CurrentSlot != itemSlot.itemSlot)
+			if (CurrentSlot != itemSlot.itemSlot) //Check if we're not interacting with our own hand
 			{
-				if (CurrentSlot.Item == null)
+				if (CurrentSlot.Item == null) //check if hand is empty
 				{
-					if (itemSlot.Item != null)
+					if (itemSlot.Item != null) //check if slot is not empty
 					{
+						//if slot is not empty and hand is empty; ask the inventory to give us that item in our hand
 						Inventory.ClientRequestTransfer(itemSlot.ItemSlot, CurrentSlot);
 						return true;
 					}
 				}
 				else
 				{
-					if (itemSlot.Item == null)
-					{
-						Inventory.ClientRequestTransfer(CurrentSlot, itemSlot.ItemSlot);
-						return true;
-					}
+					if (itemSlot.Item != null) return false;
+					//if slot is empty, ask the game to put whatever thats in out hand in it.
+					Inventory.ClientRequestTransfer(CurrentSlot, itemSlot.ItemSlot);
+					return true;
 				}
 			}
 		}
@@ -447,6 +443,7 @@ public class UI_ItemSlot : TooltipMonoBehaviour
 			//check interactables in the active hand (if active hand occupied)
 			if (PlayerManager.LocalPlayerScript.DynamicItemStorage.GetActiveHandSlot().Item != null)
 			{
+				if (combine.IsAltClick && SwapTwoItemsInInventory(combine.FromSlot)) return true;
 				var handInteractables = PlayerManager.LocalPlayerScript.DynamicItemStorage.GetActiveHandSlot().Item
 					.GetComponents<IBaseInteractable<InventoryApply>>()
 					.Where(mb => mb != null && (mb as MonoBehaviour).enabled);
@@ -461,6 +458,14 @@ public class UI_ItemSlot : TooltipMonoBehaviour
 
 		return false;
 	}
+
+	private bool SwapTwoItemsInInventory(ItemSlot CurrentSlot)
+    	{
+    		if (PlayerManager.LocalPlayerScript.playerNetworkActions == null) return false;
+            PlayerManager.LocalPlayerScript.playerNetworkActions.CmdServerReplaceItemInInventory(CurrentSlot.ItemObject,
+    			itemSlot.ItemStorageNetID, itemSlot.NamedSlot.Value);
+            return true;
+    	}
 
 
 	[ContextMenu("Debug Slot")]


### PR DESCRIPTION
Closes #8668

Allows players to quickly change items by alt clicking a slot with an occupied hand.

## Changelog:

CL: [New] - Players can now quickly change equipment by alt-clicking an item slot with an item in-hand.
