### PR TITLE
Fixes signal manager getting bricked by the despawn call

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/C4.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/C4.prefab
@@ -300,8 +300,7 @@ MonoBehaviour:
   Frequency: 122
   Emitter: {fileID: 0}
   DelayTime: 3
-  EncryptionData: {fileID: -6326205420379670096, guid: ac9bcd63f2f8a944ebd2001ce5c0a3b1,
-    type: 2}
+  EncryptionData: {fileID: 0}
   ListenToEncryptedData: 0
   explosiveType: 0
   detonateImmediatelyOnSignal: 0

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/SyndicateBomb.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/SyndicateBomb.prefab
@@ -216,8 +216,7 @@ MonoBehaviour:
   Frequency: 122
   Emitter: {fileID: 0}
   DelayTime: 3
-  EncryptionData: {fileID: -6326205420379670096, guid: ac9bcd63f2f8a944ebd2001ce5c0a3b1,
-    type: 2}
+  EncryptionData: {fileID: 0}
   ListenToEncryptedData: 0
   explosiveType: 2
   detonateImmediatelyOnSignal: 0

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/X4.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/X4.prefab
@@ -299,8 +299,7 @@ MonoBehaviour:
   Frequency: 122
   Emitter: {fileID: 0}
   DelayTime: 3
-  EncryptionData: {fileID: -6326205420379670096, guid: ac9bcd63f2f8a944ebd2001ce5c0a3b1,
-    type: 2}
+  EncryptionData: {fileID: 0}
   ListenToEncryptedData: 0
   explosiveType: 1
   detonateImmediatelyOnSignal: 0

--- a/UnityProject/Assets/Scripts/Communications/SignalReceiver.cs
+++ b/UnityProject/Assets/Scripts/Communications/SignalReceiver.cs
@@ -1,10 +1,12 @@
+using System;
 using Managers;
 using Mirror;
 using ScriptableObjects.Communications;
+using UnityEngine;
 
 namespace Communications
 {
-	public abstract class SignalReceiver : NetworkBehaviour
+	public abstract class SignalReceiver : NetworkBehaviour, IServerDespawn
 	{
 		public SignalType SignalTypeToReceive = SignalType.PING;
 		public float Frequency = 122F;
@@ -20,7 +22,7 @@ namespace Communications
 			SignalsManager.Instance.Receivers.Add(this);
 		}
 
-		private void OnDisable()
+		public void OnDespawnServer(DespawnInfo info)
 		{
 			RemoveSelfFromManager();
 		}

--- a/UnityProject/Assets/Scripts/Communications/SignalReceiver.cs
+++ b/UnityProject/Assets/Scripts/Communications/SignalReceiver.cs
@@ -16,13 +16,22 @@ namespace Communications
 
 		private void OnEnable()
 		{
-			if(CustomNetworkManager.Instance._isServer == false) return;
+			if(CustomNetworkManager.IsServer == false) return;
 			SignalsManager.Instance.Receivers.Add(this);
 		}
 
 		private void OnDisable()
 		{
-			if(CustomNetworkManager.Instance._isServer == false) return;
+			RemoveSelfFromManager();
+		}
+
+		/// <summary>
+		/// Sometimes OnDisable() gets overriden or doesn't get called properly when called using the Despawn class so manually call this in your extended script.
+		/// Or when you need to remove this receiver from the manager for whatever reason.
+		/// </summary>
+		protected void RemoveSelfFromManager()
+		{
+			if(CustomNetworkManager.IsServer == false) return;
 			SignalsManager.Instance.Receivers.Remove(this);
 		}
 
@@ -33,7 +42,7 @@ namespace Communications
 
 
 		/// <summary>
-		/// Optional. If ReceiveSignal logic has been succesful we can respond to the emitter with some logic.
+		/// Optional. If ReceiveSignal logic has been successful we can respond to the emitter with some logic.
 		/// </summary>
 		public virtual void Respond(SignalEmitter signalEmitter) { }
 	}

--- a/UnityProject/Assets/Scripts/Items/Weapons/ExplosiveBase.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/ExplosiveBase.cs
@@ -90,6 +90,7 @@ namespace Items.Weapons
 			// Get data before despawning
 			var worldPos = objectBehaviour.AssumedWorldPositionServer();
 			// Despawn the explosive
+			RemoveSelfFromManager();
 			_ = Despawn.ServerSingle(gameObject);
 			Explosion.StartExplosion(worldPos, explosiveStrength);
 		}

--- a/UnityProject/Assets/Scripts/Managers/SignalsManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SignalsManager.cs
@@ -24,6 +24,8 @@ namespace Managers
 
 			foreach (SignalReceiver receiver in Receivers)
 			{
+				if (receiver.gameObject == null) continue;
+				;
 				if (receiver.SignalTypeToReceive != type) continue;
 
 				if (receiver.Frequency.IsBetween(signalDataSo.MinMaxFrequancy.x, signalDataSo.MinMaxFrequancy.y) == false) continue;

--- a/UnityProject/Assets/Scripts/Managers/SignalsManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SignalsManager.cs
@@ -25,7 +25,6 @@ namespace Managers
 			foreach (SignalReceiver receiver in Receivers)
 			{
 				if (receiver.gameObject == null) continue;
-				;
 				if (receiver.SignalTypeToReceive != type) continue;
 
 				if (receiver.Frequency.IsBetween(signalDataSo.MinMaxFrequancy.x, signalDataSo.MinMaxFrequancy.y) == false) continue;


### PR DESCRIPTION
Ever wondered why all devices that use signal emitters/receivers would suddenly stop working on staging until the server fully reboots?
The reason behind this is the use of the `Despawn` class which doesn't trigger `OnDisable` at all; causing the signal manager to get stuck on an object that has been destroyed but was never properly removed from the list on the server. This fixes it

This should fix issues regarding C4/X4s/Synidcate bombs/etc from being only used once in a lifetime until the server completely reboots and accidentally destroying a handheld radio will no longer cause this.

## Changelog:

CL: [Fix] - Fixed an issue that caused the signal manager to completely break when despawning objects.