### PR TITLE
Fixes kick when adjusting cargo bounties

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
@@ -537,7 +537,7 @@ namespace AdminCommands
 		{
 			if (IsAdmin(sender, out var admin) == false) return;
 			List<CargoManager.BountySyncData> simpleData = new List<CargoManager.BountySyncData>();
-			for (int i = 0; i < CargoManager.Instance.ActiveBounties.Count; i++)
+			for (int i = 0; i < CargoManager.Instance.ActiveBounties.Count - 1; i++)
 			{
 				var foundBounty = new CargoManager.BountySyncData();
 				foundBounty.Title = CargoManager.Instance.ActiveBounties[i].Title;

--- a/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
@@ -537,7 +537,7 @@ namespace AdminCommands
 		{
 			if (IsAdmin(sender, out var admin) == false) return;
 			List<CargoManager.BountySyncData> simpleData = new List<CargoManager.BountySyncData>();
-			for (int i = 0; i < CargoManager.Instance.ActiveBounties.Count - 1; i++)
+			for (int i = 0; i < CargoManager.Instance.ActiveBounties.Count; i++)
 			{
 				var foundBounty = new CargoManager.BountySyncData();
 				foundBounty.Title = CargoManager.Instance.ActiveBounties[i].Title;

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/AdminBountyManagerListEntry.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/AdminBountyManagerListEntry.cs
@@ -29,13 +29,13 @@ namespace UI.Systems.AdminTools
 		public void RemoveBounty()
 		{
 			AdminCommandsManager.Instance.CmdRemoveBounty(BountyIndex, false);
-			Destroy(gameObject);
+			AdminCommandsManager.Instance.CmdRequestCargoServerData();
 		}
 
 		public void CompleteBounty()
 		{
 			AdminCommandsManager.Instance.CmdRemoveBounty(BountyIndex, true);
-			Destroy(gameObject);
+			AdminCommandsManager.Instance.CmdRequestCargoServerData();
 		}
 	}
 }


### PR DESCRIPTION
Title 

CL: [Fix] - Admins will no longer get kicked over out of sync data regarding cargo bounties in their tools.