### PR TITLE
Adds stun immunity to armor

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/Armor/ArmorVests/WardensArmoredJacket.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/Armor/ArmorVests/WardensArmoredJacket.prefab
@@ -54,6 +54,11 @@ PrefabInstance:
       propertyPath: armoredBodyParts.Array.data[0].armor.Bullet
       value: 40
       objectReference: {fileID: 0}
+    - target: {fileID: 5480096206054138487, guid: 259354123db311145a0ccc3922005d0f,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.StunImmunity
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8076471909809007804, guid: 259354123db311145a0ccc3922005d0f,
         type: 3}
       propertyPath: m_AssetId

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/Armor/ArmoredGreatcoat.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/Armor/ArmoredGreatcoat.prefab
@@ -204,6 +204,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 855803449108065293, guid: e606c25f8104ffa4e94b68151182a216,
         type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.StunImmunity
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 855803449108065293, guid: e606c25f8104ffa4e94b68151182a216,
+        type: 3}
       propertyPath: armoredBodyParts.Array.data[1].armoringBodyPartType
       value: 3
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/SpaceSuits/Hardsuits/ERTHardsuits/ERTSecurityHardsuit.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/SpaceSuits/Hardsuits/ERTHardsuits/ERTSecurityHardsuit.prefab
@@ -7,6 +7,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1382959582050582858, guid: 05f59888eb108484aabd67b53074c7a6,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.StunImmunity
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 2905032154871127383, guid: 05f59888eb108484aabd67b53074c7a6,
         type: 3}
       propertyPath: initialName

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/SpaceSuits/Hardsuits/ERTHardsuits/InquisitorsHardsuit.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/SpaceSuits/Hardsuits/ERTHardsuits/InquisitorsHardsuit.prefab
@@ -37,6 +37,11 @@ PrefabInstance:
       propertyPath: armoredBodyParts.Array.data[5].armor.Magic
       value: 30
       objectReference: {fileID: 0}
+    - target: {fileID: 145137995162664296, guid: 12c1799d210b6b444a768fd61642f614,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.StunImmunity
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4134971925973852533, guid: 12c1799d210b6b444a768fd61642f614,
         type: 3}
       propertyPath: initialName

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/SpaceSuits/Hardsuits/EliteSyndicateHardsuit.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/SpaceSuits/Hardsuits/EliteSyndicateHardsuit.prefab
@@ -382,6 +382,11 @@ PrefabInstance:
       propertyPath: armoredBodyParts.Array.data[5].armor.Energy
       value: 60
       objectReference: {fileID: 0}
+    - target: {fileID: 4278487051228794417, guid: eec487290ececeb4db71bab916465099,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.StunImmunity
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6028708010380084937, guid: eec487290ececeb4db71bab916465099,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/SpaceSuits/Hardsuits/HeadOfSecuritysHardsuit.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/SpaceSuits/Hardsuits/HeadOfSecuritysHardsuit.prefab
@@ -167,6 +167,11 @@ PrefabInstance:
       propertyPath: armoredBodyParts.Array.data[5].armor.Energy
       value: 40
       objectReference: {fileID: 0}
+    - target: {fileID: 756736423731080748, guid: 57ebbb1ff3ac5d6478cafc0e84d81f3b,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.StunImmunity
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3594306772352922161, guid: 57ebbb1ff3ac5d6478cafc0e84d81f3b,
         type: 3}
       propertyPath: initialName

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/SpaceSuits/Hardsuits/SecurityHardsuit.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/SpaceSuits/Hardsuits/SecurityHardsuit.prefab
@@ -214,6 +214,11 @@ PrefabInstance:
       propertyPath: armoredBodyParts.Array.data[5].armor.Energy
       value: 40
       objectReference: {fileID: 0}
+    - target: {fileID: 4992377332610353592, guid: 5da2eb22d55c9c045bd7c22925c9b948,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.StunImmunity
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 8702110326122445511, guid: 5da2eb22d55c9c045bd7c22925c9b948,
         type: 3}
       propertyPath: m_Name

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/SpaceSuits/Hardsuits/SyndicateHardsuit.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/SpaceSuits/Hardsuits/SyndicateHardsuit.prefab
@@ -267,6 +267,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4992377332610353592, guid: 5da2eb22d55c9c045bd7c22925c9b948,
         type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.StunImmunity
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4992377332610353592, guid: 5da2eb22d55c9c045bd7c22925c9b948,
+        type: 3}
       propertyPath: armoredBodyParts.Array.data[0].armor.DismembermentProtectionChance
       value: 70
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Uniforms/Kilt.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Uniforms/Kilt.prefab
@@ -155,6 +155,11 @@ PrefabInstance:
       propertyPath: armoredBodyParts.Array.data[0].armor.Bullet
       value: 100
       objectReference: {fileID: 0}
+    - target: {fileID: 8215174308799955191, guid: de234d793cfd842599c9c8726207f217,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.StunImmunity
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: de234d793cfd842599c9c8726207f217, type: 3}
 --- !u!1 &3011710637427380133 stripped

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Uniforms/Kilt.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Uniforms/Kilt.prefab
@@ -140,6 +140,11 @@ PrefabInstance:
       propertyPath: bodyPartsCovered
       value: 144
       objectReference: {fileID: 0}
+    - target: {fileID: 8215174308799955191, guid: de234d793cfd842599c9c8726207f217,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.Bomb
+      value: 75
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: de234d793cfd842599c9c8726207f217, type: 3}
 --- !u!1 &3011710637427380133 stripped

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Uniforms/Kilt.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Uniforms/Kilt.prefab
@@ -145,6 +145,16 @@ PrefabInstance:
       propertyPath: armoredBodyParts.Array.data[0].armor.Bomb
       value: 75
       objectReference: {fileID: 0}
+    - target: {fileID: 8215174308799955191, guid: de234d793cfd842599c9c8726207f217,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.Fire
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 8215174308799955191, guid: de234d793cfd842599c9c8726207f217,
+        type: 3}
+      propertyPath: armoredBodyParts.Array.data[0].armor.Bullet
+      value: 100
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: de234d793cfd842599c9c8726207f217, type: 3}
 --- !u!1 &3011710637427380133 stripped

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/Energy/TaserV42.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/Energy/TaserV42.prefab
@@ -358,10 +358,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1be952724c3641bf965e9f9f6ba63ec5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Tip:
-    Tip: You can change a taser's firemode by activating them with Z or clicking
-      them.
-    TipIcon: {fileID: 21300000, guid: 8110b00796501a14c8c950df5556ab94, type: 3}
-    ShowAnimation: 1
-    MinimumExperienceLevelToTrigger: 0
-    ShowDuration: 25
+  TipSO: {fileID: 11400000, guid: b86b005353accc140808a2ec427f78fa, type: 2}
+  saveID: 0
+  triggerOnce: 1
+  showEvenAfterDeath: 0
+  tipCooldown: 200

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_Electrode.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_Electrode.prefab
@@ -7,6 +7,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 405957635251688022, guid: 33dfe2b5f12db3a43af6d409a2b599e5,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 00552b9802a37ba4bbe1aca46515b240
+      objectReference: {fileID: 0}
     - target: {fileID: 1365721336191138629, guid: 33dfe2b5f12db3a43af6d409a2b599e5,
         type: 3}
       propertyPath: doMsg
@@ -21,6 +26,11 @@ PrefabInstance:
         type: 3}
       propertyPath: willDisarm
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1365721336191138629, guid: 33dfe2b5f12db3a43af6d409a2b599e5,
+        type: 3}
+      propertyPath: stunProtectionRequiredToFail
+      value: 35
       objectReference: {fileID: 0}
     - target: {fileID: 1496159902752428983, guid: 33dfe2b5f12db3a43af6d409a2b599e5,
         type: 3}

--- a/UnityProject/Assets/Scripts/Health/Objects/Armor.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Armor.cs
@@ -27,6 +27,8 @@ public class Armor
 
 	[Range(0,100)] public int DismembermentProtectionChance;
 
+	public bool StunImmunity = false;
+
 	/// <summary>
 	/// Calculates how much damage would be done based on armor resistance and armor penetration.
 	/// </summary>

--- a/UnityProject/Assets/Scripts/Items/Weapons/Projectiles/Behaviours/ProjectileStun.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Projectiles/Behaviours/ProjectileStun.cs
@@ -11,8 +11,8 @@ namespace Weapons.Projectiles.Behaviours
 		[Tooltip("How long the player hit by this will be stunned")]
 		[SerializeField] private float stunTime = 4.0f;
 
-		[Tooltip("if this number is less than the total number of armor on the player's bodyparts.. stun them.")]
-		[SerializeField] private float stunProtectionRequiredToFail = 35f;
+		[Tooltip("Do you want to ignore armor stun immunity?")]
+		[SerializeField] private bool passThroughStunImmunity = true;
 
 		[Tooltip("Will this stun disarm.")]
 		[SerializeField] private bool willDisarm = true;
@@ -39,7 +39,7 @@ namespace Weapons.Projectiles.Behaviours
 			var player = coll.GetComponent<RegisterPlayer>();
 			if (player == null) return false;
 
-			player.ServerStun(stunTime, willDisarm, true, stunProtectionRequiredToFail);
+			player.ServerStun(stunTime, willDisarm, passThroughStunImmunity);
 
 			if (doMsg)
 			{

--- a/UnityProject/Assets/Scripts/Items/Weapons/Projectiles/Behaviours/ProjectileStun.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Projectiles/Behaviours/ProjectileStun.cs
@@ -11,6 +11,9 @@ namespace Weapons.Projectiles.Behaviours
 		[Tooltip("How long the player hit by this will be stunned")]
 		[SerializeField] private float stunTime = 4.0f;
 
+		[Tooltip("if this number is less than the total number of armor on the player's bodyparts.. stun them.")]
+		[SerializeField] private float stunProtectionRequiredToFail = 35f;
+
 		[Tooltip("Will this stun disarm.")]
 		[SerializeField] private bool willDisarm = true;
 
@@ -36,7 +39,7 @@ namespace Weapons.Projectiles.Behaviours
 			var player = coll.GetComponent<RegisterPlayer>();
 			if (player == null) return false;
 
-			player.ServerStun(stunTime, willDisarm);
+			player.ServerStun(stunTime, willDisarm, true, stunProtectionRequiredToFail);
 
 			if (doMsg)
 			{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
@@ -280,8 +280,18 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 	/// <param name="stunDuration">Time before the stun is removed.</param>
 	/// <param name="dropItem">If items in the hand slots should be dropped on stun.</param>
 	[Server]
-	public void ServerStun(float stunDuration = 4f, bool dropItem = true)
+	public void ServerStun(float stunDuration = 4f, bool dropItem = true, bool checkForArmor = true, float armorFailValue = 50f)
 	{
+		bool CheckArmorCanStun()
+		{
+			var stunNumbers = 0f;
+			foreach (var bodyPart in PlayerScript.playerHealth.SurfaceBodyParts)
+			{
+				stunNumbers += bodyPart.SelfArmor.Energy + bodyPart.SelfArmor.Bomb;
+			}
+			return (stunNumbers > armorFailValue);
+		}
+		if(checkForArmor && CheckArmorCanStun()) return;
 		var oldVal = IsSlippingServer;
 		IsSlippingServer = true;
 		ServerCheckStandingChange( true);


### PR DESCRIPTION
closes #4364

When stunning a player, the game will now check how much armor (Bomb and/or energy) does the player have and if it's greater than a set amount (default is 50) then the player wont get stunned.

### Changelog:
CL: [New] - Armors now have a parameter to prevent stuns.
CL: [Improvement] - Highlanders have full stun immunity on their kilts now, you can no longer cheese fights with stuns anymore.
CL: [Improvement] - Highlanders have full bullet immunity now and strong resistance to bombs.
CL: [Fix] - Fixes unity un-referencing a ProTip on tasers.