### PR TITLE
Allows chain triggering of explosions again

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Weapons/ExplosiveBase.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/ExplosiveBase.cs
@@ -122,7 +122,7 @@ namespace Items.Weapons
 			void Hack()
 			{
 				emitters.Add(emitter);
-				emitter.Frequency = Frequency;
+				Frequency = emitter.Frequency;
 				Chat.AddLocalMsgToChat($"The {gameObject.ExpensiveName()} copies {emitter.gameObject.ExpensiveName()}'s " +
 				                       $"codes from {interaction.PerformerPlayerScript.visibleName}'s hands!", interaction.Performer);
 			}


### PR DESCRIPTION
Part of #6149

Allows players to trigger multiple explosions at once again.

### Changelog:

CL : [Fix] - Fixed issue with signal emitters and explosive devices that didn't allow them to be chain triggered all at once.
