### PR TITLE
feat: new status effect manager

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/Statuses.meta
+++ b/UnityProject/Assets/ScriptableObjects/Statuses.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8d16711075fbe1b49a33a1c87b341e04
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Statuses/Convulsing.asset
+++ b/UnityProject/Assets/ScriptableObjects/Statuses/Convulsing.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f917298cb8b4b5187cef9e30f457d77, type: 3}
+  m_Name: Convulsing
+  m_EditorClassIdentifier: 
+  duration: 20
+  initialStacks: 1

--- a/UnityProject/Assets/ScriptableObjects/Statuses/Convulsing.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Statuses/Convulsing.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7c57d67ca22c5694e88b9c2aa85e9fc6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Player/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerScript.cs
@@ -7,6 +7,7 @@ using Player;
 using Player.Movement;
 using UI.Action;
 using Items;
+using Systems.StatusesAndEffects;
 
 public class PlayerScript : NetworkBehaviour, IMatrixRotation, IAdminInfo, IActionGUI
 {
@@ -61,6 +62,8 @@ public class PlayerScript : NetworkBehaviour, IMatrixRotation, IAdminInfo, IActi
 	public MouseInputController mouseInputController { get; set; }
 
 	public ChatIcon chatIcon { get; private set; }
+
+	public StatusEffectManager statusEffectManager { get; private set; }
 
 	/// <summary>
 	/// Serverside world position.
@@ -145,6 +148,7 @@ public class PlayerScript : NetworkBehaviour, IMatrixRotation, IAdminInfo, IActi
 		PlayerOnlySyncValues = GetComponent<PlayerOnlySyncValues>();
 		playerCrafting = GetComponent<PlayerCrafting>();
 		PlayerSync = GetComponent<PlayerSync>();
+		statusEffectManager = GetComponent<StatusEffectManager>();
 	}
 
 	public override void OnStartClient()

--- a/UnityProject/Assets/Scripts/Systems/StatusesAndEffects.meta
+++ b/UnityProject/Assets/Scripts/Systems/StatusesAndEffects.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c1d80a17dc3246e392e3d36c31317cdc
+timeCreated: 1653191182

--- a/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Implementations.meta
+++ b/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Implementations.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 37cf21c4725543f085e2e0b11139ff45
+timeCreated: 1653191914

--- a/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Implementations/Convulsing.cs
+++ b/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Implementations/Convulsing.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using Core.Chat;
+using Systems.StatusesAndEffects.Interfaces;
+using UnityEngine;
+using Random = UnityEngine.Random;
+
+
+namespace Systems.StatusesAndEffects.Implementations
+{
+	[CreateAssetMenu(fileName = "Convulsing", menuName = "ScriptableObjects/StatusEffects/Convulsing")]
+	public class Convulsing: StatusEffect, IStackableStatus, IExpirableStatus
+	{
+		private const int MAX_STACKS = 5;
+		private const int BASE_PROC_CHANCE = 20;
+		[SerializeField] private Vector2 triggerTimeRange = new(5f, 10f);
+		public float duration = 20f;
+
+		public event Action<IExpirableStatus> Expired;
+		public float Duration => duration;
+		public int InitialStacks { get; set; } = 1;
+		public int Stacks { get; set; }
+		public DateTime DeathTime { get; set; }
+
+		private int actualProcChance;
+		private DateTime nextTriggerTime;
+		private float Timer => Random.Range(triggerTimeRange.x, triggerTimeRange.y);
+
+		public override void OnAdded()
+		{
+			Stacks = InitialStacks;
+			actualProcChance = BASE_PROC_CHANCE;
+			nextTriggerTime = DateTime.Now.AddSeconds(Timer);
+			DeathTime = DateTime.Now.AddSeconds(duration);
+			UpdateManager.Add(Trigger, 1f);
+			UpdateManager.Add(CheckExpiration, 1f);
+		}
+
+		public override void OnRemoved()
+		{
+			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, Trigger);
+			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, CheckExpiration);
+		}
+
+		public void AddStack(int amount)
+		{
+			Stacks = Mathf.Clamp(Stacks + amount, 0, MAX_STACKS);
+			actualProcChance = BASE_PROC_CHANCE * Stacks;
+		}
+
+		public void RemoveStack(int amount)
+		{
+			Stacks -= amount;
+			actualProcChance = BASE_PROC_CHANCE * Stacks;
+		}
+
+
+		private void DropItemFromHands(NamedSlot namedSlot, PlayerScript player)
+		{
+			foreach (var slot in player.DynamicItemStorage.GetNamedItemSlots(namedSlot))
+			{
+				var item = slot.Item;
+				if (item != null)
+				{
+					Chat.AddActionMsgToChat(
+						target,
+						$"You convulse violently, and you drop {item.gameObject.ExpensiveName()}!",
+						$"{target.ExpensiveName()} convulses, and they drop their {item.gameObject.ExpensiveName()}!");
+				}
+				else
+				{
+					Chat.AddActionMsgToChat(
+						target,
+						$"You convulse violently!",
+						$"{target.ExpensiveName()} convulses!");
+				}
+				Inventory.ServerDrop(slot);
+			}
+		}
+
+
+		public override void DoEffect()
+		{
+			if (target.TryGetComponent<PlayerScript>(out var player) == false)
+			{
+				return;
+			}
+
+			if (DMMath.Prob(actualProcChance))
+			{
+				DropItemFromHands(NamedSlot.leftHand, player);
+				DropItemFromHands(NamedSlot.rightHand, player);
+			}
+			else
+			{
+				Chat.AddActionMsgToChat(
+					target,
+					"You convulse, but you maintain your composure!",
+					$"{target.ExpensiveName()} convulses!");
+			}
+
+			EmoteActionManager.DoEmote("twitch", target, Chat.Instance.emoteActionManager);
+		}
+
+		private void Trigger()
+		{
+			if (DateTime.Now < nextTriggerTime) return;
+			nextTriggerTime = DateTime.Now.AddSeconds(Timer);
+			DoEffect();
+		}
+
+		public void CheckExpiration()
+		{
+			if (DateTime.Now > DeathTime)
+			{
+				Expired?.Invoke(this);
+			}
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Implementations/Convulsing.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Implementations/Convulsing.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7f917298cb8b4b5187cef9e30f457d77
+timeCreated: 1653192644

--- a/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Interfaces.meta
+++ b/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Interfaces.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3a50f3f94df24d2d982d2cce5c8275fa
+timeCreated: 1653192253

--- a/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Interfaces/IExpirableStatus.cs
+++ b/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Interfaces/IExpirableStatus.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace Systems.StatusesAndEffects.Interfaces
+{
+	public interface IExpirableStatus
+	{
+		/// <summary>
+		/// Invoke this method in your implementation of CheckExpiration when the status should expire.
+		/// </summary>
+		event Action<IExpirableStatus> Expired;
+
+		/// <summary>
+		/// How much time should this status last before expiration.
+		/// </summary>
+		float Duration { get; }
+
+		/// <summary>
+		/// When should this status expire? If OnAdded isn't overriden in your implementation, this will automatically
+		/// be set to the current time + Duration.
+		/// </summary>
+		DateTime DeathTime { get; set; }
+
+		void OnAdded()
+		{
+			DeathTime = DateTime.Now.AddSeconds(Duration);
+			UpdateManager.Add(CheckExpiration, 1);
+		}
+
+		void OnRemoved()
+		{
+			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, CheckExpiration);
+		}
+
+		/// <summary>
+		/// Implements the behaviour to check if this status has expired.
+		/// If OnAdded and OnRemoved aren't overriden, this method will be automatically added to update manager
+		/// You will have to add it otherwise.
+		/// </summary>
+		void CheckExpiration(); //it isn't possible to invoke the event from the interface, sadly.
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Interfaces/IExpirableStatus.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Interfaces/IExpirableStatus.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ae0f7985befa449781617027b6e8fcb5
+timeCreated: 1653196690

--- a/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Interfaces/IImmediateEffect.cs
+++ b/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Interfaces/IImmediateEffect.cs
@@ -1,0 +1,7 @@
+﻿namespace Systems.StatusesAndEffects.Interfaces
+{
+	public interface IImmediateEffect
+	{
+
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Interfaces/IImmediateEffect.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Interfaces/IImmediateEffect.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7b52f01442e34791b5c624bbc9306026
+timeCreated: 1653353619

--- a/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Interfaces/IStackableStatus.cs
+++ b/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Interfaces/IStackableStatus.cs
@@ -1,0 +1,32 @@
+﻿namespace Systems.StatusesAndEffects.Interfaces
+{
+	public interface IStackableStatus
+	{
+		/// <summary>
+		/// Initial amount of stacks for this stackable status. If added and there is a previous existing stack, it
+		/// will be added to the existing stack.
+		/// </summary>
+		public int InitialStacks { get; set; }
+
+		/// <summary>
+		/// Amount of stacks this status has.
+		/// </summary>
+		int Stacks { get; set; }
+
+		/// <summary>
+		/// This is what the manager calls when adding stacks to an active status
+		/// </summary>
+		void AddStack(int amount)
+		{
+			Stacks += amount;
+		}
+
+		/// <summary>
+		/// This is what the manager calls when removing stacks to an active status
+		/// </summary>
+		void RemoveStack(int amount)
+		{
+			Stacks -= amount;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Interfaces/IStackableStatus.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Interfaces/IStackableStatus.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b9f0579d4ccd4029ac859647b0cb3ce1
+timeCreated: 1653192271

--- a/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/StatusEffect.cs
+++ b/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/StatusEffect.cs
@@ -1,0 +1,40 @@
+using UnityEngine;
+
+namespace Systems.StatusesAndEffects
+{
+	public abstract class StatusEffect: ScriptableObject
+	{
+		protected GameObject target;
+
+		public void Initialize(GameObject go)
+		{
+			target = go;
+			OnAdded();
+		}
+
+		/// <summary>
+		/// What should happen when this status is added to a manager.
+		/// </summary>
+		public virtual void OnAdded() {}
+
+		/// <summary>
+		/// What should ahppen when this status is removed from the manager
+		/// </summary>
+		public virtual void OnRemoved() {}
+
+		/// <summary>
+		/// What should happen when this status does its effect.
+		/// </summary>
+		public virtual void DoEffect() {}
+
+		public override bool Equals(object other)
+		{
+			return other != null && other.GetHashCode() == GetHashCode();
+		}
+
+		public override int GetHashCode()
+		{
+			return name.GetHashCode();
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/StatusEffect.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/StatusEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e5dda59b7c5c419458c2608126f797ac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/StatusEffectManager.cs
+++ b/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/StatusEffectManager.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using Systems.StatusesAndEffects.Interfaces;
+using UnityEngine;
+
+namespace Systems.StatusesAndEffects
+{
+	public class StatusEffectManager : MonoBehaviour
+	{
+		public HashSet<StatusEffect> Statuses { get; } = new();
+
+		public void AddStatus(StatusEffect status)
+		{
+			HandleExpirableStatusAddition(status);
+			HandleStackableStatusAddition(status);
+			HandleImmediateStatusAddition(status);
+
+			if (HasStatus(status)) return;
+			status.Initialize(gameObject);
+			Statuses.Add(status);
+		}
+
+		private void HandleExpirableStatusAddition(StatusEffect status)
+		{
+			if (status is IExpirableStatus expirable)
+			{
+				expirable.Expired += OnExpiredStatus;
+			}
+		}
+
+		private void HandleStackableStatusAddition(StatusEffect status)
+		{
+			if (status is not IStackableStatus newStackable) return;
+			if (Statuses.TryGetValue(status, out var oldStatus))
+			{
+				if (oldStatus is IStackableStatus oldStackable)
+				{
+					oldStackable.AddStack(newStackable.InitialStacks);
+				}
+			}
+			else
+			{
+				newStackable.AddStack(newStackable.InitialStacks);
+			}
+		}
+
+		private void HandleImmediateStatusAddition(StatusEffect status)
+		{
+			if (status is not IImmediateEffect) return;
+			status.DoEffect();
+		}
+
+		public void RemoveStatus(StatusEffect status)
+		{
+			status.OnRemoved();
+			Statuses.Remove(status);
+		}
+
+		private void OnExpiredStatus(IExpirableStatus expirable)
+		{
+			void RemoveExpiredStatus()
+			{
+				if (expirable is StatusEffect status) RemoveStatus(status);
+			}
+
+			if (expirable is IStackableStatus stackable)
+			{
+				stackable.RemoveStack(1);
+				if (stackable.Stacks > 0) return;
+			}
+
+			RemoveExpiredStatus();
+		}
+
+		public bool HasStatus(StatusEffect status)
+		{
+			return Statuses.Contains(status);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/StatusEffectManager.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/StatusEffectManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 30e9b773a824f6c4880afa8950869c4c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Tests/StatusAndEffectsFramework.meta
+++ b/UnityProject/Assets/Tests/StatusAndEffectsFramework.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b5d66e5b5fc74336aeed5a612c544f3d
+timeCreated: 1653350217

--- a/UnityProject/Assets/Tests/StatusAndEffectsFramework/MockStatuses.cs
+++ b/UnityProject/Assets/Tests/StatusAndEffectsFramework/MockStatuses.cs
@@ -1,0 +1,37 @@
+﻿using Systems.StatusesAndEffects;
+using Systems.StatusesAndEffects.Interfaces;
+
+namespace Tests.StatusAndEffectsFramework
+{
+	public class MockStatus : StatusEffect
+	{
+
+	}
+
+	public class ImmediateStatusEffect : StatusEffect, IImmediateEffect
+	{
+		public bool DidEffect { get; private set; } = false;
+
+		public override void DoEffect()
+		{
+			DidEffect = true;
+		}
+	}
+
+	public class StackableStatusEffect: StatusEffect, IStackableStatus
+	{
+		public int InitialStacks { get; set; } = 1;
+		public int Stacks { get; set; }
+
+		public void AddStack(int amount)
+		{
+			Stacks += amount;
+		}
+
+		public void RemoveStack(int amount)
+		{
+			Stacks -= amount;
+		}
+	}
+
+}

--- a/UnityProject/Assets/Tests/StatusAndEffectsFramework/MockStatuses.cs.meta
+++ b/UnityProject/Assets/Tests/StatusAndEffectsFramework/MockStatuses.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: beb8e0ab788949e7b42d34e0ab3f2ebe
+timeCreated: 1653350464

--- a/UnityProject/Assets/Tests/StatusAndEffectsFramework/StatusEffectManagerTest.cs
+++ b/UnityProject/Assets/Tests/StatusAndEffectsFramework/StatusEffectManagerTest.cs
@@ -1,0 +1,87 @@
+﻿using NUnit.Framework;
+using Systems.StatusesAndEffects;
+using UnityEngine;
+
+namespace Tests.StatusAndEffectsFramework
+{
+
+	public class StatusEffectManagerTest
+	{
+		private StatusEffectManager manager;
+
+		[SetUp]
+		public void Setup()
+		{
+			var mockEntity = new GameObject();
+			manager = mockEntity.AddComponent<StatusEffectManager>();
+		}
+
+		[Test]
+		public void WhenAddingAnewStatusToManagerStatusIsAdded()
+		{
+			var basicStatus = ScriptableObject.CreateInstance<MockStatus>();
+			manager.AddStatus(basicStatus);
+			Assert.True(manager.HasStatus(basicStatus));
+			Assert.AreEqual(1, manager.Statuses.Count);
+		}
+
+		[Test]
+		public void WhenAddingExistingStatusToManagerNewStatusIsNotAdded()
+		{
+			var basicStatus = ScriptableObject.CreateInstance<MockStatus>();
+			manager.AddStatus(basicStatus);
+			manager.AddStatus(basicStatus);
+			Assert.True(manager.HasStatus(basicStatus));
+			Assert.AreEqual(1, manager.Statuses.Count);
+		}
+
+		[Test]
+		public void WhenAddingExistingStatusFromDifferentSourcesOnlyFirstIsAdded()
+		{
+			var basicStatus = ScriptableObject.CreateInstance<MockStatus>();
+			var basicStatus2 = ScriptableObject.CreateInstance<MockStatus>();
+			basicStatus.name = "basicStatus"; // in game, name property is populated by file name of the scriptable object.
+			basicStatus2.name = "basicStatus";
+			manager.AddStatus(basicStatus);
+			manager.AddStatus(basicStatus2);
+			Assert.True(manager.HasStatus(basicStatus));
+			Assert.True(manager.HasStatus(basicStatus2));
+			Assert.AreEqual(1, manager.Statuses.Count);
+		}
+
+		[Test]
+		public void WhenAddingDifferentStatusesBothAreAdded()
+		{
+			var basicStatus = ScriptableObject.CreateInstance<MockStatus>();
+			var basicStatus2 = ScriptableObject.CreateInstance<MockStatus>();
+			basicStatus.name = "basicStatus";
+			basicStatus2.name = "basicStatus2";
+			manager.AddStatus(basicStatus);
+			manager.AddStatus(basicStatus2);
+			Assert.True(manager.HasStatus(basicStatus));
+			Assert.True(manager.HasStatus(basicStatus2));
+			Assert.AreEqual(2, manager.Statuses.Count);
+		}
+
+		[Test]
+		public void WhenAddingImmediateStatusEffectIsImmediate()
+		{
+			var immediate = ScriptableObject.CreateInstance<ImmediateStatusEffect>();
+			manager.AddStatus(immediate);
+			Assert.True(manager.HasStatus(immediate));
+			Assert.True(immediate.DidEffect);
+		}
+
+		[Test]
+		public void WhenAddingStackableToAlreadyExistingEffectStackIsIncremented()
+		{
+			var stackable = ScriptableObject.CreateInstance<StackableStatusEffect>();
+			manager.AddStatus(stackable);
+			Assert.True(manager.HasStatus(stackable));
+			Assert.AreEqual(1, stackable.Stacks);
+			manager.AddStatus(stackable);
+			Assert.AreEqual(2, stackable.Stacks);
+		}
+
+	}
+}

--- a/UnityProject/Assets/Tests/StatusAndEffectsFramework/StatusEffectManagerTest.cs.meta
+++ b/UnityProject/Assets/Tests/StatusAndEffectsFramework/StatusEffectManagerTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 28561b9eb57e4a21b5d8f9dbcdca69f6
+timeCreated: 1653350253


### PR DESCRIPTION
### Purpose
The Status Effect Manager is a little component that exposes an interface to add and handle effects on players (and maybe other stuff later?). 

StatusEffects are scriptable objects that can be composed using the StatusEffect interfaces such as ``IExpirableStatusEffect``. The manager knows this composition and acts accordingly.

As a proof of concept, the convulsing effect has been added and is triggered by electrocution.

### Notes:
Known issues:
- The convulsing effect triggers action text and the twitching emote. Problem is twitching emote also adds action text and they both overlap instead of queueing.
- The process to use EmoteActionManager is convoluted.
- Haven't tested triggering the emote over the network.

### Changelog:
CL:[New] Added convulsing status effect when electrocuted.
