### PR TITLE
Fix NetworkManagerTests

### DIFF
--- a/UnityProject/Assets/Tests/Asset/NetworkManagerTests.cs
+++ b/UnityProject/Assets/Tests/Asset/NetworkManagerTests.cs
@@ -44,9 +44,12 @@ namespace Tests.Asset
 				storedIDs[prefabTracker.ForeverID] = prefabTracker;
 			}
 
-			report.FailIfNot(networkManager!.TryGetComponent<SpawnListMonitor>(out var spawnListMonitor))
-				.AppendLine($"{nameof(CustomNetworkManager)} does not contain a {nameof(SpawnListMonitor)}!")
-				.AssertPassed();
+			if (networkManager!.TryGetComponent<SpawnListMonitor>(out var spawnListMonitor) == false)
+			{
+				report.Fail()
+					.AppendLine($"{nameof(CustomNetworkManager)} does not contain a {nameof(SpawnListMonitor)}!")
+					.AssertPassed();
+			}
 
 			if (spawnListMonitor.GenerateSpawnList())
 			{


### PR DESCRIPTION
Prefabs should now actually be added to the NetworkManager prefab if they aren't in it. Accidentally asserted after checking for the SpawnListMonitor which caused the test to bail out before the generator ran.