### PR TITLE
Takes Caverna's base layer out of objects

### DIFF
--- a/UnityProject/Assets/Scenes/AwaySites/Caverna.unity
+++ b/UnityProject/Assets/Scenes/AwaySites/Caverna.unity
@@ -134,7 +134,7 @@ PrefabInstance:
     - target: {fileID: 7371814641826451810, guid: 2f8cb9998dfedc044ae5b62918037b96,
         type: 3}
       propertyPath: m_RootOrder
-      value: 105
+      value: 104
       objectReference: {fileID: 0}
     - target: {fileID: 7371814641826451810, guid: 2f8cb9998dfedc044ae5b62918037b96,
         type: 3}
@@ -219,7 +219,7 @@ PrefabInstance:
     - target: {fileID: 315272389688970755, guid: 9ebdd8fb093d8434db3fe4a38f8100c6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 84
+      value: 83
       objectReference: {fileID: 0}
     - target: {fileID: 315272389688970755, guid: 9ebdd8fb093d8434db3fe4a38f8100c6,
         type: 3}
@@ -309,7 +309,7 @@ PrefabInstance:
     - target: {fileID: 7026721227541041631, guid: 6dad1248a16ebbd48a81433d413e37ec,
         type: 3}
       propertyPath: m_RootOrder
-      value: 60
+      value: 59
       objectReference: {fileID: 0}
     - target: {fileID: 7026721227541041631, guid: 6dad1248a16ebbd48a81433d413e37ec,
         type: 3}
@@ -822,7 +822,7 @@ PrefabInstance:
     - target: {fileID: 8080698523358435093, guid: 30c1980ca0250624a893b6e4f398f2a9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 98
+      value: 97
       objectReference: {fileID: 0}
     - target: {fileID: 8080698523358435093, guid: 30c1980ca0250624a893b6e4f398f2a9,
         type: 3}
@@ -930,7 +930,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4973277796872332647}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &472897716
 MonoBehaviour:
@@ -1224,7 +1224,7 @@ PrefabInstance:
     - target: {fileID: 6443293881846660846, guid: db34b9991c6517848999bc6bfe8ba25d,
         type: 3}
       propertyPath: m_RootOrder
-      value: 100
+      value: 99
       objectReference: {fileID: 0}
     - target: {fileID: 6443293881846660846, guid: db34b9991c6517848999bc6bfe8ba25d,
         type: 3}
@@ -1309,7 +1309,7 @@ PrefabInstance:
     - target: {fileID: 3783067603822704685, guid: 4325ff5e8c92fee47b53476d3cd97788,
         type: 3}
       propertyPath: m_RootOrder
-      value: 106
+      value: 105
       objectReference: {fileID: 0}
     - target: {fileID: 3783067603822704685, guid: 4325ff5e8c92fee47b53476d3cd97788,
         type: 3}
@@ -1484,7 +1484,7 @@ PrefabInstance:
     - target: {fileID: 7371814641826451810, guid: 2f8cb9998dfedc044ae5b62918037b96,
         type: 3}
       propertyPath: m_RootOrder
-      value: 107
+      value: 106
       objectReference: {fileID: 0}
     - target: {fileID: 7371814641826451810, guid: 2f8cb9998dfedc044ae5b62918037b96,
         type: 3}
@@ -1726,6 +1726,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1846403220085434226, guid: 397461e981e81df4c8983f127dbabae6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.00000014901144
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 397461e981e81df4c8983f127dbabae6, type: 3}
 --- !u!4 &784494305 stripped
@@ -1818,7 +1823,7 @@ PrefabInstance:
     - target: {fileID: 1002719256847154502, guid: 2a39aefa5aa903240b20a8b5a5185fbf,
         type: 3}
       propertyPath: m_RootOrder
-      value: 59
+      value: 58
       objectReference: {fileID: 0}
     - target: {fileID: 1002719256847154502, guid: 2a39aefa5aa903240b20a8b5a5185fbf,
         type: 3}
@@ -1908,7 +1913,7 @@ PrefabInstance:
     - target: {fileID: 1002719256847154502, guid: 2a39aefa5aa903240b20a8b5a5185fbf,
         type: 3}
       propertyPath: m_RootOrder
-      value: 58
+      value: 57
       objectReference: {fileID: 0}
     - target: {fileID: 1002719256847154502, guid: 2a39aefa5aa903240b20a8b5a5185fbf,
         type: 3}
@@ -1998,7 +2003,7 @@ PrefabInstance:
     - target: {fileID: 6371202620035631115, guid: 81e1dcfb97892054295d23cfd69c5542,
         type: 3}
       propertyPath: m_RootOrder
-      value: 101
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 6371202620035631115, guid: 81e1dcfb97892054295d23cfd69c5542,
         type: 3}
@@ -2133,7 +2138,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 90
+      value: 89
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -2213,7 +2218,7 @@ PrefabInstance:
     - target: {fileID: 315272389688970755, guid: 9ebdd8fb093d8434db3fe4a38f8100c6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 53
+      value: 52
       objectReference: {fileID: 0}
     - target: {fileID: 315272389688970755, guid: 9ebdd8fb093d8434db3fe4a38f8100c6,
         type: 3}
@@ -2473,7 +2478,7 @@ PrefabInstance:
     - target: {fileID: 7026721227541041631, guid: 6dad1248a16ebbd48a81433d413e37ec,
         type: 3}
       propertyPath: m_RootOrder
-      value: 61
+      value: 60
       objectReference: {fileID: 0}
     - target: {fileID: 7026721227541041631, guid: 6dad1248a16ebbd48a81433d413e37ec,
         type: 3}
@@ -2568,7 +2573,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 109
+      value: 108
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -2663,7 +2668,7 @@ PrefabInstance:
     - target: {fileID: 3541449163993279649, guid: abe9c13902b62ce449fdfec99db8f554,
         type: 3}
       propertyPath: m_RootOrder
-      value: 62
+      value: 61
       objectReference: {fileID: 0}
     - target: {fileID: 3541449163993279649, guid: abe9c13902b62ce449fdfec99db8f554,
         type: 3}
@@ -2738,7 +2743,7 @@ PrefabInstance:
     - target: {fileID: 3783067603822704685, guid: 4325ff5e8c92fee47b53476d3cd97788,
         type: 3}
       propertyPath: m_RootOrder
-      value: 108
+      value: 107
       objectReference: {fileID: 0}
     - target: {fileID: 3783067603822704685, guid: 4325ff5e8c92fee47b53476d3cd97788,
         type: 3}
@@ -2831,7 +2836,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 114
+      value: 113
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -2914,7 +2919,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 91
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -3084,7 +3089,7 @@ PrefabInstance:
     - target: {fileID: 3541449163993279649, guid: abe9c13902b62ce449fdfec99db8f554,
         type: 3}
       propertyPath: m_RootOrder
-      value: 83
+      value: 82
       objectReference: {fileID: 0}
     - target: {fileID: 3541449163993279649, guid: abe9c13902b62ce449fdfec99db8f554,
         type: 3}
@@ -3164,7 +3169,7 @@ PrefabInstance:
     - target: {fileID: 8305882254983888476, guid: f5de2b6011113f0469b27cd8289f2d8b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 110
+      value: 109
       objectReference: {fileID: 0}
     - target: {fileID: 8305882254983888476, guid: f5de2b6011113f0469b27cd8289f2d8b,
         type: 3}
@@ -3244,7 +3249,7 @@ PrefabInstance:
     - target: {fileID: 9073506637506376762, guid: 14eb60754136feb4ebbf4e990721439a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 97
+      value: 96
       objectReference: {fileID: 0}
     - target: {fileID: 9073506637506376762, guid: 14eb60754136feb4ebbf4e990721439a,
         type: 3}
@@ -3339,7 +3344,7 @@ PrefabInstance:
     - target: {fileID: 836487917318320442, guid: 612b94b3afdd65d488e97c5fd244a026,
         type: 3}
       propertyPath: m_RootOrder
-      value: 94
+      value: 93
       objectReference: {fileID: 0}
     - target: {fileID: 836487917318320442, guid: 612b94b3afdd65d488e97c5fd244a026,
         type: 3}
@@ -3419,7 +3424,7 @@ PrefabInstance:
     - target: {fileID: 8946129733050971242, guid: 5de3487372396e34e839c297ece28ef0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 102
+      value: 101
       objectReference: {fileID: 0}
     - target: {fileID: 8946129733050971242, guid: 5de3487372396e34e839c297ece28ef0,
         type: 3}
@@ -3504,7 +3509,7 @@ PrefabInstance:
     - target: {fileID: 1002719256847154502, guid: 2a39aefa5aa903240b20a8b5a5185fbf,
         type: 3}
       propertyPath: m_RootOrder
-      value: 63
+      value: 62
       objectReference: {fileID: 0}
     - target: {fileID: 1002719256847154502, guid: 2a39aefa5aa903240b20a8b5a5185fbf,
         type: 3}
@@ -3599,7 +3604,7 @@ PrefabInstance:
     - target: {fileID: 6034095428633112817, guid: 23bcc19bcba70e242836e9a7a9dc0c2e,
         type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 6034095428633112817, guid: 23bcc19bcba70e242836e9a7a9dc0c2e,
         type: 3}
@@ -3728,7 +3733,7 @@ PrefabInstance:
     - target: {fileID: 1002719256847154502, guid: 2a39aefa5aa903240b20a8b5a5185fbf,
         type: 3}
       propertyPath: m_RootOrder
-      value: 57
+      value: 56
       objectReference: {fileID: 0}
     - target: {fileID: 1002719256847154502, guid: 2a39aefa5aa903240b20a8b5a5185fbf,
         type: 3}
@@ -3987,7 +3992,7 @@ PrefabInstance:
     - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
         type: 3}
       propertyPath: m_RootOrder
-      value: 104
+      value: 103
       objectReference: {fileID: 0}
     - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
         type: 3}
@@ -4072,7 +4077,7 @@ PrefabInstance:
     - target: {fileID: 3383979214839746496, guid: cd57a2813ebc4ff4caf28b5fb793b3eb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 56
+      value: 55
       objectReference: {fileID: 0}
     - target: {fileID: 3383979214839746496, guid: cd57a2813ebc4ff4caf28b5fb793b3eb,
         type: 3}
@@ -4155,7 +4160,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 113
+      value: 112
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -4235,7 +4240,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 111
+      value: 110
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -4330,7 +4335,7 @@ PrefabInstance:
     - target: {fileID: 4249355701057277291, guid: c05c071c51fbfec408e4c9f6240dc824,
         type: 3}
       propertyPath: m_RootOrder
-      value: 93
+      value: 92
       objectReference: {fileID: 0}
     - target: {fileID: 4249355701057277291, guid: c05c071c51fbfec408e4c9f6240dc824,
         type: 3}
@@ -4482,6 +4487,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1846403220085434226, guid: 397461e981e81df4c8983f127dbabae6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.00000014901144
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 397461e981e81df4c8983f127dbabae6, type: 3}
 --- !u!4 &1756556397 stripped
@@ -4595,7 +4605,7 @@ PrefabInstance:
     - target: {fileID: 2413525652997339073, guid: 996245457b67ce049bcb361024617659,
         type: 3}
       propertyPath: m_RootOrder
-      value: 96
+      value: 95
       objectReference: {fileID: 0}
     - target: {fileID: 2413525652997339073, guid: 996245457b67ce049bcb361024617659,
         type: 3}
@@ -4675,7 +4685,7 @@ PrefabInstance:
     - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 95
+      value: 94
       objectReference: {fileID: 0}
     - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
         type: 3}
@@ -4760,7 +4770,7 @@ PrefabInstance:
     - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
         type: 3}
       propertyPath: m_RootOrder
-      value: 103
+      value: 102
       objectReference: {fileID: 0}
     - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
         type: 3}
@@ -4960,7 +4970,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 115
+      value: 114
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -5043,7 +5053,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 112
+      value: 111
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -5377,7 +5387,7 @@ PrefabInstance:
     - target: {fileID: 7529218229981866049, guid: 6d0e5d5bc9d6eeb4bac0fcf68fc738b8,
         type: 3}
       propertyPath: m_RootOrder
-      value: 99
+      value: 98
       objectReference: {fileID: 0}
     - target: {fileID: 7529218229981866049, guid: 6d0e5d5bc9d6eeb4bac0fcf68fc738b8,
         type: 3}
@@ -6005,12 +6015,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6939602303077258408}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.5, y: -0.5045045, z: 0}
+  m_LocalPosition: {x: 0, y: -0.0043945312, z: 0}
   m_LocalScale: {x: 1, y: 1.001001, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1998928700528175337}
-  m_RootOrder: 52
+  m_Father: {fileID: 4973277796872332647}
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &679599618514267872
 MonoBehaviour:
@@ -6269,7 +6279,7 @@ PrefabInstance:
     - target: {fileID: 6511207373575406613, guid: 1488f67a55cb9b84098e095e65e5a2b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 54
+      value: 53
       objectReference: {fileID: 0}
     - target: {fileID: 6511207373575406613, guid: 1488f67a55cb9b84098e095e65e5a2b3,
         type: 3}
@@ -6365,7 +6375,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4699640297835872, guid: fa26dc8a7e76973489beed18bc59d792, type: 3}
       propertyPath: m_RootOrder
-      value: 66
+      value: 65
       objectReference: {fileID: 0}
     - target: {fileID: 4699640297835872, guid: fa26dc8a7e76973489beed18bc59d792, type: 3}
       propertyPath: m_LocalScale.y
@@ -6483,7 +6493,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 70
+      value: 69
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -6578,7 +6588,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 88
+      value: 87
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -6873,7 +6883,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4973277796872332647}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1567958514550298789
 PrefabInstance:
@@ -6888,7 +6898,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 82
+      value: 81
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -7174,7 +7184,6 @@ Transform:
   - {fileID: 1069494580}
   - {fileID: 1772370541}
   - {fileID: 1864554311}
-  - {fileID: 659045225855197089}
   - {fileID: 1044446748}
   - {fileID: 1155567317340634260}
   - {fileID: 8292531862337681999}
@@ -7239,7 +7248,7 @@ Transform:
   - {fileID: 1216794233}
   - {fileID: 1936907019}
   m_Father: {fileID: 4973277796872332647}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &2043655520668355598
 PrefabInstance:
@@ -7254,7 +7263,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 73
+      value: 72
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -7491,7 +7500,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 92
+      value: 91
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -7826,7 +7835,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 71
+      value: 70
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -8188,7 +8197,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 75
+      value: 74
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -8283,7 +8292,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 86
+      value: 85
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -8696,7 +8705,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 81
+      value: 80
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -9109,7 +9118,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 89
+      value: 88
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -9204,7 +9213,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 77
+      value: 76
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -9299,7 +9308,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 79
+      value: 78
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -9394,7 +9403,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4973277796872332647}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &3856163840207389847
 PrefabInstance:
@@ -10123,7 +10132,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 76
+      value: 75
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -10830,6 +10839,7 @@ Transform:
   - {fileID: 6869200684377436319}
   - {fileID: 4462894794123917076}
   - {fileID: 6615429748901614858}
+  - {fileID: 659045225855197089}
   - {fileID: 1998928700528175337}
   - {fileID: 472897715}
   - {fileID: 3811915283260935408}
@@ -10852,7 +10862,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 78
+      value: 77
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -11087,7 +11097,7 @@ PrefabInstance:
     - target: {fileID: 1925386106379506438, guid: 5cb5bf2efb47fce45b5b2e7311b9a6fc,
         type: 3}
       propertyPath: m_RootOrder
-      value: 67
+      value: 66
       objectReference: {fileID: 0}
     - target: {fileID: 1925386106379506438, guid: 5cb5bf2efb47fce45b5b2e7311b9a6fc,
         type: 3}
@@ -11364,7 +11374,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 1
-      m_TileSpriteIndex: 186
+      m_TileSpriteIndex: 208
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -12294,7 +12304,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 1
-      m_TileSpriteIndex: 145
+      m_TileSpriteIndex: 186
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -17654,7 +17664,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 2
-      m_TileSpriteIndex: 141
+      m_TileSpriteIndex: 145
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -22554,7 +22564,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 2
-      m_TileSpriteIndex: 117
+      m_TileSpriteIndex: 141
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -24574,7 +24584,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 5
-      m_TileSpriteIndex: 112
+      m_TileSpriteIndex: 117
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -25904,7 +25914,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 2
-      m_TileSpriteIndex: 111
+      m_TileSpriteIndex: 112
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -31294,7 +31304,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 0
-      m_TileSpriteIndex: 108
+      m_TileSpriteIndex: 111
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -39024,7 +39034,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 0
-      m_TileSpriteIndex: 106
+      m_TileSpriteIndex: 108
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -50344,7 +50354,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 11
-      m_TileSpriteIndex: 101
+      m_TileSpriteIndex: 106
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -59024,8 +59034,8 @@ Tilemap:
     m_Data: {fileID: -801947067, guid: c9dec44dc5961dd4180adc11f31b42ba, type: 3}
   - m_RefCount: 2
     m_Data: {fileID: 21300012, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
-  - m_RefCount: 1
-    m_Data: {fileID: 1754844944, guid: c9dec44dc5961dd4180adc11f31b42ba, type: 3}
+  - m_RefCount: 0
+    m_Data: {fileID: 0}
   - m_RefCount: 2
     m_Data: {fileID: 21300022, guid: b058b7252e3d4da4b8bd51add65b0930, type: 3}
   - m_RefCount: 1
@@ -59037,19 +59047,19 @@ Tilemap:
   - m_RefCount: 5
     m_Data: {fileID: 1877875480, guid: c9dec44dc5961dd4180adc11f31b42ba, type: 3}
   - m_RefCount: 1
-    m_Data: {fileID: 21300064, guid: 7c3a7336be2637043a7f39cec5350bba, type: 3}
+    m_Data: {fileID: 1754844944, guid: c9dec44dc5961dd4180adc11f31b42ba, type: 3}
   - m_RefCount: 3
     m_Data: {fileID: 21300024, guid: 311271c83c0b5f846884d0b57f9c22bf, type: 3}
   - m_RefCount: 1
-    m_Data: {fileID: 21300058, guid: 7c3a7336be2637043a7f39cec5350bba, type: 3}
+    m_Data: {fileID: 21300064, guid: 7c3a7336be2637043a7f39cec5350bba, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 1067626160, guid: 3fbb536e1aa316e4d8ffac9ab66b7ac0, type: 3}
   - m_RefCount: 19
     m_Data: {fileID: 1358674663, guid: 3fbb536e1aa316e4d8ffac9ab66b7ac0, type: 3}
   - m_RefCount: 1
-    m_Data: {fileID: 21300090, guid: 34fae7bba294bb24a90001d055efbbe4, type: 3}
+    m_Data: {fileID: 21300058, guid: 7c3a7336be2637043a7f39cec5350bba, type: 3}
   - m_RefCount: 1
-    m_Data: {fileID: 21300044, guid: b058b7252e3d4da4b8bd51add65b0930, type: 3}
+    m_Data: {fileID: 21300090, guid: 34fae7bba294bb24a90001d055efbbe4, type: 3}
   - m_RefCount: 2
     m_Data: {fileID: -516113650, guid: c9dec44dc5961dd4180adc11f31b42ba, type: 3}
   - m_RefCount: 2
@@ -59059,7 +59069,7 @@ Tilemap:
   - m_RefCount: 1
     m_Data: {fileID: 21300018, guid: 311271c83c0b5f846884d0b57f9c22bf, type: 3}
   - m_RefCount: 1
-    m_Data: {fileID: 21300068, guid: 34fae7bba294bb24a90001d055efbbe4, type: 3}
+    m_Data: {fileID: 21300044, guid: b058b7252e3d4da4b8bd51add65b0930, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300008, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
   - m_RefCount: 2
@@ -59107,7 +59117,7 @@ Tilemap:
   - m_RefCount: 2
     m_Data: {fileID: 21300052, guid: 34fae7bba294bb24a90001d055efbbe4, type: 3}
   - m_RefCount: 1
-    m_Data: {fileID: 21300050, guid: 34fae7bba294bb24a90001d055efbbe4, type: 3}
+    m_Data: {fileID: 21300068, guid: 34fae7bba294bb24a90001d055efbbe4, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300026, guid: 311271c83c0b5f846884d0b57f9c22bf, type: 3}
   - m_RefCount: 1
@@ -59115,8 +59125,7 @@ Tilemap:
   - m_RefCount: 1
     m_Data: {fileID: 21300048, guid: 311271c83c0b5f846884d0b57f9c22bf, type: 3}
   - m_RefCount: 1
-    m_Data: {fileID: -6833815332315337119, guid: c6e9cad3946d90740a61fe80c79c0919,
-      type: 3}
+    m_Data: {fileID: 21300050, guid: 34fae7bba294bb24a90001d055efbbe4, type: 3}
   - m_RefCount: 4
     m_Data: {fileID: 21300006, guid: 0a0f91b9c43ff9743a56ea9ef270abbd, type: 3}
   - m_RefCount: 2
@@ -59198,7 +59207,7 @@ Tilemap:
   - m_RefCount: 4
     m_Data: {fileID: 2035454595, guid: 3fbb536e1aa316e4d8ffac9ab66b7ac0, type: 3}
   - m_RefCount: 1
-    m_Data: {fileID: -907896969790811466, guid: c6e9cad3946d90740a61fe80c79c0919,
+    m_Data: {fileID: -6833815332315337119, guid: c6e9cad3946d90740a61fe80c79c0919,
       type: 3}
   - m_RefCount: 6
     m_Data: {fileID: -2064880245, guid: c9dec44dc5961dd4180adc11f31b42ba, type: 3}
@@ -59242,8 +59251,9 @@ Tilemap:
     m_Data: {fileID: 21300008, guid: b058b7252e3d4da4b8bd51add65b0930, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300086, guid: 952bd23eb2328fb4d98fa7d067e19763, type: 3}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
+  - m_RefCount: 1
+    m_Data: {fileID: -907896969790811466, guid: c6e9cad3946d90740a61fe80c79c0919,
+      type: 3}
   m_TileMatrixArray:
   - m_RefCount: 4743
     m_Data:
@@ -59797,7 +59807,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 87
+      value: 86
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -59904,7 +59914,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 80
+      value: 79
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -60027,7 +60037,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4992776679171040, guid: 4da47599005396e47a0534bd2f998de1, type: 3}
       propertyPath: m_RootOrder
-      value: 68
+      value: 67
       objectReference: {fileID: 0}
     - target: {fileID: 4992776679171040, guid: 4da47599005396e47a0534bd2f998de1, type: 3}
       propertyPath: m_LocalScale.y
@@ -60109,7 +60119,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4973277796872332647}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &7222146871198008234
 PrefabInstance:
@@ -145160,7 +145170,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 74
+      value: 73
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -146410,7 +146420,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4992776679171040, guid: 4da47599005396e47a0534bd2f998de1, type: 3}
       propertyPath: m_RootOrder
-      value: 64
+      value: 63
       objectReference: {fileID: 0}
     - target: {fileID: 4992776679171040, guid: 4da47599005396e47a0534bd2f998de1, type: 3}
       propertyPath: m_LocalScale.y
@@ -146501,7 +146511,7 @@ PrefabInstance:
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 55
+      value: 54
       objectReference: {fileID: 0}
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
@@ -146602,7 +146612,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4699640297835872, guid: fa26dc8a7e76973489beed18bc59d792, type: 3}
       propertyPath: m_RootOrder
-      value: 65
+      value: 64
       objectReference: {fileID: 0}
     - target: {fileID: 4699640297835872, guid: fa26dc8a7e76973489beed18bc59d792, type: 3}
       propertyPath: m_LocalScale.y
@@ -146704,7 +146714,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 72
+      value: 71
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -146899,7 +146909,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 85
+      value: 84
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -146994,7 +147004,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 69
+      value: 68
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y


### PR DESCRIPTION
Somehow Caverna's base tilemap layer found its way into its objects. Hasn't been reported to cause any problems- but probably best its taken out to be safe.
![Capture](https://user-images.githubusercontent.com/48405920/169809826-8a09e9ad-a1ce-4c9c-9a5c-b4b3cafb7dcf.PNG)

