### PR TITLE
Clears receivers in signal manager at round end

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/EventManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/EventManager.cs
@@ -17,6 +17,7 @@ public enum Event
 	LoggedOut,
 	RoundStarted,
 	PostRoundStarted,
+	SceneUnloading,
 	RoundEnded,
 	DisableInternals,
 	EnableInternals,

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -821,6 +821,7 @@ public partial class GameManager : MonoBehaviour, IInitialise
 			Chat.AddGameWideSystemMsgToChat("<b>The round is now restarting...</b>");
 			// Notify all clients that the round has ended
 			EventManager.Broadcast(Event.RoundEnded, true);
+			EventManager.Broadcast(Event.SceneUnloading, true);
 
 			yield return WaitFor.Seconds(0.2f);
 

--- a/UnityProject/Assets/Scripts/Managers/SignalsManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SignalsManager.cs
@@ -16,12 +16,7 @@ namespace Managers
 		private void Start()
 		{
 			base.Start();
-			EventManager.AddHandler(Event.RoundEnded, ClearAtRoundEnd);
-		}
-
-		private void ClearAtRoundEnd()
-		{
-			Receivers.Clear();
+			EventManager.AddHandler(Event.SceneUnloading, () => Receivers.Clear());
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/Managers/SignalsManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SignalsManager.cs
@@ -13,6 +13,17 @@ namespace Managers
 
 		public HashSet<SignalReceiver> Receivers = new HashSet<SignalReceiver>();
 
+		private void Start()
+		{
+			base.Start();
+			EventManager.AddHandler(Event.RoundEnded, ClearAtRoundEnd);
+		}
+
+		private void ClearAtRoundEnd()
+		{
+			Receivers.Clear();
+		}
+
 		/// <summary>
 		/// Called from the server as the Receivers list is only available for the host and to avoid clients from cheating.
 		/// Loops through all receivers and sends the signal if they match the signal type and/or frequancy


### PR DESCRIPTION
This should be the last time tackling the signal manager getting bricked.

CL: [Fix] - The signal manager will now clear it's receivers list at the end of the round.
