### PR TITLE
Remove APC empty list test

### DIFF
--- a/UnityProject/Assets/Tests/Scenes/PowerAndLightsSceneTests.cs
+++ b/UnityProject/Assets/Tests/Scenes/PowerAndLightsSceneTests.cs
@@ -49,17 +49,17 @@ namespace Tests.Scenes
 		public void APCsConnectedDevicesContainsValidReferences()
 		{
 			var sceneName = Scene.name;
-			foreach (var device in RootObjects.ComponentsInChildren<APC>())
+			foreach (var apc in RootObjects.ComponentsInChildren<APC>())
 			{
-				var deviceName = device.name;
+				var apcName = apc.name;
 
-				foreach (var connectedDevice in device.ConnectedDevices)
+				foreach (var connectedDevice in apc.ConnectedDevices)
 				{
 					Report.FailIf(connectedDevice, Is.Null)
-						.AppendLine($"{sceneName}: \"{deviceName}\" has a null value in the list.")
+						.AppendLine($"{sceneName}: \"{apcName}\" has a null value in the list.")
 						.MarkDirtyIfFailed()
-						.FailIf(connectedDevice.OrNull()?.RelatedAPC, Is.Not.EqualTo(device))
-						.AppendLine($"{sceneName}: \"{deviceName}\" is not assigned to \"{connectedDevice.name}\"");
+						.FailIf(connectedDevice.OrNull()?.RelatedAPC, Is.Not.EqualTo(apc))
+						.AppendLine($"{sceneName}: \"{apcName}\" is not assigned to \"{connectedDevice.name}\"");
 				}
 			}
 

--- a/UnityProject/Assets/Tests/Scenes/PowerAndLightsSceneTests.cs
+++ b/UnityProject/Assets/Tests/Scenes/PowerAndLightsSceneTests.cs
@@ -46,7 +46,7 @@ namespace Tests.Scenes
 		/// if device is not assigned to this APC
 		/// </summary>
 		[Test]
-		public void APCsHaveConnectedDevices()
+		public void APCsConnectedDevicesContainsValidReferences()
 		{
 			var sceneName = Scene.name;
 			foreach (var device in RootObjects.ComponentsInChildren<APC>())

--- a/UnityProject/Assets/Tests/Scenes/PowerAndLightsSceneTests.cs
+++ b/UnityProject/Assets/Tests/Scenes/PowerAndLightsSceneTests.cs
@@ -52,8 +52,6 @@ namespace Tests.Scenes
 			foreach (var device in RootObjects.ComponentsInChildren<APC>())
 			{
 				var deviceName = device.name;
-				Report.FailIf(device.ConnectedDevices.Count, Is.EqualTo(0))
-					.AppendLine($"{sceneName}: \"{deviceName}\" has an empty list of devices.");
 
 				foreach (var connectedDevice in device.ConnectedDevices)
 				{


### PR DESCRIPTION
Removes the empty list check in the APCs test as it is unnecessary.