### PR TITLE
mob limit

### DIFF
--- a/UnityProject/Assets/Scripts/NPC/AI/Friendly/GenericFriendlyAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Friendly/GenericFriendlyAI.cs
@@ -33,11 +33,10 @@ namespace Systems.MobAIs
 
 		#endregion Lifecycle
 
-		protected override void UpdateMe()
+		public override void ContemplatePriority()
 		{
 			if (MatrixManager.IsInitialized == false || health.IsDead || health.IsCrit) return;
-
-			base.UpdateMe();
+			base.ContemplatePriority();
 			MonitorExtras();
 		}
 

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/GenericHostileAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/GenericHostileAI.cs
@@ -81,10 +81,9 @@ namespace Systems.MobAIs
 		}
 
 		#endregion
-
-		protected override void UpdateMe()
+		public override void ContemplatePriority()
 		{
-			base.UpdateMe();
+			base.ContemplatePriority();
 
 			if (!isServer || !MatrixManager.IsInitialized)
 			{
@@ -159,7 +158,6 @@ namespace Systems.MobAIs
 				}
 			}
 		}
-
 		/// <summary>
 		/// Looks around and tries to find players to target
 		/// </summary>
@@ -263,12 +261,6 @@ namespace Systems.MobAIs
 		protected virtual void HandleSearch()
 		{
 			moveWaitTime += Time.deltaTime;
-			if (moveWaitTime >= movementTickRate)
-			{
-				moveWaitTime = 0f;
-				DoRandomMove();
-			}
-
 			searchWaitTime += Time.deltaTime;
 			if (!(searchWaitTime >= searchTickRate)) return;
 			searchWaitTime = 0f;

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/StatueAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/StatueAI.cs
@@ -13,7 +13,7 @@ namespace Systems.MobAIs
 	[RequireComponent(typeof(ConeOfSight))]
 	public class StatueAI : GenericHostileAI
 	{
-		protected override void UpdateMe()
+		public override void ContemplatePriority()
 		{
 			if (!isServer) return;
 

--- a/UnityProject/Assets/Scripts/NPC/AI/MobAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobAI.cs
@@ -10,7 +10,7 @@ namespace Systems.MobAIs
 	[RequireComponent(typeof(MobFollow))]
 	[RequireComponent(typeof(MobExplore))]
 	[RequireComponent(typeof(MobFlee))]
-	public class MobAI : MonoBehaviour, IServerLifecycle
+	public class MobAI : MobObjective, IServerLifecycle
 	{
 		public string mobName;
 
@@ -77,8 +77,6 @@ namespace Systems.MobAIs
 				simpleAnimal.SetDeadState(false);
 			}
 
-			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
-			UpdateManager.Add(PeriodicUpdate, 1f);
 			health.applyDamageEvent += AttackReceivedCoolDown;
 			isServer = true;
 
@@ -92,11 +90,6 @@ namespace Systems.MobAIs
 			ResetBehaviours();
 		}
 
-		public void OnDisable()
-		{
-			UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);
-			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, PeriodicUpdate);
-		}
 
 		/// <summary>
 		/// Called after the mob is spawned, before the AI comes online
@@ -112,11 +105,13 @@ namespace Systems.MobAIs
 
 		#endregion
 
-		/// <summary>
-		/// Server only update loop. Make sure to call base.UpdateMe() if overriding
-		/// </summary>
-		protected virtual void UpdateMe()
+
+		public override void ContemplatePriority()
 		{
+			if (damageAttempts >= maxDamageAttempts)
+			{
+				damageAttempts = 0;
+			}
 			if (MonitorKnockedDown())
 			{
 				return;
@@ -127,13 +122,6 @@ namespace Systems.MobAIs
 			MonitorFleeingTime();
 		}
 
-		protected void PeriodicUpdate()
-		{
-			if (damageAttempts >= maxDamageAttempts)
-			{
-				damageAttempts = 0;
-			}
-		}
 
 		/// <summary>
 		/// Updates the mob to fall down or stand up where appropriate

--- a/UnityProject/Assets/Scripts/NPC/AI/MobController.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobController.cs
@@ -32,7 +32,7 @@ namespace Systems.MobAIs
 		{
 			if (CustomNetworkManager.IsServer == false) return;
 			SceneManager.activeSceneChanged += OnRoundRestart;
-			if (CurrentMobs > 10)
+			if (CurrentMobs > 20)
 			{
 				return;
 			}

--- a/UnityProject/Assets/Scripts/NPC/AI/MobController.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobController.cs
@@ -3,30 +3,56 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace Systems.MobAIs
 {
 	public class MobController : MonoBehaviour
 	{
+
+		public static int CurrentMobs = 0;
+
+		public bool Active = false;
+
 		public List<MobObjective> MobObjectives = new List<MobObjective>();
+
+
+		void OnRoundRestart(Scene oldScene, Scene newScene)
+		{
+			CurrentMobs = 0;
+		}
 
 		public void Awake()
 		{
+
 			MobObjectives = this.GetComponents<MobObjective>().ToList();
 		}
 
 		private void OnEnable()
 		{
 			if (CustomNetworkManager.IsServer == false) return;
-		
+			SceneManager.activeSceneChanged += OnRoundRestart;
+			if (CurrentMobs > 10)
+			{
+				return;
+			}
+
+			Active = true;
+			CurrentMobs++;
 			UpdateManager.Add(UpdateMe, 0.85f);
 		}
 
 		private void OnDisable()
 		{
 			if (CustomNetworkManager.IsServer == false) return;
-			
-			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, UpdateMe);
+			SceneManager.activeSceneChanged -= OnRoundRestart;
+
+			if (Active)
+			{
+				CurrentMobs--;
+				Active = false;
+				UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, UpdateMe);
+			}
 		}
 
 		public void UpdateMe()

--- a/UnityProject/Assets/Scripts/NPC/AI/MobController.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobController.cs
@@ -34,6 +34,9 @@ namespace Systems.MobAIs
 			SceneManager.activeSceneChanged += OnRoundRestart;
 			if (CurrentMobs > 20)
 			{
+				var mobError = " mob limit hit with  " + name + " Disabling new mobs";
+				Logger.LogError(mobError);
+				UIManager.Instance.adminChatWindows.adminLogWindow.ServerAddChatRecord(mobError, null);
 				return;
 			}
 


### PR DESCRIPTION
why because the thing that always is responsible for tanking performances bloody mobs, 
so adds a limit to the number of mobs that can be active , can change limit is needed
Looking at the profiles there was 81 hostile mobs looking for players at the same time