### PR TITLE
Fix APC test missing null check

### DIFF
--- a/UnityProject/Assets/Tests/Scenes/PowerAndLightsSceneTests.cs
+++ b/UnityProject/Assets/Tests/Scenes/PowerAndLightsSceneTests.cs
@@ -49,17 +49,21 @@ namespace Tests.Scenes
 		public void APCsConnectedDevicesContainsValidReferences()
 		{
 			var sceneName = Scene.name;
-			foreach (var apc in RootObjects.ComponentsInChildren<APC>())
+			foreach (var apc in RootObjects.ComponentsInChildren<APC>().NotNull())
 			{
-				var apcName = apc.name;
-
 				foreach (var connectedDevice in apc.ConnectedDevices)
 				{
-					Report.FailIf(connectedDevice, Is.Null)
-						.AppendLine($"{sceneName}: \"{apcName}\" has a null value in the list.")
-						.MarkDirtyIfFailed()
-						.FailIf(connectedDevice.OrNull()?.RelatedAPC, Is.Not.EqualTo(apc))
-						.AppendLine($"{sceneName}: \"{apcName}\" is not assigned to \"{connectedDevice.name}\"");
+					if (connectedDevice == null)
+					{
+						Report.Fail()
+							.AppendLine($"{sceneName}: APC at \"{apc.transform.HierarchyName()}\" has a null value in the list.");
+						continue;
+					}
+
+					Report.FailIfNot(connectedDevice.RelatedAPC, Is.EqualTo(apc))
+						.Append($"{sceneName}: Device at \"{connectedDevice.transform.HierarchyName()}\" ")
+						.Append($"is not assigned to connected devices in APC at \"{apc.transform.HierarchyName()}\".")
+						.AppendLine();
 				}
 			}
 


### PR DESCRIPTION
Forgot a null check when generating the error string. Rearrange to fail and continue on a null device.

Also changed the error messages to show the exact location in the hierarchy of the APC and/or the connected device.