### PR TITLE
Adds tool to easily map out conveyor belts for admins

### DIFF
--- a/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
+++ b/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
@@ -21,6 +21,28 @@ namespace IngameDebugConsole
 	public class DebugLogUnitystationCommands : MonoBehaviour
 	{
 
+		[ConsoleMethod("CBTool", "Allows users to quickly build conveyor belts.")]
+		public static void EnableCBTool()
+		{
+			if(PlayerManager.LocalPlayerObject == null || PlayerManager.LocalPlayerScript == null)
+			{
+				Logger.Log("Attempted to open the conveyor belt tool when the player has not joined the round yet.");
+				return;
+			}
+			if (PlayerManager.LocalPlayerScript.IsDeadOrGhost)
+			{
+				Logger.Log("Only alive players can use this.");
+				return;
+			}
+			//TODO : Add a check to see which gamemode the player is on currently once sandbox is in instead of locking this behind for admins only.
+			if (AdminCommands.AdminCommandsManager.IsAdmin(PlayerManager.LocalPlayerScript.PlayerInfo.Connection, out _) == false)
+			{
+				Logger.Log("This function can only be executed by admins.", Category.DebugConsole);
+				return;
+			}
+			UIManager.BuildMenu.ShowConveyorBeltMenu();
+		}
+
 		[ConsoleMethod("CloneSelf", "Allows user to test cloning quickly.")]
 		public static void CloneSelf()
 		{

--- a/UnityProject/Assets/Prefabs/UI/Ingame/BuildMenu/BuildMenu.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Ingame/BuildMenu/BuildMenu.prefab
@@ -3485,6 +3485,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 137a7a8415189834c94d786cb8c03cef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  conveyorBeltPrefab:
+    name: 
+    prefab: {fileID: 7144248469089430455, guid: d029ccf2e161c824f931cda8b7404f9a,
+      type: 3}
+    cost: 1
+    buildTime: 1
+    spawnAmount: 1
+    onePerTile: 1
 --- !u!1 &7365842271658246817
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Messages/Client/RequestConveyorBuildMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/RequestConveyorBuildMessage.cs
@@ -17,16 +17,27 @@ namespace Messages.Client
 			//index of the entry in the ConstructionList.
 			public byte EntryIndex;
 			public ConveyorBelt.ConveyorDirection Direction;
+			public bool Sandboxing;
 		}
 
 		public override void Process(NetMessage msg)
 		{
 			var playerScript = SentByPlayer.Script;
+			if (msg.Sandboxing)
+			{
+				var spawnedObj = Spawn.ServerPrefab(UIManager.BuildMenu.ConveyorBuildMenu.ConveyorBeltPrefab.Prefab, playerScript.registerTile.WorldPosition)?.GameObject;
+				if (spawnedObj)
+				{
+					var conveyorBelt = spawnedObj.GetComponent<ConveyorBelt>();
+					if (conveyorBelt != null) conveyorBelt.SetBeltFromBuildMenu(msg.Direction);
+				}
+				return;
+			}
+
 			var playerObject = SentByPlayer.GameObject;
 			var clientStorage = playerScript.DynamicItemStorage;
 			var usedSlot = clientStorage.GetActiveHandSlot();
 			if (usedSlot == null || usedSlot.ItemObject == null) return;
-
 			var hasConstructionMenu = usedSlot.ItemObject.GetComponent<BuildingMaterial>();
 			if (hasConstructionMenu == null) return;
 
@@ -89,10 +100,9 @@ namespace Messages.Client
 					if (conveyorBelt != null) conveyorBelt.SetBeltFromBuildMenu(msg.Direction);
 
 					Chat.AddActionMsgToChat(playerObject, $"You finish building the {entry.Name}.",
-						$"{playerObject.ExpensiveName()} finishes building the {entry.Name}.");
+						 $"{playerObject.ExpensiveName()} finishes building the {entry.Name}.");
 				}
 			}
-
 			Chat.AddActionMsgToChat(playerObject, $"You begin building the {entry.Name}...",
 				$"{playerObject.ExpensiveName()} begins building the {entry.Name}...");
 			ToolUtils.ServerUseTool(playerObject, usedSlot.ItemObject,
@@ -101,15 +111,26 @@ namespace Messages.Client
 		}
 
 		public static NetMessage Send(BuildList.Entry entry, BuildingMaterial hasMenu,
-			ConveyorBelt.ConveyorDirection direction)
+			ConveyorBelt.ConveyorDirection direction, bool isSandbox)
 		{
+			if (isSandbox)
+			{
+				var smsg = new NetMessage
+				{
+					Direction = direction,
+					Sandboxing = isSandbox,
+				};
+				Send(smsg);
+				return smsg;
+			}
 			var entryIndex = hasMenu.BuildList.Entries.ToList().IndexOf(entry);
 			if (entryIndex == -1) return new NetMessage();
 
 			var msg = new NetMessage
 			{
 				EntryIndex = (byte)entryIndex,
-				Direction = direction
+				Direction = direction,
+				Sandboxing = isSandbox,
 			};
 
 			Send(msg);

--- a/UnityProject/Assets/Scripts/Messages/Client/RequestConveyorBuildMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/RequestConveyorBuildMessage.cs
@@ -23,7 +23,7 @@ namespace Messages.Client
 		public override void Process(NetMessage msg)
 		{
 			var playerScript = SentByPlayer.Script;
-			if (msg.Sandboxing)
+			if (msg.Sandboxing && AdminCommands.AdminCommandsManager.IsAdmin(playerScript.connectionToServer, out var _))
 			{
 				var spawnedObj = Spawn.ServerPrefab(UIManager.BuildMenu.ConveyorBuildMenu.ConveyorBeltPrefab.Prefab, playerScript.registerTile.WorldPosition)?.GameObject;
 				if (spawnedObj)

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/Construction/BuildMenu.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/Construction/BuildMenu.cs
@@ -18,6 +18,8 @@ namespace UI.UI_Bottom
 
 		[SerializeField] private ConveyorBuildMenu conveyorBuildMenu = null;
 
+		public ConveyorBuildMenu ConveyorBuildMenu => conveyorBuildMenu;
+
 		// current object whose menu is being shown
 		private BuildingMaterial currentBuildingMaterial;
 
@@ -49,6 +51,12 @@ namespace UI.UI_Bottom
 		{
 			CloseBuildMenu();
 			conveyorBuildMenu.OpenConveyorBuildMenu(entry, buildingMaterial);
+		}
+
+		public void ShowConveyorBeltMenu()
+		{
+			CloseBuildMenu();
+			conveyorBuildMenu.OpenConveyorBuildMenu();
 		}
 
 		public void CloseBuildMenu()

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/Construction/ConveyorBuildMenu.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/Construction/ConveyorBuildMenu.cs
@@ -10,18 +10,32 @@ namespace Construction.Conveyors
 		private BuildingMaterial materials;
 		private BuildList.Entry entry;
 
+		[SerializeField] private BuildList.Entry conveyorBeltPrefab;
+
+		public BuildList.Entry ConveyorBeltPrefab => conveyorBeltPrefab;
+
+		private bool isSandbox = false;
+
 		public void OpenConveyorBuildMenu(BuildList.Entry entry, BuildingMaterial materials)
 		{
+			this.isSandbox = false;
 			this.materials = materials;
 			this.entry = entry;
+			gameObject.SetActive(true);
+		}
+
+		public void OpenConveyorBuildMenu()
+		{
+			//FIXME : Add extra checks here when the sandbox gamemode is fully rolled out to not let people use this unless they're in that gamemode or are admins.
+			this.isSandbox = true;
 			gameObject.SetActive(true);
 		}
 
 		public void TryBuildBelt(int direction)
 		{
 			_ = SoundManager.Play(CommonSounds.Instance.Click01);
-			CloseWindow();
-			RequestConveyorBuildMessage.Send(entry, materials, (ConveyorBelt.ConveyorDirection)direction);
+			if(isSandbox == false) CloseWindow();
+			RequestConveyorBuildMessage.Send(isSandbox ? conveyorBeltPrefab : entry, materials, (ConveyorBelt.ConveyorDirection)direction, isSandbox);
 		}
 
 		public void GoToMainMenu()


### PR DESCRIPTION
### Purpose
In preparation for the sandbox gamemode I've been experimenting with a few tools to make the mapping life easier for mappers when the gamemode rolls out. This new tool in this PR re-uses the conveyor belt construction menu to allow mappers/testers to build long belts quickly without the need of resources.

### Notes:
Currently locked for admins only until the sandbox gamemode is finished.
Can be accessed from the console using the command `CBTool`

### Changelog:
CL: [New] - Adds a new command for admins/testers (and soon mappers) to build conveyor belts quickly.
