### PR TITLE
Fixes admin getting kicked due to out of sync data in the cargo manager tool (again) + Other fixes

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
@@ -516,7 +516,7 @@ namespace AdminCommands
 		public void CmdRemoveBounty(int index, bool completeBounty, NetworkConnectionToClient sender = null)
 		{
 			if (IsAdmin(sender, out var admin) == false) return;
-			if (CargoManager.Instance.ActiveBounties.Count - 1 < index) return; 
+			if (CargoManager.Instance.ActiveBounties.Count <= index) return; 
 			if (completeBounty)
 			{
 				CargoManager.Instance.CompleteBounty(CargoManager.Instance.ActiveBounties[index]);

--- a/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
@@ -516,6 +516,7 @@ namespace AdminCommands
 		public void CmdRemoveBounty(int index, bool completeBounty, NetworkConnectionToClient sender = null)
 		{
 			if (IsAdmin(sender, out var admin) == false) return;
+			if (CargoManager.Instance.ActiveBounties.Count - 1 < index) return; 
 			if (completeBounty)
 			{
 				CargoManager.Instance.CompleteBounty(CargoManager.Instance.ActiveBounties[index]);

--- a/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
@@ -572,6 +572,7 @@ namespace AdminCommands
 			if (IsAdmin(sender, out var admin) == false) return;
 			CargoManager.Instance.AddBounty(trait, amount, title, description, reward, announce);
 			CargoManager.Instance.OnBountiesUpdate?.Invoke();
+			LogAdminAction($"{admin.Username} has added a new bounty -> Title : {title} || reward : {reward} || Announce : {announce}");
 		}
 
 		[Command(requiresAuthority = false)]
@@ -580,6 +581,7 @@ namespace AdminCommands
 			if (IsAdmin(sender, out var admin) == false) return;
 			CargoManager.Instance.Credits = budget;
 			CargoManager.Instance.OnCreditsUpdate?.Invoke();
+			LogAdminAction($"{admin.Username} has changed the cargo budget to -> {budget}");
 		}
 
 		[Command(requiresAuthority = false)]
@@ -596,6 +598,8 @@ namespace AdminCommands
 		{
 			if (IsAdmin(sender, out var admin) == false) return;
 			CargoManager.Instance.CargoOffline = state;
+			CargoManager.Instance.OnConnectionChangeToCentComm?.Invoke();
+			LogAdminAction($"{admin.Username} has changed the cargo random bounties status to -> {state}");
 		}
 
 		#endregion

--- a/UnityProject/Assets/Scripts/UI/Objects/Cargo/GUI_Cargo.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Cargo/GUI_Cargo.cs
@@ -77,7 +77,11 @@ namespace UI.Objects.Cargo
 		private void SwitchToOfflinePage()
 		{
 			//If the event has been invoked and cargo is online, ignore.
-			if(CargoManager.Instance.CargoOffline == false) return;
+			if (CargoManager.Instance.CargoOffline == false)
+			{
+				OpenTab(pageCart);
+				return;
+			}
 			OpenTab(OfflinePage);
 			ResetId();
 		}

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/AdminBountyManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/AdminBountyManager.cs
@@ -87,16 +87,21 @@ namespace UI.Systems.AdminTools
 
 		public void RefreshBountiesList(List<CargoManager.BountySyncData> data)
 		{
-			foreach (Transform child in bountiesList.transform)
-			{
-				Destroy(child.gameObject);
-			}
+			ClearBountiesList();
 
 			foreach (var activeBounty in data)
 			{
 				var newEntry = Instantiate(bountyEntryTemplate, bountiesList.transform);
-				newEntry.GetComponent<AdminBountyManagerListEntry>().Setup(activeBounty.Index, activeBounty.Title, activeBounty.Reward);
+				newEntry.GetComponent<AdminBountyManagerListEntry>().Setup(activeBounty.Index, activeBounty.Title, activeBounty.Reward, this);
 				newEntry.SetActive(true);
+			}
+		}
+
+		public void ClearBountiesList()
+		{
+			foreach (Transform child in bountiesList.transform)
+			{
+				Destroy(child.gameObject);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/AdminBountyManagerListEntry.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/AdminBountyManagerListEntry.cs
@@ -9,12 +9,14 @@ namespace UI.Systems.AdminTools
 		public int BountyIndex;
 		public TMP_Text bountyDesc;
 		public TMP_InputField bountyReward;
+		private AdminBountyManager bountyManagerPage;
 
-		public void Setup(int index, string desc, int reward)
+		public void Setup(int index, string desc, int reward, AdminBountyManager manager)
 		{
 			BountyIndex = index;
 			bountyDesc.text = desc;
 			bountyReward.text = reward.ToString();
+			bountyManagerPage = manager;
 		}
 
 		private void Update()
@@ -29,12 +31,14 @@ namespace UI.Systems.AdminTools
 		public void RemoveBounty()
 		{
 			AdminCommandsManager.Instance.CmdRemoveBounty(BountyIndex, false);
+			bountyManagerPage.ClearBountiesList();
 			AdminCommandsManager.Instance.CmdRequestCargoServerData();
 		}
 
 		public void CompleteBounty()
 		{
 			AdminCommandsManager.Instance.CmdRemoveBounty(BountyIndex, true);
+			bountyManagerPage.ClearBountiesList();
 			AdminCommandsManager.Instance.CmdRequestCargoServerData();
 		}
 	}


### PR DESCRIPTION
For admins with slow connections and servers that are running at 0FPS, i've finally found the perfect solution to prevent all of you from getting kicked.
You cant use wrong outdated data if there is none, the game will now completely empty the entire cargo bounty list when a change is made and you'll have to wait until you receive the new changes.
Also the `CompleteBounty()` function now has a check for stopping admins from using index values that are higher than the ones that exist on the active bounties list.

# Changelog:

CL: [Fix] - Admins can no longer get kicked when experiencing lag while editing the cargo bounties.
CL: [Fix] - When the cargo console goes back online it will now switch pages to a the cart instead of staying on the offline page.
CL: [Improvement] - Admins have more logs now when using the cargo manager tool.
