### PR TITLE
Fix Vendor display of Item Name

### DIFF
--- a/UnityProject/Assets/Scripts/UI/Objects/Common/Vending/VendorItemEntry.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Common/Vending/VendorItemEntry.cs
@@ -31,8 +31,19 @@ namespace UI.Objects
 			vendorWindow = correspondingWindow;
 
 			var itemGO = vendorItem.Item;
+
 			// try get human-readable item name
-			var itemNameStr = TextUtils.UppercaseFirst(item.ItemName);
+			string itemNameStr;
+			if (item.ItemName != "")
+			{
+				// Use the override name provided by the VendorItem whenever available.
+				itemNameStr = TextUtils.UppercaseFirst(item.ItemName);
+			}
+			else
+			{
+				// If no override is specified, default to the prefab provided name
+				itemNameStr = TextUtils.UppercaseFirst(itemGO.ExpensiveName());
+			}
 
 			itemName.SetValueServer(itemNameStr);
 			itemIcon.SetValueServer(itemGO.name);

--- a/UnityProject/Assets/Scripts/UI/Objects/Common/Vending/VendorItemEntry.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Common/Vending/VendorItemEntry.cs
@@ -32,7 +32,7 @@ namespace UI.Objects
 
 			var itemGO = vendorItem.Item;
 			// try get human-readable item name
-			var itemNameStr = TextUtils.UppercaseFirst(itemGO.ExpensiveName());
+			var itemNameStr = TextUtils.UppercaseFirst(item.ItemName);
 
 			itemName.SetValueServer(itemNameStr);
 			itemIcon.SetValueServer(itemGO.name);


### PR DESCRIPTION
### Purpose
Currently, Vendors display the name of the item they dispense. This PR allows that name to be overridden for the display.
Fixes #4942