### PR TITLE
Removes alien eggs from Caverna

### DIFF
--- a/UnityProject/Assets/Scenes/AwaySites/Caverna.unity
+++ b/UnityProject/Assets/Scenes/AwaySites/Caverna.unity
@@ -134,7 +134,7 @@ PrefabInstance:
     - target: {fileID: 7371814641826451810, guid: 2f8cb9998dfedc044ae5b62918037b96,
         type: 3}
       propertyPath: m_RootOrder
-      value: 104
+      value: 80
       objectReference: {fileID: 0}
     - target: {fileID: 7371814641826451810, guid: 2f8cb9998dfedc044ae5b62918037b96,
         type: 3}
@@ -219,7 +219,7 @@ PrefabInstance:
     - target: {fileID: 315272389688970755, guid: 9ebdd8fb093d8434db3fe4a38f8100c6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 83
+      value: 53
       objectReference: {fileID: 0}
     - target: {fileID: 315272389688970755, guid: 9ebdd8fb093d8434db3fe4a38f8100c6,
         type: 3}
@@ -309,7 +309,7 @@ PrefabInstance:
     - target: {fileID: 7026721227541041631, guid: 6dad1248a16ebbd48a81433d413e37ec,
         type: 3}
       propertyPath: m_RootOrder
-      value: 59
+      value: 28
       objectReference: {fileID: 0}
     - target: {fileID: 7026721227541041631, guid: 6dad1248a16ebbd48a81433d413e37ec,
         type: 3}
@@ -737,7 +737,7 @@ PrefabInstance:
     - target: {fileID: 4799606482247584978, guid: 032e150131f53a64fbf6048aca6a879a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 43
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 4799606482247584978, guid: 032e150131f53a64fbf6048aca6a879a,
         type: 3}
@@ -822,7 +822,7 @@ PrefabInstance:
     - target: {fileID: 8080698523358435093, guid: 30c1980ca0250624a893b6e4f398f2a9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 97
+      value: 73
       objectReference: {fileID: 0}
     - target: {fileID: 8080698523358435093, guid: 30c1980ca0250624a893b6e4f398f2a9,
         type: 3}
@@ -1224,7 +1224,7 @@ PrefabInstance:
     - target: {fileID: 6443293881846660846, guid: db34b9991c6517848999bc6bfe8ba25d,
         type: 3}
       propertyPath: m_RootOrder
-      value: 99
+      value: 75
       objectReference: {fileID: 0}
     - target: {fileID: 6443293881846660846, guid: db34b9991c6517848999bc6bfe8ba25d,
         type: 3}
@@ -1299,6 +1299,91 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 510770798}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &510972188
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1998928700528175337}
+    m_Modifications:
+    - target: {fileID: 6549278993558212593, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: sceneId
+      value: 625590380
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 65
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.001001
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 36.829
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 27.138916
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6590880699883532869, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_Name
+      value: TraitorGearSpawner
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 63caee5f883552645b5a8620d8cdde0c, type: 3}
+--- !u!4 &510972189 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+    type: 3}
+  m_PrefabInstance: {fileID: 510972188}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &531777988
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1309,7 +1394,7 @@ PrefabInstance:
     - target: {fileID: 3783067603822704685, guid: 4325ff5e8c92fee47b53476d3cd97788,
         type: 3}
       propertyPath: m_RootOrder
-      value: 105
+      value: 81
       objectReference: {fileID: 0}
     - target: {fileID: 3783067603822704685, guid: 4325ff5e8c92fee47b53476d3cd97788,
         type: 3}
@@ -1404,7 +1489,7 @@ PrefabInstance:
     - target: {fileID: 4799606482247584978, guid: 032e150131f53a64fbf6048aca6a879a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 41
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 4799606482247584978, guid: 032e150131f53a64fbf6048aca6a879a,
         type: 3}
@@ -1484,17 +1569,17 @@ PrefabInstance:
     - target: {fileID: 7371814641826451810, guid: 2f8cb9998dfedc044ae5b62918037b96,
         type: 3}
       propertyPath: m_RootOrder
-      value: 106
+      value: 82
       objectReference: {fileID: 0}
     - target: {fileID: 7371814641826451810, guid: 2f8cb9998dfedc044ae5b62918037b96,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 35.078125
+      value: -11
       objectReference: {fileID: 0}
     - target: {fileID: 7371814641826451810, guid: 2f8cb9998dfedc044ae5b62918037b96,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 27.085693
+      value: 14.243
       objectReference: {fileID: 0}
     - target: {fileID: 7371814641826451810, guid: 2f8cb9998dfedc044ae5b62918037b96,
         type: 3}
@@ -1739,80 +1824,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 784494304}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &826683933
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 4338313880768651269}
-    m_Modifications:
-    - target: {fileID: 6786921701954569492, guid: 752200a7f6e7fcc48babeaeda589190a,
-        type: 3}
-      propertyPath: m_Name
-      value: RandomArtifactSpawnPoint
-      objectReference: {fileID: 0}
-    - target: {fileID: 6790442475791071328, guid: 752200a7f6e7fcc48babeaeda589190a,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6790442475791071328, guid: 752200a7f6e7fcc48babeaeda589190a,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.9
-      objectReference: {fileID: 0}
-    - target: {fileID: 6790442475791071328, guid: 752200a7f6e7fcc48babeaeda589190a,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 6790442475791071328, guid: 752200a7f6e7fcc48babeaeda589190a,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6790442475791071328, guid: 752200a7f6e7fcc48babeaeda589190a,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6790442475791071328, guid: 752200a7f6e7fcc48babeaeda589190a,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6790442475791071328, guid: 752200a7f6e7fcc48babeaeda589190a,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6790442475791071328, guid: 752200a7f6e7fcc48babeaeda589190a,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6790442475791071328, guid: 752200a7f6e7fcc48babeaeda589190a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6790442475791071328, guid: 752200a7f6e7fcc48babeaeda589190a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6790442475791071328, guid: 752200a7f6e7fcc48babeaeda589190a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6898328034275391648, guid: 752200a7f6e7fcc48babeaeda589190a,
-        type: 3}
-      propertyPath: sceneId
-      value: 1823527216
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 752200a7f6e7fcc48babeaeda589190a, type: 3}
 --- !u!1001 &869533058
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1823,7 +1834,7 @@ PrefabInstance:
     - target: {fileID: 1002719256847154502, guid: 2a39aefa5aa903240b20a8b5a5185fbf,
         type: 3}
       propertyPath: m_RootOrder
-      value: 58
+      value: 27
       objectReference: {fileID: 0}
     - target: {fileID: 1002719256847154502, guid: 2a39aefa5aa903240b20a8b5a5185fbf,
         type: 3}
@@ -1913,7 +1924,7 @@ PrefabInstance:
     - target: {fileID: 1002719256847154502, guid: 2a39aefa5aa903240b20a8b5a5185fbf,
         type: 3}
       propertyPath: m_RootOrder
-      value: 57
+      value: 26
       objectReference: {fileID: 0}
     - target: {fileID: 1002719256847154502, guid: 2a39aefa5aa903240b20a8b5a5185fbf,
         type: 3}
@@ -2003,7 +2014,7 @@ PrefabInstance:
     - target: {fileID: 6371202620035631115, guid: 81e1dcfb97892054295d23cfd69c5542,
         type: 3}
       propertyPath: m_RootOrder
-      value: 100
+      value: 76
       objectReference: {fileID: 0}
     - target: {fileID: 6371202620035631115, guid: 81e1dcfb97892054295d23cfd69c5542,
         type: 3}
@@ -2083,6 +2094,91 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 954371426}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &955059256
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1998928700528175337}
+    m_Modifications:
+    - target: {fileID: 3892245000269501020, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_Name
+      value: NukieGearSpawner
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 68
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.001001
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 35.6438
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 27.131
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4003767880824172520, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: sceneId
+      value: 2699178907
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d98f2fb82408dae4296038c656ee83fb, type: 3}
+--- !u!4 &955059257 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+    type: 3}
+  m_PrefabInstance: {fileID: 955059256}
+  m_PrefabAsset: {fileID: 0}
 --- !u!21 &982164933
 Material:
   serializedVersion: 8
@@ -2138,7 +2234,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 89
+      value: 59
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -2208,6 +2304,91 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1028955186}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1041905502
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1998928700528175337}
+    m_Modifications:
+    - target: {fileID: 3767121525936011948, guid: c3c0bef0c9fb94c4eb2a53079df54bc8,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3767121525936011948, guid: c3c0bef0c9fb94c4eb2a53079df54bc8,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.001001
+      objectReference: {fileID: 0}
+    - target: {fileID: 3767121525936011948, guid: c3c0bef0c9fb94c4eb2a53079df54bc8,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 36.04297
+      objectReference: {fileID: 0}
+    - target: {fileID: 3767121525936011948, guid: c3c0bef0c9fb94c4eb2a53079df54bc8,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 27.085693
+      objectReference: {fileID: 0}
+    - target: {fileID: 3767121525936011948, guid: c3c0bef0c9fb94c4eb2a53079df54bc8,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3767121525936011948, guid: c3c0bef0c9fb94c4eb2a53079df54bc8,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3767121525936011948, guid: c3c0bef0c9fb94c4eb2a53079df54bc8,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3767121525936011948, guid: c3c0bef0c9fb94c4eb2a53079df54bc8,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3767121525936011948, guid: c3c0bef0c9fb94c4eb2a53079df54bc8,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3767121525936011948, guid: c3c0bef0c9fb94c4eb2a53079df54bc8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3767121525936011948, guid: c3c0bef0c9fb94c4eb2a53079df54bc8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3767121525936011948, guid: c3c0bef0c9fb94c4eb2a53079df54bc8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3770642299235649496, guid: c3c0bef0c9fb94c4eb2a53079df54bc8,
+        type: 3}
+      propertyPath: m_Name
+      value: SyndicateSurgicalDuffelBag
+      objectReference: {fileID: 0}
+    - target: {fileID: 3873155781524126316, guid: c3c0bef0c9fb94c4eb2a53079df54bc8,
+        type: 3}
+      propertyPath: sceneId
+      value: 3521897362
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c3c0bef0c9fb94c4eb2a53079df54bc8, type: 3}
+--- !u!4 &1041905503 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3767121525936011948, guid: c3c0bef0c9fb94c4eb2a53079df54bc8,
+    type: 3}
+  m_PrefabInstance: {fileID: 1041905502}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1044446747
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2218,7 +2399,7 @@ PrefabInstance:
     - target: {fileID: 315272389688970755, guid: 9ebdd8fb093d8434db3fe4a38f8100c6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 52
+      value: 21
       objectReference: {fileID: 0}
     - target: {fileID: 315272389688970755, guid: 9ebdd8fb093d8434db3fe4a38f8100c6,
         type: 3}
@@ -2303,7 +2484,7 @@ PrefabInstance:
     - target: {fileID: 2913139576740966894, guid: 71270ee865885154cb3d16d97e879cc8,
         type: 3}
       propertyPath: m_RootOrder
-      value: 49
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 2913139576740966894, guid: 71270ee865885154cb3d16d97e879cc8,
         type: 3}
@@ -2478,7 +2659,7 @@ PrefabInstance:
     - target: {fileID: 7026721227541041631, guid: 6dad1248a16ebbd48a81433d413e37ec,
         type: 3}
       propertyPath: m_RootOrder
-      value: 60
+      value: 29
       objectReference: {fileID: 0}
     - target: {fileID: 7026721227541041631, guid: 6dad1248a16ebbd48a81433d413e37ec,
         type: 3}
@@ -2573,7 +2754,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 108
+      value: 84
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -2668,7 +2849,7 @@ PrefabInstance:
     - target: {fileID: 3541449163993279649, guid: abe9c13902b62ce449fdfec99db8f554,
         type: 3}
       propertyPath: m_RootOrder
-      value: 61
+      value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 3541449163993279649, guid: abe9c13902b62ce449fdfec99db8f554,
         type: 3}
@@ -2743,7 +2924,7 @@ PrefabInstance:
     - target: {fileID: 3783067603822704685, guid: 4325ff5e8c92fee47b53476d3cd97788,
         type: 3}
       propertyPath: m_RootOrder
-      value: 107
+      value: 83
       objectReference: {fileID: 0}
     - target: {fileID: 3783067603822704685, guid: 4325ff5e8c92fee47b53476d3cd97788,
         type: 3}
@@ -2836,7 +3017,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 113
+      value: 89
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -2919,7 +3100,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 90
+      value: 60
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -2989,91 +3170,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1228815363}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1299766605
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 2478885986720602284, guid: 06bafeeeafb276f41b4ac9c44857abd3,
-        type: 3}
-      propertyPath: m_Name
-      value: SurgicalDuffelBagFull
-      objectReference: {fileID: 0}
-    - target: {fileID: 2482969435297064408, guid: 06bafeeeafb276f41b4ac9c44857abd3,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2482969435297064408, guid: 06bafeeeafb276f41b4ac9c44857abd3,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 2482969435297064408, guid: 06bafeeeafb276f41b4ac9c44857abd3,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 36.043
-      objectReference: {fileID: 0}
-    - target: {fileID: 2482969435297064408, guid: 06bafeeeafb276f41b4ac9c44857abd3,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 27.085693
-      objectReference: {fileID: 0}
-    - target: {fileID: 2482969435297064408, guid: 06bafeeeafb276f41b4ac9c44857abd3,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2482969435297064408, guid: 06bafeeeafb276f41b4ac9c44857abd3,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2482969435297064408, guid: 06bafeeeafb276f41b4ac9c44857abd3,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2482969435297064408, guid: 06bafeeeafb276f41b4ac9c44857abd3,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2482969435297064408, guid: 06bafeeeafb276f41b4ac9c44857abd3,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2482969435297064408, guid: 06bafeeeafb276f41b4ac9c44857abd3,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2482969435297064408, guid: 06bafeeeafb276f41b4ac9c44857abd3,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2482969435297064408, guid: 06bafeeeafb276f41b4ac9c44857abd3,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2590396840835999000, guid: 06bafeeeafb276f41b4ac9c44857abd3,
-        type: 3}
-      propertyPath: sceneId
-      value: 3937960199
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 06bafeeeafb276f41b4ac9c44857abd3, type: 3}
---- !u!4 &1299766606 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 2482969435297064408, guid: 06bafeeeafb276f41b4ac9c44857abd3,
-    type: 3}
-  m_PrefabInstance: {fileID: 1299766605}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1304319235
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3089,7 +3185,7 @@ PrefabInstance:
     - target: {fileID: 3541449163993279649, guid: abe9c13902b62ce449fdfec99db8f554,
         type: 3}
       propertyPath: m_RootOrder
-      value: 82
+      value: 52
       objectReference: {fileID: 0}
     - target: {fileID: 3541449163993279649, guid: abe9c13902b62ce449fdfec99db8f554,
         type: 3}
@@ -3154,6 +3250,91 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1304319235}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1311281702
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1998928700528175337}
+    m_Modifications:
+    - target: {fileID: 2252916025122891987, guid: ce874e42e21343a429f39c4780a09059,
+        type: 3}
+      propertyPath: m_Name
+      value: ComputerFrame
+      objectReference: {fileID: 0}
+    - target: {fileID: 2258065906701037065, guid: ce874e42e21343a429f39c4780a09059,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 31
+      objectReference: {fileID: 0}
+    - target: {fileID: 2258065906701037065, guid: ce874e42e21343a429f39c4780a09059,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.001001
+      objectReference: {fileID: 0}
+    - target: {fileID: 2258065906701037065, guid: ce874e42e21343a429f39c4780a09059,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 43.02
+      objectReference: {fileID: 0}
+    - target: {fileID: 2258065906701037065, guid: ce874e42e21343a429f39c4780a09059,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 29
+      objectReference: {fileID: 0}
+    - target: {fileID: 2258065906701037065, guid: ce874e42e21343a429f39c4780a09059,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2258065906701037065, guid: ce874e42e21343a429f39c4780a09059,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2258065906701037065, guid: ce874e42e21343a429f39c4780a09059,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2258065906701037065, guid: ce874e42e21343a429f39c4780a09059,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2258065906701037065, guid: ce874e42e21343a429f39c4780a09059,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2258065906701037065, guid: ce874e42e21343a429f39c4780a09059,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2258065906701037065, guid: ce874e42e21343a429f39c4780a09059,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2258065906701037065, guid: ce874e42e21343a429f39c4780a09059,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7682620871540252081, guid: ce874e42e21343a429f39c4780a09059,
+        type: 3}
+      propertyPath: sceneId
+      value: 923647040
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ce874e42e21343a429f39c4780a09059, type: 3}
+--- !u!4 &1311281703 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2258065906701037065, guid: ce874e42e21343a429f39c4780a09059,
+    type: 3}
+  m_PrefabInstance: {fileID: 1311281702}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1351666592
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3169,7 +3350,7 @@ PrefabInstance:
     - target: {fileID: 8305882254983888476, guid: f5de2b6011113f0469b27cd8289f2d8b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 109
+      value: 85
       objectReference: {fileID: 0}
     - target: {fileID: 8305882254983888476, guid: f5de2b6011113f0469b27cd8289f2d8b,
         type: 3}
@@ -3249,7 +3430,7 @@ PrefabInstance:
     - target: {fileID: 9073506637506376762, guid: 14eb60754136feb4ebbf4e990721439a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 96
+      value: 72
       objectReference: {fileID: 0}
     - target: {fileID: 9073506637506376762, guid: 14eb60754136feb4ebbf4e990721439a,
         type: 3}
@@ -3344,7 +3525,7 @@ PrefabInstance:
     - target: {fileID: 836487917318320442, guid: 612b94b3afdd65d488e97c5fd244a026,
         type: 3}
       propertyPath: m_RootOrder
-      value: 93
+      value: 63
       objectReference: {fileID: 0}
     - target: {fileID: 836487917318320442, guid: 612b94b3afdd65d488e97c5fd244a026,
         type: 3}
@@ -3424,7 +3605,7 @@ PrefabInstance:
     - target: {fileID: 8946129733050971242, guid: 5de3487372396e34e839c297ece28ef0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 101
+      value: 77
       objectReference: {fileID: 0}
     - target: {fileID: 8946129733050971242, guid: 5de3487372396e34e839c297ece28ef0,
         type: 3}
@@ -3509,7 +3690,7 @@ PrefabInstance:
     - target: {fileID: 1002719256847154502, guid: 2a39aefa5aa903240b20a8b5a5185fbf,
         type: 3}
       propertyPath: m_RootOrder
-      value: 62
+      value: 32
       objectReference: {fileID: 0}
     - target: {fileID: 1002719256847154502, guid: 2a39aefa5aa903240b20a8b5a5185fbf,
         type: 3}
@@ -3733,7 +3914,7 @@ PrefabInstance:
     - target: {fileID: 1002719256847154502, guid: 2a39aefa5aa903240b20a8b5a5185fbf,
         type: 3}
       propertyPath: m_RootOrder
-      value: 56
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 1002719256847154502, guid: 2a39aefa5aa903240b20a8b5a5185fbf,
         type: 3}
@@ -3992,7 +4173,7 @@ PrefabInstance:
     - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
         type: 3}
       propertyPath: m_RootOrder
-      value: 103
+      value: 79
       objectReference: {fileID: 0}
     - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
         type: 3}
@@ -4077,7 +4258,7 @@ PrefabInstance:
     - target: {fileID: 3383979214839746496, guid: cd57a2813ebc4ff4caf28b5fb793b3eb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 55
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 3383979214839746496, guid: cd57a2813ebc4ff4caf28b5fb793b3eb,
         type: 3}
@@ -4160,7 +4341,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 112
+      value: 88
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -4240,7 +4421,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 110
+      value: 86
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -4335,7 +4516,7 @@ PrefabInstance:
     - target: {fileID: 4249355701057277291, guid: c05c071c51fbfec408e4c9f6240dc824,
         type: 3}
       propertyPath: m_RootOrder
-      value: 92
+      value: 62
       objectReference: {fileID: 0}
     - target: {fileID: 4249355701057277291, guid: c05c071c51fbfec408e4c9f6240dc824,
         type: 3}
@@ -4515,7 +4696,7 @@ PrefabInstance:
     - target: {fileID: 3319557741849199478, guid: 68ef2c0235224f347b94384d5dcdae47,
         type: 3}
       propertyPath: m_RootOrder
-      value: 50
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 3319557741849199478, guid: 68ef2c0235224f347b94384d5dcdae47,
         type: 3}
@@ -4605,7 +4786,7 @@ PrefabInstance:
     - target: {fileID: 2413525652997339073, guid: 996245457b67ce049bcb361024617659,
         type: 3}
       propertyPath: m_RootOrder
-      value: 95
+      value: 71
       objectReference: {fileID: 0}
     - target: {fileID: 2413525652997339073, guid: 996245457b67ce049bcb361024617659,
         type: 3}
@@ -4685,7 +4866,7 @@ PrefabInstance:
     - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 94
+      value: 64
       objectReference: {fileID: 0}
     - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
         type: 3}
@@ -4770,7 +4951,7 @@ PrefabInstance:
     - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
         type: 3}
       propertyPath: m_RootOrder
-      value: 102
+      value: 78
       objectReference: {fileID: 0}
     - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
         type: 3}
@@ -4850,7 +5031,7 @@ PrefabInstance:
     - target: {fileID: 616985181830910736, guid: 7be3b1eb3cca1f64f94531200c4f1e0e,
         type: 3}
       propertyPath: m_RootOrder
-      value: 51
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 616985181830910736, guid: 7be3b1eb3cca1f64f94531200c4f1e0e,
         type: 3}
@@ -4957,6 +5138,176 @@ Material:
     - _Emission: {r: 0, g: 0, b: 0, a: 0}
     - _SpecColor: {r: 1, g: 1, b: 1, a: 1}
   m_BuildTextureStacks: []
+--- !u!1001 &1896778417
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1998928700528175337}
+    m_Modifications:
+    - target: {fileID: 5641904223438961888, guid: e456d62fc63bc3344a513208fbc3018a,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 70
+      objectReference: {fileID: 0}
+    - target: {fileID: 5641904223438961888, guid: e456d62fc63bc3344a513208fbc3018a,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.001001
+      objectReference: {fileID: 0}
+    - target: {fileID: 5641904223438961888, guid: e456d62fc63bc3344a513208fbc3018a,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 43.086
+      objectReference: {fileID: 0}
+    - target: {fileID: 5641904223438961888, guid: e456d62fc63bc3344a513208fbc3018a,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 28.004
+      objectReference: {fileID: 0}
+    - target: {fileID: 5641904223438961888, guid: e456d62fc63bc3344a513208fbc3018a,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5641904223438961888, guid: e456d62fc63bc3344a513208fbc3018a,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5641904223438961888, guid: e456d62fc63bc3344a513208fbc3018a,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5641904223438961888, guid: e456d62fc63bc3344a513208fbc3018a,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5641904223438961888, guid: e456d62fc63bc3344a513208fbc3018a,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5641904223438961888, guid: e456d62fc63bc3344a513208fbc3018a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5641904223438961888, guid: e456d62fc63bc3344a513208fbc3018a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5641904223438961888, guid: e456d62fc63bc3344a513208fbc3018a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5647395047373439380, guid: e456d62fc63bc3344a513208fbc3018a,
+        type: 3}
+      propertyPath: m_Name
+      value: CombatAidKit
+      objectReference: {fileID: 0}
+    - target: {fileID: 5749872176505338912, guid: e456d62fc63bc3344a513208fbc3018a,
+        type: 3}
+      propertyPath: sceneId
+      value: 1910521966
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e456d62fc63bc3344a513208fbc3018a, type: 3}
+--- !u!4 &1896778418 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5641904223438961888, guid: e456d62fc63bc3344a513208fbc3018a,
+    type: 3}
+  m_PrefabInstance: {fileID: 1896778417}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1915658526
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1998928700528175337}
+    m_Modifications:
+    - target: {fileID: 728592394780439034, guid: 612b94b3afdd65d488e97c5fd244a026,
+        type: 3}
+      propertyPath: sceneId
+      value: 3263465486
+      objectReference: {fileID: 0}
+    - target: {fileID: 831001491632180302, guid: 612b94b3afdd65d488e97c5fd244a026,
+        type: 3}
+      propertyPath: m_Name
+      value: SyndicateExplosivesSpawner
+      objectReference: {fileID: 0}
+    - target: {fileID: 836487917318320442, guid: 612b94b3afdd65d488e97c5fd244a026,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 66
+      objectReference: {fileID: 0}
+    - target: {fileID: 836487917318320442, guid: 612b94b3afdd65d488e97c5fd244a026,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.001001
+      objectReference: {fileID: 0}
+    - target: {fileID: 836487917318320442, guid: 612b94b3afdd65d488e97c5fd244a026,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 36.388
+      objectReference: {fileID: 0}
+    - target: {fileID: 836487917318320442, guid: 612b94b3afdd65d488e97c5fd244a026,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 27.138916
+      objectReference: {fileID: 0}
+    - target: {fileID: 836487917318320442, guid: 612b94b3afdd65d488e97c5fd244a026,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 836487917318320442, guid: 612b94b3afdd65d488e97c5fd244a026,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 836487917318320442, guid: 612b94b3afdd65d488e97c5fd244a026,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 836487917318320442, guid: 612b94b3afdd65d488e97c5fd244a026,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 836487917318320442, guid: 612b94b3afdd65d488e97c5fd244a026,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 836487917318320442, guid: 612b94b3afdd65d488e97c5fd244a026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 836487917318320442, guid: 612b94b3afdd65d488e97c5fd244a026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 836487917318320442, guid: 612b94b3afdd65d488e97c5fd244a026,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 612b94b3afdd65d488e97c5fd244a026, type: 3}
+--- !u!4 &1915658527 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 836487917318320442, guid: 612b94b3afdd65d488e97c5fd244a026,
+    type: 3}
+  m_PrefabInstance: {fileID: 1915658526}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1936907018
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4970,7 +5321,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 114
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -5053,7 +5404,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 111
+      value: 87
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -5138,7 +5489,7 @@ PrefabInstance:
     - target: {fileID: 3541449163993279649, guid: abe9c13902b62ce449fdfec99db8f554,
         type: 3}
       propertyPath: m_RootOrder
-      value: 39
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 3541449163993279649, guid: abe9c13902b62ce449fdfec99db8f554,
         type: 3}
@@ -5202,6 +5553,91 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3541449163993279649, guid: abe9c13902b62ce449fdfec99db8f554,
     type: 3}
   m_PrefabInstance: {fileID: 1980317936}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2003887683
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1998928700528175337}
+    m_Modifications:
+    - target: {fileID: 6549278993558212593, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: sceneId
+      value: 4146551118
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 67
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.001001
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 35.068
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 27.139
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6590880699883532869, guid: 63caee5f883552645b5a8620d8cdde0c,
+        type: 3}
+      propertyPath: m_Name
+      value: TraitorGearSpawner
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 63caee5f883552645b5a8620d8cdde0c, type: 3}
+--- !u!4 &2003887684 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
+    type: 3}
+  m_PrefabInstance: {fileID: 2003887683}
   m_PrefabAsset: {fileID: 0}
 --- !u!43 &2057619248
 Mesh:
@@ -5367,6 +5803,91 @@ Mesh:
     offset: 0
     size: 0
     path: 
+--- !u!1001 &2108825759
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1998928700528175337}
+    m_Modifications:
+    - target: {fileID: 3892245000269501020, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_Name
+      value: NukieGearSpawner
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 69
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.001001
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 36.252
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 30.036133
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4003767880824172520, guid: d98f2fb82408dae4296038c656ee83fb,
+        type: 3}
+      propertyPath: sceneId
+      value: 2538095707
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d98f2fb82408dae4296038c656ee83fb, type: 3}
+--- !u!4 &2108825760 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
+    type: 3}
+  m_PrefabInstance: {fileID: 2108825759}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2123879099
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5387,7 +5908,7 @@ PrefabInstance:
     - target: {fileID: 7529218229981866049, guid: 6d0e5d5bc9d6eeb4bac0fcf68fc738b8,
         type: 3}
       propertyPath: m_RootOrder
-      value: 98
+      value: 74
       objectReference: {fileID: 0}
     - target: {fileID: 7529218229981866049, guid: 6d0e5d5bc9d6eeb4bac0fcf68fc738b8,
         type: 3}
@@ -5519,7 +6040,7 @@ PrefabInstance:
     - target: {fileID: 7632320555952889534, guid: 5a6e2e3a0a44146198136e4fa2798db5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 44
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 7632320555952889534, guid: 5a6e2e3a0a44146198136e4fa2798db5,
         type: 3}
@@ -5589,106 +6110,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 223727445643336974}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &229327562078443576
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 870469738
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 36
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -15.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 24.94
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &229327562078443577 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 229327562078443576}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &270179779111756408
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5701,106 +6122,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1629061c87b84efca254e0716499651e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &398296159963240452
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 958722491
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 11
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -29.137695
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -33.919666
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &398296159963240453 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 398296159963240452}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &415076003563517871
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5816,7 +6137,7 @@ PrefabInstance:
     - target: {fileID: 781168085651184303, guid: baee0b013108b4f45be339b62de456a3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 47
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 781168085651184303, guid: baee0b013108b4f45be339b62de456a3,
         type: 3}
@@ -6049,206 +6370,6 @@ Transform:
   m_Father: {fileID: 4973277796872332647}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &770978162595791984
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 3504189807
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 27
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 23.455566
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -38.824474
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &770978162595791985 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 770978162595791984}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &995839063365793353
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 3914827293
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 17
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -20.763184
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -39.458897
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &995839063365793354 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 995839063365793353}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1062548470927920079
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6279,7 +6400,7 @@ PrefabInstance:
     - target: {fileID: 6511207373575406613, guid: 1488f67a55cb9b84098e095e65e5a2b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 53
+      value: 22
       objectReference: {fileID: 0}
     - target: {fileID: 6511207373575406613, guid: 1488f67a55cb9b84098e095e65e5a2b3,
         type: 3}
@@ -6375,7 +6496,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4699640297835872, guid: fa26dc8a7e76973489beed18bc59d792, type: 3}
       propertyPath: m_RootOrder
-      value: 65
+      value: 35
       objectReference: {fileID: 0}
     - target: {fileID: 4699640297835872, guid: fa26dc8a7e76973489beed18bc59d792, type: 3}
       propertyPath: m_LocalScale.y
@@ -6493,7 +6614,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 69
+      value: 39
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -6588,7 +6709,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 87
+      value: 57
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -6670,206 +6791,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0a279ee0b30f13740a1bdacb59adeff2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &1467818696711194762
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 2386579829
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 28
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 26.36084
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -42.149086
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &1467818696711194763 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 1467818696711194762}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1487847579193487330
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 2523395844
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 23
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -25.978516
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -40.148064
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &1487847579193487331 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 1487847579193487330}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1559016907994958228
 Transform:
   m_ObjectHideFlags: 0
@@ -6898,7 +6819,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 81
+      value: 51
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -7000,106 +6921,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1001 &1697845049469525097
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 2745268171
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 25
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -2.043457
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -41.978016
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &1697845049469525098 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 1697845049469525097}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1786552280564320597
 GameObject:
   m_ObjectHideFlags: 0
@@ -7137,40 +6958,9 @@ Transform:
   - {fileID: 784494305}
   - {fileID: 1756556397}
   - {fileID: 548707995649042591}
-  - {fileID: 1299766606}
+  - {fileID: 1041905503}
   - {fileID: 2520228072746534428}
   - {fileID: 3177556912144807630}
-  - {fileID: 6673959921276504487}
-  - {fileID: 2615275256518342196}
-  - {fileID: 4533698071565277109}
-  - {fileID: 398296159963240453}
-  - {fileID: 8814207847028879434}
-  - {fileID: 3946896314324854460}
-  - {fileID: 9034556265396314758}
-  - {fileID: 4094307447743553768}
-  - {fileID: 8232860268328153051}
-  - {fileID: 995839063365793354}
-  - {fileID: 3856163840207389848}
-  - {fileID: 2902000445406243055}
-  - {fileID: 7222146871198008235}
-  - {fileID: 5460187238873657478}
-  - {fileID: 2360665160233877892}
-  - {fileID: 1487847579193487331}
-  - {fileID: 7653805817788536157}
-  - {fileID: 1697845049469525098}
-  - {fileID: 4338313880768651269}
-  - {fileID: 770978162595791985}
-  - {fileID: 1467818696711194763}
-  - {fileID: 2819367059063731362}
-  - {fileID: 3898738035835100562}
-  - {fileID: 3449456587198003086}
-  - {fileID: 4830386218019856736}
-  - {fileID: 4382407162492255943}
-  - {fileID: 4036290430947079060}
-  - {fileID: 7795361497545034530}
-  - {fileID: 229327562078443577}
-  - {fileID: 2453502460519735049}
-  - {fileID: 4128194855662144007}
   - {fileID: 1980317937}
   - {fileID: 4649813175051088804}
   - {fileID: 546166092}
@@ -7194,6 +6984,7 @@ Transform:
   - {fileID: 208951249}
   - {fileID: 1121096946}
   - {fileID: 1152049780}
+  - {fileID: 1311281703}
   - {fileID: 1467499808}
   - {fileID: 8241992796124747319}
   - {fileID: 8404965766031334139}
@@ -7227,6 +7018,12 @@ Transform:
   - {fileID: 1749363555}
   - {fileID: 1462601006}
   - {fileID: 1802102810}
+  - {fileID: 510972189}
+  - {fileID: 1915658527}
+  - {fileID: 2003887684}
+  - {fileID: 955059257}
+  - {fileID: 2108825760}
+  - {fileID: 1896778418}
   - {fileID: 1788528261}
   - {fileID: 1455390937}
   - {fileID: 469894098}
@@ -7263,7 +7060,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 72
+      value: 42
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -7369,8 +7166,8 @@ Tilemap:
   - first: {x: 36, y: 26, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 2
+      m_TileIndex: 1
+      m_TileSpriteIndex: 5
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -7379,8 +7176,8 @@ Tilemap:
   - first: {x: 37, y: 26, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 1
+      m_TileIndex: 1
+      m_TileSpriteIndex: 0
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -7389,7 +7186,7 @@ Tilemap:
   - first: {x: 44, y: 28, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 0
+      m_TileIndex: 1
       m_TileSpriteIndex: 4
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
@@ -7399,7 +7196,7 @@ Tilemap:
   - first: {x: 44, y: 29, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 0
+      m_TileIndex: 1
       m_TileSpriteIndex: 3
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
@@ -7409,8 +7206,8 @@ Tilemap:
   - first: {x: 36, y: 31, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 2
+      m_TileIndex: 1
+      m_TileSpriteIndex: 5
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -7419,8 +7216,8 @@ Tilemap:
   - first: {x: 37, y: 31, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 1
+      m_TileIndex: 1
+      m_TileSpriteIndex: 0
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -7428,19 +7225,27 @@ Tilemap:
       m_AllTileFlags: 2147483648
   m_AnimatedTiles: {}
   m_TileAssetArray:
-  - m_RefCount: 6
-    m_Data: {fileID: 11400000, guid: 1c10e6823dbf44ce3b281a6f25f514e9, type: 2}
-  m_TileSpriteArray:
   - m_RefCount: 0
     m_Data: {fileID: 0}
+  - m_RefCount: 6
+    m_Data: {fileID: 11400000, guid: fab674b25934e6c47851b75fc09783b7, type: 2}
+  m_TileSpriteArray:
   - m_RefCount: 2
-    m_Data: {fileID: 21300006, guid: fdd35d1a33ff82c4ca893aa00797cb12, type: 3}
+    m_Data: {fileID: 3196294792163662400, guid: 8a68cd9823bcbbc4ea58db062339a340,
+      type: 3}
+  - m_RefCount: 0
+    m_Data: {fileID: 0}
+  - m_RefCount: 0
+    m_Data: {fileID: 0}
+  - m_RefCount: 1
+    m_Data: {fileID: -1072390242456395133, guid: 8a68cd9823bcbbc4ea58db062339a340,
+      type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: -7912559750963844340, guid: 8a68cd9823bcbbc4ea58db062339a340,
+      type: 3}
   - m_RefCount: 2
-    m_Data: {fileID: 21300002, guid: fdd35d1a33ff82c4ca893aa00797cb12, type: 3}
-  - m_RefCount: 1
-    m_Data: {fileID: 21300004, guid: fdd35d1a33ff82c4ca893aa00797cb12, type: 3}
-  - m_RefCount: 1
-    m_Data: {fileID: 21300008, guid: fdd35d1a33ff82c4ca893aa00797cb12, type: 3}
+    m_Data: {fileID: 5046508452451233759, guid: 8a68cd9823bcbbc4ea58db062339a340,
+      type: 3}
   m_TileMatrixArray:
   - m_RefCount: 6
     m_Data:
@@ -7500,7 +7305,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 91
+      value: 61
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -7622,206 +7427,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d007c14d2939f4fb2a1121b89c7a030e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &2360665160233877891
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 1339295589
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 22
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -33.13916
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -33.88252
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &2360665160233877892 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 2360665160233877891}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &2453502460519735048
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 1235106855
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 37
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -11.959961
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.074290834
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &2453502460519735049 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 2453502460519735048}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2508207707085159119
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7835,7 +7440,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 70
+      value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -8023,106 +7628,6 @@ MonoBehaviour:
   LayerType: 3
   matrix: {fileID: 7240300236555714978}
   metaTileMap: {fileID: 1062548470927920079}
---- !u!1001 &2615275256518342195
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 4220960648
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -33.115723
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -36.89823
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &2615275256518342196 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 2615275256518342195}
-  m_PrefabAsset: {fileID: 0}
 --- !u!483693784 &2626891093083759554
 TilemapRenderer:
   m_ObjectHideFlags: 0
@@ -8197,7 +7702,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 74
+      value: 44
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -8292,7 +7797,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 85
+      value: 55
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -8374,106 +7879,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0a279ee0b30f13740a1bdacb59adeff2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &2819367059063731361
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 568126826
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 29
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 29.197266
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -38.78977
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &2819367059063731362 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 2819367059063731361}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &2830237306999073536
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8486,106 +7891,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d007c14d2939f4fb2a1121b89c7a030e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &2902000445406243054
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 2751826598
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 19
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -24.59961
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -24.77331
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &2902000445406243055 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 2902000445406243054}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &3144258009084827306
 GameObject:
   m_ObjectHideFlags: 0
@@ -8705,7 +8010,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 80
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -8820,106 +8125,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isMeleeable: 1
---- !u!1001 &3449456587198003085
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 207992094
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 31
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 44.79541
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -35.669952
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &3449456587198003086 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 3449456587198003085}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3566332924864321260
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9035,7 +8240,7 @@ PrefabInstance:
     - target: {fileID: 1840503368461670069, guid: 3266ceefb65da2f4cb4bbfd297415ad5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 42
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 1840503368461670069, guid: 3266ceefb65da2f4cb4bbfd297415ad5,
         type: 3}
@@ -9118,7 +8323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 88
+      value: 58
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -9213,7 +8418,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 76
+      value: 46
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -9308,7 +8513,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 78
+      value: 48
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -9405,206 +8610,6 @@ Transform:
   m_Father: {fileID: 4973277796872332647}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &3856163840207389847
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 1691081843
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 18
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -19.448242
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -27.96009
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &3856163840207389848 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 3856163840207389847}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &3898738035835100561
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 3078945747
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 30
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 27.952148
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -45.058247
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &3898738035835100562 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 3898738035835100561}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &3946368546908237557
 GameObject:
   m_ObjectHideFlags: 0
@@ -9629,106 +8634,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1001 &3946896314324854459
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 1556998005
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 13
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -37.09375
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -32.534492
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &3946896314324854460 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 3946896314324854459}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1839735485 &3966664080731095286
 Tilemap:
   m_ObjectHideFlags: 0
@@ -9784,106 +8689,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1001 &4036290430947079059
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 3298583041
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 34
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 39.265137
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 6.970347
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &4036290430947079060 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 4036290430947079059}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &4088882572651576782
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -9900,206 +8705,6 @@ MonoBehaviour:
   LayerType: 6
   matrix: {fileID: 7240300236555714978}
   metaTileMap: {fileID: 1062548470927920079}
---- !u!1001 &4094307447743553767
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 2262397442
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -24.745117
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -42.820656
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &4094307447743553768 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 4094307447743553767}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &4128194855662144006
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 922024225
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 38
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -31.905273
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -29.04125
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &4128194855662144007 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 4128194855662144006}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &4244228518398756899
 GameObject:
   m_ObjectHideFlags: 0
@@ -10132,7 +8737,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 75
+      value: 45
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -10214,206 +8819,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0a279ee0b30f13740a1bdacb59adeff2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &4338313880768651268
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 3883603507
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 26
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 24.078125
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -43.603664
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &4338313880768651269 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 4338313880768651268}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &4382407162492255942
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 763539377
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 33
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 39.368652
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 9.879506
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &4382407162492255943 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 4382407162492255942}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &4462894794123917076
 Transform:
   m_ObjectHideFlags: 0
@@ -10439,7 +8844,7 @@ PrefabInstance:
     - target: {fileID: 2759225302197537063, guid: 71b3af02c077fd6438d6ebe60446b971,
         type: 3}
       propertyPath: m_RootOrder
-      value: 48
+      value: 17
       objectReference: {fileID: 0}
     - target: {fileID: 2759225302197537063, guid: 71b3af02c077fd6438d6ebe60446b971,
         type: 3}
@@ -10519,106 +8924,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 4517530831385182548}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &4533698071565277108
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 2845738873
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -24.917969
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -37.00234
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &4533698071565277109 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 4533698071565277108}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4649813175051088803
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10634,7 +8939,7 @@ PrefabInstance:
     - target: {fileID: 6923871703913968321, guid: f709eab732189d6429ae3fa5beaf3fd3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 40
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 6923871703913968321, guid: f709eab732189d6429ae3fa5beaf3fd3,
         type: 3}
@@ -10649,7 +8954,7 @@ PrefabInstance:
     - target: {fileID: 6923871703913968321, guid: f709eab732189d6429ae3fa5beaf3fd3,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -24.167725
+      value: -24.018
       objectReference: {fileID: 0}
     - target: {fileID: 6923871703913968321, guid: f709eab732189d6429ae3fa5beaf3fd3,
         type: 3}
@@ -10723,106 +9028,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   MatrixSync: {fileID: 0}
   matrix: {fileID: 0}
---- !u!1001 &4830386218019856735
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 2017560209
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 32
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 41.05957
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -36.951508
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &4830386218019856736 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 4830386218019856735}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &4973277796872332647
 Transform:
   m_ObjectHideFlags: 0
@@ -10862,7 +9067,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 77
+      value: 47
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -10944,106 +9149,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0a279ee0b30f13740a1bdacb59adeff2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &5460187238873657477
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 1002573679
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 21
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -30.305664
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -26.470808
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &5460187238873657478 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 5460187238873657477}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1839735485 &5494680292929620080
 Tilemap:
   m_ObjectHideFlags: 0
@@ -11097,7 +9202,7 @@ PrefabInstance:
     - target: {fileID: 1925386106379506438, guid: 5cb5bf2efb47fce45b5b2e7311b9a6fc,
         type: 3}
       propertyPath: m_RootOrder
-      value: 66
+      value: 36
       objectReference: {fileID: 0}
     - target: {fileID: 1925386106379506438, guid: 5cb5bf2efb47fce45b5b2e7311b9a6fc,
         type: 3}
@@ -49623,8 +47728,8 @@ Tilemap:
   - first: {x: 34, y: 26, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 3
-      m_TileSpriteIndex: 100
+      m_TileIndex: 12
+      m_TileSpriteIndex: 204
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -49633,8 +47738,8 @@ Tilemap:
   - first: {x: 35, y: 26, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 8
-      m_TileSpriteIndex: 146
+      m_TileIndex: 12
+      m_TileSpriteIndex: 212
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -49643,8 +47748,8 @@ Tilemap:
   - first: {x: 39, y: 26, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 8
-      m_TileSpriteIndex: 147
+      m_TileIndex: 13
+      m_TileSpriteIndex: 101
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -49653,8 +47758,8 @@ Tilemap:
   - first: {x: 40, y: 26, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 8
-      m_TileSpriteIndex: 204
+      m_TileIndex: 13
+      m_TileSpriteIndex: 210
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -50093,8 +48198,8 @@ Tilemap:
   - first: {x: 34, y: 27, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 8
-      m_TileSpriteIndex: 94
+      m_TileIndex: 12
+      m_TileSpriteIndex: 169
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -50103,8 +48208,8 @@ Tilemap:
   - first: {x: 40, y: 27, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 3
-      m_TileSpriteIndex: 169
+      m_TileIndex: 12
+      m_TileSpriteIndex: 205
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -50113,8 +48218,8 @@ Tilemap:
   - first: {x: 41, y: 27, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 8
-      m_TileSpriteIndex: 164
+      m_TileIndex: 12
+      m_TileSpriteIndex: 211
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -50123,8 +48228,8 @@ Tilemap:
   - first: {x: 42, y: 27, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 8
-      m_TileSpriteIndex: 164
+      m_TileIndex: 12
+      m_TileSpriteIndex: 211
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -50133,8 +48238,8 @@ Tilemap:
   - first: {x: 43, y: 27, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 8
-      m_TileSpriteIndex: 164
+      m_TileIndex: 12
+      m_TileSpriteIndex: 211
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -50143,8 +48248,8 @@ Tilemap:
   - first: {x: 44, y: 27, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 8
-      m_TileSpriteIndex: 146
+      m_TileIndex: 12
+      m_TileSpriteIndex: 212
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -50573,8 +48678,8 @@ Tilemap:
   - first: {x: 34, y: 28, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 8
-      m_TileSpriteIndex: 94
+      m_TileIndex: 12
+      m_TileSpriteIndex: 169
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -51003,8 +49108,8 @@ Tilemap:
   - first: {x: 34, y: 29, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 8
-      m_TileSpriteIndex: 94
+      m_TileIndex: 12
+      m_TileSpriteIndex: 169
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -51523,8 +49628,8 @@ Tilemap:
   - first: {x: 34, y: 30, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 8
-      m_TileSpriteIndex: 94
+      m_TileIndex: 12
+      m_TileSpriteIndex: 169
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -51533,8 +49638,8 @@ Tilemap:
   - first: {x: 40, y: 30, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 3
-      m_TileSpriteIndex: 100
+      m_TileIndex: 12
+      m_TileSpriteIndex: 204
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -51543,8 +49648,8 @@ Tilemap:
   - first: {x: 41, y: 30, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 8
-      m_TileSpriteIndex: 164
+      m_TileIndex: 12
+      m_TileSpriteIndex: 211
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -51553,8 +49658,8 @@ Tilemap:
   - first: {x: 42, y: 30, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 8
-      m_TileSpriteIndex: 164
+      m_TileIndex: 12
+      m_TileSpriteIndex: 211
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -51563,8 +49668,8 @@ Tilemap:
   - first: {x: 43, y: 30, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 8
-      m_TileSpriteIndex: 164
+      m_TileIndex: 12
+      m_TileSpriteIndex: 211
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -51573,8 +49678,8 @@ Tilemap:
   - first: {x: 44, y: 30, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 8
-      m_TileSpriteIndex: 146
+      m_TileIndex: 12
+      m_TileSpriteIndex: 212
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -52143,8 +50248,8 @@ Tilemap:
   - first: {x: 34, y: 31, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 3
-      m_TileSpriteIndex: 169
+      m_TileIndex: 12
+      m_TileSpriteIndex: 205
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -52153,8 +50258,8 @@ Tilemap:
   - first: {x: 35, y: 31, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 8
-      m_TileSpriteIndex: 146
+      m_TileIndex: 12
+      m_TileSpriteIndex: 212
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -52163,8 +50268,8 @@ Tilemap:
   - first: {x: 39, y: 31, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 8
-      m_TileSpriteIndex: 147
+      m_TileIndex: 13
+      m_TileSpriteIndex: 101
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -52173,8 +50278,8 @@ Tilemap:
   - first: {x: 40, y: 31, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 8
-      m_TileSpriteIndex: 205
+      m_TileIndex: 13
+      m_TileSpriteIndex: 209
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -58808,8 +56913,8 @@ Tilemap:
     m_Data: {fileID: 11400000, guid: d45a7f773cf0d38438d36f70c94d9544, type: 2}
   - m_RefCount: 438
     m_Data: {fileID: 11400000, guid: 2b55386c030f24193bc289cd227a621e, type: 2}
-  - m_RefCount: 4
-    m_Data: {fileID: 11400000, guid: 6914ec94ffd209d458c2be9f26f7e631, type: 2}
+  - m_RefCount: 0
+    m_Data: {fileID: 0}
   - m_RefCount: 13
     m_Data: {fileID: 11400000, guid: 0fcc62fe65ef68645b4ef5863b15eaf0, type: 2}
   - m_RefCount: 15
@@ -58818,14 +56923,18 @@ Tilemap:
     m_Data: {fileID: 11400000, guid: 2c5573a92f4b03d4c809a9a90ac4ddac, type: 2}
   - m_RefCount: 22
     m_Data: {fileID: 11400000, guid: b2c3d4599a06f42568ff7d6baa90e2e3, type: 2}
-  - m_RefCount: 18
-    m_Data: {fileID: 11400000, guid: dc013ef1aa2df4ecfb06d53ae1c7d22d, type: 2}
+  - m_RefCount: 0
+    m_Data: {fileID: 0}
   - m_RefCount: 18
     m_Data: {fileID: 11400000, guid: a51dca50f2097414594a8e8478f2d7ec, type: 2}
   - m_RefCount: 1234
     m_Data: {fileID: 11400000, guid: 1a74887dbd5089445b4fe592063d2b12, type: 2}
   - m_RefCount: 373
     m_Data: {fileID: 11400000, guid: 0bb4b77d320ccb442b334891ea3222c0, type: 2}
+  - m_RefCount: 18
+    m_Data: {fileID: 11400000, guid: 26af559165d38064597b9f57bac4ff01, type: 2}
+  - m_RefCount: 4
+    m_Data: {fileID: 11400000, guid: dc0b6b17ae5d5c34988cc323b8d52e59, type: 2}
   m_TileSpriteArray:
   - m_RefCount: 46
     m_Data: {fileID: 21300008, guid: 7c3a7336be2637043a7f39cec5350bba, type: 3}
@@ -59020,8 +57129,8 @@ Tilemap:
     m_Data: {fileID: 67890983, guid: 3fbb536e1aa316e4d8ffac9ab66b7ac0, type: 3}
   - m_RefCount: 3
     m_Data: {fileID: -265222650, guid: 3fbb536e1aa316e4d8ffac9ab66b7ac0, type: 3}
-  - m_RefCount: 4
-    m_Data: {fileID: 21300022, guid: 0a0f91b9c43ff9743a56ea9ef270abbd, type: 3}
+  - m_RefCount: 0
+    m_Data: {fileID: 0}
   - m_RefCount: 67
     m_Data: {fileID: 161181356, guid: 3fbb536e1aa316e4d8ffac9ab66b7ac0, type: 3}
   - m_RefCount: 2
@@ -59032,10 +57141,11 @@ Tilemap:
     m_Data: {fileID: 354151630, guid: 3fbb536e1aa316e4d8ffac9ab66b7ac0, type: 3}
   - m_RefCount: 2
     m_Data: {fileID: -801947067, guid: c9dec44dc5961dd4180adc11f31b42ba, type: 3}
-  - m_RefCount: 2
-    m_Data: {fileID: 21300012, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
   - m_RefCount: 0
     m_Data: {fileID: 0}
+  - m_RefCount: 2
+    m_Data: {fileID: 6214499940856887236, guid: 54b28a2ecf8e2f441b98845ffb593017,
+      type: 3}
   - m_RefCount: 2
     m_Data: {fileID: 21300022, guid: b058b7252e3d4da4b8bd51add65b0930, type: 3}
   - m_RefCount: 1
@@ -59126,10 +57236,10 @@ Tilemap:
     m_Data: {fileID: 21300048, guid: 311271c83c0b5f846884d0b57f9c22bf, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300050, guid: 34fae7bba294bb24a90001d055efbbe4, type: 3}
-  - m_RefCount: 4
-    m_Data: {fileID: 21300006, guid: 0a0f91b9c43ff9743a56ea9ef270abbd, type: 3}
-  - m_RefCount: 2
-    m_Data: {fileID: 21300002, guid: 0a0f91b9c43ff9743a56ea9ef270abbd, type: 3}
+  - m_RefCount: 0
+    m_Data: {fileID: 0}
+  - m_RefCount: 0
+    m_Data: {fileID: 0}
   - m_RefCount: 3
     m_Data: {fileID: 21300018, guid: 34fae7bba294bb24a90001d055efbbe4, type: 3}
   - m_RefCount: 1
@@ -59162,8 +57272,8 @@ Tilemap:
     m_Data: {fileID: 21300002, guid: 4f0c6985232dd6d4a9c7c0377b4113bd, type: 3}
   - m_RefCount: 2
     m_Data: {fileID: 21300082, guid: 4f0c6985232dd6d4a9c7c0377b4113bd, type: 3}
-  - m_RefCount: 6
-    m_Data: {fileID: 21300020, guid: 0a0f91b9c43ff9743a56ea9ef270abbd, type: 3}
+  - m_RefCount: 0
+    m_Data: {fileID: 0}
   - m_RefCount: 1
     m_Data: {fileID: 21300022, guid: 4f0c6985232dd6d4a9c7c0377b4113bd, type: 3}
   - m_RefCount: 1
@@ -59172,8 +57282,9 @@ Tilemap:
     m_Data: {fileID: 21300038, guid: 952bd23eb2328fb4d98fa7d067e19763, type: 3}
   - m_RefCount: 2
     m_Data: {fileID: 21300026, guid: 34fae7bba294bb24a90001d055efbbe4, type: 3}
-  - m_RefCount: 2
-    m_Data: {fileID: 21300014, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
+  - m_RefCount: 4
+    m_Data: {fileID: 6684475564837683844, guid: 1cd5bf8b6b995374eb71dac51c2ce357,
+      type: 3}
   - m_RefCount: 5
     m_Data: {fileID: 1953945875, guid: 3fbb536e1aa316e4d8ffac9ab66b7ac0, type: 3}
   - m_RefCount: 58
@@ -59243,16 +57354,29 @@ Tilemap:
     m_Data: {fileID: 21300004, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300078, guid: 952bd23eb2328fb4d98fa7d067e19763, type: 3}
-  - m_RefCount: 1
-    m_Data: {fileID: 21300018, guid: 0a0f91b9c43ff9743a56ea9ef270abbd, type: 3}
-  - m_RefCount: 1
-    m_Data: {fileID: 21300016, guid: 0a0f91b9c43ff9743a56ea9ef270abbd, type: 3}
+  - m_RefCount: 2
+    m_Data: {fileID: 630064425323933984, guid: 1cd5bf8b6b995374eb71dac51c2ce357, type: 3}
+  - m_RefCount: 2
+    m_Data: {fileID: -8698259652588032985, guid: 1cd5bf8b6b995374eb71dac51c2ce357,
+      type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300008, guid: b058b7252e3d4da4b8bd51add65b0930, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300086, guid: 952bd23eb2328fb4d98fa7d067e19763, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: -907896969790811466, guid: c6e9cad3946d90740a61fe80c79c0919,
+      type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: -3155292968585528888, guid: 54b28a2ecf8e2f441b98845ffb593017,
+      type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: -4259030371064946533, guid: 54b28a2ecf8e2f441b98845ffb593017,
+      type: 3}
+  - m_RefCount: 6
+    m_Data: {fileID: 2081611350317777526, guid: 1cd5bf8b6b995374eb71dac51c2ce357,
+      type: 3}
+  - m_RefCount: 4
+    m_Data: {fileID: -2225713995990520752, guid: 1cd5bf8b6b995374eb71dac51c2ce357,
       type: 3}
   m_TileMatrixArray:
   - m_RefCount: 4743
@@ -59331,106 +57455,6 @@ Transform:
   m_Father: {fileID: 4973277796872332647}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &6673959921276504486
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 970662801
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -25.089355
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -29.9748
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &6673959921276504487 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 6673959921276504486}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6692045113111575471
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -59451,7 +57475,7 @@ PrefabInstance:
     - target: {fileID: 7632320555952889534, guid: 4d867daacf105a044ba911410ff538ec,
         type: 3}
       propertyPath: m_RootOrder
-      value: 45
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 7632320555952889534, guid: 4d867daacf105a044ba911410ff538ec,
         type: 3}
@@ -59807,7 +57831,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 86
+      value: 56
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -59914,7 +57938,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 79
+      value: 49
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -60037,7 +58061,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4992776679171040, guid: 4da47599005396e47a0534bd2f998de1, type: 3}
       propertyPath: m_RootOrder
-      value: 67
+      value: 37
       objectReference: {fileID: 0}
     - target: {fileID: 4992776679171040, guid: 4da47599005396e47a0534bd2f998de1, type: 3}
       propertyPath: m_LocalScale.y
@@ -60121,106 +58145,6 @@ Transform:
   m_Father: {fileID: 4973277796872332647}
   m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &7222146871198008234
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 1422603726
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -34.802734
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -25.708817
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &7222146871198008235 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 7222146871198008234}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &7223910199921635570
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -60249,6 +58173,7 @@ MonoBehaviour:
   IsSpaceMatrix: 0
   IsMainStation: 0
   IsLavaLand: 0
+  HasGravity: 1
 --- !u!483693784 &7256144131861789287
 TilemapRenderer:
   m_ObjectHideFlags: 0
@@ -145017,7 +142942,7 @@ PrefabInstance:
     - target: {fileID: 3927008119850082822, guid: bc71229dac2972e4e87732e2501a3dd9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 46
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 3927008119850082822, guid: bc71229dac2972e4e87732e2501a3dd9,
         type: 3}
@@ -145170,7 +143095,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 73
+      value: 43
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -145268,206 +143193,6 @@ TilemapCollider2D:
   m_Offset: {x: 0, y: 0}
   m_MaximumTileChangeCount: 1000
   m_ExtrusionFactor: 0.00001
---- !u!1001 &7653805817788536156
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 3359642289
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 24
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -6.9902344
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -42.87882
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &7653805817788536157 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 7653805817788536156}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &7795361497545034529
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 67154952
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 35
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 43.104492
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 9.048109
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &7795361497545034530 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 7795361497545034529}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1839735485 &7877861854560544598
 Tilemap:
   m_ObjectHideFlags: 0
@@ -145780,8 +143505,8 @@ Tilemap:
   - first: {x: 35, y: 27, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -145790,8 +143515,8 @@ Tilemap:
   - first: {x: 36, y: 27, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -145800,8 +143525,8 @@ Tilemap:
   - first: {x: 37, y: 27, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -145810,8 +143535,8 @@ Tilemap:
   - first: {x: 38, y: 27, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -145820,8 +143545,8 @@ Tilemap:
   - first: {x: 39, y: 27, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -145830,8 +143555,8 @@ Tilemap:
   - first: {x: 40, y: 27, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -145840,8 +143565,8 @@ Tilemap:
   - first: {x: 35, y: 28, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -145850,8 +143575,8 @@ Tilemap:
   - first: {x: 36, y: 28, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -145860,8 +143585,8 @@ Tilemap:
   - first: {x: 37, y: 28, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -145870,8 +143595,8 @@ Tilemap:
   - first: {x: 38, y: 28, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -145880,8 +143605,8 @@ Tilemap:
   - first: {x: 39, y: 28, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -145890,8 +143615,8 @@ Tilemap:
   - first: {x: 40, y: 28, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -145900,8 +143625,8 @@ Tilemap:
   - first: {x: 41, y: 28, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -145910,8 +143635,8 @@ Tilemap:
   - first: {x: 42, y: 28, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -145920,8 +143645,8 @@ Tilemap:
   - first: {x: 43, y: 28, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -145940,8 +143665,8 @@ Tilemap:
   - first: {x: 35, y: 29, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -145950,8 +143675,8 @@ Tilemap:
   - first: {x: 36, y: 29, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -145960,8 +143685,8 @@ Tilemap:
   - first: {x: 37, y: 29, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -145970,8 +143695,8 @@ Tilemap:
   - first: {x: 38, y: 29, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -145980,8 +143705,8 @@ Tilemap:
   - first: {x: 39, y: 29, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -145990,8 +143715,8 @@ Tilemap:
   - first: {x: 40, y: 29, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -146000,8 +143725,8 @@ Tilemap:
   - first: {x: 41, y: 29, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -146010,8 +143735,8 @@ Tilemap:
   - first: {x: 42, y: 29, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -146020,8 +143745,8 @@ Tilemap:
   - first: {x: 43, y: 29, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -146040,8 +143765,8 @@ Tilemap:
   - first: {x: 35, y: 30, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -146050,8 +143775,8 @@ Tilemap:
   - first: {x: 36, y: 30, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -146060,8 +143785,8 @@ Tilemap:
   - first: {x: 37, y: 30, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -146070,8 +143795,8 @@ Tilemap:
   - first: {x: 38, y: 30, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -146080,8 +143805,8 @@ Tilemap:
   - first: {x: 39, y: 30, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -146090,8 +143815,8 @@ Tilemap:
   - first: {x: 40, y: 30, z: 0}
     second:
       serializedVersion: 2
-      m_TileIndex: 1
-      m_TileSpriteIndex: 0
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -146109,10 +143834,10 @@ Tilemap:
       m_AllTileFlags: 2147483648
   m_AnimatedTiles: {}
   m_TileAssetArray:
+  - m_RefCount: 30
+    m_Data: {fileID: 11400000, guid: 0ac0b87442b0ecd418e804041305ce9b, type: 2}
   - m_RefCount: 0
     m_Data: {fileID: 0}
-  - m_RefCount: 30
-    m_Data: {fileID: 11400000, guid: 9d6d819ca2ac68d48b3f3975622e6499, type: 2}
   - m_RefCount: 18
     m_Data: {fileID: 11400000, guid: 7052c1b37a47a6c4c8747ad0d2f9ae00, type: 2}
   - m_RefCount: 1
@@ -146130,10 +143855,10 @@ Tilemap:
   - m_RefCount: 4
     m_Data: {fileID: 11400000, guid: 7b6ba8d909981fe4db9ac0cab5b38762, type: 2}
   m_TileSpriteArray:
-  - m_RefCount: 30
-    m_Data: {fileID: 21300000, guid: a62e4e222cd90674cb28602b3e912564, type: 3}
   - m_RefCount: 0
     m_Data: {fileID: 0}
+  - m_RefCount: 30
+    m_Data: {fileID: 21300000, guid: 7b66b98067bbc61448f8b682337c8451, type: 3}
   - m_RefCount: 18
     m_Data: {fileID: 21300000, guid: 3bbf2020c1d713940abc430226709ba1, type: 3}
   - m_RefCount: 1
@@ -146299,106 +144024,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   performerStartActionMessage: 
   othersStartActionMessage: 
---- !u!1001 &8232860268328153050
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 2597177148
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 16
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -31.03711
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -40.634876
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &8232860268328153051 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 8232860268328153050}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8241992796124747318
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -146420,7 +144045,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4992776679171040, guid: 4da47599005396e47a0534bd2f998de1, type: 3}
       propertyPath: m_RootOrder
-      value: 63
+      value: 33
       objectReference: {fileID: 0}
     - target: {fileID: 4992776679171040, guid: 4da47599005396e47a0534bd2f998de1, type: 3}
       propertyPath: m_LocalScale.y
@@ -146511,7 +144136,7 @@ PrefabInstance:
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 54
+      value: 23
       objectReference: {fileID: 0}
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
@@ -146612,7 +144237,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4699640297835872, guid: fa26dc8a7e76973489beed18bc59d792, type: 3}
       propertyPath: m_RootOrder
-      value: 64
+      value: 34
       objectReference: {fileID: 0}
     - target: {fileID: 4699640297835872, guid: fa26dc8a7e76973489beed18bc59d792, type: 3}
       propertyPath: m_LocalScale.y
@@ -146714,7 +144339,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 71
+      value: 41
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -146796,106 +144421,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0a279ee0b30f13740a1bdacb59adeff2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &8814207847028879433
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 3190542701
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 12
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -20.455566
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -32.361465
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &8814207847028879434 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 8814207847028879433}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8839756525047435119
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -146909,7 +144434,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 84
+      value: 54
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -147004,7 +144529,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_RootOrder
-      value: 68
+      value: 38
       objectReference: {fileID: 0}
     - target: {fileID: 4398944093973122, guid: d86823d595004274c8638eb908e5cf95, type: 3}
       propertyPath: m_LocalScale.y
@@ -147098,103 +144623,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 974152dca9d54d57a8f2e4283fb52093, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &9034556265396314757
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1998928700528175337}
-    m_Modifications:
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: sceneId
-      value: 786584099
-      objectReference: {fileID: 0}
-    - target: {fileID: 4323690967113023671, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 14
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.001001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -37.404785
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -39.0454
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: m_Name
-      value: Alien Egg
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: freezeCycle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7489533636973299563, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-        type: 3}
-      propertyPath: initialState
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9473c17e4e7f2f24d99f2d788030cd9f, type: 3}
---- !u!4 &9034556265396314758 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5316695102526796559, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
-    type: 3}
-  m_PrefabInstance: {fileID: 9034556265396314757}
-  m_PrefabAsset: {fileID: 0}


### PR DESCRIPTION

### Purpose

This PR removes 18 Alien eggs from Caverna. #8771 did temporarily cap the mob performance issues, so this change won't make as big of a change as it would have before, but still, it's very unnecessary to have so many mobs spawn, especially since they weren't connected to the away sites mobs spawning event, so they would hatch regardless of whether anyone had actually gone to Caverna or not in the round.

### Notes:

### Changelog:

CL: [Fix] Removed 18 alien eggs from Caverna, reducing performance drain for that map significantly.
