### PR TITLE
Removes highlander from the list of gamemodes

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/GameModes/GameModeData.asset
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/GameModeData.asset
@@ -18,5 +18,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: a07c32cfb5b43954c908ca8910ad76e5, type: 2}
   - {fileID: 11400000, guid: c353eaa51022b234ea81a69d54a1cee7, type: 2}
   - {fileID: 11400000, guid: be5a87a6a81f8e043a1dbddc99b71db7, type: 2}
-  - {fileID: 11400000, guid: 202e1aa242919514698d3a850a1c95d2, type: 2}
   DefaultGameMode: {fileID: 11400000, guid: a07c32cfb5b43954c908ca8910ad76e5, type: 2}


### PR DESCRIPTION
For some reason the game-mode kept triggering more frequently than it should so now it's just an event that admins trigger for the time being.

### Changelog:

CL: [Balance] - Highlander is now an event only and not a gamemode.
