### PR TITLE
CharacterSettings changes

### DIFF
--- a/UnityProject/Assets/Scripts/Clothing/RaceSOSingleton.cs
+++ b/UnityProject/Assets/Scripts/Clothing/RaceSOSingleton.cs
@@ -1,11 +1,25 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using ScriptableObjects;
+﻿using System.Collections.Generic;
 using UnityEngine;
+using ScriptableObjects;
 
 [CreateAssetMenu(fileName = "RaceSOSingleton", menuName = "Singleton/RaceSOSingleton")]
 public class RaceSOSingleton : SingletonScriptableObject<RaceSOSingleton>
 {
 	//do Config stuff to allow Certain ones
-	public List<PlayerHealthData> Races = new List<PlayerHealthData>();
+	public List<PlayerHealthData> Races = new();
+
+	public static bool TryGetRaceByName(string raceName, out PlayerHealthData race)
+	{
+		foreach (var potentialRace in Instance.Races)
+		{
+			if (potentialRace.name == raceName)
+			{
+				race = potentialRace;
+				return true;
+			}
+		}
+
+		race = null;
+		return false;
+	}
 }

--- a/UnityProject/Assets/Scripts/Core/Database/ServerData.CreateAccount.cs
+++ b/UnityProject/Assets/Scripts/Core/Database/ServerData.CreateAccount.cs
@@ -9,7 +9,7 @@ namespace DatabaseAPI
 		///Tries to create an account for the user in player accounts (now using firebase as of nov '19)
 		///</summary>
 		public async static void TryCreateAccount(string proposedName, string _password, string emailAcc,
-			Action<CharacterSettings> callBack, Action<string> errorCallBack)
+			Action<CharacterSheet> callBack, Action<string> errorCallBack)
 		{
 			try
 			{
@@ -28,11 +28,7 @@ namespace DatabaseAPI
 				Logger.LogFormat($"Firebase user created successfully: {proposedName}",
 					Category.DatabaseAPI);
 
-				var newCharacter = new CharacterSettings
-				{
-					Name = StringManager.GetRandomMaleName(),
-					Username = proposedName
-				};
+				var newCharacter = CharacterSheet.GenerateRandomCharacter();
 
 				callBack.Invoke(newCharacter);
 			}

--- a/UnityProject/Assets/Scripts/Core/Database/ServerData.UpdateChar.cs
+++ b/UnityProject/Assets/Scripts/Core/Database/ServerData.UpdateChar.cs
@@ -10,7 +10,7 @@ namespace DatabaseAPI
 {
 	public partial class ServerData
 	{
-		public static async Task<bool> UpdateCharacterProfile(CharacterSettings updateSettings)
+		public static async Task<bool> UpdateCharacterProfile(CharacterSheet updateSettings)
 		{
 			if (FirebaseAuth.DefaultInstance.CurrentUser == null)
 			{

--- a/UnityProject/Assets/Scripts/Core/Database/ServerData.ValidateUser.cs
+++ b/UnityProject/Assets/Scripts/Core/Database/ServerData.ValidateUser.cs
@@ -46,17 +46,13 @@ namespace DatabaseAPI
 			FireStoreResponse fr = JsonUtility.FromJson<FireStoreResponse>(content);
 			FireStoreCharacter fireStoreChar = fr.fields.character;
 
-			CharacterSettings characterSettings;
+			CharacterSheet characterSettings;
 			var settingsValid = false;
 
 			if (fireStoreChar == null)
 			{
 				// Make a new character since there isn't one in the database
-				characterSettings = new CharacterSettings
-				{
-					Name = StringManager.GetRandomMaleName(),
-					Username = user.DisplayName
-				};
+				characterSettings = CharacterSheet.GenerateRandomCharacter();
 			}
 			else
 			{
@@ -64,14 +60,12 @@ namespace DatabaseAPI
 				Logger.Log(unescapedJson);
 				try
 				{
-					characterSettings = JsonConvert.DeserializeObject<CharacterSettings>(unescapedJson);
+					characterSettings = JsonConvert.DeserializeObject<CharacterSheet>(unescapedJson);
 				}
 				catch
 				{
 					Logger.LogWarning($"Couldn't deserialise saved character settings.");
-					characterSettings = new CharacterSettings();
-					characterSettings.Username = user.DisplayName;
-					characterSettings.Name = StringManager.GetRandomMaleName();
+					characterSettings = CharacterSheet.GenerateRandomCharacter();
 				}
 
 				// Validate and correct settings in case the customization options change

--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/ServerValidations.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/ServerValidations.cs
@@ -117,7 +117,7 @@ public static class ServerValidations
 	/// </summary>
 	/// <param name="settings">The character sheet used to check what race the player is.</param>
 	/// <returns>True if illegal.</returns>
-	public static bool HasIllegalSkinTone(CharacterSettings settings)
+	public static bool HasIllegalSkinTone(CharacterSheet settings)
 	{
 		PlayerHealthData SetRace = null;
 		bool skinToneIsIllegal = false;

--- a/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawn.cs
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawn.cs
@@ -31,7 +31,7 @@ public static class PlayerSpawn
 	/// <param name="occupation">occupation to spawn as</param>
 	/// <param name="characterSettings">settings to use for the character</param>
 	/// <returns>the game object of the spawned player</returns>
-	public static GameObject ServerSpawnPlayer(PlayerSpawnRequest request, JoinedViewer joinedViewer, Occupation occupation, CharacterSettings characterSettings, bool showBanner = true, Vector3Int?
+	public static GameObject ServerSpawnPlayer(PlayerSpawnRequest request, JoinedViewer joinedViewer, Occupation occupation, CharacterSheet characterSettings, bool showBanner = true, Vector3Int?
 		spawnPos = null, Mind existingMind = null, NetworkConnectionToClient conn = null)
 	{
 		if(ValidateCharacter(request) == false)
@@ -183,7 +183,7 @@ public static class PlayerSpawn
 	/// thus we shouldn't send any network message which reference's the old body's ID since it won't exist.</param>
 	///
 	/// <returns>the spawned object</returns>
-	private static GameObject ServerSpawnInternal(NetworkConnectionToClient connection, Occupation occupation, CharacterSettings characterSettings,
+	private static GameObject ServerSpawnInternal(NetworkConnectionToClient connection, Occupation occupation, CharacterSheet characterSettings,
 		Mind existingMind, Vector3Int? spawnPos = null, bool spawnItems = true, bool willDestroyOldBody = false, bool showBanner = true)
 	{
 		//determine where to spawn them
@@ -393,7 +393,7 @@ public static class PlayerSpawn
 	/// <summary>
 	/// Spawns as a ghost for spectating the Round
 	/// </summary>
-	public static void ServerSpawnGhost(JoinedViewer joinedViewer, CharacterSettings characterSettings)
+	public static void ServerSpawnGhost(JoinedViewer joinedViewer, CharacterSheet characterSettings)
 	{
 		//Hard coding to assistant
 		Vector3Int spawnPosition = SpawnPoint.GetRandomPointForJob(JobType.ASSISTANT).transform.position.CutToInt();
@@ -416,16 +416,16 @@ public static class PlayerSpawn
 	/// </summary>
 	public static void ServerSpawnDummy(Transform spawnTransform = null)
 	{
-		if(spawnTransform == null)
+		if (spawnTransform == null)
+		{
 			spawnTransform = SpawnPoint.GetRandomPointForJob(JobType.ASSISTANT);
+		}
+		
 		if (spawnTransform != null)
 		{
 			var dummy = ServerCreatePlayer(spawnTransform.position.RoundToInt());
-
-			CharacterSettings randomSettings = CharacterSettings.RandomizeCharacterSettings(RaceSOSingleton.Instance.Races.PickRandom().name);
-
+			CharacterSheet randomSettings = CharacterSheet.GenerateRandomCharacter();
 			ServerTransferPlayer(null, dummy, null, Event.PlayerSpawned, randomSettings);
-
 
 			//fire all hooks
 			var info = SpawnInfo.Player(OccupationList.Instance.Get(JobType.ASSISTANT), randomSettings, CustomNetworkManager.Instance.humanPlayerPrefab,
@@ -467,7 +467,7 @@ public static class PlayerSpawn
 	}
 
 	public static void ServerTransferPlayerToNewBody(NetworkConnectionToClient conn, GameObject newBody, GameObject oldBody,
-		Event eventType, CharacterSettings characterSettings, bool willDestroyOldBody = false)
+		Event eventType, CharacterSheet characterSettings, bool willDestroyOldBody = false)
 	{
 		ServerTransferPlayer(conn, newBody, oldBody, eventType, characterSettings, willDestroyOldBody);
 	}
@@ -483,7 +483,7 @@ public static class PlayerSpawn
 	/// <param name="willDestroyOldBody">if true, indicates the old body is going to be destroyed rather than pooled,
 	/// thus we shouldn't send any network message which reference's the old body's ID since it won't exist.</param>
 	private static void ServerTransferPlayer(NetworkConnectionToClient conn, GameObject newBody, GameObject oldBody,
-		Event eventType, CharacterSettings characterSettings, bool willDestroyOldBody = false)
+		Event eventType, CharacterSheet characterSettings, bool willDestroyOldBody = false)
 	{
 		if (oldBody)
 		{

--- a/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawnRequest.cs
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawnRequest.cs
@@ -21,9 +21,9 @@ namespace Player
 		/// <summary>
 		/// Character the viewer is attempting to spawn with.
 		/// </summary>
-		public readonly CharacterSettings CharacterSettings;
+		public readonly CharacterSheet CharacterSettings;
 
-		public PlayerSpawnRequest(PlayerInfo player, Occupation requestedOccupation, CharacterSettings character = default)
+		public PlayerSpawnRequest(PlayerInfo player, Occupation requestedOccupation, CharacterSheet character = default)
 		{
 			Player = player;
 			RequestedOccupation = requestedOccupation;

--- a/UnityProject/Assets/Scripts/Core/Lifecycle/SpawnInfo.cs
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/SpawnInfo.cs
@@ -55,7 +55,7 @@ public class SpawnInfo
 	/// If SpawnType.Player, character settings the player is being spawned with.
 	/// </summary>
 	/// <returns></returns>
-	public readonly CharacterSettings CharacterSettings;
+	public readonly CharacterSheet CharacterSettings;
 
 	/// <summary>
 	/// The gear or items that spawn on creation will be enabled or not. ex: equipment on characters.
@@ -69,7 +69,7 @@ public class SpawnInfo
 
 	private SpawnInfo(SpawnType spawnType, ISpawnable spawnable, SpawnDestination spawnDestination, float? scatterRadius, int count, Occupation occupation,
 		GameObject clonedFrom = null,
-		CharacterSettings characterSettings = null, bool spawnItems = true, bool mapspawn = false)
+		CharacterSheet characterSettings = null, bool spawnItems = true, bool mapspawn = false)
 	{
 		SpawnType = spawnType;
 		SpawnableToSpawn = spawnable;
@@ -93,7 +93,7 @@ public class SpawnInfo
 	/// <param name="spawnItems">whether player should spawn naked or with their default loadout</param>
 	/// <returns>the newly created GameObject</returns>
 	/// <returns></returns>
-	public static SpawnInfo Player(Occupation occupation, CharacterSettings characterSettings, GameObject playerPrefab, SpawnDestination spawnDestination,
+	public static SpawnInfo Player(Occupation occupation, CharacterSheet characterSettings, GameObject playerPrefab, SpawnDestination spawnDestination,
 		bool spawnItems = false)
 	{
 		return new SpawnInfo(SpawnType.Player, SpawnablePrefab.For(playerPrefab), spawnDestination, null, 1, occupation, characterSettings: characterSettings, spawnItems: spawnItems);
@@ -108,7 +108,7 @@ public class SpawnInfo
 	/// <param name="spawnDestination">destinaton to spawn at</param>
 	/// <returns>the newly created GameObject</returns>
 	/// <returns></returns>
-	public static SpawnInfo Ghost(Occupation occupation, CharacterSettings characterSettings, GameObject ghostPrefab,
+	public static SpawnInfo Ghost(Occupation occupation, CharacterSheet characterSettings, GameObject ghostPrefab,
 		SpawnDestination spawnDestination)
 	{
 		return new SpawnInfo(SpawnType.Ghost, SpawnablePrefab.For(ghostPrefab), spawnDestination,

--- a/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPartSprites.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPartSprites.cs
@@ -16,7 +16,7 @@ public class BodyPartSprites : MonoBehaviour
 
 	public SpriteRenderer spriteRenderer;
 
-	public CharacterSettings ThisCharacter;
+	public CharacterSheet ThisCharacter;
 
 	public SpriteOrder SpriteOrder;
 

--- a/UnityProject/Assets/Scripts/Managers/PlayerInfo.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerInfo.cs
@@ -45,7 +45,7 @@ public class PlayerInfo
 	public bool IsAdmin => (PlayerRoles & PlayerRole.Admin) != 0;
 
 	//This is only set when the player presses the ready button? But not if late joining, wtf?????
-	public CharacterSettings CharacterSettings { get; set; }
+	public CharacterSheet CharacterSettings { get; set; }
 
 	/// <summary>The player GameObject. Different GameObject if in lobby vs. in game.</summary>
 	public GameObject GameObject

--- a/UnityProject/Assets/Scripts/Managers/PlayerList.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.cs
@@ -194,29 +194,28 @@ public partial class PlayerList : NetworkBehaviour
 			return player;
 		}
 
-		Logger.Log($"Player {player.Username}'s client ID is: {player.ClientId} User ID: {player.UserId}.", Category.Connections);
+		Logger.LogTrace($"Player {player.Username}'s client ID is: {player.ClientId} User ID: {player.UserId}.", Category.Connections);
 
 		var loggedOffClient = GetLoggedOffClient(player.ClientId, player.UserId);
 		if (loggedOffClient != null)
 		{
-			Logger.Log(
-				$"ConnectedPlayer Username({player.Username}) already exists in this server's PlayerList as Character({loggedOffClient.Name}) " +
-				$"Will update existing player instead of adding this new connected player.", Category.Connections);
+			Logger.LogTrace(
+					$"Player with account {player.UserId} already has a player object ({loggedOffClient.Name}). " +
+					$"Will update existing player instead of adding this new connected player.", Category.Connections);
 
 			if (loggedOffClient.GameObject == null)
 			{
-				Logger.LogFormat(
-					$"The existing ConnectedPlayer contains a null GameObject reference. Removing the entry", Category.Connections);
+				Logger.LogWarning(
+						$"The existing ConnectedPlayer contains a null GameObject reference. Removing the entry.", Category.Connections);
 				loggedOff.Remove(loggedOffClient);
 				return player;
 			}
 
-			// Switching over to the old player's character is handled by JoinedViewer so dont need any extra logic.
+			// Switching over to the old player's character is handled by JoinedViewer so don't need any extra logic.
 		}
 
 		loggedIn.Add(player);
-		Logger.LogFormat("Added to this server's PlayerList {0}. Total:{1}; {2}", Category.Connections, player,
-			loggedIn.Count, string.Join(";", loggedIn));
+		Logger.Log($"Player with account {player.UserId} has joined the game. Player count: {loggedIn.Count}.", Category.Connections);
 		CheckRcon();
 		return player;
 	}
@@ -573,7 +572,7 @@ public partial class PlayerList : NetworkBehaviour
 	/// <summary>
 	/// Makes a player ready/unready for job allocations
 	/// </summary>
-	public void SetPlayerReady(PlayerInfo player, bool isReady, CharacterSettings charSettings = null)
+	public void SetPlayerReady(PlayerInfo player, bool isReady, CharacterSheet charSettings = null)
 	{
 		if (isReady)
 		{

--- a/UnityProject/Assets/Scripts/Managers/StringManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/StringManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+﻿using System;
 using System.Collections.Generic;
 using Initialisation;
 using Managers;
@@ -23,49 +23,46 @@ public class StringManager : SingletonManager<StringManager>, IInitialise
 
 	void IInitialise.Initialise()
 	{
-		for (int i = 0; i < nameTextFiles.Count; i++)
+		string[] lineEndings = { "\r\n", "\r", "\n" };
+		foreach (var nameFile in nameTextFiles)
 		{
-			string[] lines = nameTextFiles[i].text.Split(
-				new [] { "\r\n", "\r", "\n" },
-				System.StringSplitOptions.None);
-			textObjects.Add(nameTextFiles[i].name, new List<string>(lines));
+			var lines = nameFile.text.Split(lineEndings, StringSplitOptions.None);
+			textObjects.Add(nameFile.name, new List<string>(lines));
 		}
 	}
 
-	public static string GetRandomLizardName(Gender gender)
+	public static string GetRandomLizardName(Gender gender = Gender.NonBinary)
 	{
 		//Uses random gendered name if NonBinary
-		if (gender == Gender.NonBinary) gender = Random.value > 0.5f ? Gender.Male : Gender.Female;
+		if (gender == Gender.NonBinary)
+		{
+			gender = DMMath.Prob(50) ? Gender.Male : Gender.Female;
+		}
 
 		//ToLowerInvariant because ToLower has different behaviour based on culture
 		var genderKey = gender.ToString().ToLowerInvariant();
 
-		//Random.Range is max exclusive and as such .Count can be used directly
-		var randomLizard =
-			Instance.textObjects[$"lizard_{genderKey}"][Random.Range(0, Instance.textObjects[$"lizard_{genderKey}"].Count)];
-
-		return randomLizard;
-	}
-
-	public static string GetRandomMaleName()
-	{
-		return GetRandomName(Gender.Male);
-	}
-
-	public static string GetRandomFemaleName()
-	{
-		return GetRandomName(Gender.Female);
+		return Instance.textObjects[$"lizard_{genderKey}"].PickRandom();
 	}
 
 	/// <summary>
-	/// Combines a random first and last name depending on gender, uses both male and female names if gender is NonBinary
+	/// Combines a random first and last name depending on gender.
+	/// Uses both male and female names if gender is NonBinary.
 	/// </summary>
-	public static string GetRandomName(Gender gender)
+	public static string GetRandomName(Gender gender = Gender.NonBinary)
 	{
-		if (gender == Gender.NonBinary) gender = Random.value > 0.5f ? Gender.Male : Gender.Female; //Uses random gendered name if NonBinary
-		var genderKey = gender.ToString().ToLowerInvariant(); //ToLowerInvariant because ToLower has different behaviour based on culture
-		var firstName = Instance.textObjects[$"first_{genderKey}"][Random.Range(0, Instance.textObjects[$"first_{genderKey}"].Count)]; //Random.Range is max exclusive and as such .Count can be used directly
-		var lastName = Instance.textObjects["last"][Random.Range(0, Instance.textObjects["last"].Count)];
+		//Uses random gendered name if NonBinary
+		if (gender == Gender.NonBinary)
+		{
+			gender = DMMath.Prob(50) ? Gender.Male : Gender.Female;
+		}
+
+		//ToLowerInvariant because ToLower has different behaviour based on culture
+		var genderKey = gender.ToString().ToLowerInvariant();
+
+		var firstName = Instance.textObjects[$"first_{genderKey}"].PickRandom();
+		var lastName = Instance.textObjects["last"].PickRandom();
+
 		return $"{firstName} {lastName}";
 	}
 }

--- a/UnityProject/Assets/Scripts/Messages/Client/Admin/AdminReplyMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Admin/AdminReplyMessage.cs
@@ -12,7 +12,7 @@ namespace Messages.Client.Admin
 
 		public override void Process(NetMessage msg)
 		{
-			UIManager.Instance.adminChatWindows.adminPlayerChat.ServerAddChatRecord(msg.Message, SentByPlayer.UserId);
+			UIManager.Instance.adminChatWindows.adminPlayerChat.ServerAddChatRecord(msg.Message, SentByPlayer);
 		}
 
 		public static NetMessage Send(string message)

--- a/UnityProject/Assets/Scripts/Messages/Client/Admin/MentorReplyMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Admin/MentorReplyMessage.cs
@@ -11,7 +11,7 @@ namespace Messages.Client.Admin
 
 		public override void Process(NetMessage msg)
 		{
-			UIManager.Instance.adminChatWindows.mentorPlayerChat.ServerAddChatRecord(msg.Message, SentByPlayer.UserId);
+			UIManager.Instance.adminChatWindows.mentorPlayerChat.ServerAddChatRecord(msg.Message, SentByPlayer);
 		}
 
 		public static NetMessage Send(string message)

--- a/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestAdminBwoink.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestAdminBwoink.cs
@@ -14,23 +14,17 @@ namespace Messages.Client.Admin
 
 		public override void Process(NetMessage msg)
 		{
-			VerifyAdminStatus(msg);
-		}
-
-		private void VerifyAdminStatus(NetMessage msg)
-		{
 			if (IsFromAdmin() == false) return;
-			
+
 			if (PlayerList.Instance.TryGetByUserID(msg.UserToBwoink, out var recipient) == false) return;
-			
-			AdminBwoinkMessage.Send(recipient.GameObject, SentByPlayer.UserId, $"<color=red>{msg.Message}</color>");
-			UIManager.Instance.adminChatWindows.adminPlayerChat.ServerAddChatRecord(
-					msg.Message, msg.UserToBwoink, SentByPlayer.UserId);
+
+			AdminBwoinkMessage.Send(recipient.GameObject, SentByPlayer.UserId, $"<color=red>{SentByPlayer.Username}: {msg.Message}</color>");
+			UIManager.Instance.adminChatWindows.adminPlayerChat.ServerAddChatRecord(msg.Message, recipient, SentByPlayer);
 		}
 
 		public static NetMessage Send(string userIDToBwoink, string message)
 		{
-			NetMessage msg = new NetMessage
+			NetMessage msg = new()
 			{
 				UserToBwoink = userIDToBwoink,
 				Message = message

--- a/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestMentorBwoink.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestMentorBwoink.cs
@@ -1,4 +1,4 @@
-﻿using Mirror;
+using Mirror;
 using Messages.Server.AdminTools;
 
 
@@ -14,17 +14,12 @@ namespace Messages.Client.Admin
 
 		public override void Process(NetMessage msg)
 		{
-			VerifyMentorStatus(msg);
-		}
-
-		private void VerifyMentorStatus(NetMessage msg)
-		{
 			if (IsFromAdmin() == false && PlayerList.Instance.IsMentor(SentByPlayer.UserId) == false) return;
 
 			if (PlayerList.Instance.TryGetByUserID(msg.UserToBwoink, out var recipient) == false) return;
-			
-			MentorBwoinkMessage.Send(recipient.GameObject, SentByPlayer.UserId, $"<color=#6400FF>{msg.Message}</color>");
-			UIManager.Instance.adminChatWindows.mentorPlayerChat.ServerAddChatRecord(msg.Message, msg.UserToBwoink, SentByPlayer.UserId);
+
+			MentorBwoinkMessage.Send(recipient.GameObject, SentByPlayer.UserId, $"<color=#6400FF>{SentByPlayer.Username}: {msg.Message}</color>");
+			UIManager.Instance.adminChatWindows.mentorPlayerChat.ServerAddChatRecord(msg.Message, recipient, SentByPlayer);
 		}
 
 		public static NetMessage Send(string userIDToBwoink, string message)

--- a/UnityProject/Assets/Scripts/Messages/Client/NewPlayer/ClientRequestJobMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/NewPlayer/ClientRequestJobMessage.cs
@@ -97,7 +97,7 @@ namespace Messages.Client.NewPlayer
 
 		private void AcceptRequest(NetMessage msg)
 		{
-			var character = JsonConvert.DeserializeObject<CharacterSettings>(msg.JsonCharSettings);
+			var character = JsonConvert.DeserializeObject<CharacterSheet>(msg.JsonCharSettings);
 			var spawnRequest = new PlayerSpawnRequest(SentByPlayer, GameManager.Instance.GetRandomFreeOccupation(msg.JobType), character);
 
 			GameManager.Instance.TrySpawnPlayer(spawnRequest);

--- a/UnityProject/Assets/Scripts/Objects/Lavaland/AshwalkerNest.cs
+++ b/UnityProject/Assets/Scripts/Objects/Lavaland/AshwalkerNest.cs
@@ -238,7 +238,7 @@ namespace Objects
 
 			if (characterSettings == null)
 			{
-				characterSettings = new CharacterSettings();
+				characterSettings = new CharacterSheet();
 			}
 
 			//TODO this replaces their old race, character settings needs a refactor to have them per body

--- a/UnityProject/Assets/Scripts/Objects/Medical/CloningConsole.cs
+++ b/UnityProject/Assets/Scripts/Objects/Medical/CloningConsole.cs
@@ -181,7 +181,7 @@ namespace Objects.Medical
 		public float toxinDmg;
 		public float bruteDmg;
 		public string uniqueIdentifier;
-		public CharacterSettings characterSettings;
+		public CharacterSheet characterSettings;
 		public int mobID;
 		public Mind mind;
 		public List<BodyPartRecord> surfaceBodyParts = new List<BodyPartRecord>();

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -12,6 +12,7 @@ using Messages.Server;
 using Messages.Client;
 using Messages.Client.NewPlayer;
 using UI;
+using DatabaseAPI;
 
 namespace Player
 {
@@ -42,19 +43,17 @@ namespace Player
 			else
 			{
 				CmdServerSetupPlayer(GetNetworkInfo(),
-					PlayerManager.CurrentCharacterSettings.Username, DatabaseAPI.ServerData.UserID, GameData.BuildNumber,
-					DatabaseAPI.ServerData.IdToken, SceneManager.GetActiveScene().name);
+					ServerData.Auth.CurrentUser.DisplayName, ServerData.UserID, GameData.BuildNumber,
+					ServerData.IdToken, SceneManager.GetActiveScene().name);
 
 			}
 		}
 
-
-
 		private async void HandleServerConnection()
 		{
 			await ServerSetUpPlayer(GetNetworkInfo(),
-				PlayerManager.CurrentCharacterSettings.Username, DatabaseAPI.ServerData.UserID, GameData.BuildNumber,
-				DatabaseAPI.ServerData.IdToken, "");
+				ServerData.Auth.CurrentUser.DisplayName, ServerData.UserID, GameData.BuildNumber,
+				ServerData.IdToken, "");
 			ClientFinishLoading();
 		}
 
@@ -306,7 +305,7 @@ namespace Player
 		[Command]
 		public void CmdSpectate(string jsonCharSettings)
 		{
-			var characterSettings = JsonConvert.DeserializeObject<CharacterSettings>(jsonCharSettings);
+			var characterSettings = JsonConvert.DeserializeObject<CharacterSheet>(jsonCharSettings);
 			PlayerSpawn.ServerSpawnGhost(this, characterSettings);
 		}
 
@@ -352,10 +351,10 @@ namespace Player
 		{
 			var player = PlayerList.Instance.GetOnline(connectionToClient);
 
-			CharacterSettings charSettings = null;
+			CharacterSheet charSettings = null;
 			if (isReady)
 			{
-				charSettings = JsonConvert.DeserializeObject<CharacterSettings>(jsonCharSettings);
+				charSettings = JsonConvert.DeserializeObject<CharacterSheet>(jsonCharSettings);
 			}
 			PlayerList.Instance.SetPlayerReady(player, isReady, charSettings);
 		}

--- a/UnityProject/Assets/Scripts/Player/PlayerManager.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerManager.cs
@@ -26,7 +26,7 @@ public class PlayerManager : MonoBehaviour
 
 	public static bool HasSpawned { get; private set; }
 
-	public static CharacterSettings CurrentCharacterSettings { get; set; }
+	public static CharacterSheet CurrentCharacterSettings { get; set; }
 
 	private int mobIDcount;
 
@@ -52,8 +52,8 @@ public class PlayerManager : MonoBehaviour
 		}
 		// Load CharacterSettings from PlayerPrefs or create a new one
 		string unescapedJson = Regex.Unescape(PlayerPrefs.GetString("currentcharacter"));
-		var deserialized = JsonConvert.DeserializeObject<CharacterSettings>(unescapedJson);
-		CurrentCharacterSettings = deserialized ?? new CharacterSettings();
+		var deserialized = JsonConvert.DeserializeObject<CharacterSheet>(unescapedJson);
+		CurrentCharacterSettings = deserialized ?? new CharacterSheet();
 	}
 #endif
 

--- a/UnityProject/Assets/Scripts/Player/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerScript.cs
@@ -20,7 +20,7 @@ public class PlayerScript : NetworkBehaviour, IMatrixRotation, IAdminInfo, IActi
 	/// <summary>
 	/// Current character settings for this player.
 	/// </summary>
-	public CharacterSettings characterSettings = new CharacterSettings();
+	public CharacterSheet characterSettings = new CharacterSheet();
 
 	[HideInInspector, SyncVar(hook = nameof(SyncPlayerName))] public string playerName = " ";
 
@@ -596,9 +596,9 @@ public class PlayerScript : NetworkBehaviour, IMatrixRotation, IAdminInfo, IActi
 		var stringBuilder = new StringBuilder();
 
 		stringBuilder.AppendLine($"Name: {characterSettings.Name}");
-		stringBuilder.AppendLine($"Acc: {characterSettings.Username}");
+		stringBuilder.AppendLine($"Acc: {PlayerInfo.Username}");
 
-		if(connectionToClient == null)
+		if (connectionToClient == null)
 		{
 			stringBuilder.AppendLine("Has No Soul");
 		}

--- a/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
@@ -54,7 +54,7 @@ namespace Player
 		//For character customization
 		public ClothingItem[] characterSprites;
 
-		public CharacterSettings ThisCharacter;
+		public CharacterSheet ThisCharacter;
 
 		//clothes for each clothing slot
 		public readonly Dictionary<NamedSlot, ClothingItem> clothes = new Dictionary<NamedSlot, ClothingItem>();
@@ -432,14 +432,14 @@ namespace Player
 			}
 		}
 
-		public void OnCharacterSettingsChange(CharacterSettings characterSettings)
+		public void OnCharacterSettingsChange(CharacterSheet characterSettings)
 		{
 			if (RootBodyPartsLoaded == false)
 			{
 				RootBodyPartsLoaded = true;
 				if (characterSettings == null)
 				{
-					characterSettings = new CharacterSettings();
+					characterSettings = new CharacterSheet();
 				}
 
 				ThisCharacter = characterSettings;

--- a/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
@@ -120,10 +120,11 @@ namespace ScriptableObjects.RP
 		/// </summary>
 		protected List<AddressableAudioSource> GetBodyTypeAudio(GameObject player)
 		{
-			if(player.TryGetComponent<PlayerScript>(out var playerScript) == false) return defaultSounds;
+			if (player.TryGetComponent<PlayerScript>(out var playerScript) == false) return defaultSounds;
 			var bodyType = playerScript.characterSettings.BodyType;
-			//Get the player's species
-			var race = CharacterSettings.GetRaceData(playerScript.characterSettings);
+			// Get the player's species
+			if (!RaceSOSingleton.TryGetRaceByName(playerScript.characterSettings.Species, out var race)) return defaultSounds;
+
 			VoiceType voiceTypeToUse = new VoiceType();
 			foreach (var voice in TypedSounds)
 			{

--- a/UnityProject/Assets/Scripts/ScriptableObjects/RP/SpeciesSpecficEmote.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/RP/SpeciesSpecficEmote.cs
@@ -23,9 +23,10 @@ namespace ScriptableObjects.RP
 		public bool IsSameSpecies(GameObject mobToCheck)
 		{
 			if (mobToCheck.TryGetComponent<PlayerScript>(out var playerScript) == false) return false;
-			var race = CharacterSettings.GetRaceData(playerScript.characterSettings);
-			if (race == null || allowedSpecies.Contains(race) == false) return false;
-			return true;
+
+			if (RaceSOSingleton.TryGetRaceByName(playerScript.characterSettings.Species, out var race) == false) return false;
+
+			return allowedSpecies.Contains(race);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Objects/Security/SecurityRecordsConsole/GUI_SecurityRecords.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Security/SecurityRecordsConsole/GUI_SecurityRecords.cs
@@ -138,7 +138,7 @@ namespace Objects.Security
 		public SecurityStatus Status;
 		public List<SecurityRecordCrime> Crimes;
 		public Occupation Occupation;
-		public CharacterSettings characterSettings;
+		public CharacterSheet characterSettings;
 
 		public SecurityRecord()
 		{

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/AdminHelpChat.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/AdminHelpChat.cs
@@ -32,7 +32,7 @@ namespace AdminTools
 
 		void OnInputReceived(string message)
 		{
-			AdminReplyMessage.Send($"{PlayerManager.CurrentCharacterSettings.Username} replied: " + message);
+			AdminReplyMessage.Send(message);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/AdminPlayerChat.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/AdminPlayerChat.cs
@@ -38,36 +38,40 @@ namespace AdminTools
 			clientAdminPlayerChatLogs.Clear();
 		}
 
-		public void ServerAddChatRecord(string message, string playerId, string adminId = "")
+		public void ServerAddChatRecord(string message, PlayerInfo player, PlayerInfo admin = default)
 		{
-			if (!serverAdminPlayerChatLogs.ContainsKey(playerId))
+			message = admin == null
+				? $"{player.Username}: {message}"
+				: $"{admin.Username}: {message}";
+
+			if (!serverAdminPlayerChatLogs.ContainsKey(player.UserId))
 			{
-				serverAdminPlayerChatLogs.Add(playerId, new List<AdminChatMessage>());
+				serverAdminPlayerChatLogs.Add(player.UserId, new List<AdminChatMessage>());
 			}
 
 			var entry = new AdminChatMessage
 			{
-				fromUserid = playerId,
+				fromUserid = player.UserId,
 				Message = message
 			};
 
-			if (!string.IsNullOrEmpty(adminId))
+			if (admin != null)
 			{
-				entry.fromUserid = adminId;
+				entry.fromUserid = admin.UserId;
 				entry.wasFromAdmin = true;
 			}
-			serverAdminPlayerChatLogs[playerId].Add(entry);
-			AdminPlayerChatUpdateMessage.SendSingleEntryToAdmins(entry, playerId);
-			if (!string.IsNullOrEmpty(adminId))
+			serverAdminPlayerChatLogs[player.UserId].Add(entry);
+			AdminPlayerChatUpdateMessage.SendSingleEntryToAdmins(entry, player.UserId);
+			if (admin != null)
 			{
-				AdminChatNotifications.SendToAll(playerId, AdminChatWindow.AdminPlayerChat, 0, true);
+				AdminChatNotifications.SendToAll(player.UserId, AdminChatWindow.AdminPlayerChat, 0, true);
 			}
 			else
 			{
-				AdminChatNotifications.SendToAll(playerId, AdminChatWindow.AdminPlayerChat, 1);
+				AdminChatNotifications.SendToAll(player.UserId, AdminChatWindow.AdminPlayerChat, 1);
 			}
 
-			ServerMessageRecording(playerId, entry);
+			ServerMessageRecording(player.UserId, entry);
 		}
 
 		private void ServerMessageRecording(string playerId, AdminChatMessage entry)
@@ -185,8 +189,7 @@ namespace AdminTools
 
 		public void OnInputSend(string message)
 		{
-			var msg = $"{ServerData.Auth.CurrentUser.DisplayName}: {message}";
-			RequestAdminBwoink.Send(selectedPlayer.uid, msg);
+			RequestAdminBwoink.Send(selectedPlayer.uid, message);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/MentorHelpChat.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/MentorHelpChat.cs
@@ -32,7 +32,7 @@ namespace AdminTools
 
 		void OnInputReceived(string message)
 		{
-			MentorReplyMessage.Send($"{PlayerManager.CurrentCharacterSettings.Username} replied: " + message);
+			MentorReplyMessage.Send(message);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/MentorPlayerChat.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/MentorPlayerChat.cs
@@ -38,36 +38,40 @@ namespace AdminTools
 			clientMentorPlayerChatLogs.Clear();
 		}
 
-		public void ServerAddChatRecord(string message, string playerId, string mentorId = "")
+		public void ServerAddChatRecord(string message, PlayerInfo player, PlayerInfo mentor = default)
 		{
-			if (!serverMentorPlayerChatLogs.ContainsKey(playerId))
+			message = mentor == null
+				? $"{player.Username}: {message}"
+				: $"{mentor.Username}: {message}";
+
+			if (!serverMentorPlayerChatLogs.ContainsKey(player.UserId))
 			{
-				serverMentorPlayerChatLogs.Add(playerId, new List<AdminChatMessage>());
+				serverMentorPlayerChatLogs.Add(player.UserId, new List<AdminChatMessage>());
 			}
 
 			var entry = new AdminChatMessage
 			{
-				fromUserid = playerId,
+				fromUserid = player.UserId,
 				Message = message
 			};
 
-			if (!string.IsNullOrEmpty(mentorId))
+			if (mentor != null)
 			{
-				entry.fromUserid = mentorId;
+				entry.fromUserid = mentor.UserId;
 				entry.wasFromAdmin = true;
 			}
-			serverMentorPlayerChatLogs[playerId].Add(entry);
-			MentorPlayerChatUpdateMessage.SendSingleEntryToMentors(entry, playerId);
-			if (!string.IsNullOrEmpty(mentorId))
+			serverMentorPlayerChatLogs[player.UserId].Add(entry);
+			MentorPlayerChatUpdateMessage.SendSingleEntryToMentors(entry, player.UserId);
+			if (mentor != null)
 			{
-				AdminChatNotifications.SendToAll(playerId, AdminChatWindow.MentorPlayerChat, 0, true);
+				AdminChatNotifications.SendToAll(player.UserId, AdminChatWindow.MentorPlayerChat, 0, true);
 			}
 			else
 			{
-				AdminChatNotifications.SendToAll(playerId, AdminChatWindow.MentorPlayerChat, 1);
+				AdminChatNotifications.SendToAll(player.UserId, AdminChatWindow.MentorPlayerChat, 1);
 			}
 
-			ServerMessageRecording(playerId, entry);
+			ServerMessageRecording(player.UserId, entry);
 		}
 
 		private void ServerMessageRecording(string playerId, AdminChatMessage entry)
@@ -184,7 +188,7 @@ namespace AdminTools
 
 		public void OnInputSend(string message)
 		{
-			RequestMentorBwoink.Send(selectedPlayer.uid, $"{ServerData.Auth.CurrentUser.DisplayName}: {message}");
+			RequestMentorBwoink.Send(selectedPlayer.uid, message);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/PlayerChatPage.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/PlayerChatPage.cs
@@ -112,8 +112,7 @@ namespace AdminTools
 
 			AddMessageToLogs(selectedPlayer.PlayerData.uid, $"You: {inputField.text}");
 			RefreshChatLog(selectedPlayer.PlayerData.uid);
-			var message = $"{PlayerManager.CurrentCharacterSettings.Username}: {inputField.text}";
-			RequestAdminBwoink.Send(selectedPlayer.PlayerData.uid, message);
+			RequestAdminBwoink.Send(selectedPlayer.PlayerData.uid, inputField.text);
 			inputField.text = "";
 			inputField.ActivateInputField();
 			StartCoroutine(AfterSubmit());

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/GUI_LobbyDialogue.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/GUI_LobbyDialogue.cs
@@ -133,7 +133,7 @@ namespace Lobby
 				//if there aren't char settings, default
 				if (PlayerManager.CurrentCharacterSettings == null)
 				{
-					PlayerManager.CurrentCharacterSettings = new CharacterSettings();
+					PlayerManager.CurrentCharacterSettings = new CharacterSheet();
 				}
 			}
 		}
@@ -258,7 +258,7 @@ namespace Lobby
 				emailAddressInput.text, AccountCreationSuccess, AccountCreationError);
 		}
 
-		private void AccountCreationSuccess(CharacterSettings charSettings)
+		private void AccountCreationSuccess(CharacterSheet charSettings)
 		{
 			pleaseWaitCreationText.text = $"Success! An email has been sent to {emailAddressInput.text}. " +
 										  $"Please click the link in the email to verify " +

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/SubCustomisation/CustomisationSubPart.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/SubCustomisation/CustomisationSubPart.cs
@@ -53,9 +53,9 @@ namespace UI.CharacterCreator
 			Dropdown.onValueChanged.AddListener(ItemChange);
 		}
 
-		public CharacterSettings.CustomisationClass Serialise()
+		public CharacterSheet.CustomisationClass Serialise()
 		{
-			var newcurrentSetting = new CharacterSettings.CustomisationClass();
+			var newcurrentSetting = new CharacterSheet.CustomisationClass();
 			// if (thisCustomisations.CanColour)
 			// {
 			newcurrentSetting.Colour = "#" + ColorUtility.ToHtmlStringRGB(color);
@@ -77,7 +77,7 @@ namespace UI.CharacterCreator
 			Refresh();
 		}
 
-		public void SetDropdownValue(CharacterSettings.CustomisationClass currentSetting)
+		public void SetDropdownValue(CharacterSheet.CustomisationClass currentSetting)
 		{
 			// Find the index of the setting in the dropdown list which matches the currentSetting
 			int settingIndex = Dropdown.options.FindIndex(option => option.text == currentSetting.SelectedName);

--- a/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
+++ b/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
@@ -378,16 +378,23 @@ public static class SweetExtensions
 		}
 	}
 
-	/// <summary>
-	/// Helped function for enums to get the next value when sorted by their base type
-	/// </summary>
+	/// <summary>Get the next value in the enum. Will loop to the top.</summary>
+	/// <remarks>Generates garbage; use sparingly.</remarks>
 	public static T Next<T>(this T src) where T : Enum
 	{
 		// if (!typeof(T).IsEnum) throw new ArgumentException(String.Format("Argument {0} is not an Enum", typeof(T).FullName));
 
-		T[] Arr = (T[])Enum.GetValues(src.GetType());
-		int j = Array.IndexOf<T>(Arr, src) + 1;
-		return (Arr.Length==j) ? Arr[0] : Arr[j];
+		T[] values = (T[])Enum.GetValues(src.GetType());
+		int j = Array.IndexOf(values, src) + 1;
+		return (values.Length == j) ? values[0] : values[j];
+	}
+
+	/// <summary>Get a random value from the given enum.</summary>
+	/// <remarks>Generates garbage; use sparingly.</remarks>
+	/// <returns>A random value from the enum</returns>
+	public static T PickRandom<T>(this T src) where T : Enum
+	{
+		return ((T[])Enum.GetValues(src.GetType())).PickRandom();
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Tests/PlayModeTests/RunTests/ActionTypes/ActionRespawnPlayer.cs
+++ b/UnityProject/Assets/Tests/PlayModeTests/RunTests/ActionTypes/ActionRespawnPlayer.cs
@@ -22,9 +22,9 @@ public partial class TestAction
 
 		public bool Initiate(TestRunSO testRunSO)
 		{
-			CharacterSettings characterSettings = string.IsNullOrEmpty(SerialisedCharacterSettings)
-					? new CharacterSettings()
-					: JsonConvert.DeserializeObject<CharacterSettings>(SerialisedCharacterSettings);
+			CharacterSheet characterSettings = string.IsNullOrEmpty(SerialisedCharacterSettings)
+					? new CharacterSheet()
+					: JsonConvert.DeserializeObject<CharacterSheet>(SerialisedCharacterSettings);
 
 			var playerInfo = PlayerList.Instance.Get(PlayerManager.LocalPlayerObject);
 			var spawnRequest = new PlayerSpawnRequest(playerInfo, Occupation, characterSettings);


### PR DESCRIPTION
- Renames `CharacterSettings` to `CharacterSheet` to make it more clear this is for details on the player's character.
- Removes `Username` field from `CharacterSettings`. It doesn't belong there. Previous usages of this member now source the username from somewhere more appropriate. Fixes #7801 (an assumption, not tested).
- Random character generation & related code refactors.
- Misc. changes  I had lying around from many months ago. 🤷 
- More instances of user ID strings converted to use `PlayerInfo`.
- Fixes an exploit where players (and admins/mentors) with modified clients could masquerade as another player in admin/mentor chats.
- Adds convenient `PickRandom()` extension to enums (generates garbage; use sparingly).

> Unable to test on headless due to unrelated issues.