### PR TITLE
Authentication move

### DIFF
--- a/UnityProject/Assets/AddressableAssetsData/link.xml
+++ b/UnityProject/Assets/AddressableAssetsData/link.xml
@@ -1,9 +1,0 @@
-<linker>
-  <assembly fullname="Unity.Addressables, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null" preserve="all">
-    <type fullname="UnityEngine.AddressableAssets.Addressables" preserve="all" />
-  </assembly>
-  <assembly fullname="Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null" preserve="all">
-    <type fullname="UnityEngine.ResourceManagement.ResourceProviders.InstanceProvider" preserve="all" />
-    <type fullname="UnityEngine.ResourceManagement.ResourceProviders.SceneProvider" preserve="all" />
-  </assembly>
-</linker>

--- a/UnityProject/Assets/AddressableAssetsData/link.xml.meta
+++ b/UnityProject/Assets/AddressableAssetsData/link.xml.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 7b47f416e1d31324bbfe53985514ead2
-TextScriptImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/NetworkManager.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/NetworkManager.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 5032898753073590648}
   - component: {fileID: 752180679074368365}
   - component: {fileID: 1404376226815865619}
+  - component: {fileID: 1670478699794476422}
   m_Layer: 0
   m_Name: NetworkManager
   m_TagString: NetworkManager
@@ -56,7 +57,7 @@ MonoBehaviour:
   transport: {fileID: 752180679074368365}
   networkAddress: localhost
   maxConnections: 100
-  authenticator: {fileID: 0}
+  authenticator: {fileID: 1670478699794476422}
   playerPrefab: {fileID: 2821122072132512938, guid: 70fd2614e91344280b501ff52714aaa4,
     type: 3}
   autoCreatePlayer: 1
@@ -11212,7 +11213,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   port: 7777
   DebugDisplay: 0
-  LogType: 2
+  LogType: 0
   serverBindsAll: 1
   serverBindAddress: 
   serverMaxPeerCapacity: 100
@@ -11239,3 +11240,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2a6f523ec7d18a647835095a8050d74b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1670478699794476422
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2920527550438430692}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db3dd5c41e32754488ab0e94e695f0b7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  OnServerAuthenticated:
+    m_PersistentCalls:
+      m_Calls: []
+  OnClientAuthenticated:
+    m_PersistentCalls:
+      m_Calls: []

--- a/UnityProject/Assets/Scripts/Core/Networking/Authenticator.cs
+++ b/UnityProject/Assets/Scripts/Core/Networking/Authenticator.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Net.NetworkInformation;
+using System.Threading.Tasks;
+using UnityEngine;
+using Mirror;
+using DatabaseAPI;
+
+namespace Core.Networking
+{
+	public struct AuthData
+	{
+		/// <summary>The identifier for the game client.</summary>
+		public string ClientId;
+		/// <summary>The identifier for the player's Unitystation account.</summary>
+		public string AccountId;
+		/// <summary>Human-friendly public-facing username of the player's account.</summary>
+		public string Username;
+	}
+
+	/// <summary>
+	/// Authentication for Mirror clients connecting to servers.
+	/// NetworkAuthenticator Documentation: https://mirror-networking.gitbook.io/docs/components/network-authenticators
+	/// API Reference: https://mirror-networking.com/docs/api/Mirror.NetworkAuthenticator.html
+	/// </summary>
+	public class Authenticator : NetworkAuthenticator
+	{
+		#region Messages
+
+		public struct AuthRequestMessage : NetworkMessage
+		{
+			public int ClientVersion;
+			public string ClientId;
+			public string AccountId;
+			public string Username;
+			public string Token;
+		}
+
+		public struct AuthDisconnectMessage : NetworkMessage
+		{
+			public DisconnectReason Reason;
+			public string Message;
+		}
+
+		public enum DisconnectReason
+		{
+			InvalidClientVersion,
+			InvalidAccountDetails,
+			AccountValidationError,
+			AccountValidationFailed,
+		}
+
+		#endregion
+
+		#region Server
+
+		private readonly Dictionary<string, (DateTime, DateTime)> connectionCooldowns = new();
+		private readonly float minCooldown = 1f;
+
+		public override void OnStartServer()
+		{
+			NetworkServer.RegisterHandler<AuthRequestMessage>(OnAuthRequestMessage, false);
+		}
+
+		public override void OnServerAuthenticate(NetworkConnection conn)
+		{
+			Logger.LogTrace($"A client not yet authenticated is joining. Address: {conn.address}.", Category.Connections);
+		}
+		
+		public async void OnAuthRequestMessage(NetworkConnectionToClient conn, AuthRequestMessage msg)
+		{
+			Logger.LogTrace($"A client is requesting authentication. " +
+					$"Address: {conn.address}. Client Version: {msg.ClientVersion}. Account ID: {msg.AccountId}.",
+					Category.Connections);
+
+			// Before proceeding, check for connection spam.
+			if (IsSpamming(conn))
+			{
+				ServerReject(conn);
+				return;
+			}
+
+			if (ValidatePlayerClient(conn, msg.ClientVersion) == false) return;
+			if (await ValidatePlayerAccount(conn, msg.AccountId, msg.Token) == false) return;
+
+			// Accept the successful authentication
+			conn.authenticationData = new AuthData
+			{
+				ClientId = msg.ClientId,
+				AccountId = msg.AccountId,
+				Username = msg.Username,
+			};
+			ServerAccept(conn);
+		}
+
+		private bool IsSpamming(NetworkConnection conn)
+		{
+			if (connectionCooldowns.ContainsKey(conn.address) == false)
+			{
+				connectionCooldowns.Add(conn.address, (DateTime.Now, DateTime.MinValue));
+				return false;
+			}
+			
+			var connSecondsElapsed = (DateTime.Now - connectionCooldowns[conn.address].Item1).TotalSeconds;
+			var logSecondsElapsed = (DateTime.Now - connectionCooldowns[conn.address].Item2).TotalSeconds;
+			connectionCooldowns[conn.address] = (DateTime.Now, DateTime.MinValue);
+
+			if (connSecondsElapsed < minCooldown)
+			{
+				// Cooldown on logging so we don't spam our logs.
+				if (logSecondsElapsed > minCooldown)
+				{
+					Logger.Log($"Connection spam alert. Address {conn.address} is trying to spam connections.",
+							Category.Connections);
+				}
+
+				return true;
+			}
+
+			return false;
+		}
+
+		private bool ValidatePlayerClient(NetworkConnection conn, int clientVersion)
+		{
+			// Check the client version is the same as the server
+			if (clientVersion != GameData.BuildNumber)
+			{
+				Logger.LogTrace($"A client tried to connect with a different client version. Version: {clientVersion}.",
+						Category.Connections);
+				DisconnectClient(conn, DisconnectReason.InvalidClientVersion,
+						$"Invalid Client Version! You need version {GameData.BuildNumber}. This can be acquired through the station hub.");
+				return false;
+			}
+
+			return true;
+		}
+
+		private async Task<bool> ValidatePlayerAccount(NetworkConnection conn, string accountId, string accountToken)
+		{
+			// Allow local offline testing
+			if (GameData.Instance.OfflineMode) return true;
+
+			// Must have account ID and token
+			if (string.IsNullOrEmpty(accountId) || string.IsNullOrEmpty(accountToken))
+			{
+				Logger.Log(
+						"A user tried to connect with an invalid account ID and/or token."
+						+ $" Account ID: '{accountId}'. IP: '{conn.address}'.",
+						Category.Connections);
+				DisconnectClient(conn, DisconnectReason.InvalidAccountDetails,
+						"Account has invalid token. Try restarting the game and relogging into your account.");
+				
+				return false;
+			}
+			
+			// Validate the provided token against the account details
+			var refresh = new RefreshToken { userID = accountId, refreshToken = accountToken };
+			var response = await ServerData.ValidateToken(refresh, true);
+			if (response == null)
+			{
+				Logger.LogError($"Server error when validating user account token."
+						+ $" Account ID: '{accountId}'. IP: '{conn.address}'.",
+						Category.Connections);
+				DisconnectClient(conn, DisconnectReason.AccountValidationError,
+						"Server Error: unknown problem encountered when attempting to validate your account token.");
+				
+				return false;
+			}
+
+			if (response.errorCode == 1)
+			{
+				Logger.Log("A user tried to authenticate with a bad token. Possible spoof attempt."
+						+ $" Account ID: '{accountId}'. IP: '{conn.address}'.",
+						Category.Connections);
+				DisconnectClient(conn, DisconnectReason.AccountValidationFailed,
+						"Account token validation failed. Try restarting the game and relogging into your account.");
+
+				return false;
+			}
+
+			return true;
+		}
+
+		private void DisconnectClient(NetworkConnection connection, DisconnectReason reason, string message = "")
+				=> StartCoroutine(_DisconnectClient(connection, reason, message));
+		private IEnumerator _DisconnectClient(NetworkConnection conn, DisconnectReason reason, string message = "")
+		{
+			var msg = new AuthDisconnectMessage
+			{
+				Reason = reason,
+				Message = message,
+			};
+			conn.Send(msg);
+
+			// Force disconnect after giving time for message receipt,
+			// if the client hasn't already disconnected gracefully
+			yield return new WaitForSeconds(1f); 
+
+			ServerReject(conn);
+		}
+
+		#endregion
+
+		#region Client
+
+		public override void OnStartClient()
+		{
+			NetworkClient.RegisterHandler<AuthDisconnectMessage>(OnAuthDisconnectMessage, false);
+		}
+
+		public override void OnClientAuthenticate()
+		{
+			AuthRequestMessage msg = new()
+			{
+				ClientVersion = GameData.BuildNumber,
+				ClientId = GetPhysicalAddress(),
+				AccountId = ServerData.UserID,
+				Username = ServerData.Auth.CurrentUser.DisplayName,
+				Token = ServerData.IdToken,
+			};
+			
+			NetworkClient.Send(msg);
+		}
+
+		public void OnAuthDisconnectMessage(AuthDisconnectMessage msg)
+		{
+			Logger.Log($"Disconnected from server. Reason: {msg.Reason}.");
+			UIManager.InfoWindow.Show(msg.Message, bwoink: false, "Disconnected");
+			ClientReject(); // Gracefully handle rejection by disconnecting.
+			CustomNetworkManager.Instance.StopClient();
+		}
+
+		private string GetPhysicalAddress()
+		{
+			var nics = NetworkInterface.GetAllNetworkInterfaces();
+			foreach (var n in nics)
+			{
+				if (string.IsNullOrEmpty(n.GetPhysicalAddress().ToString()) == false)
+				{
+					return n.GetPhysicalAddress().ToString();
+				}
+			}
+
+			return "";
+		}
+
+		#endregion
+	}
+}

--- a/UnityProject/Assets/Scripts/Core/Networking/Authenticator.cs.meta
+++ b/UnityProject/Assets/Scripts/Core/Networking/Authenticator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db3dd5c41e32754488ab0e94e695f0b7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -260,25 +260,7 @@ public partial class GameManager : MonoBehaviour, IInitialise
 			minDistanceBetweenSpaceBodies = 200f;
 		}
 
-		//Fills list of Vectors all along shuttle path
-		var beginning = GameManager.Instance.PrimaryEscapeShuttle.stationTeleportLocation;
-		var target = GameManager.Instance.PrimaryEscapeShuttle.stationDockingLocation;
-
-
-		var distance = (int) Vector2.Distance(beginning, target);
-
-		if (!EscapeShuttlePathGenerated) //Only generated once
-		{
-			EscapeShuttlePath.Add(beginning); //Adds original vector
-			for (int i = 0; i < (distance / 50); i++)
-			{
-				beginning = Vector2.MoveTowards(beginning, target, 50); //Vector 50 distance apart from prev vector
-				EscapeShuttlePath.Add(beginning);
-			}
-
-			EscapeShuttlePathGenerated = true;
-		}
-
+		GenerateShuttlePath();
 
 		bool validPos = false;
 		while (!validPos)
@@ -324,6 +306,32 @@ public partial class GameManager : MonoBehaviour, IInitialise
 
 		yield return WaitFor.EndOfFrame;
 		isProcessingSpaceBody = false;
+	}
+
+	private void GenerateShuttlePath()
+	{
+		if (EscapeShuttlePathGenerated) return;
+		if (GameManager.Instance.PrimaryEscapeShuttle == null)
+		{
+			Logger.LogWarning("Cannot generate primary escape shuttle path. Shuttle not found.");
+			return;
+		}
+
+		//Fills list of Vectors all along shuttle path
+		var beginning = GameManager.Instance.PrimaryEscapeShuttle.stationTeleportLocation;
+		var target = GameManager.Instance.PrimaryEscapeShuttle.stationDockingLocation;
+
+
+		var distance = (int)Vector2.Distance(beginning, target);
+
+		EscapeShuttlePath.Add(beginning); //Adds original vector
+		for (int i = 0; i < (distance / 50); i++)
+		{
+			beginning = Vector2.MoveTowards(beginning, target, 50); //Vector 50 distance apart from prev vector
+			EscapeShuttlePath.Add(beginning);
+		}
+
+		EscapeShuttlePathGenerated = true;
 	}
 
 	public Vector3 RandomPositionInSolarSystem()

--- a/UnityProject/Assets/Scripts/Messages/Server/ServerMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/ServerMessage.cs
@@ -14,7 +14,7 @@ namespace Messages.Server
 	{
 		public static void SendToAll(T msg, int channel = 0)
 		{
-			NetworkServer.SendToAll(msg, channel);
+			NetworkServer.SendToAll(msg, channel, sendToReadyOnly: true);
 			Logger.LogTraceFormat("SentToAll {0}", Category.Server, msg.GetType());
 		}
 


### PR DESCRIPTION
- Moves our client -> server authentication code to `Authenticator.cs`, a Mirror-derived component attached to the `NetworkManager` prefab.
This now happens _before_ we register the player on the player lists.
- Reduces `Ignorance` logging level now that the Mac issue is resolved.