### PR TITLE
we can handle moving shuttles

### DIFF
--- a/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
+++ b/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
@@ -802,14 +802,7 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable
 		}
 
 
-		if (IsMoving)
-		{
-			SetMatrixCash.ResetNewPosition(From);
-		}
-		else
-		{
-			SetMatrixCash.ResetNewPosition(From, registerTile);
-		}
+		SetMatrixCash.ResetNewPosition(From, registerTile);
 
 
 		if (MatrixManager.IsPassableAtAllMatricesV2(From,

--- a/UnityProject/Assets/Scripts/Shuttles/BetterBoundsInt.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/BetterBoundsInt.cs
@@ -22,7 +22,7 @@ namespace TileManagement
 
 		public Vector3Int size => Maximum - Minimum;
 
-		public Vector3Int center => (Minimum + Maximum) / 2;
+		public Vector3 center => (Minimum + Maximum).ToNonInt3() / 2f;
 
 		public bool Contains(Vector3Int Point)
 		{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
@@ -1844,10 +1844,9 @@ namespace TileManagement
 			{
 				Maximum = maxPosition + new Vector3(0.5f, 0.5f, 0), Minimum = minPosition + new Vector3(-0.5f, -0.5f, 0)
 			};
-
-
-			GlobalCachedBounds = newGlobalBounds;
 			
+			GlobalCachedBounds = newGlobalBounds;
+
 			return newGlobalBounds;
 		}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
@@ -1845,15 +1845,9 @@ namespace TileManagement
 				Maximum = maxPosition + new Vector3(0.5f, 0.5f, 0), Minimum = minPosition + new Vector3(-0.5f, -0.5f, 0)
 			};
 
-			if ((CustomNetworkManager.IsServer && matrix.MatrixMove.IsMovingServer == false &&
-			     matrix.MatrixMove.IsRotatingServer == false) ||
-			    (CustomNetworkManager.IsServer == false && matrix.MatrixMove.IsMovingClient == false &&
-			     matrix.MatrixMove.IsRotatingServer == false))
-			{
-				//Only save the cache if the shuttle is static!
-				GlobalCachedBounds = newGlobalBounds;
-			}
 
+			GlobalCachedBounds = newGlobalBounds;
+			
 			return newGlobalBounds;
 		}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
@@ -1845,8 +1845,7 @@ namespace TileManagement
 				Maximum = maxPosition + new Vector3(0.5f, 0.5f, 0), Minimum = minPosition + new Vector3(-0.5f, -0.5f, 0)
 			};
 
-			if (matrix.IsMovable == false ||
-			    (CustomNetworkManager.IsServer && matrix.MatrixMove.IsMovingServer == false &&
+			if ((CustomNetworkManager.IsServer && matrix.MatrixMove.IsMovingServer == false &&
 			     matrix.MatrixMove.IsRotatingServer == false) ||
 			    (CustomNetworkManager.IsServer == false && matrix.MatrixMove.IsMovingClient == false &&
 			     matrix.MatrixMove.IsRotatingServer == false))


### PR DESCRIPTION
Don't know why it was set like this, I have set all the hooks for updating it in the movement changes PR

### Changelog:


CL: [Improvement] Makes the code use the cached version of matrix bounds

