### PR TITLE
Fix headless auth

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Database/ServerData.ValidateUser.cs
+++ b/UnityProject/Assets/Scripts/Core/Database/ServerData.ValidateUser.cs
@@ -88,7 +88,7 @@ namespace DatabaseAPI
 			string jsonChar = JsonConvert.SerializeObject(characterSettings);
 			PlayerPrefs.SetString("currentcharacter", jsonChar);
 
-			PlayerManager.CurrentCharacterSettings = characterSettings;
+			PlayerManager.CurrentCharacterSheet = characterSettings;
 
 			successAction?.Invoke("Login success");
 			PlayerPrefs.SetString("lastLogin", user.Email);

--- a/UnityProject/Assets/Scripts/Core/Database/ServerData.cs
+++ b/UnityProject/Assets/Scripts/Core/Database/ServerData.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using Firebase.Extensions;
 using Initialisation;
 using UnityEngine;
+using Firebase.Auth;
 
 namespace DatabaseAPI
 {
@@ -31,35 +32,19 @@ namespace DatabaseAPI
 			}
 		}
 
-		public static string UserFirestoreURL
-		{
-			get
-			{
-				return "https://firestore.googleapis.com/v1/projects/" +
-				       $"unitystation-c6a53/databases/(default)/documents/users/{Auth.CurrentUser.UserId}";
-			}
-		}
+		public static string UserFirestoreURL => "https://firestore.googleapis.com/v1/projects/" +
+				$"unitystation-c6a53/databases/(default)/documents/users/{Auth.CurrentUser.UserId}";
 
-		private Firebase.Auth.FirebaseAuth auth;
-		public static Firebase.Auth.FirebaseAuth Auth => Instance.auth;
+		private FirebaseAuth auth;
+		public static FirebaseAuth Auth => Instance.auth;
 
-		private readonly Dictionary<string, Firebase.Auth.FirebaseUser> userByAuth =
-			new Dictionary<string, Firebase.Auth.FirebaseUser>();
+		private readonly Dictionary<string, FirebaseUser> userByAuth = new();
 
-		private Firebase.Auth.FirebaseUser user = null;
+		private FirebaseUser user = null;
 
-		public static string UserID
-		{
-			get
-			{
-				if (Instance.user == null)
-				{
-					return "";
-				}
-
-				return Instance.user.UserId;
-			}
-		}
+		public static string UserID => Instance.user == null
+				? string.Empty
+				: Instance.user.UserId;
 
 		public static Action serverDataLoaded;
 

--- a/UnityProject/Assets/Scripts/Core/Editor/PlayerPrefsEditor.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/PlayerPrefsEditor.cs
@@ -1,0 +1,111 @@
+using UnityEngine;
+using UnityEditor;
+using System.Collections;
+ 
+public class PlayerPrefsEditor : EditorWindow {
+ 
+    [MenuItem("Tools/Player Prefs Editor")]
+    public static void openWindow() {
+ 
+        PlayerPrefsEditor window = (PlayerPrefsEditor)EditorWindow.GetWindow(typeof(PlayerPrefsEditor));
+        window.titleContent = new GUIContent("Player Prefs");
+        window.Show();
+ 
+    }
+ 
+    public enum FieldType { String,Integer,Float }
+ 
+    private FieldType fieldType = FieldType.String;
+    private string setKey = "";
+    private string setVal = "";
+    private string error = null;
+ 
+    void OnGUI() {
+ 
+        EditorGUILayout.LabelField("Player Prefs Editor", EditorStyles.boldLabel);
+        EditorGUILayout.LabelField("by RomejanicDev");
+        EditorGUILayout.Separator();
+ 
+        fieldType = (FieldType)EditorGUILayout.EnumPopup("Key Type", fieldType);
+        setKey = EditorGUILayout.TextField("Key to Set", setKey);
+        setVal = EditorGUILayout.TextField("Value to Set", setVal);
+ 
+        if(error != null) {
+ 
+            EditorGUILayout.HelpBox(error, MessageType.Error);
+ 
+        }
+ 
+        if(GUILayout.Button("Set Key")) {
+ 
+            if(fieldType == FieldType.Integer) {
+ 
+                int result;
+                if(!int.TryParse(setVal, out result)) {
+                   
+                    error = "Invalid input \"" + setVal + "\"";
+                    return;
+                   
+                }
+               
+                PlayerPrefs.SetInt(setKey, result);
+ 
+            } else if(fieldType == FieldType.Float) {
+ 
+                float result;
+                if(!float.TryParse(setVal, out result)) {
+ 
+                    error = "Invalid input \"" + setVal + "\"";
+                    return;
+ 
+                }
+ 
+                PlayerPrefs.SetFloat(setKey, result);
+ 
+            } else {
+ 
+                PlayerPrefs.SetString(setKey, setVal);
+ 
+            }
+ 
+            PlayerPrefs.Save();
+            error = null;
+ 
+        }
+ 
+        if(GUILayout.Button("Get Key")) {
+       
+            if(fieldType == FieldType.Integer) {
+ 
+                setVal = PlayerPrefs.GetInt(setKey).ToString();
+ 
+            } else if(fieldType == FieldType.Float) {
+ 
+                setVal = PlayerPrefs.GetFloat(setKey).ToString();
+ 
+            } else {
+ 
+                setVal = PlayerPrefs.GetString(setKey);
+ 
+            }
+       
+        }
+ 
+        if(GUILayout.Button("Delete Key")) {
+ 
+            PlayerPrefs.DeleteKey(setKey);
+            PlayerPrefs.Save();
+ 
+        }
+ 
+        if(GUILayout.Button("Delete All Keys")) {
+ 
+            PlayerPrefs.DeleteAll();
+            PlayerPrefs.Save();
+ 
+        }
+ 
+    }
+ 
+}
+ 

--- a/UnityProject/Assets/Scripts/Core/Editor/PlayerPrefsEditor.cs.meta
+++ b/UnityProject/Assets/Scripts/Core/Editor/PlayerPrefsEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4228545b9090bee4abc91365785f9cc6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Managers/BuildPreferences.cs
+++ b/UnityProject/Assets/Scripts/Managers/BuildPreferences.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using System.IO;
 
 [ExecuteInEditMode]

--- a/UnityProject/Assets/Scripts/Managers/LobbyManager/LobbyManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/LobbyManager/LobbyManager.cs
@@ -31,20 +31,9 @@ namespace Lobby
 			EventManager.AddHandler(Event.LoggedOut, SetOnLogOut);
 		}
 
-		private void OnEnable()
-		{
-			CustomNetworkManager.Instance.OnClientDisconnected.AddListener(OnClientDisconnect);
-		}
-
 		private void OnDisable()
 		{
 			EventManager.RemoveHandler(Event.LoggedOut, SetOnLogOut);
-			CustomNetworkManager.Instance?.OnClientDisconnected?.RemoveListener(OnClientDisconnect);
-		}
-
-		public void OnClientDisconnect()
-		{
-			lobbyDialogue.OnClientDisconnect();
 		}
 
 		private void DetermineUIScale()

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -34,11 +34,11 @@ public class CustomNetworkManager : NetworkManager, IInitialise
 	/// List of ALL prefabs in the game which can be spawned, networked or not.
 	/// use spawnPrefabs to get only networked prefabs
 	/// </summary>
-	[HideInInspector] public List<GameObject> allSpawnablePrefabs = new List<GameObject>();
+	[HideInInspector] public List<GameObject> allSpawnablePrefabs = new();
 
-	public Dictionary<GameObject, int> IndexLookupSpawnablePrefabs = new Dictionary<GameObject, int>();
+	public Dictionary<GameObject, int> IndexLookupSpawnablePrefabs = new();
 
-	public Dictionary<string, GameObject> ForeverIDLookupSpawnablePrefabs = new Dictionary<string, GameObject>();
+	public Dictionary<string, GameObject> ForeverIDLookupSpawnablePrefabs = new();
 
 	/// <summary>
 	/// Invoked client side when the player has disconnected from a server.
@@ -319,7 +319,7 @@ public class CustomNetworkManager : NetworkManager, IInitialise
 		{
 			if (conn == NetworkServer.localConnection)
 			{
-				Logger.Log("Prevented headless server from spawning a player", Category.Server);
+				Logger.Log("Prevented headless server from spawning a player", Category.Connections);
 				return;
 			}
 		}

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -274,7 +274,7 @@ namespace Player
 
 		public void RequestJob(JobType job)
 		{
-			var jsonCharSettings = JsonConvert.SerializeObject(PlayerManager.CurrentCharacterSettings);
+			var jsonCharSettings = JsonConvert.SerializeObject(PlayerManager.CurrentCharacterSheet);
 
 			if (PlayerList.Instance.ClientJobBanCheck(job) == false)
 			{
@@ -288,7 +288,7 @@ namespace Player
 
 		public void Spectate()
 		{
-			var jsonCharSettings = JsonConvert.SerializeObject(PlayerManager.CurrentCharacterSettings);
+			var jsonCharSettings = JsonConvert.SerializeObject(PlayerManager.CurrentCharacterSheet);
 			CmdSpectate(jsonCharSettings);
 		}
 
@@ -320,7 +320,7 @@ namespace Player
 			var jsonCharSettings = "";
 			if (isReady)
 			{
-				jsonCharSettings = JsonConvert.SerializeObject(PlayerManager.CurrentCharacterSettings);
+				jsonCharSettings = JsonConvert.SerializeObject(PlayerManager.CurrentCharacterSheet);
 			}
 			CmdPlayerReady(isReady, jsonCharSettings);
 		}

--- a/UnityProject/Assets/Scripts/Player/PlayerManager.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerManager.cs
@@ -26,7 +26,7 @@ public class PlayerManager : MonoBehaviour
 
 	public static bool HasSpawned { get; private set; }
 
-	public static CharacterSheet CurrentCharacterSettings { get; set; }
+	public static CharacterSheet CurrentCharacterSheet { get; set; }
 
 	private int mobIDcount;
 
@@ -46,14 +46,14 @@ public class PlayerManager : MonoBehaviour
 #if UNITY_EDITOR	//Opening the station scene instead of going through the lobby
 	private void Awake()
 	{
-		if (CurrentCharacterSettings != null)
+		if (CurrentCharacterSheet != null)
 		{
 			return;
 		}
 		// Load CharacterSettings from PlayerPrefs or create a new one
 		string unescapedJson = Regex.Unescape(PlayerPrefs.GetString("currentcharacter"));
 		var deserialized = JsonConvert.DeserializeObject<CharacterSheet>(unescapedJson);
-		CurrentCharacterSettings = deserialized ?? new CharacterSheet();
+		CurrentCharacterSheet = deserialized ?? new CharacterSheet();
 	}
 #endif
 

--- a/UnityProject/Assets/Scripts/UI/Systems/CharacterCreator/AntagonistPreferences.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/CharacterCreator/AntagonistPreferences.cs
@@ -79,7 +79,7 @@ namespace UI.CharacterCreator
 		/// </summary>
 		private void LoadAntagPreferences()
 		{
-			antagPrefs = PlayerManager.CurrentCharacterSettings.AntagPreferences;
+			antagPrefs = PlayerManager.CurrentCharacterSheet.AntagPreferences;
 
 			foreach (string antagName in antagPrefs.Keys.ToList())
 			{
@@ -100,8 +100,8 @@ namespace UI.CharacterCreator
 		/// </summary>
 		private void SaveAntagPreferences()
 		{
-			PlayerManager.CurrentCharacterSettings.AntagPreferences = antagPrefs;
-			_ = ServerData.UpdateCharacterProfile(PlayerManager.CurrentCharacterSettings);
+			PlayerManager.CurrentCharacterSheet.AntagPreferences = antagPrefs;
+			_ = ServerData.UpdateCharacterProfile(PlayerManager.CurrentCharacterSheet);
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/UI/Systems/Jobs/GUI_JobPreferences.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Jobs/GUI_JobPreferences.cs
@@ -197,8 +197,8 @@ namespace UI
 		/// </summary>
 		private void SaveJobPreferences()
 		{
-			PlayerManager.CurrentCharacterSettings.JobPreferences = jobPreferences;
-			_ = ServerData.UpdateCharacterProfile(PlayerManager.CurrentCharacterSettings);
+			PlayerManager.CurrentCharacterSheet.JobPreferences = jobPreferences;
+			_ = ServerData.UpdateCharacterProfile(PlayerManager.CurrentCharacterSheet);
 		}
 
 		/// <summary>
@@ -208,7 +208,7 @@ namespace UI
 		{
 			// Loop through all jobs and set the dropdown to the specified priority.
 			// This will update the local jobPreferences variable using OnPriorityChange.
-			foreach (var jobPref in PlayerManager.CurrentCharacterSettings.JobPreferences.ToList())
+			foreach (var jobPref in PlayerManager.CurrentCharacterSheet.JobPreferences.ToList())
 			{
 				jobEntries[jobPref.Key].SetPriority(jobPref.Value);
 			}

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterCustomization.cs
@@ -124,7 +124,7 @@ namespace UI.CharacterCreator
 			ShowCharacterPreviewOnCharacterSelector();
 			CheckIfCharacterListIsEmpty();
 			WindowName.text = "Select your character";
-			LoadSettings(PlayerManager.CurrentCharacterSettings);
+			LoadSettings(PlayerManager.CurrentCharacterSheet);
 			var copyStr = JsonConvert.SerializeObject(currentCharacter);
 			lastSettings = JsonConvert.DeserializeObject<CharacterSheet>(copyStr);
 			colorPicker.gameObject.SetActive(false);
@@ -288,7 +288,7 @@ namespace UI.CharacterCreator
 		{
 			currentCharacterIndex = newValue;
 			LoadSettings(PlayerCharacters[currentCharacterIndex]);
-			PlayerManager.CurrentCharacterSettings = PlayerCharacters[currentCharacterIndex];
+			PlayerManager.CurrentCharacterSheet = PlayerCharacters[currentCharacterIndex];
 			SaveLastCharacterIndex();
 			RefreshSelectorData();
 			_ = SoundManager.Play(CommonSounds.Instance.Click01);
@@ -366,7 +366,7 @@ namespace UI.CharacterCreator
 			if (currentCharacter == null)
 			{
 				currentCharacter = new CharacterSheet();
-				PlayerManager.CurrentCharacterSettings = currentCharacter;
+				PlayerManager.CurrentCharacterSheet = currentCharacter;
 			}
 
 			PlayerHealthData SetRace = null;
@@ -407,7 +407,7 @@ namespace UI.CharacterCreator
 
 			availableSkinColors = SetRace.Base.SkinColours;
 
-			PlayerManager.CurrentCharacterSettings = currentCharacter;
+			PlayerManager.CurrentCharacterSheet = currentCharacter;
 			SetUpSpeciesBody(SetRace);
 			PopulateAllDropdowns(SetRace);
 			RefreshAll();
@@ -911,7 +911,7 @@ namespace UI.CharacterCreator
 			Logger.Log(JsonConvert.SerializeObject(bodyPartCustomisationStorage), Category.Character);
 			Logger.Log(JsonConvert.SerializeObject(ExternalCustomisationStorage), Category.Character);
 
-			PlayerManager.CurrentCharacterSettings = currentCharacter;
+			PlayerManager.CurrentCharacterSheet = currentCharacter;
 			_ = ServerData.UpdateCharacterProfile(currentCharacter);
 			SaveCharacters();
 		}
@@ -1129,7 +1129,7 @@ namespace UI.CharacterCreator
 
 		public void OnCancelBtn()
 		{
-			PlayerManager.CurrentCharacterSettings = lastSettings;
+			PlayerManager.CurrentCharacterSheet = lastSettings;
 			LoadSettings(lastSettings);
 			RefreshAll();
 			ReturnCharacterPreviewFromTheCharacterSelector();

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/GUI_LobbyDialogue.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/GUI_LobbyDialogue.cs
@@ -131,9 +131,9 @@ namespace Lobby
 				//skip login
 				ShowMainPanel();
 				//if there aren't char settings, default
-				if (PlayerManager.CurrentCharacterSettings == null)
+				if (PlayerManager.CurrentCharacterSheet == null)
 				{
-					PlayerManager.CurrentCharacterSettings = new CharacterSheet();
+					PlayerManager.CurrentCharacterSheet = new CharacterSheet();
 				}
 			}
 		}
@@ -263,7 +263,7 @@ namespace Lobby
 			pleaseWaitCreationText.text = $"Success! An email has been sent to {emailAddressInput.text}. " +
 										  $"Please click the link in the email to verify " +
 										  $"your account before signing in.";
-			PlayerManager.CurrentCharacterSettings = charSettings;
+			PlayerManager.CurrentCharacterSheet = charSettings;
 			GameData.LoggedInUsername = chosenUsernameInput.text;
 			chosenPasswordInput.text = "";
 			chosenUsernameInput.text = "";
@@ -361,7 +361,7 @@ namespace Lobby
 			dialogueTitle.text = "Hosting Game...";
 
 			// Set and cache player name
-			PlayerPrefs.SetString(UserNamePlayerPref, PlayerManager.CurrentCharacterSettings.Name);
+			PlayerPrefs.SetString(UserNamePlayerPref, PlayerManager.CurrentCharacterSheet.Name);
 
 			LoadingScreenManager.LoadFromLobby(CustomNetworkManager.Instance.StartHost);
 		}
@@ -380,13 +380,14 @@ namespace Lobby
 
 		public void OnStartGameFromHub()
 		{
-			if (PlayerManager.CurrentCharacterSettings != null)
+			if (PlayerManager.CurrentCharacterSheet != null)
 			{
-				PlayerPrefs.SetString(UserNamePlayerPref, PlayerManager.CurrentCharacterSettings.Name);
+				PlayerPrefs.SetString(UserNamePlayerPref, PlayerManager.CurrentCharacterSheet.Name);
 			}
 			
 			ConnectToServer();
-			gameObject.SetActive(false);
+			dialogueTitle.text = "Joining Game...";
+			ShowLoggingInStatus("Joining the game...");
 		}
 
 		public void OnShowInformationPanel()

--- a/UnityProject/Assets/StreamingAssets/AddressableCatalogues/SoundAndMusic.meta
+++ b/UnityProject/Assets/StreamingAssets/AddressableCatalogues/SoundAndMusic.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 150df1245637c744eb660a9286c01a3c
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
- Fixes #8875 breaking authentication on headless servers (presumably with no `PlayerPrefs` login token set).
- Fixes harmless NRE on startup from network manager not being available yet (dead code, removed).
- Adds an extra UI step about joining a game after logging into your account, instead of hiding the UI.
- Adds a tool from https://forum.unity.com/threads/editor-utility-player-prefs-editor-edit-player-prefs-inside-the-unity-editor.370292/ to manage your `PlayerPrefs` within the editor (I used the delete-all button but my local headless server still managed to authenticate fine 🤔).
