### PR TITLE
Adds 70% of ACUs in Boxstation + pipe fixes.

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/Cargo/Orders/Medical Kits Crate.asset
+++ b/UnityProject/Assets/ScriptableObjects/Cargo/Orders/Medical Kits Crate.asset
@@ -13,13 +13,14 @@ MonoBehaviour:
   m_Name: Medical Kits Crate
   m_EditorClassIdentifier: 
   OrderName: Medical Kits Crate
-  CreditCost: 800
+  CreditCost: 1000
   Crate: {fileID: 2395943996647778371, guid: a85bb77436de9574c8523fe45acffb14, type: 3}
   Items:
   - {fileID: 8635195139948178778, guid: d0eb5dacbdcd4844e8c76aabde50434f, type: 3}
-  - {fileID: 8635195139948178778, guid: d0eb5dacbdcd4844e8c76aabde50434f, type: 3}
+  - {fileID: 6060374965114659617, guid: 9d8b7ed1a7bd0de45bb195837b8aac15, type: 3}
   - {fileID: 1547119920814930578, guid: 5cf1ec03dd8d4db4388f32009cf45e68, type: 3}
   - {fileID: 1693542147258265400, guid: da48d3ea930b7f747b15cd3314c86fd0, type: 3}
   - {fileID: 5486197112001328378, guid: 28e04200f63c4714f8608d921b156edd, type: 3}
+  - {fileID: 560770769265506077, guid: eb1040cb96c8fc544a215ded005c5f97, type: 3}
   ContentSellPrice: 500
   EmagOnly: 0

--- a/UnityProject/Assets/ScriptableObjects/Cargo/Orders/Medical Peripherals Crate.asset
+++ b/UnityProject/Assets/ScriptableObjects/Cargo/Orders/Medical Peripherals Crate.asset
@@ -25,6 +25,6 @@ MonoBehaviour:
   - {fileID: 6373161644663410599, guid: 379aa4c441c691bd1810b624a675f481, type: 3}
   - {fileID: 6373161644663410599, guid: 379aa4c441c691bd1810b624a675f481, type: 3}
   - {fileID: 5914959498962467419, guid: 34a89eb06b04dc54eae02fc8048dd8f7, type: 3}
-  - {fileID: 5914959498962467419, guid: 34a89eb06b04dc54eae02fc8048dd8f7, type: 3}
-  ContentSellPrice: 510
+  - {fileID: 5755119664705955590, guid: 753e37602e1e0194cbe435fda83795c4, type: 3}
+  ContentSellPrice: 505
   EmagOnly: 0

--- a/UnityProject/Assets/ScriptableObjects/Cargo/Orders/Medical Surplus Bundle Crate.asset
+++ b/UnityProject/Assets/ScriptableObjects/Cargo/Orders/Medical Surplus Bundle Crate.asset
@@ -25,5 +25,6 @@ MonoBehaviour:
   - {fileID: 2954276314869534095, guid: dd33a51f8c440da4cb4273b8954c03b3, type: 3}
   - {fileID: 2954276314869534095, guid: dd33a51f8c440da4cb4273b8954c03b3, type: 3}
   - {fileID: 2954276314869534095, guid: dd33a51f8c440da4cb4273b8954c03b3, type: 3}
+  - {fileID: 175755116826495342, guid: d11369a9825828947a3d54cc46d63b9f, type: 3}
   ContentSellPrice: 572
   EmagOnly: 0


### PR DESCRIPTION
### Purpose

This PR adds ACUs to about 70% of Boxstation and fixes a lot of pipe related problems. Crucially, this fills out atmospherics with ACUs and fixes a lot of connector ports and pumps in atmos so atmos techs can perform proper gas loop operations. Closes #8264.

This is all that I can do atm. I would like to finish the remaining 30-35% of the map at some point, but I have no plans to right now. If anyone else wants to do the rest, here's a list what ACUs haven't been done:

- bridge
- medical
- science
- Evac
- dorms
- chapel
- bar/kitchen
- the engine room of engineering

The old deprecated air alarms need to be removed as well.

### Notes:

also slightly modified a few medical crates available in cargo;
- the medical kits crate comes with one each of the two new standard kits added in #8768. The price of the crate has been bumped very slightly.
- the medical peripherals crate comes with a roller bed now.

### Changelog:

CL: [Balance] the medical kits crate now comes with an oxygen deprivation kit and a toxins treatment kit. The price of the crate has been increased from 800 to 1000.
CL: [Balance] the medical peripherals crate now comes with a roller bed.
CL: [Fix] Many pipes, pumps and connector port problems have been fixed in boxstation.
