### PR TITLE
Fix job-ban check

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
@@ -470,21 +470,15 @@ public partial class PlayerList
 
 	#region JobBans
 
-	/// <summary>
-	/// Checks job ban state, FALSE if banned
-	/// </summary>
+	/// <summary>Checks the job ban state of the given player for the given job.</summary>
+	/// <returns>True if banned.</returns>
 	public bool IsJobBanned(string userID, JobType jobType)
 	{
 		//jobbanlist checking:
 		var jobBanEntry = FindPlayerJobBanEntryServer(userID, jobType);
 
-		if (jobBanEntry == null)
-		{
-			//No job ban so allowed
-			return true;
-		}
-
-		return false;
+		// If no entry, then not banned.
+		return jobBanEntry != null;
 	}
 
 	public JobBanEntry FindPlayerJobBanEntryServer(string userID, JobType jobType, bool serverSideCheck = false)

--- a/UnityProject/Assets/Scripts/Messages/Server/GhostRoles/GhostRoleResponseMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/GhostRoles/GhostRoleResponseMessage.cs
@@ -14,7 +14,7 @@ namespace Messages.Server.GhostRoles
 			public int responseCode;
 		}
 
-		private static readonly Dictionary<GhostRoleResponseCode, string> stringDict = new Dictionary<GhostRoleResponseCode, string>()
+		private static readonly Dictionary<GhostRoleResponseCode, string> stringDict = new()
 		{
 			{ GhostRoleResponseCode.Success, "Successfully queued for this role!" },
 			{ GhostRoleResponseCode.RoleNotFound, "Unable to give you the role. It may have timed out." },
@@ -22,7 +22,7 @@ namespace Messages.Server.GhostRoles
 			{ GhostRoleResponseCode.AlreadyQueued, "You're already queued for a role!" },
 			{ GhostRoleResponseCode.QueueFull, "All positions have been filled for this role! You're too late." },
 			{ GhostRoleResponseCode.Error, "There was a problem giving you the role." },
-			{ GhostRoleResponseCode.JobBanned, "You are job banned from this role" }
+			{ GhostRoleResponseCode.JobBanned, "You are job banned from this role." },
 		};
 
 		// To be run on client


### PR DESCRIPTION
- Fixes the (un)inverted logic of the `IsJobBanned()` method. Closes #8893.

I had renamed the method in #8783 to make it clearer the outcome but forgot to accordingly invert the logic 🙃 

CL: [Fix] Fixes job-ban logic inverted. Ghost roles work again. Non-job-banned players can now be selected for antagonism and banned players aren't.