### PR TITLE
Some cargo improvements and fixes

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Other/NuclearDisk.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/NuclearDisk.prefab
@@ -113,6 +113,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
+      propertyPath: CanBeSoldInCargo
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
       propertyPath: initialDescription
       value: Get access to the nuke.
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Other/NuclearDiskPinpointer.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/NuclearDiskPinpointer.prefab
@@ -226,6 +226,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
+      propertyPath: CanBeSoldInCargo
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
       propertyPath: initialDescription
       value: Shows disk coordinates
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Other/ObjectiveDataDisk-Crash.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/ObjectiveDataDisk-Crash.prefab
@@ -263,6 +263,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
+      propertyPath: CanBeSoldInCargo
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
       propertyPath: initialDescription
       value: Valuable data from a crash.
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Other/ObjectiveDataDisk-MegaFauna.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/ObjectiveDataDisk-MegaFauna.prefab
@@ -255,6 +255,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
+      propertyPath: CanBeSoldInCargo
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
       propertyPath: initialDescription
       value: Valuable data found.... inside megafauna?
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Objects/Atmos/PortableAtmospherics/Canisters/CanisterBase.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Atmos/PortableAtmospherics/Canisters/CanisterBase.prefab
@@ -782,6 +782,7 @@ MonoBehaviour:
   ReleasePressure: 101.325
   Volume: 1
   Temperature: 293.15
+  CargoSealApproved: 1
 --- !u!114 &3744673748159336733
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Objects/Shuttle/ShuttleHeater.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Shuttle/ShuttleHeater.prefab
@@ -153,6 +153,7 @@ MonoBehaviour:
     Magic: 0
     Bio: 0
     DismembermentProtectionChance: 0
+    StunImmunity: 0
   Resistances:
     LavaProof: 0
     FireProof: 0
@@ -222,7 +223,7 @@ MonoBehaviour:
   initialDescription: These tubes are under pressure, you rater not mess with them...
   willHighlight: 1
   exportCost: 0
-  exportType: 0
+  CanBeSoldInCargo: 0
   exportName: 
   exportMessage: 
   initialSize: 3
@@ -256,17 +257,26 @@ MonoBehaviour:
   SnapToGridOnStart: 0
   LocalTargetPosition: {x: 0, y: 0, z: 0}
   ChangesDirectionPush: 0
+  Intangible: 0
+  CanBeWindPushed: 1
+  IsPlayer: 0
+  InitialLocationSynchronised: 0
+  tileMoveSpeed: 1
   isNotPushable: 0
-  newtonianMovement: {x: 0, y: 0}
   airTime: 0
   slideTime: 0
+  SetIgnoreSticky: 0
   thrownBy: {fileID: 0}
   aim: 0
   spinMagnitude: 0
+  ForcedPushedFrame: 0
+  TryPushedFrame: 0
+  PushedFrame: 0
+  FramePushDecision: 1
   stickyMovement: 0
+  OnThrowEndResetRotation: 0
   maximumStickSpeed: 1.5
   onStationMovementsRound: 0
-  attributes: {fileID: 0}
   registerTile: {fileID: 0}
   ContextGameObjects:
   - {fileID: 0}
@@ -276,15 +286,12 @@ MonoBehaviour:
   CorrectingCourse: 0
   Pushing: []
   Hits: []
-  Speed: 1
-  AIR: 3
-  SLIDE: 4
   Animating: 0
-  IsFlyingSliding: 0
+  isFlyingSliding: 0
   IsMoving: 0
-  IsWalking: 0
   MoveIsWalking: 0
   LastUpdateClientFlying: 0
+  BuckledToObject: {fileID: 0}
 --- !u!1 &1663957144760596
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Objects/Shuttle/Shuttle_engine_E.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Shuttle/Shuttle_engine_E.prefab
@@ -169,6 +169,7 @@ MonoBehaviour:
     Magic: 0
     Bio: 0
     DismembermentProtectionChance: 0
+    StunImmunity: 0
   Resistances:
     LavaProof: 0
     FireProof: 0
@@ -238,7 +239,7 @@ MonoBehaviour:
   initialDescription: 
   willHighlight: 1
   exportCost: 0
-  exportType: 0
+  CanBeSoldInCargo: 0
   exportName: 
   exportMessage: 
   initialSize: 3
@@ -272,17 +273,26 @@ MonoBehaviour:
   SnapToGridOnStart: 0
   LocalTargetPosition: {x: 0, y: 0, z: 0}
   ChangesDirectionPush: 0
+  Intangible: 0
+  CanBeWindPushed: 1
+  IsPlayer: 0
+  InitialLocationSynchronised: 0
+  tileMoveSpeed: 1
   isNotPushable: 0
-  newtonianMovement: {x: 0, y: 0}
   airTime: 0
   slideTime: 0
+  SetIgnoreSticky: 0
   thrownBy: {fileID: 0}
   aim: 0
   spinMagnitude: 0
+  ForcedPushedFrame: 0
+  TryPushedFrame: 0
+  PushedFrame: 0
+  FramePushDecision: 1
   stickyMovement: 0
+  OnThrowEndResetRotation: 0
   maximumStickSpeed: 1.5
   onStationMovementsRound: 0
-  attributes: {fileID: 0}
   registerTile: {fileID: 0}
   ContextGameObjects:
   - {fileID: 0}
@@ -292,15 +302,12 @@ MonoBehaviour:
   CorrectingCourse: 0
   Pushing: []
   Hits: []
-  Speed: 1
-  AIR: 3
-  SLIDE: 4
   Animating: 0
-  IsFlyingSliding: 0
+  isFlyingSliding: 0
   IsMoving: 0
-  IsWalking: 0
   MoveIsWalking: 0
   LastUpdateClientFlying: 0
+  BuckledToObject: {fileID: 0}
 --- !u!1 &1304629330313378
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Objects/Shuttle/Shuttle_engine_W.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Shuttle/Shuttle_engine_W.prefab
@@ -253,6 +253,7 @@ MonoBehaviour:
     Magic: 0
     Bio: 0
     DismembermentProtectionChance: 0
+    StunImmunity: 0
   Resistances:
     LavaProof: 0
     FireProof: 0
@@ -322,7 +323,7 @@ MonoBehaviour:
   initialDescription: 
   willHighlight: 1
   exportCost: 0
-  exportType: 0
+  CanBeSoldInCargo: 0
   exportName: 
   exportMessage: 
   initialSize: 3
@@ -356,17 +357,26 @@ MonoBehaviour:
   SnapToGridOnStart: 0
   LocalTargetPosition: {x: 0, y: 0, z: 0}
   ChangesDirectionPush: 0
+  Intangible: 0
+  CanBeWindPushed: 1
+  IsPlayer: 0
+  InitialLocationSynchronised: 0
+  tileMoveSpeed: 1
   isNotPushable: 0
-  newtonianMovement: {x: 0, y: 0}
   airTime: 0
   slideTime: 0
+  SetIgnoreSticky: 0
   thrownBy: {fileID: 0}
   aim: 0
   spinMagnitude: 0
+  ForcedPushedFrame: 0
+  TryPushedFrame: 0
+  PushedFrame: 0
+  FramePushDecision: 1
   stickyMovement: 0
+  OnThrowEndResetRotation: 0
   maximumStickSpeed: 1.5
   onStationMovementsRound: 0
-  attributes: {fileID: 0}
   registerTile: {fileID: 0}
   ContextGameObjects:
   - {fileID: 0}
@@ -376,15 +386,12 @@ MonoBehaviour:
   CorrectingCourse: 0
   Pushing: []
   Hits: []
-  Speed: 1
-  AIR: 3
-  SLIDE: 4
   Animating: 0
-  IsFlyingSliding: 0
+  isFlyingSliding: 0
   IsMoving: 0
-  IsWalking: 0
   MoveIsWalking: 0
   LastUpdateClientFlying: 0
+  BuckledToObject: {fileID: 0}
 --- !u!1 &1875447609467830
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Objects/Shuttle/Shuttle_engine_center.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Shuttle/Shuttle_engine_center.prefab
@@ -169,6 +169,7 @@ MonoBehaviour:
     Magic: 0
     Bio: 0
     DismembermentProtectionChance: 0
+    StunImmunity: 0
   Resistances:
     LavaProof: 0
     FireProof: 0
@@ -238,7 +239,7 @@ MonoBehaviour:
   initialDescription: 
   willHighlight: 1
   exportCost: 0
-  exportType: 0
+  CanBeSoldInCargo: 0
   exportName: 
   exportMessage: 
   initialSize: 3
@@ -272,17 +273,26 @@ MonoBehaviour:
   SnapToGridOnStart: 0
   LocalTargetPosition: {x: 0, y: 0, z: 0}
   ChangesDirectionPush: 0
+  Intangible: 0
+  CanBeWindPushed: 1
+  IsPlayer: 0
+  InitialLocationSynchronised: 0
+  tileMoveSpeed: 1
   isNotPushable: 0
-  newtonianMovement: {x: 0, y: 0}
   airTime: 0
   slideTime: 0
+  SetIgnoreSticky: 0
   thrownBy: {fileID: 0}
   aim: 0
   spinMagnitude: 0
+  ForcedPushedFrame: 0
+  TryPushedFrame: 0
+  PushedFrame: 0
+  FramePushDecision: 1
   stickyMovement: 0
+  OnThrowEndResetRotation: 0
   maximumStickSpeed: 1.5
   onStationMovementsRound: 0
-  attributes: {fileID: 0}
   registerTile: {fileID: 0}
   ContextGameObjects:
   - {fileID: 0}
@@ -292,15 +302,12 @@ MonoBehaviour:
   CorrectingCourse: 0
   Pushing: []
   Hits: []
-  Speed: 1
-  AIR: 3
-  SLIDE: 4
   Animating: 0
-  IsFlyingSliding: 0
+  isFlyingSliding: 0
   IsMoving: 0
-  IsWalking: 0
   MoveIsWalking: 0
   LastUpdateClientFlying: 0
+  BuckledToObject: {fileID: 0}
 --- !u!1 &1649971036973084
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Items/Attributes.cs
+++ b/UnityProject/Assets/Scripts/Items/Attributes.cs
@@ -51,7 +51,7 @@ public class Attributes : NetworkBehaviour, IRightClickable, IExaminable, IServe
 	}
 
 	[SerializeField, BoxGroup("Cargo")]
-	[Tooltip("If default, will only be considered exportable if the value is not zero and the object is movable.")]
+	[Tooltip("Can this be sold while oboard a cargo shuttle?")]
 	public bool CanBeSoldInCargo = true;
 
 	[Tooltip("Should an alternate name be used when displaying this in the cargo console report?")]

--- a/UnityProject/Assets/Scripts/Items/Attributes.cs
+++ b/UnityProject/Assets/Scripts/Items/Attributes.cs
@@ -50,10 +50,9 @@ public class Attributes : NetworkBehaviour, IRightClickable, IExaminable, IServe
 		}
 	}
 
-	[SerializeField, BoxGroup("Cargo"), PrefabModeOnly]
+	[SerializeField, BoxGroup("Cargo")]
 	[Tooltip("If default, will only be considered exportable if the value is not zero and the object is movable.")]
-	private CargoExportType exportType = CargoExportType.Default;
-	public CargoExportType ExportType => exportType;
+	public bool CanBeSoldInCargo = true;
 
 	[Tooltip("Should an alternate name be used when displaying this in the cargo console report?")]
 	[SerializeField, BoxGroup("Cargo"), PrefabModeOnly]
@@ -246,13 +245,5 @@ public class Attributes : NetworkBehaviour, IRightClickable, IExaminable, IServe
 	public void ServerSetArticleDescription(string desc)
 	{
 		SyncArticleDescription(articleDescription, desc);
-	}
-
-	public enum CargoExportType
-	{
-		/// <summary>Export if value not zero and not secured.</summary>
-		Default = 0,
-		Always = 1,
-		Never = 2,
 	}
 }

--- a/UnityProject/Assets/Scripts/Managers/CargoManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/CargoManager.cs
@@ -56,7 +56,7 @@ namespace Systems.Cargo
 		[SerializeField, BoxGroup("Random Bounties")] private Vector2 randomTimeRangeForRandomBounty = new Vector2(320, 690);
 		[SerializeField, BoxGroup("Random Bounties")] private List<CargoBounty> randomBountiesList = new List<CargoBounty>();
 
-		private List<int> randomJunkPrices = new List<int>();
+		private static readonly List<int> randomJunkPrices = new List<int> { 5, 10, 15 };
 
 		private void Awake()
 		{

--- a/UnityProject/Assets/Scripts/Managers/CargoManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/CargoManager.cs
@@ -348,7 +348,7 @@ namespace Systems.Cargo
 				{
 					var chargedPrice = randomJunkPrices.PickRandom();
 					Credits -= chargedPrice;
-					export.ExportMessage += $"{chargedPrice} Charged for junk removal for item : {itemAttributes.ArticleName}.";
+					export.ExportMessage += "\n" + $"{chargedPrice} Charged for junk removal for item : {itemAttributes.ArticleName}.";
 				}
 				foreach (var itemTrait in itemAttributes.GetTraits())
 				{

--- a/UnityProject/Assets/Scripts/Managers/CargoManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/CargoManager.cs
@@ -382,7 +382,7 @@ namespace Systems.Cargo
 				playerScript.playerHealth.Gib();
 			}
 
-			if (attributes != null) return;
+			if (attributes == null) return;
 
 			DespawnItem(obj, alreadySold);
 		}

--- a/UnityProject/Assets/Scripts/Managers/CargoManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/CargoManager.cs
@@ -72,10 +72,6 @@ namespace Systems.Cargo
 			if(CustomNetworkManager.IsServer == false) return;
 			UpdateManager.Add(UpdateMe, checkForTimeCooldown);
 			randomBountyTimeCheck = UnityEngine.Random.Range((int)randomTimeRangeForRandomBounty.x, (int)randomTimeRangeForRandomBounty.y);
-
-			randomJunkPrices.Add(5);
-			randomJunkPrices.Add(10);
-			randomJunkPrices.Add(15);
 		}
 
 

--- a/UnityProject/Assets/Scripts/Managers/CargoManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/CargoManager.cs
@@ -263,6 +263,13 @@ namespace Systems.Cargo
 
 		public void ProcessCargo(GameObject obj, HashSet<GameObject> alreadySold)
 		{
+			if (obj.TryGetComponent<PlayerScript>(out var playerScript))
+			{
+				// No one must survive to tell the secrets of Central Command's cargo handling techniques.
+				Chat.AddExamineMsg(obj, "<color=red> You feel a strong force of energy run through your body before everything goes to black in the blink of the eye. </color>");
+				playerScript.playerHealth.Gib();
+			}
+
 			if (obj.TryGetComponent<WrappedBase>(out var wrappedObject))
 			{
 				var wrappedContents = wrappedObject.GetOrGenerateContent();
@@ -355,7 +362,7 @@ namespace Systems.Cargo
 			}
 
 			// Add value of mole inside gas container
-			if (obj.TryGetComponent<GasContainer>(out var gasContainer) && gasContainer.IsSealed)
+			if (obj.TryGetComponent<GasContainer>(out var gasContainer) && gasContainer.CargoSealApproved)
 			{
 				var stringBuilder = new StringBuilder(export.ExportMessage);
 
@@ -370,16 +377,8 @@ namespace Systems.Cargo
 					}
 				}
 
-
 				export.ExportMessage = stringBuilder.ToString();
 				OnCreditsUpdate.Invoke();
-			}
-
-			if (obj.TryGetComponent<PlayerScript>(out var playerScript))
-			{
-				// No one must survive to tell the secrets of Central Command's cargo handling techniques.
-				Chat.AddExamineMsg(obj, "<color=red> You feel a strong force of energy run through your body before everything goes to black in the blink of the eye. </color>");
-				playerScript.playerHealth.Gib();
 			}
 
 			DespawnItem(obj, alreadySold);

--- a/UnityProject/Assets/Scripts/Managers/CargoManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/CargoManager.cs
@@ -382,8 +382,6 @@ namespace Systems.Cargo
 				playerScript.playerHealth.Gib();
 			}
 
-			if (attributes == null) return;
-
 			DespawnItem(obj, alreadySold);
 		}
 

--- a/UnityProject/Assets/Scripts/Managers/CargoManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/CargoManager.cs
@@ -343,6 +343,13 @@ namespace Systems.Cargo
 
 			if (obj.TryGetComponent<ItemAttributesV2>(out var itemAttributes))
 			{
+				//charge cargo for getting rid of trash through centeral commmunications.
+				if (itemAttributes.HasTrait(CommonTraits.Instance.Trash))
+				{
+					var chargedPrice = randomJunkPrices.PickRandom();
+					Credits -= chargedPrice;
+					export.ExportMessage += $"{chargedPrice} Charged for junk removal for item : {itemAttributes.ArticleName}.";
+				}
 				foreach (var itemTrait in itemAttributes.GetTraits())
 				{
 					if (itemTrait == null)
@@ -378,7 +385,7 @@ namespace Systems.Cargo
 					}
 				}
 
-				export.ExportMessage = stringBuilder.ToString();
+				export.ExportMessage += "\n" + stringBuilder.ToString();
 				OnCreditsUpdate.Invoke();
 			}
 

--- a/UnityProject/Assets/Scripts/Managers/CargoManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/CargoManager.cs
@@ -268,6 +268,7 @@ namespace Systems.Cargo
 				// No one must survive to tell the secrets of Central Command's cargo handling techniques.
 				Chat.AddExamineMsg(obj, "<color=red> You feel a strong force of energy run through your body before everything goes to black in the blink of the eye. </color>");
 				playerScript.playerHealth.Gib();
+				return;
 			}
 
 			if (obj.TryGetComponent<WrappedBase>(out var wrappedObject))

--- a/UnityProject/Assets/Scripts/Objects/GasContainer.cs
+++ b/UnityProject/Assets/Scripts/Objects/GasContainer.cs
@@ -65,6 +65,9 @@ namespace Objects.Atmospherics
 		//Valid serverside only
 		public float FullPercentage => GasMix.Moles / MaximumMoles;
 
+		[Tooltip("If true : Cargo will accept gases found within this container and can be sold.")]
+		public bool CargoSealApproved = false;
+
 		#region Lifecycle
 
 		private void Awake()


### PR DESCRIPTION
Fixes #8280


# Changelog:
CL: [Improvement] - Players will now receive text explaining why they died when getting transported on the cargo shuttle.
CL: [Improvement] - Cargo will now recycle worthless items and award 5, 10 or 15 credits per item. (value is random)
CL: [Improvement] - Centeral Communications will now charge 5, 10 or 15 credits per item that contains the trash trait that is thrown in cargo shuttle. (value is random)
CL: [Improvement] - Cargo will now only sell gases in containers that are cargo approved (Like gas canisters).
CL: [Fix] - Fixed cargo randomly refusing to sell some items for no reason.
CL: [Fix] - Fixed cargo refusing to sell bounty items if they were considered worthless.
CL: [Fix] - Fixed cargo selling gas outside containers.
