### PR TITLE
Adds Emergency shuttle launch vote for command

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Consoles/EscapeShuttleConsole.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Consoles/EscapeShuttleConsole.prefab
@@ -628,3 +628,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   timeToHack: 20
   chanceToFailHack: 25
+  validAccess: 070000001900000028000000290000000a0000003e000000510000000d000000

--- a/UnityProject/Assets/Scripts/Items/IDCard.cs
+++ b/UnityProject/Assets/Scripts/Items/IDCard.cs
@@ -225,6 +225,15 @@ public class IDCard : NetworkBehaviour, IServerInventoryMove, IServerSpawn, IInt
 		return accessSyncList.Contains((int) access);
 	}
 
+	public bool HasAccess(List<Access> access)
+	{
+		foreach (var accessToCheck in access)
+		{
+			if (accessSyncList.Contains((int)accessToCheck)) return true;
+		}
+		return false;
+	}
+
 	public string GetJobTitle()
 	{
 		if (jobTitle.IsNullOrEmpty())

--- a/UnityProject/Assets/Scripts/Items/IDCard.cs
+++ b/UnityProject/Assets/Scripts/Items/IDCard.cs
@@ -225,6 +225,11 @@ public class IDCard : NetworkBehaviour, IServerInventoryMove, IServerSpawn, IInt
 		return accessSyncList.Contains((int) access);
 	}
 
+	/// <summary>
+	/// Checks if this id card has the indicated access from a list of accesses.
+	/// </summary>
+	/// <param name="access"></param>
+	/// <returns></returns>
 	public bool HasAccess(List<Access> access)
 	{
 		foreach (var accessToCheck in access)

--- a/UnityProject/Assets/Scripts/Shuttles/EscapeShuttleConsole.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/EscapeShuttleConsole.cs
@@ -119,8 +119,8 @@ namespace Objects
 		{
 			var swpiesRequired = GameManager.Instance.CentComm.CurrentAlertLevel is CentComm.AlertLevel.Red or CentComm.AlertLevel.Delta ? 2 : 4;
 			var remainingSwipes = swpiesRequired - registeredIDs.Count;
-			Chat.AddSystemMsgToChat($"\n\n<color=#FF151F><size={ChatTemplates.LargeText}><b>Escape Shuttle Emergency Launch has been request! need {remainingSwipes} more votes.</b></size></color>\n\n",
-				MatrixManager.MainStationMatrix);
+			string announcemnt = $"\n\n<color=#FF151F><size={ChatTemplates.LargeText}><b>Escape Shuttle Emergency Launch has been request! need {remainingSwipes} more votes.</b></size></color>\n\n"
+			Chat.AddSystemMsgToChat(announcemnt, MatrixManager.MainStationMatrix);
 
 			Chat.AddSystemMsgToChat($"\n\n<color=#FF151F><size={ChatTemplates.LargeText}><b>Escape Shuttle Emergency Launch has been request! need {remainingSwipes} more votes.</b></size></color>\n\n",
 				GameManager.Instance.PrimaryEscapeShuttle.MatrixInfo);
@@ -131,11 +131,11 @@ namespace Objects
 		{
 			if (GameManager.Instance.ShuttleSent) return;
 			var departTime = beenEmagged ? 5 : 10;
-			Chat.AddSystemMsgToChat($"\n\n<color=#FF151F><size={ChatTemplates.LargeText}><b>Escape Shuttle Emergency Launch Triggered! Launching in {departTime} seconds..</b></size></color>\n\n",
-				MatrixManager.MainStationMatrix);
+			string announcement =
+				$"\n\n<color=#FF151F><size={ChatTemplates.LargeText}><b>Escape Shuttle Emergency Launch Triggered! Launching in {departTime} seconds..</b></size></color>\n\n";
+			Chat.AddSystemMsgToChat(announcement, MatrixManager.MainStationMatrix);
 
-			Chat.AddSystemMsgToChat($"\n\n<color=#FF151F><size={ChatTemplates.LargeText}><b>Escape Shuttle Emergency Launch Triggered! Launching in {departTime} seconds..</b></size></color>\n\n",
-				GameManager.Instance.PrimaryEscapeShuttle.MatrixInfo);
+			Chat.AddSystemMsgToChat(announcement, GameManager.Instance.PrimaryEscapeShuttle.MatrixInfo);
 
 			_ = SoundManager.PlayNetworked(CommonSounds.Instance.Notice1);
 			GameManager.Instance.ForceSendEscapeShuttleFromStation(departTime);

--- a/UnityProject/Assets/Scripts/Shuttles/EscapeShuttleConsole.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/EscapeShuttleConsole.cs
@@ -145,8 +145,7 @@ namespace Objects
 		{
 			if (AdminCommandsManager.IsAdmin(PlayerManager.LocalPlayerScript.netIdentity.connectionToServer,
 				    out var _) == false) return null;
-			var result = RightClickableResult.Create().AddElement("Launch Early", DepartShuttle, Color.red);
-			return result;
+			return RightClickableResult.Create().AddElement("Launch Early", DepartShuttle, Color.red);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Shuttles/EscapeShuttleConsole.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/EscapeShuttleConsole.cs
@@ -143,8 +143,7 @@ namespace Objects
 
 		public RightClickableResult GenerateRightClickOptions()
 		{
-			if (AdminCommandsManager.IsAdmin(PlayerManager.LocalPlayerScript.netIdentity.connectionToServer,
-				    out var _) == false) return null;
+			if (CustomNetworkManager.IsServer == false) return null;
 			return RightClickableResult.Create().AddElement("Launch Early", DepartShuttle, Color.red);
 		}
 	}

--- a/UnityProject/Assets/Scripts/Shuttles/EscapeShuttleConsole.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/EscapeShuttleConsole.cs
@@ -129,7 +129,7 @@ namespace Objects
 				$"\n\n<color=#FF151F><size={ChatTemplates.LargeText}><b>Escape Shuttle Emergency Launch has been request! need {remainingSwipes} more votes.</b></size></color>\n\n";
 			Chat.AddSystemMsgToChat(announcemnt, MatrixManager.MainStationMatrix);
 
-			Chat.AddSystemMsgToChat($"\n\n<color=#FF151F><size={ChatTemplates.LargeText}><b>Escape Shuttle Emergency Launch has been request! need {remainingSwipes} more votes.</b></size></color>\n\n",
+			Chat.AddSystemMsgToChat(announcemnt,
 				GameManager.Instance.PrimaryEscapeShuttle.MatrixInfo);
 			_ = SoundManager.PlayNetworked(CommonSounds.Instance.Notice1);
 		}

--- a/UnityProject/Assets/Scripts/Shuttles/EscapeShuttleConsole.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/EscapeShuttleConsole.cs
@@ -100,7 +100,7 @@ namespace Objects
 			}
 			registeredIDs.Add(card);
 
-			if (GameManager.Instance.CentComm.CurrentAlertLevel is CentComm.AlertLevel.Red or CentComm.AlertLevel.Delta && registeredIDs.Count >= 2)
+			if (IsHighAlert() && registeredIDs.Count >= 2)
 			{
 				DepartShuttle();
 				return;
@@ -115,11 +115,18 @@ namespace Objects
 			AnnounceRemainingSwipesRequired();
 		}
 
+		private bool IsHighAlert()
+		{
+			return GameManager.Instance.CentComm.CurrentAlertLevel is CentComm.AlertLevel.Red
+				or CentComm.AlertLevel.Delta;
+		}
+
 		private void AnnounceRemainingSwipesRequired()
 		{
-			var swpiesRequired = GameManager.Instance.CentComm.CurrentAlertLevel is CentComm.AlertLevel.Red or CentComm.AlertLevel.Delta ? 2 : 4;
+			var swpiesRequired = IsHighAlert() ? 2 : 4;
 			var remainingSwipes = swpiesRequired - registeredIDs.Count;
-			string announcemnt = $"\n\n<color=#FF151F><size={ChatTemplates.LargeText}><b>Escape Shuttle Emergency Launch has been request! need {remainingSwipes} more votes.</b></size></color>\n\n"
+			string announcemnt =
+				$"\n\n<color=#FF151F><size={ChatTemplates.LargeText}><b>Escape Shuttle Emergency Launch has been request! need {remainingSwipes} more votes.</b></size></color>\n\n";
 			Chat.AddSystemMsgToChat(announcemnt, MatrixManager.MainStationMatrix);
 
 			Chat.AddSystemMsgToChat($"\n\n<color=#FF151F><size={ChatTemplates.LargeText}><b>Escape Shuttle Emergency Launch has been request! need {remainingSwipes} more votes.</b></size></color>\n\n",

--- a/UnityProject/Assets/Scripts/Shuttles/EscapeShuttleConsole.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/EscapeShuttleConsole.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using AdminCommands;
+using Managers;
 using UnityEngine;
 using Strings;
 
@@ -9,7 +11,7 @@ namespace Objects
 	/// <summary>
 	/// Escape shuttle logic
 	/// </summary>
-	public class EscapeShuttleConsole : MonoBehaviour, ICheckedInteractable<HandApply>
+	public class EscapeShuttleConsole : MonoBehaviour, ICheckedInteractable<HandApply>, IRightClickable
 	{
 		[SerializeField]
 		private float timeToHack = 20f;
@@ -21,6 +23,10 @@ namespace Objects
 
 		private RegisterTile registerTile;
 
+		[SerializeField] private List<Access> validAccess = new List<Access>();
+
+		private List<IDCard> registeredIDs = new List<IDCard>();
+
 		private void Awake()
 		{
 			registerTile = GetComponent<RegisterTile>();
@@ -30,11 +36,16 @@ namespace Objects
 		{
 			if (DefaultWillInteract.Default(interaction, side) == false) return false;
 
-			return Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Emag);
+			return Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Emag) || Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Id);
 		}
 
 		public void ServerPerformInteraction(HandApply interaction)
 		{
+			if (interaction.HandObject.TryGetComponent<IDCard>(out var card))
+			{
+				if(card.HasAccess(validAccess)) RegisterEarlyShuttleLaunch(card, interaction.PerformerPlayerScript);
+				return;
+			}
 			TryEmagConsole(interaction);
 		}
 
@@ -72,17 +83,70 @@ namespace Objects
 
 			beenEmagged = true;
 
-			if (GameManager.Instance.ShuttleSent) return;
+			DepartShuttle();
+		}
 
-			Chat.AddSystemMsgToChat($"\n\n<color=#FF151F><size={ChatTemplates.LargeText}><b>Escape Shuttle Emergency Launch Triggered!</b></size></color>\n\n",
+		private void RegisterEarlyShuttleLaunch(IDCard card, PlayerScript performer)
+		{
+			if (GameManager.Instance.ShuttleSent)
+			{
+				Chat.AddExamineMsg(performer.gameObject, "The shuttle is already moving!");
+				return;
+			}
+			if (registeredIDs.Contains(card))
+			{
+				Chat.AddExamineMsg(performer.gameObject, "You've already done this!");
+				return;
+			}
+			registeredIDs.Add(card);
+
+			if (GameManager.Instance.CentComm.CurrentAlertLevel is CentComm.AlertLevel.Red or CentComm.AlertLevel.Delta && registeredIDs.Count >= 2)
+			{
+				DepartShuttle();
+				return;
+			}
+
+			if (registeredIDs.Count >= 4)
+			{
+				DepartShuttle();
+				return;
+			}
+
+			AnnounceRemainingSwipesRequired();
+		}
+
+		private void AnnounceRemainingSwipesRequired()
+		{
+			var swpiesRequired = GameManager.Instance.CentComm.CurrentAlertLevel is CentComm.AlertLevel.Red or CentComm.AlertLevel.Delta ? 2 : 4;
+			var remainingSwipes = swpiesRequired - registeredIDs.Count;
+			Chat.AddSystemMsgToChat($"\n\n<color=#FF151F><size={ChatTemplates.LargeText}><b>Escape Shuttle Emergency Launch has been request! need {remainingSwipes} more votes.</b></size></color>\n\n",
 				MatrixManager.MainStationMatrix);
 
-			Chat.AddSystemMsgToChat($"\n\n<color=#FF151F><size={ChatTemplates.LargeText}><b>Escape Shuttle Emergency Launch Triggered!</b></size></color>\n\n",
+			Chat.AddSystemMsgToChat($"\n\n<color=#FF151F><size={ChatTemplates.LargeText}><b>Escape Shuttle Emergency Launch has been request! need {remainingSwipes} more votes.</b></size></color>\n\n",
+				GameManager.Instance.PrimaryEscapeShuttle.MatrixInfo);
+			_ = SoundManager.PlayNetworked(CommonSounds.Instance.Notice1);
+		}
+
+		private void DepartShuttle()
+		{
+			if (GameManager.Instance.ShuttleSent) return;
+			var departTime = beenEmagged ? 5 : 10;
+			Chat.AddSystemMsgToChat($"\n\n<color=#FF151F><size={ChatTemplates.LargeText}><b>Escape Shuttle Emergency Launch Triggered! Launching in {departTime} seconds..</b></size></color>\n\n",
+				MatrixManager.MainStationMatrix);
+
+			Chat.AddSystemMsgToChat($"\n\n<color=#FF151F><size={ChatTemplates.LargeText}><b>Escape Shuttle Emergency Launch Triggered! Launching in {departTime} seconds..</b></size></color>\n\n",
 				GameManager.Instance.PrimaryEscapeShuttle.MatrixInfo);
 
 			_ = SoundManager.PlayNetworked(CommonSounds.Instance.Notice1);
+			GameManager.Instance.ForceSendEscapeShuttleFromStation(departTime);
+		}
 
-			GameManager.Instance.ForceSendEscapeShuttleFromStation(10);
+		public RightClickableResult GenerateRightClickOptions()
+		{
+			if (AdminCommandsManager.IsAdmin(PlayerManager.LocalPlayerScript.netIdentity.connectionToServer,
+				    out var _) == false) return null;
+			var result = RightClickableResult.Create().AddElement("Launch Early", DepartShuttle, Color.red);
+			return result;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Shuttles/EscapeShuttleConsole.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/EscapeShuttleConsole.cs
@@ -25,7 +25,7 @@ namespace Objects
 
 		[SerializeField] private List<Access> validAccess = new List<Access>();
 
-		private List<IDCard> registeredIDs = new List<IDCard>();
+		private HashSet<IDCard> registeredIDs = new HashSet<IDCard>();
 
 		private void Awake()
 		{

--- a/UnityProject/Assets/Scripts/Shuttles/EscapeShuttleConsole.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/EscapeShuttleConsole.cs
@@ -27,6 +27,8 @@ namespace Objects
 
 		private HashSet<IDCard> registeredIDs = new HashSet<IDCard>();
 
+		private int requiredSwipesEarlyLaunch => GameManager.Instance.CentComm.CurrentAlertLevel is CentComm.AlertLevel.Red or CentComm.AlertLevel.Delta ? 2 : 4;
+
 		private void Awake()
 		{
 			registerTile = GetComponent<RegisterTile>();
@@ -100,13 +102,7 @@ namespace Objects
 			}
 			registeredIDs.Add(card);
 
-			if (IsHighAlert() && registeredIDs.Count >= 2)
-			{
-				DepartShuttle();
-				return;
-			}
-
-			if (registeredIDs.Count >= 4)
+			if (registeredIDs.Count >= requiredSwipesEarlyLaunch)
 			{
 				DepartShuttle();
 				return;
@@ -115,16 +111,9 @@ namespace Objects
 			AnnounceRemainingSwipesRequired();
 		}
 
-		private bool IsHighAlert()
-		{
-			return GameManager.Instance.CentComm.CurrentAlertLevel is CentComm.AlertLevel.Red
-				or CentComm.AlertLevel.Delta;
-		}
-
 		private void AnnounceRemainingSwipesRequired()
 		{
-			var swpiesRequired = IsHighAlert() ? 2 : 4;
-			var remainingSwipes = swpiesRequired - registeredIDs.Count;
+			var remainingSwipes = requiredSwipesEarlyLaunch - registeredIDs.Count;
 			string announcemnt =
 				$"\n\n<color=#FF151F><size={ChatTemplates.LargeText}><b>Escape Shuttle Emergency Launch has been request! need {remainingSwipes} more votes.</b></size></color>\n\n";
 			Chat.AddSystemMsgToChat(announcemnt, MatrixManager.MainStationMatrix);


### PR DESCRIPTION
CL: [New] - Adds the ability for station command to vote for an emergancy launch for the shuttle.
CL: [Improvement] - Emagged shuttles depart in 5 seconds now instead of 10.

- For alert levels lower than Red, the shuttle requires 4 votes to launch early.
- For alert levels greater or equal to Red, the shuttle requires 2 votes to launch early.