### PR TITLE
Fix for healing procedures

### DIFF
--- a/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Procedures/AffectHealthProcedure.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Procedures/AffectHealthProcedure.cs
@@ -22,6 +22,15 @@ namespace HealthV2
 		public override void FinnishSurgeryProcedure(BodyPart OnBodyPart, HandApply interaction,
 			Dissectible.PresentProcedure PresentProcedure)
 		{
+			if (PresentProcedure.RelatedBodyPart.ContainedIn != null)
+			{
+				PresentProcedure.ISon.currentlyOn = PresentProcedure.RelatedBodyPart.ContainedIn.gameObject;
+			}
+			else
+			{
+				PresentProcedure.ISon.currentlyOn = null;
+			}
+
 			if (interaction.HandSlot.Item != null && interaction.HandSlot.Item.GetComponent<ItemAttributesV2>().HasTrait(RequiredTrait))
 			{
 				OnBodyPart.HealDamage(interaction.UsedObject,HeelStrength,Affects);


### PR DESCRIPTION
Once healing procedures finish they leave the surgeryUI on a blank screen, this is a quick fix to make sure the surgeryUI is set correctly after the surgery is complete

### Changelog:

CL: [Fix] Fixes healing procedures leaving surgery UI on a blank screen
