### PR TITLE
Sickness improvements and fixes

### DIFF
--- a/UnityProject/Assets/Prefabs/Sickness/Bone Consumer Disease.prefab
+++ b/UnityProject/Assets/Prefabs/Sickness/Bone Consumer Disease.prefab
@@ -50,7 +50,9 @@ MonoBehaviour:
   infectOtherChance: 50
   NumberOfStages: 1
   TicksToPogressStages: 320
-  PossibleCures: []
+  PossibleCures:
+  - {fileID: 11400000, guid: 56518b94c24f4431d8c5be011a4110e7, type: 2}
+  - {fileID: 11400000, guid: 31a341c1b95c2469babbc6e0394a3bc3, type: 2}
   ImmuneRaces:
   - {fileID: 11400000, guid: f0deb843b714e8f4590d893251718804, type: 2}
   CureForSickness: {fileID: 0}
@@ -58,6 +60,9 @@ MonoBehaviour:
   emoteFeedback: {fileID: 11400000, guid: 5d61ca3eb68b81946b8226b482703158, type: 2}
   cooldownTime: 120
   IsOnCooldown: 0
+  PlayerMask:
+    serializedVersion: 2
+    m_Bits: 0
   damageToDo: 30
   chanceToDamage: 50
   specficBodyPartsToTarget:

--- a/UnityProject/Assets/Prefabs/Sickness/Common Allergies.prefab
+++ b/UnityProject/Assets/Prefabs/Sickness/Common Allergies.prefab
@@ -50,8 +50,15 @@ MonoBehaviour:
   infectOtherChance: 50
   NumberOfStages: 1
   TicksToPogressStages: 320
-  PossibleCures: []
+  PossibleCures:
+  - {fileID: 11400000, guid: fbdda32fdf6f0f548a0d7511eac67423, type: 2}
+  - {fileID: 11400000, guid: 5037ee8bb69f44d928cd02c2b6f90668, type: 2}
   ImmuneRaces: []
   CureForSickness: {fileID: 0}
   CureHints: []
   emoteFeedback: {fileID: 11400000, guid: fb8b997c55238654087b9aa99d5be1a1, type: 2}
+  cooldownTime: 10
+  IsOnCooldown: 0
+  PlayerMask:
+    serializedVersion: 2
+    m_Bits: 0

--- a/UnityProject/Assets/Prefabs/Sickness/Paranoia.prefab
+++ b/UnityProject/Assets/Prefabs/Sickness/Paranoia.prefab
@@ -49,7 +49,7 @@ MonoBehaviour:
   ContagiousRadius: 6
   infectOtherChance: 50
   NumberOfStages: 6
-  TicksToPogressStages: 50
+  TicksToPogressStages: 40
   PossibleCures:
   - {fileID: 11400000, guid: 11c84ef42476da24ab6269300e6fb12e, type: 2}
   - {fileID: 11400000, guid: c57863b3f01a344e58e3fb4a55f80d3a, type: 2}
@@ -60,7 +60,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 8514fb705e98ee7bebda14f28e67e95e, type: 2}
   - {fileID: 11400000, guid: 7536c223a16702e289aa3b3f8a3ebc5a, type: 2}
   emoteFeedback: {fileID: 11400000, guid: c330a7cbe2059774fafd4a32d2eabecc, type: 2}
-  cooldownTime: 10
+  cooldownTime: 25
   IsOnCooldown: 0
   PlayerMask:
     serializedVersion: 2

--- a/UnityProject/Assets/Prefabs/Sickness/Paranoia.prefab
+++ b/UnityProject/Assets/Prefabs/Sickness/Paranoia.prefab
@@ -51,23 +51,20 @@ MonoBehaviour:
   NumberOfStages: 6
   TicksToPogressStages: 50
   PossibleCures:
-  - {fileID: 11400000, guid: b8a781e1379c635ae89668659280df98, type: 2}
-  - {fileID: 11400000, guid: f65afb6e152474e9b912c3a97d34b97b, type: 2}
-  - {fileID: 11400000, guid: a1724b1210d8177c097a28325415c0b1, type: 2}
-  - {fileID: 11400000, guid: b571d7133905aa4b890beb106c1ca10d, type: 2}
-  - {fileID: 11400000, guid: 82692ea8680693d459ad97993dbda0f3, type: 2}
-  - {fileID: 11400000, guid: dea4682a9f1409dfe8969e8f6a60602a, type: 2}
-  - {fileID: 11400000, guid: 1f3055e745c54ad29bb7480dd5992fff, type: 2}
-  - {fileID: 11400000, guid: 1802a0454e6530d84bd66a47751602f2, type: 2}
+  - {fileID: 11400000, guid: 11c84ef42476da24ab6269300e6fb12e, type: 2}
+  - {fileID: 11400000, guid: c57863b3f01a344e58e3fb4a55f80d3a, type: 2}
+  - {fileID: 11400000, guid: 8263819d94850de0b8e73614133cc1a8, type: 2}
   ImmuneRaces: []
-  CureForSickness: {fileID: 11400000, guid: 82692ea8680693d459ad97993dbda0f3, type: 2}
+  CureForSickness: {fileID: 0}
   CureHints:
-  - {fileID: 11400000, guid: a1724b1210d8177c097a28325415c0b1, type: 2}
-  - {fileID: 11400000, guid: 911271db97b77da51889f97d6688a103, type: 2}
-  - {fileID: 11400000, guid: f79e241e14050be0ead752207c026273, type: 2}
+  - {fileID: 11400000, guid: 8514fb705e98ee7bebda14f28e67e95e, type: 2}
+  - {fileID: 11400000, guid: 7536c223a16702e289aa3b3f8a3ebc5a, type: 2}
   emoteFeedback: {fileID: 11400000, guid: c330a7cbe2059774fafd4a32d2eabecc, type: 2}
   cooldownTime: 10
   IsOnCooldown: 0
+  PlayerMask:
+    serializedVersion: 2
+    m_Bits: 256
   theThoughtsOfSomeoneAboutToRunOverSomeGreenGlowies:
   - Something moved past the corner of my eye..
   - What if a meteor hits the station and i die?

--- a/UnityProject/Assets/Prefabs/Sickness/Solar Dust Disease.prefab
+++ b/UnityProject/Assets/Prefabs/Sickness/Solar Dust Disease.prefab
@@ -51,18 +51,19 @@ MonoBehaviour:
   NumberOfStages: 1
   TicksToPogressStages: 50
   PossibleCures:
-  - {fileID: 11400000, guid: 8d1468f2ac5202e65af28854a30b9c55, type: 2}
-  - {fileID: 11400000, guid: e6830e17bac769bad861bd5ebe3b389e, type: 2}
-  - {fileID: 11400000, guid: b48438048875cfa6eb44a30478e5dc8e, type: 2}
-  - {fileID: 11400000, guid: c23fc4a36ab9c3790998749e1baee097, type: 2}
-  - {fileID: 11400000, guid: e93999e64602a55eba3f8021139e5822, type: 2}
-  - {fileID: 11400000, guid: 720afa3a7185df33baf0d79d93739983, type: 2}
+  - {fileID: 11400000, guid: 0cd9df4b4b8ad49db9e796a7be9e8b2d, type: 2}
+  - {fileID: 11400000, guid: f888c5ebe34bb0a799e6a9c29c25c859, type: 2}
+  - {fileID: 11400000, guid: 2a03fe847793f1d4f8ae1c6215012ec4, type: 2}
+  - {fileID: 11400000, guid: b177c12e9da3b4d2f810770d34c29ca3, type: 2}
   ImmuneRaces: []
   CureForSickness: {fileID: 0}
   CureHints: []
   emoteFeedback: {fileID: 11400000, guid: 5d61ca3eb68b81946b8226b482703158, type: 2}
   cooldownTime: 60
   IsOnCooldown: 0
+  PlayerMask:
+    serializedVersion: 2
+    m_Bits: 0
   damageToDo: 2
   chanceToDamage: 50
   specficBodyPartsToTarget: []

--- a/UnityProject/Assets/Prefabs/Sickness/Space Cancer.prefab
+++ b/UnityProject/Assets/Prefabs/Sickness/Space Cancer.prefab
@@ -45,20 +45,27 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   sicknessName: Space Cancer
-  contagious: 1
-  sicknessStages: []
-  possibleCures:
-  - {fileID: 11400000, guid: 82a5bc56eb2b0b03aadb87a6967e8da3, type: 2}
-  - {fileID: 11400000, guid: 6632b4728c32edfccbcb305c3958ae75, type: 2}
-  - {fileID: 11400000, guid: 3f8ba0db83a8157ae8fbb3c4115580e7, type: 2}
-  - {fileID: 11400000, guid: 16bdefd1a024c1992a1af5dfef5340f6, type: 2}
-  - {fileID: 11400000, guid: b571d7133905aa4b890beb106c1ca10d, type: 2}
-  - {fileID: 11400000, guid: b9bdb0acb54b8dc40837f92c2e7819a6, type: 2}
+  Contagious: 1
+  ContagiousRadius: 6
+  infectOtherChance: 50
+  NumberOfStages: 1
+  TicksToPogressStages: 50
+  PossibleCures:
+  - {fileID: 11400000, guid: 6dfbcf309344bfb45993ca33bd2c7ab2, type: 2}
+  - {fileID: 11400000, guid: 31a341c1b95c2469babbc6e0394a3bc3, type: 2}
+  - {fileID: 11400000, guid: 8cd7ccb568889f447ad0fac075f91d09, type: 2}
+  ImmuneRaces: []
+  CureForSickness: {fileID: 0}
+  CureHints: []
   emoteFeedback: {fileID: 11400000, guid: 5d61ca3eb68b81946b8226b482703158, type: 2}
+  cooldownTime: 24
+  IsOnCooldown: 0
+  PlayerMask:
+    serializedVersion: 2
+    m_Bits: 0
   damageToDo: 2
   chanceToDamage: 50
   specficBodyPartsToTarget: []
   attackType: 9
   damageType: 0
   hasCooldown: 1
-  cooldownTime: 24

--- a/UnityProject/Assets/Prefabs/Sickness/Space Cold.prefab
+++ b/UnityProject/Assets/Prefabs/Sickness/Space Cold.prefab
@@ -50,7 +50,8 @@ MonoBehaviour:
   infectOtherChance: 50
   NumberOfStages: 1
   TicksToPogressStages: 320
-  PossibleCures: []
+  PossibleCures:
+  - {fileID: 11400000, guid: 29dd556fea04f4589a8fc60f27b7564e, type: 2}
   ImmuneRaces:
   - {fileID: 11400000, guid: 4c4d0af544e2b6847a3902db71f721fd, type: 2}
   CureForSickness: {fileID: 0}
@@ -58,3 +59,6 @@ MonoBehaviour:
   emoteFeedback: {fileID: 0}
   cooldownTime: 10
   IsOnCooldown: 0
+  PlayerMask:
+    serializedVersion: 2
+    m_Bits: 0

--- a/UnityProject/Assets/Prefabs/Sickness/Space Flu.prefab
+++ b/UnityProject/Assets/Prefabs/Sickness/Space Flu.prefab
@@ -51,12 +51,15 @@ MonoBehaviour:
   NumberOfStages: 1
   TicksToPogressStages: 320
   PossibleCures:
-  - {fileID: 11400000, guid: b48438048875cfa6eb44a30478e5dc8e, type: 2}
-  - {fileID: 11400000, guid: c23fc4a36ab9c3790998749e1baee097, type: 2}
-  - {fileID: 11400000, guid: b571d7133905aa4b890beb106c1ca10d, type: 2}
+  - {fileID: 11400000, guid: eaf7834e0fd95d04d8ae050b94f68c34, type: 2}
   ImmuneRaces:
   - {fileID: 11400000, guid: 4c4d0af544e2b6847a3902db71f721fd, type: 2}
   - {fileID: 11400000, guid: 078513666ca7a3540bf3c90b08eb66da, type: 2}
   CureForSickness: {fileID: 0}
   CureHints: []
   emoteFeedback: {fileID: 11400000, guid: fb8b997c55238654087b9aa99d5be1a1, type: 2}
+  cooldownTime: 10
+  IsOnCooldown: 0
+  PlayerMask:
+    serializedVersion: 2
+    m_Bits: 0

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -358,13 +358,14 @@ namespace HealthV2
 			FireStacksDamage();
 			CalculateRadiationDamage();
 			BleedStacksDamage();
-			mobSickness.TriggerCustomSicknessLogic();
 
 			if (IsDead)
 			{
 				DeathPeriodicUpdate();
 				return;
 			}
+			//Sickness logic should not be triggered if the player is dead.
+			mobSickness.TriggerCustomSicknessLogic();
 
 			CalculateOverallHealth();
 		}

--- a/UnityProject/Assets/Scripts/Objects/Machines/BioChemScanner.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/BioChemScanner.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Text;
 using UnityEngine;
 
@@ -27,17 +28,29 @@ namespace Objects.Machines
 					stringBuilder.AppendLine("-----");
 					stringBuilder.AppendLine($"- Name : {sickness.Sickness.SicknessName}");
 					stringBuilder.AppendLine($"- Estimated First Exposure Time : {sickness.ContractedTime}");
+					if (CustomNetworkManager.IsServer && Application.isEditor)
+					{
+						stringBuilder.AppendLine("--DEBUG--");
+						stringBuilder.AppendLine(sickness.Sickness.CureForSickness.Name);
+						foreach (var key in sickness.Sickness.PossibleCures[sickness.Sickness.CureIndex].ingredients.Keys)
+						{
+							stringBuilder.AppendLine(key.Name);
+						}
+						stringBuilder.AppendLine("--DEBUG OVER--");
+					}
 					stringBuilder.AppendLine($"- Possible reagents that can lead to cure: ");
 					foreach (var hint in sickness.Sickness.CureHints)
 					{
-						stringBuilder.AppendLine($"-- {hint.Name} | {hint.heatDensity}'c");
+						stringBuilder.AppendLine($"-- {hint.Name} | {hint.heatDensity}'c | {hint.color.ToString()}");
 					}
 				}
 				Chat.AddExamineMsg(interaction.Performer, stringBuilder.ToString());
 				syringe.SicknessesInSyringe.Clear();
 			}
+
+			var finalScanTime = CustomNetworkManager.IsServer ? 0.5f : scanTime;
 			var action = StandardProgressAction.Create(new StandardProgressActionConfig(StandardProgressActionType.SelfHeal), Scan)
-				.ServerStartProgress(gameObject.AssumedWorldPosServer(), scanTime, interaction.Performer);
+				.ServerStartProgress(gameObject.AssumedWorldPosServer(), finalScanTime, interaction.Performer);
 		}
 	}
 }


### PR DESCRIPTION
More backend stuff, nothing new this time except some fixes

You now have to use reactions for the possible cures list to make it more accurate what players can use to cure sicknesses.


CL: [Fix] - Dead bodies will no longer trigger sickness logic.
CL: [Fix] - Sickness will only check for players when trying to spread it now.
CL: [Fix] - Replaced possible cures for some sicknesses using reagents that can be actually made in-game rather than placeholder ones that can't be obtained.
CL: [Balance] - Sickness cure hints uses reactions now to more correctly get the cure.
CL: [Balance] - The body will now check for the cure when consuming nutriant reagents.
CL: [Balance] - The paranoia sickness now has a cooldown of 25 seconds instead of 10, requires 40 ticks to progress now rather than 50.

