### PR TITLE
APC null removal serializing and test description change

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Engineering/APC.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/APC.cs
@@ -86,31 +86,13 @@ namespace Objects.Engineering
 			electricalNodeControl = GetComponent<ElectricalNodeControl>();
 			resistanceSourceModule = GetComponent<ResistanceSourceModule>();
 			integrity = GetComponent<Integrity>();
+
+			connectedDevices.RemoveAndSerialize(this, gameObject.scene, device => device == null);
 		}
 		private void OnEnable()
 		{
 			integrity.OnWillDestroyServer.AddListener(WhenDestroyed);
 			base.OnEnable();
-		}
-
-		private void Start()
-		{
-			CheckListOfDevicesForNulls();
-		}
-
-		private void CheckListOfDevicesForNulls()
-		{
-			if (connectedDevices.Count == 0) return;
-			for (int i = connectedDevices.Count - 1; i >= 0; i--)
-			{
-				if (connectedDevices[i] != null)
-				{
-					continue;
-				}
-
-				Logger.Log($"{name} has a null value in {i}.", Category.Electrical);
-				connectedDevices.RemoveAt(i);
-			}
 		}
 
 		private void OnDisable()

--- a/UnityProject/Assets/Scripts/Util/ListExtensions.cs
+++ b/UnityProject/Assets/Scripts/Util/ListExtensions.cs
@@ -1,8 +1,14 @@
-﻿using System.Collections;
+﻿using System;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
+using Object = UnityEngine.Object;
+#if UNITY_EDITOR
+using UnityEditor;
+using Util;
+#endif
 
-public static class ListExtensions 
+public static class ListExtensions
 {
   	public static void RemoveEndsOfList<T>(List<T> list, int NumberElements)
 	{
@@ -15,5 +21,49 @@ public static class ListExtensions
 		{
 			list.RemoveRange(Index, (list.Count - 1) - Index);
 		}
+	}
+
+	/// <summary>
+	/// Removes elements from a component's list. If inside the editor, this will also serialize the changes. When
+	/// called while the scene is still loading, this will automatically save the scene once the scene has finished
+	/// loading.
+	/// </summary>
+	/// <remarks>
+	/// Due to the way prefab instances work, the exact component/gameObject instance where the list is located must be
+	/// passed. For example, if you pass the component's associated gameObject instead, the prefab instance will not
+	/// recognize any changes.
+	/// </remarks>
+	/// <param name="list">The list to run the filter on.</param>
+	/// <param name="object">The GameObject or Component this list is located in.</param>
+	/// <param name="scene">The scene this GameObject or Component is found in.</param>
+	/// <param name="filter">Function to filter out elements.</param>
+	public static void RemoveAndSerialize<T>(this IList<T> list, Object @object, Scene scene, Predicate<T> filter)
+	{
+		if (list is null || filter is null || @object == null) return;
+
+		var count = list.Count;
+
+		if (count == 0) return;
+
+#if UNITY_EDITOR
+		var isPrefabInstance = PrefabUtility.IsPartOfPrefabInstance(@object);
+
+		if (isPrefabInstance == false) Undo.RecordObject(@object, $"Remove elements from list on {@object.name}");
+#endif
+
+		for (var i = count - 1; i >= 0; i--)
+		{
+			if (filter(list[i])) list.RemoveAt(i);
+		}
+
+#if UNITY_EDITOR
+		if (Application.isPlaying || count == list.Count) return;
+
+		if (isPrefabInstance) PrefabUtility.RecordPrefabInstancePropertyModifications(@object);
+
+		SceneModifiedOnLoad.RequestSaveScene(scene);
+
+		Logger.Log($"\"{@object.name}\" contained a list that had elements removed.", Category.Editor);
+#endif
 	}
 }

--- a/UnityProject/Assets/Scripts/Util/SceneModifiedOnLoad.cs
+++ b/UnityProject/Assets/Scripts/Util/SceneModifiedOnLoad.cs
@@ -1,0 +1,37 @@
+﻿#if UNITY_EDITOR
+using System.Collections.Generic;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace Util
+{
+	public static class SceneModifiedOnLoad
+	{
+		private static readonly HashSet<Scene> ModifiedScenes = new();
+
+		/// <summary>
+		/// Request to save a modified scene after the scene has finished loading. This only applies to a scene
+		/// that is still loading and not currently in play mode.
+		/// </summary>
+		public static void RequestSaveScene(Scene scene)
+		{
+			if (Application.isPlaying || ModifiedScenes.Contains(scene) || scene.isLoaded) return;
+
+			if (ModifiedScenes.Count == 0) EditorSceneManager.sceneOpened += SaveAfterLoaded;
+
+			ModifiedScenes.Add(scene);
+		}
+
+		private static void SaveAfterLoaded(Scene scene, OpenSceneMode mode)
+		{
+			if (ModifiedScenes.Remove(scene) == false) return;
+
+			if (ModifiedScenes.Count == 0) EditorSceneManager.sceneOpened -= SaveAfterLoaded;
+
+			Logger.Log($"{scene.name}: Scene was modified while loading and saved.", Category.Editor);
+			EditorSceneManager.SaveScene(scene);
+		}
+	}
+}
+#endif

--- a/UnityProject/Assets/Scripts/Util/SceneModifiedOnLoad.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/SceneModifiedOnLoad.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: dba13784944946439709e0d76ebc7ff4
+timeCreated: 1655122002

--- a/UnityProject/Assets/Tests/TestExtensions.cs
+++ b/UnityProject/Assets/Tests/TestExtensions.cs
@@ -1,4 +1,6 @@
-﻿using UnityEngine;
+﻿using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
 using UnityEngine.Pool;
 
 namespace Tests
@@ -26,6 +28,14 @@ namespace Tests
 
 			names.Reverse();
 			return string.Join(separator, names);
+		}
+
+		public static string NameAndPosition(this Transform transform, string prefix = null)
+		{
+			if (transform == null) return string.Empty;
+
+			prefix = prefix is null ? string.Empty : $"{prefix} ";
+			return $"{prefix}\"{transform.HierarchyName()}\" at {transform.localPosition}";
 		}
 	}
 }


### PR DESCRIPTION
I meant to PR this awhile ago but got distracted by other things...

Fix the APC test descriptions and add some additional information.

APC's that have nulls removed when a scene loads will serialize the changes. The scene will then save after it has completed loading. However, the scene will only save if the list was changed, if it's in the editor, and the editor is not in play mode. This should prevent any unintentional scene modifications.

#### Notes:
In order to allow it to save before tests run, the connected devices null removal had to be moved from Start to Awake.

