### PR TITLE
Cyborg Organ Balance Changes

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgHeart.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgHeart.prefab
@@ -242,7 +242,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isEMPVunerable: 1
-  EMPResistance: 2
+  EMPResistance: 1
   HeartAttack: 0
   CanTriggerHeartAttack: 1
   heartAttackThreshold: -100

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgHeart.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgHeart.prefab
@@ -149,6 +149,11 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
+      propertyPath: CanBeBroken
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
       propertyPath: BodyPartType
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgLungs.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgLungs.prefab
@@ -149,6 +149,11 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
+      propertyPath: CanBeBroken
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
       propertyPath: BodyPartType
       value: 1
       objectReference: {fileID: 0}
@@ -194,8 +199,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
+      propertyPath: DamageContributesToOverallHealth
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
       propertyPath: OptionalReplacementOrgan.Array.size
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
@@ -227,17 +237,17 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isEMPVunerable: 1
-  EMPResistance: 2
+  EMPResistance: 1
   breatheCooldown: 4
   pressureSafeMin: 8
   toxicGases:
   - GasType: {fileID: 11400000, guid: 2d3c38fe76e3df249ade18fd6fdac274, type: 2}
     PressureSafeMax: 0.8
-    UnsafeLevelDamage: 6
+    UnsafeLevelDamage: 0.1
     UnsafeLevelDamageType: 2
   - GasType: {fileID: 11400000, guid: b466ee2bb3ca27941b3c2393555d4fab, type: 2}
     PressureSafeMax: 18
-    UnsafeLevelDamage: 6
+    UnsafeLevelDamage: 0.5
     UnsafeLevelDamageType: 3
   requiredGas: {fileID: 11400000, guid: d7d4e6085864f9f4e83593f63d102d08, type: 2}
   LungSize: 0.5

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/Human Heart.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/Human Heart.prefab
@@ -190,7 +190,7 @@ PrefabInstance:
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
       propertyPath: OptionalReplacementOrgan.Array.size
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
@@ -221,11 +221,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isEMPVunerable: 0
+  EMPResistance: 2
   HeartAttack: 0
   CanTriggerHeartAttack: 1
   heartAttackThreshold: -100
   SecondsOfRevivePulse: 30
   CurrentPulse: 0
-  EMPResistance: 2
   salt: {fileID: 11400000, guid: b9bdb0acb54b8dc40837f92c2e7819a6, type: 2}
   dangerSaltLevel: 20

--- a/UnityProject/Assets/Scripts/HealthV2/Living/BodyPartFunctionality.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/BodyPartFunctionality.cs
@@ -27,15 +27,15 @@ namespace HealthV2
 		{
 			if (isEMPVunerable == false) return;
 
-			if (EMPResistance == 0 || DMMath.Prob(1 / EMPResistance))
+			if (EMPResistance == 0 || DMMath.Prob(100 / EMPResistance))
 			{
-				EmpResult();
+				EmpResult(strength);
 			}
 		}
 
-		public virtual void EmpResult()
+		public virtual void EmpResult(int strength)
 		{
-			RelatedPart.ApplyTraumaDamage(TraumaticDamageTypes.BURN);
+			RelatedPart.TakeDamage(this.gameObject,(int)(5f * strength / (EMPResistance + 1)), AttackType.Internal, DamageType.Burn, false, false, 0, (int)(100/EMPResistance + 1), TraumaticDamageTypes.BURN);
 		}
 
 		private void Awake()

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Heart.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Heart.cs
@@ -23,7 +23,7 @@ namespace HealthV2
 
 		[SerializeField] private float dangerSaltLevel = 20f; //in u
 
-		public override void EmpResult()
+		public override void EmpResult(int strength)
 		{
 			if (DMMath.Prob(0.5f))
 			{
@@ -31,7 +31,7 @@ namespace HealthV2
 			}
 			else
 			{
-				base.EmpResult();
+				base.EmpResult(strength);
 			}
 		}
 


### PR DESCRIPTION
###Changelog:

CL: [Balance] Cyborg Lungs and Hearts have had there EMP resistance reduced
CL: [Balance] EMPs now do direct damage to cyborg organs with a chance of trauma
CL: [Balance] EMP damage to cybernetic organs increased
CL: [Balance] Lungs had recently been buffed in terms of tox damage, cyborg lungs were still using old stats making them worse than regular lungs, this has been fixed and they are better again.
CL: [Fix] Players can no longer choose to start with cyborg hearts or lungs

