### PR TITLE
Fix duplicate HighlanderTimerUI events causing NREs

### DIFF
--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/HighlanderTimerUI.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/HighlanderTimerUI.cs
@@ -16,9 +16,20 @@ namespace UI
 		{
 			base.Awake();
 			content.SetActive(false);
+		}
+
+		public void OnEnable()
+		{
 			EventManager.AddHandler(Event.PlayerRejoined, Rejoin);
 			EventManager.AddHandler(Event.LoggedOut, Hide);
 			EventManager.AddHandler(Event.RoundEnded, Hide);
+		}
+
+		public void OnDisable()
+		{
+			EventManager.RemoveHandler(Event.PlayerRejoined, Rejoin);
+			EventManager.RemoveHandler(Event.LoggedOut, Hide);
+			EventManager.RemoveHandler(Event.RoundEnded, Hide);
 		}
 
 		private void UpdateTimer()


### PR DESCRIPTION
### Purpose
Here's the TLDR: this fixes the HighlanderTimerUI events getting added multiple times.

So, HighlanderTimerUI events were added multiple times. Since the managers are in the Lobby scene and the OnlineScene, awake is called twice when they load. Once loading the lobby scene and again for the OnlineScene when joining/hosting. All right, that's two events being added. This is true the first time you hit play. But start playing again and now there's more. Well the EventManager eventTable is static, domain reload is off, and the dictionary isn't cleared. The EventManager was still holding references to the old TimerUI object after exiting play mode but was invalid. This was causing NRE's whenever any of the event's fired as all but one of the TimerUI's gameobject were destroyed and the events were never removed.

### Changelog:
CL: [Fix] Exit to main menu not working - #8832
