### PR TITLE
Crawl under players

### DIFF
--- a/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
+++ b/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
@@ -432,10 +432,11 @@ public class MovementSynchronisation : UniversalObjectPhysics, IPlayerControllab
 	{
 		Pushing.Clear();
 		Bumps.Clear();
-		if (intent == Intent.Help && CurrentMovementType == MovementType.Crawling) return;
+		if(intent != Intent.Help) return;
 		if (bumpedBy.TryGetComponent<MovementSynchronisation>(out var move))
 		{
-			if (move.intent != Intent.Help || MatrixManager.IsPassableAtAllMatricesV2(bumpedBy.AssumedWorldPosServer(),
+			if (move.CurrentMovementType == MovementType.Crawling) return;
+			if (MatrixManager.IsPassableAtAllMatricesV2(bumpedBy.AssumedWorldPosServer(),
 				    this.gameObject.AssumedWorldPosServer(), SetMatrixCache, this, Pushing, Bumps) == false) return;
 			var pushVector = (bumpedBy.transform.position - this.transform.position).RoundToInt().To2Int();
 			ForceTilePush(pushVector, Pushing, client, move.TileMoveSpeed);

--- a/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
+++ b/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
@@ -432,7 +432,7 @@ public class MovementSynchronisation : UniversalObjectPhysics, IPlayerControllab
 	{
 		Pushing.Clear();
 		Bumps.Clear();
-		if (intent != Intent.Help || CurrentMovementType == MovementType.Crawling) return;
+		if (intent == Intent.Help && CurrentMovementType == MovementType.Crawling) return;
 		if (bumpedBy.TryGetComponent<MovementSynchronisation>(out var move))
 		{
 			if (MatrixManager.IsPassableAtAllMatricesV2(bumpedBy.AssumedWorldPosServer(),

--- a/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
+++ b/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
@@ -432,26 +432,17 @@ public class MovementSynchronisation : UniversalObjectPhysics, IPlayerControllab
 	{
 		Pushing.Clear();
 		Bumps.Clear();
-		if (intent == Intent.Help)
+		if (intent != Intent.Help || CurrentMovementType != MovementType.Crawling) return;
+		if (bumpedBy.TryGetComponent<MovementSynchronisation>(out var move))
 		{
-			if (bumpedBy.TryGetComponent<MovementSynchronisation>(out var move))
-			{
-				if (move.intent == Intent.Help)
-				{
-					if (MatrixManager.IsPassableAtAllMatricesV2(bumpedBy.AssumedWorldPosServer(),
-						    this.gameObject.AssumedWorldPosServer(), SetMatrixCache, this, Pushing, Bumps))
-					{
-						var pushVector = (bumpedBy.transform.position - this.transform.position).RoundToInt().To2Int();
-						ForceTilePush(pushVector, Pushing, client, move.TileMoveSpeed);
+			if (MatrixManager.IsPassableAtAllMatricesV2(bumpedBy.AssumedWorldPosServer(),
+				    this.gameObject.AssumedWorldPosServer(), SetMatrixCache, this, Pushing, Bumps) == false) return;
+			var pushVector = (bumpedBy.transform.position - this.transform.position).RoundToInt().To2Int();
+			ForceTilePush(pushVector, Pushing, client, move.TileMoveSpeed);
 
-						if (move.IsBumping)
-						{
-							pushVector *= -1;
-							move.ForceTilePush(pushVector, Pushing, client, move.TileMoveSpeed);
-						}
-					}
-				}
-			}
+			if (move.IsBumping == false) return;
+			pushVector *= -1;
+			move.ForceTilePush(pushVector, Pushing, client, move.TileMoveSpeed);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
+++ b/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
@@ -432,7 +432,7 @@ public class MovementSynchronisation : UniversalObjectPhysics, IPlayerControllab
 	{
 		Pushing.Clear();
 		Bumps.Clear();
-		if (intent != Intent.Help || CurrentMovementType != MovementType.Crawling) return;
+		if (intent != Intent.Help || CurrentMovementType == MovementType.Crawling) return;
 		if (bumpedBy.TryGetComponent<MovementSynchronisation>(out var move))
 		{
 			if (MatrixManager.IsPassableAtAllMatricesV2(bumpedBy.AssumedWorldPosServer(),

--- a/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
+++ b/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
@@ -435,7 +435,7 @@ public class MovementSynchronisation : UniversalObjectPhysics, IPlayerControllab
 		if (intent == Intent.Help && CurrentMovementType == MovementType.Crawling) return;
 		if (bumpedBy.TryGetComponent<MovementSynchronisation>(out var move))
 		{
-			if (MatrixManager.IsPassableAtAllMatricesV2(bumpedBy.AssumedWorldPosServer(),
+			if (move.intent != Intent.Help || MatrixManager.IsPassableAtAllMatricesV2(bumpedBy.AssumedWorldPosServer(),
 				    this.gameObject.AssumedWorldPosServer(), SetMatrixCache, this, Pushing, Bumps) == false) return;
 			var pushVector = (bumpedBy.transform.position - this.transform.position).RoundToInt().To2Int();
 			ForceTilePush(pushVector, Pushing, client, move.TileMoveSpeed);


### PR DESCRIPTION

### Purpose
Fixes #8499

### Notes:
Cleaned up the `OnBump()` function a little bit to avoid nested if statements.

### Changelog:
CL: [Improvement] - You can now crawl under players without swapping places or getting blocked.