### PR TITLE
Lavaland Room Optimise

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Engineering/FieldGenerator.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/FieldGenerator.cs
@@ -9,7 +9,7 @@ using Tiles;
 
 namespace Objects.Engineering
 {
-	public class FieldGenerator : MonoBehaviour, ICheckedInteractable<HandApply>, IOnHitDetect, IExaminable
+	public class FieldGenerator : MonoBehaviour, ICheckedInteractable<HandApply>, IOnHitDetect, IExaminable, IServerSpawn
 	{
 		[SerializeField]
 		private SpriteHandler topSpriteHandler = null;
@@ -97,16 +97,13 @@ namespace Objects.Engineering
 			integrity.OnWillDestroyServer.RemoveListener(OnDestroySelf);
 		}
 
-		private void Start()
+		public void OnSpawnServer(SpawnInfo info)
 		{
-			if(CustomNetworkManager.IsServer == false) return;
+			if (startSetUp == false) return;
 
-			if (startSetUp)
-			{
-				isWelded = true;
-				isWrenched = true;
-				objectPhysics.SetIsNotPushable(true);
-			}
+			isWelded = true;
+			isWrenched = true;
+			objectPhysics.SetIsNotPushable(true);
 		}
 
 		#endregion

--- a/UnityProject/Assets/Scripts/Shuttles/BetterBoundsInt.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/BetterBoundsInt.cs
@@ -46,20 +46,20 @@ namespace TileManagement
 
 		public List<Vector3Int> allPositionsWithin()
 		{
-			List<Vector3Int> Returning = new List<Vector3Int>();
-
 			var stop = Mathf.RoundToInt(Maximum.x);
 			var stop2 = Mathf.RoundToInt(Maximum.y);
+
+			List<Vector3Int> returning = new List<Vector3Int>(stop * stop2);
 
 			for (int x = Mathf.RoundToInt(Minimum.x); x <= stop; x++)
 			{
 				for (int y = Mathf.RoundToInt(Minimum.y); y <= stop2; y++)
 				{
-					Returning.Add(new Vector3Int(x, y, 0));
+					returning.Add(new Vector3Int(x, y, 0));
 				}
 			}
 
-			return Returning;
+			return returning;
 		}
 
 		public bool Equals(BetterBoundsInt other)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSimulation.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSimulation.cs
@@ -56,6 +56,9 @@ namespace Systems.Atmospherics
 			{
 				if (updateList.TryDequeue(out MetaDataNode node))
 				{
+					//Wait for initial room set up as it is spread out over multiple frames
+					if(node.MetaDataSystem.SetUpDone == false) continue;
+
 					Update(node);
 				}
 			}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSystem.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using ScriptableObjects.Atmospherics;
 using UnityEngine;
 using Mirror;
@@ -40,56 +41,13 @@ namespace Systems.Atmospherics
 
 			foreach (Vector3Int position in bounds.allPositionsWithin())
 			{
-				//Get top tile at pos to check if it should spawn with no air
-				bool spawnWithNoAir = false;
-
-				var topTile = metaTileMap.GetTile(position, LayerTypeSelection.Effects | LayerTypeSelection.Underfloor);
-				if (overriderTileSpawnWithNoAir == false && topTile is BasicTile tile)
+				try
 				{
-					spawnWithNoAir = tile.SpawnWithNoAir;
+					SetPositionGas(position, hasCustomMix);
 				}
-
-				MetaDataNode node = metaDataLayer.Get(position, false);
-				if ((node.IsRoom || node.IsOccupied) && !spawnWithNoAir)
+				catch (Exception e)
 				{
-					//Check to see if theres a special room mix
-					if (node.IsRoom && toSetRoom.Count > 0 && toSetRoom.TryGetValue(node.RoomNumber, out var roomGasSetter))
-					{
-						//We use ChangeGasMix here incase we need to add overlays, while the BaseAirMix and BaseSpaceMix can set directly since none of the gases in them do
-						//Does come with a performance penalty
-						//node.ChangeGasMix(GasMix.NewGasMix(gasSetter.GasMixToSpawn));
-
-						//TODO: above commented out due to performance on load for lavaland, remove line below if solution is found
-						node.GasMix = GasMix.NewGasMix(roomGasSetter.GasMixToSpawn);
-					}
-					//Check to see if theres a special occupied mix
-					else if (node.IsOccupied && toSetOccupied.Count > 0 && toSetOccupied.TryGetValue(position, out var occupiedGasSetter))
-					{
-						//We use ChangeGasMix here incase we need to add overlays, while the BaseAirMix and BaseSpaceMix can set directly since none of the gases in them do
-						//Does come with a performance penalty
-						//node.ChangeGasMix(GasMix.NewGasMix(gasSetter.GasMixToSpawn));
-
-						//TODO: above commented out due to performance on load for lavaland, remove line below if solution is found
-						node.GasMix = GasMix.NewGasMix(occupiedGasSetter.GasMixToSpawn);
-					}
-					//See if the whole matrix has a custom mix
-					else if (hasCustomMix)
-					{
-						//ChangeGasMix here too for the same reason as above
-						//node.ChangeGasMix(GasMix.NewGasMix(defaultRoomGasMixOverride.BaseGasMix));
-
-						//TODO: above commented out due to performance on load for lavaland, remove line below if solution is found
-						node.GasMix = GasMix.NewGasMix(defaultRoomGasMixOverride.BaseGasMix);
-					}
-					//Default to air mix otherwise
-					else
-					{
-						node.GasMix = GasMix.NewGasMix(GasMixes.BaseAirMix);
-					}
-				}
-				else
-				{
-					node.GasMix = GasMix.NewGasMix(GasMixes.BaseSpaceMix);
+					Logger.LogError(e.ToString());
 				}
 			}
 
@@ -105,6 +63,62 @@ namespace Systems.Atmospherics
 
 			toSetRoom.Clear();
 			toSetOccupied.Clear();
+		}
+
+		private void SetPositionGas(Vector3Int position, bool hasCustomMix)
+		{
+			//Get top tile at pos to check if it should spawn with no air
+			bool spawnWithNoAir = false;
+
+			var topTile = metaTileMap.GetTile(position, LayerTypeSelection.Effects | LayerTypeSelection.Underfloor);
+			if (overriderTileSpawnWithNoAir == false && topTile is BasicTile tile)
+			{
+				spawnWithNoAir = tile.SpawnWithNoAir;
+			}
+
+			MetaDataNode node = metaDataLayer.Get(position, false);
+			if ((node.IsRoom || node.IsOccupied) && !spawnWithNoAir)
+			{
+				//Check to see if theres a special room mix
+				if (node.IsRoom && toSetRoom.Count > 0 && toSetRoom.TryGetValue(node.RoomNumber, out var roomGasSetter))
+				{
+					//We use ChangeGasMix here incase we need to add overlays, while the BaseAirMix and BaseSpaceMix can set directly since none of the gases in them do
+					//Does come with a performance penalty
+					//node.ChangeGasMix(GasMix.NewGasMix(gasSetter.GasMixToSpawn));
+
+					//TODO: above commented out due to performance on load for lavaland, remove line below if solution is found
+					node.GasMix = GasMix.NewGasMix(roomGasSetter.GasMixToSpawn);
+				}
+				//Check to see if theres a special occupied mix
+				else if (node.IsOccupied && toSetOccupied.Count > 0 &&
+				         toSetOccupied.TryGetValue(position, out var occupiedGasSetter))
+				{
+					//We use ChangeGasMix here incase we need to add overlays, while the BaseAirMix and BaseSpaceMix can set directly since none of the gases in them do
+					//Does come with a performance penalty
+					//node.ChangeGasMix(GasMix.NewGasMix(gasSetter.GasMixToSpawn));
+
+					//TODO: above commented out due to performance on load for lavaland, remove line below if solution is found
+					node.GasMix = GasMix.NewGasMix(occupiedGasSetter.GasMixToSpawn);
+				}
+				//See if the whole matrix has a custom mix
+				else if (hasCustomMix)
+				{
+					//ChangeGasMix here too for the same reason as above
+					//node.ChangeGasMix(GasMix.NewGasMix(defaultRoomGasMixOverride.BaseGasMix));
+
+					//TODO: above commented out due to performance on load for lavaland, remove line below if solution is found
+					node.GasMix = GasMix.NewGasMix(defaultRoomGasMixOverride.BaseGasMix);
+				}
+				//Default to air mix otherwise
+				else
+				{
+					node.GasMix = GasMix.NewGasMix(GasMixes.BaseAirMix);
+				}
+			}
+			else
+			{
+				node.GasMix = GasMix.NewGasMix(GasMixes.BaseSpaceMix);
+			}
 		}
 
 		public override void UpdateAt(Vector3Int localPosition)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSystem.cs
@@ -13,12 +13,20 @@ namespace Systems.Atmospherics
 		[SerializeField]
 		private GasMixesSO defaultRoomGasMixOverride = null;
 
+		[SerializeField]
+		private bool overriderTileSpawnWithNoAir;
+
 		private Dictionary<int, RoomGasSetter> toSetRoom = new Dictionary<int, RoomGasSetter>();
 
 		private Dictionary<Vector3Int, RoomGasSetter> toSetOccupied = new Dictionary<Vector3Int, RoomGasSetter>();
 
-		[Server]
 		public override void Initialize()
+		{
+			//FillRoomGas not called from here as the room setting up is now a coroutine
+		}
+
+		[Server]
+		public void FillRoomGas()
 		{
 			//We have bool to stop null checks on every pos
 			var hasCustomMix = defaultRoomGasMixOverride != null;
@@ -36,7 +44,7 @@ namespace Systems.Atmospherics
 				bool spawnWithNoAir = false;
 
 				var topTile = metaTileMap.GetTile(position, LayerTypeSelection.Effects | LayerTypeSelection.Underfloor);
-				if (topTile is BasicTile tile)
+				if (overriderTileSpawnWithNoAir == false && topTile is BasicTile tile)
 				{
 					spawnWithNoAir = tile.SpawnWithNoAir;
 				}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -34,6 +35,10 @@ public class MetaDataSystem : SubsystemBehaviour
 
 	private int roomCounter = 0;
 
+	private HashSet<Vector3Int> tested;
+	private bool setUpDone;
+	public bool SetUpDone => setUpDone;
+
 	public override void Awake()
 	{
 		base.Awake();
@@ -66,7 +71,7 @@ public class MetaDataSystem : SubsystemBehaviour
 
 		if (MatrixManager.IsInitialized)
 		{
-			LocateRooms();
+			StartCoroutine(LocateRooms());
 			Stopwatch Dsw = new Stopwatch();
 			Dsw.Start();
 			matrix.MetaTileMap.InitialiseUnderFloorUtilities(CustomNetworkManager.IsServer);
@@ -134,17 +139,44 @@ public class MetaDataSystem : SubsystemBehaviour
 		}
 	}
 
-	private void LocateRooms()
+	private IEnumerator LocateRooms()
 	{
 		var bounds = metaTileMap.GetLocalBounds();
 
-		var watch = new Stopwatch();
-		watch.Start();
-		foreach (Vector3Int position in bounds.allPositionsWithin())
+		var overallWatch = new Stopwatch();
+		var frameWatch = new Stopwatch();
+		overallWatch.Start();
+
+		var count = 0;
+		var matrixName = gameObject.name;
+		var positions = bounds.allPositionsWithin();
+		tested = new HashSet<Vector3Int>(positions.Count);
+
+		Logger.LogFormat($"{matrixName}: {positions.Count} need to be set up for atmos.", Category.TileMaps);
+
+		frameWatch.Start();
+
+		foreach (Vector3Int position in positions)
 		{
+			if(tested.Contains(position)) continue;
+			count++;
+
+			//Every 500 tiles wait till next frame to continue
+			if (count % 500 == 0)
+			{
+				Logger.LogFormat($"{matrixName}: Created some rooms in {frameWatch.ElapsedMilliseconds}ms", Category.TileMaps);
+
+				frameWatch.Reset();
+				yield return WaitFor.EndOfFrame;
+				frameWatch.Restart();
+			}
+
 			FindRoomAt(position);
 		}
-		Logger.LogFormat("Created rooms in {0}ms", Category.TileMaps, watch.ElapsedMilliseconds);
+
+		setUpDone = true;
+
+		Logger.LogFormat($"{matrixName}: Created rooms in a total of {overallWatch.ElapsedMilliseconds}ms", Category.TileMaps);
 	}
 
 	private void FindRoomAt(Vector3Int position)
@@ -153,6 +185,7 @@ public class MetaDataSystem : SubsystemBehaviour
 		if (metaTileMap.IsAtmosPassableAt(position, true) == false)
 		{
 			MetaDataNode node = metaDataLayer.Get(position);
+
 			node.Type = NodeType.Occupied;
 
 			//Full doors, not windoors
@@ -183,6 +216,7 @@ public class MetaDataSystem : SubsystemBehaviour
 		{
 			return;
 		}
+
 		var roomPositions = new Dictionary<Vector3Int, NodeOccupiedType>();
 		var freePositions = new UniqueQueue<Vector3Int>();
 
@@ -275,7 +309,7 @@ public class MetaDataSystem : SubsystemBehaviour
 		{
 			var directionalPassable = freePositionDirectionalPassable[i];
 			if (directionalPassable.IsAtmosPassableOnAll) continue;
-			
+
 			//Only allow atmos to be blocked by anchored objects
 			if(directionalPassable.ObjectPhysics.HasComponent
 			   && directionalPassable.ObjectPhysics.Component.isNotPushable == false) continue;
@@ -304,6 +338,7 @@ public class MetaDataSystem : SubsystemBehaviour
 		foreach (var position in positions)
 		{
 			MetaDataNode node = metaDataLayer.Get(position.Key);
+			if(setUpDone == false) tested.Add(position.Key);
 
 			node.Type = nodeType;
 			node.OccupiedType = position.Value;
@@ -358,32 +393,32 @@ public class MetaDataSystem : SubsystemBehaviour
 							// Check if atmos can pass to the neighboring position
 							Vector3Int neighborlocalPosition = MatrixManager.WorldToLocalInt(neighborWorldPosition, matrixInfo);
 
-							var OppositeNode = matrixInfo.MetaDataLayer.Get(neighborlocalPosition);
+							var oppositeNode = matrixInfo.MetaDataLayer.Get(neighborlocalPosition);
 
 							// add node of other matrix to the neighbors of the current node
-							node.AddNeighbor(OppositeNode, dir);
+							node.AddNeighbor(oppositeNode, dir);
 
 							if (dir == Vector3Int.up)
 							{
-								OppositeNode.AddNeighbor(node, Vector3Int.down);
+								oppositeNode.AddNeighbor(node, Vector3Int.down);
 							}
 							else if (dir == Vector3Int.down)
 							{
-								OppositeNode.AddNeighbor(node, Vector3Int.up);
+								oppositeNode.AddNeighbor(node, Vector3Int.up);
 							}
 							else if (dir == Vector3Int.right)
 							{
-								OppositeNode.AddNeighbor(node, Vector3Int.left);
+								oppositeNode.AddNeighbor(node, Vector3Int.left);
 							}
 							else if (dir == Vector3Int.left)
 							{
-								OppositeNode.AddNeighbor(node, Vector3Int.right);
+								oppositeNode.AddNeighbor(node, Vector3Int.right);
 							}
 
 							// if current node is a room, but the neighboring is a space tile, this node needs to be checked regularly for changes by other matrices
-							if (OppositeNode.IsRoom && !OppositeNode.MetaDataSystem.externalNodes.ContainsKey(node) && OppositeNode.MetaDataSystem.metaTileMap.IsSpaceAt(OppositeNode.Position, true) == false)
+							if (oppositeNode.IsRoom && !oppositeNode.MetaDataSystem.externalNodes.ContainsKey(node) && oppositeNode.MetaDataSystem.metaTileMap.IsSpaceAt(oppositeNode.Position, true) == false)
 							{
-								OppositeNode.MetaDataSystem.externalNodes[OppositeNode] = OppositeNode;
+								oppositeNode.MetaDataSystem.externalNodes[oppositeNode] = oppositeNode;
 							}
 
 							// skip other checks for neighboring tile on local tilemap, to prevent the space tile to be added as a neighbor

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
@@ -33,6 +33,8 @@ public class MetaDataSystem : SubsystemBehaviour
 	/// </summary>
 	private Matrix matrix;
 
+	private AtmosSystem atmosSystem;
+
 	private int roomCounter = 0;
 
 	private HashSet<Vector3Int> tested;
@@ -45,6 +47,7 @@ public class MetaDataSystem : SubsystemBehaviour
 
 		matrix = GetComponentInChildren<Matrix>(true);
 		externalNodes = new ConcurrentDictionary<MetaDataNode, MetaDataNode>();
+		atmosSystem = GetComponent<AtmosSystem>();
 	}
 
 	private void OnEnable()
@@ -152,7 +155,7 @@ public class MetaDataSystem : SubsystemBehaviour
 		var positions = bounds.allPositionsWithin();
 		tested = new HashSet<Vector3Int>(positions.Count);
 
-		Logger.LogFormat($"{matrixName}: {positions.Count} need to be set up for atmos.", Category.TileMaps);
+		Logger.LogFormat($"{matrixName}: {positions.Count} tiles need to be set up for atmos.", Category.TileMaps);
 
 		frameWatch.Start();
 
@@ -161,8 +164,8 @@ public class MetaDataSystem : SubsystemBehaviour
 			if(tested.Contains(position)) continue;
 			count++;
 
-			//Every 500 tiles wait till next frame to continue
-			if (count % 500 == 0)
+			//Every 1000 tiles wait till next frame to continue
+			if (count % 1000 == 0)
 			{
 				Logger.LogFormat($"{matrixName}: Created some rooms in {frameWatch.ElapsedMilliseconds}ms", Category.TileMaps);
 
@@ -177,6 +180,12 @@ public class MetaDataSystem : SubsystemBehaviour
 		setUpDone = true;
 
 		Logger.LogFormat($"{matrixName}: Created rooms in a total of {overallWatch.ElapsedMilliseconds}ms", Category.TileMaps);
+		overallWatch.Reset();
+		overallWatch.Restart();
+
+		atmosSystem.FillRoomGas();
+
+		Logger.LogFormat($"{matrixName}: Filled rooms with gas in {overallWatch.ElapsedMilliseconds}ms", Category.TileMaps);
 	}
 
 	private void FindRoomAt(Vector3Int position)


### PR DESCRIPTION
-Rooms detection now done in a coroutine so can be done over multiple frames, makes the game more responsive

-Fix NRE on spawn for FieldGenerators

-Fixes Lavaland walls not containing gasmix, so mining would create wind (Added an override on the AtmosSystem of that matrix as the issue was the asteroid wall tile is set to have no gas which is good for asteroids but bad for lavaland)
