### PR TITLE
The mining scanner is now affordable

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Machines/VendingMachines/MiningEquipment.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Machines/VendingMachines/MiningEquipment.prefab
@@ -224,7 +224,7 @@ PrefabInstance:
     - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
         type: 3}
       propertyPath: InitialVendorContent.Array.data[11].Price
-      value: 2000
+      value: 250
       objectReference: {fileID: 0}
     - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
         type: 3}


### PR DESCRIPTION
2000 labor points is too damn high + most miners currently would probably not need to mine much further if they managed to grab enough ores to redeem 2000 points

Edit : It's also not a luxary item, it's a tool that miners are expected to obtain at the start to make their jobs easier.

### Changelog:

CL: [Balance] - Mining scanner price decreased to 500 from 2000
