### PR TITLE
Fixes Mentor Close Button

### DIFF
--- a/UnityProject/Assets/Prefabs/UI/ChatUI.prefab
+++ b/UnityProject/Assets/Prefabs/UI/ChatUI.prefab
@@ -176,8 +176,8 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 0}
-          m_TargetAssemblyTypeName: AdminTools.MentorHelpChat, Assets
+        - m_Target: {fileID: 1574025454844610954}
+          m_TargetAssemblyTypeName: AdminTools.AdminHelpChat, Assets
           m_MethodName: CloseWindow
           m_Mode: 1
           m_Arguments:


### PR DESCRIPTION
### Purpose
Fixes #8997

### Changelog:
CL: [Fix] You are now allowed to close the mentor tab
