### PR TITLE
Adds the ability for players to commit suicide via emote

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/Emotes/EmoteListSO.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/EmoteListSO.asset
@@ -52,3 +52,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 6e4b775c8ef02a84aa542838b5ea7178, type: 2}
   - {fileID: 11400000, guid: a367ab0ef76ae3a47aed85bd54b9965b, type: 2}
   - {fileID: 11400000, guid: 15fa025684b8a98448ca6843340eab38, type: 2}
+  - {fileID: 11400000, guid: faa860ccc517a7a489dd2cfcd83ae5b6, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Emotes/Suicide.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/Suicide.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 412a0c8074d7434fb8562fb10ddaf54a, type: 3}
+  m_Name: Suicide
+  m_EditorClassIdentifier: 
+  emoteName: Suicide
+  requiresHands: 1
+  allowEmoteWhileInCrit: 1
+  isAudibleEmote: 0
+  allowEmoteWhileCrawling: 1
+  viewText: attempts to commit suicide!
+  youText: 
+  failText: You were unable to preform this action!
+  mouthBlockedText: You are unable to make a sound!
+  critViewText: screams in pain!
+  soundsAreTyped: 0
+  defaultSounds: []
+  TypedSounds: []
+  pitchRange: {x: 0.7, y: 1}
+  allowedPlayerTypes: -1

--- a/UnityProject/Assets/ScriptableObjects/Emotes/Suicide.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/Suicide.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: faa860ccc517a7a489dd2cfcd83ae5b6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/HealthV2/ISuicide.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/ISuicide.cs
@@ -1,0 +1,27 @@
+using System.Collections;
+using UnityEngine;
+
+namespace HealthV2
+{
+	/// <summary>
+	/// Used to check if a player can suicide.
+	/// </summary>
+	public interface ISuicide
+	{
+		/// <summary>
+		/// Can this performer suicide? What are the conditions for him to be able to do this?
+		/// </summary>
+		public bool CanSuicide(GameObject performer);
+
+		/// <summary>
+		/// What happens when they can have the ability to do this?
+		/// </summary>
+		public IEnumerator OnSuicide(GameObject performer);
+	}
+}
+
+/// NOTE FROM MAX ///
+/// we can use this to create an antag or mob in the feature that can ///
+/// make use of this interface to kill players and make their deaths ///
+/// look like suicides which will be good for detective gameplay ///
+/// and ghost hunting for the chaplain. Don't forget about mind breakers as well! ///

--- a/UnityProject/Assets/Scripts/HealthV2/ISuicide.cs.meta
+++ b/UnityProject/Assets/Scripts/HealthV2/ISuicide.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 059b4c06201c41c7a03b14a38fe3f3be
+timeCreated: 1659545156

--- a/UnityProject/Assets/Scripts/Items/Others/Knife.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/Knife.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+using HealthV2;
 using Items;
 using UnityEngine;
 
@@ -7,9 +9,8 @@ using UnityEngine;
 /// Marks an item as a knife, letting it cut up items on the players other hand based on the recipe list in CraftingManager.Cuts.
 /// </summary>
 [RequireComponent(typeof(Pickupable))]
-public class Knife : MonoBehaviour, ICheckedInteractable<InventoryApply>,  ICheckedInteractable<HandApply>
+public class Knife : MonoBehaviour, ICheckedInteractable<InventoryApply>,  ICheckedInteractable<HandApply>, ISuicide
 {
-
 	public bool WillInteract(HandApply interaction, NetworkSide side)
 	{
 		//can the player act at all?
@@ -123,5 +124,19 @@ public class Knife : MonoBehaviour, ICheckedInteractable<InventoryApply>,  IChec
 		SpawnResult spwn = Spawn.ServerPrefab(CraftingManager.Cuts.FindOutputMeal(cut.name),
 			SpawnDestination.At(WodPOS), 1);
 
+	}
+
+	public bool CanSuicide(GameObject performer)
+	{
+		return true;
+	}
+
+	public IEnumerator OnSuicide(GameObject performer)
+	{
+		if (performer.TryGetComponent<LivingHealthMasterBase>(out var player) == false) yield break;
+		string suicideMessage = $"{player.playerScript.visibleName} slits their own throat, ending their life.";
+		player.ApplyDamageToBodyPart(performer, 500f, AttackType.Melee, DamageType.Brute, BodyPartType.Head);
+		player.Death();
+		Chat.AddActionMsgToChat(performer, suicideMessage, suicideMessage);
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Weapons/GunPKA.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/GunPKA.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using AddressableReferences;
+using HealthV2;
 using Messages.Server.SoundMessages;
 
 namespace Weapons
@@ -60,6 +61,21 @@ namespace Weapons
 				SoundManager.PlayNetworkedAtPos(rechargeSound, gameObject.AssumedWorldPosServer(), sourceObj: serverHolder);
 			}
 			allowRecharge = true;
+		}
+
+		protected override IEnumerator SuicideAction(GameObject performer)
+		{
+			var playerHealth = performer.GetComponent<PlayerHealthV2>();
+			foreach (var bodyPart in playerHealth.SurfaceBodyParts)
+			{
+				if(bodyPart.BodyPartType != BodyPartType.Head) continue;
+				playerHealth.DismemberBodyPart(bodyPart);
+				break;
+			}
+			playerHealth.Death(); //Just incase
+			string suicideMessage = $"{playerHealth.playerScript.visibleName} puts the gun to his mouth before blowing off his head completely.";
+			Chat.AddActionMsgToChat(performer, suicideMessage, suicideMessage);
+			yield return null;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Player/EmoteScripts/Suicide.cs
+++ b/UnityProject/Assets/Scripts/Player/EmoteScripts/Suicide.cs
@@ -21,7 +21,7 @@ namespace Player.EmoteScripts
 			if(activeHandSlot == null || activeHandSlot.IsEmpty) return; //Assuming we have no hand or no item in hand
 			if(activeHandSlot.ItemObject.TryGetComponent<ISuicide>(out var suicideObject) == false) return;
 			if(suicideObject.CanSuicide(player) == false) return;
-			suicideObject.OnSuicide(player);
+			playerScript.StartCoroutine(suicideObject.OnSuicide(player));
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Player/EmoteScripts/Suicide.cs
+++ b/UnityProject/Assets/Scripts/Player/EmoteScripts/Suicide.cs
@@ -1,0 +1,27 @@
+using HealthV2;
+using ScriptableObjects.RP;
+using UnityEngine;
+
+namespace Player.EmoteScripts
+{
+	[CreateAssetMenu(fileName = "Suicide", menuName = "ScriptableObjects/RP/Emotes/Suicide")]
+	public class Suicide : EmoteSO
+	{
+		public override void Do(GameObject player)
+		{
+			//Just end the misery early if the player has been stuck in suicide for a while now.
+			if (CheckPlayerCritState(player))
+			{
+				player.GetComponent<LivingHealthBehaviour>().Death();
+				return;
+			}
+
+			var playerScript = player.GetComponent<PlayerScript>();
+			var activeHandSlot = playerScript.DynamicItemStorage.GetActiveHandSlot();
+			if(activeHandSlot == null || activeHandSlot.IsEmpty) return; //Assuming we have no hand or no item in hand
+			if(activeHandSlot.ItemObject.TryGetComponent<ISuicide>(out var suicideObject) == false) return;
+			if(suicideObject.CanSuicide(player) == false) return;
+			suicideObject.OnSuicide(player);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Player/EmoteScripts/Suicide.cs.meta
+++ b/UnityProject/Assets/Scripts/Player/EmoteScripts/Suicide.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 412a0c8074d7434fb8562fb10ddaf54a
+timeCreated: 1659546473


### PR DESCRIPTION
As the title says; players can now commit suicide to end their misery much sooner by using the item that's in their hands or while in critical condition.

### Notes:

Not a lot of items have the `ISuicide` interface yet, but all guns currently do.


I'm not adding the ability to disable this via server config because we don't have proper medium to heavy role-playing servers yet. This can be added later or admins can just enforce it as a rule like how all ss13 servers do currently.

## Changelog:
CL: [New] - Added in a new suicide emote.
CL: [New] - You can now kill yourself while in critical condition to avoid long, boring waits of nobody finding your body.
