### PR TITLE
Fix Ghost Understanding Languages

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Chat/Chat.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/Chat.cs
@@ -67,7 +67,7 @@ public partial class Chat : MonoBehaviour
 			discordMessageBuilder.Append($"[{channel}] ");
 		}
 
-		discordMessageBuilder.Append($"\n```css\n{chatEvent.speaker}: {chatEvent.message}\n```\n");
+		discordMessageBuilder.Append($"{(chatEvent.language != null ? $"[{chatEvent.language.LanguageName}]" : "")}\n```css\n{chatEvent.speaker}: {chatEvent.message}\n```\n");
 
 		string discordMessage = discordMessageBuilder.ToString();
 		//Sends All Chat messages to a discord webhook

--- a/UnityProject/Assets/Scripts/Core/Chat/Chat.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/Chat.cs
@@ -229,7 +229,8 @@ public partial class Chat : MonoBehaviour
 				languageToUse = LanguageManager.Instance.GetLanguageById(languageId);
 			}
 
-			if (playerLanguages.CanSpeakLanguage(languageToUse) == false && playerLanguages.OmniTongue == false)
+			//Check to make sure we can speak that language, if not get the default language
+			if (playerLanguages.CanSpeakLanguage(languageToUse) == false)
 			{
 				languageToUse = playerLanguages.CurrentLanguage;
 

--- a/UnityProject/Assets/Scripts/Core/Chat/ChatRelay.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/ChatRelay.cs
@@ -389,12 +389,11 @@ public class ChatRelay : NetworkBehaviour
 		{
 			var canUnderstand = playerLanguages.CanUnderstandLanguage(language);
 
-			if ((playerLanguages.OmniTongue || canUnderstand) && language.Flags.HasFlag(LanguageFlags.HideIconIfUnderstood))
+			if (canUnderstand && language.Flags.HasFlag(LanguageFlags.HideIconIfUnderstood))
 			{
 				return null;
 			}
-			else if (playerLanguages.OmniTongue == false && canUnderstand == false &&
-			         language.Flags.HasFlag(LanguageFlags.HideIconIfNotUnderstood))
+			else if (canUnderstand == false && language.Flags.HasFlag(LanguageFlags.HideIconIfNotUnderstood))
 			{
 				return null;
 			}

--- a/UnityProject/Assets/Scripts/Core/Chat/LanguageScreen.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/LanguageScreen.cs
@@ -43,6 +43,12 @@ namespace Core.Chat
 			var understoodLanguages = player.MobLanguages.UnderstoodLanguages.OrderByDescending(x => x.Priority).ToArray();
 			var spokenLanguages = player.MobLanguages.SpokenLanguages;
 
+			if (player.MobLanguages.OmniTongue)
+			{
+				understoodLanguages = LanguageManager.Instance.AllLanguages.ToArray();
+				spokenLanguages = LanguageManager.Instance.AllLanguages.ToHashSet();
+			}
+
 			if (entryPool.Count < understoodLanguages.Length)
 			{
 				var missing = understoodLanguages.Length - entryPool.Count;

--- a/UnityProject/Assets/Scripts/Items/Bureaucracy/LanguageBook.cs
+++ b/UnityProject/Assets/Scripts/Items/Bureaucracy/LanguageBook.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Linq;
 using HealthV2;
+using Managers;
 using Player.Language;
 using UnityEngine;
 
@@ -24,6 +26,9 @@ namespace Items.Bureaucracy
 		private int usedCharges = 0;
 
 		private UniversalObjectPhysics objectPhysics;
+
+		//Used by admins to try to set this books language
+		private string languageToSet;
 
 		private void Awake()
 		{
@@ -138,6 +143,22 @@ namespace Items.Bureaucracy
 
 			//Despawn this book
 			_ = Despawn.ServerSingle(gameObject);
+		}
+
+		//Used by admin VV to set book from language string
+		private void SetFromString()
+		{
+			var languageFound = LanguageManager.Instance.AllLanguages.FirstOrDefault(x =>
+				x.LanguageName == languageToSet || x.name == languageToSet);
+
+			if(languageFound == null) return;
+
+			languageToLearn = languageFound;
+			Chat.AddLocalMsgToChat($"The book transforms into the book for {languageToLearn.LanguageName}", gameObject);
+
+			var itemAtt = GetComponent<ItemAttributesV2>();
+			itemAtt.ServerSetArticleName($"{languageToLearn.LanguageName} Manuel");
+			itemAtt.ServerSetArticleDescription($"A manuel to learn {languageToLearn.LanguageName}");
 		}
 
 		public string Examine(Vector3 worldPos = default(Vector3))

--- a/UnityProject/Assets/Scripts/Player/Language/MobLanguages.cs
+++ b/UnityProject/Assets/Scripts/Player/Language/MobLanguages.cs
@@ -79,11 +79,15 @@ namespace Player.Language
 
 		public bool CanUnderstandLanguage(LanguageSO languageToTest)
 		{
+			if (omniTongue) return true;
+
 			return UnderstoodLanguages.Contains(languageToTest);
 		}
 
 		public bool CanSpeakLanguage(LanguageSO languageToTest)
 		{
+			if (omniTongue) return true;
+
 			return SpokenLanguages.Contains(languageToTest);
 		}
 


### PR DESCRIPTION
-Fix Ghosts not understanding languages

-Send language to discordwebhook

-Allow admins to VV  a string and set a language book from it (you'll need to know the language name)