### PR TITLE
Wizards can no longer trigger the highlander event

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/Items/SpellBook/Rituals/SummonMagic.asset
+++ b/UnityProject/Assets/ScriptableObjects/Items/SpellBook/Rituals/SummonMagic.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
   conflictsWith: []
   name: Summon Magic
   eventType: 3
-  eventIndex: 1
+  eventIndex: 2
   invocationMessage: 
   castSound:
     SetLoadSetting: 0


### PR DESCRIPTION
CL: [Fix] - Wizards no longer have an end round quickly spell.
