### PR TITLE
Gibbed players will no longer have their ghosts spawn in the void of space.

### DIFF
--- a/UnityProject/Assets/Scripts/HealthV2/Living/PlayerHealthV2.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/PlayerHealthV2.cs
@@ -75,11 +75,10 @@ namespace HealthV2
 		public override void OnGib()
 		{
 			//Drop everything
+			playerNetworkActions.ServerSpawnPlayerGhost(true);
 			Inventory.ServerDropAll(dynamicItemStorage);
-
 			base.OnGib();
-			PlayerMove.playerScript.objectPhysics.DisappearFromWorld ();
-			playerNetworkActions.ServerSpawnPlayerGhost();
+			PlayerMove.playerScript.objectPhysics.DisappearFromWorld();
 		}
 
 		bool RegisterPlayer.IControlPlayerState.AllowChange(bool rest)

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -741,9 +741,14 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 	}
 
 	[Server]
-	public void ServerSpawnPlayerGhost()
+	public void ServerSpawnPlayerGhost(bool skipCheck = false)
 	{
 		//Only force to ghost if the mind belongs in to that body
+		if (skipCheck)
+		{
+			PlayerSpawn.ServerSpawnGhost(playerScript.mind);
+			return;
+		}
 		var currentMobID = GetComponent<LivingHealthMasterBase>().mobID;
 		if (GetComponent<LivingHealthMasterBase>().IsDead && !playerScript.IsGhost && playerScript.mind != null &&
 			playerScript.mind.bodyMobID == currentMobID)


### PR DESCRIPTION
Fixes #9090

CL: [Fix] - Gibbed players will no longer have their ghosts spawn in the void of space.
