### PR TITLE
remove pog and box from map pool, tweaking pop values for maps

### DIFF
--- a/UnityProject/Assets/StreamingAssets/maps.json
+++ b/UnityProject/Assets/StreamingAssets/maps.json
@@ -1,7 +1,7 @@
 {
     "lowPopMaps":["MiniStation", "FallStation", "SquareStation"],
-    "medPopMaps":["MiniStation", "FallStation", "SquareStation", "OutpostStation", "PogStation"],
-    "highPopMaps":["OutpostStation", "BoxStationV1", "PogStation"],
-    "medPopMinLimit":15,
-    "highPopMinLimit":30
+    "medPopMaps":["MiniStation", "FallStation", "SquareStation", "OutpostStation"],
+    "highPopMaps":["OutpostStation"],
+    "medPopMinLimit":25,
+    "highPopMinLimit": 40
 }


### PR DESCRIPTION
remove the pog and box station, due to how outdated they are

Tweaked what counts is high and medium pop

### Changelog:

CL: [Improvement] remove the pog and box station, due to how outdated they are     

CL: [Improvement] Tweaked what counts is high and medium pop medPopMinLimit:25 highPopMinLimit:40
