### PR TITLE
Players with invalid config files for addressables should not get kicked anymore

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/SoundAmbientManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SoundAmbientManager.cs
@@ -57,7 +57,11 @@ namespace Audio.Managers
 
 		public static void PlayAudio(string assetAddress)
 		{
-			if(string.IsNullOrEmpty(assetAddress)) return;
+			if(string.IsNullOrEmpty(assetAddress)) 
+			{
+				Logger.LogError("Cannot play ambient noise because asset address is empty or null");
+				return;
+			}
 			var audioSource = new AddressableAudioSource(assetAddress);
 
 			if (Instance.playingSource.ContainsKey(audioSource))

--- a/UnityProject/Assets/Scripts/Managers/SoundAmbientManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SoundAmbientManager.cs
@@ -57,6 +57,7 @@ namespace Audio.Managers
 
 		public static void PlayAudio(string assetAddress)
 		{
+			if(string.IsNullOrEmpty(assetAddress)) return;
 			var audioSource = new AddressableAudioSource(assetAddress);
 
 			if (Instance.playingSource.ContainsKey(audioSource))

--- a/UnityProject/Assets/Scripts/Managers/SoundManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SoundManager.cs
@@ -370,6 +370,7 @@ public class SoundManager : MonoBehaviour
 			return;
 
 		addressableAudioSource = await AudioManager.GetAddressableAudioSourceFromCache(addressableAudioSource);
+		if(addressableAudioSource == null) return;
 		SoundSpawn soundSpawn =
 			Instance.GetSoundSpawn(addressableAudioSource, addressableAudioSource.AudioSource, soundSpawnToken);
 		ApplyAudioSourceParameters(audioSourceParameters, soundSpawn);

--- a/UnityProject/Assets/Scripts/Managers/SoundManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SoundManager.cs
@@ -370,7 +370,11 @@ public class SoundManager : MonoBehaviour
 			return;
 
 		addressableAudioSource = await AudioManager.GetAddressableAudioSourceFromCache(addressableAudioSource);
-		if(addressableAudioSource == null) return;
+		if(addressableAudioSource == null) 
+		{
+			Logger.LogError("Cannot play sound! Sound is null!");
+			return;
+		}
 		SoundSpawn soundSpawn =
 			Instance.GetSoundSpawn(addressableAudioSource, addressableAudioSource.AudioSource, soundSpawnToken);
 		ApplyAudioSourceParameters(audioSourceParameters, soundSpawn);


### PR DESCRIPTION
fixes #8664

Game will no longer play audio if addressable address is blank or null when fetching its reference.
The ambient one was not originally part of the issue but when I was trying to force this problem to happen I just discovered that blank addresses can crash the player when they spawn. 

## Changelog:

CL: [Fix] - Fixes a server kick that would happen when the player has invalid/corrupt addressables.
