### PR TITLE
Fixes conveyor belts issues

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Construction/ConveyorSwitch.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Construction/ConveyorSwitch.prefab
@@ -262,6 +262,7 @@ MonoBehaviour:
     Acid: 0
     Magic: 0
     Bio: 0
+    Anomaly: 0
     DismembermentProtectionChance: 0
     StunImmunity: 0
   Resistances:
@@ -276,7 +277,6 @@ MonoBehaviour:
   HeatResistance: 100
   ExplosionsDamage: 100
   doDamageMessage: 1
-  Meleeable: {fileID: 0}
 --- !u!114 &3348285834374005981
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -312,7 +312,7 @@ MonoBehaviour:
   initialDescription: Change direction of connected conveyor belts.
   willHighlight: 1
   exportCost: 0
-  exportType: 0
+  CanBeSoldInCargo: 1
   exportName: 
   exportMessage: 
   initialSize: 3
@@ -329,7 +329,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   conveyorBelts: []
-  ConveyorBeltSpeed: 4
+  ConveyorBeltSpeed: 6
   conType: 2
 --- !u!114 &-4847964719740510200
 MonoBehaviour:
@@ -363,9 +363,11 @@ MonoBehaviour:
   ChangesDirectionPush: 0
   Intangible: 0
   CanBeWindPushed: 1
+  IsPlayer: 0
   InitialLocationSynchronised: 0
   tileMoveSpeed: 1
   isNotPushable: 1
+  HasOwnGravity: 0
   airTime: 0
   slideTime: 0
   SetIgnoreSticky: 0
@@ -390,7 +392,7 @@ MonoBehaviour:
   Pushing: []
   Hits: []
   Animating: 0
-  IsFlyingSliding: 0
+  isFlyingSliding: 0
   IsMoving: 0
   MoveIsWalking: 0
   LastUpdateClientFlying: 0

--- a/UnityProject/Assets/Scripts/Objects/Cargo/ConveyorBelts/ConveyorBelt.cs
+++ b/UnityProject/Assets/Scripts/Objects/Cargo/ConveyorBelts/ConveyorBelt.cs
@@ -100,15 +100,7 @@ namespace Construction.Conveyors
 			if (item.NewtonianMovement.magnitude > ConveyorBeltSpeed) return;
 			item.Pushing.Clear();
 
-			if (item.stickyMovement)
-			{
-				item.TryTilePush(PushDirectionPosition.RoundTo2Int(), null , ConveyorBeltSpeed);
-			}
-			else
-			{
-				item.NewtonianPush(PushDirectionPosition.RoundTo2Int(), ConveyorBeltSpeed - item.NewtonianMovement.magnitude, 0.5f);
-			}
-
+			item.TryTilePush(PushDirectionPosition.RoundTo2Int(), null , ConveyorBeltSpeed);
 		}
 
 		#endregion Belt Operation


### PR DESCRIPTION
Fixes #8795
Fixes #8796

## Notes:

Removed Newton push from conveyor belts as it's incredibly buggy and has a lot of interaction issues that are out of our control, Better wait for a complete revamp of how we do pushing with stuff like belts than continue using it in this state currently. 

#8795 seems to have been already fixed for players only but I'm also adding this area in the notes to remind people that Newton push was the cause of this problem when they look back at PRs that touch conveyor belts.

## Changelog:

CL: [Improvement] - Conveyor Belts now move things faster.
CL: [Fix] - You can now interact with items and players again that are moving on the conveyor belt.
CL: [Fix] - Items now no longer bounce off walls and solid objects while moving on the conveyor belt.
CL: [Fix] - Items will no longer go out of sync when pushed slowly for too long on conveyor belts.
