### PR TITLE
Optimise MetaDataNode Memory Usage

### DIFF
--- a/UnityProject/Assets/Scripts/Systems/SmokeAndFoam/FoamNode.cs
+++ b/UnityProject/Assets/Scripts/Systems/SmokeAndFoam/FoamNode.cs
@@ -36,13 +36,14 @@ public class FoamNode : SpreadNode
 						SmokeAndFoamManager.Instance.WallFoam);
 				}
 
-				var Tile = OnMetaDataNode.PositionMatrix.MetaTileMap.GetTile(OnMetaDataNode.Position, LayerType.Base);
-				if (Tile == null || ((BasicTile) Tile).IsSpace())
+				var tile = OnMetaDataNode.PositionMatrix.MetaTileMap.GetTile(OnMetaDataNode.Position, LayerType.Base);
+				if (tile == null || ((BasicTile) tile).IsSpace())
 				{
 					OnMetaDataNode.PositionMatrix.MetaTileMap.SetTile(OnMetaDataNode.Position,
 						SmokeAndFoamManager.Instance.BaseFoam);
 				}
 			}
+
 			OnMetaDataNode.PositionMatrix.MetaTileMap.RemoveOverlaysOfType(OnMetaDataNode.Position, LayerType.Floors,OverlayType.Foam);
 			SourceReservoir.RemoveTile(this);
 		}
@@ -51,52 +52,55 @@ public class FoamNode : SpreadNode
 
 	public override bool CheckIsEdge()
 	{
-		bool HasEmptyNeighbour = false;
-		var Worldpos = OnMetaDataNode.Position.ToWorld(OnMetaDataNode.PositionMatrix);
+		bool hasEmptyNeighbour = false;
+		var worldPos = OnMetaDataNode.Position.ToWorld(OnMetaDataNode.PositionMatrix);
 
 		foreach (var dir in dirs) //Might be lag
 		{
-			var newWorldpos = Worldpos + dir;
-			var Matrix = MatrixManager.AtPoint(Worldpos + dir, CustomNetworkManager.IsServer);
+			var newWorldPos = worldPos + dir;
+			var matrix = MatrixManager.AtPoint(worldPos + dir, CustomNetworkManager.IsServer);
+
 			MetaDataNode node = null;
-			if (MatrixManager.Instance.spaceMatrix.MatrixInfo != Matrix)
+			if (MatrixManager.Instance.spaceMatrix.MatrixInfo != matrix)
 			{
-				var newLocal = newWorldpos.ToLocal(Matrix);
-				node =  Matrix.MetaDataLayer.Get(newLocal.RoundToInt());
+				var newLocal = newWorldPos.ToLocal(matrix);
+				node =  matrix.MetaDataLayer.Get(newLocal.RoundToInt());
 			}
 			else
 			{
-				var newLocal = newWorldpos.ToLocal(OnMetaDataNode.PositionMatrix);
+				var newLocal = newWorldPos.ToLocal(OnMetaDataNode.PositionMatrix);
 				node = OnMetaDataNode.PositionMatrix.MetaDataLayer.Get(newLocal.RoundToInt());
 			}
 
 			if (node.FoamNode.IsActive == false || node.FoamNode.SourceReservoir != SourceReservoir)
 			{
-				HasEmptyNeighbour = true;
+				hasEmptyNeighbour = true;
 			}
 		}
 
-		return HasEmptyNeighbour;
+		return hasEmptyNeighbour;
 	}
 
 	public override void TrySpread()
 	{
-		var Worldpos = OnMetaDataNode.Position.ToWorld(OnMetaDataNode.PositionMatrix);
+		var worldPos = OnMetaDataNode.Position.ToWorld(OnMetaDataNode.PositionMatrix);
 
 		foreach (var dir in dirs) //Might be lag
 		{
 			if (SourceReservoir.StacksLeft == 0) break;
-			var newWorldpos = Worldpos + dir;
-			var Matrix = MatrixManager.AtPoint(Worldpos + dir, CustomNetworkManager.IsServer);
+
+			var newWorldPos = worldPos + dir;
+			var matrix = MatrixManager.AtPoint(worldPos + dir, CustomNetworkManager.IsServer);
+
 			MetaDataNode node = null;
-			if (MatrixManager.Instance.spaceMatrix.MatrixInfo != Matrix)
+			if (MatrixManager.Instance.spaceMatrix.MatrixInfo != matrix)
 			{
-				var newLocal = newWorldpos.ToLocal(Matrix);
-				node =  Matrix.MetaDataLayer.Get(newLocal.RoundToInt());
+				var newLocal = newWorldPos.ToLocal(matrix);
+				node =  matrix.MetaDataLayer.Get(newLocal.RoundToInt());
 			}
 			else
 			{
-				var newLocal = newWorldpos.ToLocal(OnMetaDataNode.PositionMatrix);
+				var newLocal = newWorldPos.ToLocal(OnMetaDataNode.PositionMatrix);
 				node = OnMetaDataNode.PositionMatrix.MetaDataLayer.Get(newLocal.RoundToInt());
 			}
 
@@ -118,21 +122,21 @@ public class FoamNode : SpreadNode
 	public override void DistributeToTile(SourceReservoir sourceReservoir)
 	{
 		base.DistributeToTile(sourceReservoir);
+
 		OnMetaDataNode.IsSlippery = true;
 		OnMetaDataNode.ForceUpdateClient();
-		var Colour = Present.MixColor;
+
+		var colour = Present.MixColor;
 		if (Present.MixColor == Color.clear)
 		{
-			Colour = Color.white;
+			colour = Color.white;
 		}
 
-		OnMetaDataNode.PositionMatrix.MetaTileMap.AddOverlay(OnMetaDataNode.Position, SmokeAndFoamManager.Instance.OverlayTileFoam, Matrix4x4.identity, Colour);
-
+		OnMetaDataNode.PositionMatrix.MetaTileMap.AddOverlay(OnMetaDataNode.Position, SmokeAndFoamManager.Instance.OverlayTileFoam, Matrix4x4.identity, colour);
 	}
 }
 public class FoamSourceReservoir : SourceReservoir
 {
-
 	public bool SmartFoam = false;
 	public bool WallFoam = false;
 
@@ -140,5 +144,4 @@ public class FoamSourceReservoir : SourceReservoir
 	{
 
 	}
-
 }

--- a/UnityProject/Assets/Scripts/Systems/SmokeAndFoam/SmokeNode.cs
+++ b/UnityProject/Assets/Scripts/Systems/SmokeAndFoam/SmokeNode.cs
@@ -9,52 +9,56 @@ public class SmokeNode : SpreadNode
 
 	public override bool CheckIsEdge()
 	{
-		bool HasEmptyNeighbour = false;
-		var Worldpos = OnMetaDataNode.Position.ToWorld(OnMetaDataNode.PositionMatrix);
+		bool hasEmptyNeighbour = false;
+		var worldPos = OnMetaDataNode.Position.ToWorld(OnMetaDataNode.PositionMatrix);
 
 		foreach (var dir in dirs) //Might be lag
 		{
-			var newWorldpos = Worldpos + dir;
-			var Matrix = MatrixManager.AtPoint(Worldpos + dir, CustomNetworkManager.IsServer);
+			var newWorldPos = worldPos + dir;
+			var matrix = MatrixManager.AtPoint(worldPos + dir, CustomNetworkManager.IsServer);
+
 			MetaDataNode node = null;
-			if (MatrixManager.Instance.spaceMatrix.MatrixInfo != Matrix)
+			if (MatrixManager.Instance.spaceMatrix.MatrixInfo != matrix)
 			{
-				var newLocal = newWorldpos.ToLocal(Matrix);
-				node =  Matrix.MetaDataLayer.Get(newLocal.RoundToInt());
+				var newLocal = newWorldPos.ToLocal(matrix);
+				node =  matrix.MetaDataLayer.Get(newLocal.RoundToInt());
 			}
 			else
 			{
-				var newLocal = newWorldpos.ToLocal(OnMetaDataNode.PositionMatrix);
+				var newLocal = newWorldPos.ToLocal(OnMetaDataNode.PositionMatrix);
 				node = OnMetaDataNode.PositionMatrix.MetaDataLayer.Get(newLocal.RoundToInt());
 			}
+
 			if (node.SmokeNode.IsActive == false || node.SmokeNode.SourceReservoir != SourceReservoir)
 			{
-				HasEmptyNeighbour = true;
+				hasEmptyNeighbour = true;
 			}
 		}
 
-		return HasEmptyNeighbour;
+		return hasEmptyNeighbour;
 	}
 
 	public override void TrySpread()
 	{
-		var Worldpos = OnMetaDataNode.Position.ToWorld(OnMetaDataNode.PositionMatrix);
+		var worldPos = OnMetaDataNode.Position.ToWorld(OnMetaDataNode.PositionMatrix);
 
 		foreach (var dir in dirs) //Might be lag
 		{
-			var newWorldpos = Worldpos + dir;
-			var Matrix = MatrixManager.AtPoint(Worldpos + dir, CustomNetworkManager.IsServer);
+			var newWorldPos = worldPos + dir;
+			var matrix = MatrixManager.AtPoint(worldPos + dir, CustomNetworkManager.IsServer);
+
 			MetaDataNode node = null;
-			if (MatrixManager.Instance.spaceMatrix.MatrixInfo != Matrix)
+			if (MatrixManager.Instance.spaceMatrix.MatrixInfo != matrix)
 			{
-				var newLocal = newWorldpos.ToLocal(Matrix);
-				node =  Matrix.MetaDataLayer.Get(newLocal.RoundToInt());
+				var newLocal = newWorldPos.ToLocal(matrix);
+				node =  matrix.MetaDataLayer.Get(newLocal.RoundToInt());
 			}
 			else
 			{
-				var newLocal = newWorldpos.ToLocal(OnMetaDataNode.PositionMatrix);
+				var newLocal = newWorldPos.ToLocal(OnMetaDataNode.PositionMatrix);
 				node = OnMetaDataNode.PositionMatrix.MetaDataLayer.Get(newLocal.RoundToInt());
 			}
+
 			if (node.SmokeNode.IsActive == false && node.IsOccupied == false)
 			{
 				SourceReservoir.SpreadToNode(this ,node.SmokeNode);
@@ -94,12 +98,9 @@ public class SmokeNode : SpreadNode
 
 public class SmokeSourceReservoir : SourceReservoir
 {
-
-
 	public override void RemoveTileInherit()
 	{
 		SmokeAndFoamManager.Instance.ActiveNodes.Remove(this);
 	}
-
 }
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataNode.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataNode.cs
@@ -36,10 +36,22 @@ public class MetaDataNode : IGasMixContainer
 	/// </summary>
 	public ExplosionNode[] ExplosionNodes = new ExplosionNode[5];
 
+	private RadiationNode radiationNode;
+
 	/// <summary>
 	/// Used for storing useful information for the radiation system and The radiation level
 	/// </summary>
-	public RadiationNode RadiationNode = new RadiationNode();
+	public RadiationNode RadiationNode
+	{
+		get
+		{
+			if (radiationNode != null) return radiationNode;
+
+			radiationNode = new RadiationNode();
+
+			return radiationNode;
+		}
+	}
 
 	/// <summary>
 	/// Contains all electrical data for this tile
@@ -76,10 +88,24 @@ public class MetaDataNode : IGasMixContainer
 	/// </summary>
 	public NodeOccupiedType OccupiedType;
 
+	private GasMix gasMix;
+
 	/// <summary>
 	/// The mixture of gases currently on this node.
 	/// </summary>
-	public GasMix GasMix { get; set; }
+	public GasMix GasMix
+	{
+		get
+		{
+			if (gasMix != null) return gasMix;
+
+			gasMix = GasMix.NewGasMix(GasMixes.BaseSpaceMix);
+
+			return gasMix;
+		}
+
+		set => gasMix = value;
+	}
 
 	/// <summary>
 	/// The hotspot state of this node - indicates a potential to ignite gases, and
@@ -96,9 +122,37 @@ public class MetaDataNode : IGasMixContainer
 	public AppliedDetails AppliedDetails = new AppliedDetails();
 
 
-	public SmokeNode SmokeNode;
+	private SmokeNode smokeNode;
+	public SmokeNode SmokeNode
+	{
+		get
+		{
+			if (smokeNode != null) return smokeNode;
 
-	public FoamNode FoamNode;
+			smokeNode = new SmokeNode()
+			{
+				OnMetaDataNode = this
+			};
+
+			return smokeNode;
+		}
+	}
+
+	private FoamNode foamNode;
+	public FoamNode FoamNode
+	{
+		get
+		{
+			if (foamNode != null) return foamNode;
+
+			foamNode = new FoamNode()
+			{
+				OnMetaDataNode = this
+			};
+
+			return foamNode;
+		}
+	}
 
 
 	//Conductivity Stuff//
@@ -194,22 +248,14 @@ public class MetaDataNode : IGasMixContainer
 		MetaDataSystem = InMetaDataSystem;
 		PositionMatrix = matrix;
 		Position = position;
+
 		neighborList = new List<MetaDataNode>(4);
 		for (var i = 0; i < neighborList.Capacity; i++)
 		{
 			neighborList.Add(null);
 		}
-		GasMix = GasMix.NewGasMix(GasMixes.BaseSpaceMix);
-		this.reactionManager = reactionManager;
-		SmokeNode = new SmokeNode()
-		{
-			OnMetaDataNode = this
-		};
 
-		FoamNode = new FoamNode()
-		{
-			OnMetaDataNode = this
-		};
+		this.reactionManager = reactionManager;
 	}
 
 	static MetaDataNode()


### PR DESCRIPTION
-Foam, smoke and radiation nodes will only be created when needed (In a further PR might add checks for some access whether they actually need to create or whether checking for existence is all they need)

-Clients won't have the memory usage for the gasMix

-Fixed some case names in Foam and Smoke scripts
