### PR TITLE
Re-adds Box to high pop map pool

### DIFF
--- a/UnityProject/Assets/StreamingAssets/maps.json
+++ b/UnityProject/Assets/StreamingAssets/maps.json
@@ -1,7 +1,7 @@
 {
     "lowPopMaps":["MiniStation", "FallStation", "SquareStation"],
     "medPopMaps":["MiniStation", "FallStation", "SquareStation", "OutpostStation"],
-    "highPopMaps":["OutpostStation"],
+  "highPopMaps": ["OutpostStation", "BoxStationV1"],
     "medPopMinLimit":25,
     "highPopMinLimit": 40
 }


### PR DESCRIPTION
### Purpose

Never received a response as to why boxstation was removed in #9133, so I'm adding it back. The map gained functioning ACUs in #8890 and #8895, which was the last major issue with the map.

### Changelog:

CL: [Improvement] Re-added boxstation to the high population map pool.