### PR TITLE
Admin Tile Changer fixes

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
@@ -1057,7 +1057,7 @@ namespace AdminCommands
 
 			if (tile is ElectricalCableTile electricalCableTile)
 			{
-				//TODO make this actually work, looking at CableCoil.cs i've got no idea whats going on. Get Bod to do it?
+				matrixInfo.Matrix.AddElectricalNode(localPos, electricalCableTile);
 				ElectricalManager.Instance.electricalSync.StructureChange = true;
 				return;
 			}

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/GUI_DevTileChanger.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/GUI_DevTileChanger.cs
@@ -226,7 +226,7 @@ namespace UI.Systems.AdminTools.DevTools
 				image.color = colourToggle.isOn ? colourPicker.CurrentColor : Color.white;
 
 				var rect = image.GetComponent<RectTransform>();
-				rect.localRotation = Quaternion.Euler(0, 0, rotation);
+				rect.localRotation = Quaternion.Euler(0, 0, -(rotation-90)); //Orientation angles are starting from the positive x axis going anti-clockwise (Like unit circle), but unity transforms start from positive y and go clockwise.
 
 				newTile.GetComponentInChildren<TMP_Text>().text = tile.name;
 			}


### PR DESCRIPTION
Fixes #9158

### Changelog:

CL: [Fix] Admin tile placer now correctly places electrical cables
CL: [Fix] Fixes an issue in the tile placer UI were all sprites were rotated incorrectly, leading to much confusion with asymmetrical tiles
