### PR TITLE
Fixes #7445

### DIFF
--- a/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.TransferInteraction.cs
+++ b/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.TransferInteraction.cs
@@ -84,6 +84,8 @@ namespace Chemistry.Components
 			}
 			else
 			{
+				//Only spill if we're holding the alt key.
+				if (interaction.IsAltClick == false) return false;
 				//checks if it's possible to spill contents on player
 				if (!WillInteractHarm(interaction.HandObject, interaction.TargetObject, side)) return false;
 			}


### PR DESCRIPTION
Fixes #7445

CL: [Fix] - Attacking someone with a welding tool now works again.
CL: [Improvement] - Pouring reagents onto things now requires you to hold the alt-key.
