### PR TITLE
Add BindAddress and PublicAddress Config options

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Database/ServerData.ServerStatus.cs
+++ b/UnityProject/Assets/Scripts/Core/Database/ServerData.ServerStatus.cs
@@ -217,6 +217,7 @@ namespace DatabaseAPI
 		public string RconPass;
 		public int RconPort;
 		public int ServerPort;
+		public string BindAddress;
 		//CertKey needed in the future for SSL Rcon
 		public string certKey;
 		public string HubUser;

--- a/UnityProject/Assets/Scripts/Core/Database/ServerData.ServerStatus.cs
+++ b/UnityProject/Assets/Scripts/Core/Database/ServerData.ServerStatus.cs
@@ -96,9 +96,20 @@ namespace DatabaseAPI
 				{
 					string s = req.GetResponseHeader("set-cookie");
 					hubCookie = s.Split(';') [0];
-					req = UnityWebRequest.Get("http://ipinfo.io/ip");
-					yield return req.SendWebRequest();
-					publicIP = Regex.Replace(req.downloadHandler.text, @"\t|\n|\r", "");
+					if (string.IsNullOrEmpty(config.PublicAddress) == false)
+					{
+						publicIP = config.PublicAddress;
+					} 
+					else if (string.IsNullOrEmpty(config.BindAddress) == false)
+					{
+						publicIP = config.BindAddress;
+					}
+					else
+					{
+						req = UnityWebRequest.Get("http://ipinfo.io/ip");
+						yield return req.SendWebRequest();
+						publicIP = Regex.Replace(req.downloadHandler.text, @"\t|\n|\r", "");
+					}
 				}
 				else if (response.errorCode == 901)
 				{
@@ -218,6 +229,7 @@ namespace DatabaseAPI
 		public int RconPort;
 		public int ServerPort;
 		public string BindAddress;
+		public string PublicAddress;
 		//CertKey needed in the future for SSL Rcon
 		public string certKey;
 		public string HubUser;

--- a/UnityProject/Assets/Scripts/Core/Database/ServerData.ServerStatus.cs
+++ b/UnityProject/Assets/Scripts/Core/Database/ServerData.ServerStatus.cs
@@ -108,6 +108,8 @@ namespace DatabaseAPI
 					{
 						req = UnityWebRequest.Get("http://ipinfo.io/ip");
 						yield return req.SendWebRequest();
+						// Regex: /\t|\n|\r/ = Matches Tab, Newline, or Carriage Return.
+						// Effectively, this line removes those three characters from the response body, assigning it to the publicIp variable.
 						publicIP = Regex.Replace(req.downloadHandler.text, @"\t|\n|\r", "");
 					}
 				}

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -171,6 +171,10 @@ public class CustomNetworkManager : NetworkManager, IInitialise
 			if (ignorance != null)
 			{
 				ignorance.port = (ushort) config.ServerPort;
+				if(config.BindAddress != string.Empty){
+					ignorance.serverBindsAll = false;
+					ignorance.serverBindAddress = config.BindAddress;
+				}
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -171,7 +171,7 @@ public class CustomNetworkManager : NetworkManager, IInitialise
 			if (ignorance != null)
 			{
 				ignorance.port = (ushort) config.ServerPort;
-				if(config.BindAddress != string.Empty){
+				if(string.IsNullOrEmpty(config.BindAddress) == false){
 					ignorance.serverBindsAll = false;
 					ignorance.serverBindAddress = config.BindAddress;
 				}

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -164,17 +164,23 @@ public class CustomNetworkManager : NetworkManager, IInitialise
 			var telepathy = GetComponent<TelepathyTransport>();
 			if (telepathy != null)
 			{
-				telepathy.port = (ushort) config.ServerPort;
+				telepathy.port = (ushort)config.ServerPort;
 			}
 
 			var ignorance = GetComponent<Ignorance>();
 			if (ignorance != null)
 			{
-				ignorance.port = (ushort) config.ServerPort;
-				if(string.IsNullOrEmpty(config.BindAddress) == false){
-					ignorance.serverBindsAll = false;
-					ignorance.serverBindAddress = config.BindAddress;
-				}
+				ignorance.port = (ushort)config.ServerPort;
+
+			}
+		}
+		if (string.IsNullOrEmpty(config.BindAddress) == false)
+		{
+			var ignorance = GetComponent<Ignorance>();
+			if (ignorance != null)
+			{
+				ignorance.serverBindsAll = false;
+				ignorance.serverBindAddress = config.BindAddress;
 			}
 		}
 	}
@@ -200,7 +206,7 @@ public class CustomNetworkManager : NetworkManager, IInitialise
 
 		Dictionary<string, PrefabTracker> StoredIDs = new Dictionary<string, PrefabTracker>();
 
-		var networkObjectsGUIDs = AssetDatabase.FindAssets("t:prefab", new string[] {"Assets/Prefabs"});
+		var networkObjectsGUIDs = AssetDatabase.FindAssets("t:prefab", new string[] { "Assets/Prefabs" });
 		var objectsPaths = networkObjectsGUIDs.Select(AssetDatabase.GUIDToAssetPath);
 		foreach (var objectsPath in objectsPaths)
 		{
@@ -234,13 +240,13 @@ public class CustomNetworkManager : NetworkManager, IInitialise
 					var Preexisting = StoredIDs[OriginalOldID];
 
 					if (Preexisting.ForeverID != OriginalOldID &&
-					    prefabTracker.ForeverID != OriginalOldID)
+						prefabTracker.ForeverID != OriginalOldID)
 					{
 						Logger.LogError("OH GOD What is the original I can't tell!! " +
-						                "Manually edit the ForeverID For the newly created prefab to not be the same as " +
-						                "the prefab variant parent for " +
-						                Preexisting.gameObject +
-						                " and " + prefabTracker.gameObject);
+										"Manually edit the ForeverID For the newly created prefab to not be the same as " +
+										"the prefab variant parent for " +
+										Preexisting.gameObject +
+										" and " + prefabTracker.gameObject);
 
 						prefabTracker.ForeverID = OriginalOldID;
 						Preexisting.ForeverID = OriginalOldID;


### PR DESCRIPTION
<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->

### Purpose
This PR allows server hosts to specify which Interface Address to bind to, instead of the default of *all* addresses.
Aswell, This allows a server host to change the IP address their server presents to the Hub, if the IP address lookup result gets the wrong address (IE, on multi-address systems).
This also allows server hosts to put a *domain* instead of an IP address in their hub listing, Potentially allowing extra smartness in the launcher with DNS SRV, A, and AAAA records.

### Notes:
<!-- Please enter any other relevant information here -->
**IMPORTANT**: Domains in hub listing is not supported by the hub yet (see unitystation/stationhub#161)



### Changelog:
CL: [New] Bind Address field for Server Hosts
CL: [New] Public Address field for Server Hosts