### PR TITLE
devops: updates pr2changelog action to use the new api integration

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -47,21 +47,10 @@ jobs:
 
       - name: pr2changelog
         id: pr2changelog
-        uses: corp-0/pr2changelog@master
+        uses: corp-0/pr2changelog@api-integration
         with:
           categories: Fix;New;Improvement;Balance
+          write_to_file: false
+          api_secret_token: ${{ secrets.CHANGELOG_API_SECRET }}
+          api_url: "https://changelog.unitystation.org/register-change"
 
-      -   name: Commit files
-          if: ${{ steps.pr2changelog.outputs.generated_changelog == 1}}
-          run: |
-              git config --local user.email "action@github.com"
-              git config --local user.name "GitHub Action"
-              git add *
-              git commit -m "misc: update Changelog" -a
-              
-      -   name: Push changes
-          if: ${{ steps.pr2changelog.outputs.generated_changelog == 1}}
-          uses: ad-m/github-push-action@master
-          with:
-              github_token: ${{ secrets.PR2CHANGELOG_TOKEN }}
-              repository: unitystation/changelog


### PR DESCRIPTION
### Purpose
We are migrating our changelog to be based in a data base and served in an API so it is easier to fetch and filter in our website, discord or even in game.

This change will make it so pr2changelog registers the new changes after a merge to the API instead of writing them in a file like we do now.

### Notes:
For the whole circuit to work, a change in our build script is also needed so it pings the API with the new build number and we take all unversioned changes and relate the to the new build version.