### PR TITLE
Some fixes for sickness and round end screen

### DIFF
--- a/UnityProject/Assets/Scripts/Health/Sickness/MobSickness.cs
+++ b/UnityProject/Assets/Scripts/Health/Sickness/MobSickness.cs
@@ -74,8 +74,13 @@ namespace Health.Sickness
 			{
 				foreach (var sickness in sicknessAfflictions)
 				{
+					if(sickness.IsHealed) return;
+					if (sickness.Sickness.CheckForCureInHealth(MobHealth))
+					{
+						sickness.Heal();
+						return;
+					}
 					sickness.Sickness.SicknessBehavior(mobHealth);
-					if (sickness.Sickness.CheckForCureInHealth(MobHealth)) sickness.Heal();
 				}
 			}
 		}

--- a/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.Data.cs
+++ b/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.Data.cs
@@ -8,7 +8,7 @@ namespace Systems.Score
 		/// How much does score entry that returns true or false score?
 		/// </summary>
 		[SerializeField] private int boolScore = 10;
-		[SerializeField] private int negativeModifer = 5;
+		[SerializeField] private int negativeModifer = -5;
 		[SerializeField] private Occupation captainOccupation;
 
 		public static string COMMON_SCORE_LABORPOINTS = "laborPoints";
@@ -19,5 +19,6 @@ namespace Systems.Score
 		public static string COMMON_SCORE_FOODEATEN = "foodeaten";
 		public static string COMMON_SCORE_EXPLOSION = "explosions";
 		public static string COMMON_SCORE_CLOWNABUSE = "clownBeaten";
+		public static int DEAD_CREW_SCORE = -250;
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.cs
+++ b/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.cs
@@ -41,9 +41,15 @@ namespace Systems.Score
 				ScoreMachine.AddToScoreBool(MatrixManager.MainStationMatrix.Matrix.PresentPlayers.Any(crew =>
 					crew.PlayerScript.mind.occupation == captainOccupation), "captainWithHisShip");
 			}
-			//How many dead crew are there?
-			ScoreMachine.AddNewScoreEntry("deadCrew", "Dead Crew", ScoreMachine.ScoreType.Int, ScoreCategory.StationScore, ScoreAlignment.Bad);
-			ScoreMachine.AddToScoreInt(-PlayerList.Instance.AllPlayers.Count(playerbody => playerbody.Script.playerHealth.IsDead) * negativeModifer, "deadCrew");
+			//How many dead crew are there if there are more than two crewmembers?
+			if (PlayerList.Instance.AllPlayers.Count > 2)
+			{
+				ScoreMachine.AddNewScoreEntry("deadCrew", "Dead Crew", ScoreMachine.ScoreType.Int, ScoreCategory.StationScore, ScoreAlignment.Bad);
+				foreach (var player in PlayerList.Instance.AllPlayers.Where(player => player.Mind != null && player.Script != null))
+				{
+					ScoreMachine.AddToScoreInt(DEAD_CREW_SCORE * negativeModifer, "deadCrew");
+				}
+			}
 			//Who's the crew member with the worst overall health?
 			var lowestHealthCrewMemberNumber = 200f;
 			var lowestHealthCrewMemberName = "";

--- a/UnityProject/Assets/Scripts/UI/Systems/EndRound/RoundEndScoreScreen.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/EndRound/RoundEndScoreScreen.cs
@@ -82,7 +82,7 @@ namespace UI.Systems.EndRound
 		{
 			scoreSummary.text = finalResult;
 			scoreResult.text = finalScore;
-			ratingResult.text = finalScore;
+			ratingResult.text = finalRating;
 			this.SetActive(true);
 		}
 


### PR DESCRIPTION
CL: [Fix] Fixed NRE that would happen when the round ends while observers (haven't joined the round) exist.
CL: [Fix] Fixed round end screen showing score result twice.
CL: [Fix] Fixed a math error that gave negative scores a positive value to the final score,
CL: [Fix] Fixed sickness logic still triggering even after a player has healed it.
CL: [Balance] Dead crew now are reported as negative 250 each instead of showing how many dead crew there were.
