### PR TITLE
remove game objects from synchvars

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Bureaucracy/PaperBin.cs
+++ b/UnityProject/Assets/Scripts/Items/Bureaucracy/PaperBin.cs
@@ -16,7 +16,13 @@ namespace Items.Bureaucracy
 		private int paperCount;
 
 		[SyncVar (hook = nameof(SyncStoredPen))]
-		private GameObject storedPen;
+		private uint storedPenID;
+
+		private GameObject storedPen
+		{
+			get => storedPenID.NetIdToGameObject();
+			set => SyncStoredPen(storedPenID, value.NetId());
+		}
 
 		private ItemStorage itemStorage;
 		private ItemSlot penSlot;
@@ -36,10 +42,10 @@ namespace Items.Bureaucracy
 			UpdateSpriteState();
 		}
 
-		private void SyncStoredPen(GameObject oldPen, GameObject pen)
+		private void SyncStoredPen(uint oldPen, uint pen)
 		{
+			storedPenID = pen;
 			EnsureInit();
-			storedPen = pen;
 			UpdateSpriteState();
 		}
 
@@ -61,8 +67,9 @@ namespace Items.Bureaucracy
 			binRenderer = renderers[0];
 			penRenderer = renderers[1];
 
+			SyncStoredPen(storedPenID, storedPenID);
 			SyncPaperCount(paperCount, paperCount);
-			SyncStoredPen(storedPen, storedPen);
+
 		}
 
 		private void Awake()
@@ -172,7 +179,8 @@ namespace Items.Bureaucracy
 				{
 					Chat.AddExamineMsgFromServer(interaction.Performer, "You take the pen out of the paper bin.");
 					Inventory.ServerTransfer(penSlot, interaction.HandSlot);
-					SyncStoredPen(storedPen, null);
+					storedPen = null;
+					SyncStoredPen(storedPenID, storedPenID);
 					return;
 				}
 
@@ -211,7 +219,8 @@ namespace Items.Bureaucracy
 				// Player is adding a piece of paper or a pen
 				if (handObj.GetComponent<Pen>())
 				{
-					SyncStoredPen(storedPen, handObj);
+					storedPen = handObj;
+					SyncStoredPen(storedPenID, storedPenID);
 					Chat.AddExamineMsgFromServer(interaction.Performer, "You put the pen in the paper bin.");
 					Inventory.ServerTransfer(interaction.HandSlot, penSlot);
 					return;

--- a/UnityProject/Assets/Scripts/Items/Bureaucracy/PaperBin.cs
+++ b/UnityProject/Assets/Scripts/Items/Bureaucracy/PaperBin.cs
@@ -16,12 +16,12 @@ namespace Items.Bureaucracy
 		private int paperCount;
 
 		[SyncVar (hook = nameof(SyncStoredPen))]
-		private uint storedPenID;
+		private NetworkIdentity _storedPenID;
 
 		private GameObject storedPen
 		{
-			get => storedPenID.NetIdToGameObject();
-			set => SyncStoredPen(storedPenID, value.NetId());
+			get => _storedPenID.gameObject;
+			set => SyncStoredPen(_storedPenID, value.NetWorkIdentity());
 		}
 
 		private ItemStorage itemStorage;
@@ -42,9 +42,9 @@ namespace Items.Bureaucracy
 			UpdateSpriteState();
 		}
 
-		private void SyncStoredPen(uint oldPen, uint pen)
+		private void SyncStoredPen(NetworkIdentity oldPen, NetworkIdentity pen)
 		{
-			storedPenID = pen;
+			_storedPenID = pen;
 			EnsureInit();
 			UpdateSpriteState();
 		}
@@ -67,7 +67,7 @@ namespace Items.Bureaucracy
 			binRenderer = renderers[0];
 			penRenderer = renderers[1];
 
-			SyncStoredPen(storedPenID, storedPenID);
+			SyncStoredPen(_storedPenID, _storedPenID);
 			SyncPaperCount(paperCount, paperCount);
 
 		}
@@ -180,7 +180,7 @@ namespace Items.Bureaucracy
 					Chat.AddExamineMsgFromServer(interaction.Performer, "You take the pen out of the paper bin.");
 					Inventory.ServerTransfer(penSlot, interaction.HandSlot);
 					storedPen = null;
-					SyncStoredPen(storedPenID, storedPenID);
+					SyncStoredPen(_storedPenID, _storedPenID);
 					return;
 				}
 
@@ -220,7 +220,7 @@ namespace Items.Bureaucracy
 				if (handObj.GetComponent<Pen>())
 				{
 					storedPen = handObj;
-					SyncStoredPen(storedPenID, storedPenID);
+					SyncStoredPen(_storedPenID, _storedPenID);
 					Chat.AddExamineMsgFromServer(interaction.Performer, "You put the pen in the paper bin.");
 					Inventory.ServerTransfer(interaction.HandSlot, penSlot);
 					return;

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -45,6 +45,9 @@ public class CustomNetworkManager : NetworkManager, IInitialise
 	/// </summary>
 	[NonSerialized] public UnityEvent OnClientDisconnected = new UnityEvent();
 
+	public static Dictionary<uint, NetworkIdentity> spawned => IsServer ? NetworkServer.spawned : NetworkClient.spawned;
+
+
 	public override void Awake()
 	{
 		if (IndexLookupSpawnablePrefabs.Count == 0)

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -45,7 +45,7 @@ public class CustomNetworkManager : NetworkManager, IInitialise
 	/// </summary>
 	[NonSerialized] public UnityEvent OnClientDisconnected = new UnityEvent();
 
-	public static Dictionary<uint, NetworkIdentity> spawned => IsServer ? NetworkServer.spawned : NetworkClient.spawned;
+	public static Dictionary<uint, NetworkIdentity> Spawned => IsServer ? NetworkServer.spawned : NetworkClient.spawned;
 
 
 	public override void Awake()

--- a/UnityProject/Assets/Scripts/Messages/Server/SpritesMessages/SpriteUpdateMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/SpritesMessages/SpriteUpdateMessage.cs
@@ -40,7 +40,7 @@ namespace Messages.Server.SpritesMessages
 
 		private bool ProcessEntry(SpriteUpdateEntry spriteUpdateEntry)
 		{
-			var spawned = CustomNetworkManager.spawned;
+			var spawned = CustomNetworkManager.Spawned;
 			if (spawned.TryGetValue(spriteUpdateEntry.id, out var networkIdentity) == false) return false;
 			if (networkIdentity == null) return false;
 

--- a/UnityProject/Assets/Scripts/Messages/Server/SpritesMessages/SpriteUpdateMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/SpritesMessages/SpriteUpdateMessage.cs
@@ -40,7 +40,7 @@ namespace Messages.Server.SpritesMessages
 
 		private bool ProcessEntry(SpriteUpdateEntry spriteUpdateEntry)
 		{
-			var spawned = CustomNetworkManager.IsServer ? NetworkServer.spawned : NetworkClient.spawned;
+			var spawned = CustomNetworkManager.spawned;
 			if (spawned.TryGetValue(spriteUpdateEntry.id, out var networkIdentity) == false) return false;
 			if (networkIdentity == null) return false;
 

--- a/UnityProject/Assets/Scripts/Player/GhostOrbit.cs
+++ b/UnityProject/Assets/Scripts/Player/GhostOrbit.cs
@@ -11,12 +11,12 @@ namespace Player
 		public static GhostOrbit Instance;
 
 		[SyncVar(hook = nameof(SyncOrbitObject))]
-		private uint IDtarget;
+		private NetworkIdentity IDtarget;
 
 		private GameObject target
 		{
-			get => IDtarget.NetIdToGameObject();
-			set => SyncOrbitObject(IDtarget, value.NetId());
+			get => IDtarget.gameObject;
+			set => SyncOrbitObject(IDtarget, value.NetWorkIdentity());
 		}
 
 
@@ -45,7 +45,7 @@ namespace Player
 			StopOrbiting();
 		}
 
-		private void SyncOrbitObject(uint oldObject, uint newObject)
+		private void SyncOrbitObject(NetworkIdentity oldObject, NetworkIdentity newObject)
 		{
 			IDtarget = newObject;
 

--- a/UnityProject/Assets/Scripts/Player/GhostOrbit.cs
+++ b/UnityProject/Assets/Scripts/Player/GhostOrbit.cs
@@ -11,7 +11,14 @@ namespace Player
 		public static GhostOrbit Instance;
 
 		[SyncVar(hook = nameof(SyncOrbitObject))]
-		private GameObject target;
+		private uint IDtarget;
+
+		private GameObject target
+		{
+			get => IDtarget.NetIdToGameObject();
+			set => SyncOrbitObject(IDtarget, value.NetId());
+		}
+
 
 		[SerializeField] private GhostMove GhostMove;
 		[SerializeField] private RotateAroundTransform rotateTransform;
@@ -38,9 +45,9 @@ namespace Player
 			StopOrbiting();
 		}
 
-		private void SyncOrbitObject(GameObject oldObject, GameObject newObject)
+		private void SyncOrbitObject(uint oldObject, uint newObject)
 		{
-			target = newObject;
+			IDtarget = newObject;
 
 			if (target == null)
 			{

--- a/UnityProject/Assets/Scripts/Systems/Ai/AiPlayer.cs
+++ b/UnityProject/Assets/Scripts/Systems/Ai/AiPlayer.cs
@@ -27,9 +27,19 @@ namespace Systems.Ai
 		[SerializeField]
 		private GameObject corePrefab = null;
 
+
+
 		[SyncVar(hook = nameof(SyncCore))]
 		//Ai core or card
-		private GameObject vesselObject;
+		private uint IDvesselObject;
+
+		private GameObject vesselObject
+		{
+			get => IDvesselObject.NetIdToGameObject();
+			set => SyncCore(IDvesselObject, value.NetId());
+		}
+
+
 		public GameObject VesselObject => vesselObject;
 
 		[SerializeField]
@@ -237,7 +247,7 @@ namespace Systems.Ai
 
 			Init();
 
-			SyncCore(vesselObject, vesselObject);
+			SyncCore(IDvesselObject, IDvesselObject);
 			SyncPowerState(hasPower, hasPower);
 			CmdSetVisibilityToOtherAis();
 		}
@@ -264,25 +274,25 @@ namespace Systems.Ai
 		/// This is only sync'd to the client which owns this object, due to setting on script
 		/// </summary>
 		[Client]
-		private void SyncCore(GameObject oldCore, GameObject newCore)
+		private void SyncCore(uint oldCore, uint newCore)
 		{
-			vesselObject = newCore;
-			if(newCore == null) return;
+			IDvesselObject = newCore;
+			if(vesselObject == null) return;
 
 			//Something weird with headless and local host triggering the sync even though its set to owner
 			if (CustomNetworkManager.IsHeadless || PlayerManager.LocalPlayerObject != gameObject) return;
 
 			Init();
 			aiUi.OrNull()?.SetUp(this);
-			coreCamera = newCore.GetComponent<SecurityCamera>();
+			coreCamera = vesselObject.GetComponent<SecurityCamera>();
 
 			//Reset location to core
 			CmdTeleportToCore();
 
-			isCarded = newCore.GetComponent<AiVessel>().IsInteliCard;
+			isCarded = vesselObject.GetComponent<AiVessel>().IsInteliCard;
 			if (isCarded == false)
 			{
-				ClientSetCameraLocation(newCore.transform);
+				ClientSetCameraLocation(vesselObject.transform);
 			}
 
 			//Ask server to force sync laws

--- a/UnityProject/Assets/Scripts/Systems/Ai/AiPlayer.cs
+++ b/UnityProject/Assets/Scripts/Systems/Ai/AiPlayer.cs
@@ -31,12 +31,12 @@ namespace Systems.Ai
 
 		[SyncVar(hook = nameof(SyncCore))]
 		//Ai core or card
-		private uint IDvesselObject;
+		private NetworkIdentity IDvesselObject;
 
 		private GameObject vesselObject
 		{
-			get => IDvesselObject.NetIdToGameObject();
-			set => SyncCore(IDvesselObject, value.NetId());
+			get => IDvesselObject.gameObject;
+			set => SyncCore(IDvesselObject, value.NetWorkIdentity());
 		}
 
 
@@ -274,7 +274,7 @@ namespace Systems.Ai
 		/// This is only sync'd to the client which owns this object, due to setting on script
 		/// </summary>
 		[Client]
-		private void SyncCore(uint oldCore, uint newCore)
+		private void SyncCore(NetworkIdentity oldCore, NetworkIdentity newCore)
 		{
 			IDvesselObject = newCore;
 			if(vesselObject == null) return;

--- a/UnityProject/Assets/Scripts/Systems/Spells/Wizard/TeleportSpell.cs
+++ b/UnityProject/Assets/Scripts/Systems/Spells/Wizard/TeleportSpell.cs
@@ -17,7 +17,14 @@ namespace Systems.Spells.Wizard
 
 		// We sync the teleporting player so we can play animations locally.
 		[SyncVar(hook = nameof(SyncPlayer))]
-		private GameObject teleportingPlayer;
+		private uint IDteleportingPlayer;
+
+		private GameObject teleportingPlayer
+		{
+			get => IDteleportingPlayer.NetIdToGameObject();
+			set => SyncPlayer(IDteleportingPlayer, value.NetId());
+		}
+
 
 		private Transform playerSprite;
 
@@ -55,9 +62,9 @@ namespace Systems.Spells.Wizard
 			IsBusy = false;
 		}
 
-		private void SyncPlayer(GameObject oldPlayer, GameObject newPlayer)
+		private void SyncPlayer(uint oldPlayer, uint newPlayer)
 		{
-			teleportingPlayer = newPlayer;
+			IDteleportingPlayer = newPlayer;
 			playerSprite = teleportingPlayer.transform.Find("Sprites");
 
 			if (playerSprite == null)

--- a/UnityProject/Assets/Scripts/Systems/Spells/Wizard/TeleportSpell.cs
+++ b/UnityProject/Assets/Scripts/Systems/Spells/Wizard/TeleportSpell.cs
@@ -17,12 +17,12 @@ namespace Systems.Spells.Wizard
 
 		// We sync the teleporting player so we can play animations locally.
 		[SyncVar(hook = nameof(SyncPlayer))]
-		private uint IDteleportingPlayer;
+		private NetworkIdentity IDteleportingPlayer;
 
 		private GameObject teleportingPlayer
 		{
-			get => IDteleportingPlayer.NetIdToGameObject();
-			set => SyncPlayer(IDteleportingPlayer, value.NetId());
+			get => IDteleportingPlayer.gameObject;
+			set => SyncPlayer(IDteleportingPlayer, value.NetWorkIdentity());
 		}
 
 
@@ -62,7 +62,7 @@ namespace Systems.Spells.Wizard
 			IsBusy = false;
 		}
 
-		private void SyncPlayer(uint oldPlayer, uint newPlayer)
+		private void SyncPlayer(NetworkIdentity oldPlayer, NetworkIdentity newPlayer)
 		{
 			IDteleportingPlayer = newPlayer;
 			playerSprite = teleportingPlayer.transform.Find("Sprites");

--- a/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
+++ b/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
@@ -95,7 +95,7 @@ public static class SweetExtensions
 
 	public static GameObject NetIdToGameObject(this uint NetID)
 	{
-		if ( NetID != global::NetId.Invalid && NetID != global::NetId.Empty && CustomNetworkManager.spawned.TryGetValue(NetID, out var Object  ))
+		if ( NetID != global::NetId.Invalid && NetID != global::NetId.Empty && CustomNetworkManager.Spawned.TryGetValue(NetID, out var Object  ))
 		{
 			return Object.gameObject;
 		}

--- a/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
+++ b/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
@@ -106,27 +106,40 @@ public static class SweetExtensions
 
 	}
 
-	public static uint NetId(this GameObject go)
+	public static NetworkIdentity NetWorkIdentity(this GameObject go)
 	{
 		if (go)
 		{
 			go.TryGetComponent<Matrix>(out var matrix);
 			if (matrix)
 			{
-				return matrix.NetworkedMatrix.MatrixSync.netId;
+				return matrix.NetworkedMatrix.MatrixSync.netIdentity;
 			}
 			else
 			{
 				matrix = go.GetComponentInChildren<Matrix>();
 				if (matrix != null)
 				{
-					return matrix.NetworkedMatrix.MatrixSync.netId;
+					return matrix.NetworkedMatrix.MatrixSync.netIdentity;
 				}
 				else
 				{
-					return go.GetComponent<NetworkIdentity>().netId;
+					return go.GetComponent<NetworkIdentity>();
 				}
 			}
+		}
+		else
+		{
+			return null;
+		}
+	}
+
+	public static uint NetId(this GameObject go)
+	{
+		var net = NetWorkIdentity(go);
+		if (go)
+		{
+			return net.netId;
 		}
 		else
 		{

--- a/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
+++ b/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
@@ -93,6 +93,19 @@ public static class SweetExtensions
 		return list?.Count > 0 ? list.PickRandom() : default(T);
 	}
 
+	public static GameObject NetIdToGameObject(this uint NetID)
+	{
+		if ( NetID != global::NetId.Invalid && NetID != global::NetId.Empty && CustomNetworkManager.spawned.TryGetValue(NetID, out var Object  ))
+		{
+			return Object.gameObject;
+		}
+		else
+		{
+			return null;
+		}
+
+	}
+
 	public static uint NetId(this GameObject go)
 	{
 		if (go)

--- a/docs/development/SyncVar-Best-Practices-for-Easy-Networking.md
+++ b/docs/development/SyncVar-Best-Practices-for-Easy-Networking.md
@@ -13,12 +13,12 @@ Use something like this Instead.
         public class ItemAttributes : NetworkBehavior
         {
            [SyncVar(hook = nameof(SyncOrbitObject))]
-           private uint IDtarget;
+           private NetworkIdentity IDtarget;
    
            private GameObject target //ues target as your main reference
            {
-               get => IDtarget.NetIdToGameObject();
-               set => SyncOrbitObject(IDtarget, value.NetId());
+               get => IDtarget.gameObject;
+               set => SyncOrbitObject(IDtarget, value.NetWorkIdentity());
            }
         }
 

--- a/docs/development/SyncVar-Best-Practices-for-Easy-Networking.md
+++ b/docs/development/SyncVar-Best-Practices-for-Easy-Networking.md
@@ -3,7 +3,27 @@ The [SyncVar attribute](https://mirror-networking.com/docs/Guides/Sync/SyncVars.
 # Proper SyncVar Usage
 These are things you should almost ALWAYS do if using syncvar. If you see places in the code where these rules are violated, be suspicious of bugs. Note that most of these tips only apply if you define a "hook" method.
 
-1. Add SyncVar to the field you want to sync. The field should ALWAYS be private, and it should NOT be editor assignable. NEVER allow the field to be directly modified by other components or in editor. If you want to configure an initial value for this field, create a separate editor field for it.
+
+1. ****** **Do not use Gameobject in SyncVars** ******, Due to our multithreaded implementation of mirror, 
+Mirror does a get component In one of the threads outside of the main unity thread causing unity, Throw an error in the network loop causing many unforeseen consequences
+Use something like this Instead.
+
+
+        :::csharp
+        public class ItemAttributes : NetworkBehavior
+        {
+           [SyncVar(hook = nameof(SyncOrbitObject))]
+           private uint IDtarget;
+   
+           private GameObject target //ues target as your main reference
+           {
+               get => IDtarget.NetIdToGameObject();
+               set => SyncOrbitObject(IDtarget, value.NetId());
+           }
+        }
+
+
+2. Add SyncVar to the field you want to sync. The field should ALWAYS be private, and it should NOT be editor assignable. NEVER allow the field to be directly modified by other components or in editor. If you want to configure an initial value for this field, create a separate editor field for it.
 
         :::csharp
         public class ItemAttributes : NetworkBehavior
@@ -43,7 +63,7 @@ These are things you should almost ALWAYS do if using syncvar. If you see places
             }
         }
 
-2. (Only if you have a hook method) Define a private hook method named "Sync(name of field)". The line of the hook after EnsureInit should update the field based on the new value. Do NOT make a protected or public hook method. Starting the method name with Sync is important because it makes it easier for others to know that this method is exclusively for changing this syncvar.
+4. (Only if you have a hook method) Define a private hook method named "Sync(name of field)". The line of the hook after EnsureInit should update the field based on the new value. Do NOT make a protected or public hook method. Starting the method name with Sync is important because it makes it easier for others to know that this method is exclusively for changing this syncvar.
 
         :::csharp
         private void SyncItemName(string oldName, string newName)
@@ -56,7 +76,7 @@ These are things you should almost ALWAYS do if using syncvar. If you see places
     * You generally will need a hook unless the client doesn't need to invoke any special logic when the value changes.
     * Note that Mirror actually does set the field automatically on the clientside when the hook is triggered by a server update, but if you called the hook directly on server side (instead of actually changing the field's value) it would not automatically change the value. This has created a lot of needless confusion and mistakes in the past because it is so situational, so sticking to the conventions documented on this page will avoid that confusion.
 
-3. (Only if you have a hook method) Override OnStartClient (make sure to use the "override" keyword!) and invoke the hook, passing it the current value of the field. If you are extending a component, make sure to call base.OnStartClient(). This ensures the SyncVar hook is called based on the initial value of the field that the server sends. Also call EnsureInit at the top to ensure any necessary init logic is called (Mirror may call OnStartClient before Awake/Start)
+5. (Only if you have a hook method) Override OnStartClient (make sure to use the "override" keyword!) and invoke the hook, passing it the current value of the field. If you are extending a component, make sure to call base.OnStartClient(). This ensures the SyncVar hook is called based on the initial value of the field that the server sends. Also call EnsureInit at the top to ensure any necessary init logic is called (Mirror may call OnStartClient before Awake/Start)
 
         :::csharp
         //make sure to use "override" and use correct name "OnStartClient"
@@ -67,7 +87,7 @@ These are things you should almost ALWAYS do if using syncvar. If you see places
             base.OnStartClient();
         }
         
-4. (Only if you have a hook method) Implement the IServerSpawn interface and set the syncvar field to the initial value in the method. This is a method which is invoked when an object is being spawned, regardless of if it's coming from the pool or not. This ensures that the object is properly re-initialized when it is being spawned from the object pool.
+6. (Only if you have a hook method) Implement the IServerSpawn interface and set the syncvar field to the initial value in the method. This is a method which is invoked when an object is being spawned, regardless of if it's coming from the pool or not. This ensures that the object is properly re-initialized when it is being spawned from the object pool.
 
         :::csharp
         public void OnSpawnServer()
@@ -79,7 +99,7 @@ These are things you should almost ALWAYS do if using syncvar. If you see places
             base.OnSpawnServer();
         }
         
-5. (Only if you have a hook method) The ONLY place you are allowed to change the value of the syncvar field is via the syncvar hook and only on the server! Never change the value on the client side, and never modify the field directly. If you are on the server and you want to change the field value, call the hook method and pass it the new value. This ensures that the hook logic will always be fired on both client and server side.
+7. (Only if you have a hook method) The ONLY place you are allowed to change the value of the syncvar field is via the syncvar hook and only on the server! Never change the value on the client side, and never modify the field directly. If you are on the server and you want to change the field value, call the hook method and pass it the new value. This ensures that the hook logic will always be fired on both client and server side.
 
         :::csharp
         [Server]
@@ -92,7 +112,7 @@ These are things you should almost ALWAYS do if using syncvar. If you see places
             SyncItemName(newName);
         }
         
-6. Do not rely on a consistent ordering when it comes to syncvar changes and net messages sent from the server. Due to network latency, if you change 2 syncvars and send a net message on the server, the updates could arrive on the client in any order.
+8. Do not rely on a consistent ordering when it comes to syncvar changes and net messages sent from the server. Due to network latency, if you change 2 syncvars and send a net message on the server, the updates could arrive on the client in any order.
 
 # Various Issues Caused by Improper SyncVar Usage
 Here's some symptoms of improper syncvar usage:


### PR DESCRIPTION
this is due to mirror doing a get component in the multithreaded portion, and causing unity to explode because it's apparently impossible to do a get component from a different thread
### Notes:

CL: [Fix] should fixed weird synchronisation issues
