### PR TITLE
Improvements to protips and interaction fix in editor

### DIFF
--- a/UnityProject/Assets/Prefabs/UI/Learning/ProTipUI.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Learning/ProTipUI.prefab
@@ -241,6 +241,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3429471952733610678}
+  - {fileID: 2320792367323772480}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -370,3 +371,151 @@ MonoBehaviour:
   m_ChildScaleWidth: 1
   m_ChildScaleHeight: 1
   m_ReverseArrangement: 0
+--- !u!1 &8274033448253940392
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2320792367323772480}
+  - component: {fileID: 4887093065853611696}
+  - component: {fileID: 1595829935691437357}
+  - component: {fileID: 5069574088400209811}
+  - component: {fileID: 3978907735991155639}
+  m_Layer: 5
+  m_Name: ButtonRemember
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2320792367323772480
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8274033448253940392}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1527629224210436775}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 775.9436, y: -17.643494}
+  m_SizeDelta: {x: 36.3609, y: 35.287}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4887093065853611696
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8274033448253940392}
+  m_CullTransparentMesh: 1
+--- !u!114 &1595829935691437357
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8274033448253940392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 11433caf457fffc4baa12960619ae6ec, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5069574088400209811
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8274033448253940392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1595829935691437357}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6066991351506611152}
+        m_TargetAssemblyTypeName: Learning.ProtipUI, Assets
+        m_MethodName: RememberTip
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &3978907735991155639
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8274033448253940392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 24274225ed0937e46a973d5d78bbcaac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  useObjectName: 0
+  hoverName: Don't show up again.

--- a/UnityProject/Assets/Scripts/Learning/ProtipManager.cs
+++ b/UnityProject/Assets/Scripts/Learning/ProtipManager.cs
@@ -72,8 +72,6 @@ namespace Learning
 
 		private void ShowTip(ProtipSO tip)
 		{
-			var duration = tip.TipData.ShowDuration;
-			if(tip.TipData.ShowDuration <= 0) duration = 25f; //Incase whoever was setting the SO data forgot to set the duration.
 			UI.gameObject.SetActive(true);
 			UI.ShowTip(tip);
 			IsShowingTip = true;

--- a/UnityProject/Assets/Scripts/Learning/ProtipManager.cs
+++ b/UnityProject/Assets/Scripts/Learning/ProtipManager.cs
@@ -11,7 +11,7 @@ namespace Learning
 		public ExperienceLevel PlayerExperienceLevel;
 		public List<ProtipSO> RecordedProtips;
 
-		private readonly Queue<ProTipUIData> queuedTips = new Queue<ProTipUIData>();
+		private readonly Queue<ProtipSO> queuedTips = new Queue<ProtipSO>();
 
 		public enum ExperienceLevel
 		{
@@ -19,14 +19,6 @@ namespace Learning
 			NewToUnityStation = 1, //Unitystation changes only
 			SomewhatExperienced = 2, //Life critical Advice only
 			Robust = 3 //Nothing will get triggered on this level.
-		}
-
-		private struct ProTipUIData
-		{
-			public string Text;
-			public float Duration;
-			public Sprite Sprite;
-			public ProtipUI.SpriteAnimation Animation;
 		}
 
 		public bool IsShowingTip { get; set; }
@@ -70,26 +62,20 @@ namespace Learning
 		{
 			if(IsShowingTip || queuedTips.Count == 0) return;
 			var tip = queuedTips.Dequeue();
-			ShowTip(tip.Text, tip.Duration, tip.Sprite, tip.Animation);
+			ShowTip(tip);
 		}
 
-		public void QueueTip(string TipText, float duration = 25f, Sprite img = null, ProtipUI.SpriteAnimation showAnim = ProtipUI.SpriteAnimation.ROCKING)
+		public void QueueTip(ProtipSO tip)
 		{
-			ProTipUIData newEntry = new ProTipUIData
-			{
-				Text = TipText,
-				Duration = duration,
-				Sprite = img,
-				Animation = showAnim
-			};
-			queuedTips.Enqueue(newEntry);
+			queuedTips.Enqueue(tip);
 		}
 
-		private void ShowTip(string TipText, float duration = 25f, Sprite img = null, ProtipUI.SpriteAnimation showAnim = ProtipUI.SpriteAnimation.ROCKING)
+		private void ShowTip(ProtipSO tip)
 		{
-			if(duration <= 0) duration = 25f; //Incase whoever was setting the SO data forgot to set the duration.
+			var duration = tip.TipData.ShowDuration;
+			if(tip.TipData.ShowDuration <= 0) duration = 25f; //Incase whoever was setting the SO data forgot to set the duration.
 			UI.gameObject.SetActive(true);
-			UI.ShowTip(TipText, duration, img, showAnim);
+			UI.ShowTip(tip);
 			IsShowingTip = true;
 		}
 	}

--- a/UnityProject/Assets/Scripts/Learning/ProtipObject.cs
+++ b/UnityProject/Assets/Scripts/Learning/ProtipObject.cs
@@ -9,9 +9,6 @@ namespace Learning
 	public class ProtipObject : MonoBehaviour
 	{
 		public ProtipSO TipSO;
-
-		[SerializeField, Tooltip("Incase there are more than one Protip on a single item/object")]
-		private int saveID;
 		[SerializeField, Tooltip("Does this tip object only trigger once then saved as so?")]
 		private bool triggerOnce = true;
 
@@ -26,8 +23,19 @@ namespace Learning
 
 		private void Awake()
 		{
-			var saved = PlayerPrefs.GetString($"{gameObject.GetComponent<PrefabTracker>().ForeverID}/{saveID.ToString()}", "false");
-			if(saved == "true" || TipSO == null) Destroy(this);
+			if (TipSO == null)
+			{
+				Logger.LogError("[ProtipObject] - Component missing tip data.");
+				Destroy(this);
+				return;
+			}
+			if(CheckSaveStatus()) Destroy(this);
+		}
+
+		private bool CheckSaveStatus()
+		{
+			var saved = PlayerPrefs.GetString($"{TipSO.TipTitle}", "false");
+			return saved != "false";
 		}
 
 		protected virtual bool TriggerConditions(GameObject triggeredBy)
@@ -46,10 +54,10 @@ namespace Learning
 		public void TriggerTip(GameObject triggeredBy = null)
 		{
 			if(TriggerConditions(triggeredBy) == false) return;
-			ProtipManager.Instance.QueueTip(TipSO.TipData.Tip, TipSO.TipData.ShowDuration, TipSO.TipData.TipIcon, TipSO.TipData.ShowAnimation);
+			ProtipManager.Instance.QueueTip(TipSO);
 			if (triggerOnce)
 			{
-				PlayerPrefs.SetString($"{gameObject.GetComponent<PrefabTracker>().ForeverID}/{saveID.ToString()}", "true");
+				PlayerPrefs.SetString($"{TipSO.TipTitle}", "true");
 				PlayerPrefs.Save();
 				return;
 			}
@@ -65,10 +73,10 @@ namespace Learning
 				Logger.LogError("Passed ProtipSO is null. Cannot trigger tip.");
 				return;
 			}
-			ProtipManager.Instance.QueueTip(protipSo.TipData.Tip, protipSo.TipData.ShowDuration, protipSo.TipData.TipIcon, protipSo.TipData.ShowAnimation);
-			if (triggerOnce)
+			ProtipManager.Instance.QueueTip(TipSO);
+			if (triggerOnce && ProtipManager.Instance.PlayerExperienceLevel > ProtipManager.ExperienceLevel.NewToSpaceStation)
 			{
-				PlayerPrefs.SetString($"{gameObject.GetComponent<PrefabTracker>().ForeverID}/{saveID.ToString()}", "true");
+				PlayerPrefs.SetString($"{protipSo.TipTitle}", "true");
 				PlayerPrefs.Save();
 				return;
 			}

--- a/UnityProject/Assets/Scripts/Learning/UI/ProtipUI.cs
+++ b/UnityProject/Assets/Scripts/Learning/UI/ProtipUI.cs
@@ -13,6 +13,7 @@ namespace Learning
 		[SerializeField] private bool isOnRightSide = false;
 
 		private bool isShown = false;
+		private ProtipSO currentTip;
 
 		public enum SpriteAnimation
 		{
@@ -26,14 +27,14 @@ namespace Learning
 			transform.localScale = Vector3.zero;
 		}
 
-		public void ShowTip(string tip, float showDuration = 25f, Sprite img = null, SpriteAnimation animation = SpriteAnimation.ROCKING)
+		public void ShowTip(ProtipSO tip)
 		{
 			StopAllCoroutines();
 			SetPositionInTransform();
-			tipText.text = tip;
-			if (img != null) tipImage.sprite = img;
-			StartCoroutine(TipShowCooldown(showDuration));
-			switch (animation)
+			tipText.text = tip.TipData.Tip;
+			if (tip.TipData.TipIcon != null) tipImage.sprite = tip.TipData.TipIcon;
+			StartCoroutine(TipShow(tip.TipData.ShowDuration));
+			switch (tip.TipData.ShowAnimation)
 			{
 				case SpriteAnimation.ROCKING:
 					StartCoroutine(DoImageRockAnimations());
@@ -44,6 +45,7 @@ namespace Learning
 				default:
 					break;
 			}
+			currentTip = tip;
 		}
 
 		private void SetPositionInTransform()
@@ -51,11 +53,16 @@ namespace Learning
 			tipImage.transform.SetSiblingIndex(isOnRightSide ? 0 : 1);
 		}
 
-		private IEnumerator TipShowCooldown(float duration)
+		private IEnumerator TipShow(float duration)
 		{
 			LeanTween.scale(gameObject, Vector3.one, 1f).setEase(LeanTweenType.easeOutBounce);
 			isShown = true;
 			yield return WaitFor.Seconds(duration);
+			StartCoroutine(TipHide());
+		}
+
+		private IEnumerator TipHide()
+		{
 			isShown = false;
 			LeanTween.scale(gameObject, Vector3.zero, 0.7f).setEase(LeanTweenType.easeInBounce);
 			yield return WaitFor.Seconds(1.5f);
@@ -89,6 +96,14 @@ namespace Learning
 				yield return WaitFor.Seconds(rockTime);
 				halfRockDone = !halfRockDone;
 			}
+		}
+
+		public void RememberTip()
+		{
+			PlayerPrefs.SetString($"{currentTip.TipTitle}", "true");
+			PlayerPrefs.Save();
+			StopCoroutine(nameof(ShowTip));
+			StartCoroutine(TipHide());
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Learning/UI/ProtipUI.cs
+++ b/UnityProject/Assets/Scripts/Learning/UI/ProtipUI.cs
@@ -14,6 +14,7 @@ namespace Learning
 
 		private bool isShown = false;
 		private ProtipSO currentTip;
+		private const float DEFAULT_DURATION = 25f;
 
 		public enum SpriteAnimation
 		{
@@ -29,11 +30,12 @@ namespace Learning
 
 		public void ShowTip(ProtipSO tip)
 		{
+			var duration = tip.TipData.ShowDuration <= 0 ? tip.TipData.ShowDuration : DEFAULT_DURATION; //Incase whoever was setting the SO data forgot to set the duration.
 			StopAllCoroutines();
 			SetPositionInTransform();
 			tipText.text = tip.TipData.Tip;
 			if (tip.TipData.TipIcon != null) tipImage.sprite = tip.TipData.TipIcon;
-			StartCoroutine(TipShow(tip.TipData.ShowDuration));
+			StartCoroutine(TipShow(duration));
 			switch (tip.TipData.ShowAnimation)
 			{
 				case SpriteAnimation.ROCKING:

--- a/UnityProject/Assets/Scripts/Systems/Inventory/Pickupable.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/Pickupable.cs
@@ -225,6 +225,7 @@ public class Pickupable : NetworkBehaviour, IPredictedCheckedInteractable<HandAp
 		if (interactor == null) return;
 
 		PickupAnim(interactor);
+		if(CustomNetworkManager.IsServer == false) OnMoveToPlayerInventory?.Invoke(interactor);
 	}
 
 	[ClientRpc]

--- a/UnityProject/Assets/Scripts/Systems/Inventory/Pickupable.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/Pickupable.cs
@@ -170,6 +170,7 @@ public class Pickupable : NetworkBehaviour, IPredictedCheckedInteractable<HandAp
 		//Start the animation on the server and clients.
 		PickupAnim(interaction.Performer.gameObject);
 		RpcPickupAnimation(interaction.Performer.gameObject);
+		OnMoveToPlayerInventory?.Invoke(interaction.Performer);
 		yield return WaitFor.Seconds(pickupAnimSpeed);
 
 		//Make sure that the object is scaled back to it's original size.
@@ -224,7 +225,6 @@ public class Pickupable : NetworkBehaviour, IPredictedCheckedInteractable<HandAp
 		if (interactor == null) return;
 
 		PickupAnim(interactor);
-		OnMoveToPlayerInventory?.Invoke(interactor);
 	}
 
 	[ClientRpc]


### PR DESCRIPTION
Based on an idea Jack suggested in the last protips PR
Just a small PR to deal with some things that have been bugging me for a while + a fix for people not receiving protips in the editor. part of #5316.

# Changelog:

CL: [New] Protips now have the option to be manually remembered by clicking on the brain icon at the top of the protip.
CL: [Improvement] Protips that are designed to trigger once will not be automatically remembered for players with an experience level of 0 (new to ss13).
CL: [Improvement] Protips will now print an error when they're not setup correctly on Awake().
CL: [Improvement] Protips are saved a bit differently now, expect tips popping up again.
CL: [Fix] Protips trigger now again in the editor.