### PR TITLE
More scores for the score machine

### DIFF
--- a/UnityProject/Assets/Scripts/Items/ServiceBell.cs
+++ b/UnityProject/Assets/Scripts/Items/ServiceBell.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using AddressableReferences;
+using Systems.Score;
 
 namespace Objects
 {
@@ -14,6 +15,9 @@ namespace Objects
 		private AddressableAudioSource BigBellRingSound = null;
 
 		[SerializeField] private SpriteHandler BellSpriteRenderer;
+
+		private const string BIG_BELL_SCORE_ENTRY = "bigServiceBell";
+		private const int BIG_BELL_SCORE_VALUE = 1;
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
@@ -37,6 +41,9 @@ namespace Objects
 			{
 				RingSound = BigBellRingSound;
 				BellSpriteRenderer.ChangeSpriteVariant(1);
+				ScoreMachine.AddNewScoreEntry(BIG_BELL_SCORE_ENTRY, "Number of Big Service Bells",
+					ScoreMachine.ScoreType.Int, ScoreCategory.StationScore, ScoreAlignment.Weird);
+				ScoreMachine.AddToScoreInt(BIG_BELL_SCORE_VALUE ,BIG_BELL_SCORE_ENTRY);
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Objects/Nuke.cs
+++ b/UnityProject/Assets/Scripts/Objects/Nuke.cs
@@ -8,6 +8,7 @@ using AddressableReferences;
 using Antagonists;
 using HealthV2;
 using Managers;
+using Systems.Score;
 using UI.Chat_UI;
 using Random = UnityEngine.Random;
 
@@ -68,6 +69,9 @@ namespace Objects.Command
 		//Nuke code is only populated on the server
 		private int nukeCode;
 		public int NukeCode => nukeCode;
+
+		private const string ON_NUKE_SCORE_ENTRY = "nukedStation";
+		private const int ON_NUKE_SCORE_VALUE = -550000;
 
 		private void Awake()
 		{
@@ -138,6 +142,9 @@ namespace Objects.Command
 				StartCoroutine(WaitForDeath());
 				GameManager.Instance.RespawnCurrentlyAllowed = false;
 				DetonateVideo();
+				ScoreMachine.AddNewScoreEntry(ON_NUKE_SCORE_ENTRY, "Station Nuked",
+					ScoreMachine.ScoreType.Int, ScoreCategory.StationScore, ScoreAlignment.Bad);
+				ScoreMachine.AddToScoreInt(ON_NUKE_SCORE_VALUE, ON_NUKE_SCORE_ENTRY);
 			}
 			else
 			{

--- a/UnityProject/Assets/Scripts/Player/Huggable.cs
+++ b/UnityProject/Assets/Scripts/Player/Huggable.cs
@@ -1,5 +1,6 @@
 using HealthV2;
 using Messages.Server.SoundMessages;
+using Systems.Score;
 using UnityEngine;
 
 
@@ -27,7 +28,7 @@ namespace Player
 
     	[SerializeField] private ItemTrait tailTrait;
 
-    	public bool WillInteract(HandApply interaction, NetworkSide side)
+        public bool WillInteract(HandApply interaction, NetworkSide side)
     	{
     		if (!DefaultWillInteract.Default(interaction, side)) return false;
     		if (interaction.Intent != Intent.Help) return false;
@@ -128,6 +129,7 @@ namespace Player
     				$"<color=#be2596>{performerName} pulls on {targetName}'s tail!</color>");
     			Chat.AddExamineMsgFromServer(interaction.TargetObject, $"<color=#be2596>{performerName} hugs you.</color>");
     			Judgement(performerLHB);
+                ScoreMachine.AddToScoreInt(RoundEndScoreBuilder.TAIL_SCORE_VALUE, RoundEndScoreBuilder.COMMON_TAIL_SCORE_ENTRY);
     			return true;
     		}
     		return false;
@@ -138,6 +140,7 @@ namespace Player
     		if(interaction.TargetBodyPart == BodyPartType.Groin && PullTail()) return;
     		Chat.AddActionMsgToChat(interaction.Performer, $"You hug {targetName}.", $"{performerName} hugs {targetName}.");
     		Chat.AddExamineMsgFromServer(interaction.TargetObject, $"{performerName} hugs you.");
+            ScoreMachine.AddToScoreInt(RoundEndScoreBuilder.HUG_SCORE_VALUE, RoundEndScoreBuilder.COMMON_HUG_SCORE_ENTRY);
     	}
     }
 }

--- a/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.Data.cs
+++ b/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.Data.cs
@@ -20,5 +20,6 @@ namespace Systems.Score
 		public static string COMMON_SCORE_EXPLOSION = "explosions";
 		public static string COMMON_SCORE_CLOWNABUSE = "clownBeaten";
 		public static int DEAD_CREW_SCORE = -250;
+		public static int HURT_CREW_MINIMUM_SCORE = 50;
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.Data.cs
+++ b/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.Data.cs
@@ -23,7 +23,7 @@ namespace Systems.Score
 		public static string COMMON_TAIL_SCORE_ENTRY = "tailsPulled";
 		public static int HUG_SCORE_VALUE = 2;
 		public static int TAIL_SCORE_VALUE = -2;
-		public static int DEAD_CREW_SCORE = -250;
-		public static int HURT_CREW_MINIMUM_SCORE = 50;
+		private static int DEAD_CREW_SCORE = -250;
+		private static int HURT_CREW_MINIMUM_SCORE = 50;
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.Data.cs
+++ b/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.Data.cs
@@ -21,6 +21,7 @@ namespace Systems.Score
 		public static string COMMON_SCORE_CLOWNABUSE = "clownBeaten";
 		public static string COMMON_HUG_SCORE_ENTRY = "hugsGiven";
 		public static string COMMON_TAIL_SCORE_ENTRY = "tailsPulled";
+		public static string COMMON_DOOR_ELECTRIC_ENTRY = "electricDoors";
 		public static int HUG_SCORE_VALUE = 2;
 		public static int TAIL_SCORE_VALUE = -2;
 		private static int DEAD_CREW_SCORE = -250;

--- a/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.Data.cs
+++ b/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.Data.cs
@@ -19,6 +19,10 @@ namespace Systems.Score
 		public static string COMMON_SCORE_FOODEATEN = "foodeaten";
 		public static string COMMON_SCORE_EXPLOSION = "explosions";
 		public static string COMMON_SCORE_CLOWNABUSE = "clownBeaten";
+		public static string COMMON_HUG_SCORE_ENTRY = "hugsGiven";
+		public static string COMMON_TAIL_SCORE_ENTRY = "tailsPulled";
+		public static int HUG_SCORE_VALUE = 2;
+		public static int TAIL_SCORE_VALUE = -2;
 		public static int DEAD_CREW_SCORE = -250;
 		public static int HURT_CREW_MINIMUM_SCORE = 50;
 	}

--- a/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.Data.cs
+++ b/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.Data.cs
@@ -11,20 +11,20 @@ namespace Systems.Score
 		[SerializeField] private int negativeModifer = -5;
 		[SerializeField] private Occupation captainOccupation;
 
-		public static string COMMON_SCORE_LABORPOINTS = "laborPoints";
-		public static string COMMON_SCORE_RANDOMEVENTSTRIGGERED = "randomEventsTriggered";
-		public static string COMMON_SCORE_FOODMADE = "foodmade";
-		public static string COMMON_SCORE_HOSTILENPCDEAD = "hostileNPCdead";
-		public static string COMMON_SCORE_HEALING = "healing";
-		public static string COMMON_SCORE_FOODEATEN = "foodeaten";
-		public static string COMMON_SCORE_EXPLOSION = "explosions";
-		public static string COMMON_SCORE_CLOWNABUSE = "clownBeaten";
-		public static string COMMON_HUG_SCORE_ENTRY = "hugsGiven";
-		public static string COMMON_TAIL_SCORE_ENTRY = "tailsPulled";
-		public static string COMMON_DOOR_ELECTRIC_ENTRY = "electricDoors";
-		public static int HUG_SCORE_VALUE = 2;
-		public static int TAIL_SCORE_VALUE = -2;
-		private static int DEAD_CREW_SCORE = -250;
-		private static int HURT_CREW_MINIMUM_SCORE = 50;
+		public const string COMMON_SCORE_LABORPOINTS = "laborPoints";
+		public const string COMMON_SCORE_RANDOMEVENTSTRIGGERED = "randomEventsTriggered";
+		public const string COMMON_SCORE_FOODMADE = "foodmade";
+		public const string COMMON_SCORE_HOSTILENPCDEAD = "hostileNPCdead";
+		public const string COMMON_SCORE_HEALING = "healing";
+		public const string COMMON_SCORE_FOODEATEN = "foodeaten";
+		public const string COMMON_SCORE_EXPLOSION = "explosions";
+		public const string COMMON_SCORE_CLOWNABUSE = "clownBeaten";
+		public const string COMMON_HUG_SCORE_ENTRY = "hugsGiven";
+		public const string COMMON_TAIL_SCORE_ENTRY = "tailsPulled";
+		public const string COMMON_DOOR_ELECTRIC_ENTRY = "electricDoors";
+		public const int HUG_SCORE_VALUE = 2;
+		public const int TAIL_SCORE_VALUE = -2;
+		private const int DEAD_CREW_SCORE = -250;
+		private const int HURT_CREW_MINIMUM_SCORE = 50;
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.cs
+++ b/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.cs
@@ -5,6 +5,9 @@ using Shared.Managers;
 
 namespace Systems.Score
 {
+	/// <summary>
+	/// Here is where all common entries are initialised once and where we check for extra stuff when the round ends.
+	/// </summary>
 	public partial class RoundEndScoreBuilder : SingletonManager<RoundEndScoreBuilder>
 	{
 		public override void Start()
@@ -21,7 +24,9 @@ namespace Systems.Score
 			ScoreMachine.AddNewScoreEntry(COMMON_SCORE_FOODMADE, "Meals Prepared", ScoreMachine.ScoreType.Int, ScoreCategory.StationScore, ScoreAlignment.Good);
 			ScoreMachine.AddNewScoreEntry(COMMON_SCORE_HOSTILENPCDEAD, "Hostile NPCs dead", ScoreMachine.ScoreType.Int, ScoreCategory.StationScore, ScoreAlignment.Good);
 			ScoreMachine.AddNewScoreEntry(COMMON_SCORE_HEALING, "Healing Done", ScoreMachine.ScoreType.Int, ScoreCategory.StationScore, ScoreAlignment.Good);
+			ScoreMachine.AddNewScoreEntry(COMMON_HUG_SCORE_ENTRY, "Hugs Given", ScoreMachine.ScoreType.Int, ScoreCategory.StationScore, ScoreAlignment.Good);
 			ScoreMachine.AddNewScoreEntry(COMMON_SCORE_FOODEATEN, "Food Eaten", ScoreMachine.ScoreType.Int, ScoreCategory.StationScore, ScoreAlignment.Weird);
+			ScoreMachine.AddNewScoreEntry(COMMON_TAIL_SCORE_ENTRY, "Tails Pulled", ScoreMachine.ScoreType.Int, ScoreCategory.StationScore, ScoreAlignment.Weird);
 			ScoreMachine.AddNewScoreEntry(COMMON_SCORE_EXPLOSION, "Number of explosions this round", ScoreMachine.ScoreType.Int, ScoreCategory.StationScore, ScoreAlignment.Weird);
 			ScoreMachine.AddNewScoreEntry(COMMON_SCORE_CLOWNABUSE, "Clown Abused", ScoreMachine.ScoreType.Int, ScoreCategory.StationScore, ScoreAlignment.Bad);
 		}
@@ -45,6 +50,7 @@ namespace Systems.Score
 			if (PlayerList.Instance.AllPlayers.Count > 2)
 			{
 				ScoreMachine.AddNewScoreEntry("deadCrew", "Dead Crew", ScoreMachine.ScoreType.Int, ScoreCategory.StationScore, ScoreAlignment.Bad);
+				//We can get away with using expensive LINQ methods here at round end.
 				foreach (var player in PlayerList.Instance.AllPlayers.Where(player => player.Mind != null && player.Script != null))
 				{
 					ScoreMachine.AddToScoreInt(DEAD_CREW_SCORE * negativeModifer, "deadCrew");
@@ -79,6 +85,11 @@ namespace Systems.Score
 
 			List<ScoreEntry> stationScoreEntries = new List<ScoreEntry>();
 			List<ScoreEntry> antagScoreEntries = new List<ScoreEntry>();
+
+			//Removes all int scores from the weird category with a score of 0
+			stationScoreEntries.RemoveAll(x => x.Category == ScoreCategory.StationScore
+			                                   && x.Alignment == ScoreAlignment.Weird
+			                                   && x is ScoreEntryInt { Score: 0 });
 
 			var finalStationScore = 0;
 			var finalAntagScore = 0;

--- a/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.cs
+++ b/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.cs
@@ -87,9 +87,11 @@ namespace Systems.Score
 			var numberOfDoors = 0;
 			foreach (var door in MatrixManager.MainStationMatrix.Objects.GetComponentsInChildren<DoorMasterController>())
 			{
-				var module = door.GetComponentInChildren<ElectrifiedDoorModule>();
-				if (module == null) continue;
-				if (module.IsElectrified) numberOfDoors++;
+				foreach (var module in door.ModulesList)
+				{
+					if(module is ElectrifiedDoorModule c == false) continue;
+					if (c.IsElectrified) numberOfDoors++;
+				}
 			}
 
 			if (numberOfDoors == 0) return;

--- a/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.cs
+++ b/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.cs
@@ -89,8 +89,7 @@ namespace Systems.Score
 			{
 				foreach (var module in door.ModulesList)
 				{
-					if(module is ElectrifiedDoorModule c == false) continue;
-					if (c.IsElectrified) numberOfDoors++;
+					if (module is ElectrifiedDoorModule { IsElectrified: true }) numberOfDoors++;
 				}
 			}
 

--- a/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.cs
+++ b/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.cs
@@ -51,14 +51,22 @@ namespace Systems.Score
 				}
 			}
 			//Who's the crew member with the worst overall health?
+			FindLowestHealthCrew();
+		}
+
+		private static void FindLowestHealthCrew()
+		{
 			var lowestHealthCrewMemberNumber = 200f;
 			var lowestHealthCrewMemberName = "";
 			foreach (var alivePlayer in PlayerList.Instance.GetAlivePlayers())
 			{
+				if (alivePlayer.Script == null || alivePlayer.Script.playerHealth == null) continue;
+				if (alivePlayer.Script.playerHealth.OverallHealth > HURT_CREW_MINIMUM_SCORE) continue;
 				if (alivePlayer.Script.playerHealth.OverallHealth >= lowestHealthCrewMemberNumber) continue;
 				lowestHealthCrewMemberNumber = alivePlayer.Script.playerHealth.OverallHealth;
 				lowestHealthCrewMemberName = alivePlayer.Script.playerName;
 			}
+			if(string.IsNullOrEmpty(lowestHealthCrewMemberName)) return;
 			var lowestHealthWinner = $"{lowestHealthCrewMemberName} - {lowestHealthCrewMemberNumber}HP";
 			ScoreMachine.AddNewScoreEntry("worstBatteredCrewMemeber", "Crewmember with the lowest health", ScoreMachine.ScoreType.String, ScoreCategory.StationScore, ScoreAlignment.Bad);
 			ScoreMachine.AddToScoreString(lowestHealthWinner, "worstBatteredCrewMemeber");

--- a/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.cs
+++ b/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
+using Doors;
+using Doors.Modules;
 using Managers;
 using Shared.Managers;
 
@@ -58,6 +60,8 @@ namespace Systems.Score
 			}
 			//Who's the crew member with the worst overall health?
 			FindLowestHealthCrew();
+			//Are there any electrified doors on the station?
+			FindHarmfulDoors();
 		}
 
 		private static void FindLowestHealthCrew()
@@ -78,6 +82,22 @@ namespace Systems.Score
 			ScoreMachine.AddToScoreString(lowestHealthWinner, "worstBatteredCrewMemeber");
 		}
 
+		private static void FindHarmfulDoors()
+		{
+			var numberOfDoors = 0;
+			foreach (var door in MatrixManager.MainStationMatrix.Objects.GetComponentsInChildren<DoorMasterController>())
+			{
+				var module = door.GetComponentInChildren<ElectrifiedDoorModule>();
+				if (module == null) continue;
+				if (module.IsElectrified) numberOfDoors++;
+			}
+
+			if (numberOfDoors == 0) return;
+			ScoreMachine.AddNewScoreEntry(COMMON_DOOR_ELECTRIC_ENTRY, "Doors Electrified",
+				ScoreMachine.ScoreType.Int, ScoreCategory.StationScore, ScoreAlignment.Weird);
+			ScoreMachine.AddToScoreInt(numberOfDoors, COMMON_DOOR_ELECTRIC_ENTRY);
+		}
+
 		public void CalculateScoresAndShow()
 		{
 			if(CustomNetworkManager.IsServer == false) return;
@@ -85,11 +105,6 @@ namespace Systems.Score
 
 			List<ScoreEntry> stationScoreEntries = new List<ScoreEntry>();
 			List<ScoreEntry> antagScoreEntries = new List<ScoreEntry>();
-
-			//Removes all int scores from the weird category with a score of 0
-			stationScoreEntries.RemoveAll(x => x.Category == ScoreCategory.StationScore
-			                                   && x.Alignment == ScoreAlignment.Weird
-			                                   && x is ScoreEntryInt { Score: 0 });
 
 			var finalStationScore = 0;
 			var finalAntagScore = 0;


### PR DESCRIPTION
# Changelog:

CL: [New] Station getting nuked has a massive score penalty now.
CL: [New] Hugs are now recorded in the score machine.
CL: [New] Electrified doors from an AI are now recorded in the score machine.
CL: [New] When the big service bell Easter egg triggers, it will show up in the round end score screen.
CL: [Improvement] "Most hurt crewmember" score will only appear if there is a crew member below 50 overall health.

