### PR TITLE
Highlight changes

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/GlassSheet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/GlassSheet.prefab
@@ -24,6 +24,44 @@ PrefabInstance:
       propertyPath: foreverID
       value: 66a5287d0bf216847a2f4fe34228a0cf
       objectReference: {fileID: 0}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 765921f2297194049b3f466f57bd6414,
+        type: 2}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: ca179e5fd5789594bafd97c262903703,
+        type: 2}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 3adf8013b76050746a5dac13d7bcd70e,
+        type: 2}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].OverAmount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].OverAmount
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].OverAmount
+      value: 34
+      objectReference: {fileID: 0}
     - target: {fileID: 8340835308478918493, guid: b56fec0300832ce48ade0ddf2e577ee7,
         type: 3}
       propertyPath: exportCost

--- a/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/MetalRods.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/MetalRods.prefab
@@ -12,6 +12,66 @@ PrefabInstance:
       propertyPath: maxAmount
       value: 50
       objectReference: {fileID: 0}
+    - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: stackSprites.Array.size
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 49f578709c4c65c4eb705af98a116726,
+        type: 2}
+    - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: bb19676ff17c55141a29596978671f52,
+        type: 2}
+    - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 79614046afd28b747b6c269360adf6be,
+        type: 2}
+    - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: stackSprites.Array.data[3].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: ab0937a821f439f46b0ecdd52face859,
+        type: 2}
+    - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: stackSprites.Array.data[4].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: b6a697866fac9e343b2a82648560327f,
+        type: 2}
+    - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].OverAmount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].OverAmount
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].OverAmount
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: stackSprites.Array.data[3].OverAmount
+      value: 34
+      objectReference: {fileID: 0}
+    - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: stackSprites.Array.data[4].OverAmount
+      value: 45
+      objectReference: {fileID: 0}
     - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: m_RootOrder

--- a/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/MetalSheet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/MetalSheet.prefab
@@ -55,12 +55,12 @@ PrefabInstance:
     - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
         type: 3}
       propertyPath: stackSprites.Array.data[1].OverAmount
-      value: 3
+      value: 17
       objectReference: {fileID: 0}
     - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
         type: 3}
       propertyPath: stackSprites.Array.data[2].OverAmount
-      value: 51
+      value: 34
       objectReference: {fileID: 0}
     - target: {fileID: 8340835308478918493, guid: b56fec0300832ce48ade0ddf2e577ee7,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/MineralSheets/GoldBar.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/MineralSheets/GoldBar.prefab
@@ -153,6 +153,44 @@ PrefabInstance:
       propertyPath: itemSprites.RightHand.Texture
       value: 
       objectReference: {fileID: 2800000, guid: 81c33674da4dde3459a17aa2d2b07b54, type: 3}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 324d2cc0777c8204f859d8701a475683,
+        type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: f184491a3a6642943b01e8f7785f62a7,
+        type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 1322990e2be6cee438efa5b1fedaec18,
+        type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].OverAmount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].OverAmount
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].OverAmount
+      value: 34
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8a023982b9ee4fd40b87f69c23492dd6, type: 3}
 --- !u!1 &2044367008419646583 stripped

--- a/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/MineralSheets/MetallicHydrogenicBar.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/MineralSheets/MetallicHydrogenicBar.prefab
@@ -145,5 +145,43 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 37d2662a2c345b04e8b6ed6af550563f,
         type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 377ff9cb420d3f8488d4ab45a836c8cb,
+        type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 59fb2cfffa799f84fadb2017670bf616,
+        type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: f5cc3fb347693164ea0e9cd83e4f12df,
+        type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].OverAmount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].OverAmount
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].OverAmount
+      value: 34
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8a023982b9ee4fd40b87f69c23492dd6, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/MineralSheets/PlastitaniumSheet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/MineralSheets/PlastitaniumSheet.prefab
@@ -147,5 +147,43 @@ PrefabInstance:
       propertyPath: itemSprites.RightHand.Texture
       value: 
       objectReference: {fileID: 2800000, guid: 887a8fbb13e8d4446a0783d3b65db3e8, type: 3}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 00f857575b6b86144a0d7c672839fdb0,
+        type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 0253202f2db6ee34b921acb2b0428df8,
+        type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 26f284681b2f9f647b83b5d52c505374,
+        type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].OverAmount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].OverAmount
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].OverAmount
+      value: 34
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8a023982b9ee4fd40b87f69c23492dd6, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/MineralSheets/SandstoneBrick.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/MineralSheets/SandstoneBrick.prefab
@@ -136,5 +136,43 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: ac806947043a5a44d9492f7a0498fe5b,
         type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: b9ff912ebcd44a34b949944b59bc1771,
+        type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 48d5ba6f011d3d54c9151714988fb448,
+        type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: d3f8f57c768ab754cbf42780b95059d0,
+        type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].OverAmount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].OverAmount
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].OverAmount
+      value: 34
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8a023982b9ee4fd40b87f69c23492dd6, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/MineralSheets/SilverBar.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/MineralSheets/SilverBar.prefab
@@ -154,6 +154,44 @@ PrefabInstance:
       propertyPath: itemSprites.RightHand.Texture
       value: 
       objectReference: {fileID: 2800000, guid: 066cf796f95f89a46aca5da3c8902570, type: 3}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: dc5e22848cb6c8943892c84e7a0754f5,
+        type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: b0f7c1da36b371f4d9da7d9d113ff1bf,
+        type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 1053e02368b288647b3102f18d5d5f0c,
+        type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].OverAmount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].OverAmount
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].OverAmount
+      value: 34
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8a023982b9ee4fd40b87f69c23492dd6, type: 3}
 --- !u!1 &3133677340243276592 stripped

--- a/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/MineralSheets/SnowBlock.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/MineralSheets/SnowBlock.prefab
@@ -130,6 +130,44 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 09fc4c0277f0f3f48a1f240474bdd0dd,
         type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 6d0b18e49d7ba234daf28929a7c95dab,
+        type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 8fd11a9a3c9c79b4c9f02b2d67ddda58,
+        type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 324f87578f63dd34086d666e95f87c43,
+        type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].OverAmount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].OverAmount
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].OverAmount
+      value: 34
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8a023982b9ee4fd40b87f69c23492dd6, type: 3}
 --- !u!1 &7047077720590262593 stripped

--- a/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/MineralSheets/SolidPlasmaSheet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/MineralSheets/SolidPlasmaSheet.prefab
@@ -225,12 +225,12 @@ PrefabInstance:
     - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
         type: 3}
       propertyPath: stackSprites.Array.data[1].OverAmount
-      value: 3
+      value: 17
       objectReference: {fileID: 0}
     - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
         type: 3}
       propertyPath: stackSprites.Array.data[2].OverAmount
-      value: 51
+      value: 34
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8a023982b9ee4fd40b87f69c23492dd6, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/MineralSheets/TitaniumSheet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/MineralSheets/TitaniumSheet.prefab
@@ -137,5 +137,43 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: d0b31b5b76d5f904ca42b428ebc09e6d,
         type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: b7438e2fccafe154e96e4910973ab8aa,
+        type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 7e65ac6bb6516734aa5f951a4b27b942,
+        type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 6a13499b865db814795bc64dea9bdbe7,
+        type: 2}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].OverAmount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].OverAmount
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 8026742801534802552, guid: 8a023982b9ee4fd40b87f69c23492dd6,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].OverAmount
+      value: 34
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8a023982b9ee4fd40b87f69c23492dd6, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/PlasmaGlassSheet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/PlasmaGlassSheet.prefab
@@ -33,19 +33,19 @@ PrefabInstance:
         type: 3}
       propertyPath: stackSprites.Array.data[0].SpriteSO
       value: 
-      objectReference: {fileID: 11400000, guid: 60d48ace82878ad49a58a0d58bffba61,
+      objectReference: {fileID: 11400000, guid: 4186ff50cbdbff241a9f20e27af524ff,
         type: 2}
     - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
         type: 3}
       propertyPath: stackSprites.Array.data[1].SpriteSO
       value: 
-      objectReference: {fileID: 11400000, guid: 1f7368cf5aab61e489a768161ee811d0,
+      objectReference: {fileID: 11400000, guid: 4ff0e5c2168333e4794f27b80d290824,
         type: 2}
     - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
         type: 3}
       propertyPath: stackSprites.Array.data[2].SpriteSO
       value: 
-      objectReference: {fileID: 11400000, guid: dfec86c6d5a66eb4b8996956992d949e,
+      objectReference: {fileID: 11400000, guid: 61bfd30157001804e811392b625be297,
         type: 2}
     - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
         type: 3}
@@ -55,12 +55,12 @@ PrefabInstance:
     - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
         type: 3}
       propertyPath: stackSprites.Array.data[1].OverAmount
-      value: 3
+      value: 17
       objectReference: {fileID: 0}
     - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
         type: 3}
       propertyPath: stackSprites.Array.data[2].OverAmount
-      value: 51
+      value: 34
       objectReference: {fileID: 0}
     - target: {fileID: 8340835308478918493, guid: b56fec0300832ce48ade0ddf2e577ee7,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/ReinforcedGlassSheet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/ReinforcedGlassSheet.prefab
@@ -24,6 +24,44 @@ PrefabInstance:
       propertyPath: foreverID
       value: d2f2400aac0da54468da76680579c29b
       objectReference: {fileID: 0}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: c30d2c6fb84cb9543b61b0d6021ab012,
+        type: 2}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 4cacf882962bf274ea032ded3b3b4ffc,
+        type: 2}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 626238b231d78f049a048312af5f48d6,
+        type: 2}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].OverAmount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].OverAmount
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].OverAmount
+      value: 34
+      objectReference: {fileID: 0}
     - target: {fileID: 8340835308478918493, guid: b56fec0300832ce48ade0ddf2e577ee7,
         type: 3}
       propertyPath: exportCost

--- a/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/ReinforcedPlasmaGlassSheet.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Construction/Materials/Resources/ReinforcedPlasmaGlassSheet.prefab
@@ -24,6 +24,44 @@ PrefabInstance:
       propertyPath: foreverID
       value: b6a0d928019a24a4f9cee04a1d06b3b1
       objectReference: {fileID: 0}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 60d48ace82878ad49a58a0d58bffba61,
+        type: 2}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 1f7368cf5aab61e489a768161ee811d0,
+        type: 2}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].SpriteSO
+      value: 
+      objectReference: {fileID: 11400000, guid: dfec86c6d5a66eb4b8996956992d949e,
+        type: 2}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[0].OverAmount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[1].OverAmount
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 5200803135255930768, guid: b56fec0300832ce48ade0ddf2e577ee7,
+        type: 3}
+      propertyPath: stackSprites.Array.data[2].OverAmount
+      value: 34
+      objectReference: {fileID: 0}
     - target: {fileID: 8340835308478918493, guid: b56fec0300832ce48ade0ddf2e577ee7,
         type: 3}
       propertyPath: exportCost

--- a/UnityProject/Assets/Prefabs/Items/Research/ArtifactsDetector.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Research/ArtifactsDetector.prefab
@@ -69,7 +69,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 5913341457214842545, guid: 1b33fd6f08ad5314abbf8561f1d98ec2,
+      objectReference: {fileID: -446112788531309089, guid: 1b33fd6f08ad5314abbf8561f1d98ec2,
         type: 3}
     - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Research/ArtifactsDetector.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Research/ArtifactsDetector.prefab
@@ -69,7 +69,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: -446112788531309089, guid: 1b33fd6f08ad5314abbf8561f1d98ec2,
+      objectReference: {fileID: 5913341457214842545, guid: 1b33fd6f08ad5314abbf8561f1d98ec2,
         type: 3}
     - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
@@ -85,6 +85,11 @@ PrefabInstance:
         type: 3}
       propertyPath: initialName
       value: Alden-Saraspova counter
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialSize
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}

--- a/UnityProject/Assets/Scripts/Items/Others/RandomItemSpot.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/RandomItemSpot.cs
@@ -74,7 +74,7 @@ namespace Items
 			{
 				if (this.GetComponent<RuntimeSpawned>() != null)
 				{
-					Destroy(this.gameObject);
+					_ = Despawn.ServerSingle(gameObject);
 					return;
 				}
 

--- a/UnityProject/Assets/Scripts/Managers/PlayerList.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.cs
@@ -194,6 +194,11 @@ public partial class PlayerList : NetworkBehaviour
 			return player;
 		}
 
+		if (loggedOff.Contains(player))
+		{
+			loggedOff.Remove(player);
+		}
+
 		if (loggedIn.Contains(player))
 		{
 			return player;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
@@ -200,6 +200,7 @@ namespace Systems.Atmospherics
 
 				//Quicker to get all RegisterTiles and grab the cached PushPull component from it than to get it manually using Get<>
 				if (registerTile.ObjectPhysics.HasComponent == false) continue;
+				if (registerTile.ObjectPhysics.Component.Intangible) continue;
 				var pushable = registerTile.ObjectPhysics.Component;
 
 				float correctedForce = (windyNode.WindForce ) / (int) pushable.GetSize();


### PR DESCRIPTION
### Changelog:

CL: [Improvement] highlights should now update when sprite changes happen
CL: [Improvement] Wind Can't push intangible things now
CL: [Improvement] Makes it so Artefact scanner can fit in pockets 
CL: [Fix] Fixed ore generator spawning on non-mineable tiles
CL: [Fix] Fixed ore spawning Multiple times on one tile
CL: [Fix] Fixed randomm generators being visible on Lavaland 
CL: [Fix] Fixes multiple player info entries on admin UI
CL: [Improvement] Updates stacking textures now corresponds with crusty Byond values 17 = mid stack 34 = full stack sprites