### PR TITLE
Alden Saraspova size Medium -> Small

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Research/ArtifactsDetector.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Research/ArtifactsDetector.prefab
@@ -88,6 +88,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
+      propertyPath: initialSize
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
       propertyPath: initialDescription
       value: Aids in triangulation of exotic particles.
       objectReference: {fileID: 0}


### PR DESCRIPTION
### Purpose
Fixes #9240 

### Changelog:
CL: [Fix] Give the Alden-Saraspova detector a size, rather than the default (medium) which doesn't fit in your pocket.