### PR TITLE
Protip fixes and improvements for health state

### DIFF
--- a/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
+++ b/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
@@ -1465,34 +1465,34 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac47bea17421462d9123cc255b61a475, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  TipSO: {fileID: 0}
+  TipSO: {fileID: 11400000, guid: 3b38af0357f6fa44399a8b14f539a581, type: 2}
   triggerOnce: 1
   showEvenAfterDeath: 1
   tipCooldown: 200
-  BleedingVeryLowEvent: {fileID: 11400000, guid: 9840743232461594d952b82560fe1eeb,
+  bleedingVeryLowEvent: {fileID: 11400000, guid: 9840743232461594d952b82560fe1eeb,
     type: 2}
-  BleedingLowEvent: {fileID: 11400000, guid: 674dd66c6a6ff5f40a52d8b8b9e742bf, type: 2}
-  BleedingHighEvent: {fileID: 11400000, guid: 15b39b0191818c04cb098b5ff0848cb8, type: 2}
-  BleedingDanagerEvent: {fileID: 11400000, guid: 1160df88f3c00344fac0d74d818b3907,
+  bleedingLowEvent: {fileID: 11400000, guid: 674dd66c6a6ff5f40a52d8b8b9e742bf, type: 2}
+  bleedingHighEvent: {fileID: 11400000, guid: 15b39b0191818c04cb098b5ff0848cb8, type: 2}
+  bleedingDanagerEvent: {fileID: 11400000, guid: 1160df88f3c00344fac0d74d818b3907,
     type: 2}
-  HungerEvent: {fileID: 11400000, guid: 2849afa5708d7b445b7eccab05c2826c, type: 2}
-  StarvingEvent: {fileID: 11400000, guid: f83cd98cc385fbc4ca7371e70e9f9604, type: 2}
-  FatsoEvent: {fileID: 11400000, guid: fbc620038f7c4204cbed8c766fabd086, type: 2}
-  CritHealthEvent: {fileID: 11400000, guid: 97a30d051863be242a2d5435c1879dfb, type: 2}
-  SoftHealthEvent: {fileID: 11400000, guid: f5f80aa9222c534469ed4b48eb14968e, type: 2}
-  DeathlHealthEvent: {fileID: 11400000, guid: bbaf9123b7a31974ca6fc120eb465d86, type: 2}
-  FireStacksEvent: {fileID: 11400000, guid: 343cbe9dec8d8fc41898fceda8c13083, type: 2}
-  SuffuicationEvent: {fileID: 11400000, guid: 963f6a6de169c484bad0d08fbdf230ce, type: 2}
-  ToxinEvent: {fileID: 11400000, guid: 3b38af0357f6fa44399a8b14f539a581, type: 2}
-  TemperatureColdEvent: {fileID: 11400000, guid: 95ef98c8f385f7b4382a1d283224cfee,
+  hungerEvent: {fileID: 11400000, guid: 2849afa5708d7b445b7eccab05c2826c, type: 2}
+  starvingEvent: {fileID: 11400000, guid: f83cd98cc385fbc4ca7371e70e9f9604, type: 2}
+  fatsoEvent: {fileID: 11400000, guid: fbc620038f7c4204cbed8c766fabd086, type: 2}
+  critHealthEvent: {fileID: 11400000, guid: 97a30d051863be242a2d5435c1879dfb, type: 2}
+  softHealthEvent: {fileID: 11400000, guid: f5f80aa9222c534469ed4b48eb14968e, type: 2}
+  deathlHealthEvent: {fileID: 11400000, guid: bbaf9123b7a31974ca6fc120eb465d86, type: 2}
+  fireStacksEvent: {fileID: 11400000, guid: 343cbe9dec8d8fc41898fceda8c13083, type: 2}
+  suffuicationEvent: {fileID: 11400000, guid: 963f6a6de169c484bad0d08fbdf230ce, type: 2}
+  toxinEvent: {fileID: 11400000, guid: 3b38af0357f6fa44399a8b14f539a581, type: 2}
+  temperatureColdEvent: {fileID: 11400000, guid: 95ef98c8f385f7b4382a1d283224cfee,
     type: 2}
-  TemperatureHotEvent: {fileID: 11400000, guid: 76b1fee33a8e5334aafd5f6c95d3aedd,
+  temperatureHotEvent: {fileID: 11400000, guid: 76b1fee33a8e5334aafd5f6c95d3aedd,
     type: 2}
-  UnconsciousEvent: {fileID: 11400000, guid: c56aa3f2b478ff94e9b78957d75fd3e7, type: 2}
-  BarelyConsciousEvent: {fileID: 11400000, guid: 95ca26ead48bff34b9ca3f710b04d1a9,
+  unconsciousEvent: {fileID: 11400000, guid: c56aa3f2b478ff94e9b78957d75fd3e7, type: 2}
+  barelyConsciousEvent: {fileID: 11400000, guid: 95ca26ead48bff34b9ca3f710b04d1a9,
     type: 2}
-  PressureHighEvent: {fileID: 11400000, guid: 4b51b193b167eec4ea3108add75e852a, type: 2}
-  PressureLowEvent: {fileID: 11400000, guid: 03a097741db78a648a4cb07a947ddeff, type: 2}
+  pressureHighEvent: {fileID: 11400000, guid: 4b51b193b167eec4ea3108add75e852a, type: 2}
+  pressureLowEvent: {fileID: 11400000, guid: 03a097741db78a648a4cb07a947ddeff, type: 2}
 --- !u!1 &1147423205297840
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/UI/Learning/ProTipManager.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Learning/ProTipManager.prefab
@@ -382,6 +382,26 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2320792367323772480, guid: f9ef294f20eae074680f17933c2b77f8,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 46.471
+      objectReference: {fileID: 0}
+    - target: {fileID: 2320792367323772480, guid: f9ef294f20eae074680f17933c2b77f8,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 45.879
+      objectReference: {fileID: 0}
+    - target: {fileID: 2320792367323772480, guid: f9ef294f20eae074680f17933c2b77f8,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 772.06
+      objectReference: {fileID: 0}
+    - target: {fileID: 2320792367323772480, guid: f9ef294f20eae074680f17933c2b77f8,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -26.488
+      objectReference: {fileID: 0}
     - target: {fileID: 5337936773495964423, guid: f9ef294f20eae074680f17933c2b77f8,
         type: 3}
       propertyPath: m_AnchorMax.y

--- a/UnityProject/Assets/ScriptableObjects/Learning/ProtipSOs/HealthTips/BarelyAwakeTip.asset
+++ b/UnityProject/Assets/ScriptableObjects/Learning/ProtipSOs/HealthTips/BarelyAwakeTip.asset
@@ -19,4 +19,4 @@ MonoBehaviour:
     TipIcon: {fileID: 21300000, guid: d53d1d1f14a8a354ea3a016a53f55fa5, type: 3}
     ShowAnimation: 1
     MinimumExperienceLevelToTrigger: 0
-    ShowDuration: 7
+    ShowDuration: 5

--- a/UnityProject/Assets/ScriptableObjects/Learning/ProtipSOs/HealthTips/BleedingDangerTip.asset
+++ b/UnityProject/Assets/ScriptableObjects/Learning/ProtipSOs/HealthTips/BleedingDangerTip.asset
@@ -19,4 +19,4 @@ MonoBehaviour:
     TipIcon: {fileID: 21300000, guid: 5fca9a70bcc4b9b43840756bf9f489f1, type: 3}
     ShowAnimation: 1
     MinimumExperienceLevelToTrigger: 2
-    ShowDuration: 30
+    ShowDuration: 8

--- a/UnityProject/Assets/ScriptableObjects/Learning/ProtipSOs/HealthTips/BleedingLowTip.asset
+++ b/UnityProject/Assets/ScriptableObjects/Learning/ProtipSOs/HealthTips/BleedingLowTip.asset
@@ -19,4 +19,4 @@ MonoBehaviour:
     TipIcon: {fileID: 21300000, guid: 6f13e5e5ba62ae2449f3d869c4947bba, type: 3}
     ShowAnimation: 2
     MinimumExperienceLevelToTrigger: 2
-    ShowDuration: 8
+    ShowDuration: 6

--- a/UnityProject/Assets/ScriptableObjects/Learning/ProtipSOs/HealthTips/BleedingVeryLowTip.asset
+++ b/UnityProject/Assets/ScriptableObjects/Learning/ProtipSOs/HealthTips/BleedingVeryLowTip.asset
@@ -19,4 +19,4 @@ MonoBehaviour:
     TipIcon: {fileID: 21300000, guid: 6f13e5e5ba62ae2449f3d869c4947bba, type: 3}
     ShowAnimation: 2
     MinimumExperienceLevelToTrigger: 2
-    ShowDuration: 5
+    ShowDuration: 6

--- a/UnityProject/Assets/ScriptableObjects/Learning/ProtipSOs/HealthTips/HungerTip.asset
+++ b/UnityProject/Assets/ScriptableObjects/Learning/ProtipSOs/HealthTips/HungerTip.asset
@@ -19,4 +19,4 @@ MonoBehaviour:
     TipIcon: {fileID: 21300000, guid: a3b3f97efc254004f9d8301efdad5d46, type: 3}
     ShowAnimation: 2
     MinimumExperienceLevelToTrigger: 0
-    ShowDuration: 0
+    ShowDuration: 5

--- a/UnityProject/Assets/ScriptableObjects/Learning/ProtipSOs/HealthTips/UnconincousTip.asset
+++ b/UnityProject/Assets/ScriptableObjects/Learning/ProtipSOs/HealthTips/UnconincousTip.asset
@@ -19,4 +19,4 @@ MonoBehaviour:
     TipIcon: {fileID: 21300000, guid: 13caba6fa69654f409508a1b989c0fd6, type: 3}
     ShowAnimation: 1
     MinimumExperienceLevelToTrigger: 2
-    ShowDuration: 12
+    ShowDuration: 5

--- a/UnityProject/Assets/Scripts/Learning/ProtipObjectTypes/ProtipObjectOnHealthStateChange.cs
+++ b/UnityProject/Assets/Scripts/Learning/ProtipObjectTypes/ProtipObjectOnHealthStateChange.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using HealthV2;
 using Systems.Atmospherics;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace Learning.ProtipObjectTypes
 {
@@ -10,31 +11,55 @@ namespace Learning.ProtipObjectTypes
 	{
 		private HealthStateController healthState;
 
-		[SerializeField] private ProtipSO BleedingVeryLowEvent;
-		[SerializeField] private ProtipSO BleedingLowEvent;
-		[SerializeField] private ProtipSO BleedingHighEvent;
-		[SerializeField] private ProtipSO BleedingDanagerEvent;
-		[SerializeField] private ProtipSO HungerEvent;
-		[SerializeField] private ProtipSO StarvingEvent;
-		[SerializeField] private ProtipSO FatsoEvent;
-		[SerializeField] private ProtipSO CritHealthEvent;
-		[SerializeField] private ProtipSO SoftHealthEvent;
-		[SerializeField] private ProtipSO DeathlHealthEvent;
-		[SerializeField] private ProtipSO FireStacksEvent;
-		[SerializeField] private ProtipSO SuffuicationEvent;
-		[SerializeField] private ProtipSO ToxinEvent;
-		[SerializeField] private ProtipSO TemperatureColdEvent;
-		[SerializeField] private ProtipSO TemperatureHotEvent;
-		[SerializeField] private ProtipSO UnconsciousEvent;
-		[SerializeField] private ProtipSO BarelyConsciousEvent;
-		[SerializeField] private ProtipSO PressureHighEvent;
-		[SerializeField] private ProtipSO PressureLowEvent;
+		[FormerlySerializedAs("BleedingVeryLowEvent")] [SerializeField]
+		private ProtipSO bleedingVeryLowEvent;
+		[FormerlySerializedAs("BleedingLowEvent")] [SerializeField]
+		private ProtipSO bleedingLowEvent;
+		[FormerlySerializedAs("BleedingHighEvent")] [SerializeField]
+		private ProtipSO bleedingHighEvent;
+		[FormerlySerializedAs("BleedingDanagerEvent")] [SerializeField]
+		private ProtipSO bleedingDanagerEvent;
+		[FormerlySerializedAs("HungerEvent")] [SerializeField]
+		private ProtipSO hungerEvent;
+		[FormerlySerializedAs("StarvingEvent")] [SerializeField]
+		private ProtipSO starvingEvent;
+		[FormerlySerializedAs("FatsoEvent")] [SerializeField]
+		private ProtipSO fatsoEvent;
+		[FormerlySerializedAs("CritHealthEvent")] [SerializeField]
+		private ProtipSO critHealthEvent;
+		[FormerlySerializedAs("SoftHealthEvent")] [SerializeField]
+		private ProtipSO softHealthEvent;
+		[FormerlySerializedAs("DeathlHealthEvent")] [SerializeField]
+		private ProtipSO deathlHealthEvent;
+		[FormerlySerializedAs("FireStacksEvent")] [SerializeField]
+		private ProtipSO fireStacksEvent;
+		[FormerlySerializedAs("SuffuicationEvent")] [SerializeField]
+		private ProtipSO suffuicationEvent;
+		[FormerlySerializedAs("ToxinEvent")] [SerializeField]
+		private ProtipSO toxinEvent;
+		[FormerlySerializedAs("TemperatureColdEvent")] [SerializeField]
+		private ProtipSO temperatureColdEvent;
+		[FormerlySerializedAs("TemperatureHotEvent")] [SerializeField]
+		private ProtipSO temperatureHotEvent;
+		[FormerlySerializedAs("UnconsciousEvent")] [SerializeField]
+		private ProtipSO unconsciousEvent;
+		[FormerlySerializedAs("BarelyConsciousEvent")] [SerializeField]
+		private ProtipSO barelyConsciousEvent;
+		[FormerlySerializedAs("PressureHighEvent")] [SerializeField]
+		private ProtipSO pressureHighEvent;
+		[FormerlySerializedAs("PressureLowEvent")] [SerializeField]
+		private ProtipSO pressureLowEvent;
 
-		private bool PressureTipOnCooldown = false;
-		private bool TempTipOnCooldown = false;
-		private bool SufficationTipCooldown = false;
-		private bool ToxinTipCooldown = false;
-		private HungerState LastHungerState = HungerState.Normal;
+		private bool pressureTipOnCooldown = false;
+		private bool tempTipOnCooldown = false;
+		private bool sufficationTipCooldown = false;
+		private bool toxinTipCooldown = false;
+		private bool hungerTipCooldown = false;
+		private bool deathTipCooldown = false;
+		private bool unconciousTipCooldown = false;
+		private bool fireStackTipCooldown = false;
+		private bool bleedingTipCooldown = false;
+		private HungerState lastHungerState = HungerState.Normal;
 
 		private const float PROTIP_COOLDOWN_TO_AVOID_QUEUE_SPAM = 35f;
 
@@ -74,18 +99,20 @@ namespace Learning.ProtipObjectTypes
 
 		private void TriggerConsciousEvent(ConsciousState state)
 		{
+			if(unconciousTipCooldown || deathTipCooldown || IsPlayerGhostInBody()) return;
 			switch (state)
 			{
-				case ConsciousState.CONSCIOUS:
-					break;
 				case ConsciousState.BARELY_CONSCIOUS:
-					TriggerTip(BarelyConsciousEvent);
+					TriggerTip(barelyConsciousEvent);
+					StartCoroutine(AsleepTipCooldown());
 					break;
 				case ConsciousState.UNCONSCIOUS:
-					TriggerTip(UnconsciousEvent);
+					TriggerTip(unconsciousEvent);
+					StartCoroutine(AsleepTipCooldown());
 					break;
 				case ConsciousState.DEAD:
-					TriggerTip(DeathlHealthEvent);
+					TriggerTip(deathlHealthEvent);
+					StartCoroutine(DeathTipCooldown());
 					break;
 				default:
 					break;
@@ -94,15 +121,15 @@ namespace Learning.ProtipObjectTypes
 
 		private void TriggerPressureEvent(float state)
 		{
-			if(PressureTipOnCooldown) return;
+			if(pressureTipOnCooldown || IsPlayerGhostInBody()) return;
 			switch (state)
 			{
 				case <= AtmosConstants.HAZARD_LOW_PRESSURE:
-					TriggerTip(PressureLowEvent);
+					TriggerTip(pressureLowEvent);
 					StartCoroutine(PressureCooldown());
 					break;
 				case >= AtmosConstants.WARNING_HIGH_PRESSURE:
-					TriggerTip(PressureHighEvent);
+					TriggerTip(pressureHighEvent);
 					StartCoroutine(PressureCooldown());
 					break;
 			}
@@ -110,88 +137,90 @@ namespace Learning.ProtipObjectTypes
 
 		private void TriggerHungerTip(HungerState state)
 		{
-			if(LastHungerState == state) return;
-			LastHungerState = state;
+			if(lastHungerState == state || IsPlayerGhostInBody()) return;
+			lastHungerState = state;
 			switch (state)
 			{
 				case HungerState.Full:
-					TriggerTip(FatsoEvent);
-					break;
-				case HungerState.Normal:
+					TriggerTip(fatsoEvent);
 					break;
 				case HungerState.Hungry:
-					TriggerTip(HungerEvent);
+					TriggerTip(hungerEvent);
 					break;
 				case HungerState.Malnourished:
-					TriggerTip(HungerEvent);
+					TriggerTip(hungerEvent);
 					break;
 				case HungerState.Starving:
-					TriggerTip(StarvingEvent);
+					TriggerTip(starvingEvent);
 					break;
 				default:
 					break;
 			}
+
+			if(lastHungerState != HungerState.Normal) StartCoroutine(HungerCooldown());
 		}
 
 		private void TriggerBleedingTip(BleedingState state)
 		{
+			if(bleedingTipCooldown || IsPlayerGhostInBody()) return;
 			switch (state)
 			{
-				case BleedingState.None:
-					break;
 				case BleedingState.VeryLow:
-					TriggerTip(BleedingVeryLowEvent);
+					TriggerTip(bleedingVeryLowEvent);
 					break;
 				case BleedingState.Low:
-					TriggerTip(BleedingLowEvent);
+					TriggerTip(bleedingLowEvent);
 					break;
 				case BleedingState.Medium:
-					TriggerTip(BleedingHighEvent);
+					TriggerTip(bleedingHighEvent);
 					break;
 				case BleedingState.High:
-					TriggerTip(BleedingHighEvent);
+					TriggerTip(bleedingHighEvent);
 					break;
 				case BleedingState.UhOh:
-					TriggerTip(BleedingDanagerEvent);
+					TriggerTip(bleedingDanagerEvent);
 					break;
 				default:
 					break;
 			}
+			StartCoroutine(BleedingCooldown());
 		}
 
 		private void TriggerFireStacksTip(float state)
 		{
+			if(fireStackTipCooldown || IsPlayerGhostInBody()) return;
 			if (state > 1f)
 			{
-				TriggerTip(FireStacksEvent);
+				TriggerTip(fireStacksEvent);
+				StartCoroutine(FireStackTipCooldown());
 			}
 		}
 
 		private void TriggerSuffocatingTip(bool state)
 		{
-			if (state == false || SufficationTipCooldown) return;
-			TriggerTip(SuffuicationEvent);
+			if (state == false || sufficationTipCooldown || IsPlayerGhostInBody()) return;
+			TriggerTip(suffuicationEvent);
 			StartCoroutine(SufficationCooldown());
 		}
 
 		private void TriggerToxinsTip(bool state)
 		{
-			if(state == false || ToxinTipCooldown) return;
-			TriggerTip(ToxinEvent);
+			if(state == false || toxinTipCooldown || IsPlayerGhostInBody()) return;
+			TriggerTip(toxinEvent);
 			StartCoroutine(ToxinCooldown());
 		}
 
 		private void TriggerTemperatureTip(float state)
 		{
-			if(TempTipOnCooldown) return;
+			if(tempTipOnCooldown || IsPlayerGhostInBody()) return;
 			switch (state)
 			{
 				case <= AtmosConstants.BARELY_COLD_HEAT:
-					TriggerTip(TemperatureColdEvent);
+					TriggerTip(temperatureColdEvent);
 					StartCoroutine(TempCooldown());
 					break;
 				case >= AtmosConstants.HOT_HEAT:
-					TriggerTip(TemperatureHotEvent);
+					TriggerTip(temperatureHotEvent);
 					StartCoroutine(TempCooldown());
 					break;
 				default:
@@ -199,32 +228,72 @@ namespace Learning.ProtipObjectTypes
 			}
 		}
 
+		private bool IsPlayerGhostInBody()
+		{
+			return healthState.livingHealthMasterBase.playerScript.IsGhost;
+		}
+
 		private IEnumerator TempCooldown()
 		{
-			TempTipOnCooldown = true;
+			tempTipOnCooldown = true;
 			yield return WaitFor.Seconds(PROTIP_COOLDOWN_TO_AVOID_QUEUE_SPAM);
-			TempTipOnCooldown = false;
+			tempTipOnCooldown = false;
 		}
 
 		private IEnumerator PressureCooldown()
 		{
-			PressureTipOnCooldown = true;
+			pressureTipOnCooldown = true;
 			yield return WaitFor.Seconds(PROTIP_COOLDOWN_TO_AVOID_QUEUE_SPAM);
-			PressureTipOnCooldown = false;
+			pressureTipOnCooldown = false;
 		}
 
 		private IEnumerator SufficationCooldown()
 		{
-			SufficationTipCooldown = true;
+			sufficationTipCooldown = true;
 			yield return WaitFor.Seconds(PROTIP_COOLDOWN_TO_AVOID_QUEUE_SPAM);
-			SufficationTipCooldown = false;
+			sufficationTipCooldown = false;
 		}
 
 		private IEnumerator ToxinCooldown()
 		{
-			ToxinTipCooldown = true;
+			toxinTipCooldown = true;
 			yield return WaitFor.Seconds(PROTIP_COOLDOWN_TO_AVOID_QUEUE_SPAM);
-			ToxinTipCooldown = false;
+			toxinTipCooldown = false;
+		}
+
+		private IEnumerator HungerCooldown()
+		{
+			hungerTipCooldown = true;
+			yield return WaitFor.Seconds(PROTIP_COOLDOWN_TO_AVOID_QUEUE_SPAM);
+			hungerTipCooldown = false;
+		}
+
+		private IEnumerator DeathTipCooldown()
+		{
+			deathTipCooldown = true;
+			yield return WaitFor.Seconds(PROTIP_COOLDOWN_TO_AVOID_QUEUE_SPAM);
+			deathTipCooldown = false;
+		}
+
+		private IEnumerator AsleepTipCooldown()
+		{
+			unconciousTipCooldown = true;
+			yield return WaitFor.Seconds(PROTIP_COOLDOWN_TO_AVOID_QUEUE_SPAM);
+			unconciousTipCooldown = false;
+		}
+
+		private IEnumerator FireStackTipCooldown()
+		{
+			fireStackTipCooldown = true;
+			yield return WaitFor.Seconds(PROTIP_COOLDOWN_TO_AVOID_QUEUE_SPAM);
+			fireStackTipCooldown = false;
+		}
+
+		private IEnumerator BleedingCooldown()
+		{
+			bleedingTipCooldown = true;
+			yield return WaitFor.Seconds(PROTIP_COOLDOWN_TO_AVOID_QUEUE_SPAM);
+			bleedingTipCooldown = false;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Learning/UI/ProtipUI.cs
+++ b/UnityProject/Assets/Scripts/Learning/UI/ProtipUI.cs
@@ -30,7 +30,10 @@ namespace Learning
 
 		public void ShowTip(ProtipSO tip)
 		{
-			var duration = tip.TipData.ShowDuration <= 0 ? tip.TipData.ShowDuration : DEFAULT_DURATION; //Incase whoever was setting the SO data forgot to set the duration.
+			// In-case whoever was setting the SO data forgot to set the duration.
+			var duration = tip.TipData.ShowDuration <= 0 ? tip.TipData.ShowDuration : DEFAULT_DURATION;
+			// reset the rotation before starting a new animation.
+			tipImage.transform.rotation = Quaternion.Euler(0,0,0);
 			StopAllCoroutines();
 			SetPositionInTransform();
 			tipText.text = tip.TipData.Tip;


### PR DESCRIPTION
CL: [Balance] Cooldowns for some tips have been readjusted so they don't stay on for too long or too shortly.
CL: [Fix] The "Remember Tip" brain button is now slightly bigger to help odd screen resolutions.
CL: [Fix] The tip's icon has it's rotation now resets to 0 when there's no animation defined for a tip.
CL: [Fix] Some health tips were missing cooldowns which caused them to spam the tip queue, this has been fixed.
CL: [Fix] Health tips will now check if you're inside your body still before queuing.
