### PR TITLE
the option between classic and new hover tooltip

### DIFF
--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager.prefab
@@ -1747,6 +1747,7 @@ MonoBehaviour:
   <ServerInfoPanelWindow>k__BackingField: {fileID: 8545035906042272779}
   ScoreScreen: {fileID: 1177098319968032072}
   isInputFocus: 0
+  tooltipHoverManager: {fileID: 6137620108066464516}
 --- !u!114 &8587366065717414501
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -9567,27 +9568,27 @@ PrefabInstance:
     - target: {fileID: 2338513360790555045, guid: 38f86d80081975e479b53b82beb3b116,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2338513360790555045, guid: 38f86d80081975e479b53b82beb3b116,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2338513360790555045, guid: 38f86d80081975e479b53b82beb3b116,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2338513360790555045, guid: 38f86d80081975e479b53b82beb3b116,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2338513360790555045, guid: 38f86d80081975e479b53b82beb3b116,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 1599.4
+      value: 1604.238
       objectReference: {fileID: 0}
     - target: {fileID: 2338513360790555045, guid: 38f86d80081975e479b53b82beb3b116,
         type: 3}
@@ -9597,12 +9598,12 @@ PrefabInstance:
     - target: {fileID: 2338513360790555045, guid: 38f86d80081975e479b53b82beb3b116,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 29
+      value: 817.69
       objectReference: {fileID: 0}
     - target: {fileID: 2338513360790555045, guid: 38f86d80081975e479b53b82beb3b116,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 1125
+      value: 40.43
       objectReference: {fileID: 0}
     - target: {fileID: 2338729149468139205, guid: 38f86d80081975e479b53b82beb3b116,
         type: 3}
@@ -9707,12 +9708,12 @@ PrefabInstance:
     - target: {fileID: 2521656241382242825, guid: 38f86d80081975e479b53b82beb3b116,
         type: 3}
       propertyPath: m_Color.b
-      value: 0.33490568
+      value: 0.18401527
       objectReference: {fileID: 0}
     - target: {fileID: 2521656241382242825, guid: 38f86d80081975e479b53b82beb3b116,
         type: 3}
       propertyPath: m_Color.g
-      value: 0.7849674
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2521656241382242825, guid: 38f86d80081975e479b53b82beb3b116,
         type: 3}
@@ -9727,12 +9728,12 @@ PrefabInstance:
     - target: {fileID: 2521656241382242825, guid: 38f86d80081975e479b53b82beb3b116,
         type: 3}
       propertyPath: m_FontData.m_FontSize
-      value: 32
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 2521656241382242825, guid: 38f86d80081975e479b53b82beb3b116,
         type: 3}
       propertyPath: m_FontData.m_Alignment
-      value: 4
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 2553322715527811953, guid: 38f86d80081975e479b53b82beb3b116,
         type: 3}
@@ -9783,6 +9784,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &6137620108066464516 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 71929184658808242, guid: 38f86d80081975e479b53b82beb3b116,
+    type: 3}
+  m_PrefabInstance: {fileID: 6184216130338094774}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0d68eca7a0ae473e975e4f769b16f693, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!224 &8477579944802426995 stripped

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/Panel_ToolTip.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/Panel_ToolTip.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 2341012954230024805}
   - component: {fileID: 2521656241382242825}
   m_Layer: 5
-  m_Name: Tooltip_Placeholder
+  m_Name: OldTooltip
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -91,6 +91,7 @@ GameObject:
   - component: {fileID: 2338729149468139205}
   - component: {fileID: 2340930569063245211}
   - component: {fileID: 2521908554719778531}
+  - component: {fileID: 71929184658808242}
   m_Layer: 5
   m_Name: Panel_ToolTip
   m_TagString: Untagged
@@ -113,6 +114,7 @@ RectTransform:
   - {fileID: 2338513360790555045}
   - {fileID: 2749770474105519504}
   - {fileID: 4291166550735643140}
+  - {fileID: 1176630739323901263}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -159,6 +161,156 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &71929184658808242
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2553322715527811953}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0d68eca7a0ae473e975e4f769b16f693, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  defaultTooltip: {fileID: 9204913234738890692}
+  classicTooltip: {fileID: 2521656241382242825}
+--- !u!1 &3101227304071924200
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1176630739323901263}
+  - component: {fileID: 321535724979529254}
+  - component: {fileID: 9204913234738890692}
+  m_Layer: 5
+  m_Name: HoverTooltipV2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1176630739323901263
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3101227304071924200}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2338729149468139205}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.000040054, y: 1232}
+  m_SizeDelta: {x: 2818.761, y: 52.545}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &321535724979529254
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3101227304071924200}
+  m_CullTransparentMesh: 1
+--- !u!114 &9204913234738890692
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3101227304071924200}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 3ec0f3e555d158046b753f5bcd36b1cc, type: 2}
+  m_sharedMaterial: {fileID: -5499892936835490120, guid: 3ec0f3e555d158046b753f5bcd36b1cc,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278231807
+  m_fontColor: {r: 1, g: 0.6366447, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 0
+  m_fontColorGradient:
+    topLeft: {r: 0, g: 0, b: 0, a: 1}
+    topRight: {r: 0, g: 0, b: 0, a: 1}
+    bottomLeft: {r: 0, g: 0, b: 0, a: 1}
+    bottomRight: {r: 0, g: 0, b: 0, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &4255000533146734361
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/OptionsScreen.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/OptionsScreen.prefab
@@ -19360,9 +19360,9 @@ MonoBehaviour:
           m_IntArgument: 0
           m_FloatArgument: 0
           m_StringArgument: 
-          m_BoolArgument: 0
+          m_BoolArgument: 1
         m_CallState: 2
-  m_IsOn: 0
+  m_IsOn: 1
 --- !u!1 &6814240183176671361
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/OptionsScreen.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/OptionsScreen.prefab
@@ -3141,6 +3141,82 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1502787544614230821
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 588455715624426207}
+  - component: {fileID: 4937084199400027565}
+  - component: {fileID: 4031335048162072733}
+  m_Layer: 5
+  m_Name: Checkmark
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &588455715624426207
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1502787544614230821}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7611038496847530463}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 30, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4937084199400027565
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1502787544614230821}
+  m_CullTransparentMesh: 0
+--- !u!114 &4031335048162072733
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1502787544614230821}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10901, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &1530930638274873791
 GameObject:
   m_ObjectHideFlags: 0
@@ -3747,8 +3823,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 7807788660649586917}
   m_HandleRect: {fileID: 1139529994206577920}
   m_Direction: 2
-  m_Value: 0.4999999
-  m_Size: 0.45607728
+  m_Value: 0.5
+  m_Size: 0.43504548
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -4170,6 +4246,84 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: -20, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1848372331225117534
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3851825648104110176}
+  - component: {fileID: 5735229452596868579}
+  - component: {fileID: 7313468408312001779}
+  m_Layer: 5
+  m_Name: ClassicTooltipPositionToggle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3851825648104110176
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1848372331225117534}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8047565371944308475}
+  - {fileID: 7236196527109970246}
+  m_Father: {fileID: 3311291840069775786}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1431.5513, y: 142.64862}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5735229452596868579
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1848372331225117534}
+  m_CullTransparentMesh: 0
+--- !u!114 &7313468408312001779
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1848372331225117534}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.047058824}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &1892343203404720588
 GameObject:
   m_ObjectHideFlags: 0
@@ -6780,6 +6934,86 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &3141611280281243053
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8047565371944308475}
+  - component: {fileID: 537145765358787868}
+  - component: {fileID: 5977631501336150750}
+  m_Layer: 5
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8047565371944308475
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3141611280281243053}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3851825648104110176}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 369.62988, y: -1.5073242}
+  m_SizeDelta: {x: 631.87, y: -44.639}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &537145765358787868
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3141611280281243053}
+  m_CullTransparentMesh: 0
+--- !u!114 &5977631501336150750
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3141611280281243053}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 0
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 0
+    m_MaxSize: 40
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Enable Classic Hover Tooltip
 --- !u!1 &3157476032614322789
 GameObject:
   m_ObjectHideFlags: 0
@@ -7863,12 +8097,13 @@ RectTransform:
   - {fileID: 7270715640298790213}
   - {fileID: 3855821206148638362}
   - {fileID: 2158048401927493441}
+  - {fileID: 3851825648104110176}
   m_Father: {fileID: 3788036204741962250}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: -2, y: -502.28058}
+  m_AnchoredPosition: {x: -2, y: -521.25433}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2208241204637172415
@@ -11683,7 +11918,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -25}
+  m_AnchoredPosition: {x: 0, y: -24.99997}
   m_SizeDelta: {x: 0, y: -50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &4663901235587051492
@@ -19030,6 +19265,104 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &6781280903528054255
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7236196527109970246}
+  - component: {fileID: 165509182495233690}
+  m_Layer: 5
+  m_Name: Toggle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7236196527109970246
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6781280903528054255}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7611038496847530463}
+  m_Father: {fileID: 3851825648104110176}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5186986, y: 0.5}
+  m_AnchorMax: {x: 0.5186986, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -1.5074997}
+  m_SizeDelta: {x: 73.099976, y: 103}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &165509182495233690
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6781280903528054255}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4715287456542448757}
+  toggleTransition: 1
+  graphic: {fileID: 4031335048162072733}
+  m_Group: {fileID: 0}
+  onValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 3825634513002827830}
+        m_TargetAssemblyTypeName: Unitystation.Options.ThemeManager, Assets
+        m_MethodName: ClassicHoverTooltipToggle
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  m_IsOn: 0
 --- !u!1 &6814240183176671361
 GameObject:
   m_ObjectHideFlags: 0
@@ -20695,6 +21028,7 @@ MonoBehaviour:
       m_SubObjectName: 
       m_SubObjectType: 
       m_EditorAssetChanged: 0
+  enableClassicHoverTooltip: {fileID: 165509182495233690}
 --- !u!1 &7759432634905933299
 GameObject:
   m_ObjectHideFlags: 0
@@ -22188,6 +22522,83 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: 'Instant Chat Bubbles:'
+--- !u!1 &8704328129834671655
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7611038496847530463}
+  - component: {fileID: 4568294856488745818}
+  - component: {fileID: 4715287456542448757}
+  m_Layer: 5
+  m_Name: InputBox
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7611038496847530463
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8704328129834671655}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.6854, y: 1.6854, z: 1.6854}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 588455715624426207}
+  m_Father: {fileID: 7236196527109970246}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -2, y: -0.00005722046}
+  m_SizeDelta: {x: 29.47998, y: 30.009995}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4568294856488745818
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8704328129834671655}
+  m_CullTransparentMesh: 0
+--- !u!114 &4715287456542448757
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8704328129834671655}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &8711680244411398928
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/PlayerPrefs/PlayerPrefKeys.cs
+++ b/UnityProject/Assets/Scripts/PlayerPrefs/PlayerPrefKeys.cs
@@ -176,4 +176,6 @@
 	/// </summary>
 	public static readonly string ChatBackgroundMinimumAlpha = "ChatBackgroundMinimumAlpha";
 
+	public static readonly string EnableClassicHoverTooltip = "EnableClassicHoverTooltip";
+
 }

--- a/UnityProject/Assets/Scripts/UI/Core/OptionsMenu/ThemeOptions/ThemeManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/OptionsMenu/ThemeOptions/ThemeManager.cs
@@ -79,7 +79,7 @@ namespace Unitystation.Options
 
 	        if (PlayerPrefs.HasKey(PlayerPrefKeys.EnableClassicHoverTooltip) == false)
 	        {
-		        ClassicHoverTooltipToggle(false);
+		        ClassicHoverTooltipToggle(true);
 	        }
 
 	        ChatHighlight = PlayerPrefs.GetInt(PlayerPrefKeys.HighlightChat) == 1;

--- a/UnityProject/Assets/Scripts/UI/Core/OptionsMenu/ThemeOptions/ThemeManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/OptionsMenu/ThemeOptions/ThemeManager.cs
@@ -7,6 +7,7 @@ using AddressableReferences;
 using Initialisation;
 using Shared.Util;
 using UnityEngine;
+using UnityEngine.UI;
 using Util;
 using YamlDotNet.RepresentationModel;
 
@@ -23,6 +24,8 @@ namespace Unitystation.Options
 
         [SerializeField]
         private List<AddressableAudioSource> mentionSounds = new List<AddressableAudioSource>();
+
+        [SerializeField] private Toggle enableClassicHoverTooltip;
 
         public List<AddressableAudioSource> MentionSounds => mentionSounds;
 
@@ -74,6 +77,11 @@ namespace Unitystation.Options
 		        PlayerPrefs.SetInt(PlayerPrefKeys.MentionSoundIndex, 0);
 	        }
 
+	        if (PlayerPrefs.HasKey(PlayerPrefKeys.EnableClassicHoverTooltip) == false)
+	        {
+		        ClassicHoverTooltipToggle(false);
+	        }
+
 	        ChatHighlight = PlayerPrefs.GetInt(PlayerPrefKeys.HighlightChat) == 1;
 	        MentionSound = PlayerPrefs.GetInt(PlayerPrefKeys.MentionSound) == 1;
 
@@ -84,6 +92,14 @@ namespace Unitystation.Options
 
 	        MentionSoundIndex = PlayerPrefs.GetInt(PlayerPrefKeys.MentionSoundIndex);
 	        CurrentMentionSound = MentionSounds[MentionSoundIndex];
+        }
+
+        public void ClassicHoverTooltipToggle(bool toggle)
+        {
+	        var result = enableClassicHoverTooltip.isOn ? 1 : 0;
+	        UIManager.Instance.TooltipHoverManager.SetActiveTransform(enableClassicHoverTooltip.isOn);
+	        PlayerPrefs.SetInt(PlayerPrefKeys.EnableClassicHoverTooltip, result);
+	        PlayerPrefs.Save();
         }
 
         public void ChatHighlightToggle(bool toggle)

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/TooltipHoverManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/TooltipHoverManager.cs
@@ -1,0 +1,54 @@
+using System;
+using Learning;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace UI
+{
+	public class TooltipHoverManager : MonoBehaviour
+	{
+		private Transform activeTooltip;
+		[SerializeField] private TMP_Text defaultTooltip;
+		[SerializeField] private Text classicTooltip;
+
+		private void Awake()
+		{
+			if (PlayerPrefs.HasKey(PlayerPrefKeys.EnableClassicHoverTooltip) == false)
+				activeTooltip = defaultTooltip.transform;
+		}
+
+		public void UpdateActiveTooltip(string tip)
+		{
+			if (activeTooltip == null) return;
+
+			if (activeTooltip == defaultTooltip.transform && DefaultTooltipChecks())
+			{
+				defaultTooltip.text = tip;
+				return;
+			}
+			//classic tooltip does not have any extra checks.
+			classicTooltip.text = tip;
+		}
+
+		public void SetActiveTransform(bool transformNumber)
+		{
+			activeTooltip = transformNumber ? classicTooltip.transform : defaultTooltip.transform;
+		}
+
+		private bool DefaultTooltipChecks()
+		{
+			// If protip is still not loaded in or player has set their experience level to Robust, hide the tooltip
+			// away from them.
+			if (ProtipManager.Instance == null ||
+			    ProtipManager.Instance.PlayerExperienceLevel == ProtipManager.ExperienceLevel.Robust) return false;
+			if (ProtipManager.Instance.PlayerExperienceLevel == ProtipManager.ExperienceLevel.SomewhatExperienced)
+			{
+				// If the player set their experience level to somewhat experienced, show only if shift is pressed.
+				if(KeyboardInputManager.IsShiftPressed() == false) return false;
+			}
+
+			return true;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/TooltipHoverManager.cs.meta
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/TooltipHoverManager.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0d68eca7a0ae473e975e4f769b16f693
+timeCreated: 1667178108

--- a/UnityProject/Assets/Scripts/UI/Systems/UIManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/UIManager.cs
@@ -212,17 +212,15 @@ public class UIManager : MonoBehaviour, IInitialise
 
 	private float pingUpdate;
 
+	[SerializeField] private TooltipHoverManager tooltipHoverManager;
+	public TooltipHoverManager TooltipHoverManager => tooltipHoverManager;
+
 	public static string SetToolTip
 	{
 		set
 		{
-			if (ProtipManager.Instance == null ||
-			    ProtipManager.Instance.PlayerExperienceLevel == ProtipManager.ExperienceLevel.Robust) return;
-			if (ProtipManager.Instance.PlayerExperienceLevel == ProtipManager.ExperienceLevel.SomewhatExperienced)
-			{
-				if(KeyboardInputManager.IsShiftPressed() == false) return;
-			}
-			Instance.toolTip.text = value;
+			if(Instance.tooltipHoverManager == null) return;
+			Instance.tooltipHoverManager.UpdateActiveTooltip(value);
 		}
 	}
 


### PR DESCRIPTION
CL: [New] Classic tooltip can now be re-enabled via the options menu. (Though it's enabled by default from now on for the 13th of november playtest)
CL: [Improvement] The default tooltip is now more bound to the top of the screen.
CL: [Improvement] changed the font of the default tooltip.
CL: [Improvement] The classic tooltip's color is now bolder for people to be able to notice it more if they wish to enable the classic tooltip.
