### PR TITLE
(#5355) - Change sprites when someone is buckled into the rollerbed

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Medical/RollerBedSpriteChange.cs
+++ b/UnityProject/Assets/Scripts/Items/Medical/RollerBedSpriteChange.cs
@@ -3,36 +3,40 @@ using System.Collections.Generic;
 using UnityEngine;
 using Objects;
 
-public class RollerBedSpriteChange : MonoBehaviour
+namespace Items.Medical
 {
-    ///<summary>
-    /// Class which subscribes to the OnBuckle Event in BuckleInteract to enable the changing of sprites when someone 
-    /// is buckled and unbuckled from the bed. 
-    ///</summary>
-    [SerializeField] private BuckleInteract buckleInteract; 
-    [SerializeField] private SpriteHandler spriteHandler; 
-    private const int ROLLER_BED_SPRITE_INDEX_DOWN = 0;
-    private const int ROLLER_BED_SPRITE_INDEX_UP = 1;
+	///<summary>
+	/// Class which subscribes to the OnBuckle Event in BuckleInteract to enable the changing of sprites when someone 
+	/// is buckled and unbuckled from the bed. 
+	///</summary>
+
+	public class RollerBedSpriteChange : MonoBehaviour
+	{
+		[SerializeField] private BuckleInteract buckleInteract;
+		[SerializeField] private SpriteHandler spriteHandler;
+		private const int ROLLER_BED_SPRITE_INDEX_DOWN = 0;
+		private const int ROLLER_BED_SPRITE_INDEX_UP = 1;
 
 
-    private void OnEnable()
-    {
-        buckleInteract.OnBuckleEvent += OnBuckle;
-        buckleInteract.OnUnbuckleEvent += OnUnbuckle;
-    }
+		private void OnEnable()
+		{
+			buckleInteract.OnBuckleEvent += OnBuckle;
+			buckleInteract.OnUnbuckleEvent += OnUnbuckle;
+		}
 
-    private void OnDisable()
-    {
-        buckleInteract.OnBuckleEvent -= OnBuckle;
-        buckleInteract.OnUnbuckleEvent -= OnUnbuckle;
-    }
-    private void OnBuckle()
-    {
-        spriteHandler.ChangeSprite(ROLLER_BED_SPRITE_INDEX_UP);
-    }
+		private void OnDisable()
+		{
+			buckleInteract.OnBuckleEvent -= OnBuckle;
+			buckleInteract.OnUnbuckleEvent -= OnUnbuckle;
+		}
+		private void OnBuckle()
+		{
+			spriteHandler.ChangeSprite(ROLLER_BED_SPRITE_INDEX_UP);
+		}
 
-    private void OnUnbuckle()
-    {
-        spriteHandler.ChangeSprite(ROLLER_BED_SPRITE_INDEX_DOWN);
-    }
+		private void OnUnbuckle()
+		{
+			spriteHandler.ChangeSprite(ROLLER_BED_SPRITE_INDEX_DOWN);
+		}
+	}
 }

--- a/UnityProject/Assets/Scripts/Items/Medical/RollerBedSpriteChange.cs
+++ b/UnityProject/Assets/Scripts/Items/Medical/RollerBedSpriteChange.cs
@@ -1,0 +1,38 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Objects;
+
+public class RollerBedSpriteChange : MonoBehaviour
+{
+    ///<summary>
+    /// Class which subscribes to the OnBuckle Event in BuckleInteract to enable the changing of sprites when someone 
+    /// is buckled and unbuckled from the bed. 
+    ///</summary>
+    [SerializeField] private BuckleInteract buckleInteract; 
+    [SerializeField] private SpriteHandler spriteHandler; 
+    private const int ROLLER_BED_SPRITE_INDEX_DOWN = 0;
+    private const int ROLLER_BED_SPRITE_INDEX_UP = 1;
+
+
+    private void OnEnable()
+    {
+        buckleInteract.OnBuckleEvent += OnBuckle;
+        buckleInteract.OnUnbuckleEvent += OnUnbuckle;
+    }
+
+    private void OnDisable()
+    {
+        buckleInteract.OnBuckleEvent -= OnBuckle;
+        buckleInteract.OnUnbuckleEvent -= OnUnbuckle;
+    }
+    private void OnBuckle()
+    {
+        spriteHandler.ChangeSprite(ROLLER_BED_SPRITE_INDEX_UP);
+    }
+
+    private void OnUnbuckle()
+    {
+        spriteHandler.ChangeSprite(ROLLER_BED_SPRITE_INDEX_DOWN);
+    }
+}

--- a/UnityProject/Assets/Scripts/Items/Medical/RollerBedSpriteChange.cs
+++ b/UnityProject/Assets/Scripts/Items/Medical/RollerBedSpriteChange.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using Objects;
 

--- a/UnityProject/Assets/Scripts/Items/Medical/RollerBedSpriteChange.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Medical/RollerBedSpriteChange.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fdcc072f762ede14d82059ea40e8b150
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Objects/Furniture/BuckleInteract.cs
+++ b/UnityProject/Assets/Scripts/Objects/Furniture/BuckleInteract.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using HealthV2;
 using Player.Movement;
 using UnityEngine;
@@ -16,6 +17,12 @@ namespace Objects
 		[SerializeField]
 		private SpriteHandler occupiedSpriteHandler;
 		private Integrity integrity;
+
+		///<summary>
+		/// Events created to change the sprite of the roller bed
+		///</summary>
+		public event Action OnBuckleEvent;
+		public event Action OnUnbuckleEvent;
 
 		/// <summary>
 		/// Do the resist even if uncuffed, e.g alien nest
@@ -61,11 +68,11 @@ namespace Objects
 				var playerPushPull = playerScript.objectPhysics;
 				if (side == NetworkSide.Server)
 				{
-					canPush = playerPushPull.CanPush( dir);
+					canPush = playerPushPull.CanPush(dir);
 				}
 				else
 				{
-					canPush = playerPushPull.CanPush( dir);
+					canPush = playerPushPull.CanPush(dir);
 				}
 
 				if (canPush == false) return false;
@@ -76,7 +83,7 @@ namespace Objects
 		public bool WillInteract(MouseDrop interaction, NetworkSide side)
 		{
 			if (DefaultWillInteract.Default(interaction, side,
-				    Validations.CheckState(x => x.CanBuckleOthers)) == false) return false;
+					Validations.CheckState(x => x.CanBuckleOthers)) == false) return false;
 
 			if (Validations.HasComponent<MovementSynchronisation>(interaction.DroppedObject) == false) return false;
 
@@ -133,6 +140,7 @@ namespace Objects
 			}
 
 			objectPhysics.BuckleObjectToThis(playerScript.playerMove);
+			OnBuckleEvent?.Invoke();
 			occupiedSpriteHandler.OrNull()?.ChangeSprite(0);
 		}
 
@@ -208,6 +216,7 @@ namespace Objects
 		{
 			playerScript.PlayerSync.Unbuckle();
 			objectPhysics.Unbuckle();
+			OnUnbuckleEvent?.Invoke();
 			occupiedSpriteHandler.OrNull()?.PushClear();
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/Furniture/BuckleInteract.cs
+++ b/UnityProject/Assets/Scripts/Objects/Furniture/BuckleInteract.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using HealthV2;
-using Player.Movement;
 using UnityEngine;
 
 namespace Objects

--- a/UnityProject/Assets/Scripts/Objects/Furniture/BuckleInteract.cs
+++ b/UnityProject/Assets/Scripts/Objects/Furniture/BuckleInteract.cs
@@ -19,9 +19,12 @@ namespace Objects
 		private Integrity integrity;
 
 		///<summary>
-		/// Events created to change the sprite of the roller bed
+		/// Event that get invoked when a player Buckles into an object that has this component
 		///</summary>
 		public event Action OnBuckleEvent;
+		///<summary>
+		/// Event that get invoked when a player Unbuckles into an object that has this component
+		///</summary>
 		public event Action OnUnbuckleEvent;
 
 		/// <summary>
@@ -140,8 +143,8 @@ namespace Objects
 			}
 
 			objectPhysics.BuckleObjectToThis(playerScript.playerMove);
-			OnBuckleEvent?.Invoke();
 			occupiedSpriteHandler.OrNull()?.ChangeSprite(0);
+			OnBuckleEvent?.Invoke();
 		}
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)
@@ -216,8 +219,8 @@ namespace Objects
 		{
 			playerScript.PlayerSync.Unbuckle();
 			objectPhysics.Unbuckle();
-			OnUnbuckleEvent?.Invoke();
 			occupiedSpriteHandler.OrNull()?.PushClear();
+			OnUnbuckleEvent?.Invoke();
 		}
 
 		private bool CanUnBuckleSelf(PlayerScript playerScript)

--- a/UnityProject/Assets/Scripts/Objects/Furniture/BuckleInteract.cs
+++ b/UnityProject/Assets/Scripts/Objects/Furniture/BuckleInteract.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using HealthV2;
 using UnityEngine;
-
 namespace Objects
 {
 	/// <summary>


### PR DESCRIPTION
CL: [New] When a player is buckled into the roller bed, the sprite now changes based on status of the bed.  When the player is buckled the bed will raise, when the bed is free, the bed will lower. 

CL: [Improvement] Created event system on the back end which developers can now use should any more features need to be added when someone is buckled / unbuckled from the bed. 



