### PR TITLE
Various fixes

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Implants/Explosives/ImplantExplosive.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Explosives/ImplantExplosive.prefab
@@ -231,9 +231,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 08a5324d1ed58d54eb78577c22157392, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  isEMPVunerable: 0
+  syncMode: 0
+  syncInterval: 0.1
+  isEMPVunerable: 1
   EMPResistance: 2
-  TriggerOnDeath: 0
+  <TriggerOnDeath>k__BackingField: 0
+  <OverrideDeathCountDown>k__BackingField: -1
 --- !u!114 &2959315849646831725
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -387,6 +390,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   OrganStorage: {fileID: 2959315849646831725}
+  CommonComponents: {fileID: 0}
   playerSprites: {fileID: 0}
   IsBleeding: 0
   limbLossBleedingValue: 0

--- a/UnityProject/Assets/Prefabs/Items/Implants/Explosives/MacrobombImplant.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Explosives/MacrobombImplant.prefab
@@ -9,8 +9,28 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: -1335230176832777347, guid: 414ec5b5318df6f4bbd000a4dfb298ca,
         type: 3}
+      propertyPath: EMPResistance
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: -1335230176832777347, guid: 414ec5b5318df6f4bbd000a4dfb298ca,
+        type: 3}
       propertyPath: TriggerOnDeath
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -1335230176832777347, guid: 414ec5b5318df6f4bbd000a4dfb298ca,
+        type: 3}
+      propertyPath: isEMPVunerable
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -1335230176832777347, guid: 414ec5b5318df6f4bbd000a4dfb298ca,
+        type: 3}
+      propertyPath: <TriggerOnDeath>k__BackingField
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -1335230176832777347, guid: 414ec5b5318df6f4bbd000a4dfb298ca,
+        type: 3}
+      propertyPath: <OverrideDeathCountDown>k__BackingField
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 2925014835611581738, guid: 414ec5b5318df6f4bbd000a4dfb298ca,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Explosives/MicrobombImplant.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Explosives/MicrobombImplant.prefab
@@ -9,8 +9,28 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: -1335230176832777347, guid: 414ec5b5318df6f4bbd000a4dfb298ca,
         type: 3}
+      propertyPath: EMPResistance
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -1335230176832777347, guid: 414ec5b5318df6f4bbd000a4dfb298ca,
+        type: 3}
       propertyPath: TriggerOnDeath
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -1335230176832777347, guid: 414ec5b5318df6f4bbd000a4dfb298ca,
+        type: 3}
+      propertyPath: isEMPVunerable
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -1335230176832777347, guid: 414ec5b5318df6f4bbd000a4dfb298ca,
+        type: 3}
+      propertyPath: <TriggerOnDeath>k__BackingField
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -1335230176832777347, guid: 414ec5b5318df6f4bbd000a4dfb298ca,
+        type: 3}
+      propertyPath: <OverrideDeathCountDown>k__BackingField
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 2925014835611581738, guid: 414ec5b5318df6f4bbd000a4dfb298ca,
         type: 3}

--- a/UnityProject/Assets/Scripts/Items/Medical/Implanter.cs
+++ b/UnityProject/Assets/Scripts/Items/Medical/Implanter.cs
@@ -1,8 +1,8 @@
 using UnityEngine;
 using HealthV2;
-using Items;
+using Mirror;
 
-public class Implanter : MonoBehaviour, ICheckedInteractable<HandApply>, ICheckedInteractable<InventoryApply>, ICheckedInteractable<HandActivate>
+public class Implanter : NetworkBehaviour, ICheckedInteractable<HandApply>, ICheckedInteractable<InventoryApply>, ICheckedInteractable<HandActivate>
 {
 	[SerializeField,Tooltip("The implant that this implanter starts with, leave as null if implanter is inted to be empty.")]
 	private GameObject implantObject = null;
@@ -19,7 +19,7 @@ public class Implanter : MonoBehaviour, ICheckedInteractable<HandApply>, IChecke
 
 	private ItemSlot implantSlot;
 
-	private bool primed = false;
+	[SyncVar] private bool primed = false;
 
 
 	private void Awake()

--- a/UnityProject/Assets/Scripts/Items/Weapons/ImplantExplosive.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/ImplantExplosive.cs
@@ -2,7 +2,6 @@ using System.Collections;
 using UnityEngine;
 using Communications;
 using HealthV2;
-using Managers;
 using System.Threading.Tasks;
 using Mirror;
 

--- a/UnityProject/Assets/Scripts/Items/Weapons/ImplantExplosiveTrigger.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/ImplantExplosiveTrigger.cs
@@ -1,14 +1,14 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using HealthV2;
+using UnityEngine;
 
 namespace Items.Weapons
 {
 	public class ImplantExplosiveTrigger : BodyPartFunctionality
 	{
-		public bool TriggerOnDeath = false;
+		[field: SerializeField] public bool TriggerOnDeath { get; private set; } = false;
+
+		[field: SerializeField] public int OverrideDeathCountDown { get; private set; } = -1;
+
 		bool hasDetonated = false;
 
 		private ImplantExplosive explosive;
@@ -26,9 +26,21 @@ namespace Items.Weapons
 
 			if(RelatedPart.HealthMaster.IsDead && TriggerOnDeath && hasDetonated == false) //Makes sure bombs dont double detonate
 			{
-				hasDetonated = true;
-				StartCoroutine(explosive.Countdown());
+				Detonate();
 			}
+		}
+
+		private void Detonate()
+		{
+			hasDetonated = true;
+			if (OverrideDeathCountDown >= 0) explosive.TimeToDetonate = OverrideDeathCountDown;
+
+			StartCoroutine(explosive.Countdown());
+		}
+
+		public override void EmpResult(int strength)
+		{
+			Detonate();
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/NPC/AI/Friendly/MouseAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Friendly/MouseAI.cs
@@ -86,7 +86,6 @@ namespace Systems.MobAIs
 			float voltage = cable.Data.ActualVoltage;
 
 			// Remove the cable and spawn the item.
-			cable.DestroyThisPlease();
 			var electricalTile = registerObject.TileChangeManager.MetaTileMap.GetTile(registerObject.WorldPosition, LayerType.Electrical) as ElectricalCableTile;
 			// Electrical tile is not null iff this is the first mousechew. Why?
 			if (electricalTile != null)
@@ -94,6 +93,8 @@ namespace Systems.MobAIs
 				Spawn.ServerPrefab(electricalTile.SpawnOnDeconstruct, registerObject.WorldPosition,
 					count: electricalTile.SpawnAmountOnDeconstruct);
 			}
+
+			cable.DestroyThisPlease();
 
 			Electrocute(voltage);
 		}
@@ -105,7 +106,7 @@ namespace Systems.MobAIs
 			//TODO get rid of this part once health rework is done!
 			//var electrocution = new Electrocution(voltage, registerObject.WorldPosition);
 			//performerLHB.Electrocute(electrocution);
-			performerLHB.ApplyDamage(gameObject, 200, AttackType.Internal, DamageType.Tox);
+			performerLHB.ApplyDamage(gameObject, 200, AttackType.Energy, DamageType.Burn);
 		}
 
 		protected override void DoRandomAction()


### PR DESCRIPTION
### Changelog:
CL: [Improvement] Implant explosives will now be affected by EMPs, having a chance to detonate if affected.
CL: [Improvement] Fixes the issue for nuke ops that if they had both a microbomb and macrobomb implant, the micro would detonate first destroying the macro, rendering it useless.
CL: [Fix] Mice will now die again upon chewing electrical cables
CL: [Fix] Implanters should now work for clients
CL: [Fix] Fixes misaligned firelock in Ministation medical


