### PR TITLE
Alternative prefab names

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Cards/IDCards/IDCardCaptainsSpare.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Cards/IDCards/IDCardCaptainsSpare.prefab
@@ -747,6 +747,11 @@ PrefabInstance:
       propertyPath: foreverID
       value: 72e9a61271099da41b6bbb328707815f
       objectReference: {fileID: 0}
+    - target: {fileID: 5888389431172269479, guid: da8e7a51ad26f8f48ac7cff66da55f3e,
+        type: 3}
+      propertyPath: <AlternativePrefabName>k__BackingField
+      value: AA
+      objectReference: {fileID: 0}
     - target: {fileID: 8722901897224431713, guid: da8e7a51ad26f8f48ac7cff66da55f3e,
         type: 3}
       propertyPath: allClothingData.Array.data[0]

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Eyewear/NightVisionGoggles.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Eyewear/NightVisionGoggles.prefab
@@ -120,6 +120,11 @@ PrefabInstance:
       propertyPath: foreverID
       value: 5668f8777ce1a794980fbd35aa58f56b
       objectReference: {fileID: 0}
+    - target: {fileID: 9007641923583695906, guid: 28c72054b1f484ed4a6253c4feee3eb4,
+        type: 3}
+      propertyPath: <AlternativePrefabName>k__BackingField
+      value: nvg
+      objectReference: {fileID: 0}
     - target: {fileID: 9062951044728521674, guid: 28c72054b1f484ed4a6253c4feee3eb4,
         type: 3}
       propertyPath: clothData
@@ -181,8 +186,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  nightVisionVisibility: {x: 10.5, y: 10.5, z: 21}
   visibilityAnimationSpeed: 0.75
+  OnBodyID: 0
 --- !u!114 &8851959254138389390 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 8141721191079898056, guid: 28c72054b1f484ed4a6253c4feee3eb4,

--- a/UnityProject/Assets/Prefabs/Items/Food/Drinks/_DrinkBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Drinks/_DrinkBase.prefab
@@ -174,6 +174,11 @@ PrefabInstance:
       propertyPath: foreverID
       value: 46bb2fe95f4f66341aadfb4600751333
       objectReference: {fileID: 0}
+    - target: {fileID: 5934183858157482218, guid: 6eb9748e1eaf8dc4598a50e5b09df3b3,
+        type: 3}
+      propertyPath: <AlternativePrefabName>k__BackingField
+      value: drink
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6eb9748e1eaf8dc4598a50e5b09df3b3, type: 3}
 --- !u!1 &7902349682654515116 stripped
@@ -197,6 +202,7 @@ MonoBehaviour:
   brokenItem: {fileID: 2265521501557685915, guid: 82677ff961fa72944936cc923625a1bc,
     type: 3}
   chanceToBreak: 100
+  RequiredImpactSpeed: 3
   useCustomSound: 1
   customSound:
     SetLoadSetting: 0

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/_SnackBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/_SnackBase.prefab
@@ -129,6 +129,11 @@ PrefabInstance:
       propertyPath: foreverID
       value: eaf8c1f2a0f9374488e16061fd5b4dcd
       objectReference: {fileID: 0}
+    - target: {fileID: 5934183858157482218, guid: 6eb9748e1eaf8dc4598a50e5b09df3b3,
+        type: 3}
+      propertyPath: <AlternativePrefabName>k__BackingField
+      value: food snack
+      objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 1481962708363400442, guid: 6eb9748e1eaf8dc4598a50e5b09df3b3, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 6eb9748e1eaf8dc4598a50e5b09df3b3, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Food/_FoodBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/_FoodBase.prefab
@@ -12,6 +12,11 @@ PrefabInstance:
       propertyPath: foreverID
       value: 6eb9748e1eaf8dc4598a50e5b09df3b3
       objectReference: {fileID: 0}
+    - target: {fileID: 3798299677133241229, guid: f866b44bcdd7d734885f7c49999d85c9,
+        type: 3}
+      propertyPath: <AlternativePrefabName>k__BackingField
+      value: food
+      objectReference: {fileID: 0}
     - target: {fileID: 7701549257419364482, guid: f866b44bcdd7d734885f7c49999d85c9,
         type: 3}
       propertyPath: initialSize

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/Energy/_GunEnergyBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/Energy/_GunEnergyBase.prefab
@@ -438,6 +438,11 @@ PrefabInstance:
       propertyPath: foreverID
       value: 143d3926d4a5fa84f95f987c152b33a2
       objectReference: {fileID: 0}
+    - target: {fileID: 3001407139512993015, guid: da85b7a590e7c8444af73629fcb5dd22,
+        type: 3}
+      propertyPath: <AlternativePrefabName>k__BackingField
+      value: gun energy
+      objectReference: {fileID: 0}
     - target: {fileID: 4644871529314044369, guid: da85b7a590e7c8444af73629fcb5dd22,
         type: 3}
       propertyPath: ammoType
@@ -618,6 +623,14 @@ MonoBehaviour:
   loadMagSound:
     SetLoadSetting: 0
     AssetAddress: Assets/Prefabs/Weapons/KineticReload.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
+  unloadMagSound:
+    SetLoadSetting: 0
+    AssetAddress: 
     AssetReference:
       m_AssetGUID: 
       m_SubObjectName: 

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/_GunBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/_GunBase.prefab
@@ -166,6 +166,11 @@ PrefabInstance:
       propertyPath: foreverID
       value: da85b7a590e7c8444af73629fcb5dd22
       objectReference: {fileID: 0}
+    - target: {fileID: 6393191727481188567, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: <AlternativePrefabName>k__BackingField
+      value: gun
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
 --- !u!1 &8150840225578731674 stripped
@@ -215,6 +220,22 @@ MonoBehaviour:
   casingPrefabOverride: {fileID: 0}
   allowMagazineRemoval: 1
   ammoType: 0
+  loadMagSound:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
+  unloadMagSound:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
   pinPrefab: {fileID: 6004521592186936485, guid: 0c0328cbf94ffe648a0903cfc375ab91,
     type: 3}
   suppressorPrefab: {fileID: 0}

--- a/UnityProject/Assets/Scripts/UI/Core/PrefabTracker.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/PrefabTracker.cs
@@ -28,6 +28,7 @@ namespace Util
 		}
 
 		[SerializeField] private string foreverID;
+		[field:SerializeField] public string AlternativePrefabName { get; set; }
 
 		public void ReassignID() //Assuming it's a prefab Variant
 		{

--- a/UnityProject/Assets/Scripts/UI/Core/PrefabTracker.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/PrefabTracker.cs
@@ -28,7 +28,7 @@ namespace Util
 		}
 
 		[SerializeField] private string foreverID;
-		[field:SerializeField] public string AlternativePrefabName { get; set; }
+		[field:SerializeField] public string AlternativePrefabName { get; private set; }
 
 		public void ReassignID() //Assuming it's a prefab Variant
 		{

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/AdminGiveItemEntry.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/AdminGiveItemEntry.cs
@@ -17,7 +17,7 @@ namespace UI.Systems.AdminTools
 		{
 			itemWindow = window;
 			doc = document;
-			itemName.text = document.SearchableName.Capitalize();
+			itemName.text = document.SearchableName[0].Capitalize();
 			Sprite toUse = doc.Prefab.GetComponentInChildren<SpriteRenderer>()?.sprite;
 			if (toUse != null) itemIcon.sprite = toUse;
 		}

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/Search/DevSpawnerDocument.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/Search/DevSpawnerDocument.cs
@@ -23,13 +23,12 @@ namespace UI.Systems.AdminTools.DevTools.Search
 		private DevSpawnerDocument(GameObject prefab)
 		{
 			Prefab = prefab;
-			var possibleNames = new List<string>();
-			possibleNames.Add(SpawnerSearch.Standardize(prefab.name));
+			SearchableName.Add(SpawnerSearch.Standardize(prefab.name));
 			if (prefab.TryGetComponent<PrefabTracker>(out var tracker))
 			{
-				if(string.IsNullOrWhiteSpace(tracker.AlternativePrefabName) == false) possibleNames.Add(tracker.AlternativePrefabName);
+				if(string.IsNullOrWhiteSpace(tracker.AlternativePrefabName) == false) 
+				SearchableName.Add(tracker.AlternativePrefabName);
 			}
-			SearchableName = possibleNames;
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/Search/DevSpawnerDocument.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/Search/DevSpawnerDocument.cs
@@ -23,13 +23,10 @@ namespace UI.Systems.AdminTools.DevTools.Search
 		private DevSpawnerDocument(GameObject prefab)
 		{
 			Prefab = prefab;
-			var possibleNames = new List<string>();
-			possibleNames.Add(SpawnerSearch.Standardize(prefab.name));
-			if (prefab.TryGetComponent<PrefabTracker>(out var tracker))
-			{
-				if(string.IsNullOrWhiteSpace(tracker.AlternativePrefabName) == false) possibleNames.Add(tracker.AlternativePrefabName);
-			}
-			SearchableName = possibleNames;
+			SearchableName = new List<string>();
+			SearchableName.Add(SpawnerSearch.Standardize(prefab.name));
+			if (prefab.TryGetComponent<PrefabTracker>(out var tracker) == false) return;
+			if (string.IsNullOrWhiteSpace(tracker.AlternativePrefabName) == false) SearchableName.Add(tracker.AlternativePrefabName);
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/Search/DevSpawnerDocument.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/Search/DevSpawnerDocument.cs
@@ -1,4 +1,7 @@
-﻿using UnityEngine;
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using Util;
 
 namespace UI.Systems.AdminTools.DevTools.Search
 {
@@ -15,12 +18,18 @@ namespace UI.Systems.AdminTools.DevTools.Search
 		/// <summary>
 		/// Name cleaned up for searchability (like lowercase).
 		/// </summary>
-		public readonly string SearchableName;
+		public readonly List<string> SearchableName;
 
 		private DevSpawnerDocument(GameObject prefab)
 		{
 			Prefab = prefab;
-			SearchableName = SpawnerSearch.Standardize(prefab.name);
+			var possibleNames = new List<string>();
+			possibleNames.Add(SpawnerSearch.Standardize(prefab.name));
+			if (prefab.TryGetComponent<PrefabTracker>(out var tracker))
+			{
+				if(string.IsNullOrWhiteSpace(tracker.AlternativePrefabName) == false) possibleNames.Add(tracker.AlternativePrefabName);
+			}
+			SearchableName = possibleNames;
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/Search/DevSpawnerDocument.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/Search/DevSpawnerDocument.cs
@@ -23,12 +23,13 @@ namespace UI.Systems.AdminTools.DevTools.Search
 		private DevSpawnerDocument(GameObject prefab)
 		{
 			Prefab = prefab;
-			SearchableName.Add(SpawnerSearch.Standardize(prefab.name));
+			var possibleNames = new List<string>();
+			possibleNames.Add(SpawnerSearch.Standardize(prefab.name));
 			if (prefab.TryGetComponent<PrefabTracker>(out var tracker))
 			{
-				if(string.IsNullOrWhiteSpace(tracker.AlternativePrefabName) == false) 
-				SearchableName.Add(tracker.AlternativePrefabName);
+				if(string.IsNullOrWhiteSpace(tracker.AlternativePrefabName) == false) possibleNames.Add(tracker.AlternativePrefabName);
 			}
+			SearchableName = possibleNames;
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/Search/SpawnerSearch.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/Search/SpawnerSearch.cs
@@ -45,7 +45,7 @@ public class SpawnerSearch
 			documents.Add(DevSpawnerDocument.ForPrefab(prefab));
 		}
 
-		return new SpawnerSearch(documents.OrderBy(doc => doc.SearchableName).ToArray());
+		return new SpawnerSearch(documents.OrderBy(doc => doc.SearchableName[0]).ToArray());
 	}
 
 	/// <summary>
@@ -56,8 +56,13 @@ public class SpawnerSearch
 	public IEnumerable<DevSpawnerDocument> Search(string rawSearch)
 	{
 		string standardizedSearch = Standardize(rawSearch);
+		// Linq expression that handles grabbing multiple names from a prefab.
+		// it grabs all prefabs in documents then loops through all prefabs and grabs all searchable names.
+		// if the searchable name contains a substring that the user is searching it will return it.
+		var docs = (from doc in documents from prefabNames in doc.SearchableName
+			where prefabNames.Contains(standardizedSearch) select doc).ToList();
 
-		return documents.Where(doc => doc.SearchableName.Contains(standardizedSearch));
+		return docs;
 	}
 
 	/// <summary>


### PR DESCRIPTION
closes #6438

A bit of a backstory on this PR

This feature was actually done MONTHS ago when I was working on the base stuff for the sandbox PR. However, my branch for that had been lost, sadly, and with it some of the stuff I did in preparation for the sandbox gamemode.

This PR lets admins (and players in the future) to easily search for stuff using alternative names instead of base prefab names.

For example:
NightVisionGoggles is nvg
any food prefab has an alternative starting name of "food"
any drink prefab has an alternative starting name of "drink"
guns are "gun"
energy guns are "gun energy"
captain ID's is "AA"
and so on and so fourth

### Changelog:

CL: [New] Added alternative names for prefabs for easier searching in spawn tools.
