### PR TITLE
Ministation cargo refactor

### DIFF
--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHuggerAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHuggerAI.cs
@@ -12,6 +12,7 @@ namespace Systems.MobAIs
 		[SerializeField]
 		[Tooltip("If true, this hugger won't be counted for the cap Queens use for lying eggs.")]
 		private bool ignoreInQueenCount = false;
+		private bool processedRemovalFromQueenCount = false; //Lifecycle updates can still occur on dead creatures due to healing and the like. We only want to remove the hugger from the queen count once.
 		//private MobMeleeAction mobMeleeAction;
 		private FaceHugAction faceHugAction;
 
@@ -29,6 +30,7 @@ namespace Systems.MobAIs
 			if (ignoreInQueenCount == false)
 			{
 				XenoQueenAI.AddFacehuggerToCount();
+				processedRemovalFromQueenCount = false;
 			}
 			ResetBehaviours();
 		}
@@ -66,12 +68,13 @@ namespace Systems.MobAIs
 		/// </summary>
 		protected override void HandleDeathOrUnconscious()
 		{
-			base.HandleDeathOrUnconscious();
-
-			if (ignoreInQueenCount == false)
+			if (ignoreInQueenCount == false && processedRemovalFromQueenCount == false)
 			{
 				XenoQueenAI.RemoveFacehuggerFromCount();
+				processedRemovalFromQueenCount = true;
 			}
+
+			base.HandleDeathOrUnconscious();
 		}
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)

--- a/UnityProject/Assets/Scripts/Shuttles/CargoShuttle.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/CargoShuttle.cs
@@ -14,7 +14,11 @@ namespace Systems.Cargo
 
 		[SerializeField]
 		private Vector2 centcomDest = new Vector2(4, 150);
+		[SerializeField]
+		private OrientationEnum centcommTravelDirection = OrientationEnum.Up_By0;
 		public Vector2 StationDest = new Vector2(4, 85);
+		[SerializeField]
+		private OrientationEnum stationTravelDirection = OrientationEnum.Down_By180;
 		[SerializeField]
 		private int dockOffset = 23;
 		[SerializeField]
@@ -74,7 +78,7 @@ namespace Systems.Cargo
 		/// </summary>
 		public void MoveToStation()
 		{
-			mm.ChangeFlyingDirection(Orientation.Down);
+			mm.ChangeFlyingDirection(Orientation.FromEnum(stationTravelDirection));
 			MoveTo(StationDest);
 		}
 
@@ -84,7 +88,7 @@ namespace Systems.Cargo
 		/// </summary>
 		public void MoveToCentcom()
 		{
-			mm.ChangeFlyingDirection(Orientation.Up);
+			mm.ChangeFlyingDirection(Orientation.FromEnum(centcommTravelDirection));
 			MoveTo(centcomDest);
 		}
 
@@ -104,11 +108,11 @@ namespace Systems.Cargo
 				moving = false;
 				mm.SetPosition(destination);
 				mm.StopMovement();
-				mm.SteerTo(Orientation.Up);
+				mm.SteerTo(Orientation.FromEnum(centcommTravelDirection));
 
 				if (CargoManager.Instance.ShuttleStatus == ShuttleStatus.OnRouteStation)
 				{
-					mm.ChangeFlyingDirection(Orientation.Down);
+					mm.ChangeFlyingDirection(Orientation.FromEnum(stationTravelDirection));
 					StartCoroutine(ReverseIntoStation());
 				}
 			}
@@ -124,8 +128,8 @@ namespace Systems.Cargo
 		{
 			if (ChangeDirectionAtOffset)
 			{
-				mm.SteerTo(Orientation.Down);
-				mm.ChangeFlyingDirection(Orientation.Up);
+				mm.SteerTo(Orientation.FromEnum(stationTravelDirection));
+				mm.ChangeFlyingDirection(Orientation.FromEnum(centcommTravelDirection));
 			}
 
 			if (dockOffset != 0)


### PR DESCRIPTION
Rebuilds ministation cargo so It no longer blocks science expansion, also expands ministation science to have a proper ordnance setup and a research server.

This PR also has a bug fix and improvements to go in hand with this remapping.

The cargo shuttle autopilot has been given options for fly direction so we can now have cargo shuttles leave the station horizontally without having horrible crashes from rotations.

Fixes the bug with the facehugger count that allowed the xeno queen to spawn an uncapped number of facehuggers.

Fixes #9028 
![Capture](https://user-images.githubusercontent.com/48405920/203827226-689f72a6-9458-4548-9958-737e47dd41c1.PNG)


### Changelog:

CL: [Improvement] Added ability for cargo shuttles to fly horizontal
CL: [Improvement] Remapped ministation cargo and expanded science to include ordnance.
CL: [Fix] Fixed bug with facehugger cap allowing queen to produce an unfiltered amount of spawn
