### PR TITLE
Protip save states are now saved in AppData rather than in the build folder

### DIFF
--- a/UnityProject/Assets/Scripts/Learning/ProtipManager.cs
+++ b/UnityProject/Assets/Scripts/Learning/ProtipManager.cs
@@ -33,7 +33,7 @@ namespace Learning
 		public override void Awake()
 		{
 			base.Awake();
-			jsonPath = Application.streamingAssetsPath + jsonFileName;
+			jsonPath = Application.persistentDataPath + jsonFileName;
 			var experience = PlayerPrefs.GetInt("Learning/ExperienceLevel", -1);
 			if(experience == -1)
 			{


### PR DESCRIPTION
CL: [Improvement] Protip save states are now saved in AppData rather than in the build folder