### PR TITLE
Object highlighter and protips list screen fix

### DIFF
--- a/UnityProject/Assets/Prefabs/Effects/Lights/Resources/lighting/HighlightLight.prefab
+++ b/UnityProject/Assets/Prefabs/Effects/Lights/Resources/lighting/HighlightLight.prefab
@@ -1,0 +1,457 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1066820872290564
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4352916681049056}
+  - component: {fileID: 114974185547909448}
+  - component: {fileID: 23313937845071608}
+  - component: {fileID: 33526499662398226}
+  - component: {fileID: 7794235625031140621}
+  m_Layer: 21
+  m_Name: HighlightLight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4352916681049056
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1066820872290564}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1171945790989921880}
+  - {fileID: 5637921671084476783}
+  - {fileID: 1148893092558269121}
+  - {fileID: 4197792853623432267}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114974185547909448
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1066820872290564}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 61930e16e81db5c43a4ecc22422a0953, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Color: {r: 0.36405307, g: 0.5752158, b: 0.764151, a: 0.83137256}
+  Sprite: {fileID: 21300000, guid: e892e7bfc7d486943aae2b5acb2857e6, type: 3}
+  SortingOrder: 0
+  Material: {fileID: 2100000, guid: 43ab5d29726e6814a824ac235da99f49, type: 2}
+  LightOrigin: {x: 0, y: 0, z: 1}
+  Shape: 0
+--- !u!23 &23313937845071608
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1066820872290564}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &33526499662398226
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1066820872290564}
+  m_Mesh: {fileID: 0}
+--- !u!114 &7794235625031140621
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1066820872290564}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e48d731168684c989c42d600c6568bbc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2937476067856276077
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1148893092558269121}
+  - component: {fileID: 3642959281957624740}
+  m_Layer: 21
+  m_Name: Square (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1148893092558269121
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2937476067856276077}
+  m_LocalRotation: {x: -0, y: -0, z: 0.7116256, w: 0.70255893}
+  m_LocalPosition: {x: 0.008, y: 0.435, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4352916681049056}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90.735}
+--- !u!212 &3642959281957624740
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2937476067856276077}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: f7e2f559c0b07134c9eb276f60f3bcaa, type: 3}
+  m_Color: {r: 0, g: 0.4245283, b: 0.049723804, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &4894617573888397259
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5637921671084476783}
+  - component: {fileID: 2798493545831826123}
+  m_Layer: 21
+  m_Name: Square (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5637921671084476783
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4894617573888397259}
+  m_LocalRotation: {x: -0, y: -0, z: 0.9999867, w: 0.0051508085}
+  m_LocalPosition: {x: -0.412, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4352916681049056}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -180.59}
+--- !u!212 &2798493545831826123
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4894617573888397259}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: f7e2f559c0b07134c9eb276f60f3bcaa, type: 3}
+  m_Color: {r: 0, g: 0.4245283, b: 0.049723804, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &7942492409763400231
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4197792853623432267}
+  - component: {fileID: 3264991988393626966}
+  m_Layer: 21
+  m_Name: Square (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4197792853623432267
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942492409763400231}
+  m_LocalRotation: {x: -0, y: -0, z: 0.7103861, w: -0.7038121}
+  m_LocalPosition: {x: 0.03, y: -0.458, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4352916681049056}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -90.533}
+--- !u!212 &3264991988393626966
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942492409763400231}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: f7e2f559c0b07134c9eb276f60f3bcaa, type: 3}
+  m_Color: {r: 0, g: 0.4245283, b: 0.049723804, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &8799513298382955679
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1171945790989921880}
+  - component: {fileID: 6653841889102508856}
+  m_Layer: 21
+  m_Name: Square (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1171945790989921880
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8799513298382955679}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.443, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4352916681049056}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &6653841889102508856
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8799513298382955679}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: f7e2f559c0b07134c9eb276f60f3bcaa, type: 3}
+  m_Color: {r: 0, g: 0.4245283, b: 0.049723804, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0

--- a/UnityProject/Assets/Prefabs/Effects/Lights/Resources/lighting/HighlightLight.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Effects/Lights/Resources/lighting/HighlightLight.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8d984de2ede71aa47b8c9d30340c768b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Items/Bureaucracy/Paper.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Bureaucracy/Paper.prefab
@@ -64,7 +64,7 @@ PrefabInstance:
         type: 3}
       propertyPath: customNetTransform
       value: 
-      objectReference: {fileID: 8692860622524097638}
+      objectReference: {fileID: 0}
     - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: m_Sprite
@@ -248,18 +248,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
---- !u!114 &8692860622524097638 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 114341119007412586, guid: a7abba22164ce49f0bf9b9b219f39298,
-    type: 3}
-  m_PrefabInstance: {fileID: 8733893691203122444}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8734328976324889014}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &8734328976324889014 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1011433845357754, guid: a7abba22164ce49f0bf9b9b219f39298,
@@ -298,6 +286,24 @@ MonoBehaviour:
   NetTabType: 13
   originalName: 
   customName: 
+--- !u!114 &4897634797340284583
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8734328976324889014}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1be952724c3641bf965e9f9f6ba63ec5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TipSO: {fileID: 11400000, guid: a151f299d3c16a24c87bc1883f18cdd6, type: 2}
+  triggerOnce: 1
+  showEvenAfterDeath: 0
+  tipCooldown: 200
+  highlightableObjectNames:
+  - pen
 --- !u!114 &6377258629491125575
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -328,20 +334,3 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   NetTabType: 4
   paper: {fileID: 585395312865148023}
---- !u!114 &4897634797340284583
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8734328976324889014}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1be952724c3641bf965e9f9f6ba63ec5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  TipSO: {fileID: 11400000, guid: a151f299d3c16a24c87bc1883f18cdd6, type: 2}
-  saveID: 0
-  triggerOnce: 1
-  showEvenAfterDeath: 0
-  tipCooldown: 200

--- a/UnityProject/Assets/Prefabs/SceneConstruction/Managers.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/Managers.prefab
@@ -72,6 +72,7 @@ Transform:
   - {fileID: 9160233621485501886}
   - {fileID: 2814085986732872573}
   - {fileID: 8810713153213744065}
+  - {fileID: 7165609935498025567}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -278,6 +279,53 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dff27241e0ca476499651da6c30bcd72, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &2384265861382536711
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7165609935498025567}
+  - component: {fileID: 7040443682087329741}
+  m_Layer: 0
+  m_Name: GlobalHighlightManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7165609935498025567
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2384265861382536711}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4244501537706558}
+  m_RootOrder: 40
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7040443682087329741
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2384265861382536711}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 90d277878d744079a2fe8326b5ce5160, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maximumSearchIndexesPerFrame: 20
+  highlightObjectWorld: {fileID: 1066820872290564, guid: 8d984de2ede71aa47b8c9d30340c768b,
+    type: 3}
 --- !u!1 &2562141563749181643
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/GameManager.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/GameManager.prefab
@@ -54,7 +54,7 @@ MonoBehaviour:
   minDistanceBetweenSpaceBodies: 200
   solarSystemRadius: 600
   CentComm: {fileID: 5244294626086762232}
-  QuickLoad: 1
+  QuickLoad: 0
   QuickJoinLoad: 0
   endOfRoundSounds: {fileID: 11400000, guid: 3505a71866d7e9e43a6cdc336306b41f, type: 2}
   LowPopCheckTimeAfterRoundStart: 300

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/GameManager.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/GameManager.prefab
@@ -54,7 +54,7 @@ MonoBehaviour:
   minDistanceBetweenSpaceBodies: 200
   solarSystemRadius: 600
   CentComm: {fileID: 5244294626086762232}
-  QuickLoad: 0
+  QuickLoad: 1
   QuickJoinLoad: 0
   endOfRoundSounds: {fileID: 11400000, guid: 3505a71866d7e9e43a6cdc336306b41f, type: 2}
   LowPopCheckTimeAfterRoundStart: 300

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/NetworkManager.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/NetworkManager.prefab
@@ -5619,6 +5619,7 @@ MonoBehaviour:
   - {fileID: 1455342170646118, guid: fd40c08c9e8ef41199b2aff06993d79d, type: 3}
   - {fileID: 1066820872290564, guid: 328edb992af384194bef34bd277bbf2f, type: 3}
   - {fileID: 1066820872290564, guid: 0e368c27226174ee0ab5faf170a49651, type: 3}
+  - {fileID: 1066820872290564, guid: 8d984de2ede71aa47b8c9d30340c768b, type: 3}
   - {fileID: 1595177584672772, guid: ebffaf917bb3f4675adc3b93da617930, type: 3}
   - {fileID: 6770364348648799666, guid: f509953bc6beb934f920b927bb4ea694, type: 3}
   - {fileID: 1558421102126524431, guid: 36094128399f8704da2ff54a58c2f4f5, type: 3}

--- a/UnityProject/Assets/Prefabs/UI/Learning/HelpWindow.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Learning/HelpWindow.prefab
@@ -585,8 +585,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0.000061035156}
-  m_SizeDelta: {x: -314.91, y: -190.52}
+  m_AnchoredPosition: {x: 10.715027, y: 0.000061035156}
+  m_SizeDelta: {x: -336.33, y: -190.52}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &7161827552320008256
 CanvasRenderer:
@@ -1903,8 +1903,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 259.9195, y: 39.954926}
-  m_SizeDelta: {x: 118.82471, y: 103.72876}
+  m_AnchoredPosition: {x: 5.3582153, y: 0.6503601}
+  m_SizeDelta: {x: -336.33, y: -190.52}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7236747523960057131
 CanvasRenderer:

--- a/UnityProject/Assets/Scripts/Core/Highlight/IHighlightable.cs
+++ b/UnityProject/Assets/Scripts/Core/Highlight/IHighlightable.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace Core.Highlight
+{
+	public interface IHighlightable
+	{
+		public List<string>  SearchableString();
+		public void HighlightObject();
+	}
+}

--- a/UnityProject/Assets/Scripts/Core/Highlight/IHighlightable.cs.meta
+++ b/UnityProject/Assets/Scripts/Core/Highlight/IHighlightable.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5e475989a4484722bcfae460ed349b0c
+timeCreated: 1670968188

--- a/UnityProject/Assets/Scripts/Core/Highlight/LightHighlight.cs
+++ b/UnityProject/Assets/Scripts/Core/Highlight/LightHighlight.cs
@@ -1,0 +1,25 @@
+using System;
+using Light2D;
+using Objects.Lighting;
+using UnityEngine;
+
+namespace Core.Highlight
+{
+	public class LightHighlight : MonoBehaviour
+	{
+		private LightSprite source;
+
+		private void Awake()
+		{
+			source = GetComponent<LightSprite>();
+		}
+
+		private void Update()
+		{
+			var newColor = source.Color;
+			newColor.a = Mathf.Lerp(source.Color.a, 0, .55f);
+			source.Color = newColor;
+			if(source.Color.a <= 0) Destroy(gameObject);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Core/Highlight/LightHighlight.cs.meta
+++ b/UnityProject/Assets/Scripts/Core/Highlight/LightHighlight.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e48d731168684c989c42d600c6568bbc
+timeCreated: 1670976095

--- a/UnityProject/Assets/Scripts/Learning/ProtipObject.cs
+++ b/UnityProject/Assets/Scripts/Learning/ProtipObject.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
+using Managers;
 using NaughtyAttributes;
 using UnityEngine;
 using Util;
@@ -20,6 +22,8 @@ namespace Learning
 		private float tipCooldown = 200f;
 
 		private bool isOnCooldown = false;
+
+		[SerializeField] protected List<string> highlightableObjectNames;
 
 		private void Awake()
 		{
@@ -76,12 +80,11 @@ namespace Learning
 
 		protected void TriggerTip(GameObject triggeredBy = null)
 		{
-			if(TriggerConditions(triggeredBy, TipSO) == false) return;
-			ProtipManager.Instance.QueueTip(TipSO);
+			if (TriggerConditions(triggeredBy, TipSO) == false) return;
+			ProtipManager.Instance.QueueTip(TipSO, highlightableObjectNames);
 			if (triggerOnce)
 			{
-				PlayerPrefs.SetString($"{TipSO.TipTitle}", "true");
-				PlayerPrefs.Save();
+				ProtipManager.Instance.SaveTipState(TipSO.TipTitle);
 				RemoveThisComponent();
 				return;
 			}
@@ -89,15 +92,15 @@ namespace Learning
 			StartCoroutine(Cooldown());
 		}
 
-		protected void TriggerTip(ProtipSO protipSo, GameObject triggeredBy = null)
+		protected void TriggerTip(ProtipSO protipSo, GameObject triggeredBy = null, List<string> highlightNames = null)
 		{
-			if(TriggerConditions(triggeredBy, protipSo) == false && CheckSaveStatus(protipSo)) return;
-			if(protipSo == null)
+			if (TriggerConditions(triggeredBy, protipSo) == false && CheckSaveStatus(protipSo)) return;
+			if (protipSo == null)
 			{
 				Logger.LogError("Passed ProtipSO is null. Cannot trigger tip.");
 				return;
 			}
-			ProtipManager.Instance.QueueTip(protipSo);
+			ProtipManager.Instance.QueueTip(protipSo, highlightableObjectNames);
 			if (triggerOnce)
 			{
 				ProtipManager.Instance.SaveTipState(protipSo.TipTitle);

--- a/UnityProject/Assets/Scripts/Learning/ProtipObjectTypes/ProtipObjectOnHealthStateChange.cs
+++ b/UnityProject/Assets/Scripts/Learning/ProtipObjectTypes/ProtipObjectOnHealthStateChange.cs
@@ -99,7 +99,7 @@ namespace Learning.ProtipObjectTypes
 
 		private void TriggerConsciousEvent(ConsciousState state)
 		{
-			if(unconciousTipCooldown || deathTipCooldown || IsPlayerGhostInBody()) return;
+			if (unconciousTipCooldown || deathTipCooldown || IsPlayerGhostInBody()) return;
 			switch (state)
 			{
 				case ConsciousState.BARELY_CONSCIOUS:

--- a/UnityProject/Assets/Scripts/Learning/ProtipObjectTypes/ProtipObjectOnPickupTrait.cs
+++ b/UnityProject/Assets/Scripts/Learning/ProtipObjectTypes/ProtipObjectOnPickupTrait.cs
@@ -38,7 +38,7 @@ namespace Learning.ProtipObjectTypes
 			foreach (var trait in handslot.ItemAttributes.GetTraits())
 			{
 				if(protipsForTraits.ContainsKey(trait) == false) continue;
-				TriggerTip(protipsForTraits[trait]);
+				TriggerTip(protipsForTraits[trait], null, highlightableObjectNames);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Managers/GlobalHighlighterManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GlobalHighlighterManager.cs
@@ -25,7 +25,7 @@ namespace Managers
 			foreach (var possibleTarget in FindObjectsOfType<GameObject>())
 			{
 				index++;
-				if (maximumSearchIndexesPerFrame > index)
+				if (index > maximumSearchIndexesPerFrame)
 				{
 					index = 0;
 					yield return WaitFor.EndOfFrame;

--- a/UnityProject/Assets/Scripts/Managers/GlobalHighlighterManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GlobalHighlighterManager.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections;
+using System.Linq;
+using Core.Highlight;
+using Shared.Managers;
+using UnityEngine;
+
+namespace Managers
+{
+	public class GlobalHighlighterManager : SingletonManager<GlobalHighlighterManager>
+	{
+		[SerializeField] private int maximumSearchIndexesPerFrame = 50;
+		[SerializeField] private GameObject highlightObjectWorld;
+
+		public static GameObject HighlightObject => Instance.highlightObjectWorld;
+
+		public static void Highlight(string searchName)
+		{
+			Instance.StartCoroutine(Instance.Search(searchName.ToLower()));
+		}
+
+		private IEnumerator Search(string searchName)
+		{
+			var index = -1;
+			foreach (var possibleTarget in FindObjectsOfType<GameObject>())
+			{
+				index++;
+				if (maximumSearchIndexesPerFrame > index)
+				{
+					index = 0;
+					yield return WaitFor.EndOfFrame;
+				}
+				if (possibleTarget.TryGetComponent<IHighlightable>(out var target) == false) continue;
+				if (target.SearchableString().Any(foundName => string.Equals(foundName, searchName, StringComparison.CurrentCultureIgnoreCase)))
+				{
+					target.HighlightObject();
+				}
+			}
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Managers/GlobalHighlighterManager.cs.meta
+++ b/UnityProject/Assets/Scripts/Managers/GlobalHighlighterManager.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 90d277878d744079a2fe8326b5ce5160
+timeCreated: 1670968070


### PR DESCRIPTION
I was working on a super-secret-update for this new years and I needed the object highlighter that was planned for the protips so here is it and some fixes as well

### Changelog

CL: [New] Added a new system to highlight any game object on the client's side which is utilized by the protips only for now.
CL: [Fix] The `triggerOnce` condition for protips did not correctly save under some circumstances, now this has been fixed.
CL: [Fix] The protips list screen has had its viewport fixed.
