### PR TITLE
Singulo Improvements

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Electricity/Engines/SingularityEngine/SingularityStages/Singularity.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Electricity/Engines/SingularityEngine/SingularityStages/Singularity.prefab
@@ -102,6 +102,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5124450014596669819}
+  - component: {fileID: 6281549647186351087}
   - component: {fileID: 6604085803539985251}
   - component: {fileID: 5198684123758150572}
   - component: {fileID: 6356715080128028321}
@@ -127,6 +128,17 @@ Transform:
   m_Father: {fileID: 4692177491394706899}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!210 &6281549647186351087
+SortingGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4225673206677485874}
+  m_Enabled: 1
+  m_SortingLayerID: -2035547137
+  m_SortingLayer: 29
+  m_SortingOrder: 1
 --- !u!33 &6604085803539985251
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -143,8 +155,8 @@ MeshRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4225673206677485874}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
   m_DynamicOccludee: 1
   m_StaticShadowCaster: 0
   m_MotionVectors: 1
@@ -200,6 +212,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1917010104315098165}
+  - component: {fileID: 5230911568476702437}
   - component: {fileID: 7405739772679748990}
   - component: {fileID: 5759546546122504261}
   - component: {fileID: 2967432370711235922}
@@ -225,6 +238,17 @@ Transform:
   m_Father: {fileID: 4692177491394706899}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!210 &5230911568476702437
+SortingGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8690972991113334663}
+  m_Enabled: 1
+  m_SortingLayerID: -2035547137
+  m_SortingLayer: 29
+  m_SortingOrder: 0
 --- !u!33 &7405739772679748990
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -241,8 +265,8 @@ MeshRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8690972991113334663}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
   m_DynamicOccludee: 1
   m_StaticShadowCaster: 0
   m_MotionVectors: 1
@@ -360,7 +384,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 5e98f507e5003bc42a894effba848e78,
+      objectReference: {fileID: 21300002, guid: 5e98f507e5003bc42a894effba848e78,
         type: 3}
     - target: {fileID: 4116897424394887774, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
@@ -496,7 +520,7 @@ PrefabInstance:
         type: 3}
       propertyPath: CurrentsortingGroup
       value: 
-      objectReference: {fileID: 8053698836628426681}
+      objectReference: {fileID: 0}
     - target: {fileID: 4800765294880679425, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
       propertyPath: initialCrawlPassable
@@ -586,7 +610,25 @@ PrefabInstance:
         type: 2}
     m_RemovedComponents:
     - {fileID: 90804091474310291, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
+    - {fileID: 1481169419180323577, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
+--- !u!1 &3567433086965516595 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5388634654466307187, guid: ebb08cf966efc084aa918bd8d9429604,
+    type: 3}
+  m_PrefabInstance: {fileID: 8884009795189538112}
+  m_PrefabAsset: {fileID: 0}
+--- !u!210 &5431217265815002489
+SortingGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3567433086965516595}
+  m_Enabled: 1
+  m_SortingLayerID: -2035547137
+  m_SortingLayer: 29
+  m_SortingOrder: 2
 --- !u!1 &4686069471335676681 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4197940402254186057, guid: ebb08cf966efc084aa918bd8d9429604,
@@ -638,12 +680,6 @@ MonoBehaviour:
 --- !u!4 &4692177491394706899 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4204006106222477459, guid: ebb08cf966efc084aa918bd8d9429604,
-    type: 3}
-  m_PrefabInstance: {fileID: 8884009795189538112}
-  m_PrefabAsset: {fileID: 0}
---- !u!210 &8053698836628426681 stripped
-SortingGroup:
-  m_CorrespondingSourceObject: {fileID: 1481169419180323577, guid: ebb08cf966efc084aa918bd8d9429604,
     type: 3}
   m_PrefabInstance: {fileID: 8884009795189538112}
   m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Objects/Electricity/Engines/SingularityEngine/SingularityStages/Singularity.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Electricity/Engines/SingularityEngine/SingularityStages/Singularity.prefab
@@ -384,7 +384,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300002, guid: 5e98f507e5003bc42a894effba848e78,
+      objectReference: {fileID: 21300000, guid: 5e98f507e5003bc42a894effba848e78,
         type: 3}
     - target: {fileID: 4116897424394887774, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}

--- a/UnityProject/Assets/Scripts/Objects/Singularity.cs
+++ b/UnityProject/Assets/Scripts/Objects/Singularity.cs
@@ -26,6 +26,7 @@ namespace Objects
 
 		private Orientation currentFacing = Orientation.Up;
 		private const float directionThreshold = 93.5f;
+		//Chance in % that the singulo will stay its current course each move action.
 		//With this value, the singularity will move in a straight line for 10tiles 50% of the time.
 		//I thought that was a good compromise between moving in straight lines and still changing direction at random.
 
@@ -149,9 +150,10 @@ namespace Objects
 			if (CustomNetworkManager.IsServer == false) return;
 
 			CurrentStage = startingStage;
+			currentFacing = currentFacing.Rotate(Random.Range(1, 4)); //Random direction on start
 		}
 
-		private void OnEnable()
+		private void OnEnable() 
 		{
 			UpdateManager.Add(SingularityUpdate, updateFrequency);
 		}
@@ -502,8 +504,6 @@ namespace Objects
 		{
 			int radius = GetRadius(CurrentStage);
 
-			if (Random.Range(0, 100) >= directionThreshold) currentFacing.Rotate(Random.Range(1,3)); //Random new angle excluding current angle.
-
 			var coord = currentFacing.LocalVectorInt.To3Int() + registerTile.WorldPositionServer;
 
 			bool noObstructions = true;
@@ -527,7 +527,7 @@ namespace Objects
 				if (CurrentStage != SingularityStages.Stage5 && CurrentStage != SingularityStages.Stage4)
 				{
 					//Hit in front, to give a bump effect so smaller singularity doesnt get stuck in walls
-					HitLineInFront(radius, adjacentCoord);
+					HitLineInFront(radius, currentFacing.LocalVectorInt.To3Int());
 					return;
 				}
 
@@ -539,6 +539,7 @@ namespace Objects
 				return;
 			}
 
+			if (Random.Range(0, 101) >= directionThreshold) currentFacing = currentFacing.Rotate(Random.Range(1, 4)); //Random new angle excluding current angle.
 			//Move
 			ObjectPhysics.AppearAtWorldPositionServer(coord, true);
 		}

--- a/UnityProject/Assets/Scripts/Objects/Singularity.cs
+++ b/UnityProject/Assets/Scripts/Objects/Singularity.cs
@@ -24,6 +24,11 @@ namespace Objects
 
 		private readonly float updateFrequency = 0.5f;
 
+		private Orientation currentFacing = Orientation.Up;
+		private const float directionThreshold = 93.5f;
+		//With this value, the singularity will move in a straight line for 10tiles 50% of the time.
+		//I thought that was a good compromise between moving in straight lines and still changing direction at random.
+
 		public SingularityStages CurrentStage
 		{
 			get
@@ -497,9 +502,9 @@ namespace Objects
 		{
 			int radius = GetRadius(CurrentStage);
 
-			//Get random coordinate adjacent to current
-			var adjacentCoord = adjacentCoords.GetRandom();
-			var coord = adjacentCoord + registerTile.WorldPositionServer;
+			if (Random.Range(0, 100) >= directionThreshold) currentFacing.Rotate(Random.Range(1,3)); //Random new angle excluding current angle.
+
+			var coord = currentFacing.LocalVectorInt.To3Int() + registerTile.WorldPositionServer;
 
 			bool noObstructions = true;
 

--- a/UnityProject/Assets/Shaders/WarpShader.shader
+++ b/UnityProject/Assets/Shaders/WarpShader.shader
@@ -15,7 +15,9 @@ Shader "Custom/WarpShader"
 			"RenderType" = "Transparent"
 			"Queue" = "Transparent"
 		}
-		GrabPass { }
+		//Recalculates grabTexture for each singulo. More expensive to render however allows multiple singulos to effect that same area. 
+		//Won't be a issue unless we have admins spamming like 20+ singularities. It's a tradeoff between having singulos render correctly and performance.
+		GrabPass { } 
 		Pass
 		{
 			Name "UNITY_PASS_FORWARDBASE"

--- a/UnityProject/Assets/Shaders/WarpShader.shader
+++ b/UnityProject/Assets/Shaders/WarpShader.shader
@@ -15,7 +15,7 @@ Shader "Custom/WarpShader"
 			"RenderType" = "Transparent"
 			"Queue" = "Transparent"
 		}
-		GrabPass { "_BackgroundTexture" }
+		GrabPass { }
 		Pass
 		{
 			Name "UNITY_PASS_FORWARDBASE"
@@ -39,7 +39,7 @@ Shader "Custom/WarpShader"
 
 			float vec(float x) { return float(x); }
 
-			uniform sampler2D _BackgroundTexture;
+			sampler2D _GrabTexture;
 
 			struct VertexInput
 			{
@@ -86,7 +86,7 @@ Shader "Custom/WarpShader"
 				i.projPos.xy = i.projPos.xy - uv.xy;
 				i.projPos.xy += spiral;
 
-				fixed4 output = tex2Dproj(_BackgroundTexture, UNITY_PROJ_COORD(i.projPos) );
+				fixed4 output = tex2Dproj(_GrabTexture, UNITY_PROJ_COORD(i.projPos) );
 		
 				return output;
 			}


### PR DESCRIPTION
Fixes #8790

About the shader changes:
I left a comment in the shader script but Ill say it again here because I think it is of relevance to mention.
So the shader not working before has to do with GrabPasses. As it was only doing one grab pass per frame the singularities were drawing over the top of one another. This change means each singulo does its own grab pass, allowing them to distort the distortion of other singulos. This allows the singulos to render correctly but does come at the cost of performance. I opted to do this anyways as it is very rare that players will even have 5 singulos on screen at once so the performace impact of doing the multiple passes will be neglible most of the time. However in the scenarios where an admin spawns a whole bunch of singulos all at the same place, it could result in a client side performance impact for people looking at the singulos.
See also: Comment in warpShader.shader

![image](https://user-images.githubusercontent.com/48405920/208294550-daf7a3e9-dfc2-4b36-9d22-9510086af8e0.png)

### Changelog:
CL: [Improvement] Singularities will now follow more distinct lines as opposed to hovering about in one spot.
CL: [Fix] Fixed the visual bug where multiple singularities next to one another would overlap and cut each other off.
