### PR TITLE
Some balancing and fixes

### DIFF
--- a/UnityProject/Assets/Scenes/AwaySites/Backrooms.unity
+++ b/UnityProject/Assets/Scenes/AwaySites/Backrooms.unity
@@ -139,7 +139,7 @@ PrefabInstance:
     - target: {fileID: 3383979214839746496, guid: c10109559e87d924bb10ee31d3bd33cb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 20
+      value: 23
       objectReference: {fileID: 0}
     - target: {fileID: 3383979214839746496, guid: c10109559e87d924bb10ee31d3bd33cb,
         type: 3}
@@ -924,7 +924,7 @@ PrefabInstance:
     - target: {fileID: 7645387831379206111, guid: bc87c38bbcd94b24598001367ccfcebc,
         type: 3}
       propertyPath: m_RootOrder
-      value: 61
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7645387831379206111, guid: bc87c38bbcd94b24598001367ccfcebc,
         type: 3}
@@ -1002,7 +1002,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4935453910410470, guid: a58eb8439b40f4edcb454576873ef674, type: 3}
       propertyPath: m_RootOrder
-      value: 37
+      value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 4935453910410470, guid: a58eb8439b40f4edcb454576873ef674, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1152,7 +1152,7 @@ PrefabInstance:
     - target: {fileID: 3648120864297585865, guid: 2407c0dfdb50498458bb73d34951803b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 3648120864297585865, guid: 2407c0dfdb50498458bb73d34951803b,
         type: 3}
@@ -1248,7 +1248,7 @@ PrefabInstance:
     - target: {fileID: 6040282718721912025, guid: 7020b235ecf8ece4ca00af70a60258f8,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 6040282718721912025, guid: 7020b235ecf8ece4ca00af70a60258f8,
         type: 3}
@@ -1630,7 +1630,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: b5d421f0156248b4297eecc918b8758a, type: 3}
       propertyPath: m_RootOrder
-      value: 11
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: b5d421f0156248b4297eecc918b8758a, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1874,7 +1874,7 @@ PrefabInstance:
     - target: {fileID: 5343057899039145872, guid: ce971a77eb7c2894e8583efec1c56965,
         type: 3}
       propertyPath: m_RootOrder
-      value: 47
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 5343057899039145872, guid: ce971a77eb7c2894e8583efec1c56965,
         type: 3}
@@ -1939,7 +1939,7 @@ PrefabInstance:
     - target: {fileID: 7045011890306318302, guid: 4e067333d18d9724690055be203850b5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 16
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 7045011890306318302, guid: 4e067333d18d9724690055be203850b5,
         type: 3}
@@ -2105,7 +2105,7 @@ PrefabInstance:
     - target: {fileID: 5343057899039145872, guid: ce971a77eb7c2894e8583efec1c56965,
         type: 3}
       propertyPath: m_RootOrder
-      value: 46
+      value: 49
       objectReference: {fileID: 0}
     - target: {fileID: 5343057899039145872, guid: ce971a77eb7c2894e8583efec1c56965,
         type: 3}
@@ -2644,18 +2644,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 272183588}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &277783355
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &296603096
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2749,7 +2737,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4444041875581058, guid: 262061330351f42c88cd0ac8729f38c2, type: 3}
       propertyPath: m_RootOrder
-      value: 31
+      value: 34
       objectReference: {fileID: 0}
     - target: {fileID: 4444041875581058, guid: 262061330351f42c88cd0ac8729f38c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -3686,7 +3674,7 @@ PrefabInstance:
     - target: {fileID: 7645387831379206111, guid: bc87c38bbcd94b24598001367ccfcebc,
         type: 3}
       propertyPath: m_RootOrder
-      value: 62
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 7645387831379206111, guid: bc87c38bbcd94b24598001367ccfcebc,
         type: 3}
@@ -4351,7 +4339,7 @@ PrefabInstance:
     - target: {fileID: 3949891756602586987, guid: 1a29d7430eef409409b622cc8278453e,
         type: 3}
       propertyPath: m_RootOrder
-      value: 54
+      value: 57
       objectReference: {fileID: 0}
     - target: {fileID: 3949891756602586987, guid: 1a29d7430eef409409b622cc8278453e,
         type: 3}
@@ -5549,7 +5537,7 @@ PrefabInstance:
     - target: {fileID: 6667420018481962187, guid: 38fc3366c44c5c74985ac2eca341696d,
         type: 3}
       propertyPath: m_RootOrder
-      value: 53
+      value: 56
       objectReference: {fileID: 0}
     - target: {fileID: 6667420018481962187, guid: 38fc3366c44c5c74985ac2eca341696d,
         type: 3}
@@ -5632,7 +5620,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4444041875581058, guid: 262061330351f42c88cd0ac8729f38c2, type: 3}
       propertyPath: m_RootOrder
-      value: 41
+      value: 44
       objectReference: {fileID: 0}
     - target: {fileID: 4444041875581058, guid: 262061330351f42c88cd0ac8729f38c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -5937,7 +5925,7 @@ PrefabInstance:
     - target: {fileID: 2650052370968986085, guid: 8f1ce2b118c25334fa660be931e62dbf,
         type: 3}
       propertyPath: m_RootOrder
-      value: 24
+      value: 27
       objectReference: {fileID: 0}
     - target: {fileID: 2650052370968986085, guid: 8f1ce2b118c25334fa660be931e62dbf,
         type: 3}
@@ -6319,7 +6307,7 @@ PrefabInstance:
     - target: {fileID: 5343057899039145872, guid: ce971a77eb7c2894e8583efec1c56965,
         type: 3}
       propertyPath: m_RootOrder
-      value: 45
+      value: 48
       objectReference: {fileID: 0}
     - target: {fileID: 5343057899039145872, guid: ce971a77eb7c2894e8583efec1c56965,
         type: 3}
@@ -6390,7 +6378,7 @@ PrefabInstance:
     - target: {fileID: 5343057899039145872, guid: ce971a77eb7c2894e8583efec1c56965,
         type: 3}
       propertyPath: m_RootOrder
-      value: 42
+      value: 45
       objectReference: {fileID: 0}
     - target: {fileID: 5343057899039145872, guid: ce971a77eb7c2894e8583efec1c56965,
         type: 3}
@@ -6535,7 +6523,7 @@ PrefabInstance:
     - target: {fileID: 7045011890306318302, guid: 4e067333d18d9724690055be203850b5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 17
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 7045011890306318302, guid: 4e067333d18d9724690055be203850b5,
         type: 3}
@@ -7240,7 +7228,7 @@ PrefabInstance:
     - target: {fileID: 3383979214839746496, guid: c10109559e87d924bb10ee31d3bd33cb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 19
+      value: 22
       objectReference: {fileID: 0}
     - target: {fileID: 3383979214839746496, guid: c10109559e87d924bb10ee31d3bd33cb,
         type: 3}
@@ -7469,7 +7457,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4444041875581058, guid: 262061330351f42c88cd0ac8729f38c2, type: 3}
       propertyPath: m_RootOrder
-      value: 32
+      value: 35
       objectReference: {fileID: 0}
     - target: {fileID: 4444041875581058, guid: 262061330351f42c88cd0ac8729f38c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -7947,7 +7935,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: b5d421f0156248b4297eecc918b8758a, type: 3}
       propertyPath: m_RootOrder
-      value: 12
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: b5d421f0156248b4297eecc918b8758a, type: 3}
       propertyPath: m_LocalPosition.x
@@ -8112,7 +8100,7 @@ PrefabInstance:
     - target: {fileID: 1485512523104261457, guid: 5ec00bb76bef2cb4c82733598b9e3c47,
         type: 3}
       propertyPath: m_RootOrder
-      value: 52
+      value: 55
       objectReference: {fileID: 0}
     - target: {fileID: 1485512523104261457, guid: 5ec00bb76bef2cb4c82733598b9e3c47,
         type: 3}
@@ -8357,7 +8345,7 @@ PrefabInstance:
     - target: {fileID: 8927680018489269236, guid: a34b9bd5acaa56348acb4c3a83be928a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 18
+      value: 21
       objectReference: {fileID: 0}
     - target: {fileID: 8927680018489269236, guid: a34b9bd5acaa56348acb4c3a83be928a,
         type: 3}
@@ -8738,18 +8726,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 748780762}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &749620359
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &750171582
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8935,7 +8911,7 @@ PrefabInstance:
     - target: {fileID: 5503893774013820961, guid: 712602426c244754cbfc696362bb07c5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 57
+      value: 60
       objectReference: {fileID: 0}
     - target: {fileID: 5503893774013820961, guid: 712602426c244754cbfc696362bb07c5,
         type: 3}
@@ -9468,7 +9444,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4444041875581058, guid: 262061330351f42c88cd0ac8729f38c2, type: 3}
       propertyPath: m_RootOrder
-      value: 27
+      value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 4444041875581058, guid: 262061330351f42c88cd0ac8729f38c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -9599,7 +9575,7 @@ PrefabInstance:
     - target: {fileID: 3886420102415239829, guid: c86f63f8057a7394b86caf74c060ba96,
         type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 3886420102415239829, guid: c86f63f8057a7394b86caf74c060ba96,
         type: 3}
@@ -10231,7 +10207,7 @@ PrefabInstance:
     - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 58
+      value: 61
       objectReference: {fileID: 0}
     - target: {fileID: 3897735824069816104, guid: d98f2fb82408dae4296038c656ee83fb,
         type: 3}
@@ -10554,7 +10530,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4935453910410470, guid: a58eb8439b40f4edcb454576873ef674, type: 3}
       propertyPath: m_RootOrder
-      value: 30
+      value: 33
       objectReference: {fileID: 0}
     - target: {fileID: 4935453910410470, guid: a58eb8439b40f4edcb454576873ef674, type: 3}
       propertyPath: m_LocalPosition.x
@@ -10910,6 +10886,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 943429046}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &954853095
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &966529927
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10936,7 +10924,7 @@ PrefabInstance:
     - target: {fileID: 6040282718721912025, guid: 7020b235ecf8ece4ca00af70a60258f8,
         type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 6040282718721912025, guid: 7020b235ecf8ece4ca00af70a60258f8,
         type: 3}
@@ -11002,7 +10990,7 @@ PrefabInstance:
     - target: {fileID: 5343057899039145872, guid: ce971a77eb7c2894e8583efec1c56965,
         type: 3}
       propertyPath: m_RootOrder
-      value: 43
+      value: 46
       objectReference: {fileID: 0}
     - target: {fileID: 5343057899039145872, guid: ce971a77eb7c2894e8583efec1c56965,
         type: 3}
@@ -11065,7 +11053,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4935453910410470, guid: a58eb8439b40f4edcb454576873ef674, type: 3}
       propertyPath: m_RootOrder
-      value: 28
+      value: 31
       objectReference: {fileID: 0}
     - target: {fileID: 4935453910410470, guid: a58eb8439b40f4edcb454576873ef674, type: 3}
       propertyPath: m_LocalPosition.x
@@ -11915,7 +11903,7 @@ PrefabInstance:
     - target: {fileID: 7645387831379206111, guid: bc87c38bbcd94b24598001367ccfcebc,
         type: 3}
       propertyPath: m_RootOrder
-      value: 63
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 7645387831379206111, guid: bc87c38bbcd94b24598001367ccfcebc,
         type: 3}
@@ -12479,7 +12467,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4935453910410470, guid: a58eb8439b40f4edcb454576873ef674, type: 3}
       propertyPath: m_RootOrder
-      value: 38
+      value: 41
       objectReference: {fileID: 0}
     - target: {fileID: 4935453910410470, guid: a58eb8439b40f4edcb454576873ef674, type: 3}
       propertyPath: m_LocalPosition.x
@@ -12932,7 +12920,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: b5d421f0156248b4297eecc918b8758a, type: 3}
       propertyPath: m_RootOrder
-      value: 10
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: b5d421f0156248b4297eecc918b8758a, type: 3}
       propertyPath: m_LocalPosition.x
@@ -13343,7 +13331,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4444041875581058, guid: 262061330351f42c88cd0ac8729f38c2, type: 3}
       propertyPath: m_RootOrder
-      value: 26
+      value: 29
       objectReference: {fileID: 0}
     - target: {fileID: 4444041875581058, guid: 262061330351f42c88cd0ac8729f38c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -13573,7 +13561,7 @@ PrefabInstance:
     - target: {fileID: 3383979214839746496, guid: c10109559e87d924bb10ee31d3bd33cb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 3383979214839746496, guid: c10109559e87d924bb10ee31d3bd33cb,
         type: 3}
@@ -13659,7 +13647,7 @@ PrefabInstance:
     - target: {fileID: 5343057899039145872, guid: ce971a77eb7c2894e8583efec1c56965,
         type: 3}
       propertyPath: m_RootOrder
-      value: 44
+      value: 47
       objectReference: {fileID: 0}
     - target: {fileID: 5343057899039145872, guid: ce971a77eb7c2894e8583efec1c56965,
         type: 3}
@@ -13789,18 +13777,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1190082245}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1192303852
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1199468138
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -14171,7 +14147,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4935453910410470, guid: a58eb8439b40f4edcb454576873ef674, type: 3}
       propertyPath: m_RootOrder
-      value: 29
+      value: 32
       objectReference: {fileID: 0}
     - target: {fileID: 4935453910410470, guid: a58eb8439b40f4edcb454576873ef674, type: 3}
       propertyPath: m_LocalPosition.x
@@ -14239,7 +14215,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4444041875581058, guid: 262061330351f42c88cd0ac8729f38c2, type: 3}
       propertyPath: m_RootOrder
-      value: 35
+      value: 38
       objectReference: {fileID: 0}
     - target: {fileID: 4444041875581058, guid: 262061330351f42c88cd0ac8729f38c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -14469,7 +14445,7 @@ PrefabInstance:
     - target: {fileID: 3552308765170740155, guid: 7b65f5bb143163543b2243f4ca5a2327,
         type: 3}
       propertyPath: m_RootOrder
-      value: 60
+      value: 63
       objectReference: {fileID: 0}
     - target: {fileID: 3552308765170740155, guid: 7b65f5bb143163543b2243f4ca5a2327,
         type: 3}
@@ -15185,6 +15161,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1350465812}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1354808932
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1355931513
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -16263,7 +16251,7 @@ PrefabInstance:
     - target: {fileID: 6040282718721912025, guid: 7020b235ecf8ece4ca00af70a60258f8,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 6040282718721912025, guid: 7020b235ecf8ece4ca00af70a60258f8,
         type: 3}
@@ -16541,7 +16529,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_RootOrder
-      value: 15
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_LocalPosition.x
@@ -16701,7 +16689,7 @@ PrefabInstance:
     - target: {fileID: 2650052370968986085, guid: 8f1ce2b118c25334fa660be931e62dbf,
         type: 3}
       propertyPath: m_RootOrder
-      value: 23
+      value: 26
       objectReference: {fileID: 0}
     - target: {fileID: 2650052370968986085, guid: 8f1ce2b118c25334fa660be931e62dbf,
         type: 3}
@@ -17032,7 +17020,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_RootOrder
-      value: 14
+      value: 17
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_LocalPosition.x
@@ -17296,7 +17284,7 @@ PrefabInstance:
     - target: {fileID: 995578021490848257, guid: f9ff40cac6d52c24f9ec8988a13bf9e0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 995578021490848257, guid: f9ff40cac6d52c24f9ec8988a13bf9e0,
         type: 3}
@@ -17356,18 +17344,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1646774786}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1647751114
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1647855627
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -17386,7 +17362,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: b5d421f0156248b4297eecc918b8758a, type: 3}
       propertyPath: m_RootOrder
-      value: 13
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: b5d421f0156248b4297eecc918b8758a, type: 3}
       propertyPath: m_LocalPosition.x
@@ -17469,7 +17445,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4444041875581058, guid: 262061330351f42c88cd0ac8729f38c2, type: 3}
       propertyPath: m_RootOrder
-      value: 34
+      value: 37
       objectReference: {fileID: 0}
     - target: {fileID: 4444041875581058, guid: 262061330351f42c88cd0ac8729f38c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -18118,18 +18094,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1685833643}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1686528743
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1693545721
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -18423,7 +18387,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4935453910410470, guid: a58eb8439b40f4edcb454576873ef674, type: 3}
       propertyPath: m_RootOrder
-      value: 39
+      value: 42
       objectReference: {fileID: 0}
     - target: {fileID: 4935453910410470, guid: a58eb8439b40f4edcb454576873ef674, type: 3}
       propertyPath: m_LocalPosition.x
@@ -18493,7 +18457,7 @@ PrefabInstance:
     - target: {fileID: 5503893774013820961, guid: 712602426c244754cbfc696362bb07c5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 56
+      value: 59
       objectReference: {fileID: 0}
     - target: {fileID: 5503893774013820961, guid: 712602426c244754cbfc696362bb07c5,
         type: 3}
@@ -18658,7 +18622,7 @@ PrefabInstance:
     - target: {fileID: 6040282718721912025, guid: 7020b235ecf8ece4ca00af70a60258f8,
         type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 6040282718721912025, guid: 7020b235ecf8ece4ca00af70a60258f8,
         type: 3}
@@ -18708,7 +18672,7 @@ PrefabInstance:
     - target: {fileID: 4649377290120665551, guid: b2106f2bb290cd04481e9a31d2820d83,
         type: 3}
       propertyPath: m_RootOrder
-      value: 49
+      value: 52
       objectReference: {fileID: 0}
     - target: {fileID: 4649377290120665551, guid: b2106f2bb290cd04481e9a31d2820d83,
         type: 3}
@@ -18854,6 +18818,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1772068728}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1775555934
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1777115535
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -19029,7 +19005,7 @@ PrefabInstance:
     - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 59
+      value: 62
       objectReference: {fileID: 0}
     - target: {fileID: 6585389875953749809, guid: 63caee5f883552645b5a8620d8cdde0c,
         type: 3}
@@ -19104,7 +19080,7 @@ PrefabInstance:
     - target: {fileID: 4649377290120665551, guid: b2106f2bb290cd04481e9a31d2820d83,
         type: 3}
       propertyPath: m_RootOrder
-      value: 48
+      value: 51
       objectReference: {fileID: 0}
     - target: {fileID: 4649377290120665551, guid: b2106f2bb290cd04481e9a31d2820d83,
         type: 3}
@@ -19272,7 +19248,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: b5d421f0156248b4297eecc918b8758a, type: 3}
       propertyPath: m_RootOrder
-      value: 21
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: b5d421f0156248b4297eecc918b8758a, type: 3}
       propertyPath: m_LocalPosition.x
@@ -19355,7 +19331,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4935453910410470, guid: a58eb8439b40f4edcb454576873ef674, type: 3}
       propertyPath: m_RootOrder
-      value: 25
+      value: 28
       objectReference: {fileID: 0}
     - target: {fileID: 4935453910410470, guid: a58eb8439b40f4edcb454576873ef674, type: 3}
       propertyPath: m_LocalPosition.x
@@ -20046,7 +20022,7 @@ PrefabInstance:
     - target: {fileID: 4649377290120665551, guid: b2106f2bb290cd04481e9a31d2820d83,
         type: 3}
       propertyPath: m_RootOrder
-      value: 51
+      value: 54
       objectReference: {fileID: 0}
     - target: {fileID: 4649377290120665551, guid: b2106f2bb290cd04481e9a31d2820d83,
         type: 3}
@@ -20609,7 +20585,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4444041875581058, guid: 262061330351f42c88cd0ac8729f38c2, type: 3}
       propertyPath: m_RootOrder
-      value: 33
+      value: 36
       objectReference: {fileID: 0}
     - target: {fileID: 4444041875581058, guid: 262061330351f42c88cd0ac8729f38c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -20744,6 +20720,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1950967776}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1960946220
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1975669249
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -20837,7 +20825,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4444041875581058, guid: 262061330351f42c88cd0ac8729f38c2, type: 3}
       propertyPath: m_RootOrder
-      value: 40
+      value: 43
       objectReference: {fileID: 0}
     - target: {fileID: 4444041875581058, guid: 262061330351f42c88cd0ac8729f38c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -21200,6 +21188,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2010423810}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2010688129
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2025034745
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -21210,7 +21210,7 @@ PrefabInstance:
     - target: {fileID: 2650052370968986085, guid: 8f1ce2b118c25334fa660be931e62dbf,
         type: 3}
       propertyPath: m_RootOrder
-      value: 22
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 2650052370968986085, guid: 8f1ce2b118c25334fa660be931e62dbf,
         type: 3}
@@ -21373,7 +21373,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4935453910410470, guid: a58eb8439b40f4edcb454576873ef674, type: 3}
       propertyPath: m_RootOrder
-      value: 36
+      value: 39
       objectReference: {fileID: 0}
     - target: {fileID: 4935453910410470, guid: a58eb8439b40f4edcb454576873ef674, type: 3}
       propertyPath: m_LocalPosition.x
@@ -21448,7 +21448,7 @@ PrefabInstance:
     - target: {fileID: 8242232534866279461, guid: 6af0a221ec6985a46956ac77fab1f771,
         type: 3}
       propertyPath: m_RootOrder
-      value: 55
+      value: 58
       objectReference: {fileID: 0}
     - target: {fileID: 8242232534866279461, guid: 6af0a221ec6985a46956ac77fab1f771,
         type: 3}
@@ -21623,7 +21623,7 @@ PrefabInstance:
     - target: {fileID: 4649377290120665551, guid: b2106f2bb290cd04481e9a31d2820d83,
         type: 3}
       propertyPath: m_RootOrder
-      value: 50
+      value: 53
       objectReference: {fileID: 0}
     - target: {fileID: 4649377290120665551, guid: b2106f2bb290cd04481e9a31d2820d83,
         type: 3}
@@ -22056,7 +22056,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   config: {fileID: 11400000, guid: 316fa4f2494e2b443b1160ddd1a53b6f, type: 2}
-  runOnStart: 1
 --- !u!114 &220145765678919404
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -22232,6 +22231,9 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 829928416}
+  - {fileID: 77826102}
+  - {fileID: 381231998}
+  - {fileID: 1034116079}
   - {fileID: 5757992992992682694}
   - {fileID: 1181106936}
   - {fileID: 830486221}
@@ -22292,9 +22294,6 @@ Transform:
   - {fileID: 891735006}
   - {fileID: 1784393505}
   - {fileID: 1300291926}
-  - {fileID: 77826102}
-  - {fileID: 381231998}
-  - {fileID: 1034116079}
   - {fileID: 701859513}
   - {fileID: 1337446322}
   - {fileID: 1685833644}
@@ -23145,7 +23144,7 @@ PrefabInstance:
     - target: {fileID: 1925386106379506438, guid: 5cb5bf2efb47fce45b5b2e7311b9a6fc,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 1925386106379506438, guid: 5cb5bf2efb47fce45b5b2e7311b9a6fc,
         type: 3}

--- a/UnityProject/Assets/ScriptableObjects/PDA/UplinkCategoryList.asset
+++ b/UnityProject/Assets/ScriptableObjects/PDA/UplinkCategoryList.asset
@@ -254,17 +254,17 @@ MonoBehaviour:
         type: 3}
       name: Syndicate Bomb
       isNukeOps: 0
-    - cost: 1
+    - cost: 2
       item: {fileID: 3349033025192972872, guid: 414ec5b5318df6f4bbd000a4dfb298ca,
         type: 3}
       name: Implant Explosive
       isNukeOps: 0
-    - cost: 3
+    - cost: 4
       item: {fileID: 7387852776840792558, guid: dc94bc35b5fe6704b851fa3e1f97bfff,
         type: 3}
       name: Microbomb Implant
       isNukeOps: 1
-    - cost: 5
+    - cost: 6
       item: {fileID: 8932607892331406976, guid: a34b9bd5acaa56348acb4c3a83be928a,
         type: 3}
       name: Macrobomb Implant
@@ -325,7 +325,7 @@ MonoBehaviour:
         type: 3}
       name: Chest Rig
       isNukeOps: 0
-    - cost: 2
+    - cost: 6
       item: {fileID: 5743668296517273336, guid: 01e3ea9613a7f1a4a9daee3064c63702,
         type: 3}
       name: Implanter

--- a/UnityProject/Assets/Scripts/Objects/Gateway/TransportUtility.cs
+++ b/UnityProject/Assets/Scripts/Objects/Gateway/TransportUtility.cs
@@ -12,7 +12,7 @@ namespace Gateway
 	public class TransportUtility : NetworkBehaviour //Would be a regular static class, but Weaver complains if it doesn't inherit NetworkBehaviour
 	{
 		public static List<GameObject> MaintRoomLocations { get; set; } = new List<GameObject>();
-		private const int MAINTROOM_CHANCE = 1000; //Once in 1000 chance
+		private const int MAINTROOM_CHANCE = 20; //One in 20 chance
 
 		/// <summary>
 		/// <para>Transports a <paramref name="objectPhysics"/> to <paramref name="transportTo"/> without lerping.</para>
@@ -23,12 +23,13 @@ namespace Gateway
 		/// <param name="transportTo">Destination to transport <paramref name="objectPhysics"/> to.</param>
 		/// <param name="doTileStep">Whether step interactions should trigger on teleport</param>
 		[Server]
-		public static void TransportObject(UniversalObjectPhysics objectPhysics, Vector3 transportTo, bool doTileStep = true)
+		public static void TransportObject(UniversalObjectPhysics objectPhysics, Vector3 transportTo, bool doTileStep = true, float maintRoomChanceModifier = 1f)
 		{
 			if (objectPhysics == null) return; //Don't even bother...
 
 			var dest = transportTo;
-			if (SubSceneManager.Instance.IsMaintRooms && Random.Range(0, MAINTROOM_CHANCE) <= 1) //If maintrooms are loaded, all teleports will have a 0.1% chance of resulting in teleporting to the maintrooms
+			
+			if (SubSceneManager.Instance.IsMaintRooms && Random.Range(0, MAINTROOM_CHANCE/maintRoomChanceModifier) <= 1) //If maintrooms are loaded, all teleports will have a 0.1% chance of resulting in teleporting to the maintrooms
 			{
 				dest = MaintRoomLocations.PickRandom().RegisterTile().WorldPositionServer;
 			}
@@ -47,7 +48,7 @@ namespace Gateway
 		/// <param name="doTileStep">Whether step interactions should trigger on teleport</param>
 		[Server]
 		public static void TransportObjectAndPulled(UniversalObjectPhysics objectPhysics, Vector3 transportTo,
-			bool doTileStep = true)
+			bool doTileStep = true, float maintRoomChanceModifier = 1f)
 		{
 			if (objectPhysics == null) return; //Don't even bother...
 
@@ -76,7 +77,7 @@ namespace Gateway
 				currentObj.PullSet(null, false); //TODO Test without
 
 				//Transport current
-				TransportObject(currentObj, transportTo, doTileStep);
+				TransportObject(currentObj, transportTo, doTileStep, maintRoomChanceModifier);
 
 				if (previous != null && currentObj.gameObject != null)
 				{

--- a/UnityProject/Assets/Scripts/Objects/Machines/QuantumPad.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/QuantumPad.cs
@@ -32,6 +32,7 @@ namespace Objects.Science
 		public string messageOnTravelToThis;
 
 		private RegisterTile registerTile;
+		[SerializeField] private float maintRoomChanceModifier = 1f; //Squarestation quantum pads are less likely to teleport to maintrooms due to their nessasity.
 
 		private Matrix Matrix => registerTile.Matrix;
 
@@ -176,7 +177,7 @@ namespace Objects.Science
 			{
 				Chat.AddExamineMsgFromServer(player.gameObject, message);
 				SoundManager.PlayNetworkedForPlayer(player.gameObject, CommonSounds.Instance.StealthOff); //very weird, sometimes does the sound other times not.
-				TransportUtility.TransportObjectAndPulled(player, travelCoord);
+				TransportUtility.TransportObjectAndPulled(player, travelCoord, true, maintRoomChanceModifier);
 				somethingTeleported = true;
 
 				if (IsLavaLandBase1Connector && firstEnteredTriggered == false)

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/FairygrassFloor.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/FairygrassFloor.asset
@@ -26,6 +26,7 @@ MonoBehaviour:
   passable: 1
   mineable: 0
   miningTime: 5
+  miningHardness: 1
   constructable: 1
   RadiationPassability: 1
   ThermalConductivity: 0.05
@@ -50,7 +51,9 @@ MonoBehaviour:
     Acid: 0
     Magic: 0
     Bio: 100
+    Anomaly: 0
     DismembermentProtectionChance: 0
+    StunImmunity: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   tileStepInteractions: []
@@ -70,4 +73,7 @@ MonoBehaviour:
       m_SubObjectType: 
       m_EditorAssetChanged: 0
   SoundOnDestroy: []
-  sprite: {fileID: 21300000, guid: 6902624dac204bc48ade4e4b317f269c, type: 3}
+  sprite: {fileID: 21300000, guid: 5104096e3324c854e8f9316e51a65582, type: 3}
+  CanBeHighlightedThroughScanners: 0
+  AssoicatedSpawnedObjects: []
+  HighlightObject: {fileID: 0}


### PR DESCRIPTION
To accomodate the maintroom chance, quantum pads have a new field that influences the chance of being sent to the maintrooms. Square station quantum pads are 10x less likely to sent someone to the maintrooms due to their nessacity to station movement (1 in 200 instead of 1 in 20), With the exception of the two quantum pads in maint which are 10x MORE likely, for the fun and cause they in maint.

### Changelog:
CL: [Balance] Increased price of implanter in syndicate uplink from 2 TC to 6 TC.
CL: [Balance] Increased price of all implant explosives in syndicate uplink by 1 TC
CL: [Balance] Chance of randomly being teleported to Maintrooms increased from 1 in 1000 to 1 in 20 if Maintrooms is loaded.
CL: [Fix] Fixed sprite issue where fairy grass had the sprite of regular grass.
