### PR TITLE
Improvement to auto job picker

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/JobAllocator.cs
+++ b/UnityProject/Assets/Scripts/Managers/JobAllocator.cs
@@ -81,7 +81,7 @@ namespace Managers
 		private void ChoosePlayers(IEnumerable<Occupation> occupations, Priority priority,
 			IReadOnlyCollection<PlayerInfo> playerPool)
 		{
-			var Shuffledoccupations = occupations.ToList().Shuffle();
+			var shuffledoccupations = occupations.ToList().Shuffle();
 
 			foreach (var occupation in Shuffledoccupations)
 			{

--- a/UnityProject/Assets/Scripts/Managers/JobAllocator.cs
+++ b/UnityProject/Assets/Scripts/Managers/JobAllocator.cs
@@ -81,7 +81,9 @@ namespace Managers
 		private void ChoosePlayers(IEnumerable<Occupation> occupations, Priority priority,
 			IReadOnlyCollection<PlayerInfo> playerPool)
 		{
-			foreach (var occupation in occupations)
+			var Shuffledoccupations = occupations.ToList().Shuffle();
+
+			foreach (var occupation in Shuffledoccupations)
 			{
 				occupationCount.TryGetValue(occupation, out int filledSlots);
 				int slotsLeft = occupation.Limit - filledSlots;

--- a/UnityProject/Assets/Scripts/Managers/JobAllocator.cs
+++ b/UnityProject/Assets/Scripts/Managers/JobAllocator.cs
@@ -83,7 +83,7 @@ namespace Managers
 		{
 			var shuffledoccupations = occupations.ToList().Shuffle();
 
-			foreach (var occupation in Shuffledoccupations)
+			foreach (var occupation in shuffledoccupations)
 			{
 				occupationCount.TryGetValue(occupation, out int filledSlots);
 				int slotsLeft = occupation.Limit - filledSlots;


### PR DESCRIPTION

### Purpose
currently if you have everything set to medium excluding heads
currently The job picker will try and full the assistance first before any other normal jobs.
this fixes it by shuffleing the list of jobs to full up before looping,


### Notes:
still results in if everyone has picked medium, some roles being empty if there's not enough players to fill all of them, since it prefers to fill a role versus split out over multiple roles

### Changelog:


CL: [Improvement] round start job picker will Shuffle jobs before looping over them, resulting in different results if you have everything set to medium each round
