### PR TITLE
Hunger simplification [Draft]

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Implants/BreathingTubeImplant.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/BreathingTubeImplant.prefab
@@ -155,6 +155,11 @@ PrefabInstance:
       objectReference: {fileID: 7374505056648468181}
     - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
+      propertyPath: HungerConsumption
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
       propertyPath: ReagentMetabolism
       value: 0
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Explosives/ImplantExplosive.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Explosives/ImplantExplosive.prefab
@@ -420,7 +420,7 @@ MonoBehaviour:
   SurgeryProcedureBase:
   - {fileID: 11400000, guid: 3bd3c430ab0ee0647bdc059d2bc31329, type: 2}
   isBloodCirculated: 0
-  CanGetHungry: 0
+  HungerConsumption: 0
   HasNaturalToxicity: 0
   isBloodReagentConsumed: 0
   requiredReagent: {fileID: 11400000, guid: 72991f100b5704f5fb63c9629fcdeb6c, type: 2}
@@ -428,13 +428,11 @@ MonoBehaviour:
   bloodReagentConsumedPercentageb: 0
   bloodThroughput: 0
   currentBloodSaturation: 0
-  Nutriment: {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237, type: 2}
-  HealingNutrimentMultiplier: 0
   ReagentMetabolism: 0
+  HealingNutrimentMultiplier: 0
   NaturalToxinReagent: {fileID: 11400000, guid: 6c3a3878e8878972ea633a27c6d0ba12,
     type: 2}
   ToxinGeneration: 0
-  HungerState: 1
   SelfArmor:
     Melee: 0
     Bullet: 0
@@ -449,6 +447,8 @@ MonoBehaviour:
     Anomaly: 0
     DismembermentProtectionChance: 0
     StunImmunity: 0
+    TemperatureProtectionInK: {x: 268.15, y: 313.15}
+    PressureProtectionInKpa: {x: 30, y: 300}
   SubOrganBodyPartArmour:
     Melee: 100
     Bullet: 90
@@ -463,6 +463,8 @@ MonoBehaviour:
     Anomaly: 0
     DismembermentProtectionChance: 0
     StunImmunity: 0
+    TemperatureProtectionInK: {x: 268.15, y: 313.15}
+    PressureProtectionInKpa: {x: 30, y: 300}
   SubOrganDamageIncreasePoint: 80
   DamageContributesToOverallHealth: 0
   DamageEfficiencyMultiplier: 1

--- a/UnityProject/Assets/Prefabs/Items/Implants/NutrientPumpImplant.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/NutrientPumpImplant.prefab
@@ -1,0 +1,399 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4015290184458145129
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4305036595317287007}
+  - component: {fileID: 1035664615217789213}
+  - component: {fileID: 3995221377186465101}
+  m_Layer: 10
+  m_Name: Overlay
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4305036595317287007
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4015290184458145129}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4790181145912823077}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1035664615217789213
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4015290184458145129}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: c122dd7923e087c48bf08da9da455514, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -1463207863
+  m_SortingLayer: 13
+  m_SortingOrder: 40
+  m_Sprite: {fileID: 21300000, guid: a9e7adb24e0764345a34a7de6b37a199, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &3995221377186465101
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4015290184458145129}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  NetworkThis: 1
+  SubCatalogue: []
+  PresentSpriteSet: {fileID: 11400000, guid: 9c47b60dcaf2da347a102487710120e6, type: 2}
+  randomInitialSprite: 0
+  doReverseAnimation: 0
+  pushTextureOnStartUp: 1
+  initialVariantIndex: 0
+  palette: []
+--- !u!1001 &5930475597155213129
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1163316686972202776, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: m_Name
+      value: NutrientPumpImplant
+      objectReference: {fileID: 0}
+    - target: {fileID: 1168521912962732652, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1168521912962732652, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1168521912962732652, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1168521912962732652, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1168521912962732652, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1168521912962732652, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1168521912962732652, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1168521912962732652, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1168521912962732652, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1168521912962732652, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1168521912962732652, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1274760333973328556, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 8e780c874ca8cc347bb5daa8d3b4949b
+      objectReference: {fileID: 0}
+    - target: {fileID: 1357021381986229316, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: a866a25a5618e5f45861516ffda879f6,
+        type: 3}
+    - target: {fileID: 1357021381986229316, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1641972083238813818, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: initialName
+      value: Reviver Implant
+      objectReference: {fileID: 0}
+    - target: {fileID: 1641972083238813818, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: initialSize
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1641972083238813818, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: initialDescription
+      value: This implant will heal you whenever you fall into critical health status;
+        it will go on cooldown after each revival. If hit by EMP, has the chance
+        to cause a heart attack.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1641972083238813818, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1641972083238813818, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 892f0c642e2049640b08d738517bb0f5,
+        type: 2}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: GibChance
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: BodyPartType
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: CanGetHungry
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: OrganStorage
+      value: 
+      objectReference: {fileID: 2959315849646831725, guid: 414ec5b5318df6f4bbd000a4dfb298ca,
+        type: 3}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: ItemAttributes
+      value: 
+      objectReference: {fileID: 2925014835611581738, guid: 414ec5b5318df6f4bbd000a4dfb298ca,
+        type: 3}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: ToxinGeneration
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: bloodThroughput
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: CommonComponents
+      value: 
+      objectReference: {fileID: 7374505056648468181}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: HungerConsumption
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: ReagentMetabolism
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: isBloodCirculated
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: BodyPartItemSprite
+      value: 
+      objectReference: {fileID: 56063919708023611, guid: cfda4a920ce328d449993498e023ddfc,
+        type: 3}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: HasNaturalToxicity
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: BodyPartReadableName
+      value: Reviver Implant
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: limbLossBleedingValue
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: isBloodReagentConsumed
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: spillChanceWhenCutPresent
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: HealingNutrimentMultiplier
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: maximumInternalBleedDamage
+      value: 165
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: SurgeryProcedureBase.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: bloodReagentConsumedPercentageb
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: DamageContributesToOverallHealth
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: SurgeryProcedureBase.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 3bd3c430ab0ee0647bdc059d2bc31329,
+        type: 2}
+    - target: {fileID: 4999823976648774815, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 0e9175977d0a4744fbfda8c6656cb802,
+        type: 2}
+    - target: {fileID: 5232716269704749941, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: foreverID
+      value: nutrientpump
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1162a9966a460f940a18b4d183b04c30, type: 3}
+--- !u!1 &4785539145425236049 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1163316686972202776, guid: 1162a9966a460f940a18b4d183b04c30,
+    type: 3}
+  m_PrefabInstance: {fileID: 5930475597155213129}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &5234431865089970326
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4785539145425236049}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 06b0f5e4e4cefd34baaa3cb263b7de33, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  isEMPVunerable: 1
+  EMPResistance: 2
+  HungerState: 3
+  toxinMix:
+    temperature: 273.15
+    reagents:
+      m_keys:
+      - {fileID: 11400000, guid: 6c3a3878e8878972ea633a27c6d0ba12, type: 2}
+      m_values:
+      - 5
+    reagentKeys: []
+--- !u!4 &4790181145912823077 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1168521912962732652, guid: 1162a9966a460f940a18b4d183b04c30,
+    type: 3}
+  m_PrefabInstance: {fileID: 5930475597155213129}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7374505056648468181 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3754534672887286172, guid: 1162a9966a460f940a18b4d183b04c30,
+    type: 3}
+  m_PrefabInstance: {fileID: 5930475597155213129}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4785539145425236049}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 13b3f20d3b30cb24fb70b1f35524c360, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Prefabs/Items/Implants/NutrientPumpImplant.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Items/Implants/NutrientPumpImplant.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8e780c874ca8cc347bb5daa8d3b4949b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Items/Implants/NutrientPumpPlus.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/NutrientPumpPlus.prefab
@@ -1,0 +1,91 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5488422061579323696
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1932923417123077180, guid: 8e780c874ca8cc347bb5daa8d3b4949b,
+        type: 3}
+      propertyPath: foreverID
+      value: nutrientpumpplus
+      objectReference: {fileID: 0}
+    - target: {fileID: 4785539145425236049, guid: 8e780c874ca8cc347bb5daa8d3b4949b,
+        type: 3}
+      propertyPath: m_Name
+      value: NutrientPumpPlus
+      objectReference: {fileID: 0}
+    - target: {fileID: 4790181145912823077, guid: 8e780c874ca8cc347bb5daa8d3b4949b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4790181145912823077, guid: 8e780c874ca8cc347bb5daa8d3b4949b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4790181145912823077, guid: 8e780c874ca8cc347bb5daa8d3b4949b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4790181145912823077, guid: 8e780c874ca8cc347bb5daa8d3b4949b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4790181145912823077, guid: 8e780c874ca8cc347bb5daa8d3b4949b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4790181145912823077, guid: 8e780c874ca8cc347bb5daa8d3b4949b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4790181145912823077, guid: 8e780c874ca8cc347bb5daa8d3b4949b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4790181145912823077, guid: 8e780c874ca8cc347bb5daa8d3b4949b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4790181145912823077, guid: 8e780c874ca8cc347bb5daa8d3b4949b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4790181145912823077, guid: 8e780c874ca8cc347bb5daa8d3b4949b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4790181145912823077, guid: 8e780c874ca8cc347bb5daa8d3b4949b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4899234591701863909, guid: 8e780c874ca8cc347bb5daa8d3b4949b,
+        type: 3}
+      propertyPath: m_AssetId
+      value: bd8dddf817de2d5439a0f98dadcadae6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5234431865089970326, guid: 8e780c874ca8cc347bb5daa8d3b4949b,
+        type: 3}
+      propertyPath: HungerState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5234431865089970326, guid: 8e780c874ca8cc347bb5daa8d3b4949b,
+        type: 3}
+      propertyPath: toxinMix.reagents.m_values.Array.data[0]
+      value: 10
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8e780c874ca8cc347bb5daa8d3b4949b, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/NutrientPumpPlus.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Items/Implants/NutrientPumpPlus.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bd8dddf817de2d5439a0f98dadcadae6
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgHead.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgHead.prefab
@@ -30,6 +30,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6597352703958914049, guid: 78253771c2047f94c9ae40161a6be7ee,
         type: 3}
+      propertyPath: HungerConsumption
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6597352703958914049, guid: 78253771c2047f94c9ae40161a6be7ee,
+        type: 3}
       propertyPath: isBloodCirculated
       value: 0
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgHeart.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgHeart.prefab
@@ -174,6 +174,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
+      propertyPath: HungerConsumption
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
       propertyPath: isBloodCirculated
       value: 0
       objectReference: {fileID: 0}
@@ -246,6 +251,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d907426271c5e5544a1c7131da7c493c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
   isEMPVunerable: 1
   EMPResistance: 1
   HeartAttack: 0

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgLeftArm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgLeftArm.prefab
@@ -112,6 +112,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2934630090728222927, guid: 719377fefb0114b448fc6ca9f7a5a6df,
         type: 3}
+      propertyPath: HungerConsumption
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2934630090728222927, guid: 719377fefb0114b448fc6ca9f7a5a6df,
+        type: 3}
       propertyPath: isBloodCirculated
       value: 0
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgLeftLeg.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgLeftLeg.prefab
@@ -19,6 +19,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1544594378003915950, guid: 2e6f2ff9beb985749940d242877d84f0,
         type: 3}
+      propertyPath: HungerConsumption
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1544594378003915950, guid: 2e6f2ff9beb985749940d242877d84f0,
+        type: 3}
       propertyPath: isBloodCirculated
       value: 0
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgLiver.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgLiver.prefab
@@ -223,6 +223,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
+      propertyPath: HungerConsumption
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
       propertyPath: CanBleedInternally
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgLungs.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgLungs.prefab
@@ -169,6 +169,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
+      propertyPath: HungerConsumption
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
       propertyPath: CanBleedInternally
       value: 1
       objectReference: {fileID: 0}
@@ -236,6 +241,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7fae19aae8ddc974c84a11abe4f1279e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
   isEMPVunerable: 1
   EMPResistance: 1
   breatheCooldown: 4

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgRightArm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgRightArm.prefab
@@ -42,6 +42,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6313817628243374210, guid: ba9a875c31908af4ab3749cd127a2edb,
         type: 3}
+      propertyPath: HungerConsumption
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6313817628243374210, guid: ba9a875c31908af4ab3749cd127a2edb,
+        type: 3}
       propertyPath: isBloodCirculated
       value: 0
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgRightLeg.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgRightLeg.prefab
@@ -129,6 +129,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
         type: 3}
+      propertyPath: HungerConsumption
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7644184727980254197, guid: 51326f2264a075148a8aaa6bf95604c7,
+        type: 3}
       propertyPath: isBloodCirculated
       value: 0
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgTorso.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/CyborgParts/CyborgTorso.prefab
@@ -30,6 +30,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5445495118236055813, guid: cc032f91cda505e44b066c36db32760d,
         type: 3}
+      propertyPath: HungerConsumption
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5445495118236055813, guid: cc032f91cda505e44b066c36db32760d,
+        type: 3}
       propertyPath: isBloodCirculated
       value: 0
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/Human Stomach.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/Human Stomach.prefab
@@ -279,6 +279,31 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 7132720453719274872}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2897573663319701833
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2556953724642564633}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fdce8a163088453ca593c0e98f2c5f07, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemStorageStructure: {fileID: 11400000, guid: 54cbb4402f813441cb503dcd1d440082,
+    type: 2}
+  itemStorageCapacity: {fileID: 11400000, guid: 411b6b7a74c524a91b9a38a0c692761b,
+    type: 2}
+  itemStoragePopulator: {fileID: 0}
+  forceSpawnContents: 0
+  dropItemsOnDespawn: 0
+  UesAddlistPopulater: 0
+  Populater:
+    SlotContents: []
+    DeprecatedContents: []
+  ashPrefab: {fileID: 2957035178188790827, guid: 9ac6968a3f3ed54428662c9aae5a4b32,
+    type: 3}
 --- !u!114 &7673327661231706934
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -295,9 +320,24 @@ MonoBehaviour:
   syncInterval: 0.1
   isEMPVunerable: 0
   EMPResistance: 2
+  stomachContents: {fileID: 2897573663319701833}
+  reagentContainer: {fileID: 4886297188270677302}
   nutrientReagents:
   - {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237, type: 2}
   DigesterAmountPerSecond: 1
   MaxFat: 5
   fatPrefab: {fileID: 5324125373314380594, guid: 940a7490c94c6b3478f0b4268b2cf2c0,
     type: 3}
+  StartingFatCount: 100
+--- !u!114 &4886297188270677302 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2392288886832539726, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+    type: 3}
+  m_PrefabInstance: {fileID: 7132720453719274872}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2556953724642564633}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fed226d36f0fdcd40a51a7bfbf8fb6d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/Human Stomach.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/Human Stomach.prefab
@@ -82,6 +82,11 @@ PrefabInstance:
       propertyPath: foreverID
       value: 69104df12837d1e48bb456dce5301bfa
       objectReference: {fileID: 0}
+    - target: {fileID: 2392288886832539726, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
+      propertyPath: maxCapacity
+      value: 100
+      objectReference: {fileID: 0}
     - target: {fileID: 4617501557389857493, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
       propertyPath: m_AssetId
@@ -274,7 +279,7 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 7132720453719274872}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1458293514004664868
+--- !u!114 &7673327661231706934
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -283,14 +288,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 2556953724642564633}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6db4404109ee5304895b5058a7eff177, type: 3}
+  m_Script: {fileID: 11500000, guid: c8062700515a2cd4fb294003089beede, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
   isEMPVunerable: 0
   EMPResistance: 2
-  StomachContents: {fileID: 7073899732039749527}
+  nutrientReagents:
+  - {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237, type: 2}
   DigesterAmountPerSecond: 1
-  BodyFats: []
-  BodyFatToInstantiate: {fileID: 5722168868389364961, guid: 940a7490c94c6b3478f0b4268b2cf2c0,
+  MaxFat: 5
+  fatPrefab: {fileID: 5324125373314380594, guid: 940a7490c94c6b3478f0b4268b2cf2c0,
     type: 3}
-  InitialFatSpawned: 0

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanFat.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanFat.prefab
@@ -27,7 +27,7 @@ PrefabInstance:
         type: 3}
       propertyPath: customNetTransform
       value: 
-      objectReference: {fileID: 5221563751139155682}
+      objectReference: {fileID: 0}
     - target: {fileID: 4719944670933102433, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
       propertyPath: m_Name
@@ -109,10 +109,21 @@ PrefabInstance:
       propertyPath: initialDescription
       value: Fat shaming is rude.
       objectReference: {fileID: 0}
+    - target: {fileID: 5146776682568007683, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5146776682568007683, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 892f0c642e2049640b08d738517bb0f5,
+        type: 2}
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
       propertyPath: BodyPartType
-      value: -1
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
@@ -147,18 +158,6 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 8095853447068111044, guid: 35ef0ee8523cfc342bc863c12a3ac07c, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 35ef0ee8523cfc342bc863c12a3ac07c, type: 3}
---- !u!114 &5221563751139155682 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4617654077899113137, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
-    type: 3}
-  m_PrefabInstance: {fileID: 604480131879869523}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5324125373314380594}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &5324125373314380594 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4719944670933102433, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
@@ -177,15 +176,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5a623491ff7b9fe46aaa75051206d496, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxRunSpeedDebuff: -2
-  maxWalkingDebuff: -1.5
-  maxCrawlDebuff: -0.2
-  RelatedStomach: {fileID: 0}
-  ReleaseNutrimentPercentage: 0.01
-  AbsorbNutrimentPercentage: 0.02
-  ReleaseAmount: 2
-  MinuteStoreMaxAmount: 60
-  DDebuffInPoint: 35
-  NoticeableDebuffInPoint: 45
-  WasApplyingDebuff: 0
-  isFreshBlood: 0
+  syncMode: 0
+  syncInterval: 0.1
+  isEMPVunerable: 0
+  EMPResistance: 2
+  <maxNutrientStore>k__BackingField: 20
+  maxNutrientDischarge: 5

--- a/UnityProject/Assets/Prefabs/Items/Implants/ReviverImplant.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/ReviverImplant.prefab
@@ -260,6 +260,11 @@ PrefabInstance:
       objectReference: {fileID: 7374505056648468181}
     - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
+      propertyPath: HungerConsumption
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
       propertyPath: ReagentMetabolism
       value: 0
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/WeldingShieldImplant.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/WeldingShieldImplant.prefab
@@ -154,6 +154,11 @@ PrefabInstance:
       objectReference: {fileID: 7374505056648468181}
     - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
+      propertyPath: HungerConsumption
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
       propertyPath: ReagentMetabolism
       value: 0
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Xenomorph/XenomorphLarvaeOrgan.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Xenomorph/XenomorphLarvaeOrgan.prefab
@@ -137,6 +137,7 @@ PrefabInstance:
         type: 2}
     m_RemovedComponents:
     - {fileID: 8095853447068111044, guid: 35ef0ee8523cfc342bc863c12a3ac07c, type: 3}
+    - {fileID: -4791504671035111961, guid: 35ef0ee8523cfc342bc863c12a3ac07c, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 35ef0ee8523cfc342bc863c12a3ac07c, type: 3}
 --- !u!1 &2515321529866027611 stripped
 GameObject:
@@ -163,3 +164,25 @@ MonoBehaviour:
   xenomorphLarvaeOccupation: {fileID: 11400000, guid: aafe8bd761e215b4d8af3394211f6db2,
     type: 2}
   incubationTime: 180
+--- !u!114 &6743514940294372847
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2515321529866027611}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f7c26f467e8e3034aa80b29130890432, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  leavings: {fileID: 0}
+  sound:
+    SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/Effects/EatFood.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
+  larvae: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
+++ b/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
@@ -443,6 +443,7 @@ GameObject:
   - component: {fileID: 1354417930896543338}
   - component: {fileID: 2708192528502292653}
   - component: {fileID: 4232843736106124361}
+  - component: {fileID: 673354623609822083}
   - component: {fileID: -5098788322438649402}
   - component: {fileID: 1742783117560001162}
   - component: {fileID: 1175812212782356347}
@@ -542,7 +543,6 @@ MonoBehaviour:
   RTT: 0
   RcsMode: 0
   RcsMatrixMove: {fileID: 0}
-  actionData: {fileID: 11400000, guid: 288088e3bb7768d41a2fe1b2c170fbce, type: 2}
   playerChatLocation: {fileID: 1133514949248654}
   canVentCrawl: 0
   ClueHandsImprintInverseChance: 55
@@ -1007,7 +1007,6 @@ MonoBehaviour:
   syncInterval: 0.1
   BodyType: 0
   RTT: 0
-  brain: {fileID: 0}
   BodyPartList: []
   SurfaceBodyParts: []
   BodyPartStorage: {fileID: 0}
@@ -1021,6 +1020,7 @@ MonoBehaviour:
   BodyPartSurfaceVolume: 5
   playerScript: {fileID: 0}
   CannotRecognizeNames: 0
+  UsedZones: 000000000100000003000000020000000500000004000000
   meatProduce: {fileID: 0}
   skinProduce: {fileID: 0}
   allExternalMetabolismReactions:
@@ -1098,10 +1098,25 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fad55d26381ef594c8bff2db4222570c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
   canBreathAnywhere: 0
-  takeLowPressureDamage: 1
-  takeHighPressureDamage: 1
   tickRate: 1
+--- !u!114 &673354623609822083
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1133514949248654}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 28c31b780e04c764e9c38c7eee5a7de8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxRunSpeedDebuff: -2
+  maxWalkingDebuff: -1.5
+  maxCrawlDebuff: -0.2
 --- !u!114 &-5098788322438649402
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1363,6 +1378,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  WeldingShieldImplants: 0
 --- !u!114 &7265610720913237329
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1476,6 +1492,7 @@ MonoBehaviour:
   triggerOnce: 1
   showEvenAfterDeath: 1
   tipCooldown: 200
+  highlightableObjectNames: []
   bleedingVeryLowEvent: {fileID: 11400000, guid: 9840743232461594d952b82560fe1eeb,
     type: 2}
   bleedingLowEvent: {fileID: 11400000, guid: 674dd66c6a6ff5f40a52d8b8b9e742bf, type: 2}
@@ -1516,6 +1533,7 @@ MonoBehaviour:
   triggerOnce: 1
   showEvenAfterDeath: 0
   tipCooldown: 200
+  highlightableObjectNames: []
   protipsForTraits:
     m_keys:
     - {fileID: 11400000, guid: ba923436cf6803a4f99a5ed73f885d61, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Systems/Research/DefaultTechWebData.asset
+++ b/UnityProject/Assets/ScriptableObjects/Systems/Research/DefaultTechWebData.asset
@@ -36,6 +36,7 @@ MonoBehaviour:
     DesignIDs:
     - cyber_heart
     - cyber_lung
+    - cyber_liver
     ResearchCosts: 15
     ExportPrice: 0
     PotentialUnlocks: []
@@ -84,18 +85,18 @@ MonoBehaviour:
     prefabID: weld
     techType: 1
   - ID: filtering
-    DisplayName: Cybernetic Filtering
-    Description: Cybernetic livers are more efficient at filtering toxins from the
-      body, completely protecting the host from certain toxins.
+    DisplayName: Nutriment Pumps
+    Description: Never go hungry again! These chest implants will keep you well fed.
     StartingNode: 0
     RequiredTechnologies:
     - advcyber
     DesignIDs:
-    - cyber_liver
+    - ci_nutriment
+    - ci_nutrimentplus
     ResearchCosts: 20
     ExportPrice: 0
     PotentialUnlocks: []
-    prefabID: liver
+    prefabID: nutrient
     techType: 1
   - ID: bluespace
     DisplayName: Bluespace Technology

--- a/UnityProject/Assets/Scripts/Clothing/FacehuggerImpregnation.cs
+++ b/UnityProject/Assets/Scripts/Clothing/FacehuggerImpregnation.cs
@@ -1,13 +1,12 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Threading.Tasks;
 using Items;
 using Mirror;
 using UnityEngine;
 using Systems.Clothing;
 using HealthV2;
-using Systems.Antagonists;
 using Systems.MobAIs;
+using Items.Implants.Organs;
 
 namespace Clothing
 {
@@ -107,7 +106,10 @@ namespace Clothing
 
 			if (player.GetStomachs().Count == 0) return;
 
-			player.GetStomachs()[0].RelatedPart.OrganStorage.ServerTryAdd(embryo);
+			Stomach stomachToImplant = player.GetStomachs()[0] as Stomach;
+			if(stomachToImplant == null) return;
+
+			stomachToImplant.RelatedPart.OrganStorage.ServerTryAdd(embryo);
 		}
 
 		private IEnumerator Release()

--- a/UnityProject/Assets/Scripts/Clothing/FacehuggerImpregnation.cs
+++ b/UnityProject/Assets/Scripts/Clothing/FacehuggerImpregnation.cs
@@ -109,7 +109,7 @@ namespace Clothing
 			Stomach stomachToImplant = player.GetStomachs()[0] as Stomach;
 			if(stomachToImplant == null) return;
 
-			stomachToImplant.RelatedPart.OrganStorage.ServerTryAdd(embryo);
+			Inventory.ServerAdd(embryo.GetComponent<Pickupable>(), stomachToImplant.RelatedPart.OrganStorage.GetNextFreeIndexedSlot());
 		}
 
 		private IEnumerator Release()

--- a/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPart.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPart.cs
@@ -281,6 +281,7 @@ namespace HealthV2
 				{
 					addedOrgan.BodyPartAddHealthMaster(HealthMaster);
 				}
+				OrganStorage.ServerTryAdd(newImplant.gameObject);
 			}
 			else if (prevImplant && prevImplant.TryGetComponent<BodyPart>(out var removedOrgan))
 			{
@@ -291,6 +292,7 @@ namespace HealthV2
 				{
 					removedOrgan.BodyPartRemoveHealthMaster();
 				}
+				OrganStorage.ServerTryRemove(prevImplant.gameObject);
 			}
 		}
 
@@ -366,9 +368,11 @@ namespace HealthV2
 			DropItemsOnDismemberment(this);
 
 
-			var bodyPartUISlot = GetComponent<BodyPartUISlots>();
-			var dynamicItemStorage = HealthMaster.GetComponent<DynamicItemStorage>();
-			dynamicItemStorage.Remove(bodyPartUISlot);
+			if (TryGetComponent<BodyPartUISlots>(out var bodyPartUISlot) == true)
+			{
+				var dynamicItemStorage = HealthMaster.GetComponent<DynamicItemStorage>();
+				dynamicItemStorage.Remove(bodyPartUISlot);
+			}
 			//Fixes an error where externally bleeding body parts would continue to try bleeding even after their removal.
 			if (IsBleedingExternally)
 			{

--- a/UnityProject/Assets/Scripts/HealthV2/Living/CirculatorySystem/BodyPartBlood.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/CirculatorySystem/BodyPartBlood.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
-using Chemistry;
-using Chemistry.Components;
 using NaughtyAttributes;
 using UnityEngine;
 
@@ -20,7 +17,7 @@ namespace HealthV2
 		[HorizontalLine] [Tooltip("Is this connected to the blood stream at all?")] [SerializeField]
 		private bool isBloodCirculated = true;
 
-		public bool CanGetHungry = true;
+		public float HungerConsumption = 1f; //Will this body part increase the hunger requirement of the body? If so by how much.
 
 		public bool HasNaturalToxicity = true;
 
@@ -77,19 +74,6 @@ namespace HealthV2
 
 		public float CurrentBloodSaturation => currentBloodSaturation;
 
-		/// <summary>
-		/// The nutriment reagent that this part consumes in order to perform tasks
-		/// </summary>
-		[Tooltip("What does this live off?")] [SerializeField]
-		public Reagent Nutriment;
-
-		/// <summary>
-		/// The amount of of nutriment to consumed each tick as part of passive metabolism
-		/// </summary>
-		[NonSerialized] //Automatically generated runtime
-		public float PassiveConsumptionNutriment = 0.00012f;
-
-
 
 		[Tooltip("How many metabolic reactions can happen inside of this body part Per tick per 1u of blood flow ")]
 		public float ReagentMetabolism = 0.2f;
@@ -114,9 +98,6 @@ namespace HealthV2
 
 		[Tooltip("How much natural toxicity does this body part generate Per tick per 1u of blood flow ")]
 		public float ToxinGeneration = 0.0002f;
-
-
-		public HungerState HungerState = HungerState.Normal;
 
 		/// <summary>
 		/// Initializes the body part as part of the circulatory system

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -258,6 +258,8 @@ namespace HealthV2
 
 		[SyncVar] public bool CannotRecognizeNames = false;
 
+		private bool disgestiveInitialised = false;
+
 
 		public Dictionary<BodyPartType, ReagentMix> SurfaceReagents = new Dictionary<BodyPartType, ReagentMix>()
 		{
@@ -540,8 +542,9 @@ namespace HealthV2
 				BodyPartList[i].ImplantPeriodicUpdate();
 			}
 
+			DigestiveSystem?.PeriodicUpdate();
+
 			CirculatorySystem.BloodUpdate();
-			DigestiveSystem.PeriodicUpdate();
 			ExternalMetaboliseReactions();
 
 			FireStacksDamage();
@@ -1903,6 +1906,7 @@ namespace HealthV2
 			CirculatorySystem.InitialiseMetabolism(RaceBodyparts);
 			CirculatorySystem.InitialiseDefaults(RaceBodyparts);
 			CirculatorySystem.BodyPartListChange();
+			DigestiveSystem?.Initialised(this);
 
 			meatProduce = RaceBodyparts.Base.MeatProduce;
 			skinProduce = RaceBodyparts.Base.SkinProduce;

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Metabolism/DigestiveSystemBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Metabolism/DigestiveSystemBase.cs
@@ -1,0 +1,209 @@
+using System.Collections.Generic;
+using System;
+using Chemistry;
+using UnityEngine;
+using Player.Movement;
+using Items.Implants.Organs;
+
+namespace HealthV2
+{
+	public class DigestiveSystemBase : MonoBehaviour, IMovementEffect
+	{
+		private const float NORMAL_THRESHOLD = 85f;
+		private const float HUNGRY_THRESHOLD = 50f;
+		private const float MALNURISHED_THRESHOLD = 25f;
+		private const float STARVING_THRESHOLD = 5f;
+
+		//Assuming 20 bodyparts (including organs) on average with a consumption of one.
+		//That is 2 Hunger per second. We want around 0.055 per second to have a full stoamch last half an hour
+		//2 / 0.055 is 36.
+		private const float HUNGER_DEPLETION_DIVIDER = 36f; 
+
+		private bool isActive = true;
+		private float secondsToProcess = 10f;
+		public float CurrentHunger { get; private set; } = 0;
+		private float maxHunger = 100;
+
+		private List<IStomachProcess> stomachList = new List<IStomachProcess>();
+		public List<BodyFat> BodyFat { get; private set; } = new List<BodyFat>();
+
+		private LivingHealthMasterBase livingHealthMaster;
+
+		public HungerState HungerState
+		{
+			get
+			{
+				return GetCurrentHungerState();
+			}
+		}
+
+		#region MovementFields
+
+		[SerializeField] private float maxRunSpeedDebuff = -2;
+		[SerializeField] private float maxWalkingDebuff = -1.5f;
+		[SerializeField] private float maxCrawlDebuff = -0.2f;
+
+		public float RunningSpeedModifier { get; private set; }
+
+		public float WalkingSpeedModifier { get; private set; }
+
+		public float CrawlingSpeedModifier { get; private set; }
+
+		#endregion
+
+		public void Start()
+		{
+			if (isActive) UpdateManager.Add(ProcessStomachs, secondsToProcess);
+		}
+
+		private void ProcessStomachs()
+		{
+			foreach (BodyPart part in livingHealthMaster.BodyPartList) //Consume food from body parts
+			{
+				CurrentHunger -= part.HungerConsumption / HUNGER_DEPLETION_DIVIDER;
+			}
+			CurrentHunger = Math.Max(CurrentHunger, 0); 
+
+
+			foreach (IStomachProcess stomach in stomachList) //Get Stomachs to digest food
+			{
+				if (CurrentHunger >= maxHunger) break;
+				CurrentHunger += stomach.ProcessContent();
+			}
+			CurrentHunger = Math.Min(CurrentHunger, maxHunger);
+
+			List<BodyFat> fats = new List<BodyFat>(BodyFat); //We might destroy a fat object.
+
+			foreach (BodyFat fat in fats) //If still not at full hunger, get food from fat stores
+			{
+				if (maxHunger <= CurrentHunger) break;
+
+				CurrentHunger += fat.ConsumeNutrient(maxHunger - CurrentHunger);
+				if (fat.CurrentNutrient <= 0)
+				{
+					BodyFat.Remove(fat);
+					Despawn.ServerSingle(fat.gameObject);
+				}
+			}
+		}
+
+		public void ClampHunger(HungerState hungerState) //Used by Nutrient Pump Implants to prevent hunger from falling below certain values.
+		{
+			float clampValue;
+
+			switch(hungerState)
+			{
+				case HungerState.Normal:
+					clampValue = NORMAL_THRESHOLD;
+					break;
+				case HungerState.Hungry:
+					clampValue = HUNGRY_THRESHOLD;
+					break;
+				case HungerState.Starving:
+					clampValue = STARVING_THRESHOLD;
+					break;
+				case HungerState.Malnourished:
+					clampValue = MALNURISHED_THRESHOLD;
+					break;
+				default:
+					clampValue = MALNURISHED_THRESHOLD;
+					break;
+			}
+
+			CurrentHunger = Math.Max(CurrentHunger, clampValue);
+		}
+
+		public void Initialised(LivingHealthMasterBase livingHealth)
+		{
+			livingHealthMaster = livingHealth;
+			ClampHunger(HungerState.Full);
+
+			var playerHealthV2 = livingHealthMaster as PlayerHealthV2;
+			if (playerHealthV2 != null)
+			{
+				playerHealthV2.PlayerMove.AddModifier(this);
+			}
+		}
+
+		public void PeriodicUpdate()
+		{
+			InfluenceSpeed();
+		}
+
+		public void AddStomach(IStomachProcess stomach)
+		{
+			stomachList.Add(stomach);
+			maxHunger = CalculateMaxHunger();
+		}
+
+		public void RemoveStomach(IStomachProcess stomach)
+		{
+			stomachList.Remove(stomach);
+			maxHunger = CalculateMaxHunger();
+		}
+
+		public List<IStomachProcess> GetStomachs()
+		{
+			return stomachList;
+		}
+
+		private float CalculateMaxHunger()
+		{
+			float capacity = 0;
+			foreach(IStomachProcess stomach in stomachList)
+			{
+				capacity += stomach.GetStomachMaxHunger();
+			}
+			foreach(BodyFat fat in BodyFat)
+			{
+				capacity += fat.maxNutrientStore;
+			}
+
+			return capacity;
+		}
+
+		private HungerState GetCurrentHungerState()
+		{
+			float percentFull = (CurrentHunger / maxHunger) * 100;
+
+			switch(percentFull)
+			{
+				case > NORMAL_THRESHOLD:
+					return HungerState.Full;
+				case > HUNGRY_THRESHOLD:
+					return HungerState.Normal;
+				case > MALNURISHED_THRESHOLD:
+					return HungerState.Hungry;
+				case > STARVING_THRESHOLD:
+					return HungerState.Malnourished;
+				default:
+					return HungerState.Starving;
+			}
+		}
+
+		private void InfluenceSpeed()
+		{
+			float DeBuffMultiplier = (int)HungerState / (int)HungerState.Starving;
+
+			RunningSpeedModifier = maxRunSpeedDebuff * DeBuffMultiplier;
+			WalkingSpeedModifier = maxWalkingDebuff * DeBuffMultiplier;
+			CrawlingSpeedModifier = maxCrawlDebuff * DeBuffMultiplier;
+			var playerHealthV2 = livingHealthMaster as PlayerHealthV2;
+			if (playerHealthV2 != null)
+			{
+				playerHealthV2.PlayerMove.UpdateSpeeds();
+			}
+		}
+	}
+
+	public interface IStomachProcess
+	{
+		public float ProcessContent();
+
+		public float GetStomachMaxHunger();
+
+		public bool AddObjectToStomach(Consumable edible);
+
+		public float TryAddReagentsToStomach(ReagentMix reagentMix);
+	}
+}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Metabolism/DigestiveSystemBase.cs.meta
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Metabolism/DigestiveSystemBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 28c31b780e04c764e9c38c7eee5a7de8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Metabolism/MetabolismSystemV2.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Metabolism/MetabolismSystemV2.cs
@@ -34,10 +34,10 @@ public struct MetabolismEffect
 
 public enum HungerState
 {
-	Full,
-	Normal,
-	Hungry,
-	Malnourished,
-	Starving
+	Full = 0,
+	Normal = 1,
+	Hungry = 2,
+	Malnourished = 3,
+	Starving = 4
 
 }

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Mutations/BigStomachMutation.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Mutations/BigStomachMutation.cs
@@ -6,7 +6,6 @@ namespace HealthV2.Living.Mutations
 	[CreateAssetMenu(fileName = "BigStomachMutation", menuName = "ScriptableObjects/Mutations/BigStomachMutation")]
 	public class BigStomachMutation : MutationSO
 	{
-
 		public override Mutation GetMutation(BodyPart BodyPart,MutationSO _RelatedMutationSO)
 		{
 			return new InBigStomachMutation(BodyPart,_RelatedMutationSO);
@@ -22,13 +21,13 @@ namespace HealthV2.Living.Mutations
 			public override void SetUp()
 			{
 				var Stomach = BodyPart.GetComponent<Stomach>();
-				Stomach.StomachContents.SetMaxCapacity(99); //TODO better implementation //idk Custom thing, if it's preset custom
+				Stomach.ChangeStomachCapacity(200);
 			}
 
 			public override void Remove()
 			{
 				var Stomach = BodyPart.GetComponent<Stomach>();
-				Stomach.StomachContents.SetMaxCapacity(2); //TODO better implementation
+				Stomach.ChangeStomachCapacity(100);
 			}
 
 		}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Mutations/Bones/Anemia.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Mutations/Bones/Anemia.cs
@@ -27,12 +27,12 @@ namespace HealthV2.Living.Mutations.Bones
 			public override void SetUp()
 			{
 				Bone = BodyPart.GetComponent<Items.Implants.Organs.Bones>();
-				Bone.BloodGeneratedByOneNutriment -= Anemia.BloodRegenerationRemove;
+				Bone.BloodGeneratedByOneHunger -= Anemia.BloodRegenerationRemove;
 			}
 
 			public override void Remove()
 			{
-				Bone.BloodGeneratedByOneNutriment += Anemia.BloodRegenerationRemove;
+				Bone.BloodGeneratedByOneHunger += Anemia.BloodRegenerationRemove;
 			}
 
 		}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Mutations/Bones/BigBoned.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Mutations/Bones/BigBoned.cs
@@ -7,7 +7,7 @@ namespace HealthV2.Living.Mutations.Bones
 	public class BigBoned : MutationSO
 	{
 
-		public float AddedBloodGeneratedByOneNutriment = 30;
+		public float AddedBloodGeneratedByOneHunger = 30;
 
 		public override Mutation GetMutation(BodyPart BodyPart,MutationSO _RelatedMutationSO)
 		{
@@ -28,12 +28,12 @@ namespace HealthV2.Living.Mutations.Bones
 			public override void SetUp()
 			{
 				Bone = BodyPart.GetComponent<Items.Implants.Organs.Bones>();
-				Bone.BloodGeneratedByOneNutriment += BigBoned.AddedBloodGeneratedByOneNutriment;
+				Bone.BloodGeneratedByOneHunger += BigBoned.AddedBloodGeneratedByOneHunger;
 			}
 
 			public override void Remove()
 			{
-				Bone.BloodGeneratedByOneNutriment -= BigBoned.AddedBloodGeneratedByOneNutriment;
+				Bone.BloodGeneratedByOneHunger -= BigBoned.AddedBloodGeneratedByOneHunger;
 			}
 
 		}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Mutations/Bones/Polycythemia.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Mutations/Bones/Polycythemia.cs
@@ -6,7 +6,7 @@ namespace HealthV2.Living.Mutations.Bones
 	public class Polycythemia : MutationSO
 	{
 		public float GenerationOvershoot = 1;
-		public float AddedBloodGeneratedByOneNutriment = 50;
+		public float AddedBloodGeneratedByOneHunger = 50;
 
 		public override Mutation GetMutation(BodyPart BodyPart,MutationSO _RelatedMutationSO)
 		{
@@ -28,13 +28,13 @@ namespace HealthV2.Living.Mutations.Bones
 			{
 				Bone = BodyPart.GetComponent<Items.Implants.Organs.Bones>();
 				Bone.GenerationOvershoot += Polycythemia.GenerationOvershoot;
-				Bone.BloodGeneratedByOneNutriment += Polycythemia.AddedBloodGeneratedByOneNutriment;
+				Bone.BloodGeneratedByOneHunger += Polycythemia.AddedBloodGeneratedByOneHunger;
 			}
 
 			public override void Remove()
 			{
 				Bone.GenerationOvershoot -= Polycythemia.GenerationOvershoot;
-				Bone.BloodGeneratedByOneNutriment -= Polycythemia.AddedBloodGeneratedByOneNutriment;
+				Bone.BloodGeneratedByOneHunger -= Polycythemia.AddedBloodGeneratedByOneHunger;
 			}
 
 		}

--- a/UnityProject/Assets/Scripts/Items/Food/DrinkableContainer.cs
+++ b/UnityProject/Assets/Scripts/Items/Food/DrinkableContainer.cs
@@ -91,15 +91,11 @@ public class DrinkableContainer : Consumable
 		// Start drinking reagent mix
 		var drinkAmount = container.TransferAmount;
 
-		List<Stomach> stomachs = eater.playerHealth.GetStomachs();
-		foreach (Stomach currentStomach in stomachs)
-		{
-			ReagentContainer stomachContainer = currentStomach.StomachContents;
+		List<IStomachProcess> stomachs = eater.playerHealth.GetStomachs();
 
-			//fill current stomach as much as we can until empty
-			float transferred = Mathf.Min(drinkAmount,
-				stomachContainer.MaxCapacity - stomachContainer.CurrentReagentMix.Total);
-			container.TransferTo(transferred, stomachContainer);
+		foreach (IStomachProcess currentStomach in stomachs)
+		{
+			float transferred = currentStomach.TryAddReagentsToStomach(container.TakeReagents(drinkAmount));
 
 			//update how much is left
 			drinkAmount -= transferred;

--- a/UnityProject/Assets/Scripts/Items/Food/PillStackRemover.cs
+++ b/UnityProject/Assets/Scripts/Items/Food/PillStackRemover.cs
@@ -15,13 +15,28 @@ namespace Items
 		public override void TryConsume(GameObject feeder, GameObject eater)
 		{
 			var health = eater.GetComponent<LivingHealthMasterBase>();
+
 			var Stomachs = health.GetStomachs();
+			if (Stomachs.Count == 0)
+			{
+				//No stomachs?!
+				return;
+			}
+			bool success = false;
 			foreach (var Stomach in Stomachs)
 			{
-				Stomach.StomachContents.Add(new ReagentMix(RADRemover,Amount/Stomachs.Count));
+				if (Stomach.AddObjectToStomach(this))
+				{
+					success = true;
+					break;
+				}
 			}
-			//health.RadiationStacks *= StackPercentageRemove / 100f;
-			_ = Despawn.ServerSingle(gameObject);
+	
+			if (success == true)
+			{
+				//health.RadiationStacks *= StackPercentageRemove / 100f;
+				_ = Despawn.ServerSingle(gameObject);
+			}
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Food/PillToxHeale.cs
+++ b/UnityProject/Assets/Scripts/Items/Food/PillToxHeale.cs
@@ -18,11 +18,27 @@ namespace Items
 		{
 			var Health = eater.GetComponent<LivingHealthMasterBase>();
 			var Stomachs = Health.GetStomachs();
+
+			if (Stomachs.Count == 0)
+			{
+				//No stomachs?!
+				return;
+			}
+			bool success = false;
 			foreach (var Stomach in Stomachs)
 			{
-				Stomach.StomachContents.Add(new ReagentMix(Antitoxin,HealingAmount/Stomachs.Count));
+				if (Stomach.TryAddReagentsToStomach(new ReagentMix(Antitoxin, HealingAmount)) > 0)
+				{
+					success = true;
+					break;
+				}
 			}
-			_ = Despawn.ServerSingle(gameObject);
+
+			if (success == true)
+			{
+				//health.RadiationStacks *= StackPercentageRemove / 100f;
+				_ = Despawn.ServerSingle(gameObject);
+			}
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Food/WishSoup.cs
+++ b/UnityProject/Assets/Scripts/Items/Food/WishSoup.cs
@@ -25,16 +25,16 @@ namespace Items.Food
 
 			if (feedNutrients)
 			{
-				var stomachs = eater.playerHealth.GetStomachs();
-				if (stomachs.Count == 0)
+				var Stomachs = eater.playerHealth.GetStomachs();
+				if (Stomachs.Count == 0)
 				{
 					//No stomachs?!
 					return;
 				}
-				FoodContents.Divide(stomachs.Count);
-				foreach (var stomach in stomachs)
+
+				foreach (var Stomach in Stomachs)
 				{
-					stomach.StomachContents.Add(FoodContents.CurrentReagentMix.Clone());
+					if(Stomach.AddObjectToStomach(this)) break;			
 				}
 			}
 

--- a/UnityProject/Assets/Scripts/Items/Food/XenomorphFood.cs
+++ b/UnityProject/Assets/Scripts/Items/Food/XenomorphFood.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using UnityEngine;
-using System.Threading.Tasks;
+﻿using UnityEngine;
 using HealthV2;
-using Items;
+using Items.Implants.Organs;
 
 namespace Items.Food
 {
@@ -32,7 +30,7 @@ namespace Items.Food
 			var feeder = feederGO.GetComponent<PlayerScript>();
 
 			// Show eater message
-			var eaterHungerState = eater.playerHealth.HungerState;
+			var eaterHungerState = eater.playerHealth.DigestiveSystem.HungerState;
 			ConsumableTextUtils.SendGenericConsumeMessage(feeder, eater, eaterHungerState, Name, "eat");
 
 			// Check if eater can eat anything
@@ -57,17 +55,25 @@ namespace Items.Food
 			// TODO: missing sound?
 			//SoundManager.PlayNetworkedAtPos(sound, eater.WorldPos, sourceObj: eater.gameObject);
 
-			var stomachs = eater.playerHealth.GetStomachs();
-			if (stomachs.Count == 0)
+			var Stomachs = eater.playerHealth.GetStomachs();
+			if (Stomachs.Count == 0)
 			{
 				//No stomachs?!
 				return;
 			}
-			FoodContents.Divide(stomachs.Count);
-			foreach (var stomach in stomachs)
+
+
+			bool success = false;
+			foreach (var Stomach in Stomachs)
 			{
-				stomach.StomachContents.Add(FoodContents.CurrentReagentMix.Clone());
+				if (Stomach.AddObjectToStomach(this) == true)
+				{
+					success = true;
+					break;
+				}
 			}
+
+			if (success == false) return;
 
 			Pregnancy(eater.playerHealth);
 			var feederSlot = feeder.DynamicItemStorage.GetActiveHandSlot();
@@ -83,7 +89,10 @@ namespace Items.Food
 
 			if (player.GetStomachs().Count == 0) return;
 
-			player.GetStomachs()[0].RelatedPart.OrganStorage.ServerTryAdd(embryo);
+			Stomach stomachToImplant = player.GetStomachs()[0] as Stomach;
+			if (stomachToImplant == null) return;
+
+			stomachToImplant.RelatedPart.OrganStorage.ServerTryAdd(embryo);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Food/XenomorphFood.cs
+++ b/UnityProject/Assets/Scripts/Items/Food/XenomorphFood.cs
@@ -6,7 +6,6 @@ namespace Items.Food
 {
 	[RequireComponent(typeof(RegisterItem))]
 	[RequireComponent(typeof(ItemAttributesV2))]
-	[RequireComponent(typeof(Edible))]
 	public class XenomorphFood : Edible
 	{
 		[SerializeField]
@@ -92,7 +91,7 @@ namespace Items.Food
 			Stomach stomachToImplant = player.GetStomachs()[0] as Stomach;
 			if (stomachToImplant == null) return;
 
-			stomachToImplant.RelatedPart.OrganStorage.ServerTryAdd(embryo);
+			Inventory.ServerAdd(embryo.GetComponent<Pickupable>(), stomachToImplant.RelatedPart.OrganStorage.GetNextFreeIndexedSlot());
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/BodyFat.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/BodyFat.cs
@@ -22,12 +22,14 @@ namespace Items.Implants.Organs
 		{
 			if (livingHealth.DigestiveSystem == null) return;
 			if(livingHealth.DigestiveSystem.BodyFat.Contains(this)) livingHealth.DigestiveSystem.BodyFat.Remove(this);
+			livingHealth.DigestiveSystem.CalculateMaxHunger();
 		}
 
 		public override void AddedToBody(LivingHealthMasterBase livingHealth)
 		{
 			if (livingHealth.DigestiveSystem == null) return;
 			if (livingHealth.DigestiveSystem.BodyFat.Contains(this) == false) livingHealth.DigestiveSystem.BodyFat.Add(this);
+			livingHealth.DigestiveSystem.CalculateMaxHunger();
 		}
 
 		public float ConsumeNutrient(float amount)

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/BodyFat.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/BodyFat.cs
@@ -1,159 +1,42 @@
-﻿using System;
-using HealthV2;
-using Player.Movement;
+﻿using HealthV2;
+using System;
 using UnityEngine;
 
 namespace Items.Implants.Organs
 {
-	public class BodyFat : BodyPartFunctionality, IMovementEffect
+	public class BodyFat : BodyPartFunctionality
 	{
-		[SerializeField] private float maxRunSpeedDebuff = -2;
-		[SerializeField] private float maxWalkingDebuff = -1.5f;
-		[SerializeField] private float maxCrawlDebuff = -0.2f;
+		public float CurrentNutrient { get; private set; } = 0;
+		[field: SerializeField] public int maxNutrientStore { get; private set; } = 20;
+		[SerializeField] private int maxNutrientDischarge = 5; //The max amount of nutrient one piece of fat can donate each update
 
-		public float RunningSpeedModifier { get; private set; }
-
-		public float WalkingSpeedModifier { get; private set; }
-
-		public float CrawlingSpeedModifier { get; private set; }
-
-		public Stomach RelatedStomach;
-
-		public float ReleaseNutrimentPercentage = 0.01f;
-
-		public float AbsorbNutrimentPercentage  = 0.02f;
-
-		public float ReleaseAmount = 2f;
-
-		public float MinuteStoreMaxAmount =  60; //Last for 60 minutes
-
-		[NonSerialized] public const float StartAbsorbedAmount = 30;
-
-		[NonSerialized]	public float AbsorbedAmount = 0;
-
-		public bool IsFull => Math.Abs(MinuteStoreMaxAmount - AbsorbedAmount) < 0.01f;
-
-		public float DDebuffInPoint = 35; //some fat is ok
-
-		public float NoticeableDebuffInPoint = 45;
-
-		public bool WasApplyingDebuff = false;
-
-		public bool isFreshBlood;
-
-		public void Awake()
+		public float AddNutrient(float amount)
 		{
-			AbsorbedAmount = StartAbsorbedAmount;
-		}
+			float newAmount = Math.Min(amount, maxNutrientStore - CurrentNutrient);
+			CurrentNutrient += newAmount;
 
-		public void SetAbsorbedAmount(float newAbsorbedAmount)
-		{
-			AbsorbedAmount = newAbsorbedAmount;
-		}
-
-		public override void ImplantPeriodicUpdate()
-		{
-			isFreshBlood = true;
-			base.ImplantPeriodicUpdate();
-			// Logger.Log("Absorbing >" + Absorbing);
-			float NutrimentPercentage = (RelatedPart.HealthMaster.CirculatorySystem.BloodPool[RelatedPart.Nutriment] / RelatedPart.HealthMaster.CirculatorySystem.BloodPool.Total);
-			//Logger.Log("NutrimentPercentage >" + NutrimentPercentage);
-			if (NutrimentPercentage < ReleaseNutrimentPercentage)
-			{
-				float ToRelease = ReleaseAmount;
-				if (ToRelease > AbsorbedAmount)
-				{
-					ToRelease = AbsorbedAmount;
-				}
-
-				RelatedPart.HealthMaster.CirculatorySystem.BloodPool.Add(RelatedPart.Nutriment, ToRelease);
-				AbsorbedAmount -= ToRelease;
-				isFreshBlood = false;
-				// Logger.Log("ToRelease >" + ToRelease);
-			}
-			else if (isFreshBlood && NutrimentPercentage > AbsorbNutrimentPercentage && AbsorbedAmount < MinuteStoreMaxAmount)
-			{
-				float ToAbsorb = RelatedPart.HealthMaster.CirculatorySystem.BloodPool[RelatedPart.Nutriment];
-				if (AbsorbedAmount + ToAbsorb > MinuteStoreMaxAmount)
-				{
-					ToAbsorb = ToAbsorb - ((AbsorbedAmount + ToAbsorb) - MinuteStoreMaxAmount);
-				}
-
-				float Absorbing = RelatedPart.HealthMaster.CirculatorySystem.BloodPool.Remove(RelatedPart.Nutriment, ToAbsorb);
-				AbsorbedAmount += Absorbing;
-				// Logger.Log("Absorbing >" + Absorbing);
-			}
-
-			//Logger.Log("AbsorbedAmount >" + AbsorbedAmount);
-			//TODOH Proby doesn't need to be updated so often
-			if (DDebuffInPoint < AbsorbedAmount)
-			{
-				WasApplyingDebuff = true;
-				float DeBuffMultiplier = (AbsorbedAmount - DDebuffInPoint) / (MinuteStoreMaxAmount - DDebuffInPoint);
-				// Logger.Log("DeBuffMultiplier >" + DeBuffMultiplier);
-				RunningSpeedModifier = maxRunSpeedDebuff * DeBuffMultiplier;
-				WalkingSpeedModifier = maxWalkingDebuff * DeBuffMultiplier;
-				CrawlingSpeedModifier = maxCrawlDebuff * DeBuffMultiplier;
-				var playerHealthV2 = RelatedPart.HealthMaster as PlayerHealthV2;
-				if (playerHealthV2 != null)
-				{
-					playerHealthV2.PlayerMove.UpdateSpeeds();
-				}
-			}
-
-			if (AbsorbedAmount == 0)
-			{
-				RelatedPart.HungerState = HungerState.Malnourished;
-			}
-			else if (AbsorbedAmount < 5) //Five minutes of food
-			{
-				RelatedPart.HungerState = HungerState.Hungry;
-			}
-			else  if (NoticeableDebuffInPoint < AbsorbedAmount)
-			{
-				RelatedPart.HungerState = HungerState.Full;
-			}
-			else
-			{
-				RelatedPart.HungerState = HungerState.Normal;
-			}
-		}
-
-		[NaughtyAttributes.Button()]
-		public void BecomeSkinny()
-		{
-			AbsorbedAmount = 0;
-		}
-
-		public override void AddedToBody(LivingHealthMasterBase livingHealth)
-		{
-			base.AddedToBody(livingHealth);
-			var playerHealthV2 = RelatedPart.HealthMaster as PlayerHealthV2;
-			if (playerHealthV2 != null)
-			{
-				playerHealthV2.PlayerMove.AddModifier(this);
-			}
+			return amount - newAmount; //left over
 		}
 
 		public override void RemovedFromBody(LivingHealthMasterBase livingHealth)
 		{
-			base.RemovedFromBody(livingHealth);
-			RelatedStomach.BodyFats.Remove(this);
-			var playerHealthV2 = livingHealth as PlayerHealthV2;
-			if (playerHealthV2 != null)
-			{
-				playerHealthV2.PlayerMove.RemoveModifier(this);
-			}
+			if (livingHealth.DigestiveSystem == null) return;
+			if(livingHealth.DigestiveSystem.BodyFat.Contains(this)) livingHealth.DigestiveSystem.BodyFat.Remove(this);
 		}
 
-		public override void SetUpSystems()
+		public override void AddedToBody(LivingHealthMasterBase livingHealth)
 		{
-			base.SetUpSystems();
-			var playerHealthV2 = RelatedPart.HealthMaster as PlayerHealthV2;
-			if (playerHealthV2 != null)
-			{
-				playerHealthV2.PlayerMove.AddModifier(this);
-			}
+			if (livingHealth.DigestiveSystem == null) return;
+			if (livingHealth.DigestiveSystem.BodyFat.Contains(this) == false) livingHealth.DigestiveSystem.BodyFat.Add(this);
 		}
+
+		public float ConsumeNutrient(float amount)
+		{
+			float consumedAmount = Math.Min(Math.Min(amount, maxNutrientDischarge), maxNutrientDischarge);
+			CurrentNutrient -= consumedAmount;
+
+			return consumedAmount;
+		}
+		
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Bones.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Bones.cs
@@ -5,7 +5,8 @@ namespace Items.Implants.Organs
 {
 	public class Bones : BodyPartFunctionality
 	{
-		[SerializeField] public float BloodGeneratedByOneNutriment = 30;
+		[SerializeField] private float hungerUsedNormal;
+		[SerializeField] public float BloodGeneratedByOneHunger = 30;
 		[SerializeField] private BloodType GeneratesThis;
 
 		public float GenerationOvershoot = 1;
@@ -23,14 +24,8 @@ namespace Items.Implants.Organs
 		{
 			if ((RelatedPart.HealthMaster.CirculatorySystem.StartingBlood * GenerationOvershoot) > RelatedPart.HealthMaster.CirculatorySystem.BloodPool.Total)  //Assuming this is blood cap max)
 			{
-				float toConsume = RelatedPart.PassiveConsumptionNutriment * RelatedPart.HealingNutrimentMultiplier;
-				if (toConsume > RelatedPart.HealthMaster.CirculatorySystem.BloodPool[RelatedPart.Nutriment])
-				{
-					toConsume = RelatedPart.HealthMaster.CirculatorySystem.BloodPool[RelatedPart.Nutriment];
-				}
-
-				RelatedPart.HealthMaster.CirculatorySystem.BloodPool.Remove(RelatedPart.Nutriment, toConsume);
-				RelatedPart.HealthMaster.CirculatorySystem.BloodPool.Add(GeneratesThis, BloodGeneratedByOneNutriment * toConsume);
+				RelatedPart.HungerConsumption = hungerUsedNormal * RelatedPart.HealingNutrimentMultiplier;
+				RelatedPart.HealthMaster.CirculatorySystem.BloodPool.Add(GeneratesThis, BloodGeneratedByOneHunger * RelatedPart.HungerConsumption);
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/FatProducingStomach.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/FatProducingStomach.cs
@@ -1,0 +1,80 @@
+using Chemistry;
+using Items.Food;
+using HealthV2;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Items.Implants.Organs
+{
+	public class FatProducingStomach : Stomach
+	{
+		[SerializeField] private int MaxFat = 5;
+		[SerializeField] private GameObject fatPrefab;
+
+		public override float ProcessContent()
+		{
+			foreach (ItemSlot slot in stomachContents.GetItemSlots()) //Gets reagent from food in stomach, and then despawns food once digested.
+			{
+				if (slot.IsEmpty == true) continue;
+
+				ReagentMix chemicalsFromFood = new ReagentMix();
+				if (slot.ItemObject.TryGetComponent<Edible>(out var edible) == false)
+				{
+					if (slot.ItemObject.TryGetComponent<NotHandEdible>(out var notHandEdible) == false) continue;
+					chemicalsFromFood.Add(notHandEdible.TakeReagentsFromFood(DigesterAmountPerSecond));
+				}
+				else chemicalsFromFood.Add(edible.TakeReagentsFromFood(DigesterAmountPerSecond));
+
+				if (chemicalsFromFood.Total == 0)
+				{
+					Inventory.ServerDespawn(slot);
+					continue;
+				}
+
+				reagentContainer.Add(chemicalsFromFood);
+				break;
+			}
+
+			return Digest(); //Adds nutrient to fat and returns left over.
+		}
+
+		public override float Digest()
+		{
+			float newNutrient = 0;
+
+			foreach (Reagent nutrientReagent in nutrientReagents)
+			{
+				float amount = reagentContainer.AmountOfReagent(nutrientReagent);
+				if (amount > 0)
+				{
+					newNutrient += amount;
+					reagentContainer.CurrentReagentMix.reagents.Remove(nutrientReagent);
+				}
+			}
+			RelatedPart.HealthMaster.CirculatorySystem.BloodPool.Add(reagentContainer.CurrentReagentMix.Take(DigesterAmountPerSecond)); //Adds non nutrient chemicals to blood pool.
+
+			List<BodyFat> bodyFat = RelatedPart.HealthMaster.DigestiveSystem.BodyFat;
+
+			foreach (BodyFat fat in bodyFat)
+			{
+				newNutrient = fat.AddNutrient(newNutrient);
+				if (newNutrient == 0) break;
+			}
+			if(newNutrient > 0 && bodyFat.Count < 5) //Unable to get rid of all nutrient to fat stores;
+			{
+				SpawnResult newFat = Spawn.ServerPrefab(fatPrefab, SpawnDestination.At(GetComponent<UniversalObjectPhysics>().OfficialPosition));
+				if (newFat.Successful == false || newFat.GameObject.TryGetComponent<BodyFat>(out var fat) == false) return newNutrient;
+
+				newNutrient = fat.AddNutrient(newNutrient);
+				RelatedPart.ContainedIn.OrganStorage.ServerTryAdd(newFat.GameObject);
+			}
+
+			return newNutrient;
+		}
+
+		public override float GetStomachMaxHunger()
+		{
+			return 0f;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/FatProducingStomach.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/FatProducingStomach.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8062700515a2cd4fb294003089beede
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Kidneys.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Kidneys.cs
@@ -20,7 +20,6 @@ namespace Items.Implants.Organs
 			{
 				WhiteListReagents.Add(RelatedPart.requiredReagent);
 				WhiteListReagents.Add(RelatedPart.wasteReagent);
-				WhiteListReagents.Add(RelatedPart.Nutriment);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Stomach.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Stomach.cs
@@ -12,18 +12,13 @@ namespace Items.Implants.Organs
 	{
 		//General Stomach Class does not contain functions for fat as only organic stomachs will produce it. See FatProducingStomach.cs
 
-		protected ItemStorage stomachContents;
-		protected ReagentContainer reagentContainer;
+		[SerializeField] protected ItemStorage stomachContents;
+			
+		[SerializeField] protected ReagentContainer reagentContainer;
 
 		[SerializeField] protected List<Reagent> nutrientReagents; //What reagents this stomach treats as food. Nutrient is base, but stomachs like Moths might consume different reagents for food.
 
 		[SerializeField] protected int DigesterAmountPerSecond = 1; //On average takes 18 seconds to deplete one nutrient.
-
-		public void Start()
-		{
-			stomachContents = GetComponent<ItemStorage>();
-			reagentContainer = GetComponent<ReagentContainer>();
-		}
 
 		public bool AddObjectToStomach(Consumable edible)
 		{
@@ -84,19 +79,23 @@ namespace Items.Implants.Organs
 			return newNutrient;
 		}
 
-		public virtual float GetStomachMaxHunger()
+		public float GetStomachMaxHunger()
 		{
 			return reagentContainer.MaxCapacity;
 		}
 
 		public override void AddedToBody(LivingHealthMasterBase livingHealth)
 		{
-			RelatedPart.HealthMaster.DigestiveSystem.AddStomach(this);
+			livingHealth.DigestiveSystem.AddStomach(this);
+		}
+
+		public virtual void InitialiseHunger(DigestiveSystemBase digestiveSystem) //On round start we give the player a full stomach if said stomach cant produce fat
+		{
+			RelatedPart.HealthMaster.DigestiveSystem.ClampHunger(HungerState.Full);
 		}
 
 		public override void RemovedFromBody(LivingHealthMasterBase livingHealth)
 		{
-			base.RemovedFromBody(livingHealth);
 			RelatedPart.HealthMaster.DigestiveSystem.RemoveStomach(this);
 		}
 

--- a/UnityProject/Assets/Scripts/Items/Science/Implants/NutrientPump.cs
+++ b/UnityProject/Assets/Scripts/Items/Science/Implants/NutrientPump.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+using HealthV2;
+using Chemistry;
+
+namespace Items.Implants.Organs
+{
+	public class NutrientPump : BodyPartFunctionality
+	{
+		[SerializeField] private HungerState HungerState = HungerState.Hungry;
+		[SerializeField] private ReagentMix toxinMix;
+
+		public override void ImplantPeriodicUpdate()
+		{
+			if (RelatedPart.HealthMaster.DigestiveSystem == null) return;
+
+			RelatedPart.HealthMaster.DigestiveSystem.ClampHunger(HungerState);
+		}
+
+		public override void EmpResult(int strength)
+		{
+			RelatedPart.HealthMaster.CirculatorySystem.BloodPool.Add(toxinMix);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Science/Implants/NutrientPump.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Science/Implants/NutrientPump.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 06b0f5e4e4cefd34baaa3cb263b7de33
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
@@ -309,7 +309,7 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 			|| playerScript.playerHealth.IsCrit
 			|| playerScript.playerHealth.IsSoftCrit
 			|| playerScript.playerHealth.IsDead
-			|| playerScript.playerHealth.HungerState == HungerState.Starving)
+			|| playerScript.playerHealth.DigestiveSystem?.HungerState == HungerState.Starving)
 		{
 			return;
 		}

--- a/UnityProject/Assets/StreamingAssets/TechWeb/Designs/MedicalDesigns.json
+++ b/UnityProject/Assets/StreamingAssets/TechWeb/Designs/MedicalDesigns.json
@@ -358,7 +358,7 @@
         "Item_ID": "weldingshield"
     },
     {
-        "Internal_ID": "ci-nutriment",
+        "Internal_ID": "ci_nutriment",
         "Description": "This implant with synthesize and pump into your bloodstream a small amount of nutriment when you are starving.",
         "Category": [
             "Misc",
@@ -378,10 +378,10 @@
             "Science"
         ],
         "name": "Nutriment Pump Implant",
-        "Item_ID": "/obj/item/organ/cyberimp/chest/nutriment"
+        "Item_ID": "nutrientpump"
     },
     {
-        "Internal_ID": "ci-nutrimentplus",
+        "Internal_ID": "ci_nutrimentplus",
         "Description": "This implant with synthesize and pump into your bloodstream a small amount of nutriment when you are hungry.",
         "Category": [
             "Misc",
@@ -402,7 +402,7 @@
             "Science"
         ],
         "name": "Nutriment Pump Implant PLUS",
-        "Item_ID": "/obj/item/organ/cyberimp/chest/nutriment/plus"
+        "Item_ID": "nutrientpumpplus"
     },
     {
         "Internal_ID": "ci_reviver",

--- a/UnityProject/Assets/StreamingAssets/TechWeb/TechwebData.json
+++ b/UnityProject/Assets/StreamingAssets/TechWeb/TechwebData.json
@@ -27,7 +27,8 @@
     ],
     "DesignIDs": [
       "cyber_heart",
-      "cyber_lung"
+      "cyber_lung",
+      "cyber_liver"
     ],
     "ResearchCosts": 15,
     "ExportPrice": 0,
@@ -92,19 +93,20 @@
   },
   {
     "ID": "filtering",
-    "DisplayName": "Cybernetic Filtering",
-    "Description": "Cybernetic livers are more efficient at filtering toxins from the body, completely protecting the host from certain toxins.",
+    "DisplayName": "Nutriment Pumps",
+    "Description": "Never go hungry again! These chest implants will keep you well fed.",
     "StartingNode": false,
     "RequiredTechnologies": [
       "advcyber"
     ],
     "DesignIDs": [
-      "cyber_liver"
+      "ci_nutriment",
+      "ci_nutrimentplus"
     ],
     "ResearchCosts": 20,
     "ExportPrice": 0,
     "PotentialUnlocks": [],
-    "prefabID": "liver",
+    "prefabID": "nutrient",
     "techType": 1,
     "Techweb": null
   },


### PR DESCRIPTION
THIS PR IS W.I.P AND NOT YET COMPLETED
I have not yet bothered to do networking as this PR is still experiemental
And there is a few bugs rn that I am still working on, I just wanted to open this as a draft to get feedback on the actual structure of the system.

This PR aims to simplify our hunger system and make it far nicer to work with aswell as elevating points of error.

While the description below sounds complicated, the system itself is very simple and modular. Player hunger levels can be accessed and changed reliably from one script. And food sources like stomachs can be added and changed (like to require different food sources) without any code changes and without breaking any systems. The system also requires nothing from the player to work so can be applied to mobs with no issue. As an example of working with this new system, I have also added the NutrientPump Implant in this PR. And its entire functionality can be done with one line (Seen in its relevant class).
Reading the scripts will probably give you a better idea of the system, but below I have tried putting it into words anyways.

Hunger is no longer on a part limb basis and is now unified in a singular manager DigestiveSystemBase.cs

Digestive system base handles hunger consumption and manages stomaches. The amount of hunger consumed is based of the bodyparts in the body (every body part has a field that says how much hunger it consumes. Cyborg limbs and organs use 0, human stuff uses 1). The digestive system has a list of IStomachProcess's that it calls to gain nutrient. Movement debuffs due to hunger are now also controlled in this script.

Stomachs have been reworked, when eating food, the food object is moved into the stomach, and then during the DigestiveSystem process, the stomach will extract some reagent from the food. If the stomach is able to digest any of the reagents, said reagent will be removed and player hunger gained. All other reagents are then moved into the circulatory system to be metabolised. When a food object runs out of reagents it is fully digested and is deleted.

Stomachs dont produce fat normally, but there is now a fat producing stomach. A fat producing stomach will put any excess produced into fat stores. Nutrients will be taken from the fat stores if the stomachs dont have any food. The fat itself does NO calculations, it merely stores the nutrient.

The hunger state, such as hungry and straving, are now dependent on on how much food the body is consuming. For an example of what I mean. A normal human may consume 20u of food each time period. They will become starving if they have 20u of food left. A cyborg that is only supporting a human brain consuming 1u per timeperiod. WIll only become starving when they have 1u of food left. This means your hunger state is a better indicator of how long you have and is more useful then being told you are starving when you still have enough food to last you an hour (for cyborgs and such)