### PR TITLE
fix: id console won't eat cards all the time now

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Consoles/IdentificationConsole.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Consoles/IdentificationConsole.prefab
@@ -319,6 +319,20 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 1210071305953523191}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &-5108634961606219251
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8891374403570406798}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09b7e5ca3d7645bf909222e46af44b5f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  requiredClearance: 0e000000
+  type: 0
 --- !u!114 &-3864671906557840849
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/UI/Objects/Command/IDConsole/GUI_IDConsole.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Command/IDConsole/GUI_IDConsole.cs
@@ -245,7 +245,7 @@ namespace UI.Objects.Command
 
 		public void ServerLogin()
 		{
-			var idClearance = console.AccessCard.GetComponent<IClearanceSource>();
+			var idClearance = console.AccessCard.OrNull()?.GetComponent<IClearanceSource>();
 			if (idClearance != null && console.Restricted.HasClearance(idClearance) || IsAIInteracting())
 			{
 				console.LoggedIn = true;


### PR DESCRIPTION
### Purpose
Fixes some NREs on ID console which resulted in it eating people's ID cards.

### Changelog:
CL: [Fix] ID console won't eat your card all the time now. Only sometimes.