### PR TITLE
Make flaps so they cannot be pushed by players walking into them

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Furniture/Flaps.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Furniture/Flaps.prefab
@@ -236,7 +236,11 @@ MonoBehaviour:
     Acid: 0
     Magic: 0
     Bio: 0
+    Anomaly: 0
     DismembermentProtectionChance: 0
+    StunImmunity: 0
+    TemperatureProtectionInK: {x: 268.15, y: 313.15}
+    PressureProtectionInKpa: {x: 30, y: 300}
   Resistances:
     LavaProof: 0
     FireProof: 0
@@ -249,7 +253,6 @@ MonoBehaviour:
   HeatResistance: 100
   ExplosionsDamage: 100
   doDamageMessage: 1
-  Meleeable: {fileID: 0}
 --- !u!114 &114876689548865824
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -297,17 +300,27 @@ MonoBehaviour:
   SnapToGridOnStart: 0
   LocalTargetPosition: {x: 0, y: 0, z: 0}
   ChangesDirectionPush: 0
-  isNotPushable: 0
-  newtonianMovement: {x: 0, y: 0}
+  Intangible: 0
+  CanBeWindPushed: 0
+  IsPlayer: 0
+  InitialLocationSynchronised: 0
+  tileMoveSpeed: 1
+  isNotPushable: 1
+  HasOwnGravity: 0
   airTime: 0
   slideTime: 0
+  SetIgnoreSticky: 0
   thrownBy: {fileID: 0}
   aim: 0
   spinMagnitude: 0
+  ForcedPushedFrame: 0
+  TryPushedFrame: 0
+  PushedFrame: 0
+  FramePushDecision: 1
   stickyMovement: 0
+  OnThrowEndResetRotation: 0
   maximumStickSpeed: 1.5
   onStationMovementsRound: 0
-  attributes: {fileID: 0}
   registerTile: {fileID: 0}
   ContextGameObjects:
   - {fileID: 0}
@@ -317,12 +330,9 @@ MonoBehaviour:
   CorrectingCourse: 0
   Pushing: []
   Hits: []
-  Speed: 1
-  AIR: 3
-  SLIDE: 4
   Animating: 0
-  IsFlyingSliding: 0
+  isFlyingSliding: 0
   IsMoving: 0
-  IsWalking: 0
   MoveIsWalking: 0
   LastUpdateClientFlying: 0
+  BuckledToObject: {fileID: 0}


### PR DESCRIPTION
### Purpose
Currently flaps could be pushed around by players walking into them. This PR changes the `Is Not Pushable` attribute on the prefab for them to true and the `Can Be Wind Pushed` attribute to false. 

![image](https://user-images.githubusercontent.com/5573038/213280394-9d24f90e-8d77-4147-88a5-0db1ed52d42b.png)


### Notes:
As far as I can tell items cannot pass through flaps still, but that is an entirely separate issue.

### Changelog:
CL: [Fix] Flaps can no longer be pushed by players walking into them
