### PR TITLE
fixes an issue with bodies building up toxic damage Too fast after being beheaded

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Heart.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Heart.cs
@@ -26,7 +26,7 @@ namespace Items.Implants.Organs
 		{
 			if (DMMath.Prob(50)) DoHeartAttack();
 
-			base.EmpResult(strength);		
+			base.EmpResult(strength);
 		}
 
 		public override void ImplantPeriodicUpdate()
@@ -118,7 +118,7 @@ namespace Items.Implants.Organs
 
 		public float CalculateHeartbeat()
 		{
-			if (HeartAttack)
+			if (HeartAttack || RelatedPart.HealthMaster.brain == null) //Needs a brain for heart to work
 			{
 				return 0;
 			}


### PR DESCRIPTION
the issue was if you were beheaded your heart would still work , but your lungs wouldn't so therefore your liver would Die of damage but your body would still generate the regular amount of toxin

### Changelog:


CL: [Fix] fixes an issue with bodies building up toxic damage Too fast after being beheaded