### PR TITLE
Fixes bluespace bananas not working.

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Botany/Produce/Bananas/BluespaceBananaPeel.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Botany/Produce/Bananas/BluespaceBananaPeel.prefab
@@ -106,9 +106,15 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 3800479214992426251, guid: 7c4d6f08fc4da3b4dbd86d2f111812ea,
         type: 3}
-      propertyPath: initialTraits.Array.data[4]
+      propertyPath: initialTraits.Array.data[3]
       value: 
       objectReference: {fileID: 11400000, guid: 6365ad3bdf400fc49915f8c5a3d2ccf1,
+        type: 2}
+    - target: {fileID: 3800479214992426251, guid: 7c4d6f08fc4da3b4dbd86d2f111812ea,
+        type: 3}
+      propertyPath: initialTraits.Array.data[4]
+      value: 
+      objectReference: {fileID: 11400000, guid: 63ebb1ff93c93354994ab009bc8ccf7d,
         type: 2}
     - target: {fileID: 3800479214992426251, guid: 7c4d6f08fc4da3b4dbd86d2f111812ea,
         type: 3}

--- a/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
+++ b/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
@@ -10,6 +10,7 @@ using Newtonsoft.Json;
 using Objects;
 using Player.Movement;
 using ScriptableObjects.Audio;
+using Systems.Teleport;
 using Tiles;
 using UI;
 using UI.Core.Action;
@@ -1154,7 +1155,7 @@ public class MovementSynchronisation : UniversalObjectPhysics, IPlayerControllab
 		return false;
 	}
 
-	public bool DoesSlip(MoveData moveAction, out ItemAttributesV2 slippedOn)
+	private bool DoesSlip(MoveData moveAction, out ItemAttributesV2 slippedOn)
 	{
 		bool slipProtection = true;
 		if (playerScript.DynamicItemStorage != null)
@@ -1187,6 +1188,13 @@ public class MovementSynchronisation : UniversalObjectPhysics, IPlayerControllab
 		var crossedItems = toMatrix.Get<ItemAttributesV2>(localTo, isServer);
 		foreach (var crossedItem in crossedItems)
 		{
+			if (crossedItem.HasTrait(CommonTraits.Instance.BluespaceActivity))
+			{
+				// (Max): There's better ways to do this but due to how movement code is designed
+				// you can't extend functionality that easily without bloating the code more than it already is.
+				// TODO: Rework movement to be open for extension and closed for modifications.
+				TeleportUtils.ServerTeleportRandom(playerScript.gameObject);
+			}
 			if (crossedItem.HasTrait(CommonTraits.Instance.Slippery))
 			{
 				slippedOn = crossedItem;


### PR DESCRIPTION
Fixes #9527

CL: [Fix] Fixes bluespace banana peels not teleporting prank victims.
