### PR TITLE
You can no longer sell footprints

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/CargoManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/CargoManager.cs
@@ -203,7 +203,7 @@ namespace Systems.Cargo
 				}
 			}
 
-			OnShuttleUpdate.Invoke();
+			OnShuttleUpdate?.Invoke();
 		}
 
 		private IEnumerator Timer(bool launchToStation)
@@ -211,7 +211,7 @@ namespace Systems.Cargo
 			while (CurrentFlyTime > 0f)
 			{
 				CurrentFlyTime -= 1f;
-				OnTimerUpdate.Invoke();
+				OnTimerUpdate?.Invoke();
 				yield return WaitFor.Seconds(1);
 			}
 


### PR DESCRIPTION
fixes #9559

CL: [Fix] You can no longer sell footprints
CL: [Fix] You can no longer sell items or objects that do not have an attributes component on them.