### PR TITLE
Some floor decals are now uncleanable.

### DIFF
--- a/UnityProject/Assets/Prefabs/Decal/Resources/_FloorDecalBase.prefab
+++ b/UnityProject/Assets/Prefabs/Decal/Resources/_FloorDecalBase.prefab
@@ -53,12 +53,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  Cleanable: 1
+  Cleanable: 0
   CanDryUp: 0
   isBlood: 0
+  IsFootprint: 0
   color: {r: 0, g: 0, b: 0, a: 0}
   PossibleSprites:
   - {fileID: 21300000, guid: 98d39d817ace60f418830bb5d6a3f009, type: 3}
+  DontTouchSpriteRenderer: 0
 --- !u!114 &114595774069620348
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -172,12 +174,15 @@ MonoBehaviour:
   LocalTargetPosition: {x: 0, y: 0, z: 0}
   ChangesDirectionPush: 0
   Intangible: 0
+  CanBeWindPushed: 1
+  IsPlayer: 0
   InitialLocationSynchronised: 0
   tileMoveSpeed: 1
   isNotPushable: 1
-  newtonianMovement: {x: 0, y: 0}
+  HasOwnGravity: 0
   airTime: 0
   slideTime: 0
+  SetIgnoreSticky: 0
   thrownBy: {fileID: 0}
   aim: 0
   spinMagnitude: 0
@@ -186,9 +191,9 @@ MonoBehaviour:
   PushedFrame: 0
   FramePushDecision: 1
   stickyMovement: 0
+  OnThrowEndResetRotation: 0
   maximumStickSpeed: 1.5
   onStationMovementsRound: 0
-  attributes: {fileID: 0}
   registerTile: {fileID: 0}
   ContextGameObjects:
   - {fileID: 0}
@@ -199,10 +204,11 @@ MonoBehaviour:
   Pushing: []
   Hits: []
   Animating: 0
-  IsFlyingSliding: 0
+  isFlyingSliding: 0
   IsMoving: 0
   MoveIsWalking: 0
   LastUpdateClientFlying: 0
+  BuckledToObject: {fileID: 0}
 --- !u!1 &1230737790073880
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Decal/Resources/dirty floor decal.prefab
+++ b/UnityProject/Assets/Prefabs/Decal/Resources/dirty floor decal.prefab
@@ -80,6 +80,11 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 5908745450454926434, guid: 66aad43ea1945ac458990cb6d4169cde,
         type: 3}
+      propertyPath: Cleanable
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5908745450454926434, guid: 66aad43ea1945ac458990cb6d4169cde,
+        type: 3}
       propertyPath: PossibleSprites.Array.size
       value: 21
       objectReference: {fileID: 0}


### PR DESCRIPTION
fixes #9565 

CL: [Fix] Some floor decals are now uncleanable so that they don't get accidentally removed by janitors when mopping.
