### PR TITLE
Supermatter Log, Exposed events in inspector and admin nofitication sounds.

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Item.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Item.prefab
@@ -138,6 +138,7 @@ MonoBehaviour:
   OnMoveToPlayerInventory:
     m_PersistentCalls:
       m_Calls: []
+  lastTouch: {fileID: 4885464012290422036}
 --- !u!114 &114776788309089574
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Items/Item.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Item.prefab
@@ -22,6 +22,7 @@ GameObject:
   - component: {fileID: 6393191727481188567}
   - component: {fileID: 5414819541850508356}
   - component: {fileID: 2611437823404169790}
+  - component: {fileID: 4885464012290422036}
   m_Layer: 10
   m_Name: Item
   m_TagString: Abstract
@@ -134,6 +135,9 @@ MonoBehaviour:
   syncInterval: 0.1
   pickupAnimSpeed: 0.2
   ItemAttributesV2: {fileID: 0}
+  OnMoveToPlayerInventory:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!114 &114776788309089574
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -205,6 +209,8 @@ MonoBehaviour:
     Anomaly: 0
     DismembermentProtectionChance: 0
     StunImmunity: 0
+    TemperatureProtectionInK: {x: 268.15, y: 313.15}
+    PressureProtectionInKpa: {x: 30, y: 300}
   Resistances:
     LavaProof: 0
     FireProof: 0
@@ -307,6 +313,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   foreverID: a7abba22164ce49f0bf9b9b219f39298
+  <AlternativePrefabName>k__BackingField: 
 --- !u!114 &5414819541850508356
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -371,6 +378,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 13b3f20d3b30cb24fb70b1f35524c360, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4885464012290422036
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1011433845357754}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9306f5c12c5c44b1a525a287c5cced72, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1344926539164060

--- a/UnityProject/Assets/Prefabs/UI/AdminUI.prefab
+++ b/UnityProject/Assets/Prefabs/UI/AdminUI.prefab
@@ -2954,6 +2954,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   label: {fileID: 1527715116472615289}
   background: {fileID: 3372888502040208029}
+  nofticationSound:
+    SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/UI/Bwoink.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
 --- !u!1 &1076313762393491491
 GameObject:
   m_ObjectHideFlags: 0
@@ -3079,7 +3087,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0.6993114}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -4790,7 +4798,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 8349485413676950156}
   m_Direction: 2
   m_Value: 0
-  m_Size: 1
+  m_Size: 0.6993114
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -7855,6 +7863,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   label: {fileID: 6565343638914778210}
   background: {fileID: 7364811699000415073}
+  nofticationSound:
+    SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/UI/Bwoink.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
 --- !u!1 &3944144288921864205
 GameObject:
   m_ObjectHideFlags: 0
@@ -9861,6 +9877,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   label: {fileID: 4163435171594612950}
   background: {fileID: 8772760767575208117}
+  nofticationSound:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
 --- !u!1 &4982867252802006474
 GameObject:
   m_ObjectHideFlags: 0
@@ -10480,6 +10504,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   label: {fileID: 8907958984669296785}
   background: {fileID: 5126437123559741154}
+  nofticationSound:
+    SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/UI/Tick.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
 --- !u!1 &5298459481828212154
 GameObject:
   m_ObjectHideFlags: 0
@@ -10835,7 +10867,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 0.000030517578, y: -5.3390503}
+  m_AnchoredPosition: {x: 0.000030517578, y: -326.41437}
   m_SizeDelta: {x: 0, y: 81}
   m_Pivot: {x: 0, y: -0.01}
 --- !u!114 &8153881301832577279
@@ -13505,6 +13537,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   label: {fileID: 6972311850147296919}
   background: {fileID: 8101869038184451758}
+  nofticationSound:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
 --- !u!1 &6787479068599820315
 GameObject:
   m_ObjectHideFlags: 0
@@ -13960,6 +14000,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   label: {fileID: 7898257571701440257}
   background: {fileID: 8197587673837848016}
+  nofticationSound:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
 --- !u!1 &6924320007123187704
 GameObject:
   m_ObjectHideFlags: 0
@@ -20809,7 +20857,7 @@ PrefabInstance:
     - target: {fileID: 1268877190625434404, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -286.06
+      value: -216.06
       objectReference: {fileID: 0}
     - target: {fileID: 1547275681838769713, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
@@ -20844,7 +20892,7 @@ PrefabInstance:
     - target: {fileID: 1675726846448114705, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -426.06
+      value: -356.06
       objectReference: {fileID: 0}
     - target: {fileID: 1995023899456984380, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
@@ -20894,7 +20942,7 @@ PrefabInstance:
     - target: {fileID: 2300210093956084321, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -286.06
+      value: -216.06
       objectReference: {fileID: 0}
     - target: {fileID: 2473494848379212645, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
@@ -20924,7 +20972,7 @@ PrefabInstance:
     - target: {fileID: 2473494848379212645, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -286.06
+      value: -216.06
       objectReference: {fileID: 0}
     - target: {fileID: 2800070812383424814, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
@@ -20961,6 +21009,16 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -18.60065
       objectReference: {fileID: 0}
+    - target: {fileID: 2958734172288387973, guid: 56a6f9494007d064a8f9c7fde98a31ab,
+        type: 3}
+      propertyPath: m_Size
+      value: 0.66097504
+      objectReference: {fileID: 0}
+    - target: {fileID: 2958734172288387973, guid: 56a6f9494007d064a8f9c7fde98a31ab,
+        type: 3}
+      propertyPath: m_Value
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3226595742494241600, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -20989,7 +21047,7 @@ PrefabInstance:
     - target: {fileID: 3226595742494241600, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -426.06
+      value: -356.06
       objectReference: {fileID: 0}
     - target: {fileID: 3682685676033689283, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
@@ -21034,7 +21092,7 @@ PrefabInstance:
     - target: {fileID: 3755087979155411765, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -426.06
+      value: -356.06
       objectReference: {fileID: 0}
     - target: {fileID: 4038883241762955758, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
@@ -21045,6 +21103,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4038883241762955758, guid: 56a6f9494007d064a8f9c7fde98a31ab,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.33902496
       objectReference: {fileID: 0}
     - target: {fileID: 4427115934648860669, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
@@ -21209,7 +21272,7 @@ PrefabInstance:
     - target: {fileID: 5185232339583884655, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -426.06
+      value: -356.06
       objectReference: {fileID: 0}
     - target: {fileID: 5244155140893598572, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
@@ -21239,7 +21302,7 @@ PrefabInstance:
     - target: {fileID: 5244155140893598572, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -426.06
+      value: -356.06
       objectReference: {fileID: 0}
     - target: {fileID: 5616882820016886140, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
@@ -21274,7 +21337,7 @@ PrefabInstance:
     - target: {fileID: 5723466169221834917, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -286.06
+      value: -216.06
       objectReference: {fileID: 0}
     - target: {fileID: 6460945125158060582, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
@@ -21305,6 +21368,36 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -18.60065
+      objectReference: {fileID: 0}
+    - target: {fileID: 7237687817597577282, guid: 56a6f9494007d064a8f9c7fde98a31ab,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7237687817597577282, guid: 56a6f9494007d064a8f9c7fde98a31ab,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7237687817597577282, guid: 56a6f9494007d064a8f9c7fde98a31ab,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 7237687817597577282, guid: 56a6f9494007d064a8f9c7fde98a31ab,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 7237687817597577282, guid: 56a6f9494007d064a8f9c7fde98a31ab,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 79.158264
+      objectReference: {fileID: 0}
+    - target: {fileID: 7237687817597577282, guid: 56a6f9494007d064a8f9c7fde98a31ab,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -496.06
       objectReference: {fileID: 0}
     - target: {fileID: 7568914503429585651, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
@@ -21355,6 +21448,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 8175451287347996716, guid: 56a6f9494007d064a8f9c7fde98a31ab,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 1380.1726
       objectReference: {fileID: 0}
     - target: {fileID: 8544607000549404794, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
@@ -21434,7 +21532,7 @@ PrefabInstance:
     - target: {fileID: 8560776635561198632, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -286.06
+      value: -216.06
       objectReference: {fileID: 0}
     - target: {fileID: 8701020302271651959, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
@@ -21464,7 +21562,7 @@ PrefabInstance:
     - target: {fileID: 8701020302271651959, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -426.06
+      value: -356.06
       objectReference: {fileID: 0}
     - target: {fileID: 8717485026364307419, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
@@ -21504,7 +21602,7 @@ PrefabInstance:
     - target: {fileID: 8748029020018418699, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -286.06
+      value: -216.06
       objectReference: {fileID: 0}
     - target: {fileID: 8848015536832186106, guid: 56a6f9494007d064a8f9c7fde98a31ab,
         type: 3}

--- a/UnityProject/Assets/Scripts/Items/LastTouch.cs
+++ b/UnityProject/Assets/Scripts/Items/LastTouch.cs
@@ -1,0 +1,22 @@
+﻿using UnityEngine;
+
+namespace Items
+{
+	public class LastTouch : MonoBehaviour
+	{
+		public PlayerInfo LastTouchedBy { get; set; }
+		private Pickupable pickupable;
+
+		private void Awake()
+		{
+			pickupable = GetComponent<Pickupable>();
+			pickupable.OnMoveToPlayerInventory.AddListener(SetLastTouch);
+		}
+
+		private void SetLastTouch(GameObject player)
+		{
+			if (pickupable.ItemSlot.Player == null) return;
+			LastTouchedBy = pickupable.ItemSlot.Player.PlayerScript.PlayerInfo;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/LastTouch.cs
+++ b/UnityProject/Assets/Scripts/Items/LastTouch.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 namespace Items
 {
@@ -13,10 +14,17 @@ namespace Items
 			pickupable.OnMoveToPlayerInventory.AddListener(SetLastTouch);
 		}
 
+		private void OnDestroy()
+		{
+			pickupable.OnMoveToPlayerInventory.RemoveListener(SetLastTouch);
+			pickupable = null;
+			LastTouchedBy = null;
+		}
+
 		private void SetLastTouch(GameObject player)
 		{
-			if (pickupable.ItemSlot.Player == null) return;
-			LastTouchedBy = pickupable.ItemSlot.Player.PlayerScript.PlayerInfo;
+			if (player.TryGetComponent<PlayerScript>(out var info) == false) return;
+			LastTouchedBy = info.PlayerInfo;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/LastTouch.cs
+++ b/UnityProject/Assets/Scripts/Items/LastTouch.cs
@@ -6,18 +6,9 @@ namespace Items
 	public class LastTouch : MonoBehaviour
 	{
 		public PlayerInfo LastTouchedBy { get; set; }
-		private Pickupable pickupable;
-
-		private void Awake()
-		{
-			pickupable = GetComponent<Pickupable>();
-			pickupable.OnMoveToPlayerInventory.AddListener(SetLastTouch);
-		}
 
 		private void OnDestroy()
 		{
-			pickupable.OnMoveToPlayerInventory.RemoveListener(SetLastTouch);
-			pickupable = null;
 			LastTouchedBy = null;
 		}
 

--- a/UnityProject/Assets/Scripts/Items/LastTouch.cs
+++ b/UnityProject/Assets/Scripts/Items/LastTouch.cs
@@ -11,11 +11,5 @@ namespace Items
 		{
 			LastTouchedBy = null;
 		}
-
-		private void SetLastTouch(GameObject player)
-		{
-			if (player.TryGetComponent<PlayerScript>(out var info) == false) return;
-			LastTouchedBy = info.PlayerInfo;
-		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/LastTouch.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/LastTouch.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9306f5c12c5c44b1a525a287c5cced72
+timeCreated: 1675645805

--- a/UnityProject/Assets/Scripts/Learning/ProtipObjectTypes/ProtipObjectOnPickup.cs
+++ b/UnityProject/Assets/Scripts/Learning/ProtipObjectTypes/ProtipObjectOnPickup.cs
@@ -8,12 +8,12 @@ namespace Learning.ProtipObjectTypes
 	{
 		public void OnEnable()
 		{
-			gameObject.PickupableOrNull().OnMoveToPlayerInventory += Trigger;
+			gameObject.PickupableOrNull().OnMoveToPlayerInventory.AddListener(Trigger);
 		}
 
 		private void OnDisable()
 		{
-			gameObject.PickupableOrNull().OnMoveToPlayerInventory -= Trigger;
+			gameObject.PickupableOrNull().OnMoveToPlayerInventory.RemoveListener(Trigger);
 		}
 
 		private void Trigger(GameObject picker)

--- a/UnityProject/Assets/Scripts/Objects/Engineering/SuperMatter.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/SuperMatter.cs
@@ -1183,7 +1183,7 @@ namespace Objects.Engineering
 			if (thrownObject.TryGetComponent<LastTouch>(out var touch) == false || touch.LastTouchedBy == null) return;
 			var time = DateTime.Now.ToString(CultureInfo.InvariantCulture);
 			UIManager.Instance.playerAlerts.ServerAddNewEntry(time, PlayerAlertTypes.RDM, touch.LastTouchedBy,
-				$"{time} : A {thrownObject.ExpensiveName()} was thrown at a super-matter and was last touched by {touch.LastTouchedBy.Script.playerName}.");
+				$"{time} : A {thrownObject.ExpensiveName()} was thrown at a super-matter and was last touched by {touch.LastTouchedBy.Script.playerName} ({touch.LastTouchedBy.Username}).");
 		}
 
 		#endregion

--- a/UnityProject/Assets/Scripts/Objects/Engineering/SuperMatter.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/SuperMatter.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Systems.Atmospherics;
 using Systems.ElectricalArcs;
 using Systems.Explosions;
 using Systems.Radiation;
 using AddressableReferences;
+using AdminTools;
 using Core.Lighting;
 using HealthV2;
 using Light2D;
@@ -22,6 +24,7 @@ using Objects.Machines.ServerMachines.Communications;
 using ScriptableObjects.Communications;
 using Systems.Communications;
 using InGameEvents;
+using Items;
 
 
 namespace Objects.Engineering
@@ -1080,7 +1083,7 @@ namespace Objects.Engineering
 			if (sendToCommon) chatEvent.channels |= ChatChannel.Common;
 
 			InfluenceChat(chatEvent);
-			
+
 		}
 
 		protected override bool SendSignalLogic()
@@ -1138,8 +1141,7 @@ namespace Objects.Engineering
 		//Called when bumped by players or collided with by flying items
 		public void OnBump(GameObject bumpedBy, GameObject client)
 		{
-			if (isServer == false) return;
-			if(isHugBox) return;
+			if (isServer == false || isHugBox) return;
 
 			if (bumpedBy.TryGetComponent<PlayerHealthV2>(out var playerHealth))
 			{
@@ -1162,10 +1164,11 @@ namespace Objects.Engineering
 
 				health.OnGib();
 			}
-			else if(bumpedBy.TryGetComponent<Integrity>(out var integrity))
+			else if (bumpedBy.TryGetComponent<Integrity>(out var integrity))
 			{
 				//Items flying
 				Chat.AddLocalMsgToChat($"The {bumpedBy.ExpensiveName()} smacks into the {gameObject.ExpensiveName()} and rapidly flashes to ash", bumpedBy);
+				LogBumpForAdmin(bumpedBy);
 
 				integrity.ApplyDamage(1000, AttackType.Rad, DamageType.Brute, true, ignoreArmor: true);
 			}
@@ -1173,6 +1176,14 @@ namespace Objects.Engineering
 			matterPower += 150;
 			RadiationManager.Instance.RequestPulse( registerTile.WorldPositionServer, 200, GetInstanceID());
 			SoundManager.PlayNetworkedAtPos(lightningSound, registerTile.WorldPositionServer, sourceObj: gameObject);
+		}
+
+		private void LogBumpForAdmin(GameObject thrownObject)
+		{
+			if (thrownObject.TryGetComponent<LastTouch>(out var touch) == false || touch.LastTouchedBy == null) return;
+			var time = DateTime.Now.ToString(CultureInfo.InvariantCulture);
+			UIManager.Instance.playerAlerts.ServerAddNewEntry(time, PlayerAlertTypes.RDM, touch.LastTouchedBy,
+				$"{time} : A {thrownObject.ExpensiveName()} was thrown at a super-matter and was last touched by {touch.LastTouchedBy.Script.playerName}.");
 		}
 
 		#endregion

--- a/UnityProject/Assets/Scripts/Objects/Engineering/SuperMatter.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/SuperMatter.cs
@@ -1182,7 +1182,7 @@ namespace Objects.Engineering
 		{
 			if (thrownObject.TryGetComponent<LastTouch>(out var touch) == false || touch.LastTouchedBy == null) return;
 			var time = DateTime.Now.ToString(CultureInfo.InvariantCulture);
-			UIManager.Instance.playerAlerts.ServerAddNewEntry(time, PlayerAlertTypes.RDM, touch.LastTouchedBy,
+			UIManager.LogPlayerAction(time, PlayerAlertTypes.RDM, touch.LastTouchedBy,
 				$"{time} : A {thrownObject.ExpensiveName()} was thrown at a super-matter and was last touched by {touch.LastTouchedBy.Script.playerName} ({touch.LastTouchedBy.Username}).");
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/Engineering/SuperMatter.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/SuperMatter.cs
@@ -1182,7 +1182,7 @@ namespace Objects.Engineering
 		{
 			if (thrownObject.TryGetComponent<LastTouch>(out var touch) == false || touch.LastTouchedBy == null) return;
 			var time = DateTime.Now.ToString(CultureInfo.InvariantCulture);
-			UIManager.LogPlayerAction(time, PlayerAlertTypes.RDM, touch.LastTouchedBy,
+			PlayerAlerts.LogPlayerAction(time, PlayerAlertTypes.RDM, touch.LastTouchedBy,
 				$"{time} : A {thrownObject.ExpensiveName()} was thrown at a super-matter and was last touched by {touch.LastTouchedBy.Script.playerName} ({touch.LastTouchedBy.Username}).");
 		}
 

--- a/UnityProject/Assets/Scripts/Shuttles/EscapeShuttleConsole.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/EscapeShuttleConsole.cs
@@ -104,7 +104,7 @@ namespace Objects
 		private void ServerLogEarlyVoteEvent(HandApply prep)
 		{
 			var time = DateTime.Now.ToString(CultureInfo.InvariantCulture);
-			UIManager.Instance.playerAlerts.ServerAddNewEntry(time, PlayerAlertTypes.Emag, prep.PerformerPlayerScript.PlayerInfo,
+			UIManager.LogPlayerAction(time, PlayerAlertTypes.Emag, prep.PerformerPlayerScript.PlayerInfo,
 				$"{time} : {prep.PerformerPlayerScript.playerName} voted for the shuttle to leave early.");
 		}
 

--- a/UnityProject/Assets/Scripts/Shuttles/EscapeShuttleConsole.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/EscapeShuttleConsole.cs
@@ -104,7 +104,7 @@ namespace Objects
 		private void ServerLogEarlyVoteEvent(HandApply prep)
 		{
 			var time = DateTime.Now.ToString(CultureInfo.InvariantCulture);
-			UIManager.LogPlayerAction(time, PlayerAlertTypes.Emag, prep.PerformerPlayerScript.PlayerInfo,
+			PlayerAlerts.LogPlayerAction(time, PlayerAlertTypes.Emag, prep.PerformerPlayerScript.PlayerInfo,
 				$"{time} : {prep.PerformerPlayerScript.playerName} voted for the shuttle to leave early.");
 		}
 

--- a/UnityProject/Assets/Scripts/Systems/Inventory/Pickupable.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/Pickupable.cs
@@ -73,6 +73,8 @@ public class Pickupable : NetworkBehaviour, IPredictedCheckedInteractable<HandAp
 	/// </summary>
 	public UnityEvent<GameObject> OnMoveToPlayerInventory;
 
+	[SerializeField] private LastTouch lastTouch;
+
 
 
 	#region Lifecycle
@@ -81,6 +83,7 @@ public class Pickupable : NetworkBehaviour, IPredictedCheckedInteractable<HandAp
 	{
 		ItemAttributesV2 =  GetComponent<ItemAttributesV2>();
 		universalObjectPhysics = GetComponent<UniversalObjectPhysics>();
+		if (lastTouch == null) lastTouch = GetComponent<LastTouch>();
 	}
 
 	// make sure to call this in subclasses
@@ -216,6 +219,7 @@ public class Pickupable : NetworkBehaviour, IPredictedCheckedInteractable<HandAp
 		PickupAnim(interaction.Performer.gameObject);
 		RpcPickupAnimation(interaction.Performer.gameObject);
 		OnMoveToPlayerInventory?.Invoke(interaction.Performer);
+		if (lastTouch != null) lastTouch.LastTouchedBy = interaction.PerformerPlayerScript.PlayerInfo;
 		yield return WaitFor.Seconds(pickupAnimSpeed);
 
 		//Make sure that the object is scaled back to it's original size.

--- a/UnityProject/Assets/Scripts/Systems/Inventory/Pickupable.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/Pickupable.cs
@@ -96,6 +96,7 @@ public class Pickupable : NetworkBehaviour, IPredictedCheckedInteractable<HandAp
 		{
 			Inventory.ServerDespawn(itemSlot);
 		}
+		OnMoveToPlayerInventory?.RemoveAllListeners();
 	}
 
 	#endregion

--- a/UnityProject/Assets/Scripts/Systems/Inventory/Pickupable.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/Pickupable.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Items;
 using UI;
 using UnityEngine;
+using UnityEngine.Events;
 using Random = UnityEngine.Random;
 
 /// <summary>
@@ -67,7 +68,11 @@ public class Pickupable : NetworkBehaviour, IPredictedCheckedInteractable<HandAp
 
 	public ItemAttributesV2 ItemAttributesV2;
 
-	public event Action<GameObject> OnMoveToPlayerInventory;
+	/// <summary>
+	/// Client Side Events. Expects an interactor.
+	/// </summary>
+	public UnityEvent<GameObject> OnMoveToPlayerInventory;
+
 
 
 	#region Lifecycle

--- a/UnityProject/Assets/Scripts/UI/Core/GUI/Components/GUI_Notification.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/GUI/Components/GUI_Notification.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using AddressableReferences;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -11,6 +12,7 @@ public class GUI_Notification : MonoBehaviour
 
 	[SerializeField] private Text label = null;
 	[SerializeField] private Image background = null;
+	[SerializeField] private AddressableAudioSource nofticationSound;
 
 	private void OnEnable()
 	{
@@ -31,6 +33,11 @@ public class GUI_Notification : MonoBehaviour
 		if (notifications[key] < 0)
 		{
 			notifications[key] = 0;
+		}
+
+		if (nofticationSound != null)
+		{
+			SoundManager.Play(nofticationSound);
 		}
 		UpdateText();
 	}

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/PlayerAlerts.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/PlayerAlerts.cs
@@ -1,16 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
-using DatabaseAPI;
 using Messages.Client.Admin;
 using Messages.Server.AdminTools;
 using Mirror;
+using Shared.Managers;
 using UnityEngine;
 
 namespace AdminTools
 {
-	public class PlayerAlerts : MonoBehaviour
+	public class PlayerAlerts : SingletonManager<PlayerAlerts>
 	{
-		public static PlayerAlerts Instance;
 		[SerializeField] private GameObject playerAlertsWindow = null;
 		[SerializeField] private PlayerAlertsScroll playerAlertsScroll = null;
 		[SerializeField] private GUI_Notification notifications = null;
@@ -20,15 +19,6 @@ namespace AdminTools
 
 		private readonly List<PlayerAlertData> clientPlayerAlerts = new List<PlayerAlertData>();
 
-		private void Awake()
-		{
-			Instance = this;
-		}
-
-		private void OnDestroy()
-		{
-			Instance = null;
-		}
 
 		public void LoadAllEntries(List<PlayerAlertData> alertEntries)
 		{
@@ -232,7 +222,7 @@ namespace AdminTools
 			}
 			if (perp == null)
 			{
-				Logger.LogError("[UIManager/LogPlayerAction] - PlayerInfo cannot be null!");
+				Logger.LogError("[PlayerAlerts/LogPlayerAction] - PlayerInfo cannot be null!");
 				return;
 			}
 

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/PlayerAlerts.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/PlayerAlerts.cs
@@ -10,6 +10,7 @@ namespace AdminTools
 {
 	public class PlayerAlerts : MonoBehaviour
 	{
+		public static PlayerAlerts Instance;
 		[SerializeField] private GameObject playerAlertsWindow = null;
 		[SerializeField] private PlayerAlertsScroll playerAlertsScroll = null;
 		[SerializeField] private GUI_Notification notifications = null;
@@ -18,6 +19,16 @@ namespace AdminTools
 		private readonly List<PlayerAlertData> serverPlayerAlerts = new List<PlayerAlertData>();
 
 		private readonly List<PlayerAlertData> clientPlayerAlerts = new List<PlayerAlertData>();
+
+		private void Awake()
+		{
+			Instance = this;
+		}
+
+		private void OnDestroy()
+		{
+			Instance = null;
+		}
 
 		public void LoadAllEntries(List<PlayerAlertData> alertEntries)
 		{
@@ -210,6 +221,22 @@ namespace AdminTools
 			{
 				playerAlertsWindow.SetActive(false);
 			}
+		}
+
+		public static void LogPlayerAction(string incidentTime, PlayerAlertTypes alertType, PlayerInfo perp, string message)
+		{
+			if (Instance == null)
+			{
+				Logger.LogError("[PlayerAlerts] - Instance is null!");
+				return;
+			}
+			if (perp == null)
+			{
+				Logger.LogError("[UIManager/LogPlayerAction] - PlayerInfo cannot be null!");
+				return;
+			}
+
+			Instance.ServerAddNewEntry(incidentTime, alertType, perp, message);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/UI/Systems/UIManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/UIManager.cs
@@ -626,15 +626,4 @@ public class UIManager : MonoBehaviour, IInitialise
 
 		ChatUI.Instance.OpenChatWindow();
 	}
-
-	public static void LogPlayerAction(string incidentTime, PlayerAlertTypes alertType, PlayerInfo perp, string message)
-	{
-		if (perp == null)
-		{
-			Logger.LogError("[UIManager/LogPlayerAction] - PlayerInfo cannot be null!");
-			return;
-		}
-
-		Instance.playerAlerts.ServerAddNewEntry(incidentTime, alertType, perp, message);
-	}
 }

--- a/UnityProject/Assets/Scripts/UI/Systems/UIManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/UIManager.cs
@@ -42,9 +42,10 @@ public class UIManager : MonoBehaviour, IInitialise
 	public StatsTab statsTab;
 	public Text toolTip;
 	public Text pingDisplay;
-	[SerializeField]
-	[Tooltip("Text displaying the game's version number.")]
+
+	[SerializeField] [Tooltip("Text displaying the game's version number.")]
 	public Text versionDisplay;
+
 	public GUI_Info infoWindow;
 	public TeleportWindow teleportWindow;
 	[SerializeField] private GhostRoleWindow ghostRoleWindow = default;
@@ -63,7 +64,7 @@ public class UIManager : MonoBehaviour, IInitialise
 	public PlayerAlerts playerAlerts;
 	[FormerlySerializedAs("antagBanner")] public GUIAntagBanner spawnBanner;
 	private bool preventChatInput;
-	[SerializeField] [Range(0.1f,10f)] private float PhoneZoomFactor = 1.6f;
+	[SerializeField] [Range(0.1f, 10f)] private float PhoneZoomFactor = 1.6f;
 	public LobbyUIPlayerListController lobbyUIPlayerListController = null;
 
 	public SurgeryDialogue SurgeryDialogue;
@@ -80,13 +81,11 @@ public class UIManager : MonoBehaviour, IInitialise
 
 	public GUI_DevTileChanger TileChanger;
 
-	[field: SerializeField]
-	public ServerInfoPanelWindow ServerInfoPanelWindow { get; private set; }
+	[field: SerializeField] public ServerInfoPanelWindow ServerInfoPanelWindow { get; private set; }
 
 	public RoundEndScoreScreen ScoreScreen;
 
-	[field:SerializeField]
-	public ExpLevelUI FirstTimePlayerExperienceScreen { get; set; }
+	[field: SerializeField] public ExpLevelUI FirstTimePlayerExperienceScreen { get; set; }
 
 	public static bool PreventChatInput
 	{
@@ -157,8 +156,9 @@ public class UIManager : MonoBehaviour, IInitialise
 #endif
 
 	public static bool IsTablet => DeviceDiagonalSizeInInches > 6.5f && AspectRatio < 2f;
+
 	public static float AspectRatio =>
-		(float) Mathf.Max(Screen.width, Screen.height) / Mathf.Min(Screen.width, Screen.height);
+		(float)Mathf.Max(Screen.width, Screen.height) / Mathf.Min(Screen.width, Screen.height);
 
 	public static float DeviceDiagonalSizeInInches
 	{
@@ -166,7 +166,7 @@ public class UIManager : MonoBehaviour, IInitialise
 		{
 			float screenWidth = Screen.width / Screen.dpi;
 			float screenHeight = Screen.height / Screen.dpi;
-			float diagonalInches = Mathf.Sqrt (Mathf.Pow (screenWidth, 2) + Mathf.Pow (screenHeight, 2));
+			float diagonalInches = Mathf.Sqrt(Mathf.Pow(screenWidth, 2) + Mathf.Pow(screenHeight, 2));
 
 			Logger.Log("Getting mobile device screen size in inches: " + diagonalInches, Category.UI);
 
@@ -226,7 +226,7 @@ public class UIManager : MonoBehaviour, IInitialise
 	{
 		set
 		{
-			if(Instance.PanelTooltipManager == null) return;
+			if (Instance.PanelTooltipManager == null) return;
 			Instance.PanelTooltipManager.UpdateActiveTooltip(value);
 		}
 	}
@@ -235,7 +235,7 @@ public class UIManager : MonoBehaviour, IInitialise
 	{
 		set
 		{
-			if(Instance.HoverTooltipUI == null) return;
+			if (Instance.HoverTooltipUI == null) return;
 			Instance.hoverTooltipUI.SetupTooltip(value);
 		}
 	}
@@ -324,7 +324,7 @@ public class UIManager : MonoBehaviour, IInitialise
 			canvasScaler.screenMatchMode = CanvasScaler.ScreenMatchMode.MatchWidthOrHeight;
 			canvasScaler.matchWidthOrHeight = 0f; //match width
 			canvasScaler.referenceResolution =
-				new Vector2(Screen.width/PhoneZoomFactor, canvasScaler.referenceResolution.y);
+				new Vector2(Screen.width / PhoneZoomFactor, canvasScaler.referenceResolution.y);
 
 		}
 	}
@@ -352,7 +352,7 @@ public class UIManager : MonoBehaviour, IInitialise
 
 	void DetermineInitialTargetFrameRate()
 	{
-		if(!PlayerPrefs.HasKey(PlayerPrefKeys.TargetFrameRate))
+		if (!PlayerPrefs.HasKey(PlayerPrefKeys.TargetFrameRate))
 		{
 			PlayerPrefs.SetInt(PlayerPrefKeys.TargetFrameRate, 99);
 			PlayerPrefs.Save();
@@ -522,7 +522,7 @@ public class UIManager : MonoBehaviour, IInitialise
 	/// <returns>progress bar associated with this action (can use this to interrupt progress). Null if
 	/// progress was not started for some reason (such as already in progress for this action on the specified tile).</returns>
 	public static ProgressBar _ServerStartProgress(
-			IProgressAction progressAction, ActionTarget actionTarget, float timeForCompletion, GameObject player)
+		IProgressAction progressAction, ActionTarget actionTarget, float timeForCompletion, GameObject player)
 	{
 		var targetMatrixInfo = MatrixManager.AtPoint(actionTarget.TargetWorldPosition.CutToInt(), true);
 		var targetParent = targetMatrixInfo.Objects;
@@ -535,7 +535,8 @@ public class UIManager : MonoBehaviour, IInitialise
 		if (!progressAction.OnServerStartProgress(startProgressInfo))
 		{
 			//stop it without even having started it
-			Logger.LogTraceFormat("Server cancelling progress start, OnServerStartProgress=false for {0}", Category.ProgressAction,
+			Logger.LogTraceFormat("Server cancelling progress start, OnServerStartProgress=false for {0}",
+				Category.ProgressAction,
 				startProgressInfo);
 			Despawn.ClientSingle(barObject);
 			return null;
@@ -624,5 +625,16 @@ public class UIManager : MonoBehaviour, IInitialise
 		}
 
 		ChatUI.Instance.OpenChatWindow();
+	}
+
+	public static void LogPlayerAction(string incidentTime, PlayerAlertTypes alertType, PlayerInfo perp, string message)
+	{
+		if (perp == null)
+		{
+			Logger.LogError("[UIManager/LogPlayerAction] - PlayerInfo cannot be null!");
+			return;
+		}
+
+		Instance.playerAlerts.ServerAddNewEntry(incidentTime, alertType, perp, message);
 	}
 }


### PR DESCRIPTION
CL: [New] Admins will get a notification when a player attempts to grief the super matter by throwing objects at it. (Parity feature with admin tools on /tg/)
CL: [New] Admins can now investigate who was the last person to touch an item via VV.
CL: [New] Admins will hear a bwoink whenever an alert or prayer notification is unread.
CL: [Improvement] Mappers and designers can now hook events into the pickupable component directly in the inspector without touching code. 