### PR TITLE
Janitor Cart improvements

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Chemistry/OpenContainers/Bucket.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Chemistry/OpenContainers/Bucket.prefab
@@ -243,6 +243,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6421186659643855438, guid: 364841a08150e9345b119e71191c8dcf,
         type: 3}
+      propertyPath: transferSound.Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6421186659643855438, guid: 364841a08150e9345b119e71191c8dcf,
+        type: 3}
       propertyPath: possibleTransferAmounts.Array.size
       value: 8
       objectReference: {fileID: 0}
@@ -250,6 +255,26 @@ PrefabInstance:
         type: 3}
       propertyPath: possibleTransferAmounts.Array.data[7]
       value: 70
+      objectReference: {fileID: 0}
+    - target: {fileID: 6421186659643855438, guid: 364841a08150e9345b119e71191c8dcf,
+        type: 3}
+      propertyPath: transferSound.Array.data[0].AssetAddress
+      value: Assets/Prefabs/footsteps/water/FootstepWater1.prefab
+      objectReference: {fileID: 0}
+    - target: {fileID: 6421186659643855438, guid: 364841a08150e9345b119e71191c8dcf,
+        type: 3}
+      propertyPath: transferSound.Array.data[1].AssetAddress
+      value: Assets/Prefabs/footsteps/water/FootstepWater2.prefab
+      objectReference: {fileID: 0}
+    - target: {fileID: 6421186659643855438, guid: 364841a08150e9345b119e71191c8dcf,
+        type: 3}
+      propertyPath: transferSound.Array.data[2].AssetAddress
+      value: Assets/Prefabs/footsteps/water/FootstepWater3.prefab
+      objectReference: {fileID: 0}
+    - target: {fileID: 6421186659643855438, guid: 364841a08150e9345b119e71191c8dcf,
+        type: 3}
+      propertyPath: transferSound.Array.data[3].AssetAddress
+      value: Assets/Prefabs/footsteps/water/FootstepWater4.prefab
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 364841a08150e9345b119e71191c8dcf, type: 3}
@@ -313,7 +338,11 @@ MonoBehaviour:
       Acid: 50
       Magic: 0
       Bio: 0
+      Anomaly: 0
       DismembermentProtectionChance: 0
+      StunImmunity: 0
+      TemperatureProtectionInK: {x: 268.15, y: 313.15}
+      PressureProtectionInKpa: {x: 30, y: 300}
 --- !u!114 &6812290110784052155
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Items/Janitor/Mop.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Janitor/Mop.prefab
@@ -311,3 +311,32 @@ MonoBehaviour:
   transferMode: 3
   possibleTransferAmounts: []
   transferAmount: 25
+  transferSound:
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/footsteps/water/FootstepWater1.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/footsteps/water/FootstepWater2.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/footsteps/water/FootstepWater3.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/footsteps/water/FootstepWater4.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0

--- a/UnityProject/Assets/Prefabs/Objects/Misc/JanitorialCart.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Misc/JanitorialCart.prefab
@@ -74,7 +74,7 @@ SpriteRenderer:
   m_SortingLayerID: 142874271
   m_SortingLayer: 12
   m_SortingOrder: 0
-  m_Sprite: {fileID: 21300002, guid: a5f4f4df60b0b9140bfbfcf452db0502, type: 3}
+  m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -82,7 +82,7 @@ SpriteRenderer:
   m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
+  m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
 --- !u!114 &2350731637513909216
@@ -98,9 +98,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   NetworkThis: 1
-  SubCatalogue:
-  - {fileID: 11400000, guid: 1b5719aef4916f249b24e55c0abe1650, type: 2}
-  PresentSpriteSet: {fileID: 11400000, guid: 1b5719aef4916f249b24e55c0abe1650, type: 2}
+  SubCatalogue: []
+  PresentSpriteSet: {fileID: 0}
   randomInitialSprite: 0
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
@@ -352,15 +351,16 @@ MonoBehaviour:
   transferMode: 0
   possibleTransferAmounts: []
   transferAmount: 20
-  dippingSound:
+  transferSound:
     SetLoadSetting: 0
-    AssetAddress: Assets/Prefabs/Effects/Refill.prefab
+    AssetAddress: Assets/Prefabs/Effects/Slurp.prefab
     AssetReference:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
       m_EditorAssetChanged: 0
-  waterSprite: {fileID: 2350731637513909216}
+  waterSpriteHandler: {fileID: 2350731637513909216}
+  waterSpriteSO: {fileID: 11400000, guid: 1b5719aef4916f249b24e55c0abe1650, type: 2}
   mopTrait: {fileID: 11400000, guid: 20597800d3cec8f438706d926881018b, type: 2}
   trashbagTrait: {fileID: 11400000, guid: 3bc88a6fd0eb5cd49a3295a04e1ca62d, type: 2}
 --- !u!4 &456495059165993566 stripped

--- a/UnityProject/Assets/Prefabs/Objects/Misc/JanitorialCart.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Misc/JanitorialCart.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &7962188687854415904
+--- !u!1 &4948741880483377976
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,22 +8,23 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 797168042095257632}
-  - component: {fileID: 4758289030963813880}
+  - component: {fileID: 7887437029977102411}
+  - component: {fileID: 6321453614482599917}
+  - component: {fileID: 2350731637513909216}
   m_Layer: 0
-  m_Name: FillSprite
+  m_Name: WaterSprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &797168042095257632
+--- !u!4 &7887437029977102411
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7962188687854415904}
+  m_GameObject: {fileID: 4948741880483377976}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -32,13 +33,13 @@ Transform:
   m_Father: {fileID: 456495059165993566}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &4758289030963813880
+--- !u!212 &6321453614482599917
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7962188687854415904}
+  m_GameObject: {fileID: 4948741880483377976}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -72,8 +73,8 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 142874271
   m_SortingLayer: 12
-  m_SortingOrder: 1
-  m_Sprite: {fileID: 0}
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300002, guid: a5f4f4df60b0b9140bfbfcf452db0502, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -81,9 +82,30 @@ SpriteRenderer:
   m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 0
+  m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &2350731637513909216
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4948741880483377976}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  NetworkThis: 1
+  SubCatalogue:
+  - {fileID: 11400000, guid: 1b5719aef4916f249b24e55c0abe1650, type: 2}
+  PresentSpriteSet: {fileID: 11400000, guid: 1b5719aef4916f249b24e55c0abe1650, type: 2}
+  randomInitialSprite: 0
+  doReverseAnimation: 0
+  pushTextureOnStartUp: 1
+  initialVariantIndex: 1
+  palette: []
 --- !u!1001 &8248558368109462878
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -265,7 +287,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   itemStorageStructure: {fileID: 11400000, guid: 74bf3e872403e488695c17ecdde194ab,
     type: 2}
-  itemStorageCapacity: {fileID: 11400000, guid: 411b6b7a74c524a91b9a38a0c692761b,
+  itemStorageCapacity: {fileID: 11400000, guid: 13124803b6014704199b00db12778493,
     type: 2}
   itemStoragePopulator: {fileID: 0}
   forceSpawnContents: 1
@@ -298,23 +320,6 @@ MonoBehaviour:
   IgnoreServerUpdatesIfLocalPlayer: 0
   IsAtmosphericDevice: 0
   doNotResetOtherSpriteOptions: 0
---- !u!114 &4320299406662285398
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 450498622285847684}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d8872d4cc4320514995f91133f2a5adb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  fillSpriteRender: {fileID: 4758289030963813880}
-  fillIcons:
-  - {fileID: 21300002, guid: a5f4f4df60b0b9140bfbfcf452db0502, type: 3}
 --- !u!114 &7087012579486443808
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -349,12 +354,13 @@ MonoBehaviour:
   transferAmount: 20
   dippingSound:
     SetLoadSetting: 0
-    AssetAddress: Assets/Prefabs/footsteps/water/FootstepWater1.prefab
+    AssetAddress: Assets/Prefabs/Effects/Refill.prefab
     AssetReference:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
       m_EditorAssetChanged: 0
+  waterSprite: {fileID: 2350731637513909216}
   mopTrait: {fileID: 11400000, guid: 20597800d3cec8f438706d926881018b, type: 2}
   trashbagTrait: {fileID: 11400000, guid: 3bc88a6fd0eb5cd49a3295a04e1ca62d, type: 2}
 --- !u!4 &456495059165993566 stripped

--- a/UnityProject/Assets/Prefabs/Objects/Misc/JanitorialCart.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Misc/JanitorialCart.prefab
@@ -25,7 +25,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4948741880483377976}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -161,17 +161,17 @@ PrefabInstance:
     - target: {fileID: 5718954047647765097, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 5718954047647765097, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 5718954047647765097, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 8371364824666529536, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
@@ -352,8 +352,29 @@ MonoBehaviour:
   possibleTransferAmounts: []
   transferAmount: 20
   transferSound:
-    SetLoadSetting: 0
-    AssetAddress: Assets/Prefabs/Effects/Slurp.prefab
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/footsteps/water/FootstepWater1.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/footsteps/water/FootstepWater2.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/footsteps/water/FootstepWater3.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/footsteps/water/FootstepWater4.prefab
     AssetReference:
       m_AssetGUID: 
       m_SubObjectName: 

--- a/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.TransferInteraction.cs
+++ b/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.TransferInteraction.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using AddressableReferences;
+using Castle.Core.Internal;
 using UnityEngine;
 using UnityEngine.Serialization;
 
@@ -51,7 +52,7 @@ namespace Chemistry.Components
 		[FormerlySerializedAs("InitialTransferAmount")]
 		[SerializeField] private float transferAmount = 20;
 
-		[SerializeField] private AddressableAudioSource transferSound;
+		[SerializeField] private List<AddressableAudioSource> transferSound;
 
 		public bool TraitWhitelistOn => traitWhitelist.Count > 0;
 
@@ -354,7 +355,7 @@ namespace Chemistry.Components
 			bool updateReactions = true
 		)
 		{
-			if (transferSound != null) _ = SoundManager.PlayNetworkedAtPosAsync(transferSound, gameObject.AssumedWorldPosServer());
+			if (transferSound.IsNullOrEmpty() == false) _ = SoundManager.PlayNetworkedAtPosAsync(transferSound.PickRandom(), gameObject.AssumedWorldPosServer());
 			TransferResult transferResult;
 
 			// save total ammount before mixing

--- a/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.TransferInteraction.cs
+++ b/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.TransferInteraction.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using AddressableReferences;
 using UnityEngine;
 using UnityEngine.Serialization;
 
@@ -49,6 +50,8 @@ namespace Chemistry.Components
 		[FormerlySerializedAs("TransferAmount")]
 		[FormerlySerializedAs("InitialTransferAmount")]
 		[SerializeField] private float transferAmount = 20;
+
+		[SerializeField] private AddressableAudioSource transferSound;
 
 		public bool TraitWhitelistOn => traitWhitelist.Count > 0;
 
@@ -351,6 +354,7 @@ namespace Chemistry.Components
 			bool updateReactions = true
 		)
 		{
+			if (transferSound != null) _ = SoundManager.PlayNetworkedAtPosAsync(transferSound, gameObject.AssumedWorldPosServer());
 			TransferResult transferResult;
 
 			// save total ammount before mixing

--- a/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs
+++ b/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs
@@ -164,13 +164,7 @@ namespace Chemistry.Components
 		/// <summary>
 		/// Server side only. Total reagent mix amount in units
 		/// </summary>
-		public float ReagentMixTotal
-		{
-			get
-			{
-				return CurrentReagentMix.Total;
-			}
-		}
+		public float ReagentMixTotal => CurrentReagentMix.Total;
 
 		private void Awake()
 		{

--- a/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandler.cs
+++ b/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandler.cs
@@ -343,6 +343,10 @@ public class SpriteHandler : MonoBehaviour
 		}
 	}
 
+	/// <summary>
+	/// Forces the sprite handler to clear out the current sprites being displayed.
+	/// </summary>
+	/// <param name="networked">Network this action to all clients.</param>
 	public void PushClear(bool networked = true)
 	{
 		if (HasSpriteInImageComponent() == false) return;

--- a/UnityProject/Assets/Scripts/Objects/Other/JanitorCart.cs
+++ b/UnityProject/Assets/Scripts/Objects/Other/JanitorCart.cs
@@ -9,8 +9,8 @@ namespace Objects.Other
 {
 	public class JanitorCart : ReagentContainer, ICheckedInteractable<HandApply>
 	{
-		[SerializeField] private AddressableAudioSource dippingSound;
-		[SerializeField] private SpriteHandler waterSprite;
+		[SerializeField] private SpriteHandler waterSpriteHandler;
+		[SerializeField] private SpriteDataSO waterSpriteSO;
 		[SerializeField] private ItemTrait mopTrait;
 		[SerializeField] private ItemTrait trashbagTrait;
 
@@ -29,6 +29,7 @@ namespace Objects.Other
 
 		public new void ServerPerformInteraction(HandApply interaction)
 		{
+			CheckSpriteStatus();
 			if (interaction.HandObject == null)
 			{
 				if (GrabTool(interaction, mopTrait))      return;
@@ -95,27 +96,29 @@ namespace Objects.Other
 
 		private void MopInteraction(HandApply interaction)
 		{
-			if (interaction.IsAltClick || interaction.Intent == Intent.Disarm)
+			if (interaction.Intent == Intent.Disarm)
 			{
 				if (jaintorToolsHolding.GetNextEmptySlot() == null) return;
-				if (jaintorToolsHolding.ServerTransferGameObjectToItemSlot(interaction.HandObject, jaintorToolsHolding.GetNextEmptySlot()) == false) return;
+				if (jaintorToolsHolding.ServerTryTransferFrom(interaction.HandObject) == false)
+				{
+					Logger.LogError("WHY THE FUCK DOES THIS NOT WORK?");
+					return;
+				}
 				Chat.AddLocalMsgToChat($"{interaction.PerformerPlayerScript.visibleName} adds a {interaction.HandObject.ExpensiveName()} to the {gameObject.ExpensiveName()}", interaction.Performer);
 				return;
 			}
 			base.ServerPerformInteraction(interaction);
-			if (dippingSound != null) _ = SoundManager.PlayNetworkedAtPosAsync(dippingSound, gameObject.AssumedWorldPosServer());
-			CheckSpriteStatus();
 		}
 
 		private void CheckSpriteStatus()
 		{
-			if (ReagentMixTotal.Approx(0))
+			if (IsEmpty)
 			{
-				waterSprite.PushClear();
+				waterSpriteHandler.PushClear();
 			}
 			else
 			{
-				waterSprite.ChangeSprite(0);
+				waterSpriteHandler.SetSpriteSO(waterSpriteSO);
 			}
 		}
 	}


### PR DESCRIPTION
### Known issues:

- Water sprites don't immediately update and requires a second interaction without a mop or bucket to update correctly.

### Changelog:

CL: [New] Janitor carts can now hold mops.
CL: [Improvement] Streamlined janitor cart interactions. Making them much more obvious and quicker to interact with.
CL: [Improvement] Added hover tooltips to janitorial carts. Giving you extra context on what you can do with carts based on the item you're holding.
CL: [Fix] Fixed janitorial carts having their water sprites not update at all.
CL: [Fix] Fixed janitorial carts not playing sounds when transferring liquids between mops, buckets and the carts.
