### PR TITLE
chore: actually fix unusable namespace with a simple null check.

### DIFF
--- a/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.TransferInteraction.cs
+++ b/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.TransferInteraction.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using AddressableReferences;
 using UnityEngine;
 using UnityEngine.Serialization;
@@ -354,7 +353,12 @@ namespace Chemistry.Components
 			bool updateReactions = true
 		)
 		{
-			if (transferSound.IsNullOrEmpty() == false) _ = SoundManager.PlayNetworkedAtPosAsync(transferSound.PickRandom(), gameObject.AssumedWorldPosServer());
+			if (transferSound != null)
+			{
+				_ = SoundManager.PlayNetworkedAtPosAsync(transferSound.PickRandom(),
+					gameObject.AssumedWorldPosServer());
+			}
+
 			TransferResult transferResult;
 
 			// save total ammount before mixing


### PR DESCRIPTION
fixes compilation errors introduced in my last fix to the unusable and unavailable during runtime namespace.