### PR TITLE
small fixes

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -365,10 +365,17 @@ public class CustomNetworkManager : NetworkManager, IInitialise
 
 		//note that we can't remove authority from player owned objects, the workaround is to transfer authority to
 		//a different temporary object, remove authority from the original, and then run the normal disconnect logic
-		
+
+
 		//transfer to a temporary object
 		GameObject disconnectedViewer = Instantiate(CustomNetworkManager.Instance.disconnectedViewerPrefab);
 		NetworkServer.ReplacePlayerForConnection(conn, disconnectedViewer, System.Guid.NewGuid());
+
+		foreach (var ownedObject in conn.clientOwnedObjects.ToArray())
+		{
+			if (disconnectedViewer == ownedObject.gameObject) continue;
+			ownedObject.RemoveClientAuthority();
+		}
 
 		//now we can call mirror's normal disconnect logic, which will destroy all the player's owned objects
 		//which will preserve their actual body because they no longer own it

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -365,15 +365,10 @@ public class CustomNetworkManager : NetworkManager, IInitialise
 
 		//note that we can't remove authority from player owned objects, the workaround is to transfer authority to
 		//a different temporary object, remove authority from the original, and then run the normal disconnect logic
-
+		
 		//transfer to a temporary object
 		GameObject disconnectedViewer = Instantiate(CustomNetworkManager.Instance.disconnectedViewerPrefab);
 		NetworkServer.ReplacePlayerForConnection(conn, disconnectedViewer, System.Guid.NewGuid());
-
-		foreach (var ownedObject in conn.clientOwnedObjects.ToArray())
-		{
-			ownedObject.RemoveClientAuthority();
-		}
 
 		//now we can call mirror's normal disconnect logic, which will destroy all the player's owned objects
 		//which will preserve their actual body because they no longer own it

--- a/UnityProject/Assets/Scripts/Systems/Chemistry/ReagentMix.cs
+++ b/UnityProject/Assets/Scripts/Systems/Chemistry/ReagentMix.cs
@@ -295,7 +295,7 @@ namespace Chemistry
 
 		public void Add(Reagent reagent, float amount)
 		{
-			if (amount == 0f)
+			if (Mathf.Approximately(amount, 0f))
 			{
 				return;
 			}


### PR DESCRIPTION
should hopefully reduce log spam
and I wondered how this has never errored before,  because the client always owns the the object it has been assigned