### PR TITLE
Light Fixtures now drop the correct cables

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/Inventory/Populators/LightFixtureContent.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Populators/LightFixtureContent.asset
@@ -14,5 +14,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   SlotContents: []
   DeprecatedContents:
-  - {fileID: 7657921970005526780, guid: 7f32e42309899114b9c122f261161bc5, type: 3}
+  - {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38, type: 3}
   - {fileID: 5770283965274354279, guid: b83b68cfa4a201748aeeece963a989c3, type: 3}

--- a/UnityProject/Assets/ScriptableObjects/LightMountStates/LightBulb/LightBulbLoot/LootLightBulb.asset
+++ b/UnityProject/Assets/ScriptableObjects/LightMountStates/LightBulb/LightBulbLoot/LootLightBulb.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
       type: 3}
     maxAmount: 1
     probability: 20
-  - prefab: {fileID: 5680136605834777345, guid: c3e6805b264a935428b0de415ea57943,
+  - prefab: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
       type: 3}
     maxAmount: 3
     probability: 25

--- a/UnityProject/Assets/ScriptableObjects/LightMountStates/LightTube/LightTubeLootDrops/LootLightTubeBroken.asset
+++ b/UnityProject/Assets/ScriptableObjects/LightMountStates/LightTube/LightTubeLootDrops/LootLightTubeBroken.asset
@@ -13,7 +13,11 @@ MonoBehaviour:
   m_Name: LootLightTubeBroken
   m_EditorClassIdentifier: 
   pool:
-  - prefab: {fileID: 5680136605834777345, guid: c3e6805b264a935428b0de415ea57943,
+  - prefab: {fileID: 4766721875690198130, guid: 24b56977c4055b64cb1f133b59595e60,
+      type: 3}
+    maxAmount: 1
+    probability: 15
+  - prefab: {fileID: 4433336198165141055, guid: 827dad187b7a6e449b5b73aa0e691a38,
       type: 3}
     maxAmount: 3
     probability: 25
@@ -21,7 +25,3 @@ MonoBehaviour:
       type: 3}
     maxAmount: 2
     probability: 50
-  - prefab: {fileID: 4766721875690198130, guid: 24b56977c4055b64cb1f133b59595e60,
-      type: 3}
-    maxAmount: 1
-    probability: 15


### PR DESCRIPTION
<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->

### Purpose
<!-- Describe the problem the PR fixes or the feature it introduces. --> <br>
<!-- Don't forget to use "Fixes #issuenumber" to select issues and auto close them on merge. -->
Fixes #9536 , Light fixtures now correctly drop singular low voltage cables, as well as random loot drops of lightbulbs and light tubes will contain the correct 1-3 low voltage cable coils, and not full stacks of medium voltage cable coils.

### Notes:
<!-- Please enter any other relevant information here -->
I did re-sort the loot drops simply for being able to change both the bulb and tube loot drops at the same time but otherwise only focused on what was mentioned before.

### Changelog:
<!-- Add here individual lines with all your remarkable changes using the prefix ``CL:`` -->
<!-- Mind that the changes meant to be logged in the in changelog are those that are remarkable for the end user, so things like new features and fixes of known bugs are perfect for this section -->
CL: [Fix] Fixed light tubes getting destroyed and wrongly dropping full stacks of low voltage cables.
CL: [Fix] Fixed loot drops of on-start broken light tubes and bulbs wrongly giving medium voltage cable coil stacks instead of 1-3 low voltage cables.

<!-- CL: [New] For new features, things that didn't exist before the PR. -->

<!-- CL: [Improvement] For any change on any existing feature. -->

<!-- CL: [Balance] For any change on an existing feature done in the sake of improving game balance. It's the only exception to the rule above. -->

<!-- CL: [Fix] For any change that fixes a bug. -->
