### PR TITLE
Resolves Codacy issues for `"nameof" should be used`

### DIFF
--- a/UnityProject/Assets/Mirror/Runtime/Transports/Ignorance/Dependencies/ENet.cs
+++ b/UnityProject/Assets/Mirror/Runtime/Transports/Ignorance/Dependencies/ENet.cs
@@ -172,7 +172,7 @@ namespace ENet
         public bool SetIP(string ip)
         {
             if (ip == null)
-                throw new ArgumentNullException("ip");
+                throw new ArgumentNullException(nameof(ip));
 
             return Native.enet_address_set_ip(ref nativeAddress, ip) == 0;
         }
@@ -190,7 +190,7 @@ namespace ENet
         public bool SetHost(string hostName)
         {
             if (hostName == null)
-                throw new ArgumentNullException("hostName");
+                throw new ArgumentNullException(nameof(hostName));
 
             return Native.enet_address_set_hostname(ref nativeAddress, hostName) == 0;
         }
@@ -393,7 +393,7 @@ namespace ENet
         public void Create(byte[] data)
         {
             if (data == null)
-                throw new ArgumentNullException("data");
+                throw new ArgumentNullException(nameof(data));
 
             Create(data, data.Length);
         }
@@ -411,10 +411,10 @@ namespace ENet
         public void Create(byte[] data, int length, PacketFlags flags)
         {
             if (data == null)
-                throw new ArgumentNullException("data");
+                throw new ArgumentNullException(nameof(data));
 
             if (length < 0 || length > data.Length)
-                throw new ArgumentOutOfRangeException("length");
+                throw new ArgumentOutOfRangeException(nameof(length));
 
             nativePacket = Native.enet_packet_create(data, (IntPtr)length, flags);
         }
@@ -422,10 +422,10 @@ namespace ENet
         public void Create(IntPtr data, int length, PacketFlags flags)
         {
             if (data == IntPtr.Zero)
-                throw new ArgumentNullException("data");
+                throw new ArgumentNullException(nameof(data));
 
             if (length < 0)
-                throw new ArgumentOutOfRangeException("length");
+                throw new ArgumentOutOfRangeException(nameof(length));
 
             nativePacket = Native.enet_packet_create(data, (IntPtr)length, flags);
         }
@@ -433,13 +433,13 @@ namespace ENet
         public void Create(byte[] data, int offset, int length, PacketFlags flags)
         {
             if (data == null)
-                throw new ArgumentNullException("data");
+                throw new ArgumentNullException(nameof(data));
 
             if (offset < 0)
-                throw new ArgumentOutOfRangeException("offset");
+                throw new ArgumentOutOfRangeException(nameof(offset));
 
             if (length < 0 || length > data.Length)
-                throw new ArgumentOutOfRangeException("length");
+                throw new ArgumentOutOfRangeException(nameof(length));
 
             nativePacket = Native.enet_packet_create_offset(data, (IntPtr)length, (IntPtr)offset, flags);
         }
@@ -447,13 +447,13 @@ namespace ENet
         public void Create(IntPtr data, int offset, int length, PacketFlags flags)
         {
             if (data == IntPtr.Zero)
-                throw new ArgumentNullException("data");
+                throw new ArgumentNullException(nameof(data));
 
             if (offset < 0)
-                throw new ArgumentOutOfRangeException("offset");
+                throw new ArgumentOutOfRangeException(nameof(offset));
 
             if (length < 0)
-                throw new ArgumentOutOfRangeException("length");
+                throw new ArgumentOutOfRangeException(nameof(length));
 
             nativePacket = Native.enet_packet_create_offset(data, (IntPtr)length, (IntPtr)offset, flags);
         }
@@ -461,7 +461,7 @@ namespace ENet
         public void CopyTo(byte[] destination, int startPos = 0)
         {
             if (destination == null)
-                throw new ArgumentNullException("destination");
+                throw new ArgumentNullException(nameof(destination));
 
             // Fix by katori, prevents trying to copy a NULL
             // from native world (ie. disconnect a client)			
@@ -578,7 +578,7 @@ namespace ENet
         private static void ThrowIfChannelsExceeded(int channelLimit)
         {
             if (channelLimit < 0 || channelLimit > Library.maxChannelCount)
-                throw new ArgumentOutOfRangeException("channelLimit");
+                throw new ArgumentOutOfRangeException(nameof(channelLimit));
         }
 
         public void Create()
@@ -622,7 +622,7 @@ namespace ENet
                 throw new InvalidOperationException("Host already created");
 
             if (peerLimit < 0 || peerLimit > Library.maxPeers)
-                throw new ArgumentOutOfRangeException("peerLimit");
+                throw new ArgumentOutOfRangeException(nameof(peerLimit));
 
             ThrowIfChannelsExceeded(channelLimit);
 
@@ -669,7 +669,7 @@ namespace ENet
         public void Broadcast(byte channelID, ref Packet packet, Peer[] peers)
         {
             if (peers == null)
-                throw new ArgumentNullException("peers");
+                throw new ArgumentNullException(nameof(peers));
 
             ThrowIfNotCreated();
 
@@ -742,7 +742,7 @@ namespace ENet
         public int Service(int timeout, out Event @event)
         {
             if (timeout < 0)
-                throw new ArgumentOutOfRangeException("timeout");
+                throw new ArgumentOutOfRangeException(nameof(timeout));
 
             ThrowIfNotCreated();
 
@@ -1105,7 +1105,7 @@ namespace ENet
         public static int StringLength(this byte[] data)
         {
             if (data == null)
-                throw new ArgumentNullException("data");
+                throw new ArgumentNullException(nameof(data));
 
             int i;
 
@@ -1149,7 +1149,7 @@ namespace ENet
         public static bool Initialize(Callbacks callbacks)
         {
             if (callbacks == null)
-                throw new ArgumentNullException("callbacks");
+                throw new ArgumentNullException(nameof(callbacks));
 
             if (Native.enet_linked_version() != version)
                 throw new InvalidOperationException("ENet native is out of date. Download the latest release from https://github.com/SoftwareGuy/ENet-CSharp/releases");

--- a/UnityProject/Assets/Scripts/Core/Lighting/LightingRoom.cs
+++ b/UnityProject/Assets/Scripts/Core/Lighting/LightingRoom.cs
@@ -43,7 +43,7 @@ namespace Core.Lighting
 
 		private void Start()
 		{
-			Invoke("PrintBounds", 1f);
+			Invoke(nameof(PrintBounds), 1f);
 		}
 
 		private void PrintBounds()

--- a/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
+++ b/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
@@ -416,7 +416,7 @@ public static class SweetExtensions
 	{
 		if (chunkSize <= 0)
 		{
-			throw new ArgumentException("chunkSize must be greater than 0.");
+			throw new ArgumentException($"{nameof(chunkSize)} must be greater than 0.", nameof(chunkSize));
 		}
 
 		while (list.Any())


### PR DESCRIPTION
### Purpose
Inspired by #7389 I have fixed a handful of issues labeled critical on Codacy, the ones this doesn't fix didn't make sense to me and I think should be marked as false positives.

### Notes:
I have no idea what to put for the changelog since this is something players will never see, so I just left it blank.

### Changelog:
<!-- Add here individual lines with all your remarkable changes using the prefix ``CL:`` -->
<!-- Mind that the changes meant to be logged in the in changelog are those that are remarkable for the end user, so things like new features and fixes of known bugs are perfect for this section -->

<!-- CL: [New] For new features, things that didn't exist before the PR. -->

<!-- CL: [Improvement] For any change on any existing feature. -->

<!-- CL: [Balance] For any change on an existing feature done in the sake of improving game balance. It's the only exception to the rule above. -->

<!-- CL: [Fix] For any change that fixes a bug. -->
