### PR TITLE
feat: add new action to toggle game UI visibility

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Chat/ChatUI.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/ChatUI.cs
@@ -502,21 +502,14 @@ namespace UI.Chat_UI
 			RefreshChannelPanel();
 		}
 
-		public void CloseChatWindow(bool QuickClose = false)
+		public void CloseChatWindow(bool quickClose = false)
 		{
 			StartWindowCooldown();
 			UIManager.IsInputFocus = false;
 			chatInputWindow.SetActive(false);
 			languagePanel.gameObject.SetActive(false);
 
-			if (QuickClose)
-			{
-				EventManager.Broadcast(Event.ChatQuickUnfocus);
-			}
-			else
-			{
-				EventManager.Broadcast(Event.ChatUnfocused);
-			}
+			EventManager.Broadcast(quickClose ? Event.ChatQuickUnfocus : Event.ChatUnfocused);
 
 			Showing = false;
 			StartCoroutine(AnimateBackground());

--- a/UnityProject/Assets/Scripts/Core/Input System/KeybindManager.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/KeybindManager.cs
@@ -81,6 +81,8 @@ public enum KeyAction
 	//Interactions that only happen when this key is pressed
 	RadialScrollBackward,
 	RadialScrollForward,
+
+	HideUi
 }
 
 /// <summary>
@@ -377,8 +379,9 @@ public class KeybindManager : MonoBehaviour {
 		{ KeyAction.RadialScrollForward, new KeybindMetadata("Radial Scroll Forward", ActionType.UI)},
 		{ KeyAction.RadialScrollBackward, new KeybindMetadata("Radial Scroll Backward", ActionType.UI)},
 		{ KeyAction.EmoteWindowUI,	new KeybindMetadata("Open Emote Window.", ActionType.UI)},
+		{ KeyAction.HideUi, new KeybindMetadata("Hide UI", ActionType.UI) },
 
-		};
+	};
 
 	private readonly KeybindDict defaultKeybinds = new KeybindDict
 	{
@@ -441,6 +444,7 @@ public class KeybindManager : MonoBehaviour {
 		{ KeyAction.RadialScrollForward,	new DualKeyCombo(new KeyCombo(KeyCode.E, KeyCode.LeftShift), null)},
 		{ KeyAction.RadialScrollBackward,	new DualKeyCombo(new KeyCombo(KeyCode.Q, KeyCode.LeftShift), null)},
 		{ KeyAction.EmoteWindowUI,	new DualKeyCombo(new KeyCombo(KeyCode.T, KeyCode.LeftShift), null)},
+		{ KeyAction.HideUi, new DualKeyCombo(new KeyCombo(KeyCode.F11), null) },
 
 	};
 	public KeybindDict userKeybinds = new KeybindDict();

--- a/UnityProject/Assets/Scripts/Core/Input System/KeyboardInputManager.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/KeyboardInputManager.cs
@@ -256,6 +256,7 @@ public class KeyboardInputManager : MonoBehaviour
 
 		{ KeyAction.PocketOne, 		() => { PlayerManager.LocalPlayerScript.DynamicItemStorage.TryItemInteract(NamedSlot.storage01);}},
 		{ KeyAction.PocketTwo, 		() => { PlayerManager.LocalPlayerScript.DynamicItemStorage.TryItemInteract(NamedSlot.storage02);}},
-		{ KeyAction.PocketThree, 	() => { PlayerManager.LocalPlayerScript.DynamicItemStorage.TryItemInteract(NamedSlot.suitStorage); }}
+		{ KeyAction.PocketThree, 	() => { PlayerManager.LocalPlayerScript.DynamicItemStorage.TryItemInteract(NamedSlot.suitStorage); }},
+		{ KeyAction.HideUi,         () => { UIManager.Instance.ToggleUiVisibility(); }},
 	};
 }

--- a/UnityProject/Assets/Scripts/UI/Systems/UIManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/UIManager.cs
@@ -626,4 +626,10 @@ public class UIManager : MonoBehaviour, IInitialise
 
 		ChatUI.Instance.OpenChatWindow();
 	}
+
+	public void ToggleUiVisibility()
+	{
+		gameObject.SetActive(!gameObject.activeInHierarchy);
+		ChatUI.Instance.CloseChatWindow(true);
+	}
 }


### PR DESCRIPTION
### Purpose
adds a new action, binded by default to F11, that will toggle the UI visibility for screenshots or whatever purpose.

![GIF 18-02-2023 18-24-50](https://user-images.githubusercontent.com/43683714/219901420-9991c688-22cf-4d19-9245-1ba57ec98008.gif)


### Notes:
It will also quick close the chat window but sadly if I try to hide it, the game breaks so chat will still be present.

### Changelog:
CL: [New] Added new action, binded by default to F11, that will toggle UI visibility.
