### PR TITLE
Networks emote commands

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Chat/EmoteActionManager.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/EmoteActionManager.cs
@@ -36,8 +36,7 @@ namespace Core.Chat
 				newChoice.Text = emote.EmoteName;
 				newChoice.Icon = emote.EmoteIcon;
 				// Emotes can only be ran server side, so we have to invoke a command on the server.
-				newChoice.ChoiceAction = () => PlayerManager.LocalPlayerScript.PlayerNetworkActions
-					.CmdDoEmote(PlayerManager.LocalPlayerObject, emote.EmoteName);
+				newChoice.ChoiceAction = () => PlayerManager.LocalPlayerScript.PlayerNetworkActions.CmdDoEmote(emote.EmoteName);
 				choices.Add(newChoice);
 			}
 			DynamicChoiceUI.DisplayChoices("Emotes", "Choose an emote you'd like to perform.", choices);

--- a/UnityProject/Assets/Scripts/Core/Chat/EmoteActionManager.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/EmoteActionManager.cs
@@ -35,7 +35,9 @@ namespace Core.Chat
 				var newChoice = new DynamicUIChoiceEntryData();
 				newChoice.Text = emote.EmoteName;
 				newChoice.Icon = emote.EmoteIcon;
-				newChoice.ChoiceAction = () => emote.Do(PlayerManager.LocalPlayerObject);
+				// Emotes can only be ran server side, so we have to invoke a command on the server.
+				newChoice.ChoiceAction = () => PlayerManager.LocalPlayerScript.PlayerNetworkActions
+					.CmdDoEmote(PlayerManager.LocalPlayerObject, emote.EmoteName);
 				choices.Add(newChoice);
 			}
 			DynamicChoiceUI.DisplayChoices("Emotes", "Choose an emote you'd like to perform.", choices);

--- a/UnityProject/Assets/Scripts/Core/Input System/KeybindManager.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/KeybindManager.cs
@@ -443,7 +443,7 @@ public class KeybindManager : MonoBehaviour {
 
 		{ KeyAction.RadialScrollForward,	new DualKeyCombo(new KeyCombo(KeyCode.E, KeyCode.LeftShift), null)},
 		{ KeyAction.RadialScrollBackward,	new DualKeyCombo(new KeyCombo(KeyCode.Q, KeyCode.LeftShift), null)},
-		{ KeyAction.EmoteWindowUI,	new DualKeyCombo(new KeyCombo(KeyCode.T, KeyCode.LeftShift), null)},
+		{ KeyAction.EmoteWindowUI,	new DualKeyCombo(new KeyCombo(KeyCode.Backslash), null)},
 		{ KeyAction.HideUi, new DualKeyCombo(new KeyCombo(KeyCode.F11), null) },
 
 	};

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-using AdminTools;
 using Items.PDA;
 using UnityEngine;
 using Mirror;
@@ -11,12 +9,11 @@ using Audio.Containers;
 using ScriptableObjects;
 using AdminCommands;
 using Antagonists;
-using Systems.Atmospherics;
+using Core.Chat;
 using HealthV2;
 using Items;
 using Items.Tool;
 using Messages.Server;
-using UI.Systems.AdminTools.DevTools;
 using Objects.Other;
 using Player.Movement;
 using Shuttles;
@@ -25,11 +22,7 @@ using UI.Items;
 using Doors;
 using Managers;
 using Objects;
-using Objects.Atmospherics;
-using Objects.Disposals;
 using Player.Language;
-using Systems.Electricity;
-using Systems.Pipes;
 using Tiles;
 using Util;
 using Random = UnityEngine.Random;
@@ -989,5 +982,11 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		{
 			Inventory.ServerTransfer(gameObjectSent.PickupableOrNull().ItemSlot, slot, ReplacementStrategy.DropOther);
 		}
+	}
+
+	[Command]
+	public void CmdDoEmote(GameObject player, string emoteName)
+	{
+		EmoteActionManager.DoEmote(emoteName, player);
 	}
 }

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -985,8 +985,8 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 	}
 
 	[Command]
-	public void CmdDoEmote(GameObject player, string emoteName)
+	public void CmdDoEmote(string emoteName)
 	{
-		EmoteActionManager.DoEmote(emoteName, player);
+		EmoteActionManager.DoEmote(emoteName, playerScript.gameObject);
 	}
 }

--- a/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
@@ -81,7 +81,7 @@ namespace ScriptableObjects.RP
 
 		public virtual void Do(GameObject player)
 		{
-			if(CheckAllBaseConditions(player) == false) return;
+			if (CheckAllBaseConditions(player) == false) return;
 			Chat.AddActionMsgToChat(player, $"{youText}", $"{player.ExpensiveName()} {viewText}.");
 			PlayAudio(defaultSounds, player);
 		}

--- a/UnityProject/Assets/Scripts/UI/Core/DynamicChoiceUI.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/DynamicChoiceUI.cs
@@ -8,6 +8,9 @@ using UnityEngine.UI;
 
 namespace UI.Core
 {
+	/// <summary>
+	/// Client side menu that lists a bunch of choices that invokes commands.
+	/// </summary>
 	public class DynamicChoiceUI : SingletonManager<DynamicChoiceUI>
 	{
 		[SerializeField] private Transform entryPrefab;


### PR DESCRIPTION
fixes #9617

CL: [Improvement] Changed the default emote window button to `backslash` to avoid the backlash of all the angry gamers that I've upset with my preference and are now planning on using the gulitone I created against me.
CL: [Fix] Emote window works now on headless servers.
