### PR TITLE
Fix server-client auth rejection when not headless

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Networking/Authenticator.cs
+++ b/UnityProject/Assets/Scripts/Core/Networking/Authenticator.cs
@@ -385,6 +385,7 @@ namespace Core.Networking
 			Logger.Log($"Disconnecting from server. Reason: {msg.Code}.");
 			ClientReject(); // Gracefully handle rejection by disconnecting.
 
+			// Then shut down the client to return to the main menu.
 			// If this client is also the host but not headless (i.e. not handled by OnServerClientAuthRequest()),
 			// we should handle a disconnect request slightly differently.
 			if (CustomNetworkManager.IsServer)


### PR DESCRIPTION
CL: [Fix] Fixes the server's client authentication rejection handling, when self-hosting and not headless. The network server will now correctly be shut down instead of leaving the client stuck in the server lobby.