### PR TITLE
Memory leak fixing : Adding foundation

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Lifecycle/CleanupUtil.cs
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/CleanupUtil.cs
@@ -8,7 +8,12 @@ using Audio.Containers;
 
 public static class CleanupUtil
 {
-
+	/// <summary>
+	/// this methods scans the provided list and removes from it all elements, that are not marked as DontDestroyOnLoad. Will keep elements that are equal to null
+	/// <paramref name="targetExtractor"/> is just used to get the MonoBehaviour that is then being used to figure out whether or not element should be removed
+	/// </summary>
+	/// <param name="listInQuestion"> is a list that should be altered according to the rules provided by the method</param>
+	/// <param name="targetExtractor"> is a delegate that is transforming <typeparamref name="T"/> into a <c>UnityEngine.MonoBehaviour</c> that is later then removed from the <paramref name="listInQuestion"> if it's not marked as DontDestroyOnLoad </param>
 	public static int RidListOfSoonToBeDeadElements<T>(IList<T> listInQuestion, Func<T, UnityEngine.MonoBehaviour> targetExtractor)
 	{
 		if (listInQuestion == null)
@@ -39,6 +44,13 @@ public static class CleanupUtil
 		return res;
 	}
 
+	/// <summary>
+	/// this methods scans the provided list and removes from it all elements that are equal to null
+	/// <paramref name="targetExtractor"/> is just used to get the MonoBehaviour that is then being used to figure out whether or not element should be removed
+	/// </summary>
+	/// <param name="listInQuestion"> is a  list that should be altered according to the rules provided by the method</param>
+	/// <param name="targetExtractor"> is a delegate that is transforming <typeparamref name="T"/> into a <c>UnityEngine.MonoBehaviour</c> that is later then removed from the <paramref name="listInQuestion"> if it's equal to null </param>
+	/// <param name="verbose"> set it to True if you want to allow it to attempt to log typenames or even object names of objects, that would be removed from the list </param>
 	public static int RidListOfDeadElements<T>(IList<T> listInQuestion, Func<T, UnityEngine.MonoBehaviour> targetExtractor, bool verbose = false)
 	{
 		if (listInQuestion == null)
@@ -91,6 +103,11 @@ public static class CleanupUtil
 
 		return res;
 	}
+	/// <summary>
+	/// this methods scans the provided list and removes from it all instances of <c>System.Action</c> that have targets equal to null
+	/// </summary>
+	/// <param name="listInQuestion"> is a list that should be altered according to the rules provided by the method</param>
+	/// <param name="verbose"> set it to True if you want to allow it to attempt to log typenames or even object names of objects, that would be removed from the list </param>
 
 	public static int RidListOfDeadElements(IList<Action> listInQuestion, bool verbose = false)
 	{
@@ -143,6 +160,11 @@ public static class CleanupUtil
 		return res;
 	}
 
+	/// <summary>
+	/// this methods scans the provided list and removes from it all elements that are equal to null
+	/// </summary>
+	/// <param name="listInQuestion"> is a  list that should be altered according to the rules provided by the method</param>
+	/// <param name="verbose"> set it to True if you want to allow it to attempt to log typenames or even object names of objects, that would be removed from the list </param>
 	public static int RidListOfDeadElements<T>(IList<T> listInQuestion, bool verbose = false) where T: MonoBehaviour
 	{
 		if (listInQuestion == null)
@@ -193,6 +215,13 @@ public static class CleanupUtil
 		return res;
 	}
 
+	/// <summary>
+	/// this methods scans the provided dictionary and removes from it all elements that didn't pass <paramref name="survivalCondition"> curvival condition
+	/// <paramref name="survivalCondition"/> should return true of provided pair of key and value is supposed to stay in the dictionary
+	/// </summary>
+	/// <param name="dictInQuestion"> is a dictionary that should be altered according to the rules provided by the method</param>
+	/// <param name="survivalCondition"> is a delegate that is deciding whether or not pair of key and value of the dictionary should stay in the dictionary</param>
+	/// <param name="verbose"> set it to True if you want to allow it to attempt to log typenames or even object names of objects, that would be removed from the list </param>
 	public static int RidDictionaryOfDeadElements<TKey, TValue>(IDictionary<TKey, TValue> dictInQuestion, Func<TKey, TValue, bool> survivalCondition, bool verbose = false)
 	{
 		if (dictInQuestion == null)
@@ -243,7 +272,11 @@ public static class CleanupUtil
 
 		return res;
 	}
-
+	/// <summary>
+	/// this methods scans the provided dictionary and removes from it all keyvaluepairs in which either key or value are equal to null
+	/// </summary>
+	/// <param name="dictInQuestion"> is a dictionary that should be altered according to the rules provided by the method</param>
+	/// <param name="verbose"> set it to True if you want to allow it to attempt to log typenames or even object names of objects, that would be removed from the list </param>
 	public static int RidDictionaryOfDeadElements<TKey, TValue>(IDictionary<TKey, TValue> dictInQuestion, bool verbose = false)
 	{
 		if (dictInQuestion == null)
@@ -295,14 +328,23 @@ public static class CleanupUtil
 		return res;
 	}
 
+	/// <summary>
+	/// Should be called right when round ended, but before any scene unloaded
+	/// </summary>
 	public static void EndRoundCleanup()
 	{
 	}
 
+	/// <summary>
+	/// Should be called right after previous round ended, and some scenes might already be unloaded
+	/// </summary>
 	public static void CleanupInbetweenScenes()
 	{
 	}
 
+	/// <summary>
+	/// Should be called sometimes after round started and all necessary scenes are loaded
+	/// </summary>
 	public static void RoundStartCleanup()
 	{
 	}

--- a/UnityProject/Assets/Scripts/Core/Lifecycle/CleanupUtil.cs
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/CleanupUtil.cs
@@ -62,7 +62,7 @@ public static class CleanupUtil
 				{
 					try
 					{
-						Debug.Log("Name of leaked object : " + target.name);
+						Logger.Log("Name of leaked object : " + target.name, Category.MemoryCleanup);
 					}
 					catch (Exception ee)
 					{
@@ -71,7 +71,7 @@ public static class CleanupUtil
 
 					try
 					{
-						Debug.Log("Typename of leaked object : " + target.GetType().Name);
+						Logger.Log("Typename of leaked object : " + target.GetType().Name, Category.MemoryCleanup);
 					}
 					catch (Exception ee)
 					{
@@ -113,7 +113,7 @@ public static class CleanupUtil
 				{
 					try
 					{
-						Debug.Log("Name of leaked object : " + (list_in_question[i].Target as MonoBehaviour).name);
+						Logger.Log("Name of leaked object : " + (list_in_question[i].Target as MonoBehaviour).name, Category.MemoryCleanup);
 					}
 					catch (Exception ee)
 					{
@@ -122,7 +122,7 @@ public static class CleanupUtil
 
 					try
 					{
-						Debug.Log("Typename of leaked object : " + list_in_question[i].Target.GetType().Name);
+						Logger.Log("Typename of leaked object : " + list_in_question[i].Target.GetType().Name, Category.MemoryCleanup);
 					}
 					catch (Exception ee)
 					{
@@ -163,7 +163,7 @@ public static class CleanupUtil
 				{
 					try
 					{
-						Debug.Log("Name of leaked object : " + list_in_question[i].name);
+						Logger.Log("Name of leaked object : " + list_in_question[i].name, Category.MemoryCleanup);
 					}
 					catch (Exception ee)
 					{
@@ -172,7 +172,7 @@ public static class CleanupUtil
 
 					try
 					{
-						Debug.Log("Typename of leaked object : " + list_in_question[i].GetType().Name);
+						Logger.Log("Typename of leaked object : " + list_in_question[i].GetType().Name, Category.MemoryCleanup);
 					}
 					catch (Exception ee)
 					{
@@ -214,7 +214,7 @@ public static class CleanupUtil
 				{
 					try
 					{
-						Debug.Log("Typename of (possibly) leaked object : " + a.Key.GetType().Name);
+						Logger.Log("Typename of (possibly) leaked object : " + a.Key.GetType().Name, Category.MemoryCleanup);
 					}
 					catch (Exception ee)
 					{
@@ -223,7 +223,7 @@ public static class CleanupUtil
 
 					try
 					{
-						Debug.Log("Typename of (possibly) leaked object : " + a.Value.GetType().Name);
+						Logger.Log("Typename of (possibly) leaked object : " + a.Value.GetType().Name, Category.MemoryCleanup);
 					}
 					catch (Exception ee)
 					{
@@ -265,7 +265,7 @@ public static class CleanupUtil
 				{
 					try
 					{
-						Debug.Log("Typename of (possibly) leaked object : " + a.Key.GetType().Name);
+						Logger.Log("Typename of (possibly) leaked object : " + a.Key.GetType().Name, Category.MemoryCleanup);
 					}
 					catch (Exception ee)
 					{
@@ -274,7 +274,7 @@ public static class CleanupUtil
 
 					try
 					{
-						Debug.Log("Typename of (possibly) leaked object : " + a.Value.GetType().Name);
+						Logger.Log("Typename of (possibly) leaked object : " + a.Value.GetType().Name, Category.MemoryCleanup);
 					}
 					catch (Exception ee)
 					{

--- a/UnityProject/Assets/Scripts/Core/Lifecycle/CleanupUtil.cs
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/CleanupUtil.cs
@@ -9,52 +9,52 @@ using Audio.Containers;
 public static class CleanupUtil
 {
 
-	public static int RidListOfSoonToBeDeadElements<T>(IList<T> list_in_question, Func<T, UnityEngine.MonoBehaviour> target_extractor)
+	public static int RidListOfSoonToBeDeadElements<T>(IList<T> listInQuestion, Func<T, UnityEngine.MonoBehaviour> targetExtractor)
 	{
-		if (list_in_question == null)
+		if (listInQuestion == null)
 		{
 			return -1;
 		}
 
-		List<T> survivor_list = new List<T>();
+		List<T> survivorList = new List<T>();
 
-		for (int i = 0, max = list_in_question.Count; i < max; i++)
+		for (int i = 0, max = listInQuestion.Count; i < max; i++)
 		{
-			MonoBehaviour target = target_extractor(list_in_question[i]);
+			MonoBehaviour target = targetExtractor(listInQuestion[i]);
 
-			if (list_in_question[i] != null && (target == null || target.gameObject.scene.buildIndex == -1))
+			if (listInQuestion[i] != null && (target == null || target.gameObject.scene.buildIndex == -1))
 			{
-				survivor_list.Add(list_in_question[i]);
+				survivorList.Add(listInQuestion[i]);
 			}
 		}
 
-		int res = list_in_question.Count - survivor_list.Count;
-		list_in_question.Clear();
+		int res = listInQuestion.Count - survivorList.Count;
+		listInQuestion.Clear();
 
-		for (int i = 0, max = survivor_list.Count; i < max; i++)
+		for (int i = 0, max = survivorList.Count; i < max; i++)
 		{
-			list_in_question.Add(survivor_list[i]);
+			listInQuestion.Add(survivorList[i]);
 		}
 
 		return res;
 	}
 
-	public static int RidListOfDeadElements<T>(IList<T> list_in_question, Func<T, UnityEngine.MonoBehaviour> target_extractor, bool verbose = false)
+	public static int RidListOfDeadElements<T>(IList<T> listInQuestion, Func<T, UnityEngine.MonoBehaviour> targetExtractor, bool verbose = false)
 	{
-		if (list_in_question == null)
+		if (listInQuestion == null)
 		{
 			return -1;
 		}
 
-		List<T> survivor_list = new List<T>();
+		List<T> survivorList = new List<T>();
 
-		for (int i = 0, max = list_in_question.Count; i < max; i++)
+		for (int i = 0, max = listInQuestion.Count; i < max; i++)
 		{
-			MonoBehaviour target = target_extractor(list_in_question[i]);
+			MonoBehaviour target = targetExtractor(listInQuestion[i]);
 
-			if (list_in_question[i] != null && target == null)
+			if (listInQuestion[i] != null && target == null)
 			{
-				survivor_list.Add(list_in_question[i]);
+				survivorList.Add(listInQuestion[i]);
 			}
 			else
 			{
@@ -81,31 +81,31 @@ public static class CleanupUtil
 			}
 		}
 
-		int res = list_in_question.Count - survivor_list.Count;
-		list_in_question.Clear();
+		int res = listInQuestion.Count - survivorList.Count;
+		listInQuestion.Clear();
 
-		for (int i = 0, max = survivor_list.Count; i < max; i++)
+		for (int i = 0, max = survivorList.Count; i < max; i++)
 		{
-			list_in_question.Add(survivor_list[i]);
+			listInQuestion.Add(survivorList[i]);
 		}
 
 		return res;
 	}
 
-	public static int RidListOfDeadElements(IList<Action> list_in_question, bool verbose = false)
+	public static int RidListOfDeadElements(IList<Action> listInQuestion, bool verbose = false)
 	{
-		if (list_in_question == null)
+		if (listInQuestion == null)
 		{
 			return -1;
 		}
 
-		List<Action> survivor_list = new List<Action>();
+		List<Action> survivorList = new List<Action>();
 
-		for (int i = 0, max = list_in_question.Count; i < max; i++)
+		for (int i = 0, max = listInQuestion.Count; i < max; i++)
 		{
-			if (list_in_question[i] != null && list_in_question[i].Target == null)
+			if (listInQuestion[i] != null && listInQuestion[i].Target == null)
 			{
-				survivor_list.Add(list_in_question[i]);
+				survivorList.Add(listInQuestion[i]);
 			}
 			else
 			{
@@ -113,7 +113,7 @@ public static class CleanupUtil
 				{
 					try
 					{
-						Logger.Log("Name of leaked object : " + (list_in_question[i].Target as MonoBehaviour).name, Category.MemoryCleanup);
+						Logger.Log("Name of leaked object : " + (listInQuestion[i].Target as MonoBehaviour).name, Category.MemoryCleanup);
 					}
 					catch (Exception ee)
 					{
@@ -122,7 +122,7 @@ public static class CleanupUtil
 
 					try
 					{
-						Logger.Log("Typename of leaked object : " + list_in_question[i].Target.GetType().Name, Category.MemoryCleanup);
+						Logger.Log("Typename of leaked object : " + listInQuestion[i].Target.GetType().Name, Category.MemoryCleanup);
 					}
 					catch (Exception ee)
 					{
@@ -132,30 +132,30 @@ public static class CleanupUtil
 			}
 		}
 
-		int res = list_in_question.Count - survivor_list.Count;
-		list_in_question.Clear();
+		int res = listInQuestion.Count - survivorList.Count;
+		listInQuestion.Clear();
 
-		for (int i = 0, max = survivor_list.Count; i < max; i++)
+		for (int i = 0, max = survivorList.Count; i < max; i++)
 		{
-			list_in_question.Add(survivor_list[i]);
+			listInQuestion.Add(survivorList[i]);
 		}
 
 		return res;
 	}
 
-	public static int RidListOfDeadElements<T>(IList<T> list_in_question, bool verbose = false) where T: MonoBehaviour
+	public static int RidListOfDeadElements<T>(IList<T> listInQuestion, bool verbose = false) where T: MonoBehaviour
 	{
-		if (list_in_question == null)
+		if (listInQuestion == null)
 		{
 			return -1;
 		}
-		List<T> survivor_list = new List<T>();
+		List<T> survivorList = new List<T>();
 		
-		for (int i = 0, max = list_in_question.Count; i < max; i++)
+		for (int i = 0, max = listInQuestion.Count; i < max; i++)
 		{
-			if (list_in_question[i] != null)
+			if (listInQuestion[i] != null)
 			{
-				survivor_list.Add(list_in_question[i]);
+				survivorList.Add(listInQuestion[i]);
 			}
 			else
 			{
@@ -163,7 +163,7 @@ public static class CleanupUtil
 				{
 					try
 					{
-						Logger.Log("Name of leaked object : " + list_in_question[i].name, Category.MemoryCleanup);
+						Logger.Log("Name of leaked object : " + listInQuestion[i].name, Category.MemoryCleanup);
 					}
 					catch (Exception ee)
 					{
@@ -172,7 +172,7 @@ public static class CleanupUtil
 
 					try
 					{
-						Logger.Log("Typename of leaked object : " + list_in_question[i].GetType().Name, Category.MemoryCleanup);
+						Logger.Log("Typename of leaked object : " + listInQuestion[i].GetType().Name, Category.MemoryCleanup);
 					}
 					catch (Exception ee)
 					{
@@ -182,31 +182,31 @@ public static class CleanupUtil
 			}
 		}
 
-		int res = list_in_question.Count - survivor_list.Count;
-		list_in_question.Clear();
+		int res = listInQuestion.Count - survivorList.Count;
+		listInQuestion.Clear();
 
-		for (int i = 0, max = survivor_list.Count; i < max; i++)
+		for (int i = 0, max = survivorList.Count; i < max; i++)
 		{
-			list_in_question.Add(survivor_list[i]);
+			listInQuestion.Add(survivorList[i]);
 		}
 
 		return res;
 	}
 
-	public static int RidDictionaryOfDeadElements<TKey, TValue>(IDictionary<TKey, TValue> dict_in_question, Func<TKey, TValue, bool> condition, bool verbose = false)
+	public static int RidDictionaryOfDeadElements<TKey, TValue>(IDictionary<TKey, TValue> dictInQuestion, Func<TKey, TValue, bool> survivalCondition, bool verbose = false)
 	{
-		if (dict_in_question == null)
+		if (dictInQuestion == null)
 		{
 			return -1;
 		}
 
-		List<KeyValuePair<TKey, TValue>> survivor_list = new List<KeyValuePair<TKey, TValue>>();
+		List<KeyValuePair<TKey, TValue>> survivorList = new List<KeyValuePair<TKey, TValue>>();
 
-		foreach (var a in dict_in_question)
+		foreach (var keyValuePair in dictInQuestion)
 		{
-			if (condition(a.Key, a.Value))
+			if (survivalCondition(keyValuePair.Key, keyValuePair.Value))
 			{
-				survivor_list.Add(a);
+				survivorList.Add(keyValuePair);
 			}
 			else
 			{
@@ -214,7 +214,7 @@ public static class CleanupUtil
 				{
 					try
 					{
-						Logger.Log("Typename of (possibly) leaked object : " + a.Key.GetType().Name, Category.MemoryCleanup);
+						Logger.Log("Typename of (possibly) leaked object : " + keyValuePair.Key.GetType().Name, Category.MemoryCleanup);
 					}
 					catch (Exception ee)
 					{
@@ -223,7 +223,7 @@ public static class CleanupUtil
 
 					try
 					{
-						Logger.Log("Typename of (possibly) leaked object : " + a.Value.GetType().Name, Category.MemoryCleanup);
+						Logger.Log("Typename of (possibly) leaked object : " + keyValuePair.Value.GetType().Name, Category.MemoryCleanup);
 					}
 					catch (Exception ee)
 					{
@@ -233,31 +233,31 @@ public static class CleanupUtil
 			}
 		}
 
-		int res = dict_in_question.Count - survivor_list.Count;
-		dict_in_question.Clear();
+		int res = dictInQuestion.Count - survivorList.Count;
+		dictInQuestion.Clear();
 
-		for (int i = 0, max = survivor_list.Count; i < max; i++)
+		for (int i = 0, max = survivorList.Count; i < max; i++)
 		{
-			dict_in_question.Add(survivor_list[i].Key, survivor_list[i].Value);
+			dictInQuestion.Add(survivorList[i].Key, survivorList[i].Value);
 		}
 
 		return res;
 	}
 
-	public static int RidDictionaryOfDeadElements<TKey, TValue>(IDictionary<TKey, TValue> dict_in_question, bool verbose = false)
+	public static int RidDictionaryOfDeadElements<TKey, TValue>(IDictionary<TKey, TValue> dictInQuestion, bool verbose = false)
 	{
-		if (dict_in_question == null)
+		if (dictInQuestion == null)
 		{
 			return -1;
 		}
 
-		List<KeyValuePair<TKey, TValue>> survivor_list = new List<KeyValuePair<TKey, TValue>>();
+		List<KeyValuePair<TKey, TValue>> survivorList = new List<KeyValuePair<TKey, TValue>>();
 		
-		foreach(var a in dict_in_question)
+		foreach(var keyValuePair in dictInQuestion)
 		{
-			if (a.Key != null && a.Value != null)
+			if (keyValuePair.Key != null && keyValuePair.Value != null)
 			{
-				survivor_list.Add(a);
+				survivorList.Add(keyValuePair);
 			}
 			else
 			{
@@ -265,7 +265,7 @@ public static class CleanupUtil
 				{
 					try
 					{
-						Logger.Log("Typename of (possibly) leaked object : " + a.Key.GetType().Name, Category.MemoryCleanup);
+						Logger.Log("Typename of (possibly) leaked object : " + keyValuePair.Key.GetType().Name, Category.MemoryCleanup);
 					}
 					catch (Exception ee)
 					{
@@ -274,7 +274,7 @@ public static class CleanupUtil
 
 					try
 					{
-						Logger.Log("Typename of (possibly) leaked object : " + a.Value.GetType().Name, Category.MemoryCleanup);
+						Logger.Log("Typename of (possibly) leaked object : " + keyValuePair.Value.GetType().Name, Category.MemoryCleanup);
 					}
 					catch (Exception ee)
 					{
@@ -284,12 +284,12 @@ public static class CleanupUtil
 			}
 		}
 
-		int res = dict_in_question.Count - survivor_list.Count;
-		dict_in_question.Clear();
+		int res = dictInQuestion.Count - survivorList.Count;
+		dictInQuestion.Clear();
 
-		for (int i = 0, max = survivor_list.Count; i < max; i++)
+		for (int i = 0, max = survivorList.Count; i < max; i++)
 		{
-			dict_in_question.Add(survivor_list[i].Key, survivor_list[i].Value);
+			dictInQuestion.Add(survivorList[i].Key, survivorList[i].Value);
 		}
 
 		return res;

--- a/UnityProject/Assets/Scripts/Core/Lifecycle/CleanupUtil.cs
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/CleanupUtil.cs
@@ -39,7 +39,7 @@ public static class CleanupUtil
 		return res;
 	}
 
-	public static int RidListOfDeadElements<T>(IList<T> list_in_question, Func<T, UnityEngine.MonoBehaviour> target_extractor)
+	public static int RidListOfDeadElements<T>(IList<T> list_in_question, Func<T, UnityEngine.MonoBehaviour> target_extractor, bool verbose = false)
 	{
 		if (list_in_question == null)
 		{
@@ -56,6 +56,29 @@ public static class CleanupUtil
 			{
 				survivor_list.Add(list_in_question[i]);
 			}
+			else
+			{
+				if (verbose)
+				{
+					try
+					{
+						Debug.Log("Name of leaked object : " + target.name);
+					}
+					catch (Exception ee)
+					{
+						//do nothing
+					}
+
+					try
+					{
+						Debug.Log("Typename of leaked object : " + target.GetType().Name);
+					}
+					catch (Exception ee)
+					{
+						//do nothing
+					}
+				}
+			}
 		}
 
 		int res = list_in_question.Count - survivor_list.Count;
@@ -69,7 +92,7 @@ public static class CleanupUtil
 		return res;
 	}
 
-	public static int RidListOfDeadElements(IList<Action> list_in_question)
+	public static int RidListOfDeadElements(IList<Action> list_in_question, bool verbose = false)
 	{
 		if (list_in_question == null)
 		{
@@ -84,32 +107,28 @@ public static class CleanupUtil
 			{
 				survivor_list.Add(list_in_question[i]);
 			}
-		}
-
-		int res = list_in_question.Count - survivor_list.Count;
-		list_in_question.Clear();
-
-		for (int i = 0, max = survivor_list.Count; i < max; i++)
-		{
-			list_in_question.Add(survivor_list[i]);
-		}
-
-		return res;
-	}
-
-	public static int RidListOfDeadElements<T>(IList<T> list_in_question) where T: MonoBehaviour
-	{
-		if (list_in_question == null)
-		{
-			return -1;
-		}
-		List<T> survivor_list = new List<T>();
-		
-		for (int i = 0, max = list_in_question.Count; i < max; i++)
-		{
-			if (list_in_question[i] != null)
+			else
 			{
-				survivor_list.Add(list_in_question[i]);
+				if (verbose)
+				{
+					try
+					{
+						Debug.Log("Name of leaked object : " + (list_in_question[i].Target as MonoBehaviour).name);
+					}
+					catch (Exception ee)
+					{
+						//do nothing
+					}
+
+					try
+					{
+						Debug.Log("Typename of leaked object : " + list_in_question[i].Target.GetType().Name);
+					}
+					catch (Exception ee)
+					{
+						//do nothing
+					}
+				}
 			}
 		}
 
@@ -124,7 +143,57 @@ public static class CleanupUtil
 		return res;
 	}
 
-	public static int RidDictionaryOfDeadElements<TKey, TValue>(IDictionary<TKey, TValue> dict_in_question, Func<TKey, TValue, bool> condition )
+	public static int RidListOfDeadElements<T>(IList<T> list_in_question, bool verbose = false) where T: MonoBehaviour
+	{
+		if (list_in_question == null)
+		{
+			return -1;
+		}
+		List<T> survivor_list = new List<T>();
+		
+		for (int i = 0, max = list_in_question.Count; i < max; i++)
+		{
+			if (list_in_question[i] != null)
+			{
+				survivor_list.Add(list_in_question[i]);
+			}
+			else
+			{
+				if (verbose)
+				{
+					try
+					{
+						Debug.Log("Name of leaked object : " + list_in_question[i].name);
+					}
+					catch (Exception ee)
+					{
+						//do nothing
+					}
+
+					try
+					{
+						Debug.Log("Typename of leaked object : " + list_in_question[i].GetType().Name);
+					}
+					catch (Exception ee)
+					{
+						//do nothing
+					}
+				}
+			}
+		}
+
+		int res = list_in_question.Count - survivor_list.Count;
+		list_in_question.Clear();
+
+		for (int i = 0, max = survivor_list.Count; i < max; i++)
+		{
+			list_in_question.Add(survivor_list[i]);
+		}
+
+		return res;
+	}
+
+	public static int RidDictionaryOfDeadElements<TKey, TValue>(IDictionary<TKey, TValue> dict_in_question, Func<TKey, TValue, bool> condition, bool verbose = false)
 	{
 		if (dict_in_question == null)
 		{
@@ -139,6 +208,29 @@ public static class CleanupUtil
 			{
 				survivor_list.Add(a);
 			}
+			else
+			{
+				if (verbose)
+				{
+					try
+					{
+						Debug.Log("Typename of (possibly) leaked object : " + a.Key.GetType().Name);
+					}
+					catch (Exception ee)
+					{
+						//do nothing
+					}
+
+					try
+					{
+						Debug.Log("Typename of (possibly) leaked object : " + a.Value.GetType().Name);
+					}
+					catch (Exception ee)
+					{
+						//do nothing
+					}
+				}
+			}
 		}
 
 		int res = dict_in_question.Count - survivor_list.Count;
@@ -152,7 +244,7 @@ public static class CleanupUtil
 		return res;
 	}
 
-	public static int RidDictionaryOfDeadElements<TKey, TValue>(IDictionary<TKey, TValue> dict_in_question)
+	public static int RidDictionaryOfDeadElements<TKey, TValue>(IDictionary<TKey, TValue> dict_in_question, bool verbose = false)
 	{
 		if (dict_in_question == null)
 		{
@@ -166,6 +258,29 @@ public static class CleanupUtil
 			if (a.Key != null && a.Value != null)
 			{
 				survivor_list.Add(a);
+			}
+			else
+			{
+				if (verbose)
+				{
+					try
+					{
+						Debug.Log("Typename of (possibly) leaked object : " + a.Key.GetType().Name);
+					}
+					catch (Exception ee)
+					{
+						//do nothing
+					}
+
+					try
+					{
+						Debug.Log("Typename of (possibly) leaked object : " + a.Value.GetType().Name);
+					}
+					catch (Exception ee)
+					{
+						//do nothing
+					}
+				}
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Core/Lifecycle/CleanupUtil.cs
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/CleanupUtil.cs
@@ -1,0 +1,194 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+using System;
+using UI.Action;
+using Audio.Containers;
+
+public static class CleanupUtil
+{
+
+	public static int RidListOfSoonToBeDeadElements<T>(IList<T> list_in_question, Func<T, UnityEngine.MonoBehaviour> target_extractor)
+	{
+		if (list_in_question == null)
+		{
+			return -1;
+		}
+
+		List<T> survivor_list = new List<T>();
+
+		for (int i = 0, max = list_in_question.Count; i < max; i++)
+		{
+			MonoBehaviour target = target_extractor(list_in_question[i]);
+
+			if (list_in_question[i] != null && (target == null || target.gameObject.scene.buildIndex == -1))
+			{
+				survivor_list.Add(list_in_question[i]);
+			}
+		}
+
+		int res = list_in_question.Count - survivor_list.Count;
+		list_in_question.Clear();
+
+		for (int i = 0, max = survivor_list.Count; i < max; i++)
+		{
+			list_in_question.Add(survivor_list[i]);
+		}
+
+		return res;
+	}
+
+	public static int RidListOfDeadElements<T>(IList<T> list_in_question, Func<T, UnityEngine.MonoBehaviour> target_extractor)
+	{
+		if (list_in_question == null)
+		{
+			return -1;
+		}
+
+		List<T> survivor_list = new List<T>();
+
+		for (int i = 0, max = list_in_question.Count; i < max; i++)
+		{
+			MonoBehaviour target = target_extractor(list_in_question[i]);
+
+			if (list_in_question[i] != null && target == null)
+			{
+				survivor_list.Add(list_in_question[i]);
+			}
+		}
+
+		int res = list_in_question.Count - survivor_list.Count;
+		list_in_question.Clear();
+
+		for (int i = 0, max = survivor_list.Count; i < max; i++)
+		{
+			list_in_question.Add(survivor_list[i]);
+		}
+
+		return res;
+	}
+
+	public static int RidListOfDeadElements(IList<Action> list_in_question)
+	{
+		if (list_in_question == null)
+		{
+			return -1;
+		}
+
+		List<Action> survivor_list = new List<Action>();
+
+		for (int i = 0, max = list_in_question.Count; i < max; i++)
+		{
+			if (list_in_question[i] != null && list_in_question[i].Target == null)
+			{
+				survivor_list.Add(list_in_question[i]);
+			}
+		}
+
+		int res = list_in_question.Count - survivor_list.Count;
+		list_in_question.Clear();
+
+		for (int i = 0, max = survivor_list.Count; i < max; i++)
+		{
+			list_in_question.Add(survivor_list[i]);
+		}
+
+		return res;
+	}
+
+	public static int RidListOfDeadElements<T>(IList<T> list_in_question) where T: MonoBehaviour
+	{
+		if (list_in_question == null)
+		{
+			return -1;
+		}
+		List<T> survivor_list = new List<T>();
+		
+		for (int i = 0, max = list_in_question.Count; i < max; i++)
+		{
+			if (list_in_question[i] != null)
+			{
+				survivor_list.Add(list_in_question[i]);
+			}
+		}
+
+		int res = list_in_question.Count - survivor_list.Count;
+		list_in_question.Clear();
+
+		for (int i = 0, max = survivor_list.Count; i < max; i++)
+		{
+			list_in_question.Add(survivor_list[i]);
+		}
+
+		return res;
+	}
+
+	public static int RidDictionaryOfDeadElements<TKey, TValue>(IDictionary<TKey, TValue> dict_in_question, Func<TKey, TValue, bool> condition )
+	{
+		if (dict_in_question == null)
+		{
+			return -1;
+		}
+
+		List<KeyValuePair<TKey, TValue>> survivor_list = new List<KeyValuePair<TKey, TValue>>();
+
+		foreach (var a in dict_in_question)
+		{
+			if (condition(a.Key, a.Value))
+			{
+				survivor_list.Add(a);
+			}
+		}
+
+		int res = dict_in_question.Count - survivor_list.Count;
+		dict_in_question.Clear();
+
+		for (int i = 0, max = survivor_list.Count; i < max; i++)
+		{
+			dict_in_question.Add(survivor_list[i].Key, survivor_list[i].Value);
+		}
+
+		return res;
+	}
+
+	public static int RidDictionaryOfDeadElements<TKey, TValue>(IDictionary<TKey, TValue> dict_in_question)
+	{
+		if (dict_in_question == null)
+		{
+			return -1;
+		}
+
+		List<KeyValuePair<TKey, TValue>> survivor_list = new List<KeyValuePair<TKey, TValue>>();
+		
+		foreach(var a in dict_in_question)
+		{
+			if (a.Key != null && a.Value != null)
+			{
+				survivor_list.Add(a);
+			}
+		}
+
+		int res = dict_in_question.Count - survivor_list.Count;
+		dict_in_question.Clear();
+
+		for (int i = 0, max = survivor_list.Count; i < max; i++)
+		{
+			dict_in_question.Add(survivor_list[i].Key, survivor_list[i].Value);
+		}
+
+		return res;
+	}
+
+	public static void EndRoundCleanup()
+	{
+	}
+
+	public static void CleanupInbetweenScenes()
+	{
+	}
+
+	public static void RoundStartCleanup()
+	{
+	}
+}

--- a/UnityProject/Assets/Scripts/Core/Lifecycle/CleanupUtil.cs.meta
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/CleanupUtil.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7215c04e30f78cc4e8b38090440891d7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Standard Assets/Logger/Logger.cs
+++ b/UnityProject/Assets/Standard Assets/Logger/Logger.cs
@@ -500,6 +500,11 @@ public enum Category
 		/// Logs for use in the editor
 		/// </summary>
 		Editor,
+
+		/// <summary>
+		/// Logs that describe work of memory cleanup actions
+		/// </summary>
+		MemoryCleanup,
 }
 
 [Serializable]


### PR DESCRIPTION
<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->

### Purpose
Adds foundation that will be used later in all future PR's related to fixing memory leaks 

### Notes:
Should not break anything on it's own but double checking would always be nice

### Changelog:
Added ability to log typenames and, sometimes, names of leaked objects 
Replaced Debug.Log with Logger.Log
Added special logger category specifically for memory cleanup debug messages
Got rid of snake case
Added docstrings