### PR TITLE
Memory leak fix : UI_ItemImage, Highlight, SpriteHandler

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Highlight/Highlight.cs
+++ b/UnityProject/Assets/Scripts/Core/Highlight/Highlight.cs
@@ -83,7 +83,7 @@ public class Highlight : MonoBehaviour, IInitialise
 			foreach (var SH in SubscribeSpriteHandlers)
 			{
 				if (SH == null) continue;
-				SH.OnSpriteChanged -= UpdateCurrentHighlight;
+				SH.OnSpriteChanged.Remove(UpdateCurrentHighlight);
 			}
 			SubscribeSpriteHandlers.Clear();
 		}
@@ -103,7 +103,7 @@ public class Highlight : MonoBehaviour, IInitialise
 			foreach (var SH in SubscribeSpriteHandlers)
 			{
 				if (SH == null) continue;
-				SH.OnSpriteChanged -= UpdateCurrentHighlight;
+				SH.OnSpriteChanged.Remove(UpdateCurrentHighlight);
 			}
 			SubscribeSpriteHandlers.Clear();
 
@@ -155,15 +155,15 @@ public class Highlight : MonoBehaviour, IInitialise
 		foreach (var SH in SubscribeSpriteHandlers)
 		{
 			if (SH == null) continue;
-			SH.OnSpriteChanged -= UpdateCurrentHighlight;
+			SH.OnSpriteChanged.Remove(UpdateCurrentHighlight);
 		}
 
 		SubscribeSpriteHandlers = Highlightobject.GetComponentsInChildren<SpriteHandler>().ToList();
 		foreach (var SH in SubscribeSpriteHandlers)
 		{
 			if (SH == null) continue;
-			SH.OnSpriteChanged -= UpdateCurrentHighlight;
-			SH.OnSpriteChanged += UpdateCurrentHighlight;
+			SH.OnSpriteChanged.Remove(UpdateCurrentHighlight);
+			SH.OnSpriteChanged.Add(UpdateCurrentHighlight);
 		}
 
 		SpriteRenderers = SpriteRenderers.Where(x => x.sprite != null && x != instance.spriteRenderer).ToArray();
@@ -219,7 +219,7 @@ public class Highlight : MonoBehaviour, IInitialise
 		foreach (var SH in SubscribeSpriteHandlers)
 		{
 			if (SH == null) continue;
-			SH.OnSpriteChanged -= UpdateCurrentHighlight;
+			SH.OnSpriteChanged.Remove(UpdateCurrentHighlight);
 		}
 		SubscribeSpriteHandlers.Clear();
 	}

--- a/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandler.cs
+++ b/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandler.cs
@@ -89,7 +89,7 @@ public class SpriteHandler : MonoBehaviour
 	/// Invokes when sprite just changed by animation or other script
 	/// Null if sprite became hidden
 	/// </summary>
-	public event Action<Sprite> OnSpriteChanged;
+	public List<Action<Sprite>> OnSpriteChanged = new List<Action<Sprite>>();
 
 	/// <summary>
 	/// Invokes when sprite data scriptable object is changed
@@ -100,7 +100,7 @@ public class SpriteHandler : MonoBehaviour
 	/// <summary>
 	/// Invoke when sprite handler has changed color of sprite
 	/// </summary>
-	public event Action<Color> OnColorChanged;
+	public List<Action<Color>> OnColorChanged = new List<Action<Color>>();
 
 	/// <summary>
 	/// The amount of SubCatalogues defined for this SpriteHandler.
@@ -336,6 +336,8 @@ public class SpriteHandler : MonoBehaviour
 		PushClear(false);
 		PresentSpriteSet = null;
 		OnSpriteDataSOChanged?.Invoke(null);
+		OnColorChanged.Clear();
+		OnSpriteChanged.Clear();
 
 		if (networked)
 		{
@@ -655,7 +657,7 @@ public class SpriteHandler : MonoBehaviour
 			image.color = value;
 		}
 
-		OnColorChanged?.Invoke(value);
+		new List<Action<Color>>(OnColorChanged?.ToArray()).ForEach(u => u(value));
 	}
 
 	protected virtual  void UpdateImageColor()
@@ -761,7 +763,7 @@ public class SpriteHandler : MonoBehaviour
 			}
 		}
 
-		OnSpriteChanged?.Invoke(value);
+		new List<Action<Sprite>>(OnSpriteChanged?.ToArray()).ForEach(u => u(value));
 	}
 
 	protected virtual bool HasSpriteInImageComponent()
@@ -806,7 +808,8 @@ public class SpriteHandler : MonoBehaviour
 		}
 
 		TryToggleAnimationState(false);
-		OnSpriteChanged?.Invoke(null);
+		OnSpriteChanged.Clear();
+		OnColorChanged.Clear();
 	}
 
 	private bool IsPaletted()

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemImage.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemImage.cs
@@ -159,11 +159,20 @@ public class UI_ItemImage
 		while (usedImages.Count != 0)
 		{
 			var usedImage = usedImages.Pop();
-			freeImages.Push(usedImage);
+			usedImage.Clear();
+
+			if (usedImage.UIImage != null)
+			{
+				freeImages.Push(usedImage);
+			}
+			else
+			{
+				usedImage.Clear();
+			}
 
 			// reset and hide used image
-			usedImage.Handler = null;
-			usedImage.UIImage.enabled = false;
+			//usedImage.Handler = null;
+			//usedImage.UIImage.enabled = false;
 		}
 
 		SetOverlay(null);
@@ -211,13 +220,58 @@ public class UI_ItemImage
 	/// This class subscribe UIImage to SpriteHandler updates
 	/// If SpriteHandler updates sprite this will also update it for UIImage
 	/// </summary>
-	private class ImageAndHandler
+	public class ImageAndHandler
 	{
-		public Image UIImage { get; private set; }
+		public static List<System.WeakReference<ImageAndHandler>> item_list = new List<System.WeakReference<ImageAndHandler>>();
+
+		System.WeakReference<Image> _img;
+
+		public Image UIImage
+		{
+			get
+			{
+				Image trg;
+				if (!_img.TryGetTarget(out trg))
+				{
+					return null;
+				}
+				else
+				{
+					return trg;
+				}
+			}
+			private set
+			{
+				_img = new System.WeakReference<Image>(value);
+			}
+		}
 		private SpriteHandler handler;
+
+		public static void ClearAll()
+		{
+			foreach (var a in item_list)
+			{
+				ImageAndHandler iah;
+
+				if (a.TryGetTarget(out iah))
+				{
+					try
+					{
+						iah.Clear();
+					}
+					catch(System.Exception ee)
+					{
+						Debug.LogException(ee);
+					}
+				}
+			}
+
+			item_list.Clear();
+		}
 
 		public ImageAndHandler(Image image)
 		{
+			item_list.Add(new System.WeakReference<ImageAndHandler>(this));
 			UIImage = image;
 		}
 
@@ -232,8 +286,8 @@ public class UI_ItemImage
 				// unsubscribe from old handler changes
 				if (handler != null)
 				{
-					handler.OnSpriteChanged -= OnHandlerSpriteChanged;
-					handler.OnColorChanged -= OnHandlerColorChanged;
+					handler.OnSpriteChanged.Remove(OnHandlerSpriteChanged);
+					handler.OnColorChanged.Remove(OnHandlerColorChanged);
 				}
 
 				handler = value;
@@ -241,8 +295,8 @@ public class UI_ItemImage
 				// subscribe to new handler changes
 				if (handler)
 				{
-					handler.OnSpriteChanged += OnHandlerSpriteChanged;
-					handler.OnColorChanged += OnHandlerColorChanged;
+					handler.OnSpriteChanged.Add(OnHandlerSpriteChanged);
+					handler.OnColorChanged.Add(OnHandlerColorChanged);
 				}
 			}
 		}
@@ -254,8 +308,8 @@ public class UI_ItemImage
 				// looks like image was deleted from scene
 				// this happens when item is moved in container
 				// and player close this container
-				handler.OnSpriteChanged -= OnHandlerSpriteChanged;
-				handler.OnColorChanged -= OnHandlerColorChanged;
+				handler.OnSpriteChanged.Remove(OnHandlerSpriteChanged);
+				handler.OnColorChanged.Remove(OnHandlerColorChanged);
 				return;
 			}
 
@@ -269,8 +323,8 @@ public class UI_ItemImage
 				// looks like image was deleted from scene
 				// this happens when item is moved in container
 				// and player close this container
-				handler.OnSpriteChanged -= OnHandlerSpriteChanged;
-				handler.OnColorChanged -= OnHandlerColorChanged;
+				handler.OnSpriteChanged.Remove(OnHandlerSpriteChanged);
+				handler.OnColorChanged.Remove(OnHandlerColorChanged);
 				return;
 			}
 
@@ -284,6 +338,12 @@ public class UI_ItemImage
 				UIImage.gameObject.SetActive(false);
 			}
 
+		}
+
+		internal void Clear()
+		{
+			handler.OnSpriteChanged.Remove(OnHandlerSpriteChanged);
+			handler.OnColorChanged.Remove(OnHandlerColorChanged);
 		}
 	}
 }


### PR DESCRIPTION
### Purpose
Following changes enable possibility of breaking up loose references to/from UI_ItemImage, Highlight, SpriteHandler. 

### Notes:
This one's for real could break stuff. I request thorough check. 
Whenever events were replaced with lists of actions it's because I had to remove delegates that have leave references keeping objects from being GC'ed.

### Changelog:

