### PR TITLE
Memory leak fix : ship thruster

### DIFF
--- a/UnityProject/Assets/Scripts/Shuttles/MatrixMove.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/MatrixMove.cs
@@ -66,7 +66,7 @@ public class MatrixMove : ManagedBehaviour
 	/// <summary>
 	/// All the various events that can be subscribed to on this matrix
 	/// </summary>
-	public readonly MatrixMoveEvents MatrixMoveEvents = new MatrixMoveEvents();
+	public MatrixMoveEvents MatrixMoveEvents = new MatrixMoveEvents();
 
 	//server-only values
 	public MatrixState ServerState => serverState;

--- a/UnityProject/Assets/Scripts/Shuttles/ShipThruster.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/ShipThruster.cs
@@ -37,6 +37,17 @@ public class ShipThruster : MonoBehaviour
 		shipMatrixMove.MatrixMoveEvents.OnRotate.RemoveListener(RotateFX);
 	}
 
+	private void OnDestroy()
+	{
+		if (shipMatrixMove == null)
+		{
+			return;
+		}
+		shipMatrixMove.MatrixMoveEvents.OnStartMovementClient.RemoveListener(UpdateEngineState);
+		shipMatrixMove.MatrixMoveEvents.OnStopMovementClient.RemoveListener(UpdateEngineState);
+		shipMatrixMove.MatrixMoveEvents.OnRotate.RemoveListener(RotateFX);
+	}
+
 	IEnumerator Init()
 	{
 		int tries = 0;


### PR DESCRIPTION
### Purpose
This change allows ShipThruster to clean stuff after itself to not leave objects dangling in memory aimlessly

### Notes:


### Changelog:
