### PR TITLE
Memory leak fix : RoundEndScoreBuilder

### DIFF
--- a/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.cs
+++ b/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.cs
@@ -19,6 +19,12 @@ namespace Systems.Score
 			EventManager.AddHandler(Event.RoundStarted, CreateCommonScoreEntries);
 		}
 
+		public override void OnDestroy()
+		{
+			EventManager.RemoveHandler(Event.RoundEnded, CalculateScoresAndShow);
+			EventManager.RemoveHandler(Event.RoundStarted, CreateCommonScoreEntries);
+			base.OnDestroy();
+		}
 		private void CreateCommonScoreEntries()
 		{
 			ScoreMachine.AddNewScoreEntry(COMMON_SCORE_LABORPOINTS, "Total Labor Points", ScoreMachine.ScoreType.Int, ScoreCategory.StationScore, ScoreAlignment.Good);


### PR DESCRIPTION
### Purpose
Pretty straightforward : allows RoundEndScoreBuilder to remove itself from places necessary in order to not cause any memory oppsie-doopsie

### Notes:


### Changelog: