### PR TITLE
Advanced Light Replacer Fix

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Tool/AdvancedLightReplacer.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/AdvancedLightReplacer.cs
@@ -25,7 +25,7 @@ namespace Items.Tool
 		{
 			if (lightTuner && interaction.IsAltClick)
 			{
-				LightTunerWindowOpen();
+				LightTunerWindowOpen(interaction.PerformerPlayerScript.netIdentity.connectionToServer);
 				return;
 			}
 			lightTuner = !lightTuner;
@@ -81,7 +81,8 @@ namespace Items.Tool
 			source.TryAddBulb(target.ItemObject);
 		}
 
-		private void LightTunerWindowOpen()
+		[TargetRpc]
+		private void LightTunerWindowOpen(NetworkConnection target)
 		{
 			UIManager.Instance.GlobalColorPicker.EnablePicker(SetColorToTune);
 		}

--- a/UnityProject/Assets/Scripts/Items/Tool/AdvancedLightReplacer.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/AdvancedLightReplacer.cs
@@ -25,7 +25,7 @@ namespace Items.Tool
 		{
 			if (lightTuner && interaction.IsAltClick)
 			{
-				LightTunerWindowOpen(interaction.PerformerPlayerScript.netIdentity.connectionToServer);
+				LightTunerWindowOpen(interaction.PerformerPlayerScript.netIdentity.connectionToClient);
 				return;
 			}
 			lightTuner = !lightTuner;


### PR DESCRIPTION
CL: [Fix] Fixed an issue with Advanced Light Replacers that caused the color picker window to be opened on the server rather than on the interactor's client.
