### PR TITLE
Fixes Automated Announcer

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawn.cs
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawn.cs
@@ -97,9 +97,8 @@ public static class PlayerSpawn
 		public GameObject Player;
 	}
 
-	public delegate void SpawnHandler(object sender, SpawnEventArgs args);
 
-	public static event SpawnHandler SpawnEvent;
+	public static event Action<GameObject> SpawnEvent;
 
 
 	//Time to start spawning players at arrivals
@@ -167,7 +166,8 @@ public static class PlayerSpawn
 	{
 		//Validate?
 		var mind = SpawnMind(character);
-		SpawnAndApplyRole(mind, requestedOccupation, character, SpawnType.NewSpawn);
+		var playerObject = SpawnAndApplyRole(mind, requestedOccupation, character, SpawnType.NewSpawn);
+		SpawnEvent?.Invoke(playerObject);
 		return mind;
 	}
 

--- a/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawn.cs
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawn.cs
@@ -92,13 +92,7 @@ public interface IClientPlayerTransferProcess
 /// </summary>
 public static class PlayerSpawn
 {
-	public class SpawnEventArgs : EventArgs
-	{
-		public GameObject Player;
-	}
-
-
-	public static event Action<GameObject> SpawnEvent;
+	public static event Action<Mind> SpawnEvent;
 
 
 	//Time to start spawning players at arrivals
@@ -150,6 +144,7 @@ public static class PlayerSpawn
 
 			var mind = NewSpawnCharacterV2(requestedOccupation, character);
 			TransferAccountToSpawnedMind(account, mind);
+			SpawnEvent?.Invoke(mind);
 			return mind;
 		}
 		catch (Exception e)
@@ -157,7 +152,6 @@ public static class PlayerSpawn
 			Logger.LogError(e.ToString());
 			return null;
 		}
-
 	}
 
 
@@ -166,8 +160,7 @@ public static class PlayerSpawn
 	{
 		//Validate?
 		var mind = SpawnMind(character);
-		var playerObject = SpawnAndApplyRole(mind, requestedOccupation, character, SpawnType.NewSpawn);
-		SpawnEvent?.Invoke(playerObject);
+		SpawnAndApplyRole(mind, requestedOccupation, character, SpawnType.NewSpawn);
 		return mind;
 	}
 

--- a/UnityProject/Assets/Scripts/Objects/Telecomms/AutomatedAnnouncer.cs
+++ b/UnityProject/Assets/Scripts/Objects/Telecomms/AutomatedAnnouncer.cs
@@ -77,7 +77,7 @@ namespace Objects.Telecomms
 
 		private void AnnounceNewCrewmember(Mind player)
 		{
-			string playerName = player.CurrentPlayScript.characterSettings.Name;
+			string playerName = player.CurrentCharacterSettings.Name;
 			Loudness annoucementImportance = GetAnnouncementImportance(player.occupation);
 
 			ChatChannel chatChannels = ChatChannel.Common;

--- a/UnityProject/Assets/Scripts/Objects/Telecomms/AutomatedAnnouncer.cs
+++ b/UnityProject/Assets/Scripts/Objects/Telecomms/AutomatedAnnouncer.cs
@@ -57,7 +57,7 @@ namespace Objects.Telecomms
 			}
 		}
 
-		private void ServerOnPlayerSpawned(GameObject player)
+		private void ServerOnPlayerSpawned(Mind player)
 		{
 			/*
 			if (GameManager.Instance.stationTime < TIME_BEFORE_JOIN_ANNOUNCEMENTS)
@@ -78,44 +78,42 @@ namespace Objects.Telecomms
 		public override void SignalFailed() { }
 
 
-		private void AnnounceNewCrewmember(GameObject player)
+		private void AnnounceNewCrewmember(Mind player)
 		{
-			PlayerScript playerScript = player.GetComponent<PlayerScript>();
-			Occupation playerOccupation = playerScript.Mind.occupation;
-			string playerName = player.ExpensiveName();
-			Loudness annoucementImportance = GetAnnouncementImportance(playerOccupation);
+			string playerName = player.CurrentPlayScript.visibleName;
+			Loudness annoucementImportance = GetAnnouncementImportance(player.occupation);
 
 			ChatChannel chatChannels = ChatChannel.Common;
-			string commonMessage = $"{playerName} has signed up as {playerOccupation.DisplayName}.";
-			string deptMessage = $"{playerName}, {playerOccupation.DisplayName}, is the department head.";
+			string commonMessage = $"{playerName} has signed up as {player.occupation.DisplayName}.";
+			string deptMessage = $"{playerName}, {player.occupation.DisplayName}, is the department head.";
 
 			// Get the channel of the newly joined head from their occupation.
-			if (channelFromJob.ContainsKey(playerOccupation.JobType))
+			if (channelFromJob.ContainsKey(player.occupation.JobType))
 			{
-				BroadcastCommMsg(channelFromJob[playerOccupation.JobType], deptMessage, annoucementImportance);
+				BroadcastCommMsg(channelFromJob[player.occupation.JobType], deptMessage, annoucementImportance);
 			}
 
 			// Announce the arrival on the CentComm channel if is a CentComm occupation.
-			if (JobCategories.CentCommJobs.Contains(playerOccupation.JobType))
+			if (JobCategories.CentCommJobs.Contains(player.occupation.JobType))
 			{
 				chatChannels = ChatChannel.CentComm;
 			}
 
-			if (playerOccupation.JobType == JobType.AI)
+			if (player.occupation.JobType == JobType.AI)
 			{
-				commonMessage = $"{player.ExpensiveName()} has been bluespace-beamed into the AI core!";
+				commonMessage = $"{player.CurrentCharacterSettings.AiName} has been bluespace-beamed into the AI core!";
 			}
-			else if (playerOccupation.JobType == JobType.SYNDICATE)
+			else if (player.occupation.JobType == JobType.SYNDICATE)
 			{
 				chatChannels = ChatChannel.Syndicate;
 			}
-			else if (playerOccupation.IsCrewmember == false)
+			else if (player.occupation.IsCrewmember == false)
 			{
 				// Don't announce non-crewmembers like wizards, fugitives at all (they don't have their own chat channel).
 				return;
 			}
 
-			BroadcastCommMsg(chatChannels, commonMessage, GetAnnouncementImportance(playerOccupation));
+			BroadcastCommMsg(chatChannels, commonMessage, GetAnnouncementImportance(player.occupation));
 		}
 
 		private Loudness GetAnnouncementImportance(Occupation job)

--- a/UnityProject/Assets/Scripts/Objects/Telecomms/AutomatedAnnouncer.cs
+++ b/UnityProject/Assets/Scripts/Objects/Telecomms/AutomatedAnnouncer.cs
@@ -59,13 +59,10 @@ namespace Objects.Telecomms
 
 		private void ServerOnPlayerSpawned(Mind player)
 		{
-			/*
 			if (GameManager.Instance.stationTime < TIME_BEFORE_JOIN_ANNOUNCEMENTS)
 			{
 				return;
 			}
-			*/
-
 			AnnounceNewCrewmember(player);
 		}
 
@@ -80,7 +77,7 @@ namespace Objects.Telecomms
 
 		private void AnnounceNewCrewmember(Mind player)
 		{
-			string playerName = player.CurrentPlayScript.visibleName;
+			string playerName = player.CurrentPlayScript.characterSettings.Name;
 			Loudness annoucementImportance = GetAnnouncementImportance(player.occupation);
 
 			ChatChannel chatChannels = ChatChannel.Common;

--- a/UnityProject/Assets/Scripts/Objects/Telecomms/AutomatedAnnouncer.cs
+++ b/UnityProject/Assets/Scripts/Objects/Telecomms/AutomatedAnnouncer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Managers;
 using Systems.Electricity;
 using UnityEngine;
 using Communications;
@@ -58,14 +57,16 @@ namespace Objects.Telecomms
 			}
 		}
 
-		private void ServerOnPlayerSpawned(object sender, PlayerSpawn.SpawnEventArgs args)
+		private void ServerOnPlayerSpawned(GameObject player)
 		{
+			/*
 			if (GameManager.Instance.stationTime < TIME_BEFORE_JOIN_ANNOUNCEMENTS)
 			{
 				return;
 			}
+			*/
 
-			AnnounceNewCrewmember(args.Player);
+			AnnounceNewCrewmember(player);
 		}
 
 		protected override bool SendSignalLogic()


### PR DESCRIPTION
fix #9309

CL: [Fix] Fixed an issue where an engineer forgot to plug back in the automated announcement machine to the station's power. Causing a month-long confusion as to why new crew members weren't getting announced when they joined.
