### PR TITLE
refactor: lowpop clearance now works as extra clearance

### DIFF
--- a/UnityProject/Assets/Scripts/Items/IDCard.cs
+++ b/UnityProject/Assets/Scripts/Items/IDCard.cs
@@ -4,7 +4,6 @@ using Items;
 using UnityEngine;
 using Mirror;
 using Systems.Clearance;
-using UnityEngine.Serialization;
 using WebSocketSharp;
 
 /// <summary>
@@ -23,16 +22,6 @@ public class IDCard : NetworkBehaviour, IServerInventoryMove, IServerSpawn, IInt
 	[Tooltip("Sprite to use when the card is a command-tier card")]
 	[SerializeField]
 	private Sprite commandSprite = null;
-
-	[Tooltip("This is used to place ID cards via map editor and then setting their initial clearance type")]
-	[SerializeField]
-	private List<Clearance> manuallyAddedClearance = new List<Clearance>();
-
-	[Tooltip("For cards added via map editor and set their initial IDCardType here. This will only work" +
-	         "if there are entries in ManuallyAddedAccess list")]
-	[FormerlySerializedAs("ManuallyAssignCardType")]
-	[SerializeField]
-	private IDCardType manuallyAssignCardType = IDCardType.standard;
 
 	[Tooltip("If true, will initialize itself with the correct access list, name, job, etc...based on the" +
 	         " first player whose inventory it is added to. Used for initial loadout.")]

--- a/UnityProject/Assets/Scripts/Items/IDCard.cs
+++ b/UnityProject/Assets/Scripts/Items/IDCard.cs
@@ -100,12 +100,6 @@ public class IDCard : NetworkBehaviour, IServerInventoryMove, IServerSpawn, IInt
 		var issuedClearance = occupation.IssuedClearance;
 		var lowPopClearance = occupation.IssuedLowPopClearance;
 
-		if (lowPopClearance.Any() == false)
-		{
-			lowPopClearance = issuedClearance;
-			Logger.LogError($"Occupation {occupation} has no issued clearance for low pop! Using normal clearance instead.", Category.Jobs);
-		}
-
 		switch (jobType)
 		{
 			case JobType.CAPTAIN:

--- a/UnityProject/Assets/Scripts/Systems/Clearance/BasicClearanceSource.cs
+++ b/UnityProject/Assets/Scripts/Systems/Clearance/BasicClearanceSource.cs
@@ -75,12 +75,13 @@ namespace Systems.Clearance
 		[Server]
 		public void ServerAddLowPopClearance(Clearance newClearance)
 		{
+			if (syncedLowpopClearance.Contains(newClearance))
+			{
+				return;
+			}
+
 			syncedLowpopClearance.Add(newClearance);
 			netIdentity.isDirty = true;
-			if (lowPopClearance.Contains(newClearance) == false)
-			{
-				lowPopClearance.Add(newClearance);
-			}
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/Systems/Clearance/BasicClearanceSource.cs
+++ b/UnityProject/Assets/Scripts/Systems/Clearance/BasicClearanceSource.cs
@@ -43,6 +43,11 @@ namespace Systems.Clearance
 		[Server]
 		public void ServerAddClearance(Clearance newClearance)
 		{
+			if (syncedClearance.Contains(newClearance))
+			{
+				return;
+			}
+
 			syncedClearance.Add(newClearance);
 			netIdentity.isDirty = true;
 		}

--- a/UnityProject/Assets/Scripts/Systems/Clearance/IClearanceSource.cs
+++ b/UnityProject/Assets/Scripts/Systems/Clearance/IClearanceSource.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace Systems.Clearance
 {
@@ -12,7 +13,7 @@ namespace Systems.Clearance
 		/// if the round is currently a lowpop round or not.
 		/// </summary>
 		/// <returns>Current relevant clearance</returns>
-		IEnumerable<Clearance> GetCurrentClearance => GameManager.Instance.CentComm.IsLowPop ? LowPopIssuedClearance : IssuedClearance;
+		IEnumerable<Clearance> GetCurrentClearance => GameManager.Instance.CentComm.IsLowPop ? IssuedClearance.Concat(LowPopIssuedClearance).Distinct() : IssuedClearance;
 
 		/// <summary>
 		/// Issued clearance for this clearance source. This list is consulted when the current round has a normal amount of population.
@@ -20,7 +21,7 @@ namespace Systems.Clearance
 		IEnumerable<Clearance> IssuedClearance { get; }
 
 		/// <summary>
-		/// Issued clearance for this source. This list is consulted when the current round has low population.
+		/// Extra issued clearance for this source. When the round is lowpop, this list is consulted in addition to the normal
 		/// </summary>
 		IEnumerable<Clearance> LowPopIssuedClearance { get; }
 	}

--- a/UnityProject/Assets/Tests/ClearanceFramework/HasClearanceTest.cs
+++ b/UnityProject/Assets/Tests/ClearanceFramework/HasClearanceTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Systems.Clearance;
 using NUnit.Framework;
 using UnityEngine;
@@ -12,7 +13,7 @@ namespace Tests.ClearanceFramework
 		public bool IsLowPop { get; set; } = false;
 
 		// Skips dependency with GameManager.Centcomm
-		public IEnumerable<Clearance> GetCurrentClearance => IsLowPop ? issuedLowPopClearance : issuedClearance;
+		public IEnumerable<Clearance> GetCurrentClearance => IsLowPop ? IssuedClearance.Concat(LowPopIssuedClearance).Distinct() : IssuedClearance;
 		public IEnumerable<Clearance> IssuedClearance => issuedClearance;
 		public IEnumerable<Clearance> LowPopIssuedClearance => issuedLowPopClearance;
 
@@ -94,6 +95,24 @@ namespace Tests.ClearanceFramework
 				new List<Clearance> {Clearance.Bar, Clearance.Armory, Clearance.Atmospherics});
 
 			Assert.True(restricted.HasClearance(source));
+		}
+
+		[Test]
+		public void GivenSufficientExtraClearanceWhenRoundIsLowPopResultsTrue()
+		{
+			restricted.SetClearance(new List<Clearance>{ Clearance.Captain });
+			source.SetClearance(new List<Clearance>(), new List<Clearance>{ Clearance.Captain });
+			source.IsLowPop = true;
+			Assert.True(restricted.HasClearance(source));
+		}
+
+		[Test]
+		public void GivenSufficientExtraClearanceWhenRoundIsNotLowPopResultsFalse()
+		{
+			restricted.SetClearance(new List<Clearance>{ Clearance.Captain });
+			source.SetClearance(new List<Clearance>(), new List<Clearance>{ Clearance.Captain });
+			source.IsLowPop = false;
+			Assert.False(restricted.HasClearance(source));
 		}
 	}
 }


### PR DESCRIPTION
### Purpose
Before we had to set individually every clearance level granted for low pop, now when the round is lowpop it will fetch the normal clearance and lowpop clearance as an extra.

### Notes:
* Added tests for the new behaviour.
* Tested something that @FuntimeDudeski was trying to do and didn't work on his local. It works perfectly for me now.
* Corrected the method that was adding lowpop clearance. It follows the Mirror guidelines now and modifies the synced list instead of the actual list.