### PR TITLE
add reactive armor as a possible steal objective

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/Steal.asset
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/Steal.asset
@@ -28,6 +28,7 @@ MonoBehaviour:
     - {fileID: 6398340229684661186, guid: 24461e841e57b3c499e6b3621dd50639, type: 3}
     - {fileID: 5374960043103273218, guid: 5653131fc0c7f0b46af145251ab061d4, type: 3}
     - {fileID: 3921521694364753778, guid: 3bce251232ebb5a49a7a932420df0027, type: 3}
+    - {fileID: 7552157255587117345, guid: f736e201fb6e2d046ac2c309e9b62997, type: 3}
     m_values:
     - AmountToSteal: 3
       BlacklistedOccupations:
@@ -95,3 +96,7 @@ MonoBehaviour:
       - {fileID: 11400000, guid: 3d8b17fd7b70945e19b1bb25504461c0, type: 2}
       - {fileID: 11400000, guid: e54df7e9d577f4d6da43439e4a949ad4, type: 2}
       - {fileID: 11400000, guid: 2fa29e9d68e1547c4b009c1515de2372, type: 2}
+    - AmountToSteal: 1
+      BlacklistedOccupations:
+      - {fileID: 11400000, guid: ea02bc3c4a28c430ea905db72a3630ec, type: 2}
+  uniqueTargets: 1


### PR DESCRIPTION

### Purpose

Adds the reactive armor (added in #9436) to the possible steal objectives list, with the RD blacklisted for it.

### Changelog:

CL: [New] the RD's Reactive Armor is now a possible item to get as a steal objective for the traitor.

