### PR TITLE
Explosion damaged balancing

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Implants/HumanBodyPartExternal.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/HumanBodyPartExternal.prefab
@@ -215,6 +215,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1274760333973328556, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
+      propertyPath: _assetId
+      value: 953877173
+      objectReference: {fileID: 0}
+    - target: {fileID: 1274760333973328556, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
       propertyPath: m_AssetId
       value: e241039a7933eb347bd1a9bb67a9078a
       objectReference: {fileID: 0}
@@ -366,10 +371,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a35915b45cb54b97bc3c38a21c1d3209, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
-  isEMPVunerable: 0
-  EMPResistance: 2
   traumaTypesOnBodyPart:
   - {fileID: 2728592379231489674}
   - {fileID: 6102157500274823570}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanHead.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanHead.prefab
@@ -312,6 +312,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2780246240171570206, guid: e241039a7933eb347bd1a9bb67a9078a,
         type: 3}
+      propertyPath: _assetId
+      value: 4279644326
+      objectReference: {fileID: 0}
+    - target: {fileID: 2780246240171570206, guid: e241039a7933eb347bd1a9bb67a9078a,
+        type: 3}
       propertyPath: m_AssetId
       value: 78253771c2047f94c9ae40161a6be7ee
       objectReference: {fileID: 0}
@@ -374,6 +379,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7822575272286095514, guid: e241039a7933eb347bd1a9bb67a9078a,
+        type: 3}
+      propertyPath: deadlyDamageInOneHit
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 8234622556944347693, guid: e241039a7933eb347bd1a9bb67a9078a,
         type: 3}

--- a/UnityProject/Assets/Scripts/Systems/Explosions/Explosion.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/Explosion.cs
@@ -188,7 +188,7 @@ namespace Systems.Explosions
 			int Radius = 0;
 			if (fixedRadius <= 0)
 			{
-				Radius = (int)Math.Round(strength / (Math.PI * 75));
+				Radius = (int)Math.Round(strength / (Math.PI * 75)) + 5;
 			}
 			else
 			{


### PR DESCRIPTION

### Changelog:


CL: [Balance] balances explosion damag, heads should take more damage to be remove from explosions
CL: [Balance] Small explosions have a radius buff ( unless manually Overwritten)

