### PR TITLE
Fixes bruise packs using stacks when they shouldn't

### DIFF
--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/Trauma/BodyPartTrauma.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/Trauma/BodyPartTrauma.cs
@@ -51,12 +51,19 @@ namespace HealthV2
 			}
 		}
 
-		public void HealTraumaStage(TraumaticDamageTypes traumaToHeal)
+		public bool HealTraumaStage(TraumaticDamageTypes traumaToHeal)
 		{
+			var healed = false;
 			foreach (var logic in traumaTypesOnBodyPart)
 			{
-				if (traumaToHeal.HasFlag(logic.traumaTypes)) logic.HealStage();
+				if (traumaToHeal.HasFlag(logic.traumaTypes))
+				{
+					logic.HealStage();
+					healed = true;
+				}
 			}
+
+			return healed;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/Trauma/BodyPartTrauma.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/Trauma/BodyPartTrauma.cs
@@ -56,7 +56,7 @@ namespace HealthV2
 			var healed = false;
 			foreach (var logic in traumaTypesOnBodyPart)
 			{
-				if (traumaToHeal.HasFlag(logic.traumaTypes))
+				if (traumaToHeal.HasFlag(logic.traumaTypes) && logic.CurrentStage > 0)
 				{
 					logic.HealStage();
 					healed = true;

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/Trauma/CreatureTraumaManager.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/Trauma/CreatureTraumaManager.cs
@@ -18,7 +18,6 @@ namespace HealthV2
 		public bool HealBodyPartTrauma(BodyPart bodyPart, TraumaticDamageTypes traumaToHeal)
 		{
 			if (bodyPart == null || Traumas.ContainsKey(bodyPart) == false) return false;
-			if (Traumas[bodyPart])
 			Traumas[bodyPart].HealTraumaStage(traumaToHeal);
 			return true;
 		}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/Trauma/CreatureTraumaManager.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/Trauma/CreatureTraumaManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace HealthV2
@@ -14,15 +15,36 @@ namespace HealthV2
 			if (health == null) health = GetComponent<LivingHealthMasterBase>();
 		}
 
-		public void HealBodyPartTrauma(BodyPart bodyPart, TraumaticDamageTypes traumaToHeal)
+		public bool HealBodyPartTrauma(BodyPart bodyPart, TraumaticDamageTypes traumaToHeal)
 		{
-			if (bodyPart == null || Traumas.ContainsKey(bodyPart) == false) return;
+			if (bodyPart == null || Traumas.ContainsKey(bodyPart) == false) return false;
+			if (Traumas[bodyPart])
 			Traumas[bodyPart].HealTraumaStage(traumaToHeal);
+			return true;
 		}
 
-		public BodyPartTrauma CheckBodyPart(BodyPart bodyPart)
+		public bool HasAnyTrauma()
 		{
-			return bodyPart.GetComponentInChildren<BodyPartTrauma>();
+			foreach (var trauma in Traumas.Values)
+			{
+				if (trauma.TraumaTypesOnBodyPart.Any(logic => logic.CurrentStage > 0))
+				{
+					return true;
+				}
+			}
+			return false;
+		}
+
+		public bool HasAnyTraumaOfType(TraumaticDamageTypes type)
+		{
+			foreach (var trauma in Traumas.Values)
+			{
+				if (trauma.TraumaTypesOnBodyPart.Any(logic => logic.traumaTypes.HasFlag(type)))
+				{
+					return true;
+				}
+			}
+			return false;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/Trauma/CreatureTraumaManager.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/Trauma/CreatureTraumaManager.cs
@@ -18,8 +18,7 @@ namespace HealthV2
 		public bool HealBodyPartTrauma(BodyPart bodyPart, TraumaticDamageTypes traumaToHeal)
 		{
 			if (bodyPart == null || Traumas.ContainsKey(bodyPart) == false) return false;
-			Traumas[bodyPart].HealTraumaStage(traumaToHeal);
-			return true;
+			return Traumas[bodyPart].HealTraumaStage(traumaToHeal);
 		}
 
 		public bool HasAnyTrauma()

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/Trauma/TraumaLogic.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/Trauma/TraumaLogic.cs
@@ -11,6 +11,7 @@ namespace HealthV2
 		[SerializeField] protected BodyPart bodyPart;
 
 		protected int currentStage = 0;
+		public int CurrentStage => currentStage;
 
 		/// <summary>
 		/// Key: Stage Number. Value: Required Damage to trigger.

--- a/UnityProject/Assets/Scripts/Items/Medical/HealsTheLiving.cs
+++ b/UnityProject/Assets/Scripts/Items/Medical/HealsTheLiving.cs
@@ -111,19 +111,18 @@ public class HealsTheLiving : MonoBehaviour, ICheckedInteractable<HandApply>
 	protected bool HasTrauma(LivingHealthMasterBase health)
 	{
 		if (health.gameObject.TryGetComponent<CreatureTraumaManager>(out var traumaManager) == false) return false;
-		foreach (var bodyPartTrauma in traumaManager.Traumas)
-		{
-			if(bodyPartTrauma.Value.TraumaTypesOnBodyPart.Any(x => x.traumaTypes.HasFlag(TraumaTypeToHeal)) == false) continue;
-			return true;
-		}
-		return false;
+		return traumaManager.HasAnyTraumaOfType(TraumaTypeToHeal) == false;
 	}
 
 	protected virtual void HealTrauma(LivingHealthMasterBase health, HandApply interaction)
 	{
 		if (health.gameObject.TryGetComponent<CreatureTraumaManager>(out var traumaManager) == false) return;
-		foreach (var bodyPart in health.BodyPartList) traumaManager.HealBodyPartTrauma(bodyPart, TraumaTypeToHeal);
-		stackable.ServerConsume(1);
+		var healedTrauma = false;
+		foreach (var bodyPart in health.BodyPartList)
+		{
+			if (traumaManager.HealBodyPartTrauma(bodyPart, TraumaTypeToHeal)) healedTrauma = true;
+		}
+		if(healedTrauma) stackable.ServerConsume(1);
 	}
 
 	protected void RemoveLimbLossBleed(LivingHealthMasterBase livingHealth, HandApply interaction)


### PR DESCRIPTION
CL: [Fix] Fixed an issue where bruise packs and similar items can be infinitely consumed when they shouldn't have.