### PR TITLE
New Game Mode: Blood Brothers

### DIFF
--- a/UnityProject/Assets/Resources/ScriptableObjectsSingletons/adminJobsList.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjectsSingletons/adminJobsList.asset
@@ -43,3 +43,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 1d7227f39af36094bb76b5a52d690ad3, type: 2}
   - {fileID: 11400000, guid: 0f19f9b747ac2ee499c57e02517aed37, type: 2}
   - {fileID: 11400000, guid: 47b1b2dfe2f734c4a9b5785a7768807b, type: 2}
+  - {fileID: 11400000, guid: 054c3003e031e0a4c9146f6b0f806940, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Antagonists/AntagData.asset
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/AntagData.asset
@@ -20,6 +20,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 7325a4893b19676439a5fdb39d2cc069, type: 2}
   - {fileID: 11400000, guid: 4e33e3c5bcb99b34cbab164bcfa68951, type: 2}
   - {fileID: 11400000, guid: 0f19f9b747ac2ee499c57e02517aed37, type: 2}
+  - {fileID: 11400000, guid: 054c3003e031e0a4c9146f6b0f806940, type: 2}
   SharedObjectives:
   - {fileID: 11400000, guid: 180a8d8c464973b4ebcf1d9778e8b895, type: 2}
   - {fileID: 11400000, guid: 62560f1cff23ba84b9fe8e661f199730, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Antagonists/Antags/BloodBrother.asset
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/Antags/BloodBrother.asset
@@ -29,11 +29,14 @@ MonoBehaviour:
   canUseSharedObjectives: 1
   needsEscapeObjective: 0
   chanceForGimmickObjective: 50
-  coreObjectives:
-  - {fileID: 11400000, guid: 7bea1ef82dee8264aabacb465d9a7946, type: 2}
-  - {fileID: 11400000, guid: 748ac891cd195d145b7386127b0de87b, type: 2}
+  coreObjectives: []
   antagOccupation: {fileID: 0}
   showInPreferences: 1
+  <BlackListedObjectives>k__BackingField:
+  - {fileID: 11400000, guid: ae28c203a113d5b42a7099948692bb10, type: 2}
+  <AlwaysStartWithObjectives>k__BackingField:
+  - {fileID: 11400000, guid: 748ac891cd195d145b7386127b0de87b, type: 2}
+  - {fileID: 11400000, guid: 7bea1ef82dee8264aabacb465d9a7946, type: 2}
   extraHealthForBrothers: 550
   paranoiaSickness: {fileID: 8177265969630170377, guid: ad489c5a66fec7f418fa5935feb9efa2,
     type: 3}

--- a/UnityProject/Assets/ScriptableObjects/Antagonists/Antags/BloodBrother.asset
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/Antags/BloodBrother.asset
@@ -29,8 +29,7 @@ MonoBehaviour:
   canUseSharedObjectives: 1
   needsEscapeObjective: 0
   chanceForGimmickObjective: 50
-  coreObjectives:
-  - {fileID: 11400000, guid: 7bea1ef82dee8264aabacb465d9a7946, type: 2}
+  coreObjectives: []
   antagOccupation: {fileID: 0}
   showInPreferences: 1
   <BlackListedObjectives>k__BackingField:

--- a/UnityProject/Assets/ScriptableObjects/Antagonists/Antags/BloodBrother.asset
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/Antags/BloodBrother.asset
@@ -25,7 +25,7 @@ MonoBehaviour:
       m_EditorAssetChanged: 0
   textColor: {r: 1, g: 0, b: 0, a: 1}
   backgroundColor: {r: 0.1792453, g: 0, b: 0.067857586, a: 1}
-  numberOfObjectives: 2
+  numberOfObjectives: 3
   canUseSharedObjectives: 1
   needsEscapeObjective: 0
   chanceForGimmickObjective: 50
@@ -33,4 +33,6 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 7bea1ef82dee8264aabacb465d9a7946, type: 2}
   antagOccupation: {fileID: 0}
   showInPreferences: 1
-  extraHealthForBrothers: 350
+  extraHealthForBrothers: 550
+  paranoiaSickness: {fileID: 8177265969630170377, guid: ad489c5a66fec7f418fa5935feb9efa2,
+    type: 3}

--- a/UnityProject/Assets/ScriptableObjects/Antagonists/Antags/BloodBrother.asset
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/Antags/BloodBrother.asset
@@ -37,4 +37,4 @@ MonoBehaviour:
   extraHealthForBrothers: 550
   paranoiaSickness: {fileID: 8177265969630170377, guid: ad489c5a66fec7f418fa5935feb9efa2,
     type: 3}
-  initialTC: 11
+  initialTC: 8

--- a/UnityProject/Assets/ScriptableObjects/Antagonists/Antags/BloodBrother.asset
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/Antags/BloodBrother.asset
@@ -25,14 +25,16 @@ MonoBehaviour:
       m_EditorAssetChanged: 0
   textColor: {r: 1, g: 0, b: 0, a: 1}
   backgroundColor: {r: 0.1792453, g: 0, b: 0.067857586, a: 1}
-  numberOfObjectives: 3
+  numberOfObjectives: 4
   canUseSharedObjectives: 1
   needsEscapeObjective: 0
   chanceForGimmickObjective: 50
   coreObjectives:
   - {fileID: 11400000, guid: 7bea1ef82dee8264aabacb465d9a7946, type: 2}
+  - {fileID: 11400000, guid: 748ac891cd195d145b7386127b0de87b, type: 2}
   antagOccupation: {fileID: 0}
   showInPreferences: 1
   extraHealthForBrothers: 550
   paranoiaSickness: {fileID: 8177265969630170377, guid: ad489c5a66fec7f418fa5935feb9efa2,
     type: 3}
+  initialTC: 20

--- a/UnityProject/Assets/ScriptableObjects/Antagonists/Antags/BloodBrother.asset
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/Antags/BloodBrother.asset
@@ -37,4 +37,4 @@ MonoBehaviour:
   extraHealthForBrothers: 550
   paranoiaSickness: {fileID: 8177265969630170377, guid: ad489c5a66fec7f418fa5935feb9efa2,
     type: 3}
-  initialTC: 20
+  initialTC: 11

--- a/UnityProject/Assets/ScriptableObjects/Antagonists/Antags/BloodBrother.asset
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/Antags/BloodBrother.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d1f709a4738465bad8344d04d81ce34, type: 3}
+  m_Name: BloodBrother
+  m_EditorClassIdentifier: 
+  antagName: Blood Brother
+  antagJobType: 0
+  playSound: 0
+  spawnSound:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
+  textColor: {r: 1, g: 0, b: 0, a: 1}
+  backgroundColor: {r: 0.1792453, g: 0, b: 0.067857586, a: 1}
+  numberOfObjectives: 2
+  canUseSharedObjectives: 1
+  needsEscapeObjective: 0
+  chanceForGimmickObjective: 50
+  coreObjectives:
+  - {fileID: 11400000, guid: 7bea1ef82dee8264aabacb465d9a7946, type: 2}
+  antagOccupation: {fileID: 0}
+  showInPreferences: 1
+  extraHealthForBrothers: 350

--- a/UnityProject/Assets/ScriptableObjects/Antagonists/Antags/BloodBrother.asset
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/Antags/BloodBrother.asset
@@ -25,11 +25,12 @@ MonoBehaviour:
       m_EditorAssetChanged: 0
   textColor: {r: 1, g: 0, b: 0, a: 1}
   backgroundColor: {r: 0.1792453, g: 0, b: 0.067857586, a: 1}
-  numberOfObjectives: 4
+  numberOfObjectives: 5
   canUseSharedObjectives: 1
   needsEscapeObjective: 0
   chanceForGimmickObjective: 50
-  coreObjectives: []
+  coreObjectives:
+  - {fileID: 11400000, guid: 7bea1ef82dee8264aabacb465d9a7946, type: 2}
   antagOccupation: {fileID: 0}
   showInPreferences: 1
   <BlackListedObjectives>k__BackingField:

--- a/UnityProject/Assets/ScriptableObjects/Antagonists/Antags/BloodBrother.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/Antags/BloodBrother.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 054c3003e031e0a4c9146f6b0f806940
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/BloodBrotherMainObjective.asset
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/BloodBrotherMainObjective.asset
@@ -13,6 +13,6 @@ MonoBehaviour:
   m_Name: BloodBrotherMainObjective
   m_EditorClassIdentifier: 
   objectiveName: Brother's Survival
-  IsUnique: 0
+  IsUnique: 1
   description: All Blood Brothers must stay alive till the end of the round.
   aiCanHave: 1

--- a/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/BloodBrotherMainObjective.asset
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/BloodBrotherMainObjective.asset
@@ -15,4 +15,4 @@ MonoBehaviour:
   objectiveName: Brother's Survival
   IsUnique: 0
   description: All Blood Brothers must stay alive till the end of the round.
-  aiCanHave: 0
+  aiCanHave: 1

--- a/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/BloodBrotherMainObjective.asset
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/BloodBrotherMainObjective.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 861da5b264924d5cb7b8d8184cf3825a, type: 3}
+  m_Name: BloodBrotherMainObjective
+  m_EditorClassIdentifier: 
+  objectiveName: Brother's Survival
+  IsUnique: 0
+  description: All Blood Brothers must stay alive till the end of the round.
+  aiCanHave: 0

--- a/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/BloodBrotherMainObjective.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/BloodBrotherMainObjective.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7bea1ef82dee8264aabacb465d9a7946
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/GameModes/BloodBrothers.asset
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/BloodBrothers.asset
@@ -1,0 +1,31 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6cb18b3b91044f949ac792fbc90255bb, type: 3}
+  m_Name: BloodBrothers
+  m_EditorClassIdentifier: 
+  gameModeName: Blood Brothers
+  description: Two syndicate agents bound with their blood must complete objectives
+    together with limited resources. If one of the antag dies, the other ones dies
+    as well.
+  canRespawn: 0
+  minPlayers: 6
+  antagRatio: 0
+  minAntags: 2
+  maxAntags: 2
+  hardNumberOfAntagsToSpawn: 2
+  forceMinAntags: 1
+  teamGameMode: 1
+  midRoundAntags: 0
+  midRoundAntagsChance: 25
+  possibleAntags: []
+  allocateJobsToAntags: 1
+  nonAntagJobTypes: 06000000160000001700000023000000210000001100000001000000

--- a/UnityProject/Assets/ScriptableObjects/GameModes/BloodBrothers.asset
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/BloodBrothers.asset
@@ -13,19 +13,21 @@ MonoBehaviour:
   m_Name: BloodBrothers
   m_EditorClassIdentifier: 
   gameModeName: Blood Brothers
-  description: Two syndicate agents bound with their blood must complete objectives
-    together with limited resources. If one of the antag dies, the other ones dies
-    as well.
-  canRespawn: 0
+  description: Two syndicate agents bound by their blood to each other after being
+    expiremented on in prison must complete objectives together with limited resources.
+    If one of the antag dies, the other ones dies as well.
+  canRespawn: 1
   minPlayers: 6
-  antagRatio: 0
+  antagRatio: 0.2
   minAntags: 2
-  maxAntags: 2
+  maxAntags: 4
   hardNumberOfAntagsToSpawn: 2
   forceMinAntags: 1
   teamGameMode: 1
-  midRoundAntags: 0
+  midRoundAntags: 1
   midRoundAntagsChance: 25
-  possibleAntags: []
+  possibleAntags:
+  - {fileID: 11400000, guid: 054c3003e031e0a4c9146f6b0f806940, type: 2}
+  - {fileID: 11400000, guid: c060c33698c0f81449f0735a800740ca, type: 2}
   allocateJobsToAntags: 1
   nonAntagJobTypes: 06000000160000001700000023000000210000001100000001000000

--- a/UnityProject/Assets/ScriptableObjects/GameModes/BloodBrothers.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/BloodBrothers.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 603078f33eb2da242a66f808a5e1b59f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/GameModes/GameModeData.asset
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/GameModeData.asset
@@ -18,4 +18,5 @@ MonoBehaviour:
   - {fileID: 11400000, guid: a07c32cfb5b43954c908ca8910ad76e5, type: 2}
   - {fileID: 11400000, guid: c353eaa51022b234ea81a69d54a1cee7, type: 2}
   - {fileID: 11400000, guid: be5a87a6a81f8e043a1dbddc99b71db7, type: 2}
+  - {fileID: 11400000, guid: 603078f33eb2da242a66f808a5e1b59f, type: 2}
   DefaultGameMode: {fileID: 11400000, guid: a07c32cfb5b43954c908ca8910ad76e5, type: 2}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -270,6 +270,8 @@ namespace HealthV2
 		public event Action<DamageType, GameObject> OnTakeDamageType;
 		public event Action OnLowHealth;
 
+		public event Action OnDeath;
+
 		[SyncVar] public bool CannotRecognizeNames = false;
 
 
@@ -1326,6 +1328,7 @@ namespace HealthV2
 
 			SetConsciousState(ConsciousState.DEAD);
 			OnDeathActions();
+			OnDeath?.Invoke();
 		}
 
 		protected abstract void OnDeathActions();

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -1310,7 +1310,7 @@ namespace HealthV2
 		///<Summary>
 		/// Kills the creature, used for causes of death other than damage.
 		///</Summary>
-		public void Death()
+		public void Death(bool invokeDeathEvent = true)
 		{
 			//Don't trigger if already dead
 			if (ConsciousState == ConsciousState.DEAD) return;
@@ -1328,7 +1328,7 @@ namespace HealthV2
 
 			SetConsciousState(ConsciousState.DEAD);
 			OnDeathActions();
-			OnDeath?.Invoke();
+			if (invokeDeathEvent) OnDeath?.Invoke();
 		}
 
 		protected abstract void OnDeathActions();

--- a/UnityProject/Assets/Scripts/Managers/GameManager.GameMode.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.GameMode.cs
@@ -56,7 +56,7 @@ public partial class GameManager
 	/// <summary>
 	/// The current game mode
 	/// </summary>
-	private GameMode GameMode;
+	public GameMode GameMode { get; private set; }
 
 	/// <summary>
 	/// Sets the current gamemode using a string to find the gamemode name

--- a/UnityProject/Assets/Scripts/Player/Mind.cs
+++ b/UnityProject/Assets/Scripts/Player/Mind.cs
@@ -12,6 +12,7 @@ using Items.PDA;
 using Messages.Server;
 using ScriptableObjects.Audio;
 using ScriptableObjects.Systems.Spells;
+using Systems.Antagonists.Antags;
 using UI.Core.Action;
 
 /// <summary>
@@ -645,7 +646,7 @@ public class Mind : NetworkBehaviour, IActionGUI
 		Chat.AddExamineMsgFromServer(playerMob, antag.GetObjectivesForPlayer());
 
 		if (playerMob.TryGetComponent<PlayerScript>(out var body) == false) return;
-		if (antag.Antagonist.AntagJobType == JobType.TRAITOR || antag.Antagonist.AntagJobType == JobType.SYNDICATE)
+		if (antag.Antagonist.AntagJobType == JobType.TRAITOR || antag.Antagonist.AntagJobType == JobType.SYNDICATE || antag.Antagonist is BloodBrother)
 		{
 			string codeWordsString = "Code Words:";
 			for (int i = 0; i < CodeWordManager.WORD_COUNT; i++)

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/AntagData.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/AntagData.cs
@@ -124,7 +124,9 @@ namespace Antagonists
 
 			foreach (var alwaysStartWithObjective in antag.AlwaysStartWithObjectives)
 			{
-				generatedObjs.Add(Instantiate(alwaysStartWithObjective));
+				var objectiveNew = Instantiate(alwaysStartWithObjective);
+				objectiveNew.DoSetup(Mind);
+				generatedObjs.Add(objectiveNew);
 			}
 
 			return generatedObjs;

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/AntagData.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/AntagData.cs
@@ -66,10 +66,10 @@ namespace Antagonists
 		{
 			int amount = antag.NumberOfObjectives;
 			// Get all antag core and shared objectives which are possible for this player
-			List<Objective> objPool = antag.CoreObjectives.Where(obj => obj.IsPossible(Mind)).ToList();
+			List<Objective> objPool = antag.CoreObjectives.Where(obj => obj.IsPossible(Mind) && antag.BlackListedObjectives.Contains(obj) == false).ToList();
 			if (antag.CanUseSharedObjectives)
 			{
-				objPool = objPool.Concat(SharedObjectives).Where(obj => obj.IsPossible(Mind)).ToList();
+				objPool = objPool.Concat(SharedObjectives).Where(obj => obj.IsPossible(Mind) && antag.BlackListedObjectives.Contains(obj) == false).ToList();
 			}
 
 			if (objPool.Count == 0)

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/AntagData.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/AntagData.cs
@@ -124,7 +124,7 @@ namespace Antagonists
 
 			foreach (var alwaysStartWithObjective in antag.AlwaysStartWithObjectives)
 			{
-				antag.AddObjective(alwaysStartWithObjective);
+				generatedObjs.Add(Instantiate(alwaysStartWithObjective));
 			}
 
 			return generatedObjs;

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/AntagData.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/AntagData.cs
@@ -122,6 +122,11 @@ namespace Antagonists
 				generatedObjs.Add(newObjective);
 			}
 
+			foreach (var alwaysStartWithObjective in antag.AlwaysStartWithObjectives)
+			{
+				antag.AddObjective(alwaysStartWithObjective);
+			}
+
 			return generatedObjs;
 		}
 

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antagonist.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antagonist.cs
@@ -109,6 +109,8 @@ namespace Antagonists
 		/// </summary>
 		public bool ShowInPreferences => showInPreferences;
 
+		[field: SerializeField] public List<Objective> BlackListedObjectives { get; set; } = new List<Objective>();
+
 		/// <summary>
 		/// Server only. Spawn the joined viewer as the indicated antag, includes creating their player object
 		/// and transferring them to it.
@@ -128,6 +130,7 @@ namespace Antagonists
 
 		public void AddObjective(Objective objective)
 		{
+			if ( BlackListedObjectives.Contains(objective) ) return;
 			numberOfObjectives++;
 			coreObjectives.Add(objective);
 		}

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antagonist.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antagonist.cs
@@ -110,6 +110,7 @@ namespace Antagonists
 		public bool ShowInPreferences => showInPreferences;
 
 		[field: SerializeField] public List<Objective> BlackListedObjectives { get; set; } = new List<Objective>();
+		[field: SerializeField] public List<Objective> AlwaysStartWithObjectives { get; set; } = new List<Objective>();
 
 		/// <summary>
 		/// Server only. Spawn the joined viewer as the indicated antag, includes creating their player object

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/BloodBrother.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/BloodBrother.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using Antagonists;
 using GameModes;
+using Health.Sickness;
 using UnityEngine;
 using Task = System.Threading.Tasks.Task;
 
@@ -10,6 +11,7 @@ namespace Systems.Antagonists.Antags
 	public class BloodBrother : Antagonist
 	{
 		[SerializeField] private float extraHealthForBrothers = 350f;
+		[SerializeField] private Sickness paranoiaSickness;
 		public override void AfterSpawn(Mind SpawnMind)
 		{
 			Chat.AddExamineMsg(SpawnMind.Body.gameObject,
@@ -18,6 +20,11 @@ namespace Systems.Antagonists.Antags
 			CheckForOtherBloodBrothers(SpawnMind.Body.gameObject);
 			SpawnMind.Body.playerHealth.OnDeath += BloodBrothers.OnBrotherDeath;
 			SpawnMind.Body.playerHealth.SetMaxHealth(SpawnMind.Body.playerHealth.MaxHealth + extraHealthForBrothers);
+			if (DMMath.Prob(15))
+			{
+				SpawnMind.Body.playerHealth.AddSickness(paranoiaSickness);
+				Chat.AddExamineMsg(SpawnMind.Body.gameObject, "Due to your past in prison.. You've gained paranoia from the experiments they've done on you.");
+			}
 		}
 
 		private async void CheckForOtherBloodBrothers(GameObject spawnMind)

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/BloodBrother.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/BloodBrother.cs
@@ -12,6 +12,12 @@ namespace Systems.Antagonists.Antags
 	{
 		[SerializeField] private float extraHealthForBrothers = 350f;
 		[SerializeField] private Sickness paranoiaSickness;
+
+		[Tooltip("For use in Syndicate Uplinks")]
+		[SerializeField]
+		private int initialTC = 12;
+
+
 		public override void AfterSpawn(Mind SpawnMind)
 		{
 			Chat.AddExamineMsg(SpawnMind.Body.gameObject,
@@ -20,14 +26,15 @@ namespace Systems.Antagonists.Antags
 			CheckForOtherBloodBrothers(SpawnMind.Body.gameObject);
 			SpawnMind.Body.playerHealth.OnDeath += BloodBrothers.OnBrotherDeath;
 			SpawnMind.Body.playerHealth.SetMaxHealth(SpawnMind.Body.playerHealth.MaxHealth + extraHealthForBrothers);
+			AntagManager.TryInstallPDAUplink(SpawnMind, initialTC, false);
 			if (DMMath.Prob(15))
 			{
 				SpawnMind.Body.playerHealth.AddSickness(paranoiaSickness);
-				Chat.AddExamineMsg(SpawnMind.Body.gameObject, 
+				Chat.AddExamineMsg(SpawnMind.Body.gameObject,
 					"Due to your past in prison.. You've gained paranoia from the experiments they've done on you.");
 				return;
 			}
-			Chat.AddExamineMsg(SpawnMind.Body.gameObject, 
+			Chat.AddExamineMsg(SpawnMind.Body.gameObject,
 				"You feel much more resilient.");
 		}
 

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/BloodBrother.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/BloodBrother.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+using Antagonists;
+using GameModes;
+using UnityEngine;
+using Task = System.Threading.Tasks.Task;
+
+namespace Systems.Antagonists.Antags
+{
+	[CreateAssetMenu(menuName="ScriptableObjects/Antagonist/BloodBrother")]
+	public class BloodBrother : Antagonist
+	{
+		[SerializeField] private float extraHealthForBrothers = 350f;
+		public override void AfterSpawn(Mind SpawnMind)
+		{
+			Chat.AddExamineMsg(SpawnMind.Body.gameObject,
+				"<color=red>You're a convicted prisoner who was given" +
+				"a new chance for freedom by the syndicate. You and your blood brothers <b>must all succeed</b> to earn your freedom, or die trying.</color>");
+			CheckForOtherBloodBrothers(SpawnMind.Body.gameObject);
+			SpawnMind.Body.playerHealth.OnDeath += BloodBrothers.OnBrotherDeath;
+			SpawnMind.Body.playerHealth.SetMaxHealth(SpawnMind.Body.playerHealth.MaxHealth + extraHealthForBrothers);
+		}
+
+		private async void CheckForOtherBloodBrothers(GameObject spawnMind)
+		{
+			await Task.Delay(1250);
+			if (AntagManager.Instance.AntagCount < 2)
+			{
+				NoBrothersFound(spawnMind);
+				return;
+			}
+
+			var listOfBrotherNames = new List<string>();
+			foreach (var brother in AntagManager.Instance.ActiveAntags)
+			{
+				if (brother.Antagonist is not BloodBrother) continue;
+				listOfBrotherNames.Add(brother.Owner.CurrentPlayScript.characterSettings.Name);
+			}
+
+			if (listOfBrotherNames.Count < 2)
+			{
+				NoBrothersFound(spawnMind);
+				return;
+			}
+
+			Chat.AddExamineMsg(spawnMind,"<color=red>Your blood brothers are:</color>");
+			foreach (var brotherName in listOfBrotherNames)
+			{
+				Chat.AddExamineMsg(spawnMind,$"- {brotherName}");
+			}
+		}
+
+		private void NoBrothersFound(GameObject spawnMind)
+		{
+			Chat.AddExamineMsg(spawnMind,"<color=red>Your blood brother has not arrived with you..</color>");
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/BloodBrother.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/BloodBrother.cs
@@ -4,6 +4,7 @@ using GameModes;
 using Health.Sickness;
 using UnityEngine;
 using Task = System.Threading.Tasks.Task;
+using Wizard = Antagonists.Wizard;
 
 namespace Systems.Antagonists.Antags
 {
@@ -27,6 +28,12 @@ namespace Systems.Antagonists.Antags
 			SpawnMind.Body.playerHealth.OnDeath += BloodBrothers.OnBrotherDeath;
 			SpawnMind.Body.playerHealth.SetMaxHealth(SpawnMind.Body.playerHealth.MaxHealth + extraHealthForBrothers);
 			AntagManager.TryInstallPDAUplink(SpawnMind, initialTC, false);
+			if (DMMath.Prob(25))
+			{
+				Wizard.AddSpellToPlayer(Wizard.GetRandomWizardSpell(), SpawnMind);
+				Chat.AddExamineMsg(SpawnMind.Body.gameObject,
+					"Due to your past in prison.. You've gained magical ability.");
+			}
 			if (DMMath.Prob(15))
 			{
 				SpawnMind.Body.playerHealth.AddSickness(paranoiaSickness);

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/BloodBrother.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/BloodBrother.cs
@@ -15,16 +15,20 @@ namespace Systems.Antagonists.Antags
 		public override void AfterSpawn(Mind SpawnMind)
 		{
 			Chat.AddExamineMsg(SpawnMind.Body.gameObject,
-				"<color=red>You're a convicted prisoner who was given" +
-				"a new chance for freedom by the syndicate. You and your blood brothers <b>must all succeed</b> to earn your freedom, or die trying.</color>");
+				"<color=red>You're a convicted prisoner and test subject who was given " +
+				"a new chance for freedom by the syndicate.\n You and your blood brothers <b>must all succeed</b> to earn your freedom, or die trying.</color>");
 			CheckForOtherBloodBrothers(SpawnMind.Body.gameObject);
 			SpawnMind.Body.playerHealth.OnDeath += BloodBrothers.OnBrotherDeath;
 			SpawnMind.Body.playerHealth.SetMaxHealth(SpawnMind.Body.playerHealth.MaxHealth + extraHealthForBrothers);
 			if (DMMath.Prob(15))
 			{
 				SpawnMind.Body.playerHealth.AddSickness(paranoiaSickness);
-				Chat.AddExamineMsg(SpawnMind.Body.gameObject, "Due to your past in prison.. You've gained paranoia from the experiments they've done on you.");
+				Chat.AddExamineMsg(SpawnMind.Body.gameObject, 
+					"Due to your past in prison.. You've gained paranoia from the experiments they've done on you.");
+				return;
 			}
+			Chat.AddExamineMsg(SpawnMind.Body.gameObject, 
+				"You feel much more resilient.");
 		}
 
 		private async void CheckForOtherBloodBrothers(GameObject spawnMind)

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/BloodBrother.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/BloodBrother.cs
@@ -24,7 +24,7 @@ namespace Systems.Antagonists.Antags
 			Chat.AddExamineMsg(SpawnMind.Body.gameObject,
 				"<color=red>You're a convicted prisoner and test subject who was given " +
 				"a new chance for freedom by the syndicate.\n You and your blood brothers <b>must all succeed</b> to earn your freedom, or die trying.</color>");
-			CheckForOtherBloodBrothers(SpawnMind.Body.gameObject);
+			_ = CheckForOtherBloodBrothers(SpawnMind.Body.gameObject);
 			SpawnMind.Body.playerHealth.OnDeath += BloodBrothers.OnBrotherDeath;
 			SpawnMind.Body.playerHealth.SetMaxHealth(SpawnMind.Body.playerHealth.MaxHealth + extraHealthForBrothers);
 			AntagManager.TryInstallPDAUplink(SpawnMind, initialTC, false);
@@ -45,7 +45,7 @@ namespace Systems.Antagonists.Antags
 				"You feel much more resilient.");
 		}
 
-		private async void CheckForOtherBloodBrothers(GameObject spawnMind)
+		private async Task CheckForOtherBloodBrothers(GameObject spawnMind)
 		{
 			await Task.Delay(1250);
 			if (AntagManager.Instance.AntagCount < 2)

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/BloodBrother.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/BloodBrother.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5d1f709a4738465bad8344d04d81ce34
+timeCreated: 1679353919

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Wizard.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Wizard.cs
@@ -62,14 +62,25 @@ namespace Antagonists
 
 			foreach (WizardSpellData randomSpell in GetRandomWizardSpells())
 			{
-				Spell spell = randomSpell.AddToPlayer(player);
-				player.AddSpell(spell);
+				AddSpellToPlayer(randomSpell, player);
 				playerMsg.Append($"<b>{randomSpell.Name}</b>, ");
 			}
 
 			playerMsg.RemoveLast(", ").Append(".");
 
 			Chat.AddExamineMsgFromServer(player.gameObject, playerMsg.ToString());
+		}
+
+		public static void AddSpellToPlayer(WizardSpellData randomSpell, Mind player)
+		{
+			Spell spell = randomSpell.AddToPlayer(player);
+			player.AddSpell(spell);
+		}
+
+		public static void AddSpellToPlayer(SpellData randomSpell, Mind player)
+		{
+			Spell spell = randomSpell.AddToPlayer(player);
+			player.AddSpell(spell);
 		}
 
 		private void SetPapers(Mind player)
@@ -107,6 +118,16 @@ namespace Antagonists
 		private IEnumerable<SpellData> GetRandomWizardSpells()
 		{
 			return SpellList.Instance.Spells.Where(s => s is WizardSpellData).PickRandom(StartingSpellCount);
+		}
+
+		public static IEnumerable<SpellData> GetRandomWizardSpells(int numberOfSpells)
+		{
+			return SpellList.Instance.Spells.Where(s => s is WizardSpellData).PickRandom(numberOfSpells);
+		}
+
+		public static SpellData GetRandomWizardSpell()
+		{
+			return SpellList.Instance.Spells.Where(s => s is WizardSpellData).PickRandom();
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/Assassinate.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/Assassinate.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Systems.Antagonists.Antags;
 using UnityEngine;
 using Systems.GhostRoles;
 
@@ -21,7 +22,9 @@ namespace Antagonists
 		/// </summary>
 		protected override bool IsPossibleInternal(Mind candidate)
 		{
-			int targetCount = PlayerList.Instance.InGamePlayers.Count(p => (p.Mind != candidate) && !AntagManager.Instance.TargetedPlayers.Contains(p.Mind));
+			int targetCount = PlayerList.Instance.InGamePlayers.Count(p => (p.Mind != candidate)
+			                                                               && AntagManager.Instance.TargetedPlayers.Contains(p.Mind) == false
+			                                                               && p.Mind.GetAntag().Antagonist is not BloodBrother);
 			return (targetCount > 0);
 		}
 

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/BloodBrotherMainObjective.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/BloodBrotherMainObjective.cs
@@ -7,7 +7,10 @@ namespace Antagonists
 	[CreateAssetMenu(menuName="ScriptableObjects/AntagObjectives/Special/BloodBrotherMainObjective")]
 	public class BloodBrotherMainObjective : Objective
 	{
-		protected override void Setup() { }
+		protected override void Setup()
+		{
+			// PISS
+		}
 
 		protected override bool CheckCompletion()
 		{

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/BloodBrotherMainObjective.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/BloodBrotherMainObjective.cs
@@ -1,0 +1,22 @@
+﻿using Systems.Antagonists.Antags;
+using UnityEngine;
+
+namespace Antagonists
+{
+	[CreateAssetMenu(menuName="ScriptableObjects/AntagObjectives/Special/BloodBrotherMainObjective")]
+	public class BloodBrotherMainObjective : Objective
+	{
+		protected override void Setup() { }
+
+		protected override bool CheckCompletion()
+		{
+			foreach (var possibleBrother in AntagManager.Instance.ActiveAntags)
+			{
+				if (possibleBrother.Antagonist is not BloodBrother) continue;
+				if (possibleBrother.Owner.CurrentPlayScript.playerHealth.IsDead == false) continue;
+				return false;
+			}
+			return true;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/BloodBrotherMainObjective.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/BloodBrotherMainObjective.cs
@@ -1,4 +1,5 @@
-﻿using Systems.Antagonists.Antags;
+﻿using GameModes;
+using Systems.Antagonists.Antags;
 using UnityEngine;
 
 namespace Antagonists
@@ -10,13 +11,7 @@ namespace Antagonists
 
 		protected override bool CheckCompletion()
 		{
-			foreach (var possibleBrother in AntagManager.Instance.ActiveAntags)
-			{
-				if (possibleBrother.Antagonist is not BloodBrother) continue;
-				if (possibleBrother.Owner.CurrentPlayScript.playerHealth.IsDead == false) continue;
-				return false;
-			}
-			return true;
+			return BloodBrothers.AreBrothersAlive();
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/BloodBrotherMainObjective.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/BloodBrotherMainObjective.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 861da5b264924d5cb7b8d8184cf3825a
+timeCreated: 1679357137

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/NotCuffed.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/NotCuffed.cs
@@ -13,12 +13,12 @@ namespace Antagonists
 		protected override bool CheckCompletion()
 		{
 			//for whatever reason this is null, give the guy the greentext
-			if (Owner.Body == null || Owner.Body.TryGetComponent<DynamicItemStorage>(out var dynamicItemStorage) == false) return true;
+			if (Owner == null || Owner.Body == null || Owner.Body.TryGetComponent<DynamicItemStorage>(out var dynamicItemStorage) == false) return true;
 
 			foreach (var handCuffs in dynamicItemStorage.GetNamedItemSlots(NamedSlot.handcuffs))
 			{
 				if (handCuffs.IsEmpty) continue;
-				
+
 				//If any hands are cuff then we fail
 				return false;
 			}

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/NotCuffed.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/NotCuffed.cs
@@ -12,8 +12,13 @@ namespace Antagonists
 
 		protected override bool CheckCompletion()
 		{
+			if (Owner == null)
+			{
+				Logger.LogError("[Objective/NotCuffed] - No owner found! Giving free objective.");
+				return true;
+			}
 			//for whatever reason this is null, give the guy the greentext
-			if (Owner == null || Owner.Body == null || Owner.Body.TryGetComponent<DynamicItemStorage>(out var dynamicItemStorage) == false) return true;
+			if (Owner.Body == null || Owner.Body.TryGetComponent<DynamicItemStorage>(out var dynamicItemStorage) == false) return true;
 
 			foreach (var handCuffs in dynamicItemStorage.GetNamedItemSlots(NamedSlot.handcuffs))
 			{

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/NotCuffed.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/NotCuffed.cs
@@ -12,15 +12,13 @@ namespace Antagonists
 
 		protected override bool CheckCompletion()
 		{
-			DynamicItemStorage dynamicItemStorage = Owner.Body.GetComponent<DynamicItemStorage>();
-
 			//for whatever reason this is null, give the guy the greentext
-			if (dynamicItemStorage == null) return true;
+			if (Owner.Body == null || Owner.Body.TryGetComponent<DynamicItemStorage>(out var dynamicItemStorage) == false) return true;
 
 			foreach (var handCuffs in dynamicItemStorage.GetNamedItemSlots(NamedSlot.handcuffs))
 			{
-				if(handCuffs.IsEmpty) continue;
-
+				if (handCuffs.IsEmpty) continue;
+				
 				//If any hands are cuff then we fail
 				return false;
 			}

--- a/UnityProject/Assets/Scripts/Systems/GameModes/BloodBrothers.cs
+++ b/UnityProject/Assets/Scripts/Systems/GameModes/BloodBrothers.cs
@@ -14,7 +14,7 @@ namespace GameModes
 		{
 			base.EndRoundReport();
 			CheckFreedomStatus();
-			if(BrothersEarnedTheirFreedom() == false) OnBrotherDeath();
+			if (BrothersEarnedTheirFreedom() == false) OnBrotherDeath();
 		}
 
 		private static void CheckFreedomStatus()

--- a/UnityProject/Assets/Scripts/Systems/GameModes/BloodBrothers.cs
+++ b/UnityProject/Assets/Scripts/Systems/GameModes/BloodBrothers.cs
@@ -20,11 +20,11 @@ namespace GameModes
 		{
 			if (AreBrothersAlive() && BrothersEarnedTheirFreedom())
 			{
-				Chat.AddGameWideSystemMsgToChat("<color=green><size+=35>The Blood Brothers have earned their freedom.");
+				Chat.AddGameWideSystemMsgToChat("<color=green><size+=35>The Blood Brothers have earned their freedom.</size></color>");
 			}
 			else
 			{
-				Chat.AddGameWideSystemMsgToChat("<color=red><size+=35>The Blood Brothers have failed to earn their freedom.");
+				Chat.AddGameWideSystemMsgToChat("<color=red><size+=35>The Blood Brothers have failed to earn their freedom.</size></color>");
 				OnBrotherDeath();
 			}
 		}

--- a/UnityProject/Assets/Scripts/Systems/GameModes/BloodBrothers.cs
+++ b/UnityProject/Assets/Scripts/Systems/GameModes/BloodBrothers.cs
@@ -70,7 +70,7 @@ namespace GameModes
 				}
 			}
 
-			return (int)Math.Round((double)(100 * totalNumberOfObjectivesCompleted) / totalNumberOfObjectives) > 75;
+			return totalNumberOfObjectivesCompleted / totalNumberOfObjectives > 0.7;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/GameModes/BloodBrothers.cs
+++ b/UnityProject/Assets/Scripts/Systems/GameModes/BloodBrothers.cs
@@ -14,6 +14,7 @@ namespace GameModes
 		{
 			base.EndRoundReport();
 			CheckFreedomStatus();
+			if(BrothersEarnedTheirFreedom() == false) OnBrotherDeath();
 		}
 
 		private static void CheckFreedomStatus()
@@ -25,7 +26,6 @@ namespace GameModes
 			else
 			{
 				Chat.AddGameWideSystemMsgToChat("<color=red><size+=35>The Blood Brothers have failed to earn their freedom.</size></color>");
-				OnBrotherDeath();
 			}
 		}
 
@@ -44,7 +44,7 @@ namespace GameModes
 				}
 			}
 
-			if(GameManager.Instance.CurrentRoundState == RoundState.Ended) return;
+			if (GameManager.Instance.CurrentRoundState == RoundState.Ended) return;
 			if (GameManager.Instance.GameMode is BloodBrothers)
 			{
 				GameManager.Instance.EndRound();

--- a/UnityProject/Assets/Scripts/Systems/GameModes/BloodBrothers.cs
+++ b/UnityProject/Assets/Scripts/Systems/GameModes/BloodBrothers.cs
@@ -21,11 +21,11 @@ namespace GameModes
 		{
 			if (AreBrothersAlive() && BrothersEarnedTheirFreedom())
 			{
-				Chat.AddGameWideSystemMsgToChat("<color=green><size+=35>The Blood Brothers have earned their freedom.</size></color>");
+				Chat.AddGameWideSystemMsgToChat("<color=green><size=+35>The Blood Brothers have earned their freedom.</size></color>");
 			}
 			else
 			{
-				Chat.AddGameWideSystemMsgToChat("<color=red><size+=35>The Blood Brothers have failed to earn their freedom.</size></color>");
+				Chat.AddGameWideSystemMsgToChat("<color=red><size=+35>The Blood Brothers have failed to earn their freedom.</size></color>");
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Systems/GameModes/BloodBrothers.cs
+++ b/UnityProject/Assets/Scripts/Systems/GameModes/BloodBrothers.cs
@@ -1,0 +1,26 @@
+﻿using Antagonists;
+using Systems.Antagonists.Antags;
+using Systems.Explosions;
+using UnityEngine;
+
+namespace GameModes
+{
+	[CreateAssetMenu(menuName="ScriptableObjects/GameModes/BloodBrothers")]
+	public class BloodBrothers : GameMode
+	{
+		public static void OnBrotherDeath()
+		{
+			foreach (var possibleBrother in AntagManager.Instance.ActiveAntags)
+			{
+				if (possibleBrother.Antagonist is not BloodBrother) continue;
+				Chat.AddExamineMsg(possibleBrother.Owner.Body.gameObject,
+					"You feel your fellow brother part ways with their body.. And you follow them.");
+				possibleBrother.Owner.CurrentPlayScript.playerHealth.Death();
+				if (DMMath.Prob(15))
+				{
+					Explosion.StartExplosion(possibleBrother.Owner.Body.gameObject.AssumedWorldPosServer().CutToInt(), 750);
+				}
+			}
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/GameModes/BloodBrothers.cs
+++ b/UnityProject/Assets/Scripts/Systems/GameModes/BloodBrothers.cs
@@ -37,6 +37,9 @@ namespace GameModes
 					Explosion.StartExplosion(possibleBrother.Owner.Body.gameObject.AssumedWorldPosServer().CutToInt(), 750);
 				}
 			}
+
+			if(GameManager.Instance.CurrentRoundState == RoundState.Ended) return;
+			GameManager.Instance.EndRound();
 		}
 
 		public static bool AreBrothersAlive()

--- a/UnityProject/Assets/Scripts/Systems/GameModes/BloodBrothers.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/GameModes/BloodBrothers.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6cb18b3b91044f949ac792fbc90255bb
+timeCreated: 1679293438

--- a/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
+++ b/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
@@ -367,7 +367,7 @@ namespace GameModes
 			var jobAllocator = new JobAllocator();
 			var playerPool = PlayerList.Instance.ReadyPlayers;
 
-			AntagJobAllocation(jobAllocator, playerPool, playerSpawnRequests, antagSpawnRequests, antagsToSpawn);
+			AntagJobAllocation(jobAllocator, playerPool, ref playerSpawnRequests, ref antagSpawnRequests, antagsToSpawn);
 
 			// Spawn all players and antags
 			foreach (var spawnReq in playerSpawnRequests)

--- a/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
+++ b/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
@@ -468,7 +468,7 @@ namespace GameModes
 		/// <summary>
 		/// End the round and display any relevant reports
 		/// </summary>
-		public void EndRoundReport()
+		public virtual void EndRoundReport()
 		{
 			var roundDuration = GameManager.Instance.RoundTime.AddHours(-12);
 			var output = $"A round has ended. Round duration: {roundDuration.ToString("HH:mm")}.";

--- a/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
+++ b/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
@@ -412,7 +412,7 @@ namespace GameModes
 		}
 
 		protected void AntagJobAllocation(JobAllocator jobAllocator, List<PlayerInfo> playerPool,
-			List<PlayerSpawnRequest> playerSpawnRequests, List<PlayerSpawnRequest> antagSpawnRequests, int antagsToSpawn)
+			ref List<PlayerSpawnRequest> playerSpawnRequests, ref List<PlayerSpawnRequest> antagSpawnRequests, int antagsToSpawn)
 		{
 			try
 			{


### PR DESCRIPTION
closes #3128
This is my own take on the blood brothers game-mode, since i wanted it to be more unique than /tg/'s.

![posterbb](https://user-images.githubusercontent.com/34368774/226575575-9fa153b2-9773-4d30-b4ca-d3df869181a0.png)

# Introduction:

You're a convicted criminal who have been experimented on while you're in prison. During your time there, you've gained an unnatural ability to withstand more damage than any other humanoid can, and have formed a ritual with another inmate that gave you the ability to become a "Blood Brother".

A shadowy figure took interest in your bond with your blood brother, and have offered you a job on behalf of the syndicate in exchange for your freedom.

# Bonds that tie:

In this cooperative game-mode, at least two Blood Brothers start together with the sole goal of achieving at least 70% of their objectives to earn their freedom and to showcase their newly found capabilities to their shadowy employer. However:

- Blood Brothers are linked to each other, and the death of one means the failure and death of all other brothers.
- Blood Brothers start with an uplink that only has 8 TC, limiting the amount of immediate resources provided by the Syndicate for them.

If the **total** amount of greentexts is less than 70%, all blood brothers automatically fail.

# Experiments:

Every Blood brother starts with significantly more health, making them much more resilient and harder to kill. But also, some brothers have a small chance to spawn with Paranoia or a random spell.

# Changelog:

CL: [New] A new game-mode has been added, Blood Brothers! It currently requires at least 6 players to be chosen at the start of a round.
CL: [Improvement] Added a black-list and "Always spawn with objective" list for antags.