### PR TITLE
Fix auto-character generation for new game installs

### DIFF
--- a/UnityProject/Assets/Scripts/Player/PlayerManager.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerManager.cs
@@ -54,7 +54,7 @@ public class PlayerManager : MonoBehaviour
 
 	public static PlayerManager Instance => FindUtils.LazyFindObject(ref playerManager);
 
-	private void Awake()
+	private void Start()
 	{
 		CharacterManager.Init();
 	}

--- a/UnityProject/Assets/Scripts/Systems/Lobby/CharacterSheet.cs
+++ b/UnityProject/Assets/Scripts/Systems/Lobby/CharacterSheet.cs
@@ -280,6 +280,9 @@ public class CharacterSheet : ICloneable
 
 	#region StaticCustomizationFunctions
 
+	/// <summary>Generate a random character.</summary>
+	/// <remarks>not safe to use in Awake().</remarks>
+	/// <returns>a random character.</returns>
 	public static CharacterSheet GenerateRandomCharacter()
 	{
 		CharacterSheet character = new CharacterSheet();


### PR DESCRIPTION
CL: [Fix] Fix automatic character generation for new game installs (no saved characters). Fixes being unable to move until the client is restarted (doesn't fix being unable to move if the character sheet is invalid).