### PR TITLE
Fixes hand-labeler not working with containers

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Bureaucracy/HandLabeler.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Bureaucracy/HandLabeler.prefab
@@ -33,15 +33,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -81,6 +81,11 @@ PrefabInstance:
         type: 3}
       propertyPath: IsFixedMatrix
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114738972662350094, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: _assetId
+      value: 2030985636
       objectReference: {fileID: 0}
     - target: {fileID: 114738972662350094, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
@@ -124,6 +129,17 @@ PrefabInstance:
       propertyPath: hitSound.AssetAddress
       value: Assets/Prefabs/Effects/Tap.prefab
       objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialTraits.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 3b31d94e5f52dd740a920ade9a2dc27f,
+        type: 2}
     - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: PresentSpriteSet
@@ -155,6 +171,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7d55bb27d7729e44190487b1ada01adc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   refillTrait: {fileID: 11400000, guid: 9932d4994f6499b4e96c4ad0867c423f, type: 2}

--- a/UnityProject/Assets/Prefabs/Objects/ClosetsAndCrates/ClosetBase.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/ClosetsAndCrates/ClosetBase.prefab
@@ -451,6 +451,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 136634061082832056, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
+      propertyPath: _assetId
+      value: 801182241
+      objectReference: {fileID: 0}
+    - target: {fileID: 136634061082832056, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
       propertyPath: m_AssetId
       value: 68a3eee06f0a8cf4da5d8ab811ce1c73
       objectReference: {fileID: 0}
@@ -695,6 +700,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 55e27ef87b09cc84988939559a2f51ac, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   passableWhenOpen: 1
@@ -749,6 +755,8 @@ MonoBehaviour:
       m_SubObjectName: 
       m_SubObjectType: 
       m_EditorAssetChanged: 0
+  handPriorityTrait: {fileID: 11400000, guid: 3b31d94e5f52dd740a920ade9a2dc27f, type: 2}
+  CannotBeInteractedWithWhenClosed: 0
 --- !u!114 &-3721001473523075953
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -797,22 +805,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cf6a312c50114272bc561c429cbb4175, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   StoredGasMix:
     GasData:
       GasesArray:
       - GasSO: {fileID: 11400000, guid: ac2834f2705dcbc4da8731a53d3076fc, type: 2}
-        Moles: 8.314244
+        moles: 8.314244
       - GasSO: {fileID: 11400000, guid: d7d4e6085864f9f4e83593f63d102d08, type: 2}
-        Moles: 33.256973
-    Pressure: 101.32501
+        moles: 33.256973
+    pressure: 101.32501
     Volume: 1
-    Temperature: 293.15
+    temperature: 293.15
   MaximumMoles: 1013.25
   ReleasePressure: 101.325
-  Volume: 1
-  Temperature: 293.15
+  CargoSealApproved: 0
 --- !u!114 &6872015153723498109
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -825,6 +833,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 48487dad7f2bc0541964880f6187c474, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   isSecuredStateExaminable: 1

--- a/UnityProject/Assets/ScriptableObjects/Traits/Usage/PriorityHand.asset
+++ b/UnityProject/Assets/ScriptableObjects/Traits/Usage/PriorityHand.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ccfe138752d4b66bcb7c56a0c9769c7, type: 3}
+  m_Name: PriorityHand
+  m_EditorClassIdentifier: 
+  traitDescription: Gives priority to other objects in hand first.

--- a/UnityProject/Assets/ScriptableObjects/Traits/Usage/PriorityHand.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Traits/Usage/PriorityHand.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3b31d94e5f52dd740a920ade9a2dc27f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Items/Bureaucracy/HandLabeler.cs
+++ b/UnityProject/Assets/Scripts/Items/Bureaucracy/HandLabeler.cs
@@ -74,7 +74,7 @@ namespace Items
 				return;
 			}
 
-			var item = interaction.TargetObject.Item();
+			var item = interaction.TargetObject.AttributesOrNull();
 
 			item.ServerSetArticleName(item.InitialName + " '" + currentLabel + "'");
 
@@ -97,7 +97,7 @@ namespace Items
 		{
 			labelAmount = LABEL_CAPACITY;
 			_ = Despawn.ServerSingle(interaction.UsedObject);
-			Chat.AddExamineMsg(interaction.Performer, $"You insert the {interaction.UsedObject.Item().ArticleName.ToLower()} into the {gameObject.Item().InitialName.ToLower()}.");
+			Chat.AddExamineMsg(interaction.Performer, $"You insert the {interaction.UsedObject.AttributesOrNull().ArticleName.ToLower()} into the {gameObject.AttributesOrNull().InitialName.ToLower()}.");
 		}
 
 		public bool Interact(HandActivate interaction)

--- a/UnityProject/Assets/Scripts/Items/Bureaucracy/HandLabeler.cs
+++ b/UnityProject/Assets/Scripts/Items/Bureaucracy/HandLabeler.cs
@@ -45,7 +45,7 @@ namespace Items
 			if (!DefaultWillInteract.Default(interaction, side)) return false;
 			if (interaction.HandObject == null) return false;
 			if (interaction.TargetObject.AttributesOrNull() == null) return false;
-			if (HasWhiteListedComponents(interaction) == false)
+			if (HasWhiteListedComponents(interaction) == false) return false;
 
 			//if(interaction.HandObject.Item().HasTrait(refillTrait)) return true; //Check for refill
 

--- a/UnityProject/Assets/Scripts/Items/Bureaucracy/HandLabeler.cs
+++ b/UnityProject/Assets/Scripts/Items/Bureaucracy/HandLabeler.cs
@@ -44,13 +44,20 @@ namespace Items
 		{
 			if (!DefaultWillInteract.Default(interaction, side)) return false;
 			if (interaction.HandObject == null) return false;
-			if (interaction.TargetObject.Item() == null || interaction.TargetObject.HasComponent<ClosetControl>()) return false;
+			if (interaction.TargetObject.Item() == null || HasWhiteListedComponents(interaction) == false) return false;
 
 			//if(interaction.HandObject.Item().HasTrait(refillTrait)) return true; //Check for refill
 
 			if (interaction.HandObject != gameObject) return false;
 
 			return true;
+		}
+
+		private bool HasWhiteListedComponents(HandApply interaction)
+		{
+			return interaction.TargetObject.HasComponent<ClosetControl>() ||
+			       interaction.TargetObject.HasComponent<ItemStorage>() ||
+			       interaction.TargetObject.HasComponent<ObjectContainer>();
 		}
 
 		public void ServerPerformInteraction(HandApply interaction)

--- a/UnityProject/Assets/Scripts/Items/Bureaucracy/HandLabeler.cs
+++ b/UnityProject/Assets/Scripts/Items/Bureaucracy/HandLabeler.cs
@@ -1,6 +1,7 @@
 ﻿using Mirror;
 using System.Collections;
 using System.Collections.Generic;
+using Objects;
 using UnityEngine;
 
 namespace Items
@@ -43,7 +44,7 @@ namespace Items
 		{
 			if (!DefaultWillInteract.Default(interaction, side)) return false;
 			if (interaction.HandObject == null) return false;
-			if (interaction.TargetObject.Item() == null) return false; //Only works on items
+			if (interaction.TargetObject.Item() == null || interaction.TargetObject.HasComponent<ClosetControl>()) return false;
 
 			//if(interaction.HandObject.Item().HasTrait(refillTrait)) return true; //Check for refill
 

--- a/UnityProject/Assets/Scripts/Items/Bureaucracy/HandLabeler.cs
+++ b/UnityProject/Assets/Scripts/Items/Bureaucracy/HandLabeler.cs
@@ -44,7 +44,8 @@ namespace Items
 		{
 			if (!DefaultWillInteract.Default(interaction, side)) return false;
 			if (interaction.HandObject == null) return false;
-			if (interaction.TargetObject.Item() == null || HasWhiteListedComponents(interaction) == false) return false;
+			if (interaction.TargetObject.AttributesOrNull() == null) return false;
+			if (HasWhiteListedComponents(interaction) == false)
 
 			//if(interaction.HandObject.Item().HasTrait(refillTrait)) return true; //Check for refill
 
@@ -57,6 +58,7 @@ namespace Items
 		{
 			return interaction.TargetObject.HasComponent<ClosetControl>() ||
 			       interaction.TargetObject.HasComponent<ItemStorage>() ||
+				   interaction.TargetObject.HasComponent<ItemAttributesV2>() ||
 			       interaction.TargetObject.HasComponent<ObjectContainer>();
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
@@ -128,6 +128,8 @@ namespace Objects
 		public bool IsLocked => lockState == Lock.Locked;
 		public bool IsWelded => weldState == Weld.Welded;
 
+		[SerializeField] protected ItemTrait handPriorityTrait;
+
 
 		[SerializeField] private bool CannotBeInteractedWithWhenClosed = false;
 
@@ -329,11 +331,16 @@ namespace Objects
 			if (CannotBeInteractedWithWhenClosed && lockState == Lock.Locked) return false;
 			if (DefaultWillInteract.Default(interaction, side) == false) return false;
 			if (interaction.HandObject != null && interaction.Intent == Intent.Harm) return false;
+			if (interaction.HandObject != null &&
+			    handPriorityTrait != null && HasHandPriority(interaction.HandObject.PickupableOrNull()?.ItemAttributesV2)) return false;
 
 			//only allow interactions targeting this closet
-			if (interaction.TargetObject != gameObject) return false;
+			return interaction.TargetObject == gameObject;
+		}
 
-			return true;
+		private bool HasHandPriority(ItemAttributesV2 handObjectAttributes)
+		{
+			return handObjectAttributes.GetTraits().Contains(handPriorityTrait);
 		}
 
 		public void ServerPerformInteraction(PositionalHandApply interaction)

--- a/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
+++ b/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
@@ -39,6 +39,11 @@ public static class SweetExtensions
 		return go.OrNull()?.GetComponent<ObjectAttributes>();
 	}
 
+	public static Attributes AttributesOrNull(this GameObject go)
+	{
+		return go.OrNull()?.GetComponent<Attributes>();
+	}
+
 	public static bool HasComponent<T>(this GameObject go) where T : Component
 	{
 		return go.TryGetComponent<T>(out _);


### PR DESCRIPTION
fixes #9730

CL: [Improvement] hand-labeler can now work with storage containers as they should.
CL: [Fix] Interactions with closets can now be skipped in favor of items that contain the "PriorityHand" trait.
