### PR TITLE
 Fix for  #8789

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/ObjectLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/ObjectLayer.cs
@@ -139,7 +139,7 @@ public class ObjectLayer : Layer
 			}
 
 			//If you can't bump anything on an adjacent tile, you may be blocked by a bumpable object on your current tile (probably a windoor)
-			if (!Bumps.Any())
+			if (Bumps.Any() == false)
 			{
 				foreach (var objectOnTile in Matrix.Get<UniversalObjectPhysics>(originalFrom, CustomNetworkManager.IsServer))
 				{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/ObjectLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/ObjectLayer.cs
@@ -138,6 +138,23 @@ public class ObjectLayer : Layer
 				}
 			}
 
+			//If you can't bump anything on an adjacent tile, you may be blocked by a bumpable object on your current tile (probably a windoor)
+			if (!Bumps.Any())
+			{
+				foreach (var objectOnTile in Matrix.Get<UniversalObjectPhysics>(originalFrom, CustomNetworkManager.IsServer))
+				{
+					if (objectOnTile.Intangible) continue;
+					//Prevents living creatures from bumping themselves (or other living creatures) if on the same tile.
+					if (objectOnTile.GetComponent<HealthV2.HealthStateController>() != null) continue;
+
+					var bumpAbles = objectOnTile.GetComponents<IBumpableObject>();
+					foreach (var bump in bumpAbles)
+					{
+						Bumps.Add(bump);
+					}
+				}
+			}
+			
 			if (Hits != null) Hits.Add(o.ObjectPhysics.Component);
 
 			Pushings.Clear();


### PR DESCRIPTION

### Purpose
Fixes #8789

### Notes:
Adds a second layer of bump checking for tiles that have directional occlusion. This allows you to trigger bumps on non-creature objects on the same tile.

### Changelog:

CL: [Fix] Allows creatures to trigger bump actions for directional objects in the same tile (Windoors).