### PR TITLE
Balance changes for gibber

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Kitchen/Gibber.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Kitchen/Gibber.prefab
@@ -36,7 +36,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1058895993067106}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 1838, y: 1139, z: -0.1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -97,6 +97,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9a459a0316cc4d5b87d046f28dc136c8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   matrixDebugLogging: 0
@@ -135,6 +136,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f24590037b6b486082fc874d1bfd9d95, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   initialIntegrity: 100
@@ -161,6 +163,8 @@ MonoBehaviour:
     Anomaly: 0
     DismembermentProtectionChance: 0
     StunImmunity: 0
+    TemperatureProtectionInK: {x: 268.15, y: 313.15}
+    PressureProtectionInKpa: {x: 30, y: 300}
   Resistances:
     LavaProof: 0
     FireProof: 0
@@ -186,9 +190,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   sceneId: 0
+  _assetId: 743130309
   serverOnly: 0
   visible: 0
-  m_AssetId: 62fcd819e9801b541912cf5e45672c0b
   hasSpawned: 0
 --- !u!114 &-1424574345105429605
 MonoBehaviour:
@@ -233,6 +237,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   minimumWorkingVoltage: 190
@@ -245,6 +250,12 @@ MonoBehaviour:
   RelatedAPC: {fileID: 0}
   AdvancedControlToScript: 0
   StateUpdateOnClient: 1
+  OnDeviceLinked:
+    m_PersistentCalls:
+      m_Calls: []
+  OnDeviceUnLinked:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!114 &5213617630224009248
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -257,6 +268,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 52a6a264ee47433418b51f654439372f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   DEBUG: 0
@@ -314,9 +326,9 @@ MonoBehaviour:
   storage: {fileID: 5063677512132550823}
   physics: {fileID: 5213617630224009248}
   machineIntegrity: {fileID: 114847357675988776}
-  timeToGib: 16
-  produceMultiplier: 4
-  damagePerFrame: 20
+  numberOfTimesToDamage: 8
+  produceMultiplier: 3
+  damagePerFrame: 50
   defaultProduce: {fileID: 8223452375745627725, guid: a326b8be6d37c4a4ba068dbf1c296357,
     type: 3}
   lights: {fileID: 1423956099690816269}

--- a/UnityProject/Assets/Scripts/Objects/Machines/Gibber.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/Gibber.cs
@@ -1,21 +1,23 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using HealthV2;
 using Mirror;
 using NaughtyAttributes;
 using Systems.Electricity;
+using UI.Systems.Tooltips.HoverTooltips;
 using UnityEngine;
 
 namespace Objects.Machines
 {
-	public class Gibber : MonoBehaviour, ICheckedInteractable<HandApply>, ICheckedInteractable<MouseDrop>, IExaminable, IRightClickable
+	public class Gibber : MonoBehaviour, ICheckedInteractable<HandApply>, ICheckedInteractable<MouseDrop>, IExaminable, IRightClickable, IHoverTooltip
 	{
 		[SerializeField] private ObjectContainer storage;
 		[SerializeField] private UniversalObjectPhysics physics;
 		[SerializeField] private Integrity machineIntegrity;
 		[SerializeField] private int numberOfTimesToDamage = 8;
-		[SerializeField] private int produceMultiplier = 4;
+		[SerializeField] private int produceMultiplier = 3;
 		[SerializeField] private int damagePerFrame = 20;
 		[SerializeField] private GameObject defaultProduce;
 		[SerializeField] private SpriteHandler lights;
@@ -95,7 +97,7 @@ namespace Objects.Machines
 
 			foreach (var products in gibbed)
 			{
-				_ = Spawn.ServerPrefab(products.Key, gameObject.TileWorldPosition().To3(), gameObject.RegisterTile().Matrix.transform,
+				_ = Spawn.ServerPrefab(products.Key, gameObject.transform.position, gameObject.RegisterTile().Matrix.transform,
 					null, Mathf.Max(1, products.Value));
 			}
 			gibbed.Clear();
@@ -113,7 +115,8 @@ namespace Objects.Machines
 				{
 					gib.ApplyDamageAll(gameObject, gib.PainScreamDamage + damagePerFrame,
 						AttackType.Melee, DamageType.Brute, true);
-					if (gib.OverallHealth > LOW_HEALTH) continue;
+					if (numberOfTimesToDamage / 2 > damageNumber) gib.Death();
+					if (gib.IsDead == false) continue;
 					var meatToProduce = gib.MeatProduce.OrNull() ?? defaultProduce;
 					var skinToProduce = gib.SkinProduce.OrNull() ?? defaultProduce;
 					AddItemsThatWillBeSpawned(meatToProduce, skinToProduce);
@@ -125,7 +128,6 @@ namespace Objects.Machines
 				{
 					oldMob.Death();
 					AddItemsThatWillBeSpawned(defaultProduce);
-
 					continue;
 				}
 				if (slot.TryGetComponent<Integrity>(out var integrity) == false) continue;
@@ -159,11 +161,17 @@ namespace Objects.Machines
 			}
 		}
 
-		public string Examine(Vector3 worldPos = default(Vector3))
+		private string ExamineText()
 		{
+			if (physics.isNotPushable == false) return "It is not anchored. It will not function until it is.";
 			if (isRunning == false) return "The display reads 'Waiting..'";
 			var totalMeat = gibbed.Values.Sum();
 			return $"The display reads 'Current Output: {totalMeat}'";
+		}
+
+		public string Examine(Vector3 worldPos = default(Vector3))
+		{
+			return ExamineText();
 		}
 
 		public RightClickableResult GenerateRightClickOptions()
@@ -172,6 +180,48 @@ namespace Objects.Machines
 			if (isRunning) return rightClickResult;
 			rightClickResult.AddElement("Eject Content", () => storage.RetrieveObjects());
 			return rightClickResult;
+		}
+
+		public string HoverTip()
+		{
+			var SB = new StringBuilder();
+			SB.AppendLine("CAUTION: VERY DEADLY");
+			SB.AppendLine(ExamineText());
+			return SB.ToString();
+		}
+
+		public string CustomTitle()
+		{
+			var active = isRunning ? "[Active]" : "[Inactive]";
+			return gameObject.Object().ArticleName + $" {active}";
+		}
+
+		public Sprite CustomIcon()
+		{
+			return null;
+		}
+
+		public List<Sprite> IconIndicators()
+		{
+			return null;
+		}
+
+		public List<TextColor> InteractionsStrings()
+		{
+			List<TextColor> interactions = new List<TextColor>()
+			{
+				new TextColor()
+				{
+					Color = Color.red,
+					Text = "Drag and drop object, item or mob to this object to put it inside."
+				},
+				new TextColor()
+				{
+					Color = Color.red,
+					Text = "Click on this with an empty hand to activate it."
+				}
+			};
+			return interactions;
 		}
 	}
 }


### PR DESCRIPTION
CL: [Improvement] Added hover-tooltips for the gibber.
CL: [Improvement] Both examine and hover-tooltip text will report if the gibber is unanchorned and explicitly state that it will not function until it is anchored.
CL: [Balance] Gibbers have been heavily buffed, as they did not do their intended job previously with lower damage numbers.
CL: [Balance] Players die much more quickly inside gibbers.