### PR TITLE
telekinetic hand protection

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Lighting/LightSource.cs
+++ b/UnityProject/Assets/Scripts/Core/Lighting/LightSource.cs
@@ -331,8 +331,8 @@ namespace Objects.Lighting
 				{
 					foreach (var slot in handSlots)
 					{
-						if (interaction.PerformerMind.PossessingObject.TryGetComponent<Brain>(out var brain) &&
-						    brain.HasTelekinesis)
+						if (interaction.PerformerPlayerScript.playerHealth.brain != null &&
+						    interaction.PerformerPlayerScript.playerHealth.brain.HasTelekinesis)
 						{
 							Chat.AddExamineMsg(interaction.Performer, "You instinctively use your telekinetic power to protect your hand from getting burnt.");
 							return true;

--- a/UnityProject/Assets/Scripts/Core/Lighting/LightSource.cs
+++ b/UnityProject/Assets/Scripts/Core/Lighting/LightSource.cs
@@ -1,4 +1,5 @@
 using System;
+using Items.Implants.Organs;
 using UnityEngine;
 using Random = UnityEngine.Random;
 using Mirror;
@@ -330,6 +331,12 @@ namespace Objects.Lighting
 				{
 					foreach (var slot in handSlots)
 					{
+						if (interaction.PerformerMind.PossessingObject.TryGetComponent<Brain>(out var brain) &&
+						    brain.HasTelekinesis)
+						{
+							Chat.AddExamineMsg(interaction.Performer, "You instinctively use your telekinetic power to protect your hand from getting burnt.");
+							return true;
+						}
 						if (slot.IsEmpty) continue;
 						if (Validations.HasItemTrait(slot.ItemObject, CommonTraits.Instance.BlackGloves)) return true;
 					}


### PR DESCRIPTION
CL: [Improvement] Telekinetic users automatically protect their hands from light-bulb burns.
CL: [Fix] You can no longer damage your hand remotely while using telekinetic abilities on light-bulbs.