### PR TITLE
Fixes #9694

### DIFF
--- a/UnityProject/Assets/Prefabs/Decal/Resources/ChemSplat.prefab
+++ b/UnityProject/Assets/Prefabs/Decal/Resources/ChemSplat.prefab
@@ -52,6 +52,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c77080d7d322e0d46b715644eb4b0ab9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   Cleanable: 1
@@ -74,6 +75,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   matrixDebugLogging: 0
@@ -108,9 +110,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   sceneId: 0
+  _assetId: 125351275
   serverOnly: 0
   visible: 0
-  m_AssetId: ff80a95bbc8011c47b00ce4fcba0f2a6
   hasSpawned: 0
 --- !u!114 &5743653973661802587
 MonoBehaviour:
@@ -136,6 +138,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isInteractable: 0
   maxCapacity: 1000
   reactionSet: {fileID: 11400000, guid: 2d5f766d9268838aa8d819bee2a442a7, type: 2}
   AdditionalReactions: []
@@ -148,6 +151,7 @@ MonoBehaviour:
   destroyOnEmpty: 0
   ContentsSet: 1
   menuOptions: 0
+  spriteHandler: {fileID: 0}
   UseStandardExamine: 1
   ExamineAmount: 2
   ExamineContent: 1
@@ -156,6 +160,7 @@ MonoBehaviour:
   transferMode: 4
   possibleTransferAmounts: []
   transferAmount: 2
+  transferSound: []
 --- !u!114 &8158038422271111735
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -168,6 +173,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 52a6a264ee47433418b51f654439372f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   DEBUG: 0

--- a/UnityProject/Assets/Prefabs/Decal/Resources/_FloorDecalBase.prefab
+++ b/UnityProject/Assets/Prefabs/Decal/Resources/_FloorDecalBase.prefab
@@ -51,6 +51,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c77080d7d322e0d46b715644eb4b0ab9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   Cleanable: 0
@@ -73,6 +74,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   matrixDebugLogging: 0
@@ -107,9 +109,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   sceneId: 0
+  _assetId: 1425996326
   serverOnly: 0
   visible: 0
-  m_AssetId: 66aad43ea1945ac458990cb6d4169cde
   hasSpawned: 0
 --- !u!114 &3586928491308810755
 MonoBehaviour:
@@ -135,6 +137,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isInteractable: 0
   maxCapacity: 100
   reactionSet: {fileID: 0}
   AdditionalReactions: []
@@ -147,6 +150,7 @@ MonoBehaviour:
   destroyOnEmpty: 0
   ContentsSet: 0
   menuOptions: 0
+  spriteHandler: {fileID: 0}
   UseStandardExamine: 1
   ExamineAmount: 0
   ExamineContent: 0
@@ -155,6 +159,7 @@ MonoBehaviour:
   transferMode: 0
   possibleTransferAmounts: []
   transferAmount: 20
+  transferSound: []
 --- !u!114 &4498202346003398499
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -167,6 +172,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 52a6a264ee47433418b51f654439372f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   DEBUG: 0

--- a/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.TransferInteraction.cs
+++ b/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.TransferInteraction.cs
@@ -27,6 +27,8 @@ namespace Chemistry.Components
 	{
 		[Header("Transfer settings")]
 
+		[SerializeField] private bool isInteractable = true;
+
 		[Tooltip("If not empty, another container should have one of this traits to interact")]
 		[FormerlySerializedAs("TraitWhitelist")]
 		[FormerlySerializedAs("AcceptedTraits")]
@@ -74,6 +76,7 @@ namespace Chemistry.Components
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
+			if (isInteractable == false) return false;
 			if (!DefaultWillInteract.Default(interaction, side)) return false;
 
 			var playerScript = interaction.Performer.GetComponent<PlayerScript>();


### PR DESCRIPTION
Fixes #9694

CL: [Fix] You can no longer accidentally dump reagents into floor splats
