### PR TITLE
fixes #9720

### DIFF
--- a/UnityProject/Assets/Scripts/Player/Mind.cs
+++ b/UnityProject/Assets/Scripts/Player/Mind.cs
@@ -161,6 +161,11 @@ public class Mind : NetworkBehaviour, IActionGUI
 		{
 			SetProperty(pair.Key, pair.Value);
 		}
+
+		if (occupation.JobType == JobType.AI)
+		{
+			SetPermanentName(CurrentCharacterSettings.AiName ?? "H.A.L.E");
+		}
 	}
 
 


### PR DESCRIPTION
fixes #9720

CL: [Fix] AIs will now spawn with their defined names in the player's character sheet.
