### PR TITLE
Pipe fixes and Improvements

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/CrawlIntoPipe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/CrawlIntoPipe.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f8d5274f3ef34f49a10ea494e5bfb5f1, type: 3}
+  m_Name: CrawlIntoPipe
+  m_EditorClassIdentifier: 

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/CrawlIntoPipe.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/CrawlIntoPipe.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f2cd567720110334981cb9933c7b2f77
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/CrawlIntoPipeInteraction.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/CrawlIntoPipeInteraction.cs
@@ -1,0 +1,23 @@
+﻿using Systems.Disposals;
+using UnityEngine;
+
+namespace Core.InputSystem.InteractionV2
+{
+	[CreateAssetMenu(fileName = "CrawlIntoPipe",
+		menuName = "Interaction/TileInteraction/CrawlIntoPipe")]
+	public class CrawlIntoPipeInteraction : TileInteraction
+	{
+		public override bool WillInteract(TileApply interaction, NetworkSide side)
+		{
+			return DefaultWillInteract.Default(interaction, side);
+		}
+
+		public override void ServerPerformInteraction(TileApply interaction)
+		{
+			if (interaction.HandObject is not null) return;
+			global::Chat.AddActionMsgToChat(interaction.Performer,
+				$"{interaction.Performer.ExpensiveName()} crawls into the pipe.");
+			DisposalsManager.Instance.NewDisposal(interaction.Performer);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/CrawlIntoPipeInteraction.cs.meta
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/CrawlIntoPipeInteraction.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f8d5274f3ef34f49a10ea494e5bfb5f1
+timeCreated: 1682637394

--- a/UnityProject/Assets/Scripts/Objects/Disposals/DisposalPipeObject.cs
+++ b/UnityProject/Assets/Scripts/Objects/Disposals/DisposalPipeObject.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using UnityEngine;
 using Mirror;
+using Systems.Disposals;
 
 namespace Objects.Disposals
 {

--- a/UnityProject/Assets/Scripts/Systems/Disposals/DisposalTraversal.cs
+++ b/UnityProject/Assets/Scripts/Systems/Disposals/DisposalTraversal.cs
@@ -301,7 +301,6 @@ namespace Systems.Disposals
 		{
 			virtualContainer.SelfControlled = false;
 			TraversalFinished = true;
-			if (virtualContainer.SelfControlled) DisposalsManager.Instance.FinishDisposal(this);
 			_ = Despawn.ServerSingle(virtualContainer.gameObject);
 		}
 	}

--- a/UnityProject/Assets/Scripts/Util/DMMath.cs
+++ b/UnityProject/Assets/Scripts/Util/DMMath.cs
@@ -20,6 +20,11 @@ public static class DMMath
 		return Mathf.Clamp(val, min, max);
 	}
 
+	/// <summary>
+	/// this method can be used to determine whether a given event should occur with a certain probability defined by the input "percent".
+	/// For example, if percent=50, there is a 50% chance that the method will return true, and a 50% chance that it will return false.
+	/// </summary>
+	/// <returns>If the random value is less than the threshold, the method returns true. Otherwise, it returns false.</returns>
 	public static bool Prob(double percent)
 	{
 		Random rand = new Random(Guid.NewGuid().GetHashCode());

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Disposals/DisposalPipes/DisposalPipeTerminal-E.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Disposals/DisposalPipes/DisposalPipeTerminal-E.asset
@@ -50,10 +50,14 @@ MonoBehaviour:
     Acid: 30
     Magic: 0
     Bio: 100
+    Anomaly: 0
     DismembermentProtectionChance: 0
     StunImmunity: 0
+    TemperatureProtectionInK: {x: 268.15, y: 313.15}
+    PressureProtectionInKpa: {x: 30, y: 300}
   tileInteractions:
   - {fileID: 11400000, guid: 60beb21b338960e459175e414f6016ef, type: 2}
+  - {fileID: 11400000, guid: f2cd567720110334981cb9933c7b2f77, type: 2}
   tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 2025448082421612283, guid: 5cb574d8e6bf6964a97eefa7dcab9ebc,
     type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Disposals/DisposalPipes/DisposalPipeTerminal-N.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Disposals/DisposalPipes/DisposalPipeTerminal-N.asset
@@ -50,10 +50,14 @@ MonoBehaviour:
     Acid: 30
     Magic: 0
     Bio: 100
+    Anomaly: 0
     DismembermentProtectionChance: 0
     StunImmunity: 0
+    TemperatureProtectionInK: {x: 268.15, y: 313.15}
+    PressureProtectionInKpa: {x: 30, y: 300}
   tileInteractions:
   - {fileID: 11400000, guid: 60beb21b338960e459175e414f6016ef, type: 2}
+  - {fileID: 11400000, guid: f2cd567720110334981cb9933c7b2f77, type: 2}
   tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 2025448082421612283, guid: 5cb574d8e6bf6964a97eefa7dcab9ebc,
     type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Disposals/DisposalPipes/DisposalPipeTerminal-S.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Disposals/DisposalPipes/DisposalPipeTerminal-S.asset
@@ -50,10 +50,14 @@ MonoBehaviour:
     Acid: 30
     Magic: 0
     Bio: 100
+    Anomaly: 0
     DismembermentProtectionChance: 0
     StunImmunity: 0
+    TemperatureProtectionInK: {x: 268.15, y: 313.15}
+    PressureProtectionInKpa: {x: 30, y: 300}
   tileInteractions:
   - {fileID: 11400000, guid: 60beb21b338960e459175e414f6016ef, type: 2}
+  - {fileID: 11400000, guid: f2cd567720110334981cb9933c7b2f77, type: 2}
   tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 2025448082421612283, guid: 5cb574d8e6bf6964a97eefa7dcab9ebc,
     type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Disposals/DisposalPipes/DisposalPipeTerminal-W.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Disposals/DisposalPipes/DisposalPipeTerminal-W.asset
@@ -50,9 +50,13 @@ MonoBehaviour:
     Acid: 30
     Magic: 0
     Bio: 100
+    Anomaly: 0
     DismembermentProtectionChance: 0
     StunImmunity: 0
+    TemperatureProtectionInK: {x: 268.15, y: 313.15}
+    PressureProtectionInKpa: {x: 30, y: 300}
   tileInteractions:
+  - {fileID: 11400000, guid: f2cd567720110334981cb9933c7b2f77, type: 2}
   - {fileID: 11400000, guid: 60beb21b338960e459175e414f6016ef, type: 2}
   tileStepInteractions: []
   spawnOnDeconstruct: {fileID: 2025448082421612283, guid: 5cb574d8e6bf6964a97eefa7dcab9ebc,


### PR DESCRIPTION
part of #4654 

CL: [New] Pipes were missing an interaction for humanoids to crawl into them without the need of a disposal bin or such. This has been added.
CL: [Improvement] Slightly Improved some pipe crawling behaviors to make them less jank.
CL: [Improvement] Lifted a restriction on pipe crawl movement that restricted the player's movement towards a pipe they've previously crawled from.
CL: [Fix] Fixed an issue where the traversal system could not detect valid pipes to crawl out of.
CL: [Fix] Fixed an issue where players would get stuck on one tile after crawling out of a pipe.
CL: [Fix] Fixed a massive issue with virtual containers not getting cleared after they were no longer needed. This issue may have caused unnecessary CPU usage on servers, as hundreds of virtual containers were still being processed due to them not getting cleared out of the instance list.