### PR TITLE
Adds a debug command to resetting movement

### DIFF
--- a/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
+++ b/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
@@ -775,6 +775,8 @@ namespace IngameDebugConsole
 				return;
 			}
 			PlayerManager.LocalPlayerScript.PlayerNetworkActions.CmdResetMovementForSelf();
+			Logger.Log("[Console Command] - Movement Reset Successfully. " +
+			           "If you're still stuck, please report this and any errors you might find in the console on github/discord.", Category.DebugConsole);
 		}
 	}
 }

--- a/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
+++ b/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
@@ -764,5 +764,17 @@ namespace IngameDebugConsole
 			}
 
 		}
+
+		[ConsoleMethod("reset-movement", "Resets all movement values. Helpful if you get stuck for no reason.")]
+		public static void ResetMovementStats()
+		{
+			if(IsAdmin() == false) return;
+			if (PlayerManager.LocalPlayerScript == null)
+			{
+				Logger.LogError("[Console Command] - Cannot Reset movement due to null player.", Category.DebugConsole);
+				return;
+			}
+			PlayerManager.LocalPlayerScript.PlayerNetworkActions.CmdResetMovementForSelf();
+		}
 	}
 }

--- a/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
+++ b/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
@@ -768,7 +768,6 @@ namespace IngameDebugConsole
 		[ConsoleMethod("reset-movement", "Resets all movement values. Helpful if you get stuck for no reason.")]
 		public static void ResetMovementStats()
 		{
-			if(IsAdmin() == false) return;
 			if (PlayerManager.LocalPlayerScript == null)
 			{
 				Logger.LogError("[Console Command] - Cannot Reset movement due to null player.", Category.DebugConsole);

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -990,4 +990,11 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 	{
 		EmoteActionManager.DoEmote(emoteName, playerScript.gameObject);
 	}
+
+	[Command]
+	public void CmdResetMovementForSelf()
+	{
+		playerScript.playerMove.ResetEverything();
+		playerScript.playerMove.ResetLocationOnClient(playerScript.connectionToClient);
+	}
 }

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -995,6 +995,6 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 	public void CmdResetMovementForSelf()
 	{
 		playerScript.playerMove.ResetEverything();
-		playerScript.playerMove.ResetLocationOnClient(playerScript.connectionToClient);
+		playerScript.playerMove.ResetLocationOnClients();
 	}
 }


### PR DESCRIPTION
CL: [New] Added a debug command to resetting movement. This will allow players to help identify issues related to movement in the future, and let them possibly fix problems by themselves without admin intervention so they can continue playing the game. To use the new command, use "reset-movement" in the F5 console.
