### PR TITLE
Adds some more interactions to the suicide emote

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/_GunBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/_GunBase.prefab
@@ -33,15 +33,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -54,6 +54,11 @@ PrefabInstance:
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114738972662350094, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: _assetId
+      value: 422209012
       objectReference: {fileID: 0}
     - target: {fileID: 114738972662350094, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
@@ -201,6 +206,7 @@ MonoBehaviour:
   Populater:
     SlotContents: []
     DeprecatedContents: []
+  SetSlotItemNotRemovableOnStartUp: 0
   ashPrefab: {fileID: 0}
 --- !u!114 &4644871529314044369
 MonoBehaviour:
@@ -214,6 +220,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8343d0f678a24c949baac4bba12c2f59, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   ammoPrefab: {fileID: 0}
@@ -267,7 +274,7 @@ MonoBehaviour:
       m_SubObjectType: 
       m_EditorAssetChanged: 0
   FireDelay: 0.5
-  AllowSuicide: 0
+  AllowSuicide: 1
   MaxRecoilVariance: 0
   ProjectileVelocity: 20
   CameraRecoilConfig:

--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -14,6 +14,7 @@ using HealthV2;
 /// The Required component for all living creatures
 /// Monitors and calculates health
 /// </summary>
+[Obsolete("LivingHealthBehaviour is deprecated, please use LivingHealthMasterBase instead unless you are working on V1 Mobs.")]
 public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireExposable, IExaminable, IServerSpawn
 {
 	private static readonly float GIB_THRESHOLD = 200f;
@@ -541,6 +542,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 	/// CRIT + DEATH METHODS
 	/// ---------------------------
 	///Death from other causes
+	[Obsolete("LivingHealthBehaviour is deprecated, please use LivingHealthMasterBase instead unless you are working on V1 Mobs.")]
 	public void Death()
 	{
 		if (IsDead)
@@ -617,7 +619,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 		MiasmaCreation();
 	}
 
-	//Old health, dont need the TODO's
+	[Obsolete("LivingHealthBehaviour is deprecated, please use LivingHealthMasterBase instead unless you are working on V1 Mobs.")]
 	private void MiasmaCreation()
 	{
 		//Don't produce miasma until 2 minutes after death
@@ -673,6 +675,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 		Gib();
 	}
 
+	[Obsolete("LivingHealthBehaviour is deprecated, please use LivingHealthMasterBase.OnGib() instead unless you are working on V1 Mobs.")]
 	[Server]
 	protected virtual void Gib()
 	{

--- a/UnityProject/Assets/Scripts/Items/Others/HolyBook.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/HolyBook.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using HealthV2;
@@ -8,7 +9,7 @@ namespace Items
 	/// <summary>
 	/// Component which allows this object to heal or cause brain damage if used by the Chaplain.
 	/// </summary>
-	public class HolyBook : MonoBehaviour, IPredictedCheckedInteractable<PositionalHandApply>
+	public class HolyBook : MonoBehaviour, IPredictedCheckedInteractable<PositionalHandApply>, ISuicide
 	{
 		//The amount a single thwack heals or damages.
 		public int healthModifier = 10;
@@ -108,6 +109,18 @@ namespace Items
 
 			//Start server cooldown.
 			Cooldowns.TryStartServer(interaction.Performer.GetComponent<PlayerScript>(), CommonCooldowns.Instance.Melee);
+		}
+
+		public bool CanSuicide(GameObject performer)
+		{
+			return true;
+		}
+
+		public IEnumerator OnSuicide(GameObject performer)
+		{
+			yield return WaitFor.FixedUpdate;
+			Chat.AddActionMsgToChat(performer, $"{performer.ExpensiveName()} farts on the holy book.");
+			performer.Player().Script.playerHealth.OnGib();
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Others/SupermatterSliver.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/SupermatterSliver.cs
@@ -1,8 +1,10 @@
+using System.Collections;
+using HealthV2;
 using UnityEngine;
 
 namespace Items
 {
-	public class SupermatterSliver : MonoBehaviour, IServerInventoryMove, ICheckedInteractable<HandApply>
+	public class SupermatterSliver : MonoBehaviour, IServerInventoryMove, ICheckedInteractable<HandApply>, ISuicide
 	{
 		[SerializeField]
 		private ItemTrait supermatterScalpel = null;
@@ -62,6 +64,18 @@ namespace Items
 					player.playerHealth.OnGib();
 				}
 			}
+		}
+
+		public bool CanSuicide(GameObject performer)
+		{
+			return vaporizeWhenPickedUp;
+		}
+
+		public IEnumerator OnSuicide(GameObject performer)
+		{
+			yield return WaitFor.FixedUpdate;
+			Chat.AddActionMsgToChat(gameObject, $"{performer.ExpensiveName()} mistook the {gameObject.ExpensiveName()} for a tasty snack. Yumm..");
+			gameObject.Player().Script.playerHealth.OnGib();
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
@@ -932,6 +932,7 @@ namespace Weapons
 
 		public bool CanSuicide(GameObject performer)
 		{
+			if (AllowSuicide == false) return false;
 			return CurrentMagazine != null && CurrentMagazine.ServerAmmoRemains != 0;
 		}
 
@@ -947,7 +948,8 @@ namespace Weapons
 		protected virtual IEnumerator SuicideAction(GameObject performer)
 		{
 			DequeueAndProcessServerShot(performer, performer.RegisterTile().LocalPosition.ToLocal(), BodyPartType.Head, true);
-			performer.GetComponent<LivingHealthBehaviour>().Death();
+			var health = performer.GetComponent<LivingHealthMasterBase>();
+			health.ApplyDamageAll(performer, health.MaxHealth / 2, AttackType.Bullet, DamageType.Brute);
 			yield return null;
 		}
 	}

--- a/UnityProject/Assets/Scripts/Player/EmoteScripts/Suicide.cs
+++ b/UnityProject/Assets/Scripts/Player/EmoteScripts/Suicide.cs
@@ -10,19 +10,23 @@ namespace Player.EmoteScripts
 		public override void Do(GameObject player)
 		{
 			var playerScript = player.GetComponent<PlayerScript>();
-			if(playerScript.DynamicItemStorage == null) return;
+			if (playerScript.DynamicItemStorage == null) return;
 
 			//Just end the misery early if the player has been stuck in suicide for a while now.
 			if (CheckPlayerCritState(player))
 			{
-				player.GetComponent<LivingHealthBehaviour>().Death();
+				player.GetComponent<LivingHealthMasterBase>()?.Death();
 				return;
 			}
 
-			var activeHandSlot = playerScript.DynamicItemStorage.GetActiveHandSlot();
-			if(activeHandSlot == null || activeHandSlot.IsEmpty) return; //Assuming we have no hand or no item in hand
-			if(activeHandSlot.ItemObject.TryGetComponent<ISuicide>(out var suicideObject) == false) return;
-			if(suicideObject.CanSuicide(player) == false) return;
+			var activeHandSlot = playerScript.DynamicItemStorage.OrNull()?.GetActiveHandSlot();
+			if (activeHandSlot == null || activeHandSlot.IsEmpty) return; //Assuming we have no hand or no item in hand
+			if (activeHandSlot.ItemObject.TryGetComponent<ISuicide>(out var suicideObject) == false)
+			{
+				Chat.AddExamineMsg(player, "You do not have a lethal object to commit suicide with.");
+				return;
+			}
+			if (suicideObject.CanSuicide(player) == false) return;
 			playerScript.StartCoroutine(suicideObject.OnSuicide(player));
 		}
 	}


### PR DESCRIPTION
closes #8246

note: I added an `Obsolute` attribute to the `LivingHealthBehavior` class due to it being confusing sometimes and causing accidental use-cases of it when we originally meant to use `LivingHealthMasterBase`, It will now appear stricken out in IDEs, and your IDE will give you a clear warning about it when using it.

CL: [New] You can now use the suicide emote with a Bible.
CL: [New] You can now use the suicide emote with SuperMatter silver.
CL: [Improvement] You will now receive some text when failing to commit suicide due to a lack of a lethal object. (Technical: Only objects with the `ISuicide` interface will work.)
CL: [Fix] Fixed an instance where the suicide emote would attempt to access the MobV1 health system instead of the player's HealthV2 system.
