### PR TITLE
New hub fields for playercount & real round time

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Database/ServerData.ServerStatus.cs
+++ b/UnityProject/Assets/Scripts/Core/Database/ServerData.ServerStatus.cs
@@ -161,6 +161,10 @@ namespace DatabaseAPI
 				status.CurrentMap = SubSceneManager.ServerChosenMainStation;
 			}
 
+			status.Passworded = !string.IsNullOrEmpty(config.ConnectionPassword);
+            status.RoundTime = GameManager.Instance.RoundTimeInMinutes.ToString();
+            status.PlayerCountMax = GameManager.Instance.PlayerLimit;
+
 			status.GameMode = GameManager.Instance.GetGameModeName();
 			status.IngameTime = GameManager.Instance.roundTimer.text;
 			if (PlayerList.Instance != null)
@@ -215,13 +219,16 @@ namespace DatabaseAPI
 	[Serializable]
 	public class ServerStatus
 	{
+		public bool Passworded;
 		public string ServerName;
 		public string ForkName;
 		public int BuildVersion;
 		public string CurrentMap;
 		public string GameMode;
 		public string IngameTime;
+		public string RoundTime;
 		public int PlayerCount;
+		public int PlayerCountMax;
 		public string ServerIP;
 		public int ServerPort;
 		public string WinDownload;

--- a/UnityProject/Assets/Scripts/Core/Database/ServerData.ServerStatus.cs
+++ b/UnityProject/Assets/Scripts/Core/Database/ServerData.ServerStatus.cs
@@ -161,7 +161,7 @@ namespace DatabaseAPI
 				status.CurrentMap = SubSceneManager.ServerChosenMainStation;
 			}
 
-			status.Passworded = !string.IsNullOrEmpty(config.ConnectionPassword);
+			status.Passworded = string.IsNullOrEmpty(config.ConnectionPassword) == false;
             status.RoundTime = GameManager.Instance.RoundTimeInMinutes.ToString();
             status.PlayerCountMax = GameManager.Instance.PlayerLimit;
 


### PR DESCRIPTION
<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->

### Purpose
Reports three new fields to the current hub api for future use, 
RoundTime: Mirror of GameManager.Instance.RoundTimeInMinutes, Gives an accurate display of how long a round has gone on for (that doesn't include janky math on the existing IngameTime variable). This field is OPTIONAL and may not appear on the API if it's not being reported.
PlayerCountMax: Should be pretty self-explanatory. If it's not reported, this value is 0 through the api.
Passworded: ditto. If a connection password is set, this is true. Else false (also if not reported)

### Changelog:
Not userfacing, No CL.
