### PR TITLE
Fixes ashwalkers not spawning with their correct health data

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/Occupations/GhostRole/Ashwalker.asset
+++ b/UnityProject/Assets/ScriptableObjects/Occupations/GhostRole/Ashwalker.asset
@@ -17,10 +17,11 @@ MonoBehaviour:
   lateSpawnIsArrivals: 0
   inventoryPopulator: {fileID: 11400000, guid: a51bd1be8147ae4478f0cdc91d9b51e3, type: 2}
   useStandardPopulator: 0
+  useCharacterSettings: 1
+  CustomSpeciesOverwrite: {fileID: 11400000, guid: 31250f329a28a20458b0f76c1f157a7f,
+    type: 2}
   limit: 3
   priority: 1
-  allowedAccess: 
-  allowedLowPopAccess: 
   issuedClearance: 
   issuedLowPopClearance: 
   spells: []


### PR DESCRIPTION
CL: [Fix] Ashwalkers can now properly spawn again as their correct species.
