### PR TITLE
[Critical Fix] Fixes NRE spam for larva spawning

### DIFF
--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -1059,6 +1059,7 @@ namespace HealthV2
 		private void CheckHeartStatus()
 		{
 			bool hasAllHeartAttack = true;
+			if (BodyPartList.Count == 0) hasAllHeartAttack = false;
 			foreach (var Implant in BodyPartList)
 			{
 				foreach (var organ in Implant.OrganList)

--- a/UnityProject/Assets/Scripts/HealthV2/Living/PolymorphicSystems/HungerSystem.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/PolymorphicSystems/HungerSystem.cs
@@ -216,7 +216,7 @@ namespace HealthV2.Living.PolymorphicSystems
 				var newOne = GetAlertSOFromHunger(State);
 				if (newOne != null)
 				{
-					BodyAlertManager.RegisterAlert(newOne);
+					BodyAlertManager?.RegisterAlert(newOne);
 				}
 			}
 		}

--- a/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
@@ -298,8 +298,8 @@ namespace Player
 				}
 			}
 
-			infectedSpriteHandler.PushTexture(); //This is needed because  RegisterHandler in ServerCreateSprite Is busted and doesn't make sprites
-			infectedSpriteHandler.PushClear();
+			infectedSpriteHandler.OrNull()?.PushTexture(); //This is needed because  RegisterHandler in ServerCreateSprite Is busted and doesn't make sprites
+			infectedSpriteHandler.OrNull()?.PushClear();
 
 			GetComponent<RootBodyPartController>().PlayerSpritesData = JsonConvert.SerializeObject(ToClient);
 


### PR DESCRIPTION
CL: [Fix] Players are no longer immortal by having their chest bursted by an alien.
CL: [Fix] Fixed NRE spam that can potentially crash the server.
CL: [Fix] Fixed an issue with larva dying as soon as they're spawned.
