### PR TITLE
Gibtonite fixes and improvements 

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Mining/Ore/GibtoniteOre.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Mining/Ore/GibtoniteOre.prefab
@@ -205,6 +205,19 @@ MonoBehaviour:
   spriteFused: {fileID: 11400000, guid: 6f048e1bf2383d24584f5ec94a6c93bb, type: 2}
   miningScanner: {fileID: 11400000, guid: 0675322a24120d846bb40ebf9d3e5fc4, type: 2}
   pickaxe: {fileID: 11400000, guid: 1c4515f9903c29c4f8832bd2f32684ad, type: 2}
+  itemTraitsToIgnoreOnExplosion:
+  - {fileID: 11400000, guid: 3c430c1e9384ac647a81057064b1d664, type: 2}
+  - {fileID: 11400000, guid: 5454ae301f8f02a43ae7496ed16f70bc, type: 2}
+  - {fileID: 11400000, guid: 66ee6ece9a2945342a3013068032cc61, type: 2}
+  - {fileID: 11400000, guid: 1e8921a11f65f9640afc3446c7cb9320, type: 2}
+  - {fileID: 11400000, guid: b6d7aeb207e8c9d47a7744da79141799, type: 2}
+  - {fileID: 11400000, guid: 3d402a2b597113b4a97ee3710288b408, type: 2}
+  - {fileID: 11400000, guid: 9f843295728958e48bcfe5215296ee90, type: 2}
+  - {fileID: 11400000, guid: b52339a75d4b045469c79bd102bc98ea, type: 2}
+  - {fileID: 11400000, guid: e76a2305b1eac4c4786986115a5eb555, type: 2}
+  - {fileID: 11400000, guid: d3b5f22c1469bf34a81e377227b2acf5, type: 2}
+  - {fileID: 11400000, guid: 6097f8423a1b255468e2285de46bc3d3, type: 2}
+  - {fileID: 11400000, guid: eab4a0cf6ec899240b34c27ae82015e2, type: 2}
 --- !u!114 &6276593887705394392 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7879885434909570197, guid: fdb2f97a13e5b31468c170e6847a8d15,

--- a/UnityProject/Assets/Prefabs/Items/Mining/Ore/GibtoniteOre.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Mining/Ore/GibtoniteOre.prefab
@@ -197,9 +197,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spritehandler: {fileID: 6276593887705394392}
-  explosionStrength: 1270
+  explosionStrength: 5270
   fullDifuselTime: 12
-  fuseTime: 2500
+  fuseTime: 4500
   spriteActive: {fileID: 11400000, guid: b834598cef2ad3f4a9451c26b42bdcf7, type: 2}
   spriteInActive: {fileID: 11400000, guid: a079cc489d71e4b4d9199480bf4ffcf8, type: 2}
   spriteFused: {fileID: 11400000, guid: 6f048e1bf2383d24584f5ec94a6c93bb, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Ore config/LavalandOreGeneration.asset
+++ b/UnityProject/Assets/ScriptableObjects/Ore config/LavalandOreGeneration.asset
@@ -57,4 +57,4 @@ MonoBehaviour:
   - WallTile: {fileID: 11400000, guid: f01101a098e7d884a94db2af5a7b3fc0, type: 2}
     OverlayTile: {fileID: 0}
     SpawnChance: 2
-    PossibleClusterSizes: 01000000010000000300000001000000020000000100000001000000
+    PossibleClusterSizes: 01000000010000000300000001000000020000000100000002000000

--- a/UnityProject/Assets/Scripts/Core/Lighting/HighlightScan.cs
+++ b/UnityProject/Assets/Scripts/Core/Lighting/HighlightScan.cs
@@ -1,12 +1,16 @@
 using System;
 using System.Collections;
+using Core.Factories;
+using Mirror;
 using UnityEngine;
+using Util;
 
 namespace Core.Lighting
 {
 	public class HighlightScan : MonoBehaviour
 	{
 		private SpriteRenderer spriteRenderer;
+		private GameObject noHighlightSpriteObj;
 
 		private void Awake()
 		{
@@ -25,6 +29,11 @@ namespace Core.Lighting
 			HighlightScanManager.Instance.HighlightScans.Add(this);
 		}
 
+		private void OnEnable()
+		{
+			noHighlightSpriteObj = CustomNetworkManager.Instance.GetSpawnablePrefabFromName("_RandomItemSpawnerBase");
+		}
+
 		private void OnDisable()
 		{
 			HighlightScanManager.Instance.OrNull()?.HighlightScans.Remove(this);
@@ -32,6 +41,11 @@ namespace Core.Lighting
 
 		public void Setup(Sprite sprite)
 		{
+			if (sprite == null)
+			{
+				spriteRenderer.sprite = noHighlightSpriteObj.GetComponentInChildren<SpriteRenderer>().sprite;
+				return;
+			}
 			spriteRenderer.sprite = sprite;
 		}
 

--- a/UnityProject/Assets/Scripts/Core/Lighting/HighlightScan.cs
+++ b/UnityProject/Assets/Scripts/Core/Lighting/HighlightScan.cs
@@ -43,7 +43,7 @@ namespace Core.Lighting
 		{
 			if (sprite == null)
 			{
-				spriteRenderer.sprite = noHighlightSpriteObj.GetComponentInChildren<SpriteRenderer>().sprite;
+				spriteRenderer.sprite = noHighlightSpriteObj.GetComponentInChildren<SpriteRenderer>()?.sprite;
 				return;
 			}
 			spriteRenderer.sprite = sprite;

--- a/UnityProject/Assets/Scripts/Items/Cargo/MiningScanner.cs
+++ b/UnityProject/Assets/Scripts/Items/Cargo/MiningScanner.cs
@@ -45,7 +45,11 @@ namespace Items.Cargo
 		private IEnumerator Cooldown()
 		{
 			isOnCooldown = true;
+#if UNITY_EDITOR
+			yield return WaitFor.Seconds(0.5f);
+#else
 			yield return WaitFor.Seconds(IsAdvanced ? AdvancedScanCooldown : NormalScanCooldown);
+#endif
 			isOnCooldown = false;
 		}
 	}

--- a/UnityProject/Assets/Scripts/Items/Others/Gibtonite.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/Gibtonite.cs
@@ -57,21 +57,24 @@ namespace Items.Others
 				case GibState.ACTIVE:
 					spritehandler.SetSpriteSO(spriteActive);
 					StopFuse();
+					Chat.AddLocalMsgToChat("The gibtonite turns into its active state.", gameObject);
 					break;
 				case GibState.INACTIVE:
 					spritehandler.SetSpriteSO(spriteInActive);
 					StopFuse();
+					Chat.AddLocalMsgToChat("The gibtonite is no longer a threat, for now.", gameObject);
 					break;
 				case GibState.FUSED:
 					spritehandler.SetSpriteSO(spriteFused);
 					_ = Fuse();
+					Chat.AddLocalMsgToChat("<color=red>The gibtonite hisses!</color>", gameObject);
 					break;
 			}
 		}
 
 		private void OnDamageTaken(DamageInfo damageInfo)
 		{
-			if ( damageInfo.Damage == 0 ) return;
+			if ( damageInfo.Damage <= 0 ) return;
 			if ( damageInfo.DamageType == DamageType.Radiation ) return;
 			switch (state)
 			{

--- a/UnityProject/Assets/Scripts/Items/Others/Gibtonite.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/Gibtonite.cs
@@ -32,6 +32,7 @@ namespace Items.Others
 		[SerializeField] private SpriteDataSO spriteFused;
 		[SerializeField] private ItemTrait miningScanner;
 		[SerializeField] private ItemTrait pickaxe;
+		[SerializeField] private List<ItemTrait> itemTraitsToIgnoreOnExplosion = new List<ItemTrait>();
 		private bool willExpload = false;
 
 
@@ -103,7 +104,7 @@ namespace Items.Others
 		{
 			var pos = gameObject.AssumedWorldPosServer().CutToInt();
 			_ = Despawn.ServerSingle(gameObject);
-			Explosion.StartExplosion(pos, explosionStrength);
+			Explosion.StartExplosion(pos, explosionStrength, damageIgnoreAttributes: itemTraitsToIgnoreOnExplosion);
 		}
 
 		public void ServerPerformInteraction(HandApply interaction)

--- a/UnityProject/Assets/Scripts/Systems/Explosions/Explosion.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/Explosion.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using Systems.Score;
 using UnityEngine;
@@ -178,12 +177,15 @@ namespace Systems.Explosions
 			public HashSet<Vector2Int> CircleCircumference = new HashSet<Vector2Int>();
 		}
 
-		public static void StartExplosion(Vector3Int WorldPOS, float strength, ExplosionNode nodeType = null, int fixedRadius = -1, int fixedShakingStrength = -1)
+		public static void StartExplosion(Vector3Int WorldPOS, float strength, ExplosionNode nodeType = null,
+			int fixedRadius = -1, int fixedShakingStrength = -1, List<ItemTrait> damageIgnoreAttributes = null)
 		{
 			if (nodeType == null)
 			{
 				nodeType = new ExplosionNode();
 			}
+
+			nodeType.IgnoreAttributes = damageIgnoreAttributes;
 
 			int Radius = 0;
 			if (fixedRadius <= 0)

--- a/UnityProject/Assets/Scripts/Systems/Explosions/ExplosionManager.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/ExplosionManager.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Mirror;
 using UnityEngine;
@@ -36,7 +35,7 @@ namespace Systems.Explosions
 			}
 			SubCheckLines.Clear();
 
-			foreach (var explosionNode in CheckLocations.ToArray())
+			foreach (ExplosionNode explosionNode in CheckLocations.ToArray())
 			{
 				CheckLocations.Remove(explosionNode); //lets not create infinite explosions in the case of a runtime
 				explosionNode.Process();

--- a/UnityProject/Assets/Scripts/Systems/Explosions/NodeTypes/ExplosionNode.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/NodeTypes/ExplosionNode.cs
@@ -1,13 +1,11 @@
 ﻿using System.Threading.Tasks;
-using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using Light2D;
 using HealthV2;
 using Systems.Pipes;
 using Items;
-using Items.Others;
-using Systems.Electricity;
 using TileManagement;
 using AddressableReferences;
 
@@ -23,6 +21,8 @@ namespace Systems.Explosions
 		public Vector2 AngleAndIntensity;
 
 		public List<PipeNode> SavedPipes = new List<PipeNode>();
+
+		public List<ItemTrait> IgnoreAttributes = new List<ItemTrait>();
 
 		public virtual string EffectName
 		{
@@ -105,9 +105,13 @@ namespace Systems.Explosions
 			foreach (var integrity in matrix.Get<Integrity>(v3int, true))
 			{
 				//Throw items
-				if (integrity.GetComponent<ItemAttributesV2>() != null)
+				if (integrity.TryGetComponent<ItemAttributesV2>(out var traits))
 				{
-					integrity.GetComponent<UniversalObjectPhysics>().NewtonianPush(AngleAndIntensity.Rotate90(), 9,  1,3 ,  BodyPartType.Chest,integrity.gameObject, 15);
+					integrity.GetComponent<UniversalObjectPhysics>()?
+						.NewtonianPush(AngleAndIntensity.Rotate90(),
+							9,  1,3 ,
+							BodyPartType.Chest,integrity.gameObject, 15);
+					if (IgnoreAttributes != null && traits.GetTraits().Any(x => IgnoreAttributes.Contains(x))) continue;
 				}
 
 				//And do damage to objects

--- a/UnityProject/Assets/Scripts/Systems/Explosions/NodeTypes/ExplosionNode.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/NodeTypes/ExplosionNode.cs
@@ -111,7 +111,7 @@ namespace Systems.Explosions
 						.NewtonianPush(AngleAndIntensity.Rotate90(),
 							9,  1,3 ,
 							BodyPartType.Chest,integrity.gameObject, 15);
-					if (IgnoreAttributes != null && traits.GetTraits().Any(x => IgnoreAttributes.Contains(x))) continue;
+					if (IgnoreAttributes != null && traits.HasAnyTrait(IgnoreAttributes)) continue;
 				}
 
 				//And do damage to objects

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Gibtonite Ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Gibtonite Ore.asset
@@ -76,6 +76,6 @@ MonoBehaviour:
       m_EditorAssetChanged: 0
   SoundOnDestroy: []
   sprite: {fileID: 21300000, guid: a9d8f27a5eb052c4a88ae45d1bbc2acf, type: 3}
-  CanBeHighlightedThroughScanners: 0
-  AssoicatedSpawnedObjects: []
-  HighlightObject: {fileID: 0}
+  CanBeHighlightedThroughScanners: 1
+  HighlightObject: {fileID: 7029668430360334507, guid: bc9d1b1b93ab1b0409cc354d1b3595c3,
+    type: 3}


### PR DESCRIPTION
CL: [New] Gibtonite explosions will now ignore ore that is on the ground. This change is made to match the behavior of the gibtonite on SS13.
CL: [Improvement] Added chat messages to indicate state changes for gibtonite
CL: [Improvement] Increased the fuse time for the gibtonite from 2 seconds to 4 seconds.
CL: [Improvement] Gibtonite clusters have had their chances increased ever so slightly to allow for pairs of gibtonite spawning with each other.
CL: [Fix] The gibtonite had the wrong configuration that caused it to not appear on mining scanners. This has been fixed.
CL: [Fix] Tiles that do not have a specific overlay assigned will no longer obstruct the entire tile when scanned.