### PR TITLE
Improved laying down behavior

### DIFF
--- a/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
+++ b/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
@@ -467,6 +467,7 @@ GameObject:
   - component: {fileID: 1141615694652522293}
   - component: {fileID: 1568398651731903223}
   - component: {fileID: 7505980873864335948}
+  - component: {fileID: 8176686349149668929}
   m_Layer: 8
   m_Name: Player_V4(uNet)
   m_TagString: Untagged
@@ -588,7 +589,7 @@ MonoBehaviour:
     type: 3}
   infectedSpriteHandler: {fileID: 7962154314580008223}
   muzzleFlash: {fileID: 114824170203619628}
-  raceOverride: 
+  RaceOverride: 
   livingHealthMasterBase: {fileID: 1354417930896543338}
   characterSprites:
   - {fileID: 5811805431220600328}
@@ -698,6 +699,7 @@ MonoBehaviour:
   objectType: 2
   prefabTracker: {fileID: 0}
   CurrentsortingGroup: {fileID: 0}
+  <LayDownBehavior>k__BackingField: {fileID: 0}
   networkedLean: {fileID: -8106636780342977062}
 --- !u!114 &114449635359748350
 MonoBehaviour:
@@ -1004,6 +1006,7 @@ MonoBehaviour:
   syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
+  DoesNotRequireBrain: 0
   BodyType: 0
   RTT: 0
   BodyPartList: []
@@ -1370,7 +1373,6 @@ MonoBehaviour:
   Intangible: 0
   CanBeWindPushed: 1
   IsPlayer: 1
-  InitialLocationSynchronised: 0
   tileMoveSpeed: 1
   isNotPushable: 0
   HasOwnGravity: 0
@@ -1404,6 +1406,7 @@ MonoBehaviour:
   MoveIsWalking: 0
   LastUpdateClientFlying: 0
   BuckledToObject: {fileID: 0}
+  HardcodedSpeed: 0
   playerScript: {fileID: 0}
   Step: 0
   CanMoveThroughObstructions: 0
@@ -1528,7 +1531,31 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 15cb59dbd56e8f241a981fadf2adfb11, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0.1
   ConnectedAccess: []
+  AccessToChannel: 0
+--- !u!114 &8176686349149668929
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1133514949248654}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1f7e7b047d3c42e0b2df604c775f9cfe, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0.1
+  sprites: {fileID: 4962232741225816}
+  playerDirectional: {fileID: 114449635359748350}
+  playerScript: {fileID: 114617133355526680}
+  networkedLean: {fileID: -8106636780342977062}
+  IsLayingDown: 0
 --- !u!1 &1147423205297840
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
+++ b/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
@@ -1958,6 +1958,8 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 			return;
 		}
 
+		if (pullable is MovementSynchronisation c) c.playerScript.RegisterPlayer.LayDownBehavior.EnsureCorrectState();
+
 		if (Pulling.HasComponent)
 		{
 			//Just stopping pulling of object if we try pulling it again
@@ -1990,8 +1992,6 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 		SoundManager.PlayNetworkedAtPos(CommonSounds.Instance.ThudSwoosh, pullable.transform.position,
 			sourceObj: pullableObject);
 
-		if (pullable is MovementSynchronisation c) c.playerScript.RegisterPlayer.LayDownBehavior.EnsureCorrectState();
-		
 		//TODO Update the UI
 	}
 

--- a/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
+++ b/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
@@ -565,9 +565,7 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 			}
 
 			if (this is not MovementSynchronisation c) return;
-			transform.localRotation = c.playerScript.RegisterPlayer.IsLayingDown
-				? Quaternion.Euler(0, 0, -90)
-				: Quaternion.Euler(0, 0, 0);
+			c.playerScript.RegisterPlayer.LayDownBehavior.EnsureCorrectState();
 		}
 		else
 		{
@@ -1991,6 +1989,9 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 		PullSet(pullable, true);
 		SoundManager.PlayNetworkedAtPos(CommonSounds.Instance.ThudSwoosh, pullable.transform.position,
 			sourceObj: pullableObject);
+
+		if (pullable is MovementSynchronisation c) c.playerScript.RegisterPlayer.LayDownBehavior.EnsureCorrectState();
+		
 		//TODO Update the UI
 	}
 

--- a/UnityProject/Assets/Scripts/Objects/Machines/QuantumPad.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/QuantumPad.cs
@@ -176,7 +176,8 @@ namespace Objects.Science
 			foreach (UniversalObjectPhysics player in Matrix.Get<UniversalObjectPhysics>(registerTileLocation, ObjectType.Player, true))
 			{
 				Chat.AddExamineMsgFromServer(player.gameObject, message);
-				SoundManager.PlayNetworkedForPlayer(player.gameObject, CommonSounds.Instance.StealthOff); //very weird, sometimes does the sound other times not.
+				SoundManager.PlayNetworkedForPlayer(connectedPad.gameObject, CommonSounds.Instance.StealthOff);
+				SoundManager.PlayNetworkedForPlayer(gameObject, CommonSounds.Instance.StealthOff);
 				TransportUtility.TransportObjectAndPulled(player, travelCoord, true, maintRoomChanceModifier);
 				somethingTeleported = true;
 

--- a/UnityProject/Assets/Scripts/Objects/ObjectContainer.cs
+++ b/UnityProject/Assets/Scripts/Objects/ObjectContainer.cs
@@ -245,7 +245,7 @@ namespace Objects
 		private void CheckPlayerCrawlState(UniversalObjectPhysics playerBehaviour)
 		{
 			var regPlayer = playerBehaviour.GetComponent<RegisterPlayer>();
-			regPlayer.HandleGetupAnimation(!regPlayer.IsLayingDown);
+			regPlayer.LayDownBehavior.EnsureCorrectState();
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/Player/LayDown.cs
+++ b/UnityProject/Assets/Scripts/Player/LayDown.cs
@@ -1,4 +1,5 @@
-﻿using Mirror;
+﻿using HealthV2;
+using Mirror;
 using Player.Movement;
 using UnityEngine;
 
@@ -7,6 +8,7 @@ namespace Player
 	public class LayDown : NetworkBehaviour
 	{
 		[SerializeField] private Transform sprites;
+		[SerializeField] private LivingHealthMasterBase health;
 		[SerializeField] private Rotatable playerDirectional;
 		[SerializeField] private PlayerScript playerScript;
 		[SerializeField] private Util.NetworkedLeanTween networkedLean;
@@ -20,6 +22,7 @@ namespace Player
 		{
 			playerScript ??= GetComponent<PlayerScript>();
 			playerDirectional ??= GetComponent<Rotatable>();
+			health ??= GetComponent<LivingHealthMasterBase>();
 		}
 
 		private void OnEnable()
@@ -40,13 +43,12 @@ namespace Player
 
 		public void EnsureCorrectState()
 		{
-			if (IsLayingDown) { LayingDownLogic(true); }
-			else { UpLogic(true); }
+			if (IsLayingDown || health.IsDead) { LayingDownLogic(true); } else { UpLogic(true); }
 		}
 
 		public void OnLayDown(bool oldValue, bool newValue)
 		{
-			if (newValue)
+			if (newValue || health.IsDead)
 			{
 				LayingDownLogic();
 			}
@@ -65,8 +67,8 @@ namespace Player
 				spriteRenderer.sortingLayerName = "Bodies";
 			}
 			playerScript.PlayerSync.CurrentMovementType  = MovementType.Crawling;
-			if(CustomNetworkManager.IsServer) playerDirectional.LockDirectionTo(true, playerDirectional.CurrentDirection);
-			if(CustomNetworkManager.IsServer) playerScript.OnLayDown?.Invoke();
+			if (CustomNetworkManager.IsServer) playerDirectional.LockDirectionTo(true, playerDirectional.CurrentDirection);
+			if (CustomNetworkManager.IsServer) playerScript.OnLayDown?.Invoke();
 		}
 
 		private void UpLogic(bool forceState = false)

--- a/UnityProject/Assets/Scripts/Player/LayDown.cs
+++ b/UnityProject/Assets/Scripts/Player/LayDown.cs
@@ -1,0 +1,96 @@
+﻿using Mirror;
+using Player.Movement;
+using UnityEngine;
+
+namespace Player
+{
+	public class LayDown : NetworkBehaviour
+	{
+		[SerializeField] private Transform sprites;
+		[SerializeField] private Rotatable playerDirectional;
+		[SerializeField] private PlayerScript playerScript;
+		[SerializeField] private Util.NetworkedLeanTween networkedLean;
+		private readonly Quaternion layingDownRotation = Quaternion.Euler(0, 0, -90);
+		private readonly Quaternion standingUp = Quaternion.Euler(0, 0, 0);
+
+		[SyncVar(hook = nameof(OnLayDown))] public bool IsLayingDown = false;
+
+
+		private void Awake()
+		{
+			playerScript ??= GetComponent<PlayerScript>();
+			playerDirectional ??= GetComponent<Rotatable>();
+		}
+
+		private void OnEnable()
+		{
+			if (CustomNetworkManager.IsServer == false)
+			{
+				UpdateManager.Add(EnsureCorrectState, 5f);
+			}
+		}
+
+		private void OnDisable()
+		{
+			if (CustomNetworkManager.IsServer == false)
+			{
+				UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, EnsureCorrectState);
+			}
+		}
+
+		public void EnsureCorrectState()
+		{
+			if (IsLayingDown) { LayingDownLogic(true); }
+			else { UpLogic(true); }
+		}
+
+		public void OnLayDown(bool oldValue, bool newValue)
+		{
+			if (newValue)
+			{
+				LayingDownLogic();
+			}
+			else
+			{
+				UpLogic();
+			}
+			HandleGetupAnimation(newValue == false);
+		}
+
+		private void LayingDownLogic(bool forceState = false)
+		{
+			if (forceState) sprites.localRotation = layingDownRotation;
+			foreach (SpriteRenderer spriteRenderer in GetComponentsInChildren<SpriteRenderer>())
+			{
+				spriteRenderer.sortingLayerName = "Bodies";
+			}
+			playerScript.PlayerSync.CurrentMovementType  = MovementType.Crawling;
+			if(CustomNetworkManager.IsServer) playerDirectional.LockDirectionTo(true, playerDirectional.CurrentDirection);
+			if(CustomNetworkManager.IsServer) playerScript.OnLayDown?.Invoke();
+		}
+
+		private void UpLogic(bool forceState = false)
+		{
+			if (forceState) sprites.localRotation = standingUp;
+			foreach (SpriteRenderer spriteRenderer in GetComponentsInChildren<SpriteRenderer>())
+			{
+				spriteRenderer.sortingLayerName = "Players";
+			}
+			if (CustomNetworkManager.IsServer) playerDirectional.LockDirectionTo(false, playerDirectional.CurrentDirection);
+			if (CustomNetworkManager.IsServer) playerScript.PlayerSync.CurrentMovementType = MovementType.Running;
+		}
+
+		private void HandleGetupAnimation(bool getUp)
+		{
+			if (CustomNetworkManager.IsHeadless) return;
+			if (getUp == false && networkedLean.Target.rotation.z > -90)
+			{
+				networkedLean.RotateGameObject(new Vector3(0, 0, -90), 0.15f);
+			}
+			else if (getUp == true && networkedLean.Target.rotation.z < 90)
+			{
+				networkedLean.RotateGameObject(new Vector3(0, 0, 0), 0.19f);
+			}
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Player/LayDown.cs
+++ b/UnityProject/Assets/Scripts/Player/LayDown.cs
@@ -43,7 +43,14 @@ namespace Player
 
 		public void EnsureCorrectState()
 		{
-			if (IsLayingDown || health.IsDead) { LayingDownLogic(true); } else { UpLogic(true); }
+			if (IsLayingDown || health.IsDead)
+			{
+				LayingDownLogic(true);
+			}
+			else
+			{
+				UpLogic(true);
+			}
 		}
 
 		public void OnLayDown(bool oldValue, bool newValue)
@@ -67,8 +74,10 @@ namespace Player
 				spriteRenderer.sortingLayerName = "Bodies";
 			}
 			playerScript.PlayerSync.CurrentMovementType  = MovementType.Crawling;
-			if (CustomNetworkManager.IsServer) playerDirectional.LockDirectionTo(true, playerDirectional.CurrentDirection);
-			if (CustomNetworkManager.IsServer) playerScript.OnLayDown?.Invoke();
+			if (CustomNetworkManager.IsServer == false) return;
+			playerDirectional.LockDirectionTo(true, playerDirectional.CurrentDirection);
+			playerScript.OnLayDown?.Invoke();
+
 		}
 
 		private void UpLogic(bool forceState = false)
@@ -78,8 +87,9 @@ namespace Player
 			{
 				spriteRenderer.sortingLayerName = "Players";
 			}
-			if (CustomNetworkManager.IsServer) playerDirectional.LockDirectionTo(false, playerDirectional.CurrentDirection);
-			if (CustomNetworkManager.IsServer) playerScript.PlayerSync.CurrentMovementType = MovementType.Running;
+			if (CustomNetworkManager.IsServer == false) return;
+			playerDirectional.LockDirectionTo(false, playerDirectional.CurrentDirection);
+			playerScript.PlayerSync.CurrentMovementType = MovementType.Running;
 		}
 
 		private void HandleGetupAnimation(bool getUp)

--- a/UnityProject/Assets/Scripts/Player/LayDown.cs
+++ b/UnityProject/Assets/Scripts/Player/LayDown.cs
@@ -25,22 +25,6 @@ namespace Player
 			health ??= GetComponent<LivingHealthMasterBase>();
 		}
 
-		private void OnEnable()
-		{
-			if (CustomNetworkManager.IsServer == false)
-			{
-				UpdateManager.Add(EnsureCorrectState, 5f);
-			}
-		}
-
-		private void OnDisable()
-		{
-			if (CustomNetworkManager.IsServer == false)
-			{
-				UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, EnsureCorrectState);
-			}
-		}
-
 		public void EnsureCorrectState()
 		{
 			if (IsLayingDown || health.IsDead)

--- a/UnityProject/Assets/Scripts/Player/LayDown.cs.meta
+++ b/UnityProject/Assets/Scripts/Player/LayDown.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1f7e7b047d3c42e0b2df604c775f9cfe
+timeCreated: 1684666614

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
@@ -7,11 +7,13 @@ using UnityEngine.Events;
 using Random = UnityEngine.Random;
 using Systems.Teleport;
 using Messages.Server.SoundMessages;
+using Player;
 using Player.Movement;
 using Systems.Explosions;
 
 [RequireComponent(typeof(Rotatable))]
 [RequireComponent(typeof(UprightSprites))]
+[RequireComponent(typeof(LayDown))]
 [ExecuteInEditMode]
 public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IControlPlayerState
 {
@@ -23,14 +25,12 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 
 	const int HELP_CHANCE = 33; // Percent.
 
-	// tracks whether player is down or upright.
-	[SyncVar(hook = nameof(SyncIsLayingDown))]
-	private bool isLayingDown;
+	[field: SerializeField] public LayDown LayDownBehavior { get; private set; }
 
 	/// <summary>
 	/// True when the player is laying down for any reason (shown sideways)
 	/// </summary>
-	public bool IsLayingDown => isLayingDown;
+	public bool IsLayingDown => LayDownBehavior.IsLayingDown;
 
 	/// <summary>
 	/// True when the player is slipping
@@ -74,7 +74,7 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 		playerScript = GetComponent<PlayerScript>();
 		uprightSprites = GetComponent<UprightSprites>();
 		playerDirectional = GetComponent<Rotatable>();
-		//playerDirectional.ChangeDirectionWithMatrix = false;
+		LayDownBehavior ??= GetComponent<LayDown>();
 		uprightSprites.spriteMatrixRotationBehavior = SpriteMatrixRotationBehavior.RemainUpright;
 	}
 
@@ -86,7 +86,7 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 	public override void OnStartClient()
 	{
 		base.OnStartClient();
-		ServerCheckStandingChange(isLayingDown);
+		ServerCheckStandingChange(IsLayingDown);
 	}
 
 	public void OnSpawnServer(SpawnInfo info)
@@ -166,7 +166,7 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 
 	public bool ServerCheckStandingChange(bool layingDown, bool doBar = false, float time = 1.5f)
 	{
-		if (isLayingDown == layingDown) return false;
+		if (IsLayingDown == layingDown) return false;
 
 		foreach (var status in CheckableStatuses)
 		{
@@ -182,14 +182,14 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 				new StandardProgressActionConfig(StandardProgressActionType.SelfHeal, false, false, true),
 				() =>
 				{
-					SyncIsLayingDown(isLayingDown, layingDown);
+					SyncIsLayingDown(layingDown);
 				});
 
 			bar.ServerStartProgress(this, time, gameObject);
 		}
 		else
 		{
-			SyncIsLayingDown(isLayingDown, layingDown);
+			SyncIsLayingDown(layingDown);
 		}
 
 		return true;
@@ -210,57 +210,12 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 		}
 	}
 
-	private void SyncIsLayingDown(bool wasDown, bool isDown)
+	private void SyncIsLayingDown(bool isDown)
 	{
-		this.isLayingDown = isDown;
-
 		OnLyingDownChangeEvent?.Invoke(isDown);
-
-		if (CustomNetworkManager.IsHeadless == false)
-		{
-			HandleGetupAnimation(isDown == false);
-		}
-
-		if (isDown)
-		{
-			//uprightSprites.ExtraRotation = Quaternion.Euler(0, 0, -90);
-			//Change sprite layer
-			foreach (SpriteRenderer spriteRenderer in GetComponentsInChildren<SpriteRenderer>())
-			{
-				spriteRenderer.sortingLayerName = "Bodies";
-			}
-
-			playerScript.PlayerSync.CurrentMovementType  = MovementType.Crawling;
-
-			//lock current direction
-			playerDirectional.LockDirectionTo(true, playerDirectional.CurrentDirection);
-			playerScript.OnLayDown?.Invoke();
-		}
-		else
-		{
-			//uprightSprites.ExtraRotation = Quaternion.identity;
-			//back to original layer
-			foreach (SpriteRenderer spriteRenderer in GetComponentsInChildren<SpriteRenderer>())
-			{
-				spriteRenderer.sortingLayerName = "Players";
-			}
-
-			playerDirectional.LockDirectionTo(false, playerDirectional.CurrentDirection);
-			playerScript.PlayerSync.CurrentMovementType = MovementType.Running;
-		}
+		LayDownBehavior.IsLayingDown = isDown;
 	}
 
-	public void HandleGetupAnimation(bool getUp)
-	{
-		if (getUp == false && networkedLean.Target.rotation.z > -90)
-		{
-			networkedLean.RotateGameObject(new Vector3(0, 0, -90), 0.15f);
-		}
-		else if (getUp == true && networkedLean.Target.rotation.z < 90)
-		{
-			networkedLean.RotateGameObject(new Vector3(0, 0, 0), 0.19f);
-		}
-	}
 
 	/// <summary>
 	/// Try to help the player stand back up.
@@ -308,7 +263,7 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 		// Don't slip if you got no legs (HealthV2)
 		if (IsSlippingServer
 			|| !slipWhileWalking && playerScript.PlayerSync.CurrentTileMoveSpeed <= playerScript.playerMove.WalkSpeed
-            || isLayingDown
+            || IsLayingDown
 			|| playerScript.playerHealth.IsCrit
 			|| playerScript.playerHealth.IsSoftCrit
 			|| playerScript.playerHealth.IsDead)


### PR DESCRIPTION
This PR aims to take the first steps into fixing a long-standing issue with player rotations not being consistent.

We're moving away from whole gameObject rotations and are only rotating the sprites from now on.
There's also a timed safe-guard for when things go wrong, and we need to ensure that the sprite is shown correctly.

### Changelog:

CL: [Improvement] Improved laying down behavior to ensure that rotations are always consistent and added a way for them to attempt to self-correct every 5 seconds.
CL: [Fix] Fixed dead players standing up again when teleporting.
CL: [Fix] Fixed bug where pulled players would suddenly stand up after getting teleported while being dragged by another player.
CL: [Fix] Fixed players randomly losing their correct laying down state in the event of them disappearing and then reappearing again. 
CL: [Fix] Fixed chat bubble always being shifted downwards after laying down once.
CL: [Fix] Fixed an issue where sound would not play consistently on quantum pads.