### PR TITLE
Use IL2CPP instead of the soon-to-be-deprecated mono

### DIFF
--- a/UnityProject/Assets/Scripts/Messages/Server/GhostRoles/GhostRoleUpdateMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/GhostRoles/GhostRoleUpdateMessage.cs
@@ -1,5 +1,4 @@
-﻿using System.Net.Configuration;
-using Systems.GhostRoles;
+﻿using Systems.GhostRoles;
 using Mirror;
 
 namespace Messages.Server.GhostRoles

--- a/UnityProject/Assets/Scripts/UI/Systems/ServerInfoPanel/Models/ServerMotdData.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/ServerInfoPanel/Models/ServerMotdData.cs
@@ -8,3 +8,8 @@
 		public string DiscordLink { get; init; }
 	}
 }
+
+namespace System.Runtime.CompilerServices
+{
+	internal static class IsExternalInit {}
+}

--- a/UnityProject/Assets/Tests/Scenes/SceneTest.cs
+++ b/UnityProject/Assets/Tests/Scenes/SceneTest.cs
@@ -13,6 +13,7 @@ namespace Tests.Scenes
 	{
 		// This allows the tests to show the name of the scene rather than the file location
 		public override string ToString() => Path.GetFileNameWithoutExtension(File);
+		public string File { get; } = File;
 	}
 
 	[Ignore("For scene testing subclasses")]

--- a/UnityProject/ProjectSettings/ProjectSettings.asset
+++ b/UnityProject/ProjectSettings/ProjectSettings.asset
@@ -874,7 +874,7 @@ PlayerSettings:
     iPhone: 1
   scriptingBackend:
     Android: 0
-    Standalone: 0
+    Standalone: 1
     WebGL: 1
     iPhone: 1
   il2cppCompilerConfiguration: {}
@@ -970,7 +970,7 @@ PlayerSettings:
   luminVersion:
     m_VersionCode: 1
     m_VersionName: 
-  apiCompatibilityLevel: 3
+  apiCompatibilityLevel: 6
   activeInputHandler: 0
   windowsGamepadBackendHint: 0
   cloudProjectId: cd5be26b-512d-4c34-9ba7-ce526037540d

--- a/UnityProject/ProjectSettings/ProjectSettings.asset
+++ b/UnityProject/ProjectSettings/ProjectSettings.asset
@@ -526,7 +526,7 @@ PlayerSettings:
     m_APIs: 10000000
     m_Automatic: 1
   - m_BuildTarget: WindowsStandaloneSupport
-    m_APIs: 0200000011000000
+    m_APIs: 020000001100000015000000
     m_Automatic: 0
   - m_BuildTarget: LinuxStandaloneSupport
     m_APIs: 1100000015000000

--- a/UnityProject/ProjectSettings/ProjectSettings.asset
+++ b/UnityProject/ProjectSettings/ProjectSettings.asset
@@ -526,7 +526,7 @@ PlayerSettings:
     m_APIs: 10000000
     m_Automatic: 1
   - m_BuildTarget: WindowsStandaloneSupport
-    m_APIs: 020000001100000015000000
+    m_APIs: 020000001500000011000000
     m_Automatic: 0
   - m_BuildTarget: LinuxStandaloneSupport
     m_APIs: 1100000015000000


### PR DESCRIPTION
This is not only a free performance upgrade, but a change that we'll have to do sometime in the future as Unity is planning on removing Mono completely from the engine in the upcoming years.

The game will also now use the .NET Standard, which will improve compatibility between Linux, Mac and Windows and reduce those pesky moments where a library on Linux/Mac implements something a different way (or none at all) which would result in game crashes or not launching at all.

### Chagenlog:

CL: [Improvement] Unitystation now uses ILC2PP as its scripting backend. Boosting server and client performance + Linux/Mac compatibility. 
CL: [Improvement] Vulkan has been re-enabled as an optional rendering backend.
