### PR TITLE
Animate sprites for getting up/laying down instead of root object

### DIFF
--- a/UnityProject/Assets/Scripts/Player/LayDown.cs
+++ b/UnityProject/Assets/Scripts/Player/LayDown.cs
@@ -23,6 +23,7 @@ namespace Player
 			playerScript ??= GetComponent<PlayerScript>();
 			playerDirectional ??= GetComponent<Rotatable>();
 			health ??= GetComponent<LivingHealthMasterBase>();
+			networkedLean ??= GetComponent<Util.NetworkedLeanTween>();
 		}
 
 		public void EnsureCorrectState()
@@ -35,6 +36,7 @@ namespace Player
 			{
 				UpLogic(true);
 			}
+			gameObject.transform.rotation = Quaternion.Euler(0, 0, 0);
 		}
 
 		public void OnLayDown(bool oldValue, bool newValue)
@@ -61,7 +63,6 @@ namespace Player
 			if (CustomNetworkManager.IsServer == false) return;
 			playerDirectional.LockDirectionTo(true, playerDirectional.CurrentDirection);
 			playerScript.OnLayDown?.Invoke();
-
 		}
 
 		private void UpLogic(bool forceState = false)
@@ -81,11 +82,11 @@ namespace Player
 			if (CustomNetworkManager.IsHeadless) return;
 			if (getUp == false && networkedLean.Target.rotation.z > -90)
 			{
-				networkedLean.RotateGameObject(new Vector3(0, 0, -90), 0.15f);
+				networkedLean.RotateGameObject(new Vector3(0, 0, -90), 0.15f, sprites.gameObject);
 			}
-			else if (getUp == true && networkedLean.Target.rotation.z < 90)
+			else if (getUp && networkedLean.Target.rotation.z < 90)
 			{
-				networkedLean.RotateGameObject(new Vector3(0, 0, 0), 0.19f);
+				networkedLean.RotateGameObject(new Vector3(0, 0, 0), 0.19f, sprites.gameObject);
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Util/NetworkedLeanTween.cs
+++ b/UnityProject/Assets/Scripts/Util/NetworkedLeanTween.cs
@@ -115,9 +115,9 @@ namespace Util
 			LeanTween.rotate(Target.gameObject, vector, time);
 		}
 
-		public void RotateGameObject(Vector3 vector, float time)
+		public void RotateGameObject(Vector3 vector, float time, GameObject otherTarget = null)
 		{
-			LeanTween.rotate(Target.gameObject, vector, time);
+			LeanTween.rotate(otherTarget == null ? Target.gameObject : otherTarget.gameObject, vector, time);
 		}
 
 		[ClientRpc]


### PR DESCRIPTION
CL: [Improvement] The laying down/getting up animation now targets the sprites instead of the player's root gameobject
