### PR TITLE
Fix critical level Codacy issues for 'Short-circuit logic should be used in boolean contexts'

### DIFF
--- a/UnityProject/Assets/Scripts/Clothing/WearableArmor.cs
+++ b/UnityProject/Assets/Scripts/Clothing/WearableArmor.cs
@@ -41,7 +41,7 @@ namespace Clothing
 		public void OnInventoryMoveServer(InventoryMove info)
 		{
 			//Wearing
-			if (info.ToSlot != null & info.ToSlot?.NamedSlot != null)
+			if (info.ToSlot != null && info.ToSlot.NamedSlot != null)
 			{
 				playerHealthV2 = info.ToRootPlayer?.PlayerScript.playerHealth;
 
@@ -52,7 +52,7 @@ namespace Clothing
 			}
 
 			//taking off
-			if (info.FromSlot != null & info.FromSlot?.NamedSlot != null)
+			if (info.FromSlot != null && info.FromSlot.NamedSlot != null)
 			{
 				playerHealthV2 = info.FromRootPlayer?.PlayerScript.playerHealth;
 

--- a/UnityProject/Assets/Scripts/Messages/Server/MobMeleeLerpMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/MobMeleeLerpMessage.cs
@@ -21,7 +21,7 @@ namespace Messages.Server
 			var getMob = NetworkObject;
 			var mobMelee = getMob.GetComponent<MobMeleeAttack>();
 			var mobAction = getMob.GetComponent<MobMeleeAction>();
-			if (mobMelee == null & mobAction == null)
+			if (mobMelee == null && mobAction == null)
 			{
 				return;
 			}

--- a/UnityProject/Assets/Scripts/Robotics/Bots/BotConstruction.cs
+++ b/UnityProject/Assets/Scripts/Robotics/Bots/BotConstruction.cs
@@ -60,7 +60,10 @@ namespace Items.Robotics
 			// Goes through list of items and checks them against the stageParts list and stageCounter
 			for (int x = 0; x <= stageParts.Length - 1; x++)
 			{
-				if (hand == checkItem & x == stageCounter) return true;
+				if (hand == checkItem && x == stageCounter)
+				{
+					return true;
+				}
 			}
 			return false;
 		}

--- a/UnityProject/Assets/Scripts/Systems/Electricity/Electrical processes/ElectricalSynchronisation.cs
+++ b/UnityProject/Assets/Scripts/Systems/Electricity/Electrical processes/ElectricalSynchronisation.cs
@@ -479,8 +479,10 @@ namespace Systems.Electricity
 				UesAlternativeDirectionWorkOnNextList = true;
 				CircuitSearch(wire, DirectionWorkOnNextList, DirectionWorkOnNextListWait);
 
-				if (DirectionWorkOnNextList.Count <= 0 & DirectionWorkOnNextListWait.Count <= 0 &
-					_DirectionWorkOnNextList.Count <= 0 & _DirectionWorkOnNextListWait.Count <= 0)
+				if (DirectionWorkOnNextList.Count <= 0
+				    && DirectionWorkOnNextListWait.Count <= 0
+				    && _DirectionWorkOnNextList.Count <= 0
+				    && _DirectionWorkOnNextListWait.Count <= 0)
 				{
 					break;
 				}

--- a/UnityProject/Assets/Scripts/Systems/Electricity/Inheritance/CableInheritance.cs
+++ b/UnityProject/Assets/Scripts/Systems/Electricity/Inheritance/CableInheritance.cs
@@ -205,7 +205,7 @@ namespace Objects.Electrical
 		{
 			if (this != null && !BeingDestroyed)
 			{
-				if (wireConnect.InData.WireEndA != Connection.NA | wireConnect.InData.WireEndB != Connection.NA)
+				if (wireConnect.InData.WireEndA != Connection.NA || wireConnect.InData.WireEndB != Connection.NA)
 				{
 					var searchVec = wireConnect.registerTile.LocalPosition;
 					if (wireConnect.SpriteHandler == null)
@@ -253,7 +253,7 @@ namespace Objects.Electrical
 
 		public void FindOverlapsAndCombine()
 		{
-			if (WireEndA == Connection.Overlap | WireEndB == Connection.Overlap)
+			if (WireEndA == Connection.Overlap || WireEndB == Connection.Overlap)
 			{
 				List<IntrinsicElectronicData> Econns = new List<IntrinsicElectronicData>();
 

--- a/UnityProject/Assets/Scripts/Systems/Electricity/NodeModules/BatterySupplyingModule.cs
+++ b/UnityProject/Assets/Scripts/Systems/Electricity/NodeModules/BatterySupplyingModule.cs
@@ -250,7 +250,9 @@ namespace Systems.Electricity.NodeModules
 					}
 				}
 			}
-			if (current != Previouscurrent | SupplyingVoltage != PreviousSupplyingVoltage | InternalResistance != PreviousInternalResistance)
+			if (current != Previouscurrent
+			    || SupplyingVoltage != PreviousSupplyingVoltage
+			    || InternalResistance != PreviousInternalResistance)
 			{
 				ControllingNode.Node.InData.Data.SupplyingCurrent = current;
 				Previouscurrent = current;

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/AdminGlobalAudioSearchBar.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/AdminGlobalAudioSearchBar.cs
@@ -61,7 +61,7 @@ namespace AdminTools
 				if (buttons[i] != null)
 				{
 					if (buttons[i].GetComponent<AdminGlobalAudioButton>().myText.text.ToLower()
-						    .Contains(Searchtext.text.ToLower()) | Searchtext.text.Length == 0)
+						    .Contains(Searchtext.text.ToLower()) || Searchtext.text.Length == 0)
 					{
 					}
 					else


### PR DESCRIPTION
### Purpose
See: #7389 

This should fix all of the issues in this category on Codacy.

https://app.codacy.com/gh/unitystation/unitystation/issues?&filters=W3siaWQiOiJMYW5ndWFnZSIsInZhbHVlcyI6WyJDU2hhcnAiXX0seyJpZCI6IkNhdGVnb3J5IiwidmFsdWVzIjpbIkVycm9yUHJvbmUiXX0seyJpZCI6IkxldmVsIiwidmFsdWVzIjpbIkVycm9yIl19LHsiaWQiOiJQYXR0ZXJuIiwidmFsdWVzIjpbIjQzMDkiXX0seyJpZCI6IkF1dGhvciIsInZhbHVlcyI6W119XQ==

### Notes:
No player facing changes in this, just some code cleanup.

### Changelog:
n/a
