### PR TITLE
Fixes infinite monkey Glass shard death Torment

### DIFF
--- a/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
+++ b/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
@@ -1828,7 +1828,11 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 		//Can truncate as the localPos should be near enough to the int value
 		var rounded = localPos.TruncateToInt();
 
-		OnLocalTileReached.Invoke(oldLocalTilePosition, rounded);
+		if (TransformState.HiddenPos != localPos)
+		{
+			OnLocalTileReached.Invoke(oldLocalTilePosition, rounded);
+		}
+
 
 		oldLocalTilePosition = rounded;
 		SetRegisterTileLocation(rounded);
@@ -1850,6 +1854,7 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 	public virtual void LocalServerTileReached(Vector3Int localPos)
 	{
 		if (doStepInteractions == false) return;
+		if (localPos == TransformState.HiddenPos) return;
 
 		var matrix = registerTile.Matrix;
 		if (matrix == null) return;

--- a/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
+++ b/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
@@ -1018,7 +1018,10 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 			}
 			else
 			{
-				Pulling.Component.TryTilePush(inDirection.NormalizeTo2Int(), byClient, speed, pushedBy, pulledBy: this);
+
+				Pulling.Component.SetMatrixCache.ResetNewPosition(Pulling.Component.transform.position);
+				Pulling.Component.Pushing.Clear();
+				Pulling.Component.ForceTilePush(inDirection.NormalizeTo2Int(), Pulling.Component.Pushing, byClient, speed, pulledBy:  this);
 			}
 		}
 
@@ -1035,8 +1038,9 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 			}
 			else
 			{
-				ObjectIsBucklingChecked.Component.Pulling.Component.TryTilePush(inDirection.NormalizeTo2Int(), byClient,
-					speed, pushedBy);
+				ObjectIsBucklingChecked.Component.Pulling.Component.SetMatrixCache.ResetNewPosition(ObjectIsBucklingChecked.Component.Pulling.Component.transform.position);
+				ObjectIsBucklingChecked.Component.Pulling.Component.Pushing.Clear();
+				ObjectIsBucklingChecked.Component.Pulling.Component.ForceTilePush(inDirection.NormalizeTo2Int(), ObjectIsBucklingChecked.Component.Pulling.Component.Pushing, byClient, speed, pulledBy:  this);
 			}
 		}
 	}
@@ -1281,7 +1285,6 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 			TileMoveSpeedOverride = 0;
 			Animating = false;
 
-			InternalTriggerOnLocalTileReached(transform.localPosition);
 			MoveIsWalking = false;
 
 			if (IsFloating() && PulledBy.HasComponent == false && doNotApplyMomentumOnTarget == false)

--- a/UnityProject/Assets/Scripts/Shared/Extensions/SharedConverterExtensions.cs
+++ b/UnityProject/Assets/Scripts/Shared/Extensions/SharedConverterExtensions.cs
@@ -41,7 +41,7 @@ public static class SharedConverterExtensions
 
 	/// <summary>Cast (Truncate) <see cref="Vector3"/> to <see cref="Vector3Int"/> while cutting z-axis</summary>
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public static Vector3Int TruncateToInt(this Vector3 other) => new((int) other.x, (int) other.y);
+	public static Vector3Int TruncateToInt(this Vector3 other) => new((int) other.x, (int) other.y, (int) other.z);
 
 	/// <summary>Round <see cref="Vector2"/> to <see cref="Vector2Int"/>.</summary>
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/UnityProject/Assets/Scripts/Systems/Research/ItemResearchPotential.cs
+++ b/UnityProject/Assets/Scripts/Systems/Research/ItemResearchPotential.cs
@@ -62,8 +62,8 @@ public class ItemResearchPotential : MonoBehaviour
 		System.Random random = new System.Random();
 		if (random.NextDouble() < 0.15)
 		{
-			int min = 25;
-			int max = 75;
+			int min = 20;
+			int max = 35;
 			toReturn.AddedPurity = Random.Range(min, max + 1);
 		}
 		else
@@ -74,13 +74,15 @@ public class ItemResearchPotential : MonoBehaviour
 		}
 
 
-		var rng = Random.Range(0, 3000);
-		if (rng > 2990)
+		if (BasePurity + toReturn.AddedPurity > 51)
 		{
-			toReturn.AddedPurity += 100;
-			toReturn.IsTooPure = true;
+			var rng = Random.Range(0, 1000);
+			if (rng > 990)
+			{
+				toReturn.AddedPurity += 100;
+				toReturn.IsTooPure = true;
+			}
 		}
-
 
 		if (BasePurity + toReturn.AddedPurity > 50)
 		{


### PR DESCRIPTION
### Changelog:
CL: [Balance] Resonance cascade only comes from rare items now but it's now back up to 1 in 100.
CL: [Fix] Fixed infinite monkey glass shard death Torment (fixes a server crash).
CL: [Fix] Fixed not being able pull stuff properly.
CL: [Fix] Fixed footprints Getting place weirdly when walking horizontally.
