### PR TITLE
Reduces maintroom chances + Balances bomb damage

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Implants/HumanBodyPartExternal.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/HumanBodyPartExternal.prefab
@@ -141,11 +141,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   <traumaTypes>k__BackingField: 0
-  deadlyDamageInOneHit: 30
+  deadlyDamageInOneHit: 65
   bodyPart: {fileID: 1673759363237950006}
   stages:
     m_keys: 01000000
-    m_values: 1e000000
+    m_values: 41000000
+  juddgerResistence: 12
 --- !u!1 &2499910798797443627
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Damage/Trauma/TraumaTypes/TraumaBombExplosionHumanoid.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Damage/Trauma/TraumaTypes/TraumaBombExplosionHumanoid.cs
@@ -1,15 +1,34 @@
-﻿namespace HealthV2.TraumaTypes
+﻿using UnityEngine;
+
+namespace HealthV2.TraumaTypes
 {
 	public class TraumaBombExplosionHumanoid : TraumaLogic
 	{
+
+		[SerializeField] private float juddgerResistence = 12f;
+
 		public override void OnTakeDamage(BodyPartDamageData data)
 		{
 			if ( data.TramuticDamageType != TraumaticDamageTypes.NONE ) return;
 			if ( data.AttackType != AttackType.Bomb ) return;
-			if ( deadlyDamageInOneHit > data.DamageAmount ) return;
 			if ( DMMath.Prob(GetBombProtectionPercentage()) ) return;
 			if ( DMMath.Prob(data.TraumaDamageChance) == false ) return;
+			if ( deadlyDamageInOneHit > data.DamageAmount)
+			{
+				DoJuddgerDamage(data);
+				return;
+			}
 			ProgressDeadlyEffect();
+		}
+
+		private void DoJuddgerDamage(BodyPartDamageData data)
+		{
+			bodyPart.TakeDamage(data.DamagedBy, data.DamageAmount / juddgerResistence,
+				AttackType.Internal, DamageType.Brute,
+				true, false,
+				traumaDamageChance: 0, invokeOnDamageEvent: false);
+			Chat.AddExamineMsg(bodyPart.HealthMaster.gameObject,
+				$"<color=red><size=+4>You feel something itch under your skin.</size></color>");
 		}
 
 		public override void ProgressDeadlyEffect()

--- a/UnityProject/Assets/Scripts/Objects/Gateway/TransportUtility.cs
+++ b/UnityProject/Assets/Scripts/Objects/Gateway/TransportUtility.cs
@@ -22,14 +22,12 @@ namespace Gateway
 		/// <param name="transportTo">Destination to transport <paramref name="objectPhysics"/> to.</param>
 		/// <param name="doTileStep">Whether step interactions should trigger on teleport</param>
 		[Server]
-		public static void TransportObject(UniversalObjectPhysics objectPhysics, Vector3 transportTo, bool doTileStep = true, float maintRoomChanceModifier = 0.5f)
+		public static void TransportObject(UniversalObjectPhysics objectPhysics, Vector3 transportTo, bool doTileStep = true, float maintRoomChanceModifier = 0.25f)
 		{
 			if (objectPhysics == null) return; //Don't even bother...
 
 			var dest = transportTo;
-
-			var RandomChance = Random.Range(0, 100000) / 1000f; //100000 / 1000 = 100
-			if (SubSceneManager.Instance.IsMaintRooms && RandomChance <= maintRoomChanceModifier)
+			if (SubSceneManager.Instance.IsMaintRooms && DMMath.Prob(maintRoomChanceModifier))
 			{
 				dest = MaintRoomLocations.PickRandom().RegisterTile().WorldPositionServer;
 			}
@@ -48,7 +46,7 @@ namespace Gateway
 		/// <param name="doTileStep">Whether step interactions should trigger on teleport</param>
 		[Server]
 		public static void TransportObjectAndPulled(UniversalObjectPhysics objectPhysics, Vector3 transportTo,
-			bool doTileStep = true, float maintRoomChanceModifier = 0.5f)
+			bool doTileStep = true, float maintRoomChanceModifier = 0.25f)
 		{
 			if (objectPhysics == null) return; //Don't even bother...
 

--- a/UnityProject/Assets/Scripts/Objects/Gateway/TransportUtility.cs
+++ b/UnityProject/Assets/Scripts/Objects/Gateway/TransportUtility.cs
@@ -27,7 +27,7 @@ namespace Gateway
 			if (objectPhysics == null) return; //Don't even bother...
 
 			var dest = transportTo;
-			if (SubSceneManager.Instance.IsMaintRooms && DMMath.Prob(maintRoomChanceModifier))
+			if (SubSceneManager.Instance.IsMaintRooms && DMMath.Prob(0.001f * maintRoomChanceModifier))
 			{
 				dest = MaintRoomLocations.PickRandom().RegisterTile().WorldPositionServer;
 			}

--- a/UnityProject/Assets/Scripts/Player/TeleportUtils.cs
+++ b/UnityProject/Assets/Scripts/Player/TeleportUtils.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Systems.Ai;
 using Systems.MobAIs;


### PR DESCRIPTION
fixes #9803

CL: [Improvement] Added juddering as a side effect to bomb trauma to balance out how deadly explosions are currently. Juddering is when the body receives a shockwave or extreme vibrations to the body which causes internal damage.
CL: [Improvement] Reduced the chances of getting randomly teleported to the maint-rooms.
