### PR TITLE
Continues improvements for laying down behavior

### DIFF
--- a/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
+++ b/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
@@ -699,7 +699,7 @@ MonoBehaviour:
   objectType: 2
   prefabTracker: {fileID: 0}
   CurrentsortingGroup: {fileID: 0}
-  <LayDownBehavior>k__BackingField: {fileID: 0}
+  <LayDownBehavior>k__BackingField: {fileID: 8176686349149668929}
   networkedLean: {fileID: -8106636780342977062}
 --- !u!114 &114449635359748350
 MonoBehaviour:
@@ -1007,6 +1007,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   DoesNotRequireBrain: 0
+  tickRate: 1
   BodyType: 0
   RTT: 0
   BodyPartList: []
@@ -1366,25 +1367,29 @@ MonoBehaviour:
   syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
-  DEBUG: 0
-  SnapToGridOnStart: 0
+  LocalDifferenceNeeded: {x: 0, y: 0}
   LocalTargetPosition: {x: 0, y: 0, z: 0}
-  ChangesDirectionPush: 1
-  Intangible: 0
-  CanBeWindPushed: 1
-  IsPlayer: 1
-  tileMoveSpeed: 1
-  isNotPushable: 0
-  HasOwnGravity: 0
+  CorrectingCourse: 0
+  Animating: 0
+  SetIgnoreSticky: 0
   airTime: 0
   slideTime: 0
-  SetIgnoreSticky: 0
+  spinMagnitude: 0
   thrownBy: {fileID: 0}
   aim: 0
-  spinMagnitude: 0
   ForcedPushedFrame: 0
   TryPushedFrame: 0
   PushedFrame: 0
+  ChangesDirectionPush: 1
+  Intangible: 0
+  SnapToGridOnStart: 0
+  IsPlayer: 1
+  DEBUG: 0
+  tileMoveSpeed: 1
+  HasOwnGravity: 0
+  isNotPushable: 0
+  CanBeWindPushed: 1
+  rotationTarget: {fileID: 4962232741225816}
   FramePushDecision: 1
   stickyMovement: 1
   OnThrowEndResetRotation: 0
@@ -1396,17 +1401,17 @@ MonoBehaviour:
   - {fileID: 0}
   - {fileID: 0}
   IsCurrentlyFloating: 0
-  LocalDifferenceNeeded: {x: 0, y: 0}
-  CorrectingCourse: 0
   Pushing: []
   Hits: []
-  Animating: 0
   isFlyingSliding: 0
   IsMoving: 0
   MoveIsWalking: 0
   LastUpdateClientFlying: 0
   BuckledToObject: {fileID: 0}
+  IsPressedCashed: 0
+  IsPressedServer: 0
   HardcodedSpeed: 0
+  LastUpdatedFlyingPosition: 0
   playerScript: {fileID: 0}
   Step: 0
   CanMoveThroughObstructions: 0
@@ -1417,10 +1422,6 @@ MonoBehaviour:
   needsRunning: {fileID: 11400000, guid: 79263d379ff044244a9baa143471a268, type: 2}
   actionData: {fileID: 11400000, guid: 967a13d2ea206e9448f6c6e2af11a3cf, type: 2}
   IsBumping: 0
-  IsPressedCashed: 0
-  IsPressedServer: 0
-  LastUpdatedFlyingPosition: 0
-  DEBUGLastMoveMessageProcessed: 0
 --- !u!114 &3901833431230868314
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1552,9 +1553,11 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   sprites: {fileID: 4962232741225816}
+  health: {fileID: 1354417930896543338}
   playerDirectional: {fileID: 114449635359748350}
   playerScript: {fileID: 114617133355526680}
   networkedLean: {fileID: -8106636780342977062}
+  disabled: 0
   IsLayingDown: 0
 --- !u!1 &1147423205297840
 GameObject:
@@ -8313,7 +8316,7 @@ SpriteRenderer:
   m_SortingLayerID: -902452607
   m_SortingLayer: 22
   m_SortingOrder: 20
-  m_Sprite: {fileID: 7660122581263827943, guid: 2adbceb9cc674484cb9a2c58b41d5493,
+  m_Sprite: {fileID: -1841058614580174146, guid: 2adbceb9cc674484cb9a2c58b41d5493,
     type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0

--- a/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
+++ b/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
@@ -1385,10 +1385,7 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 			return;
 		}
 
-		if (IsMoving)
-		{
-			return;
-		}
+		if (IsMoving) return;
 
 		isFlyingSliding = true;
 		MoveIsWalking = false;
@@ -1407,10 +1404,7 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 			}
 		}
 
-		if (PulledBy.HasComponent)
-		{
-			return; //It is recursively handled By parent
-		}
+		if (PulledBy.HasComponent) return; //It is recursively handled By parent
 
 		if (airTime > 0)
 		{

--- a/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
+++ b/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
@@ -406,9 +406,7 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 
 		if (isServer) return;
 		if (LocalTargetPosition == newLocalTarget.Vector3) return;
-		if (hasAuthority && PulledBy.HasComponent == false) return;
-
-		//if (hasAuthority == false && PulledBy.HasComponent) return;
+		if (isOwned && PulledBy.HasComponent == false) return;
 
 		var spawned = CustomNetworkManager.Spawned;
 
@@ -570,7 +568,7 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 	public void SynchroniseUpdatePulling(PullData oldPullData, PullData newPulling)
 	{
 		ThisPullData = newPulling;
-		if (newPulling.WasCausedByClient && hasAuthority) return;
+		if (newPulling.WasCausedByClient && isOwned) return;
 		PullSet(newPulling.NewPulling, false, true);
 	}
 
@@ -1006,10 +1004,10 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 		if (ObjectIsBucklingChecked.HasComponent && ObjectIsBucklingChecked.Component.Pulling.HasComponent)
 		{
 			var inDirection = cachedPosition;
-			if (inDirection.magnitude > 2f && (isServer || hasAuthority))
+			if (inDirection.magnitude > 2f && (isServer || isOwned))
 			{
 				ObjectIsBucklingChecked.Component.PullSet(null, false); //TODO maybe remove
-				if (ObjectIsBucklingChecked.Component.hasAuthority && isServer == false)
+				if (ObjectIsBucklingChecked.Component.isOwned && isServer == false)
 				{
 					ObjectIsBucklingChecked.Component.CmdStopPulling();
 				}
@@ -1118,12 +1116,12 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 			Pulling.DirectSetComponent(toPull);
 			toPull.PulledBy.DirectSetComponent(this);
 			ContextGameObjects[1] = toPull.gameObject;
-			if (hasAuthority) UIManager.Action.UpdatePullingUI(true);
+			if (isOwned) UIManager.Action.UpdatePullingUI(true);
 		}
 		else
 		{
 
-			if (hasAuthority) UIManager.Action.UpdatePullingUI(false);
+			if (isOwned) UIManager.Action.UpdatePullingUI(false);
 			if (Pulling.HasComponent)
 			{
 				Pulling.Component.ResetClientPositionReachTile = true;
@@ -1693,10 +1691,10 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 		if (ObjectIsBucklingChecked.HasComponent && ObjectIsBucklingChecked.Component.Pulling.HasComponent)
 		{
 			var inDirection = cachedPosition - ObjectIsBucklingChecked.Component.Pulling.Component.transform.position;
-			if (inDirection.magnitude > 2f && (isServer || hasAuthority))
+			if (inDirection.magnitude > 2f && (isServer || isOwned))
 			{
 				ObjectIsBucklingChecked.Component.PullSet(null, false); //TODO maybe remove
-				if (ObjectIsBucklingChecked.Component.hasAuthority && isServer == false)
+				if (ObjectIsBucklingChecked.Component.isOwned && isServer == false)
 					ObjectIsBucklingChecked.Component.CmdStopPulling();
 			}
 			else

--- a/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
+++ b/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
@@ -35,45 +35,75 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 	//=============================================== Definitely
 	//TODO Smooth pushing, syncvar well if Statements in force and stuff On process player action,  Smooth resetting if Space wind
 
+	[PlayModeOnly] public Vector2 LocalDifferenceNeeded;
+	[PlayModeOnly] private Vector2 newtonianMovement; //* attributes.Size -> weight
+	[PlayModeOnly] public Vector3 LocalTargetPosition;
+	[PlayModeOnly] private Vector3 LastDifference = Vector3.zero;
+	[PlayModeOnly] public bool CorrectingCourse = false;
+	[PlayModeOnly] public bool Animating = false;
+	[PlayModeOnly] public bool SetIgnoreSticky = false;
+	//Cannot grab onto anything so no friction
+	[PlayModeOnly] public float airTime;
+	[PlayModeOnly] public float slideTime;
+	[PlayModeOnly] public float spinMagnitude = 0;
+	//Reduced friction during this time, if stickyMovement Just has normal friction vs just grabbing
+	[PlayModeOnly] public GameObject thrownBy;
+	[PlayModeOnly] public BodyPartType aim;
+	[PlayModeOnly] public int ForcedPushedFrame = 0;
+	[PlayModeOnly] public int TryPushedFrame = 0;
+	[PlayModeOnly] public int PushedFrame = 0;
+	[PrefabModeOnly] public bool ChangesDirectionPush = false;
+	[PrefabModeOnly] public bool Intangible = false;
+	[PrefabModeOnly] public bool SnapToGridOnStart = false;
+	[PrefabModeOnly] public bool IsPlayer = false;
+
+	protected MatrixCash SetMatrixCache = new MatrixCash();
+
 	public const float DEFAULT_PUSH_SPEED = 6;
 
 	/// <summary>
 	/// Maximum speed player can reach by throwing stuff in space
 	/// </summary>
 	public const float MAX_SPEED = 25;
-
 	public const int HIGH_SPEED_COLLISION_THRESHOLD = 13;
-
-
-	//public const float DEFAULT_Friction = 9999999999999f;
 	public const float DEFAULT_Friction = 15f;
 	public const float DEFAULT_SLIDE_FRICTION = 9f;
 
 	public bool DEBUG = false;
 
-	[PrefabModeOnly] public bool SnapToGridOnStart = false;
-
+	public CheckedComponent<Pickupable> pickupable = new CheckedComponent<Pickupable>();
 	private BoxCollider2D Collider; //TODO Checked component
-
-
-	[SyncVar]
-	private float TileMoveSpeedOverride = 0;
-
-
 	private FloorDecal floorDecal; // Used to make sure some objects are not causing gravity
+	private Vector3Int oldLocalTilePosition;
 
-	[PlayModeOnly] public Vector3 LocalTargetPosition;
+
+	[SyncVar] private float TileMoveSpeedOverride = 0;
+	[SyncVar] public float tileMoveSpeed = 1;
+	[SyncVar] private uint parentContainer;
+	[SyncVar] protected int SetTimestampID = -1;
+	[SyncVar] protected int SetLastResetID = -1;
+	[SyncVar] public bool HasOwnGravity = false;
+	[SyncVar] private bool doNotApplyMomentumOnTarget = false;
+
+	[SyncVar(hook = nameof(SynchroniseVisibility))]
+	private bool isVisible = true;
+	[SyncVar(hook = nameof(SyncIsNotPushable))]
+	public bool isNotPushable;
+	[SyncVar(hook = nameof(SyncLocalTarget))]
+	private Vector3WithData synchLocalTargetPosition;
+	[SyncVar(hook = nameof(SynchroniseUpdatePulling))]
+	private PullData ThisPullData;
 
 	protected Rotatable rotatable;
-
-	[PrefabModeOnly] public bool ChangesDirectionPush = false;
-
-	[PrefabModeOnly] public bool Intangible = false;
-
+	protected bool doStepInteractions = true;
 	public bool CanBeWindPushed = true;
 
+	[SerializeField] protected Transform rotationTarget;
 
-	[PrefabModeOnly] public bool IsPlayer = false;
+	public Vector3 OfficialPosition => GetRootObject.transform.position;
+	public bool IsVisible => isVisible;
+	public bool IsNotPushable => isNotPushable;
+	public bool CanMove => isNotPushable == false && IsBuckled == false;
 
 	public Vector3WithData SetLocalTarget
 	{
@@ -87,8 +117,6 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 			LocalTargetPosition = value.Vector3;
 		}
 	}
-
-	public Vector3 OfficialPosition => GetRootObject.transform.position;
 
 	public GameObject GetRootObject
 	{
@@ -109,17 +137,6 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 		}
 	}
 
-	private Vector3Int oldLocalTilePosition;
-
-	public CheckedComponent<Pickupable> pickupable = new CheckedComponent<Pickupable>();
-
-	public bool IsVisible => isVisible;
-
-
-	[SyncVar]
-	public float tileMoveSpeed = 1;
-
-
 	public float CurrentTileMoveSpeed
 	{
 		get
@@ -135,52 +152,22 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 		}
 	}
 
-
-	[SyncVar(hook = nameof(SyncLocalTarget))]
-	private Vector3WithData synchLocalTargetPosition;
-
-	public Vector3 SynchLocalTargetPosition => synchLocalTargetPosition.Vector3;
-
-	[SyncVar] private bool doNotApplyMomentumOnTarget = false;
-
-	[SyncVar(hook = nameof(SynchroniseVisibility))]
-	private bool isVisible = true;
-
-	[SyncVar(hook = nameof(SyncIsNotPushable))]
-	public bool isNotPushable;
-
-	public bool IsNotPushable => isNotPushable;
-
-	public bool CanMove => isNotPushable == false && IsBuckled == false;
-
-	[SyncVar(hook = nameof(SynchroniseUpdatePulling))]
-	private PullData ThisPullData;
-
-	[SyncVar] private uint parentContainer;
-
-	[SyncVar] protected int SetTimestampID = -1;
-
-	[SyncVar] protected int SetLastResetID = -1;
-
-	[SyncVar] public bool HasOwnGravity = false;
-
-	private ObjectContainer CachedContainedInContainer;
-
+	private ObjectContainer cachedContainedInContainer;
 
 	public ObjectContainer ContainedInObjectContainer
 	{
 		get
 		{
-			if (parentContainer is not (NetId.Invalid or NetId.Empty) && (CachedContainedInContainer == null || CachedContainedInContainer.registerTile.netId != parentContainer))
+			if (parentContainer is not (NetId.Invalid or NetId.Empty) && (cachedContainedInContainer == null || cachedContainedInContainer.registerTile.netId != parentContainer))
 			{
 				var spawned = CustomNetworkManager.IsServer ? NetworkServer.spawned : NetworkClient.spawned;
 				if (spawned.TryGetValue(parentContainer, out var net))
 				{
-					CachedContainedInContainer = net.GetComponent<ObjectContainer>();
+					cachedContainedInContainer = net.GetComponent<ObjectContainer>();
 				}
 				else
 				{
-					CachedContainedInContainer = null;
+					cachedContainedInContainer = null;
 				}
 			}
 
@@ -189,12 +176,9 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 				return null;
 			}
 
-			return CachedContainedInContainer;
+			return cachedContainedInContainer;
 		}
 	}
-
-	[PlayModeOnly] private Vector2 newtonianMovement; //* attributes.Size -> weight
-
 
 	public Vector2 NewtonianMovement
 	{
@@ -210,28 +194,10 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 		}
 	}
 
-	[PlayModeOnly] public float airTime; //Cannot grab onto anything so no friction
-
-	[PlayModeOnly] public float slideTime;
-
-	//Reduced friction during this time, if stickyMovement Just has normal friction vs just grabbing
-	[PlayModeOnly] public bool SetIgnoreSticky = false;
-
-	[PlayModeOnly] public GameObject thrownBy;
-
-	[PlayModeOnly] public BodyPartType aim;
-
-	[PlayModeOnly] public float spinMagnitude = 0;
-
-	[PlayModeOnly] public int ForcedPushedFrame = 0;
-	[PlayModeOnly] public int TryPushedFrame = 0;
-	[PlayModeOnly] public int PushedFrame = 0;
 	[PlayModeOnly] public bool FramePushDecision = true;
 
 	[PrefabModeOnly] public bool stickyMovement = false;
 	//If this thing likes to grab onto stuff such as like a player
-
-
 	public bool IsStickyMovement => stickyMovement && SetIgnoreSticky == false;
 
 	[PrefabModeOnly] public bool OnThrowEndResetRotation;
@@ -281,8 +247,6 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 	// TODO: Bod this is not what CheckedComponent is for as the reference is not on the same object as this script - Dan
 	public CheckedComponent<UniversalObjectPhysics> PulledBy = new CheckedComponent<UniversalObjectPhysics>();
 
-	protected bool doStepInteractions = true;
-
 	#region Events
 
 	[PlayModeOnly] public ForceEvent OnThrowStart = new ForceEvent();
@@ -310,6 +274,24 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 		registerTile = GetComponent<RegisterTile>();
 		rotatable = GetComponent<Rotatable>();
 		pickupable.DirectSetComponent(GetComponent<Pickupable>());
+		SetRotationTarget();
+	}
+
+	private void SetRotationTarget()
+	{
+		if (rotationTarget != null) return;
+		if (this is MovementSynchronisation c && c.playerScript.RegisterPlayer.LayDownBehavior != null)
+		{
+			rotationTarget = c.playerScript.RegisterPlayer.LayDownBehavior.Sprites;
+			return;
+		}
+		var sprites = GetComponentsInChildren<SpriteHandler>();
+		if (sprites.Length == 1)
+		{
+			rotationTarget = sprites[0].transform;
+			return;
+		}
+		rotationTarget = transform;
 	}
 
 	public void Start()
@@ -476,7 +458,7 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 
 		parentContainer = newParent == null ? NetId.Empty : newParent.registerTile.netId;
 
-		CachedContainedInContainer = newParent;
+		cachedContainedInContainer = newParent;
 		SynchroniseVisibility(isVisible, newParent == null);
 	}
 	//TODO Sometime Handle stuff like cart riding
@@ -618,7 +600,7 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 	public void ForceSetLocalPosition(Vector3 resetToLocal, Vector2 momentum, bool smooth, int matrixID,
 		bool updateClient = true, float rotation = 0, NetworkConnection client = null, int resetID = -1, uint IgnoreForClient = NetId.Empty)
 	{
-		transform.localRotation = Quaternion.Euler(new Vector3(0, 0, rotation));
+		rotationTarget.rotation = Quaternion.Euler(new Vector3(0, 0, rotation));
 
 		if (isServer && updateClient)
 		{
@@ -722,7 +704,7 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 		if (isServer == false) return;
 		SetLastResetID = Time.frameCount;
 		RPCForceSetPosition(transform.localPosition, newtonianMovement, smooth, registerTile.Matrix.Id,
-			transform.localRotation.eulerAngles.z, SetLastResetID, ignoreForClient);
+			rotationTarget.localRotation.eulerAngles.z, SetLastResetID, ignoreForClient);
 
 		if (Pulling.HasComponent)
 		{
@@ -743,7 +725,7 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 		isVisible = true;
 		SetLastResetID = Time.frameCount;
 		RPCForceSetPosition(client, transform.localPosition, newtonianMovement, smooth, registerTile.Matrix.Id,
-			transform.localRotation.eulerAngles.z, SetLastResetID);
+			rotationTarget.localRotation.eulerAngles.z, SetLastResetID);
 
 		if (Pulling.HasComponent)
 		{
@@ -751,10 +733,6 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 		}
 		//Update client to server state
 	}
-
-	[PlayModeOnly] public Vector2 LocalDifferenceNeeded;
-
-	[PlayModeOnly] public bool CorrectingCourse = false;
 
 
 	public void FloatingCourseCorrection()
@@ -1069,6 +1047,7 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 		slideTime = 0;
 		IsFlyingSliding = false;
 		Animating = false;
+		if (this is MovementSynchronisation c) c.playerScript.RegisterPlayer.LayDownBehavior.EnsureCorrectState();
 	}
 
 	[Server]
@@ -1241,10 +1220,6 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 			NewtonianMovement *= (newMagnitude / oldMagnitude);
 		}
 	}
-
-	[PlayModeOnly] public bool Animating = false;
-
-	[PlayModeOnly] private Vector3 LastDifference = Vector3.zero;
 
 	public void AnimationUpdateMe()
 	{
@@ -1443,7 +1418,7 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 
 			if (airTime <= 0)
 			{
-				OnImpact.Invoke(this, newtonianMovement);
+				OnImpact?.Invoke(this, newtonianMovement);
 			}
 		}
 		else if (slideTime > 0)
@@ -1506,7 +1481,7 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 					defaultInteractionLayerMask, newPosition);
 				if (hit.ItHit)
 				{
-					OnImpact.Invoke(this, newtonianMovement);
+					OnImpact?.Invoke(this, newtonianMovement);
 					NewtonianMovement -= 2 * (newtonianMovement * hit.Normal) * hit.Normal;
 					var offset = (0.1f * hit.Normal);
 					newPosition = hit.HitWorld + offset.To3();
@@ -1701,6 +1676,7 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 			if (OnThrowEndResetRotation)
 			{
 				transform.localRotation = Quaternion.Euler(0, 0, 0);
+				if (this is MovementSynchronisation c) c.playerScript.RegisterPlayer.LayDownBehavior.EnsureCorrectState();
 			}
 
 			UpdateManager.Remove(CallbackType.UPDATE, FlyingUpdateMe);
@@ -1786,9 +1762,6 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 			ObjectIsBucklingChecked.Component.Pulling.Component.ProcessNewtonianPull(InNewtonianMovement, newPosition);
 		}
 	}
-
-
-	protected MatrixCash SetMatrixCache = new MatrixCash();
 
 	public bool IsFloating()
 	{

--- a/UnityProject/Assets/Scripts/Player/LayDown.cs
+++ b/UnityProject/Assets/Scripts/Player/LayDown.cs
@@ -8,6 +8,7 @@ namespace Player
 	public class LayDown : NetworkBehaviour
 	{
 		[SerializeField] private Transform sprites;
+		public Transform Sprites => sprites;
 		[SerializeField] private LivingHealthMasterBase health;
 		[SerializeField] private Rotatable playerDirectional;
 		[SerializeField] private PlayerScript playerScript;
@@ -18,7 +19,6 @@ namespace Player
 
 		[SyncVar(hook = nameof(OnLayDown))] public bool IsLayingDown = false;
 
-
 		private void Awake()
 		{
 			playerScript ??= GetComponent<PlayerScript>();
@@ -27,6 +27,7 @@ namespace Player
 			networkedLean ??= GetComponent<Util.NetworkedLeanTween>();
 		}
 
+		[ClientRpc]
 		public void EnsureCorrectState()
 		{
 			gameObject.transform.rotation = Quaternion.Euler(0, 0, 0);

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
@@ -376,12 +376,12 @@ public class RegisterTile : NetworkBehaviour, IServerDespawn
 
 		if (appeared)
 		{
-			OnAppearClient.Invoke();
+			OnAppearClient?.Invoke();
 		}
 
 		if (disappeared)
 		{
-			OnDisappearClient.Invoke();
+			OnDisappearClient?.Invoke();
 		}
 	}
 


### PR DESCRIPTION
cleaned up some of the movement code while I'm at it
fixes #9753


CL: [Improvement] Flying and sliding animations now target the sprites instead of the Mob's root gameobject. Making the behavior much more consistent. 
CL: [Improvement] Burning animations and body overlays will now correctly follow the body sprites's rotation.
CL: [Fix] Whenever the server asks to ensure mob's laying down state, it will notify all clients respectively as well.
