### PR TITLE
feat: add initial name and job title to ID cards for story telling

### DIFF
--- a/UnityProject/Assets/Scripts/Items/IDCard.cs
+++ b/UnityProject/Assets/Scripts/Items/IDCard.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Items;
 using UnityEngine;
 using Mirror;
+using NaughtyAttributes;
 using Systems.Clearance;
 using WebSocketSharp;
 
@@ -27,6 +28,17 @@ public class IDCard : NetworkBehaviour, IServerInventoryMove, IServerSpawn, IInt
 	         " first player whose inventory it is added to. Used for initial loadout.")]
 	[SerializeField]
 	private bool autoInitOnPickup = false;
+
+	[Tooltip("If set, it will be assigned to the ID card on spawn. Useful for storytelling.")]
+	[SerializeField]
+	[HideIf(nameof(autoInitOnPickup))]
+	private string initialName = "";
+
+	[Tooltip("If set, it will be assigned to the ID card on spawn. Useful for storytelling.")]
+	[SerializeField]
+	[HideIf(nameof(autoInitOnPickup))]
+	private string initialJobTitle = "";
+
 	private bool initialized;
 	public BasicClearanceSource ClearanceSource { get; private set; }
 
@@ -46,6 +58,8 @@ public class IDCard : NetworkBehaviour, IServerInventoryMove, IServerSpawn, IInt
 	[SyncVar(hook = nameof(SyncName))]
 	private string registeredName;
 
+
+
 	// FIXME: move currencies to their own component. Labor points and credits don't really have much in common and should be handled on their own components.
 	public int[] currencies = new int[(int)CurrencyType.Total];
 
@@ -54,6 +68,9 @@ public class IDCard : NetworkBehaviour, IServerInventoryMove, IServerSpawn, IInt
 	private Pickupable pickupable;
 
 	private ItemAttributesV2 itemAttributes;
+
+	private bool HasInitialNameOrTitle => string.IsNullOrEmpty(initialName) == false || string.IsNullOrEmpty(initialJobTitle) == false;
+
 
 	private void Awake()
 	{
@@ -66,6 +83,20 @@ public class IDCard : NetworkBehaviour, IServerInventoryMove, IServerSpawn, IInt
 	public void OnSpawnServer(SpawnInfo info)
 	{
 		initialized = false;
+		if (autoInitOnPickup && HasInitialNameOrTitle)
+		{
+			Logger.LogWarning($"{gameObject.name} has autoInitOnPickup and initialName or initialJobTitle set. These values will be overriden when a player picks it up!", Category.Objects);
+		}
+
+		if (string.IsNullOrEmpty(initialName) == false)
+		{
+			SyncName("", initialName);
+		}
+
+		if (string.IsNullOrEmpty(initialJobTitle) == false)
+		{
+			SyncJobTitle("", initialJobTitle);
+		}
 	}
 
 	public void ServerPerformInteraction(HandActivate interaction)

--- a/UnityProject/Packages/packages-lock.json
+++ b/UnityProject/Packages/packages-lock.json
@@ -151,38 +151,12 @@
       },
       "url": "https://packages.unity.com"
     },
-    "com.unity.render-pipelines.core": {
-      "version": "12.1.8",
-      "depth": 1,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.ugui": "1.0.0",
-        "com.unity.modules.physics": "1.0.0",
-        "com.unity.modules.jsonserialize": "1.0.0"
-      }
-    },
     "com.unity.scriptablebuildpipeline": {
       "version": "1.20.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
-    },
-    "com.unity.searcher": {
-      "version": "4.9.1",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.shadergraph": {
-      "version": "12.1.8",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.render-pipelines.core": "12.1.8",
-        "com.unity.searcher": "4.9.1"
-      }
     },
     "com.unity.sysroot": {
       "version": "2.0.3",


### PR DESCRIPTION
### Purpose
Mappers are now able to add an initial name and job title to ID cards so they can do some story telling with their level design.


### Changelog:
__NOCL__
