### PR TITLE
feat: obfuscate IP addresses logged and sent to Discord wh

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Chat/DiscordWebhookMessage.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/DiscordWebhookMessage.cs
@@ -185,6 +185,8 @@ namespace DiscordWebhook
 				msg += queue.Dequeue() + "\n";
 			}
 
+			msg = ObfuscateIpAddress(msg);
+
 			var payLoad = new JsonPayloadContent()
 			{
 				content = msg,
@@ -196,6 +198,14 @@ namespace DiscordWebhook
 			};
 
 			Post(url, payLoad);
+		}
+
+		private string ObfuscateIpAddress(string msg)
+		{
+			//matches IPV4 addresses
+			string pattern = @"\b((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b";
+			string replacement = "xxx.xxx.xxx.xxx";
+			return Regex.Replace(msg, pattern, replacement);
 		}
 
 		private string MsgMentionProcess(string msg, string mentionID = null)


### PR DESCRIPTION
### Purpose
Since the errors channel on discord is a semi-public channel, we might not want to disclose user's IP addresses when Mirror errors and logs it.


