### PR TITLE
Fixes background parallax being broken

### DIFF
--- a/UnityProject/Assets/Materials/Background.mat
+++ b/UnityProject/Assets/Materials/Background.mat
@@ -64,6 +64,7 @@ Material:
     m_Ints: []
     m_Floats:
     - PixelSnap: 0
+    - _Alpha: 0.498
     - _BumpScale: 1
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1

--- a/UnityProject/Assets/Prefabs/SceneConstruction/Camera.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/Camera.prefab
@@ -52,6 +52,7 @@ MonoBehaviour:
   Material: {fileID: 2100000, guid: bb638c523f5b7064b9a032025a8db0a5, type: 2}
   LightOrigin: {x: 0, y: 0, z: 1}
   Shape: 0
+  GivenID: 0
 --- !u!23 &1917856997
 MeshRenderer:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Shaders/Unlit Background.shader
+++ b/UnityProject/Assets/Shaders/Unlit Background.shader
@@ -8,6 +8,7 @@
 Shader "Stencil/Unlit background" {
 	Properties{
 		_MainTex("Base (RGB) Trans (A)", 2D) = "white" {}
+		_Alpha("Alpha", Range(0, 1)) = 1
 	}
 
 		SubShader{
@@ -43,6 +44,7 @@ Shader "Stencil/Unlit background" {
 
 	sampler2D _MainTex;
 	float4 _MainTex_ST;
+		float _Alpha;
 
 	v2f vert(appdata_t v)
 	{
@@ -55,6 +57,7 @@ Shader "Stencil/Unlit background" {
 	fixed4 frag(v2f i) : SV_Target
 	{
 		fixed4 col = tex2D(_MainTex, i.texcoord);
+		col.a *= _Alpha;
 		return col;
 	}
 		ENDCG

--- a/UnityProject/Assets/Textures/Parallax/starstg_upscaled.psd.meta
+++ b/UnityProject/Assets/Textures/Parallax/starstg_upscaled.psd.meta
@@ -3,7 +3,7 @@ guid: 7b399defd4be3d94ab3988f7c66ab77b
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 11
+  serializedVersion: 12
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -20,7 +20,7 @@ TextureImporter:
     externalNormalMap: 0
     heightScale: 0.25
     normalMapFilter: 0
-  isReadable: 0
+  isReadable: 1
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
@@ -33,7 +33,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1
@@ -63,9 +63,34 @@ TextureImporter:
   textureFormatSet: 0
   ignorePngGamma: 0
   applyGammaDecoding: 0
+  cookieLightType: 1
   platformSettings:
   - serializedVersion: 3
     buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Server
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
@@ -92,7 +117,7 @@ TextureImporter:
     nameFileIdTable: {}
   spritePackingTag: 
   pSDRemoveMatte: 0
-  pSDShowRemoveMatteOption: 0
+  pSDShowRemoveMatteOption: 1
   userData: 
   assetBundleName: 
   assetBundleVariant: 


### PR DESCRIPTION
I don't know how long this has been going on for, but the background parallax was broken for quite some time now.
This is how it should look:

https://github.com/unitystation/unitystation/assets/34368774/a617e8da-98b7-409b-94c8-2663d08c8047


CL: [Fix] Fixed an issue that caused parallax backgrounds to not display correctly.