### PR TITLE
Vomit Bounty

### DIFF
--- a/UnityProject/Assets/Prefabs/Decal/Resources/Mess Decals/VomitSplat.prefab
+++ b/UnityProject/Assets/Prefabs/Decal/Resources/Mess Decals/VomitSplat.prefab
@@ -17,6 +17,7 @@ GameObject:
   - component: {fileID: 4524393934061931853}
   - component: {fileID: 6608488744510329496}
   - component: {fileID: 2773625917735950037}
+  - component: {fileID: 3615296830884964240}
   m_Layer: 0
   m_Name: VomitSplat
   m_TagString: Untagged
@@ -52,6 +53,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c77080d7d322e0d46b715644eb4b0ab9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   Cleanable: 1
@@ -77,6 +79,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   matrixDebugLogging: 0
@@ -111,9 +114,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   sceneId: 0
+  _assetId: 819688005
   serverOnly: 0
   visible: 0
-  m_AssetId: dde8d9bf0726b3140971ecd9d5ddcb87
   hasSpawned: 0
 --- !u!114 &3586928491308810755
 MonoBehaviour:
@@ -153,6 +156,7 @@ MonoBehaviour:
   destroyOnEmpty: 0
   ContentsSet: 0
   menuOptions: 0
+  spriteHandler: {fileID: 0}
   UseStandardExamine: 1
   ExamineAmount: 0
   ExamineContent: 0
@@ -174,28 +178,32 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 52a6a264ee47433418b51f654439372f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
-  DEBUG: 0
-  SnapToGridOnStart: 0
+  LocalDifferenceNeeded: {x: 0, y: 0}
   LocalTargetPosition: {x: 0, y: 0, z: 0}
-  ChangesDirectionPush: 0
-  Intangible: 0
-  CanBeWindPushed: 0
-  IsPlayer: 0
-  InitialLocationSynchronised: 0
-  tileMoveSpeed: 1
-  isNotPushable: 1
-  HasOwnGravity: 0
+  CorrectingCourse: 0
+  Animating: 0
+  SetIgnoreSticky: 0
   airTime: 0
   slideTime: 0
-  SetIgnoreSticky: 0
+  spinMagnitude: 0
   thrownBy: {fileID: 0}
   aim: 0
-  spinMagnitude: 0
   ForcedPushedFrame: 0
   TryPushedFrame: 0
   PushedFrame: 0
+  ChangesDirectionPush: 0
+  Intangible: 0
+  SnapToGridOnStart: 0
+  IsPlayer: 0
+  DEBUG: 0
+  tileMoveSpeed: 1
+  HasOwnGravity: 0
+  isNotPushable: 1
+  CanBeWindPushed: 0
+  rotationTarget: {fileID: 0}
   FramePushDecision: 1
   stickyMovement: 0
   OnThrowEndResetRotation: 0
@@ -206,11 +214,8 @@ MonoBehaviour:
   - {fileID: 0}
   - {fileID: 0}
   IsCurrentlyFloating: 0
-  LocalDifferenceNeeded: {x: 0, y: 0}
-  CorrectingCourse: 0
   Pushing: []
   Hits: []
-  Animating: 0
   isFlyingSliding: 0
   IsMoving: 0
   MoveIsWalking: 0
@@ -241,6 +246,28 @@ MonoBehaviour:
   protectiveItemTraits: []
   limbsToHurt: 
   reagentContainer: {fileID: 4524393934061931853}
+--- !u!114 &3615296830884964240
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1069497300762596}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6db4404109ee5304895b5058a7eff177, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0.1
+  StomachContents: {fileID: 0}
+  DigesterAmountPerSecond: 1
+  BodyFats: []
+  BodyFatToInstantiate: {fileID: 0}
+  InitialFatSpawned: 0
+  _ReagentCirculatedComponent: {fileID: 0}
+  HungerComponent: {fileID: 0}
 --- !u!1 &1230737790073880
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/BreadSnacks/MoldyBreadSlice.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/BreadSnacks/MoldyBreadSlice.prefab
@@ -57,7 +57,7 @@ PrefabInstance:
     - target: {fileID: 2697906132478500034, guid: d2991f5505400ab479c5262137eed380,
         type: 3}
       propertyPath: initialReagentMix.reagents.m_values.Array.data[1]
-      value: 4
+      value: 2.25
       objectReference: {fileID: 0}
     - target: {fileID: 3654515168179534600, guid: d2991f5505400ab479c5262137eed380,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/BreadSnacks/MoldyBreadSlice.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/BreadSnacks/MoldyBreadSlice.prefab
@@ -28,6 +28,37 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: bd9ce6b56fcf1284c9117e5f7a26fb24,
         type: 2}
+    - target: {fileID: 2697906132478500034, guid: d2991f5505400ab479c5262137eed380,
+        type: 3}
+      propertyPath: initialReagentMix.temperature
+      value: 285.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 2697906132478500034, guid: d2991f5505400ab479c5262137eed380,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_keys.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2697906132478500034, guid: d2991f5505400ab479c5262137eed380,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_values.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2697906132478500034, guid: d2991f5505400ab479c5262137eed380,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_keys.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 5e2a5c76d1bce6144b8b1aac987b2751,
+        type: 2}
+    - target: {fileID: 2697906132478500034, guid: d2991f5505400ab479c5262137eed380,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_values.Array.data[0]
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2697906132478500034, guid: d2991f5505400ab479c5262137eed380,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_values.Array.data[1]
+      value: 4
+      objectReference: {fileID: 0}
     - target: {fileID: 3654515168179534600, guid: d2991f5505400ab479c5262137eed380,
         type: 3}
       propertyPath: initialName
@@ -67,17 +98,17 @@ PrefabInstance:
     - target: {fileID: 3767659913715099934, guid: d2991f5505400ab479c5262137eed380,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3767659913715099934, guid: d2991f5505400ab479c5262137eed380,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3767659913715099934, guid: d2991f5505400ab479c5262137eed380,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3767659913715099934, guid: d2991f5505400ab479c5262137eed380,
         type: 3}
@@ -98,6 +129,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: MoldyBreadSlice
+      objectReference: {fileID: 0}
+    - target: {fileID: 3877279333247478238, guid: d2991f5505400ab479c5262137eed380,
+        type: 3}
+      propertyPath: _assetId
+      value: 2892573292
       objectReference: {fileID: 0}
     - target: {fileID: 3877279333247478238, guid: d2991f5505400ab479c5262137eed380,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/BurnedMess.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/BurnedMess.prefab
@@ -10,12 +10,12 @@ PrefabInstance:
     - target: {fileID: 275102857289942383, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
       propertyPath: initialReagentMix.reagents.m_keys.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 275102857289942383, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
       propertyPath: initialReagentMix.reagents.m_values.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 275102857289942383, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
@@ -25,8 +25,19 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 275102857289942383, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
+      propertyPath: initialReagentMix.reagents.m_keys.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 5e2a5c76d1bce6144b8b1aac987b2751,
+        type: 2}
+    - target: {fileID: 275102857289942383, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
       propertyPath: initialReagentMix.reagents.m_values.Array.data[0]
       value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 275102857289942383, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_values.Array.data[1]
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 1155915217242832539, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
@@ -98,6 +109,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: BurnedMess
+      objectReference: {fileID: 0}
+    - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
+      propertyPath: _assetId
+      value: 2679080035
       objectReference: {fileID: 0}
     - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/Human Stomach.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/Human Stomach.prefab
@@ -258,13 +258,19 @@ PrefabInstance:
     - target: {fileID: 5146776682568007683, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
       propertyPath: initialTraits.Array.size
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 5146776682568007683, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
       propertyPath: initialTraits.Array.data[1]
       value: 
       objectReference: {fileID: 11400000, guid: 892f0c642e2049640b08d738517bb0f5,
+        type: 2}
+    - target: {fileID: 5146776682568007683, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
+      propertyPath: initialTraits.Array.data[2]
+      value: 
+      objectReference: {fileID: 11400000, guid: 7577eabe60e5ac546901dbb7c30538fc,
         type: 2}
     - target: {fileID: 8195321311611557117, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/Human Stomach.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/Human Stomach.prefab
@@ -399,7 +399,7 @@ MonoBehaviour:
   dryHeavingEmote: {fileID: 11400000, guid: a6e6bd57706a7ac48a90238687d25868, type: 2}
   vomitReagentPrefab: {fileID: 1069497300762596, guid: dde8d9bf0726b3140971ecd9d5ddcb87,
     type: 3}
-  divisbleVomitAmount: 6
+  divisbleVomitAmount: 4
   vomitSound:
     SetLoadSetting: 0
     AssetAddress: Assets/Prefabs/Effects/CutGash.prefab

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/Human Stomach.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/Human Stomach.prefab
@@ -77,6 +77,7 @@ GameObject:
   - component: {fileID: 8020505243148839587}
   - component: {fileID: 477889042948838881}
   - component: {fileID: 7830021117134627836}
+  - component: {fileID: 1612141623047297532}
   m_Layer: 10
   m_Name: VomitLogic
   m_TagString: Untagged
@@ -125,6 +126,21 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   minMaxToxinHeal: {x: 2, y: 6}
+--- !u!114 &1612141623047297532
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8518599047709719652}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31de4dba07ad41a29b467b82c7e6056c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  traumaTypes: 2
+  minMaxToTakeFromBlood: {x: 2, y: 12}
+  traumaLevelToVomitBloodOn: 2
 --- !u!1001 &7132720453719274872
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/Human Stomach.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/Human Stomach.prefab
@@ -394,3 +394,11 @@ MonoBehaviour:
   vomitReagentPrefab: {fileID: 1069497300762596, guid: dde8d9bf0726b3140971ecd9d5ddcb87,
     type: 3}
   divisbleVomitAmount: 6
+  vomitSound:
+    SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/Effects/CutGash.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/Human Stomach.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/Human Stomach.prefab
@@ -45,7 +45,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   maxCapacity: 80
-  reactionSet: {fileID: 0}
+  reactionSet: {fileID: 11400000, guid: 9635f48a9fe17f742aee13832a4ed6c2, type: 2}
   AdditionalReactions: []
   initialReagentMix:
     temperature: 273.15

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/Human Stomach.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/Human Stomach.prefab
@@ -56,6 +56,7 @@ MonoBehaviour:
   destroyOnEmpty: 0
   ContentsSet: 0
   menuOptions: -1
+  spriteHandler: {fileID: 0}
   UseStandardExamine: 1
   ExamineAmount: 0
   ExamineContent: 0
@@ -64,6 +65,66 @@ MonoBehaviour:
   transferMode: 0
   possibleTransferAmounts: []
   transferAmount: 20
+  transferSound: []
+--- !u!1 &8518599047709719652
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8020505243148839587}
+  - component: {fileID: 477889042948838881}
+  - component: {fileID: 7830021117134627836}
+  m_Layer: 10
+  m_Name: VomitLogic
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8020505243148839587
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8518599047709719652}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2553433226350356333}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &477889042948838881
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8518599047709719652}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf51145a61cd4f15bdd5c4b77ee26205, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  stunDuration: 4
+--- !u!114 &7830021117134627836
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8518599047709719652}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b73a618a36a448796ac2321a4ddd3be, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  minMaxToxinHeal: {x: 2, y: 6}
 --- !u!1001 &7132720453719274872
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -81,6 +142,11 @@ PrefabInstance:
         type: 3}
       propertyPath: foreverID
       value: 69104df12837d1e48bb456dce5301bfa
+      objectReference: {fileID: 0}
+    - target: {fileID: 4617501557389857493, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
+        type: 3}
+      propertyPath: _assetId
+      value: 2662982056
       objectReference: {fileID: 0}
     - target: {fileID: 4617501557389857493, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
@@ -125,17 +191,17 @@ PrefabInstance:
     - target: {fileID: 4725154019080884757, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4725154019080884757, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4725154019080884757, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4725154019080884757, guid: 35ef0ee8523cfc342bc863c12a3ac07c,
         type: 3}
@@ -297,13 +363,34 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6db4404109ee5304895b5058a7eff177, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
-  isEMPVunerable: 0
-  EMPResistance: 2
   StomachContents: {fileID: 7073899732039749527}
   DigesterAmountPerSecond: 1
   BodyFats: []
   BodyFatToInstantiate: {fileID: 5722168868389364961, guid: 940a7490c94c6b3478f0b4268b2cf2c0,
     type: 3}
   InitialFatSpawned: 0
+  _ReagentCirculatedComponent: {fileID: 0}
+  HungerComponent: {fileID: 0}
+--- !u!114 &8132119848969428107
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2556953724642564633}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bb8bd890cb294ce6a2cbbff0d834af9d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0.1
+  stomach: {fileID: 1458293514004664868}
+  dryHeavingEmote: {fileID: 11400000, guid: a6e6bd57706a7ac48a90238687d25868, type: 2}
+  vomitReagentPrefab: {fileID: 1069497300762596, guid: dde8d9bf0726b3140971ecd9d5ddcb87,
+    type: 3}
+  divisbleVomitAmount: 6

--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Felinid/Felinid.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Felinid/Felinid.asset
@@ -127,6 +127,7 @@ MonoBehaviour:
         - {fileID: 11400000, guid: 85b402a852ad1ad49b64886cd42e93ce, type: 2}
         - {fileID: 11400000, guid: 3ea6d21ecff38954a9e1b05795f3f45e, type: 2}
         - {fileID: 11400000, guid: b7d0a552223af4d4d9f3eb3217df9183, type: 2}
+        - {fileID: 11400000, guid: 2902beb621ef39d42b6f061978844fc3, type: 2}
         MetabolismComponents: []
     - rid: 5920833068371804164
       type: {class: HungerSystem, ns: HealthV2.Living.PolymorphicSystems, asm: Assets}

--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Human/Human.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Human/Human.asset
@@ -127,6 +127,7 @@ MonoBehaviour:
         - {fileID: 11400000, guid: 85b402a852ad1ad49b64886cd42e93ce, type: 2}
         - {fileID: 11400000, guid: 3ea6d21ecff38954a9e1b05795f3f45e, type: 2}
         - {fileID: 11400000, guid: b7d0a552223af4d4d9f3eb3217df9183, type: 2}
+        - {fileID: 11400000, guid: 2902beb621ef39d42b6f061978844fc3, type: 2}
         MetabolismComponents: []
     - rid: 5920833068371804164
       type: {class: HungerSystem, ns: HealthV2.Living.PolymorphicSystems, asm: Assets}

--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Lizard/Lizard.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Lizard/Lizard.asset
@@ -110,6 +110,7 @@ MonoBehaviour:
         - {fileID: 11400000, guid: 85b402a852ad1ad49b64886cd42e93ce, type: 2}
         - {fileID: 11400000, guid: 3ea6d21ecff38954a9e1b05795f3f45e, type: 2}
         - {fileID: 11400000, guid: b7d0a552223af4d4d9f3eb3217df9183, type: 2}
+        - {fileID: 11400000, guid: 2902beb621ef39d42b6f061978844fc3, type: 2}
         MetabolismComponents: []
     - rid: 5920833068371804164
       type: {class: HungerSystem, ns: HealthV2.Living.PolymorphicSystems, asm: Assets}

--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Moth/Moth.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Moth/Moth.asset
@@ -104,6 +104,7 @@ MonoBehaviour:
         - {fileID: 11400000, guid: 85b402a852ad1ad49b64886cd42e93ce, type: 2}
         - {fileID: 11400000, guid: 3ea6d21ecff38954a9e1b05795f3f45e, type: 2}
         - {fileID: 11400000, guid: b7d0a552223af4d4d9f3eb3217df9183, type: 2}
+        - {fileID: 11400000, guid: 2902beb621ef39d42b6f061978844fc3, type: 2}
         MetabolismComponents: []
     - rid: 5920833068371804164
       type: {class: HungerSystem, ns: HealthV2.Living.PolymorphicSystems, asm: Assets}

--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Vulpkanin/Vulpkanin.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Vulpkanin/Vulpkanin.asset
@@ -114,6 +114,7 @@ MonoBehaviour:
         - {fileID: 11400000, guid: 85b402a852ad1ad49b64886cd42e93ce, type: 2}
         - {fileID: 11400000, guid: 3ea6d21ecff38954a9e1b05795f3f45e, type: 2}
         - {fileID: 11400000, guid: b7d0a552223af4d4d9f3eb3217df9183, type: 2}
+        - {fileID: 11400000, guid: 2902beb621ef39d42b6f061978844fc3, type: 2}
         MetabolismComponents: []
     - rid: 5920833068371804164
       type: {class: HungerSystem, ns: HealthV2.Living.PolymorphicSystems, asm: Assets}

--- a/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
+++ b/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
@@ -8374,7 +8374,7 @@ SpriteRenderer:
   m_SortingLayerID: -902452607
   m_SortingLayer: 22
   m_SortingOrder: 20
-  m_Sprite: {fileID: -4549444404219585148, guid: 2adbceb9cc674484cb9a2c58b41d5493,
+  m_Sprite: {fileID: 7660122581263827943, guid: 2adbceb9cc674484cb9a2c58b41d5493,
     type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0

--- a/UnityProject/Assets/Resources/ScriptableObjectsSingletons/ChemistryReagentsSO.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjectsSingletons/ChemistryReagentsSO.asset
@@ -27,6 +27,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 132f2cd5d79066e46af78ea80a196713, type: 2}
   - {fileID: 11400000, guid: 246b944c9799b87489519d7f19307a06, type: 2}
   - {fileID: 11400000, guid: c08bfc7b09a88c34d9be46b34e311204, type: 2}
+  - {fileID: 11400000, guid: 2902beb621ef39d42b6f061978844fc3, type: 2}
   - {fileID: 11400000, guid: e83c05c9c83ddfc4c84a80bff9a2cc8c, type: 2}
   - {fileID: 11400000, guid: 59b007343aceb79498f4899aa8108acb, type: 2}
   - {fileID: 11400000, guid: 9a4496787977597408dbeb53ca843921, type: 2}
@@ -1112,6 +1113,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: b8a781e1379c635ae89668659280df98, type: 2}
   - {fileID: 11400000, guid: 5b255694ed5e8945790b893c1975d7cc, type: 2}
   - {fileID: 11400000, guid: ae16649c67a65c05198d3a4d8e97a066, type: 2}
+  - {fileID: 11400000, guid: 5e2a5c76d1bce6144b8b1aac987b2751, type: 2}
   - {fileID: 11400000, guid: 4abba3ce4cb2cbd6f8ba92f0e44d5958, type: 2}
   - {fileID: 11400000, guid: 8c4699092c1481a0088667b562e3c68a, type: 2}
   - {fileID: 11400000, guid: 4209bcf04e780ce22ab35c7fe09e49db, type: 2}

--- a/UnityProject/Assets/Scenes/ActiveScenes/Lobby.unity
+++ b/UnityProject/Assets/Scenes/ActiveScenes/Lobby.unity
@@ -1123,6 +1123,31 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4147125179588738938, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4147125179588738938, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4199685495035560006, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4199685495035560006, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4199685495035560006, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4236498455849868228, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -2116,6 +2141,16 @@ PrefabInstance:
     - target: {fileID: 8800622826614355687, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8828654199121321389, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8828654199121321389, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8897673338037527780, guid: 829f4ca992b848d6bb4d007fb9c112e1,

--- a/UnityProject/Assets/Scenes/ActiveScenes/Lobby.unity
+++ b/UnityProject/Assets/Scenes/ActiveScenes/Lobby.unity
@@ -1123,31 +1123,6 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4147125179588738938, guid: 829f4ca992b848d6bb4d007fb9c112e1,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4147125179588738938, guid: 829f4ca992b848d6bb4d007fb9c112e1,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4199685495035560006, guid: 829f4ca992b848d6bb4d007fb9c112e1,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4199685495035560006, guid: 829f4ca992b848d6bb4d007fb9c112e1,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4199685495035560006, guid: 829f4ca992b848d6bb4d007fb9c112e1,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 4236498455849868228, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -2141,16 +2116,6 @@ PrefabInstance:
     - target: {fileID: 8800622826614355687, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8828654199121321389, guid: 829f4ca992b848d6bb4d007fb9c112e1,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8828654199121321389, guid: 829f4ca992b848d6bb4d007fb9c112e1,
-        type: 3}
-      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8897673338037527780, guid: 829f4ca992b848d6bb4d007fb9c112e1,

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/ReactionSets/BodyChemistryReactionsSet.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/ReactionSets/BodyChemistryReactionsSet.asset
@@ -33,3 +33,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: dbb670cffccbf9acea4a14732900493d, type: 2}
   - {fileID: 11400000, guid: 1d6fd38b48113c8448800db674a5110c, type: 2}
   - {fileID: 11400000, guid: 246b944c9799b87489519d7f19307a06, type: 2}
+  - {fileID: 11400000, guid: 2902beb621ef39d42b6f061978844fc3, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/ReactionSets/DefaultReactions.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/ReactionSets/DefaultReactions.asset
@@ -182,3 +182,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: b9b2d19afaa324540a0b5a9d8bb203af, type: 2}
   - {fileID: 11400000, guid: 9998e0f758ba8d46ebe5d27a6482a224, type: 2}
   - {fileID: 11400000, guid: 3f0199a60506f444c8b1bca33a5967c3, type: 2}
+  - {fileID: 11400000, guid: 2902beb621ef39d42b6f061978844fc3, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Body/InBodyEmotes/VomitWhenInBody.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Body/InBodyEmotes/VomitWhenInBody.asset
@@ -1,0 +1,55 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2d4ea11761a8f2844865df391acdc61f, type: 3}
+  m_Name: VomitWhenInBody
+  m_EditorClassIdentifier: 
+  ingredients:
+    m_keys:
+    - {fileID: 11400000, guid: 5e2a5c76d1bce6144b8b1aac987b2751, type: 2}
+    m_values: 01000000
+  useExactAmounts: 0
+  MinimumReactionMultiple: 0
+  catalysts:
+    m_keys: []
+    m_values: 
+  inhibitors:
+    m_keys: []
+    m_values: 
+  hasMinTemp: 0
+  serializableTempMin: 0
+  hasMaxTemp: 0
+  serializableTempMax: 0
+  results:
+    m_keys: []
+    m_values: 
+  effects: []
+  ReagentMetabolismMultiplier: 1
+  InternalAllRequired:
+  - {fileID: 11400000, guid: 7577eabe60e5ac546901dbb7c30538fc, type: 2}
+  InternalBlacklist: []
+  ExternalAllRequired: []
+  ExternalBlacklist: []
+  DamageEffect: 2
+  AttackType: 10
+  AttackBodyPartPerOneU: 1
+  CanOverdose: 0
+  ConcentrationBloodOverdose: 20
+  OverdoseDamageMultiplier: 1
+  MultiEffect: 0
+  Effects: []
+  EmoteEffects:
+  - CustomEmote: 0
+    CustomEmoterMessage: 
+    CustomShownMessage: 
+    Emote: {fileID: 11400000, guid: 10fbc8c0eb861c54199481242aef33a6, type: 2}
+    ChancePerTick: 100
+    StopIfOverdosed: 0

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Body/InBodyEmotes/VomitWhenInBody.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Body/InBodyEmotes/VomitWhenInBody.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   ingredients:
     m_keys:
     - {fileID: 11400000, guid: 5e2a5c76d1bce6144b8b1aac987b2751, type: 2}
-    m_values: 01000000
+    m_values: 03000000
   useExactAmounts: 0
   MinimumReactionMultiple: 0
   catalysts:
@@ -51,5 +51,5 @@ MonoBehaviour:
     CustomEmoterMessage: 
     CustomShownMessage: 
     Emote: {fileID: 11400000, guid: 10fbc8c0eb861c54199481242aef33a6, type: 2}
-    ChancePerTick: 100
+    ChancePerTick: 10
     StopIfOverdosed: 0

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Body/InBodyEmotes/VomitWhenInBody.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Body/InBodyEmotes/VomitWhenInBody.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2902beb621ef39d42b6f061978844fc3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/FungiMold.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/FungiMold.asset
@@ -17,4 +17,4 @@ MonoBehaviour:
   color: {r: 0.10076736, g: 0.6698113, b: 0, a: 0.8784314}
   state: 0
   heatDensity: 5
-  indexInSingleton: -1
+  indexInSingleton: 503

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/FungiMold.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/FungiMold.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1916b10721f72c927a14093e8210cb3f, type: 3}
+  m_Name: FungiMold
+  m_EditorClassIdentifier: 
+  displayName: Mold Fungi
+  description: Probably not the best thing to eat..
+  color: {r: 0.10076736, g: 0.6698113, b: 0, a: 0.8784314}
+  state: 0
+  heatDensity: 5
+  indexInSingleton: -1

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/FungiMold.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/FungiMold.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5e2a5c76d1bce6144b8b1aac987b2751
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/GhoulPowder.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/GhoulPowder.asset
@@ -18,4 +18,4 @@ MonoBehaviour:
   color: {r: 0.4, g: 0.2784314, b: 0, a: 1}
   state: 0
   heatDensity: 5
-  indexInSingleton: 503
+  indexInSingleton: 504

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/GroundTeaLeaves.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/GroundTeaLeaves.asset
@@ -17,4 +17,4 @@ MonoBehaviour:
   color: {r: 0.49803922, g: 0.5176471, b: 0, a: 1}
   state: 0
   heatDensity: 5
-  indexInSingleton: 504
+  indexInSingleton: 505

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Heparin.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Heparin.asset
@@ -18,4 +18,4 @@ MonoBehaviour:
   color: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
   state: 1
   heatDensity: 5
-  indexInSingleton: 505
+  indexInSingleton: 506

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Histamine.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Histamine.asset
@@ -18,4 +18,4 @@ MonoBehaviour:
   color: {r: 0.98039216, g: 0.39215687, b: 0.39215687, a: 1}
   state: 1
   heatDensity: 5
-  indexInSingleton: 506
+  indexInSingleton: 507

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Initropidril.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Initropidril.asset
@@ -18,4 +18,4 @@ MonoBehaviour:
   color: {r: 0.49803922, g: 0.0627451, b: 0.7529412, a: 1}
   state: 1
   heatDensity: 5
-  indexInSingleton: 507
+  indexInSingleton: 508

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/ItchingPowder.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/ItchingPowder.asset
@@ -18,4 +18,4 @@ MonoBehaviour:
   color: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
   state: 1
   heatDensity: 5
-  indexInSingleton: 508
+  indexInSingleton: 509

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Lean.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Lean.asset
@@ -17,4 +17,4 @@ MonoBehaviour:
   color: {r: 0.6121146, g: 0.009478444, b: 0.6698113, a: 1}
   state: 1
   heatDensity: 5
-  indexInSingleton: 509
+  indexInSingleton: 510

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Lexorin.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Lexorin.asset
@@ -17,4 +17,4 @@ MonoBehaviour:
   color: {r: 0.49019608, g: 0.7647059, b: 0.627451, a: 1}
   state: 0
   heatDensity: 5
-  indexInSingleton: 510
+  indexInSingleton: 511

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Lipolicide.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Lipolicide.asset
@@ -18,4 +18,4 @@ MonoBehaviour:
   color: {r: 0.9411765, g: 1, b: 0.9411765, a: 1}
   state: 1
   heatDensity: 5
-  indexInSingleton: 511
+  indexInSingleton: 512

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/MimesBane.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/MimesBane.asset
@@ -18,4 +18,4 @@ MonoBehaviour:
   color: {r: 0.9411765, g: 0.972549, b: 1, a: 1}
   state: 0
   heatDensity: 5
-  indexInSingleton: 512
+  indexInSingleton: 513

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/MindbreakerToxin.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/MindbreakerToxin.asset
@@ -18,4 +18,4 @@ MonoBehaviour:
   color: {r: 0.7019608, g: 0.0627451, b: 0.03137255, a: 1}
   state: 0
   heatDensity: 5
-  indexInSingleton: 513
+  indexInSingleton: 514

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/MintToxin.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/MintToxin.asset
@@ -17,4 +17,4 @@ MonoBehaviour:
   color: {r: 0.8117647, g: 0.21176471, b: 0, a: 1}
   state: 0
   heatDensity: 5
-  indexInSingleton: 514
+  indexInSingleton: 515

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/MushroomPowder.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/MushroomPowder.asset
@@ -18,4 +18,4 @@ MonoBehaviour:
   color: {r: 0.40392157, g: 0.25882354, b: 0.22745098, a: 0}
   state: 0
   heatDensity: 5
-  indexInSingleton: 515
+  indexInSingleton: 516

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/MuteToxin.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/MuteToxin.asset
@@ -17,4 +17,4 @@ MonoBehaviour:
   color: {r: 0.9411765, g: 0.972549, b: 1, a: 1}
   state: 0
   heatDensity: 5
-  indexInSingleton: 516
+  indexInSingleton: 517

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Pancuronium.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Pancuronium.asset
@@ -18,4 +18,4 @@ MonoBehaviour:
   color: {r: 0.09803922, g: 0.3137255, b: 0.5882353, a: 1}
   state: 1
   heatDensity: 5
-  indexInSingleton: 517
+  indexInSingleton: 518

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/PestKiller.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/PestKiller.asset
@@ -17,4 +17,4 @@ MonoBehaviour:
   color: {r: 0.29411766, g: 0, b: 0.29411766, a: 1}
   state: 0
   heatDensity: 5
-  indexInSingleton: 518
+  indexInSingleton: 519

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/PlantBGone.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/PlantBGone.asset
@@ -17,4 +17,4 @@ MonoBehaviour:
   color: {r: 0.28627452, g: 0, b: 0.18039216, a: 1}
   state: 0
   heatDensity: 5
-  indexInSingleton: 519
+  indexInSingleton: 520

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Plasma.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Plasma.asset
@@ -17,4 +17,4 @@ MonoBehaviour:
   color: {r: 0.50980395, g: 0.15686275, b: 0.627451, a: 1}
   state: 0
   heatDensity: 5
-  indexInSingleton: 520
+  indexInSingleton: 521

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Polonium.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Polonium.asset
@@ -18,4 +18,4 @@ MonoBehaviour:
   color: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
   state: 1
   heatDensity: 5
-  indexInSingleton: 521
+  indexInSingleton: 522

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Rotatium.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Rotatium.asset
@@ -18,4 +18,4 @@ MonoBehaviour:
   color: {r: 0.6745098, g: 0.53333336, b: 0.7921569, a: 1}
   state: 1
   heatDensity: 5
-  indexInSingleton: 522
+  indexInSingleton: 523

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Skewium.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Skewium.asset
@@ -19,4 +19,4 @@ MonoBehaviour:
   color: {r: 0.6784314, g: 0.7411765, b: 0.8039216, a: 1}
   state: 1
   heatDensity: 5
-  indexInSingleton: 523
+  indexInSingleton: 524

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/SlimeJelly.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/SlimeJelly.asset
@@ -18,4 +18,4 @@ MonoBehaviour:
   color: {r: 0.5019608, g: 0.11764706, b: 0.15686275, a: 1}
   state: 0
   heatDensity: 5
-  indexInSingleton: 524
+  indexInSingleton: 525

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/SodiumThiopental.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/SodiumThiopental.asset
@@ -18,4 +18,4 @@ MonoBehaviour:
   color: {r: 0.39215687, g: 0.5882353, b: 0.98039216, a: 1}
   state: 1
   heatDensity: 5
-  indexInSingleton: 525
+  indexInSingleton: 526

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Spewium.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Spewium.asset
@@ -18,4 +18,4 @@ MonoBehaviour:
   color: {r: 0.18431373, g: 0.4, b: 0.09019608, a: 1}
   state: 1
   heatDensity: 5
-  indexInSingleton: 526
+  indexInSingleton: 527

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/SporeToxin.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/SporeToxin.asset
@@ -18,4 +18,4 @@ MonoBehaviour:
   color: {r: 0.6039216, g: 0.8039216, b: 0.19607843, a: 1}
   state: 0
   heatDensity: 5
-  indexInSingleton: 527
+  indexInSingleton: 528

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Sulfonal.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Sulfonal.asset
@@ -18,4 +18,4 @@ MonoBehaviour:
   color: {r: 0.49019608, g: 0.7647059, b: 0.627451, a: 1}
   state: 1
   heatDensity: 5
-  indexInSingleton: 528
+  indexInSingleton: 529

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/SulphuricAcid.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/SulphuricAcid.asset
@@ -17,4 +17,4 @@ MonoBehaviour:
   color: {r: 0, g: 1, b: 0.19607843, a: 1}
   state: 0
   heatDensity: 5
-  indexInSingleton: 529
+  indexInSingleton: 530

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Tirizene.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Tirizene.asset
@@ -18,4 +18,4 @@ MonoBehaviour:
   color: {r: 0.43137255, g: 0.15686275, b: 0.15686275, a: 1}
   state: 0
   heatDensity: 5
-  indexInSingleton: 530
+  indexInSingleton: 531

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Toxin.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Toxin.asset
@@ -17,4 +17,4 @@ MonoBehaviour:
   color: {r: 0.8117647, g: 0.21176471, b: 0, a: 1}
   state: 0
   heatDensity: 5
-  indexInSingleton: 531
+  indexInSingleton: 532

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/ToxinMicrocapsules.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/ToxinMicrocapsules.asset
@@ -17,4 +17,4 @@ MonoBehaviour:
   color: {r: 0, g: 0, b: 0, a: 0}
   state: 1
   heatDensity: 5
-  indexInSingleton: 532
+  indexInSingleton: 533

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/UnstableMutagen.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/UnstableMutagen.asset
@@ -17,4 +17,4 @@ MonoBehaviour:
   color: {r: 0, g: 1, b: 0, a: 1}
   state: 0
   heatDensity: 5
-  indexInSingleton: 533
+  indexInSingleton: 534

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Venom.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/Venom.asset
@@ -19,4 +19,4 @@ MonoBehaviour:
   color: {r: 0.9411765, g: 1, b: 0.9411765, a: 1}
   state: 1
   heatDensity: 5
-  indexInSingleton: 534
+  indexInSingleton: 535

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/WeedKiller.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/WeedKiller.asset
@@ -17,4 +17,4 @@ MonoBehaviour:
   color: {r: 0.29411766, g: 0, b: 0.29411766, a: 1}
   state: 0
   heatDensity: 5
-  indexInSingleton: 535
+  indexInSingleton: 536

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/ZombiePowder.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Toxin/ZombiePowder.asset
@@ -17,4 +17,4 @@ MonoBehaviour:
   color: {r: 0.4, g: 0.6, b: 0, a: 1}
   state: 0
   heatDensity: 5
-  indexInSingleton: 536
+  indexInSingleton: 537

--- a/UnityProject/Assets/ScriptableObjects/Emotes/DryHeav.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/DryHeav.asset
@@ -19,19 +19,12 @@ MonoBehaviour:
   isAudibleEmote: 0
   allowEmoteWhileCrawling: 1
   viewText: dry heavs
-  youText: try to vomit by there's nothing in your stomach!
+  youText: You try to vomit by there's nothing in your stomach!
   failText: You were unable to preform this action!
   mouthBlockedText: You are unable to make a sound!
-  critViewText: screams in pain!
+  critViewText: lets out a lot of moans while dry heaving.
   soundsAreTyped: 0
-  defaultSounds:
-  - SetLoadSetting: 0
-    AssetAddress: Assets/Prefabs/Effects/CutGash.prefab
-    AssetReference:
-      m_AssetGUID: 
-      m_SubObjectName: 
-      m_SubObjectType: 
-      m_EditorAssetChanged: 0
+  defaultSounds: []
   TypedSounds: []
   pitchRange: {x: 0.7, y: 1}
   allowedPlayerTypes: 1

--- a/UnityProject/Assets/ScriptableObjects/Emotes/DryHeav.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/DryHeav.asset
@@ -1,0 +1,38 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b8a39a0a24444ba8a1cbb2f4d0a72796, type: 3}
+  m_Name: DryHeav
+  m_EditorClassIdentifier: 
+  emoteName: Dry Heav
+  EmoteIcon: {fileID: 21300000, guid: ba91f1e025afa7d4c8fc3d912d6b6eb7, type: 3}
+  requiresHands: 0
+  allowEmoteWhileInCrit: 1
+  isAudibleEmote: 0
+  allowEmoteWhileCrawling: 1
+  viewText: dry heavs
+  youText: try to vomit by there's nothing in your stomach!
+  failText: You were unable to preform this action!
+  mouthBlockedText: You are unable to make a sound!
+  critViewText: screams in pain!
+  soundsAreTyped: 0
+  defaultSounds:
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/Effects/CutGash.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
+  TypedSounds: []
+  pitchRange: {x: 0.7, y: 1}
+  allowedPlayerTypes: 1
+  stunDuration: 8

--- a/UnityProject/Assets/ScriptableObjects/Emotes/DryHeav.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/DryHeav.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a6e6bd57706a7ac48a90238687d25868
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Emotes/EmoteListSO.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/EmoteListSO.asset
@@ -53,3 +53,5 @@ MonoBehaviour:
   - {fileID: 11400000, guid: a367ab0ef76ae3a47aed85bd54b9965b, type: 2}
   - {fileID: 11400000, guid: 15fa025684b8a98448ca6843340eab38, type: 2}
   - {fileID: 11400000, guid: faa860ccc517a7a489dd2cfcd83ae5b6, type: 2}
+  - {fileID: 11400000, guid: c830ab85915fa824abdb51a89b9d51c3, type: 2}
+  - {fileID: 11400000, guid: a6e6bd57706a7ac48a90238687d25868, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Emotes/NonPlayerIvokableEmotes.meta
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/NonPlayerIvokableEmotes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f77142f255506b94983209120dce3730
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Emotes/NonPlayerIvokableEmotes/InstantVomit.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/NonPlayerIvokableEmotes/InstantVomit.asset
@@ -1,0 +1,31 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e888538a70a4245be42d11ebc9c13f9, type: 3}
+  m_Name: InstantVomit
+  m_EditorClassIdentifier: 
+  emoteName: Vomit
+  EmoteIcon: {fileID: 21300000, guid: ba91f1e025afa7d4c8fc3d912d6b6eb7, type: 3}
+  requiresHands: 0
+  allowEmoteWhileInCrit: 1
+  isAudibleEmote: 0
+  allowEmoteWhileCrawling: 1
+  viewText: vomits!
+  youText: 
+  failText: You were unable to preform this action!
+  mouthBlockedText: You are unable to make a sound!
+  critViewText: lets out a painful sound while they vomit.
+  soundsAreTyped: 0
+  defaultSounds: []
+  TypedSounds: []
+  pitchRange: {x: 0.7, y: 1}
+  allowedPlayerTypes: 1
+  instant: 1

--- a/UnityProject/Assets/ScriptableObjects/Emotes/NonPlayerIvokableEmotes/InstantVomit.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/NonPlayerIvokableEmotes/InstantVomit.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 10fbc8c0eb861c54199481242aef33a6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Emotes/Vomit.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/Vomit.asset
@@ -19,10 +19,10 @@ MonoBehaviour:
   isAudibleEmote: 0
   allowEmoteWhileCrawling: 1
   viewText: vomits!
-  youText: vomit all over!
+  youText: 
   failText: You were unable to preform this action!
   mouthBlockedText: You are unable to make a sound!
-  critViewText: screams in pain!
+  critViewText: lets out a painful sound while they vomit.
   soundsAreTyped: 0
   defaultSounds: []
   TypedSounds: []

--- a/UnityProject/Assets/ScriptableObjects/Emotes/Vomit.asset
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/Vomit.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e888538a70a4245be42d11ebc9c13f9, type: 3}
+  m_Name: Vomit
+  m_EditorClassIdentifier: 
+  emoteName: Vomit
+  EmoteIcon: {fileID: 21300000, guid: ba91f1e025afa7d4c8fc3d912d6b6eb7, type: 3}
+  requiresHands: 0
+  allowEmoteWhileInCrit: 1
+  isAudibleEmote: 0
+  allowEmoteWhileCrawling: 1
+  viewText: vomits!
+  youText: vomit all over!
+  failText: You were unable to preform this action!
+  mouthBlockedText: You are unable to make a sound!
+  critViewText: screams in pain!
+  soundsAreTyped: 0
+  defaultSounds: []
+  TypedSounds: []
+  pitchRange: {x: 0.7, y: 1}
+  allowedPlayerTypes: 1

--- a/UnityProject/Assets/ScriptableObjects/Emotes/Vomit.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Emotes/Vomit.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c830ab85915fa824abdb51a89b9d51c3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Health/BloodTypes/AlienBlood.asset
+++ b/UnityProject/Assets/ScriptableObjects/Health/BloodTypes/AlienBlood.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   color: {r: 0, g: 0.9811321, b: 0.025203956, a: 1}
   state: 1
   heatDensity: 5
-  indexInSingleton: 537
+  indexInSingleton: 538
   PercentageNeededInBloodFlow: 0.1
   CirculatedReagent: {fileID: 11400000, guid: 72991f100b5704f5fb63c9629fcdeb6c, type: 2}
   WasteCarryReagent: {fileID: 11400000, guid: 2a39c514112f198858f2c7407b75d8c4, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Health/BloodTypes/HumanBlood.asset
+++ b/UnityProject/Assets/ScriptableObjects/Health/BloodTypes/HumanBlood.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   color: {r: 0.8773585, g: 0, b: 0, a: 0.9647059}
   state: 1
   heatDensity: 5
-  indexInSingleton: 538
+  indexInSingleton: 539
   PercentageNeededInBloodFlow: 0.1
   CirculatedReagent: {fileID: 11400000, guid: 72991f100b5704f5fb63c9629fcdeb6c, type: 2}
   WasteCarryReagent: {fileID: 11400000, guid: 2a39c514112f198858f2c7407b75d8c4, type: 2}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/BodyPartFunctionality.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/BodyPartFunctionality.cs
@@ -1,15 +1,14 @@
 using System;
 using Mirror;
 using Systems.Explosions;
-using NaughtyAttributes;
 
 namespace HealthV2
 {
 	public class BodyPartFunctionality : NetworkBehaviour, IEmpAble
 	{
 
-		[NonSerialized]
-		public BodyPart RelatedPart;
+		[NonSerialized] public BodyPart RelatedPart;
+		protected LivingHealthMasterBase livingHealthMaster => RelatedPart.HealthMaster;
 
 
 		public virtual void ImplantPeriodicUpdate(){}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/BodyPartFunctionality.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/BodyPartFunctionality.cs
@@ -8,7 +8,7 @@ namespace HealthV2
 	{
 
 		[NonSerialized] public BodyPart RelatedPart;
-		protected LivingHealthMasterBase livingHealthMaster => RelatedPart.HealthMaster;
+		protected LivingHealthMasterBase LivingHealthMaster => RelatedPart.HealthMaster;
 
 
 		public virtual void ImplantPeriodicUpdate(){}

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit.meta
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 67a095ff1b264eef9c1c0f3f42ac0317
+timeCreated: 1688114308

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/IVomitExtension.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/IVomitExtension.cs
@@ -4,6 +4,6 @@ namespace Items.Implants.Organs.Vomit
 {
 	public interface IVomitExtension
 	{
-		public void OnVomit(float amount, LivingHealthMasterBase health);
+		public void OnVomit(float amount, LivingHealthMasterBase health, Stomach stomach);
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/IVomitExtension.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/IVomitExtension.cs
@@ -1,0 +1,9 @@
+﻿using HealthV2;
+
+namespace Items.Implants.Organs.Vomit
+{
+	public interface IVomitExtension
+	{
+		public void OnVomit(float amount, LivingHealthMasterBase health);
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/IVomitExtension.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/IVomitExtension.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9e3f3b3cb57b4919bb9f194a0c0b5e11
+timeCreated: 1688114330

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/LogicExtensions.meta
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/LogicExtensions.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0db0d0164f254d4ebadb9cbaeecc6d2b
+timeCreated: 1688114630

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/LogicExtensions/CureToxinOnVomit.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/LogicExtensions/CureToxinOnVomit.cs
@@ -1,0 +1,18 @@
+﻿using HealthV2;
+using UnityEngine;
+
+namespace Items.Implants.Organs.Vomit.LogicExtensions
+{
+	public class CureToxinOnVomit : MonoBehaviour, IVomitExtension
+	{
+
+		[SerializeField] private Vector2 minMaxToxinHeal = new Vector2(2, 6);
+
+		public void OnVomit(float amount, LivingHealthMasterBase health)
+		{
+			health.HealDamageOnAll(null,
+				Random.Range(minMaxToxinHeal.x, minMaxToxinHeal.y),
+				DamageType.Tox);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/LogicExtensions/CureToxinOnVomit.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/LogicExtensions/CureToxinOnVomit.cs
@@ -8,7 +8,7 @@ namespace Items.Implants.Organs.Vomit.LogicExtensions
 
 		[SerializeField] private Vector2 minMaxToxinHeal = new Vector2(2, 6);
 
-		public void OnVomit(float amount, LivingHealthMasterBase health)
+		public void OnVomit(float amount, LivingHealthMasterBase health, Stomach stomach)
 		{
 			health.HealDamageOnAll(null,
 				Random.Range(minMaxToxinHeal.x, minMaxToxinHeal.y),

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/LogicExtensions/CureToxinOnVomit.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/LogicExtensions/CureToxinOnVomit.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8b73a618a36a448796ac2321a4ddd3be
+timeCreated: 1688116345

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/LogicExtensions/StunOnVomit.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/LogicExtensions/StunOnVomit.cs
@@ -6,7 +6,7 @@ namespace Items.Implants.Organs.Vomit.LogicExtensions
 	public class StunOnVomit : MonoBehaviour, IVomitExtension
 	{
 		[SerializeField] private float stunDuration = 4f;
-		public void OnVomit(float amount, LivingHealthMasterBase health)
+		public void OnVomit(float amount, LivingHealthMasterBase health, Stomach stomach)
 		{
 			health.playerScript.RegisterPlayer.ServerStun(stunDuration, true, false);
 			if(DMMath.Prob(50)) health.playerScript.RegisterPlayer.ServerLayDown();

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/LogicExtensions/StunOnVomit.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/LogicExtensions/StunOnVomit.cs
@@ -8,8 +8,8 @@ namespace Items.Implants.Organs.Vomit.LogicExtensions
 		[SerializeField] private float stunDuration = 4f;
 		public void OnVomit(float amount, LivingHealthMasterBase health)
 		{
-			if(DMMath.Prob(50)) health.playerScript.RegisterPlayer.ServerLayDown();
 			health.playerScript.RegisterPlayer.ServerStun(stunDuration, true, false);
+			if(DMMath.Prob(50)) health.playerScript.RegisterPlayer.ServerLayDown();
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/LogicExtensions/StunOnVomit.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/LogicExtensions/StunOnVomit.cs
@@ -1,0 +1,15 @@
+﻿using HealthV2;
+using UnityEngine;
+
+namespace Items.Implants.Organs.Vomit.LogicExtensions
+{
+	public class StunOnVomit : MonoBehaviour, IVomitExtension
+	{
+		[SerializeField] private float stunDuration = 4f;
+		public void OnVomit(float amount, LivingHealthMasterBase health)
+		{
+			if(DMMath.Prob(50)) health.playerScript.RegisterPlayer.ServerLayDown();
+			health.playerScript.RegisterPlayer.ServerStun(stunDuration, true, false);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/LogicExtensions/StunOnVomit.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/LogicExtensions/StunOnVomit.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cf51145a61cd4f15bdd5c4b77ee26205
+timeCreated: 1688114650

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/LogicExtensions/VomitBloodOnTraumaLevel.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/LogicExtensions/VomitBloodOnTraumaLevel.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace Items.Implants.Organs.Vomit.LogicExtensions
 {
-	public class VomitBloodOnPierceTraumaLevel : MonoBehaviour, IVomitExtension
+	public class VomitBloodOnTraumaLevel : MonoBehaviour, IVomitExtension
 	{
 
 		[SerializeField] private TraumaticDamageTypes traumaTypes = TraumaticDamageTypes.PIERCE;

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/LogicExtensions/VomitBloodOnTraumaLevel.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/LogicExtensions/VomitBloodOnTraumaLevel.cs
@@ -1,0 +1,27 @@
+﻿using Core.Factories;
+using HealthV2;
+using UnityEngine;
+
+namespace Items.Implants.Organs.Vomit.LogicExtensions
+{
+	public class VomitBloodOnPierceTraumaLevel : MonoBehaviour, IVomitExtension
+	{
+
+		[SerializeField] private TraumaticDamageTypes traumaTypes = TraumaticDamageTypes.PIERCE;
+		[SerializeField] private Vector2 minMaxToTakeFromBlood = new Vector2(2, 12);
+		[SerializeField] private int traumaLevelToVomitBloodOn = 2;
+
+		public void OnVomit(float amount, LivingHealthMasterBase health, Stomach stomach)
+		{
+			if (stomach.RelatedPart.TryGetComponent<BodyPartTrauma>(out var trauma) == false) return;
+			foreach (var traumaLogic in trauma.TraumaTypesOnBodyPart)
+			{
+				if (traumaLogic.traumaTypes.HasFlag(traumaTypes) == false) continue;
+				if (traumaLogic.CurrentStage < traumaLevelToVomitBloodOn) continue;
+				var bloodReagent = health.reagentPoolSystem.BloodPool.Take(Random.Range(minMaxToTakeFromBlood.x, minMaxToTakeFromBlood.y));
+				EffectsFactory.BloodSplat(health.gameObject.AssumedWorldPosServer(),
+					bloodReagent, bloodReagent.Total > 6 ? BloodSplatSize.medium : BloodSplatSize.small);
+			}
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/LogicExtensions/VomitBloodOnTraumaLevel.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/LogicExtensions/VomitBloodOnTraumaLevel.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 31de4dba07ad41a29b467b82c7e6056c
+timeCreated: 1688129655

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/StomachExpulsion.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/StomachExpulsion.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using Castle.Core.Internal;
+using AddressableReferences;
 using Chemistry.Components;
 using HealthV2;
 using NaughtyAttributes;
@@ -15,6 +15,7 @@ namespace Items.Implants.Organs.Vomit
 		[SerializeField] private EmoteSO dryHeavingEmote;
 		[SerializeField] private GameObject vomitReagentPrefab;
 		[SerializeField] private float divisbleVomitAmount = 6;
+		[SerializeField] private AddressableAudioSource vomitSound;
 		private List<IVomitExtension> vomitLogicExtensions = new List<IVomitExtension>();
 
 		public override void Awake()
@@ -40,12 +41,12 @@ namespace Items.Implants.Organs.Vomit
 				return;
 			}
 			stomach.StomachContents.TransferTo(amountToVomit, vomitReagent);
-			//add sound here
-			//add chat message here
 			foreach (var logic in vomitLogicExtensions)
 			{
 				logic?.OnVomit(amountToVomit, livingHealthMaster);
 			}
+			if(vomitSound != null) _ = SoundManager.PlayNetworkedAtPosAsync(
+				vomitSound, livingHealthMaster.gameObject.AssumedWorldPosServer());
 		}
 
 		private bool WillDryHeave()

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/StomachExpulsion.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/StomachExpulsion.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+using Chemistry.Components;
+using HealthV2;
+using NaughtyAttributes;
+using ScriptableObjects.RP;
+using UnityEngine;
+
+namespace Items.Implants.Organs.Vomit
+{
+	[RequireComponent(typeof(Stomach))]
+	public class StomachExpulsion : BodyPartFunctionality
+	{
+		[SerializeField] private Stomach stomach;
+		[SerializeField] private EmoteSO dryHeavingEmote;
+		[SerializeField] private GameObject vomitReagentPrefab;
+		[SerializeField] private List<IVomitExtension> vomitLogicExtensions;
+		[SerializeField] private float divisbleVomitAmount = 6;
+
+		public override void Awake()
+		{
+			base.Awake();
+			stomach ??= GetComponent<Stomach>();
+		}
+
+
+		[Button()]
+		public void Vomit()
+		{
+			if (WillDryHeave()) return;
+			var amountToVomit = Random.Range(0.1f, stomach.StomachContents.CurrentReagentMix.Total / divisbleVomitAmount);
+			var vomitSplat = Spawn.ServerPrefab(
+				vomitReagentPrefab,
+				livingHealthMaster.gameObject.AssumedWorldPosServer());
+			var vomitReagent = vomitSplat.GameObject.GetComponent<ReagentContainer>();
+			if (vomitReagent == null)
+			{
+				Logger.LogError($"Vomit prefab does not have a reagent container!!!");
+				return;
+			}
+			stomach.StomachContents.TransferTo(amountToVomit, vomitReagent);
+			//add sound here
+			//add chat message here
+			foreach (var logic in vomitLogicExtensions)
+			{
+				logic.OnVomit(amountToVomit, livingHealthMaster);
+			}
+		}
+
+		private bool WillDryHeave()
+		{
+			if (dryHeavingEmote == null) return false;
+			if (stomach.StomachContents.IsEmpty == false || stomach.StomachContents.CurrentReagentMix.Total > 0.09f) return false;
+			dryHeavingEmote.Do(RelatedPart.HealthMaster.gameObject);
+			return true;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/StomachExpulsion.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/StomachExpulsion.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Castle.Core.Internal;
 using Chemistry.Components;
 using HealthV2;
 using NaughtyAttributes;
@@ -13,13 +14,14 @@ namespace Items.Implants.Organs.Vomit
 		[SerializeField] private Stomach stomach;
 		[SerializeField] private EmoteSO dryHeavingEmote;
 		[SerializeField] private GameObject vomitReagentPrefab;
-		[SerializeField] private List<IVomitExtension> vomitLogicExtensions;
 		[SerializeField] private float divisbleVomitAmount = 6;
+		private List<IVomitExtension> vomitLogicExtensions = new List<IVomitExtension>();
 
 		public override void Awake()
 		{
 			base.Awake();
 			stomach ??= GetComponent<Stomach>();
+			vomitLogicExtensions.AddRange(GetComponentsInChildren<IVomitExtension>());
 		}
 
 
@@ -42,7 +44,7 @@ namespace Items.Implants.Organs.Vomit
 			//add chat message here
 			foreach (var logic in vomitLogicExtensions)
 			{
-				logic.OnVomit(amountToVomit, livingHealthMaster);
+				logic?.OnVomit(amountToVomit, livingHealthMaster);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/StomachExpulsion.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/StomachExpulsion.cs
@@ -43,7 +43,7 @@ namespace Items.Implants.Organs.Vomit
 			stomach.StomachContents.TransferTo(amountToVomit, vomitReagent);
 			foreach (var logic in vomitLogicExtensions)
 			{
-				logic?.OnVomit(amountToVomit, livingHealthMaster);
+				logic?.OnVomit(amountToVomit, livingHealthMaster, stomach);
 			}
 			if(vomitSound != null) _ = SoundManager.PlayNetworkedAtPosAsync(
 				vomitSound, livingHealthMaster.gameObject.AssumedWorldPosServer());

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/StomachExpulsion.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/StomachExpulsion.cs
@@ -33,7 +33,7 @@ namespace Items.Implants.Organs.Vomit
 			var amountToVomit = Random.Range(0.1f, stomach.StomachContents.CurrentReagentMix.Total / divisbleVomitAmount);
 			var vomitSplat = Spawn.ServerPrefab(
 				vomitReagentPrefab,
-				livingHealthMaster.gameObject.AssumedWorldPosServer());
+				LivingHealthMaster.gameObject.AssumedWorldPosServer());
 			var vomitReagent = vomitSplat.GameObject.GetComponent<ReagentContainer>();
 			if (vomitReagent == null)
 			{
@@ -43,10 +43,10 @@ namespace Items.Implants.Organs.Vomit
 			stomach.StomachContents.TransferTo(amountToVomit, vomitReagent);
 			foreach (var logic in vomitLogicExtensions)
 			{
-				logic?.OnVomit(amountToVomit, livingHealthMaster, stomach);
+				logic?.OnVomit(amountToVomit, LivingHealthMaster, stomach);
 			}
 			if(vomitSound != null) _ = SoundManager.PlayNetworkedAtPosAsync(
-				vomitSound, livingHealthMaster.gameObject.AssumedWorldPosServer());
+				vomitSound, LivingHealthMaster.gameObject.AssumedWorldPosServer());
 		}
 
 		private bool WillDryHeave()

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/StomachExpulsion.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/StomachExpulsion.cs
@@ -14,7 +14,7 @@ namespace Items.Implants.Organs.Vomit
 		[SerializeField] private Stomach stomach;
 		[SerializeField] private EmoteSO dryHeavingEmote;
 		[SerializeField] private GameObject vomitReagentPrefab;
-		[SerializeField] private float divisbleVomitAmount = 6;
+		[SerializeField] private float divisbleVomitAmount = 4;
 		[SerializeField] private AddressableAudioSource vomitSound;
 		private List<IVomitExtension> vomitLogicExtensions = new List<IVomitExtension>();
 

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/StomachExpulsion.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/StomachExpulsion.cs
@@ -16,7 +16,7 @@ namespace Items.Implants.Organs.Vomit
 		[SerializeField] private GameObject vomitReagentPrefab;
 		[SerializeField] private float divisbleVomitAmount = 4;
 		[SerializeField] private AddressableAudioSource vomitSound;
-		private List<IVomitExtension> vomitLogicExtensions = new List<IVomitExtension>();
+		private readonly List<IVomitExtension> vomitLogicExtensions = new List<IVomitExtension>();
 
 		public override void Awake()
 		{

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/StomachExpulsion.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/StomachExpulsion.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: bb8bd890cb294ce6a2cbbff0d834af9d
+timeCreated: 1688113141

--- a/UnityProject/Assets/Scripts/Player/EmoteScripts/DryHeav.cs
+++ b/UnityProject/Assets/Scripts/Player/EmoteScripts/DryHeav.cs
@@ -1,0 +1,19 @@
+﻿using ScriptableObjects.RP;
+using UnityEngine;
+
+namespace Player.EmoteScripts
+{
+	[CreateAssetMenu(fileName = "DryHeav", menuName = "ScriptableObjects/RP/Emotes/DryHeav")]
+	public class DryHeav : GenderedEmote
+	{
+		[SerializeField] private float stunDuration = 8f;
+
+		public override void Do(GameObject player)
+		{
+			base.Do(player);
+			var script = player.GetComponent<PlayerScript>();
+			script.RegisterPlayer.ServerStun(stunDuration);
+			script.RegisterPlayer.ServerLayDown();
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Player/EmoteScripts/DryHeav.cs.meta
+++ b/UnityProject/Assets/Scripts/Player/EmoteScripts/DryHeav.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b8a39a0a24444ba8a1cbb2f4d0a72796
+timeCreated: 1688118173

--- a/UnityProject/Assets/Scripts/Player/EmoteScripts/Vomit.cs
+++ b/UnityProject/Assets/Scripts/Player/EmoteScripts/Vomit.cs
@@ -1,0 +1,36 @@
+﻿using HealthV2;
+using Items.Implants.Organs.Vomit;
+using ScriptableObjects.RP;
+using UnityEngine;
+
+namespace Player.EmoteScripts
+{
+	[CreateAssetMenu(fileName = "Vomit", menuName = "ScriptableObjects/RP/Emotes/Vomit")]
+	public class Vomit : GenderedEmote
+	{
+		public override void Do(GameObject player)
+		{
+			var health = player.GetComponent<LivingHealthMasterBase>();
+			if (health.IsDead) return;
+
+			StandardProgressAction action = StandardProgressAction.Create(
+				new StandardProgressActionConfig(StandardProgressActionType.SelfHeal),
+				() => CheckAndDo(player, health));
+			Chat.AddActionMsgToChat(player, $"<color=red>{health.playerScript.visibleName} attempts to make themselves vomit.</color>");
+			action.ServerStartProgress(player.RegisterTile(), 6f, player);
+		}
+
+		private void CheckAndDo(GameObject player, LivingHealthMasterBase health)
+		{
+			var bodyParts = health.BodyPartStorage.GetOccupiedSlots();
+			foreach (var part in bodyParts)
+			{
+				if (part.ItemObject.TryGetComponent<StomachExpulsion>(out var stomach) == false) continue;
+				stomach.Vomit();
+				base.Do(player);
+				return;
+			}
+			Chat.AddExamineMsg(player, "You do not have a stomach to do this...");
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Player/EmoteScripts/Vomit.cs
+++ b/UnityProject/Assets/Scripts/Player/EmoteScripts/Vomit.cs
@@ -22,10 +22,10 @@ namespace Player.EmoteScripts
 
 		private void CheckAndDo(GameObject player, LivingHealthMasterBase health)
 		{
-			var bodyParts = health.BodyPartStorage.GetOccupiedSlots();
+			var bodyParts = health.BodyPartList;
 			foreach (var part in bodyParts)
 			{
-				if (part.ItemObject.TryGetComponent<StomachExpulsion>(out var stomach) == false) continue;
+				if (part.TryGetComponent<StomachExpulsion>(out var stomach) == false) continue;
 				stomach.Vomit();
 				base.Do(player);
 				return;

--- a/UnityProject/Assets/Scripts/Player/EmoteScripts/Vomit.cs
+++ b/UnityProject/Assets/Scripts/Player/EmoteScripts/Vomit.cs
@@ -8,16 +8,24 @@ namespace Player.EmoteScripts
 	[CreateAssetMenu(fileName = "Vomit", menuName = "ScriptableObjects/RP/Emotes/Vomit")]
 	public class Vomit : GenderedEmote
 	{
+
+		[SerializeField] private bool instant = false;
+
 		public override void Do(GameObject player)
 		{
 			var health = player.GetComponent<LivingHealthMasterBase>();
 			if (health.IsDead) return;
 
-			StandardProgressAction action = StandardProgressAction.Create(
-				new StandardProgressActionConfig(StandardProgressActionType.SelfHeal),
-				() => CheckAndDo(player, health));
-			Chat.AddActionMsgToChat(player, $"<color=red>{health.playerScript.visibleName} attempts to make themselves vomit.</color>");
-			action.ServerStartProgress(player.RegisterTile(), 6f, player);
+			if (instant == false)
+			{
+				StandardProgressAction action = StandardProgressAction.Create(
+					new StandardProgressActionConfig(StandardProgressActionType.SelfHeal),
+					() => CheckAndDo(player, health));
+				Chat.AddActionMsgToChat(player, $"<color=red>{health.playerScript.visibleName} attempts to make themselves vomit.</color>");
+				action.ServerStartProgress(player.RegisterTile(), 6f, player);
+				return;
+			}
+			CheckAndDo(player, health);
 		}
 
 		private void CheckAndDo(GameObject player, LivingHealthMasterBase health)
@@ -30,7 +38,7 @@ namespace Player.EmoteScripts
 				base.Do(player);
 				return;
 			}
-			Chat.AddExamineMsg(player, "You do not have a stomach to do this...");
+			if(instant == false) Chat.AddExamineMsg(player, "You do not have a stomach to do this...");
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Player/EmoteScripts/Vomit.cs.meta
+++ b/UnityProject/Assets/Scripts/Player/EmoteScripts/Vomit.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2e888538a70a4245be42d11ebc9c13f9
+timeCreated: 1688117309

--- a/UnityProject/Assets/Scripts/ScriptableObjects/RP/GenderedEmote.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/RP/GenderedEmote.cs
@@ -15,7 +15,14 @@ namespace ScriptableObjects.RP
 		{
 			if(CheckAllBaseConditions(player) == false) return;
 			HealthCheck(player);
-			Chat.AddActionMsgToChat(player, $"{youText}", $"{player.ExpensiveName()} {viewTextFinal}.");
+			if (string.IsNullOrEmpty(youText))
+			{
+				Chat.AddActionMsgToChat(player, $"{player.ExpensiveName()} {viewTextFinal}.");
+			}
+			else
+			{
+				Chat.AddActionMsgToChat(player, $"{youText}", $"{player.ExpensiveName()} {viewTextFinal}.");
+			}
 			if (soundsAreTyped)
 			{
 				PlayAudio(GetBodyTypeAudio(player), player);


### PR DESCRIPTION
Works on #6400 

### Changelog:

CL: [New] Players can now vomit, either voluntarily via emotes or involuntary via gameplay mechanics. Vomiting stuns the player momentarily and if there's no content in their stomachs they will dry heav instead. 
CL: [New] Vomiting can heal a random amount of toxin.
CL: [New] Moldy Bread and burnt food can induce vomiting now.
