### PR TITLE
Fixes windows having their input interrupted by chat keybinds

### DIFF
--- a/UnityProject/Assets/Scripts/UI/Core/WindowDrag.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/WindowDrag.cs
@@ -30,6 +30,7 @@ public class WindowDrag : MonoBehaviour
 	private void OnEnable()
 	{
 		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
+		UIManager.PreventChatInput = true;
 	}
 
 	public void UpdateMe()
@@ -54,6 +55,7 @@ public class WindowDrag : MonoBehaviour
 		UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);
 
 		transform.localPosition = startPositon;
+		UIManager.PreventChatInput = false;
 	}
 
 	/// <summary>


### PR DESCRIPTION
fixes #9328
fixes #8762
fixes #7037
fixes #9475


CL: [Fix] Having a UI window open will no longer cause chat to automatically take focus when typing using letters bound to chat keybinds.
