### PR TITLE
feat: added setting to enable/disable audio reflection simulation.

### DIFF
--- a/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
+++ b/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
@@ -8686,12 +8686,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4edde236ab1f41f98f22eacbda7b2017, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  layerMask:
-    serializedVersion: 2
-    m_Bits: 393216
   updateTime: 0.75
-  clustrophobicDistance: 8
-  debug: 0
+  debug: 1
 --- !u!1 &7706745016017648645
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/OptionsScreen.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/OptionsScreen.prefab
@@ -1448,6 +1448,84 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &490944263844030196
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5511245150928668846}
+  - component: {fileID: 6060917605180030914}
+  - component: {fileID: 3909189128456020818}
+  m_Layer: 5
+  m_Name: Audio Reflections Toggle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5511245150928668846
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 490944263844030196}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 539050818144656978}
+  - {fileID: 3887454416045247835}
+  m_Father: {fileID: 7937132458435242614}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 755.18866, y: -688.24}
+  m_SizeDelta: {x: 1510.3773, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6060917605180030914
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 490944263844030196}
+  m_CullTransparentMesh: 0
+--- !u!114 &3909189128456020818
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 490944263844030196}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.047058824}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &507153613058846081
 GameObject:
   m_ObjectHideFlags: 0
@@ -2676,6 +2754,83 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1006025893846636424
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 69280430254755199}
+  - component: {fileID: 1588179674697556769}
+  - component: {fileID: 6053192965134581348}
+  m_Layer: 5
+  m_Name: InputBox
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &69280430254755199
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1006025893846636424}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.6854001, y: 1.6854001, z: 1.6854001}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8892390484689162591}
+  m_Father: {fileID: 3887454416045247835}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -1.9996338, y: -0.000045776367}
+  m_SizeDelta: {x: 29.47998, y: 30.009995}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1588179674697556769
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1006025893846636424}
+  m_CullTransparentMesh: 0
+--- !u!114 &6053192965134581348
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1006025893846636424}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &1012706013615261962
 GameObject:
   m_ObjectHideFlags: 0
@@ -3585,11 +3740,11 @@ RectTransform:
   - {fileID: 2338130353541614346}
   - {fileID: 3306465580796722983}
   m_Father: {fileID: 7937132458435242614}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 755.18866, y: -839.3}
+  m_AnchoredPosition: {x: 755.18866, y: -990.36}
   m_SizeDelta: {x: 1510.3773, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7961657655496101460
@@ -6463,6 +6618,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ambientSlider: {fileID: 1290884624823044940}
   ttsToggle: {fileID: 280303909216596478}
+  audioReflectionsToggle: {fileID: 8431319513276971668}
   masterSlider: {fileID: 5983074151611868389}
   soundFXSlider: {fileID: 8925267964084853571}
   musicSlider: {fileID: 463027567310584801}
@@ -9143,11 +9299,11 @@ RectTransform:
   - {fileID: 7584679999514055413}
   - {fileID: 3759684074422370251}
   m_Father: {fileID: 7937132458435242614}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 755.18866, y: -688.24}
+  m_AnchoredPosition: {x: 755.18866, y: -839.3}
   m_SizeDelta: {x: 1510.3773, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8217359313000579615
@@ -10884,7 +11040,7 @@ RectTransform:
   m_Father: {fileID: 3106487022591791884}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.33517337}
+  m_AnchorMin: {x: 0, y: 0.40998167}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: -0.000061035156, y: 0.00012207031}
   m_SizeDelta: {x: 20, y: 20}
@@ -11952,6 +12108,104 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: 'Chat Bubble Theme:'
+--- !u!1 &4310582428993604171
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3887454416045247835}
+  - component: {fileID: 8431319513276971668}
+  m_Layer: 5
+  m_Name: Toggle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3887454416045247835
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4310582428993604171}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 69280430254755199}
+  m_Father: {fileID: 5511245150928668846}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: -38.93052, y: 0}
+  m_SizeDelta: {x: 167.3491, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &8431319513276971668
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4310582428993604171}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 6053192965134581348}
+  toggleTransition: 1
+  graphic: {fileID: 7776407725047333204}
+  m_Group: {fileID: 0}
+  onValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 3629049502436222781}
+        m_TargetAssemblyTypeName: Unitystation.Options.SoundOptions, Assets
+        m_MethodName: AudioReflectionsToggle
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  m_IsOn: 1
 --- !u!1 &4365224338557079793
 GameObject:
   m_ObjectHideFlags: 0
@@ -12903,11 +13157,11 @@ RectTransform:
   - {fileID: 7173648739475511597}
   - {fileID: 6874149038029607888}
   m_Father: {fileID: 7937132458435242614}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 755.18866, y: -1141.42}
+  m_AnchoredPosition: {x: 755.18866, y: -1292.4801}
   m_SizeDelta: {x: 1510.3773, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5418123428780195751
@@ -13024,6 +13278,86 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4647202594162924865
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 539050818144656978}
+  - component: {fileID: 4817577454754141412}
+  - component: {fileID: 8869613371014083744}
+  m_Layer: 5
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &539050818144656978
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4647202594162924865}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5511245150928668846}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0.294, y: 1}
+  m_AnchoredPosition: {x: 96.76886, y: 7}
+  m_SizeDelta: {x: 183.5378, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4817577454754141412
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4647202594162924865}
+  m_CullTransparentMesh: 0
+--- !u!114 &8869613371014083744
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4647202594162924865}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 0
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 0
+    m_MaxSize: 40
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Enable Audio Reflections:'
 --- !u!1 &4676590773200263368
 GameObject:
   m_ObjectHideFlags: 0
@@ -19201,11 +19535,11 @@ RectTransform:
   - {fileID: 1106956850721508376}
   - {fileID: 4453319443609954143}
   m_Father: {fileID: 7937132458435242614}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 755.18866, y: -990.36}
+  m_AnchoredPosition: {x: 755.18866, y: -1141.42}
   m_SizeDelta: {x: 1510.3773, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8803134460684550721
@@ -23156,8 +23490,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 2414514785203160099}
   m_HandleRect: {fileID: 9217550034905896361}
   m_Direction: 2
-  m_Value: 1
-  m_Size: 0.6648267
+  m_Value: 1.0000002
+  m_Size: 0.5900183
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -24731,7 +25065,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -1.4003906, y: 2.8000488}
+  m_AnchoredPosition: {x: -1.4005127, y: 2.8000488}
   m_SizeDelta: {x: 1941.2, y: 1054.3}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &110540010659244091
@@ -28483,6 +28817,7 @@ RectTransform:
   - {fileID: 6832612066359658865}
   - {fileID: 5140174940145774544}
   - {fileID: 7168200959629969972}
+  - {fileID: 5511245150928668846}
   - {fileID: 6493403768785618289}
   - {fileID: 3903065236044334802}
   - {fileID: 4263243749171765114}
@@ -28493,7 +28828,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0.0000046389864, y: -0.000030517578}
-  m_SizeDelta: {x: -0.00012207, y: 1191.42}
+  m_SizeDelta: {x: -0.00012207, y: 1342.4801}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &3690283355952590908
 MonoBehaviour:
@@ -29233,6 +29568,82 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &9165973458887130720
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8892390484689162591}
+  - component: {fileID: 8412713219688793552}
+  - component: {fileID: 7776407725047333204}
+  m_Layer: 5
+  m_Name: Checkmark
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8892390484689162591
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9165973458887130720}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 69280430254755199}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0.000076293945}
+  m_SizeDelta: {x: 30, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8412713219688793552
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9165973458887130720}
+  m_CullTransparentMesh: 0
+--- !u!114 &7776407725047333204
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9165973458887130720}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10901, guid: 0000000000000000f000000000000000, type: 0}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/UnityProject/Assets/Scenes/ActiveScenes/OnlineScene.unity
+++ b/UnityProject/Assets/Scenes/ActiveScenes/OnlineScene.unity
@@ -12831,6 +12831,11 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -45.65
       objectReference: {fileID: 0}
+    - target: {fileID: 2739389561917205558, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2916427440774072448, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_IsActive
@@ -12889,12 +12894,12 @@ PrefabInstance:
     - target: {fileID: 2967335146640221780, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -24.99997
+      value: -25
       objectReference: {fileID: 0}
     - target: {fileID: 2967373415580766804, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -7.1000366
+      value: -7.1000977
       objectReference: {fileID: 0}
     - target: {fileID: 2970664891730648836, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
@@ -13211,6 +13216,16 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -57.5
       objectReference: {fileID: 0}
+    - target: {fileID: 4147125179588738938, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4147125179588738938, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4153480489544518175, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -13229,6 +13244,21 @@ PrefabInstance:
     - target: {fileID: 4153480489544518175, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4199685495035560006, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4199685495035560006, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4199685495035560006, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4236498455849868228, guid: 829f4ca992b848d6bb4d007fb9c112e1,
@@ -14554,7 +14584,7 @@ PrefabInstance:
     - target: {fileID: 8388672857892549126, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -1.4000244
+      value: -1.4002686
       objectReference: {fileID: 0}
     - target: {fileID: 8425574330911350240, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
@@ -15091,6 +15121,16 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 8828654199121321389, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8828654199121321389, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8897673338037527780, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -15281,6 +15321,7 @@ MonoBehaviour:
   syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
+  ScenesInitialLoadingComplete: 0
   SubSceneManager: {fileID: 1314589445662661194}
 --- !u!1001 &1500091029
 PrefabInstance:
@@ -15700,6 +15741,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 88cdce62f5f5af74fa58c874b74efc0a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  clientIsLoadingSubscene: 0
   awayWorldList: {fileID: 11400000, guid: 9336c6ca9dac2d94eb90f703a23a7484, type: 2}
   mainStationList: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}
   asteroidList: {fileID: 11400000, guid: b1d9059b8db83ab479c9dffdc939b281, type: 2}

--- a/UnityProject/Assets/Scripts/Core/Sound/SoundPhysics.cs
+++ b/UnityProject/Assets/Scripts/Core/Sound/SoundPhysics.cs
@@ -1,0 +1,121 @@
+﻿using System.Collections.Generic;
+using Audio.Containers;
+using UnityEngine;
+
+namespace Core.Sound
+{
+	public enum RoomSize
+	{
+		Small,
+		Medium,
+		Large,
+		ExtraLarge
+	}
+
+	public static class SoundPhysics
+	{
+		public const int DISTANT_SOUND_DISTANCE = 20;
+		public const int MAX_REVERB_RAY_TRAVEL_DISTANCE = 30;
+		public const int MEDIUM_ROOM_AREA = 5;
+		public const int LARGE_ROOM_AREA = 8;
+
+		public static LayerTypeSelection ObstructionLayerMask => LayerTypeSelection.Walls | LayerTypeSelection.Windows;
+		public static LayerTypeSelection ReverbLayerMask => LayerTypeSelection.Walls | LayerTypeSelection.Windows;
+
+		public static readonly Dictionary<RoomSize, float>  RoomSizeToReverbStrength = new()
+		{
+			{RoomSize.Small, -2000f},
+			{RoomSize.Medium, -950f},
+			{RoomSize.Large, -650f},
+			{RoomSize.ExtraLarge, -0f},
+		};
+
+		/// <summary>
+		/// Using the player perspective, is the sound obstructed by a wall or other object? Is it too far away?
+		/// </summary>
+		/// <param name="sound"></param>
+		/// <returns></returns>
+		public static bool IsObstructedOrDistant(SoundSpawn sound)
+		{
+			Vector3Int playerPos = PlayerManager.LocalPlayerObject.TileWorldPosition().To3Int();
+			Vector3Int sourcePos = sound.transform.position.CutToInt();
+
+			if ((playerPos - sourcePos).magnitude > DISTANT_SOUND_DISTANCE) return true;
+
+			var line = MatrixManager.Linecast(
+				playerPos,
+				ObstructionLayerMask,
+				null,
+				sourcePos);
+
+			return line.ItHit;
+		}
+
+		/// <summary>
+		/// Projects 4 rays, one for each direction, from the sound source. Sums and averages the distance to the nearest wall in each direction, doing an estimation of room area.
+		/// Then returns a RoomSize enum based on the average distance.
+		/// </summary>
+		/// <param name="soundObject"></param>
+		/// <param name="debug"></param>
+		/// <returns></returns>
+		public static RoomSize CalculateRoomSize(GameObject soundObject, bool debug = false)
+		{
+			float totalDistanceToWalls = 0;
+			Vector3 origin = soundObject.transform.position.CutToInt();
+
+			Vector3[] destinations =
+			{
+				//from origin to the right
+				new Vector3(origin.x + MAX_REVERB_RAY_TRAVEL_DISTANCE, origin.y, origin.z).CutToInt(),
+				//from origin to the left
+				new Vector3(origin.x - MAX_REVERB_RAY_TRAVEL_DISTANCE, origin.y, origin.z).CutToInt(),
+				//from origin to the top
+				new Vector3(origin.x, origin.y + MAX_REVERB_RAY_TRAVEL_DISTANCE, origin.z).CutToInt(),
+				//from origin to the bottom
+				new Vector3(origin.x, origin.y - MAX_REVERB_RAY_TRAVEL_DISTANCE, origin.z).CutToInt(),
+			};
+
+			foreach (var destination in destinations)
+			{
+				var line = MatrixManager.Linecast(
+					origin,
+					ReverbLayerMask,
+					null,
+					destination,
+					debug);
+
+				if (line.ItHit)
+				{
+					totalDistanceToWalls += line.Distance;
+				}
+			}
+
+			float averageDistanceToWalls = totalDistanceToWalls / destinations.Length;
+
+			return averageDistanceToWalls switch
+			{
+				< MEDIUM_ROOM_AREA => RoomSize.Small,
+				<= MEDIUM_ROOM_AREA => RoomSize.Medium,
+				<= LARGE_ROOM_AREA => RoomSize.Large,
+				> LARGE_ROOM_AREA => RoomSize.ExtraLarge,
+				_ => RoomSize.Small
+			};
+		}
+
+		/// <summary>
+		/// Evaluates the physical conditions of the sound and routes it to the appropriate mixer group.
+		/// </summary>
+		/// <param name="sound"></param>
+		public static void EvaluateAndRouteSoundToMixer(SoundSpawn sound)
+		{
+			if (IsObstructedOrDistant(sound))
+			{
+				sound.AudioSource.outputAudioMixerGroup = AudioManager.Instance.SFXMuffledMixer;
+			}
+
+			//TODO: This method used to also route sound to different mixer groups with reverb based on room size.
+			//It had to be changed because the Audio management in unity is inflexible and doesn't allow for dynamic routing at the level I wish to do it.
+			//I will revise this solution later on
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Core/Sound/SoundPhysics.cs.meta
+++ b/UnityProject/Assets/Scripts/Core/Sound/SoundPhysics.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f63bccc54d674c7abff90ce690cbd5d0
+timeCreated: 1688505256

--- a/UnityProject/Assets/Scripts/Managers/AudioManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/AudioManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -25,9 +26,22 @@ namespace Audio.Containers
         public AudioMixerGroup SFXMuffledMixer;
         public AudioMixerGroup AmbientMixer;
         public AudioMixerGroup TTSMixer;
-
         public AudioMixerGroup GameplayMixer; //Affected by deafness and air pressure and all that stuff
 
+        public event Action<bool> AudioReflectionsToggled;
+        private bool enableAudioReflections = true;
+
+        public bool EnableAudioReflections
+        {
+	        get => enableAudioReflections;
+	        set => ToggleAudioReflections(value);
+        }
+
+        private void ToggleAudioReflections(bool value)
+        {
+	        AudioReflectionsToggled?.Invoke(value);
+	        enableAudioReflections = value;
+        }
 
         private float GameplayVolumeLevel = 1;
 
@@ -64,31 +78,36 @@ namespace Audio.Containers
         {
 	        base.Start();
 	        MultiInterestFloat.OnFloatChange.AddListener(OnSetGameplayVolume);
-            MasterVolume(
-                PlayerPrefs.HasKey(PlayerPrefKeys.MasterVolumeKey)
-                    ? PlayerPrefs.GetFloat(PlayerPrefKeys.MasterVolumeKey)
-                    : 1f
-                );
-            AmbientVolume(
-                PlayerPrefs.HasKey(PlayerPrefKeys.AmbientVolumeKey)
-                    ? PlayerPrefs.GetFloat(PlayerPrefKeys.AmbientVolumeKey)
-                    : 0.8f
-                );
-            SoundFXVolume(
-                PlayerPrefs.HasKey(PlayerPrefKeys.SoundFXVolumeKey)
-                    ? PlayerPrefs.GetFloat(PlayerPrefKeys.SoundFXVolumeKey)
-                    : 0.8f
-                );
-            MusicVolume(
-                PlayerPrefs.HasKey(PlayerPrefKeys.MusicVolumeKey)
-                    ? PlayerPrefs.GetFloat(PlayerPrefKeys.MusicVolumeKey)
-                    : 0.8f
-                );
-            TtsVolume(
-                PlayerPrefs.HasKey(PlayerPrefKeys.TtsVolumeKey)
-                    ? PlayerPrefs.GetFloat(PlayerPrefKeys.TtsVolumeKey)
-                    : 0.8f
-                );
+	        MasterVolume(
+		        PlayerPrefs.HasKey(PlayerPrefKeys.MasterVolumeKey)
+			        ? PlayerPrefs.GetFloat(PlayerPrefKeys.MasterVolumeKey)
+			        : 1f
+	        );
+	        AmbientVolume(
+		        PlayerPrefs.HasKey(PlayerPrefKeys.AmbientVolumeKey)
+			        ? PlayerPrefs.GetFloat(PlayerPrefKeys.AmbientVolumeKey)
+			        : 0.8f
+	        );
+	        SoundFXVolume(
+		        PlayerPrefs.HasKey(PlayerPrefKeys.SoundFXVolumeKey)
+			        ? PlayerPrefs.GetFloat(PlayerPrefKeys.SoundFXVolumeKey)
+			        : 0.8f
+	        );
+	        MusicVolume(
+		        PlayerPrefs.HasKey(PlayerPrefKeys.MusicVolumeKey)
+			        ? PlayerPrefs.GetFloat(PlayerPrefKeys.MusicVolumeKey)
+			        : 0.8f
+	        );
+	        TtsVolume(
+		        PlayerPrefs.HasKey(PlayerPrefKeys.TtsVolumeKey)
+			        ? PlayerPrefs.GetFloat(PlayerPrefKeys.TtsVolumeKey)
+			        : 0.8f
+	        );
+
+	        // ReSharper disable once SimplifyConditionalTernaryExpression
+	        EnableAudioReflections = PlayerPrefs.HasKey(PlayerPrefKeys.AudioReflectionsToggleKey)
+		        ? PlayerPrefs.GetInt(PlayerPrefKeys.AudioReflectionsToggleKey) == 1
+		        : true;
         }
 
         /// <summary>

--- a/UnityProject/Assets/Scripts/Managers/SoundManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SoundManager.cs
@@ -1,16 +1,13 @@
-﻿using System;
-using AddressableReferences;
+﻿using AddressableReferences;
 using Mirror;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Messages.Server.SoundMessages;
 using UnityEngine;
 using UnityEngine.Audio;
-using UnityEngine.SceneManagement;
 using Audio.Containers;
+using Core.Sound;
 using Shared.Util;
-using Util;
 
 /// <summary>
 /// Manager that allows to play sounds.
@@ -368,7 +365,7 @@ public class SoundManager : MonoBehaviour
 		SoundSpawn soundSpawn =
 			Instance.GetSoundSpawn(addressableAudioSource, addressableAudioSource.AudioSource, soundSpawnToken);
 		ApplyAudioSourceParameters(audioSourceParameters, soundSpawn);
-		Instance.PlaySource(soundSpawn, polyphonic, true, audioSourceParameters.MixerType);
+		Instance.PlaySource(soundSpawn, polyphonic, true);
 	}
 
 	/// <summary>
@@ -392,25 +389,13 @@ public class SoundManager : MonoBehaviour
 	/// <param name="source">The SoundSpawn to be played</param>
 	/// <param name="polyphonic">Should the sound be played polyphonically</param>
 	/// <param name="global">Does everyone will receive the sound our just nearby players</param>
-	/// <param name="mixerType">The type of mixer to use</param>
-	private void PlaySource(SoundSpawn source, bool polyphonic = false, bool global = true, MixerType mixerType = MixerType.Master)
+	private void PlaySource(SoundSpawn source, bool polyphonic = false, bool global = true)
 	{
 		if (global == false && PlayerManager.LocalPlayerObject != null)
 		{
-			if ( ((PlayerManager.LocalPlayerObject.TileWorldPosition().To3Int() - source.transform.position.RoundTo2Int().To3Int()).magnitude > 20 ))
-			{
-				source.AudioSource.outputAudioMixerGroup = AudioManager.Instance.SFXMuffledMixer; //Maybe just not play?
-			}
-			else
-			{
-				if (MatrixManager.Linecast(PlayerManager.LocalPlayerObject.TileWorldPosition().To3Int(),
-						LayerTypeSelection.Walls, layerMask, source.transform.position.RoundTo2Int().To3Int())
-					.ItHit)
-				{
-					source.AudioSource.outputAudioMixerGroup = AudioManager.Instance.SFXMuffledMixer;
-				}
-			}
+			SoundPhysics.EvaluateAndRouteSoundToMixer(source);
 		}
+
 		if (polyphonic)
 		{
 			source.PlayOneShot();
@@ -516,7 +501,7 @@ public class SoundManager : MonoBehaviour
 				soundTransform.parent = objectToPlayAt.transform;
 				soundTransform.localPosition = Vector3.zero;
 
-				Instance.PlaySource(soundSpawn, polyphonic, isGlobal, audioSourceParameters.MixerType);
+				Instance.PlaySource(soundSpawn, polyphonic, isGlobal);
 				return;
 			}
 		}
@@ -525,7 +510,7 @@ public class SoundManager : MonoBehaviour
 		soundTransform.parent = point != null ? point.Objects.transform : Instance.transform;
 		soundTransform.position = worldPos;
 
-		Instance.PlaySource(soundSpawn, polyphonic, isGlobal, audioSourceParameters.MixerType);
+		Instance.PlaySource(soundSpawn, polyphonic, isGlobal);
 	}
 
 	/// <Summary>

--- a/UnityProject/Assets/Scripts/Messages/Server/SoundMessages/AudioSourceParameters.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/SoundMessages/AudioSourceParameters.cs
@@ -1,6 +1,6 @@
 ﻿using Newtonsoft.Json;
 
-﻿namespace Messages.Server.SoundMessages
+namespace Messages.Server.SoundMessages
 {
 	public enum MixerType
 	{
@@ -54,12 +54,12 @@
 		// True if volume is supposed to be 0.
 		// We need this because structs always initilize with with all variables equal to 0.
 		public bool IsMute;
-		
+
 		/// <Summary>
 		/// Constructor for the AudioSourceParameters Struct
 		/// </Summary>
 		public AudioSourceParameters(float pitch = 0, float volume = 0, float time = 0, float pan = 0,
-			float spatialBlend = 0, float spread = 0, float minDistance = 0, float maxDistance = 0, 
+			float spatialBlend = 0, float spread = 0, float minDistance = 0, float maxDistance = 0,
 			MixerType mixerType = MixerType.Master, VolumeRolloffType volumeRolloffType = VolumeRolloffType.Linear,
 			bool isMute = false)
 		{

--- a/UnityProject/Assets/Scripts/PlayerPrefs/PlayerPrefKeys.cs
+++ b/UnityProject/Assets/Scripts/PlayerPrefs/PlayerPrefKeys.cs
@@ -67,6 +67,13 @@
 	public static readonly string TTSToggleKey = "TTSSetting";
 
 	/// <summary>
+	/// AudioReflections Toggle Pref.
+	/// 0 = disabled
+	/// 1 = enabled
+	/// </summary>
+	public static readonly string AudioReflectionsToggleKey = "AudioReflectionsSetting";
+
+	/// <summary>
 	/// Returns the name of the currently selected theme name
 	/// </summary>
 	public static readonly string ChatBubbleThemeKey = "ChatBubbleTheme";

--- a/UnityProject/Assets/Scripts/Systems/DynamicAmbience/DynamicReverb.cs
+++ b/UnityProject/Assets/Scripts/Systems/DynamicAmbience/DynamicReverb.cs
@@ -1,30 +1,41 @@
-﻿using Audio.Containers;
+﻿using System;
+using Audio.Containers;
+using Core.Sound;
 using UnityEngine;
 
 namespace Systems.DynamicAmbience
 {
 	public class DynamicReverb : MonoBehaviour
 	{
-		[SerializeField] private LayerMask layerMask;
 		[SerializeField] private float updateTime = 0.75f;
-		[SerializeField] private float clustrophobicDistance = 8f;
 		[SerializeField] private bool debug = true;
 
-		private readonly float reverbFullStrength = 0.00f;
-		private readonly float reverbMediumStrength = -650.00f;
-		private readonly float reverbLowStrength = -950.00f;
-
 		private const string AUDIOMIXER_REVERB_KEY = "SFXReverb";
-
-		private float strength = 0.00f;
-
 		private bool isEnabled = false;
+
+		private void Start()
+		{
+			AudioManager.Instance.AudioReflectionsToggled += OnAudioReflectionsSettingToggled;
+		}
+
+		private void OnAudioReflectionsSettingToggled(bool value)
+		{
+			if (value)
+			{
+				EnableAmbienceForPlayer();
+			}
+			else
+			{
+				DisableAmbienceForPlayer();
+			}
+		}
 
 		public void EnableAmbienceForPlayer()
 		{
 			if (CustomNetworkManager.IsHeadless) return;
-			Logger.Log("Enabling Dynamic Reverb system.");
 			if (transform.parent.gameObject.NetWorkIdentity()?.isOwned == false || isEnabled) return;
+
+			Logger.Log("Enabling Dynamic Reverb system.");
 			UpdateManager.Add(UpdateMe, updateTime);
 			isEnabled = true;
 		}
@@ -32,8 +43,9 @@ namespace Systems.DynamicAmbience
 		public void DisableAmbienceForPlayer()
 		{
 			if (CustomNetworkManager.IsHeadless) return;
+			if (transform.parent.gameObject.NetWorkIdentity()?.isOwned == false || isEnabled == false) return;
+
 			Logger.Log("Disabling Dynamic Reverb system.");
-			if (transform.parent.gameObject.NetWorkIdentity()?.isOwned == false) return;
 			AudioManager.Instance.GameplayMixer.audioMixer.ClearFloat(AUDIOMIXER_REVERB_KEY);
 			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, UpdateMe);
 			isEnabled = false;
@@ -41,99 +53,9 @@ namespace Systems.DynamicAmbience
 
 		private void UpdateMe()
 		{
-			if (ClaustrophobicSpace(out var distance))
-			{
-				DistanceStrengthToUse(distance);
-				AudioManager.Instance.GameplayMixer.audioMixer.SetFloat(AUDIOMIXER_REVERB_KEY, strength);
-			}
-			else
-			{
-				AudioManager.Instance.GameplayMixer.audioMixer.ClearFloat(AUDIOMIXER_REVERB_KEY);
-			}
-		}
-
-		private void DistanceStrengthToUse(float distance)
-		{
-			if (debug)
-			{
-				Logger.Log($"Distance: " +
-				           $"{distance} -- Full {clustrophobicDistance}/{distance >= clustrophobicDistance} " +
-				           $"-- Med {clustrophobicDistance / 1.25f}/{distance < clustrophobicDistance / 1.25f} " +
-				           $"-- Low {clustrophobicDistance / 1.50f}/{distance < clustrophobicDistance /1.50f}");
-			}
-
-			if (distance >= clustrophobicDistance || distance.Approx(clustrophobicDistance) || distance.Approx(1))
-			{
-				strength = reverbFullStrength;
-				return;
-			}
-			if (distance < clustrophobicDistance / 1.50f) strength = reverbLowStrength;
-			if (distance < clustrophobicDistance / 1.25f) strength = reverbMediumStrength;
-		}
-
-		private bool ClaustrophobicSpace(out float distance)
-		{
-			distance = clustrophobicDistance / 4;
-			var pos = transform.parent.gameObject.AssumedWorldPosServer().CutToInt();
-			if (MatrixManager.IsSpaceAt(pos, CustomNetworkManager.IsServer)) return true;
-			var hitData = CheckSpace(pos);
-			var hitValidY = hitData[0].Hit && hitData[1].Hit;
-			var hitValidX = hitData[2].Hit && hitData[3].Hit;
-
-			if (hitValidX)
-			{
-				distance = DistanceCheck(hitData[2].Distance, hitData[3].Distance);
-			}
-			else if (hitValidY)
-			{
-				distance = DistanceCheck(hitData[0].Distance, hitData[1].Distance);
-			}
-			else
-			{
-				distance = 0;
-			}
-
-			return hitValidY || hitValidX;
-		}
-
-		private HitData[] CheckSpace(Vector3Int pos)
-		{
-			Vector3[] directions = new[]
-			{
-				new Vector3(pos.x, pos.y + clustrophobicDistance, pos.z), //up
-				new Vector3(pos.x, pos.y - clustrophobicDistance, pos.z), //down
-				new Vector3(pos.x + clustrophobicDistance, pos.y, pos.z), //left
-				new Vector3(pos.x - clustrophobicDistance, pos.y, pos.z) //right
-			};
-			HitData[] hitData = new HitData[4];
-			int index = -1;
-			foreach (var dir in directions)
-			{
-				index++;
-				HitData data = new HitData();
-				var line =  MatrixManager.Linecast(
-					pos,
-					LayerTypeSelection.Walls, layerMask,
-					dir,
-					debug);
-				data.Distance = line.Distance;
-				data.Hit = line.ItHit;
-				hitData[index] = data;
-			}
-
-			return hitData;
-		}
-
-		private float DistanceCheck(float one, float two)
-		{
-			//TODO: Create a better way to check how far the player is from nearby walls
-			return one + two;
-		}
-
-		private struct HitData
-		{
-			public bool Hit;
-			public float Distance;
+			var roomSize = SoundPhysics.CalculateRoomSize(gameObject, debug);
+			var strength = SoundPhysics.RoomSizeToReverbStrength[roomSize];
+			AudioManager.Instance.GameplayMixer.audioMixer.SetFloat(AUDIOMIXER_REVERB_KEY, strength);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Core/OptionsMenu/SoundOptions.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/OptionsMenu/SoundOptions.cs
@@ -1,28 +1,32 @@
 ﻿using Audio.Managers;
 using Audio.Containers;
 using UnityEngine;
+using UnityEngine.Audio;
 using UnityEngine.UI;
 
 namespace Unitystation.Options
 {
-    public class SoundOptions : MonoBehaviour
-    {
-        [SerializeField]
-        private Slider ambientSlider = null;
+	public class SoundOptions : MonoBehaviour
+	{
+		[SerializeField]
+		private Slider ambientSlider = null;
 
-        [SerializeField]
-        private Toggle ttsToggle = null;
+		[SerializeField]
+		private Toggle ttsToggle = null;
+
+		[SerializeField]
+		private Toggle audioReflectionsToggle = null;
 
 		[SerializeField]
 		private Slider masterSlider = null;
 
-        [SerializeField]
+		[SerializeField]
 		private Slider soundFXSlider = null;
 
-        [SerializeField]
+		[SerializeField]
 		private Slider musicSlider = null;
 
-        [SerializeField]
+		[SerializeField]
 		private Slider TTSSlider = null;
 
 		[SerializeField]
@@ -32,8 +36,8 @@ namespace Unitystation.Options
 		private Toggle CommonRadioToggle = null;
 
 		void OnEnable()
-        {
-            Refresh();
+		{
+			Refresh();
 		}
 
 		public void OnMasterVolumeChange()
@@ -41,78 +45,84 @@ namespace Unitystation.Options
 			AudioManager.MasterVolume(masterSlider.value);
 		}
 
-        public void OnSoundFXVolumeChange()
-        {
-	        AudioManager.SoundFXVolume(soundFXSlider.value);
-        }
+		public void OnSoundFXVolumeChange()
+		{
+			AudioManager.SoundFXVolume(soundFXSlider.value);
+		}
 
-        public void OnMusicVolumeChange()
-        {
-	        AudioManager.MusicVolume(musicSlider.value);
-        }
+		public void OnMusicVolumeChange()
+		{
+			AudioManager.MusicVolume(musicSlider.value);
+		}
 
-        public void OnAmbientVolumeChange()
-        {
-	        AudioManager.AmbientVolume(ambientSlider.value);
-        }
-
-
-        public void OnRadioChatterChange()
-        {
-	        AudioManager.RadioChatterVolume(RadioSlider.value);
-        }
-
-        public void OnCommonRadioChatterChange()
-        {
-	        AudioManager.CommonRadioChatter(CommonRadioToggle.isOn);
-        }
+		public void OnAmbientVolumeChange()
+		{
+			AudioManager.AmbientVolume(ambientSlider.value);
+		}
 
 
+		public void OnRadioChatterChange()
+		{
+			AudioManager.RadioChatterVolume(RadioSlider.value);
+		}
 
-        public void TTSToggle()
-        {
-            UIManager.ToggleTTS(ttsToggle.isOn);
-            TTSSlider.transform.parent.SetActive(ttsToggle.isOn);
-        }
+		public void OnCommonRadioChatterChange()
+		{
+			AudioManager.CommonRadioChatter(CommonRadioToggle.isOn);
+		}
 
-        public void OnTtsVolumeChange()
-        {
-	        AudioManager.TtsVolume(TTSSlider.value);
-        }
+		public void TTSToggle()
+		{
+			UIManager.ToggleTTS(ttsToggle.isOn);
+			TTSSlider.transform.parent.SetActive(ttsToggle.isOn);
+		}
 
-        void Refresh()
-        {
-            musicSlider.value = PlayerPrefs.GetFloat(PlayerPrefKeys.MusicVolumeKey);
-            soundFXSlider.value = PlayerPrefs.GetFloat(PlayerPrefKeys.SoundFXVolumeKey);
-            ambientSlider.value = PlayerPrefs.GetFloat(PlayerPrefKeys.AmbientVolumeKey);
-            TTSSlider.value = PlayerPrefs.GetFloat(PlayerPrefKeys.TtsVolumeKey);
-            ttsToggle.isOn = PlayerPrefs.GetInt(PlayerPrefKeys.TTSToggleKey) == 1;
+		public void AudioReflectionsToggle()
+		{
+			AudioManager.Instance.EnableAudioReflections = audioReflectionsToggle.isOn;
+			PlayerPrefs.SetInt(PlayerPrefKeys.AudioReflectionsToggleKey, audioReflectionsToggle.isOn ? 1 : 0);
+			PlayerPrefs.Save();
+		}
+
+		public void OnTtsVolumeChange()
+		{
+			AudioManager.TtsVolume(TTSSlider.value);
+		}
+
+		void Refresh()
+		{
+			musicSlider.value = PlayerPrefs.GetFloat(PlayerPrefKeys.MusicVolumeKey);
+			soundFXSlider.value = PlayerPrefs.GetFloat(PlayerPrefKeys.SoundFXVolumeKey);
+			ambientSlider.value = PlayerPrefs.GetFloat(PlayerPrefKeys.AmbientVolumeKey);
+			TTSSlider.value = PlayerPrefs.GetFloat(PlayerPrefKeys.TtsVolumeKey);
+			ttsToggle.isOn = PlayerPrefs.GetInt(PlayerPrefKeys.TTSToggleKey) == 1;
+			audioReflectionsToggle.isOn = !PlayerPrefs.HasKey(PlayerPrefKeys.AudioReflectionsToggleKey) || PlayerPrefs.GetInt(PlayerPrefKeys.AudioReflectionsToggleKey) == 1;
 			masterSlider.value = PlayerPrefs.GetFloat(PlayerPrefKeys.MasterVolumeKey);
-            TTSSlider.transform.parent.SetActive(ttsToggle.isOn);
+			TTSSlider.transform.parent.SetActive(ttsToggle.isOn);
 
-            CommonRadioToggle.isOn = PlayerPrefs.GetInt(PlayerPrefKeys.CommonRadioToggleKey) == 1;
-            RadioSlider.value = PlayerPrefs.GetFloat(PlayerPrefKeys.RadioVolumeKey);
+			CommonRadioToggle.isOn = PlayerPrefs.GetInt(PlayerPrefKeys.CommonRadioToggleKey) == 1;
+			RadioSlider.value = PlayerPrefs.GetFloat(PlayerPrefKeys.RadioVolumeKey);
 
 		}
 
-        public void ResetDefaults()
-        {
-            ModalPanelManager.Instance.Confirm(
-                "Are you sure?",
-                () =>
-                {
-                    UIManager.ToggleTTS(false);
-                    AudioManager.AmbientVolume(0.2f);
-                    AudioManager.SoundFXVolume(0.2f);
-                    AudioManager.MusicVolume(0.2f);
-                    AudioManager.TtsVolume(0.2f);
+		public void ResetDefaults()
+		{
+			ModalPanelManager.Instance.Confirm(
+				"Are you sure?",
+				() =>
+				{
+					UIManager.ToggleTTS(false);
+					AudioManager.AmbientVolume(0.2f);
+					AudioManager.SoundFXVolume(0.2f);
+					AudioManager.MusicVolume(0.2f);
+					AudioManager.TtsVolume(0.2f);
 					AudioListener.volume = 1;
 					AudioManager.CommonRadioChatter(false);
 					AudioManager.RadioChatterVolume(0.2f);
-                    Refresh();
-                },
-                "Reset"
-            );
-        }
-    }
+					Refresh();
+				},
+				"Reset"
+			);
+		}
+	}
 }


### PR DESCRIPTION
### Purpose
Initially I intended to improve upon Max's work by doing a more accurate aproximation of the audio physics for reverb.

1. I wanted to move the reflection calculations perspective from the hearer to the object emitting sound. I couldn't do it this time because of Unity's inflexible audio tools.
2. Dropped early reflections by simply applying a base reverb strenght that is modified based on the room size.
3. Refactored the room size calculation, streamlining it and making easier to understand and tweak.
4. Players can now go to the settings menu and enable or disable the room reflections simulation. The settings can even be extended eventually and allow more control for the player to find their sweet spot.

I'm not satisfied with this PR and I intend to revisit it sometime, but I also want to break the habit of working in something for Unitystation and never doing a PR.

### Known issues
During this development, I found out the LineCast method doesn't work properly with the optional layer mask. This was solved by using the first argument with Walls | Windows layer types, which results in both of theses tiles being detected to calcular room size. This wasn't the case before.

Sadly, this also means that until that is fixed, closed doors aren't considered for room size calculation.