### PR TITLE
Xenobio remap and quick fix

### DIFF
--- a/UnityProject/Assets/Scripts/NPC/AI/MobMeleeAction.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobMeleeAction.cs
@@ -75,6 +75,7 @@ namespace Systems.MobAIs
 		public override void DoAction()
 		{
 			if(isOnCooldown) return;
+			if (objectPhysics.ContainedInObjectContainer != null) return;
 			base.DoAction();
 			var hitInfo = ValidateTarget();
 			if (hitInfo.ItHit == false)


### PR DESCRIPTION
Closes #9951 

![Capture](https://github.com/unitystation/unitystation/assets/48405920/de6f072a-f109-49ef-a992-fac8646bfe62)

### Changelog:
CL: [Improvement] Remaps ministation's xenobiology lab
CL: [Fix] Fixed mobs being able to attack from within lockers and containers
