### PR TITLE
IL friendly

### DIFF
--- a/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainerFillVisualisation.cs
+++ b/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainerFillVisualisation.cs
@@ -16,7 +16,7 @@ public class ReagentContainerFillVisualisation : NetworkBehaviour, IServerSpawn
 	/// <summary>
 	/// Stores all information about visual state of container
 	/// </summary>
-	protected struct VisualState
+	public struct VisualState
 	{
 		public Color mixColor;
 		public float fillPercent;

--- a/UnityProject/Assets/Scripts/Core/Transform/Orientation.cs
+++ b/UnityProject/Assets/Scripts/Core/Transform/Orientation.cs
@@ -19,7 +19,7 @@ public struct Orientation : IEquatable<Orientation>
 	/// <summary>
 	/// Euler angle (rotation about the z axis, right is 0 and up is 90).
 	/// </summary>
-	public readonly int Degrees;
+	public int Degrees;
 
 	public Orientation(int degree)
 	{

--- a/UnityProject/Assets/Scripts/Items/Others/Gibtonite.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/Gibtonite.cs
@@ -14,7 +14,7 @@ namespace Items.Others
 	[RequireComponent(typeof(Pickupable))]
 	public class Gibtonite : NetworkBehaviour, ICheckedInteractable<HandApply>, IHoverTooltip
 	{
-		private enum GibState
+		public enum GibState
 		{
 			ACTIVE,
 			INACTIVE,

--- a/UnityProject/Assets/Scripts/Items/Weapons/Melee/EnergySword.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Melee/EnergySword.cs
@@ -252,7 +252,7 @@ public class EnergySword : NetworkBehaviour, ICheckedInteractable<HandActivate>,
 		return default;
 	}
 
-	private enum SwordColor
+	public enum SwordColor
 	{
 		Random = 0,
 		Red = 1,

--- a/UnityProject/Assets/Scripts/Objects/Research/Artifacts/Artifact.cs
+++ b/UnityProject/Assets/Scripts/Objects/Research/Artifacts/Artifact.cs
@@ -76,7 +76,7 @@ namespace Objects.Research
 		[SerializeField]
 		private DamageEffectBase forceWallDamageEffectSO = null;
 		private bool forceWallDamageEffect = false;
-	
+
 
 
 		[SyncVar] public string ID = "T376";
@@ -425,7 +425,7 @@ namespace Objects.Research
 		}
 
 		[TargetRpc]
-		public void SpawnClientEffect(NetworkConnectionToClient target, bool successful, Vector3 spawnDestination)
+		public void SpawnClientEffect(bool successful, Vector3 spawnDestination)
 		{
 			var effect = Spawn.ClientPrefab(successful == true ? artifactPlayerTargetEffectSuccess : artifactPlayerTargetEffectFail, spawnDestination).GameObject;
 

--- a/UnityProject/Assets/Scripts/Objects/Research/Artifacts/Artifact.cs
+++ b/UnityProject/Assets/Scripts/Objects/Research/Artifacts/Artifact.cs
@@ -425,7 +425,7 @@ namespace Objects.Research
 		}
 
 		[TargetRpc]
-		public void SpawnClientEffect(bool successful, Vector3 spawnDestination)
+		public void SpawnClientEffect(NetworkConnection target, bool successful, Vector3 spawnDestination)
 		{
 			var effect = Spawn.ClientPrefab(successful == true ? artifactPlayerTargetEffectSuccess : artifactPlayerTargetEffectFail, spawnDestination).GameObject;
 

--- a/UnityProject/Assets/Scripts/Player/Language/MobLanguages.cs
+++ b/UnityProject/Assets/Scripts/Player/Language/MobLanguages.cs
@@ -310,7 +310,7 @@ namespace Player.Language
 
 		#endregion
 
-		private struct NetworkLanguage
+		public struct NetworkLanguage
 		{
 			public ushort languageId;
 			public bool canUnderstand;

--- a/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
+++ b/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
@@ -632,7 +632,7 @@ public class MovementSynchronisation : UniversalObjectPhysics, IPlayerControllab
 
 
 	[TargetRpc]
-	public void TargetRPCClientTilePush(NetworkConnectionToClient target, Vector2Int worldDirection, float speed,
+	public void TargetRPCClientTilePush(NetworkConnection target, Vector2Int worldDirection, float speed,
 		uint causedByClient, bool overridePull,
 		int timestampID, bool forced)
 	{

--- a/UnityProject/Assets/Scripts/ScriptableObjects/Research/Artifacts/Effects/AreaEffects/AreaEffectBase.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/Research/Artifacts/Effects/AreaEffects/AreaEffectBase.cs
@@ -23,7 +23,7 @@ namespace Systems.Research
 		{
 			var objCenter = centeredAround.AssumedWorldPosServer().RoundToInt();
 			var players = Physics2D.OverlapCircleAll(objCenter.To2(), AuraRadius, LayerMask.NameToLayer("Player"));
-			
+
 			foreach (var player in players)
 			{
 				if (player.TryGetComponent<PlayerScript>(out var playerScript))
@@ -86,7 +86,7 @@ namespace Systems.Research
 				}
 
 				totalAnomalyArmour += Mathf.Clamp(bodyPartTotalArmour, 0, 100);
-				partCount++;					
+				partCount++;
 			}
 
 			if(partCount != 0) totalAnomalyArmour /= partCount;

--- a/docs/development/RPC-vs-Netmsg.md
+++ b/docs/development/RPC-vs-Netmsg.md
@@ -1,5 +1,9 @@
 When looking through our code, you'll notice different that some network actions are handles differently. We have a guideline with which one to use. But take note: although many are already in the codebase, their legacy use may be wrong in comparison to current guidelines. So don't trust the code blindly!
 
+
+### Important note:
+Any class/struct used to send data, Must be public otherwise this will cause IL errors and your Assembly will be rejected by the IL Scanner
+
 ## NetMsg
 
 Netmessages should be used in case where security of information is important. Ask yourself "If someone fakes this, could it influence the gameplay for others"?
@@ -49,5 +53,7 @@ RPC is a nice and clean solution to send non-secure data. An example for non-sec
 
 Please note, that some insignificant graffical updates, may be important to send sparsely.
 
+For target RPCs Please do not use NetworkConnectionToClient Use NetworkConnection Instead in the Function parameter, You doing it the wrong way will cause IL errors
+You Should still pass in to The function x.ConnectionToClient, mirror will be able to handle conversion fine
 ## SyncVar
 SyncVar can be a simple alternative to NetMsg or RPC for sending updates to all clients. But it has some caveats for how to use it without having unexpected behavior. See [SyncVar Best Practices for Easy Networking](SyncVar-Best-Practices-for-Easy-Networking.md)


### PR DESCRIPTION
some of the preparation for station hubs Scanning code, 
 making the dlls up to IL  standard, 
 
 this is just the first step of making them IL  standard, 
 
 the next step is limiting the usage of ffunctions and stuff
 
 # notes
 Any class/struct used to send data, Must be public otherwise this will cause IL errors and your Assembly will be rejected by the IL Scanner
 
 
For target RPCs Please do not use NetworkConnectionToClient Use NetworkConnection Instead in the Function parameter, You doing it the wrong way will cause IL errors
You Should still pass in to The function x.ConnectionToClient, mirror will be able to handle conversion fine