### PR TITLE
fix: temporarily undo rotation changes from #9957

### DIFF
--- a/UnityProject/Assets/Scripts/Player/LayDown.cs
+++ b/UnityProject/Assets/Scripts/Player/LayDown.cs
@@ -48,6 +48,7 @@ namespace Player
 
 		private void CorrectState()
 		{
+			gameObject.transform.rotation = Quaternion.Euler(0, 0, 0);
 			if (disabled) return;
 			var state = IsLayingDown;
 			if (health != null)


### PR DESCRIPTION
### Purpose
Undoes rotation changes from #9957 so players aren't always in a weird angle during this week's playtest. Everything should be working just like it did before that PR which means some dead and uncon people will appear standing but that is probably better than everyone being at weird rotation angles.

### Changelog:
__nocl__
