### PR TITLE
feat: adds examine messages for gateway and its states.

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Gateway/StationGateway.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Gateway/StationGateway.prefab
@@ -713,7 +713,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7144248469089430455}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -769,6 +769,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9a459a0316cc4d5b87d046f28dc136c8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   matrixDebugLogging: 0
@@ -820,6 +821,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f24590037b6b486082fc874d1bfd9d95, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   initialIntegrity: 20
@@ -846,6 +848,8 @@ MonoBehaviour:
     Anomaly: 0
     DismembermentProtectionChance: 0
     StunImmunity: 0
+    TemperatureProtectionInK: {x: 268.15, y: 313.15}
+    PressureProtectionInKpa: {x: 30, y: 300}
   Resistances:
     LavaProof: 0
     FireProof: 0
@@ -871,9 +875,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   sceneId: 0
+  _assetId: 3973307162
   serverOnly: 0
   visible: 0
-  m_AssetId: d95186cc91086dd448931dd3965f4b8b
   hasSpawned: 0
 --- !u!114 &7106149064385931371
 MonoBehaviour:
@@ -887,10 +891,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: baefcc8407233924095693a84ff89db1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   initialName: Gateway
-  initialDescription: Travel to distant worlds
+  initialDescription: Travel to distant worlds.
   willHighlight: 0
   exportCost: 0
   CanBeSoldInCargo: 1
@@ -909,6 +914,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3469ef3a42b225a41befd950d93d56fd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   Sprites:
@@ -1015,6 +1021,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   minimumWorkingVoltage: 190
@@ -1027,6 +1034,12 @@ MonoBehaviour:
   RelatedAPC: {fileID: 0}
   AdvancedControlToScript: 0
   StateUpdateOnClient: 1
+  OnDeviceLinked:
+    m_PersistentCalls:
+      m_Calls: []
+  OnDeviceUnLinked:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!114 &-8259569158442479417
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1039,28 +1052,32 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 52a6a264ee47433418b51f654439372f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
-  DEBUG: 0
-  SnapToGridOnStart: 0
+  LocalDifferenceNeeded: {x: 0, y: 0}
   LocalTargetPosition: {x: 0, y: 0, z: 0}
-  ChangesDirectionPush: 0
-  Intangible: 0
-  CanBeWindPushed: 1
-  IsPlayer: 0
-  InitialLocationSynchronised: 0
-  tileMoveSpeed: 1
-  isNotPushable: 1
-  HasOwnGravity: 0
+  CorrectingCourse: 0
+  Animating: 0
+  SetIgnoreSticky: 0
   airTime: 0
   slideTime: 0
-  SetIgnoreSticky: 0
+  spinMagnitude: 0
   thrownBy: {fileID: 0}
   aim: 0
-  spinMagnitude: 0
   ForcedPushedFrame: 0
   TryPushedFrame: 0
   PushedFrame: 0
+  ChangesDirectionPush: 0
+  Intangible: 0
+  SnapToGridOnStart: 0
+  IsPlayer: 0
+  DEBUG: 0
+  tileMoveSpeed: 1
+  HasOwnGravity: 0
+  isNotPushable: 1
+  CanBeWindPushed: 1
+  rotationTarget: {fileID: 0}
   FramePushDecision: 1
   stickyMovement: 0
   OnThrowEndResetRotation: 0
@@ -1071,11 +1088,8 @@ MonoBehaviour:
   - {fileID: 0}
   - {fileID: 0}
   IsCurrentlyFloating: 0
-  LocalDifferenceNeeded: {x: 0, y: 0}
-  CorrectingCourse: 0
   Pushing: []
   Hits: []
-  Animating: 0
   isFlyingSliding: 0
   IsMoving: 0
   MoveIsWalking: 0

--- a/UnityProject/Assets/Scripts/Objects/Gateway/StationGateway.cs
+++ b/UnityProject/Assets/Scripts/Objects/Gateway/StationGateway.cs
@@ -1,4 +1,5 @@
-﻿using Mirror;
+﻿using System.Collections.Generic;
+using Mirror;
 using UnityEngine;
 using System.Linq;
 using UnityEditor;
@@ -6,13 +7,14 @@ using Gateway;
 using Systems.Electricity;
 using Managers;
 using Strings;
+using UI.Systems.Tooltips.HoverTooltips;
 
 namespace Objects
 {
 	/// <summary>
 	/// For Gateways inheritable class
 	/// </summary>
-	public class StationGateway : NetworkBehaviour, IAPCPowerable
+	public class StationGateway : NetworkBehaviour, IAPCPowerable, IExaminable, IHoverTooltip
 	{
 		[SerializeField]
 		private SpriteRenderer[] Sprites = null;
@@ -104,7 +106,7 @@ namespace Objects
 					if (!string.IsNullOrEmpty(EditorPrefs.GetString("prevEditorScene")))
 					{
 						if (SubSceneManager.Instance.awayWorldList.AwayWorlds.Contains(
-							EditorPrefs.GetString("prevEditorScene")))
+							    EditorPrefs.GetString("prevEditorScene")))
 						{
 							loadNormally = false;
 							// This will ensure that the gateway is ready in 30 seconds
@@ -235,7 +237,7 @@ namespace Objects
 			}
 
 			foreach (var item in Matrix.Get<UniversalObjectPhysics>(registerTile.LocalPositionServer + Vector3Int.up, ObjectType.Object, true)
-										.Concat(Matrix.Get<UniversalObjectPhysics>(registerTile.LocalPositionServer + Vector3Int.up, ObjectType.Item, true)))
+				         .Concat(Matrix.Get<UniversalObjectPhysics>(registerTile.LocalPositionServer + Vector3Int.up, ObjectType.Item, true)))
 			{
 				TransportUtility.TransportObjectAndPulled(item, TeleportTargetCoord);
 			}
@@ -293,5 +295,34 @@ namespace Objects
 		}
 
 		#endregion
+
+		private string StateExamineMessage()
+		{
+			if (PoweredDevice.State == PowerState.Off)
+			{
+				return "The gateway stands lifeless, void of power.";
+			}
+
+			var text = selectedWorld == null
+				? "A lone red LED blinks on the gateway, signaling a missing connection."
+				: $"A green LED flashes on the gateway, hinting at a stable connection. Display says \"{selectedWorld.WorldName}\".";
+
+			return text;
+		}
+
+		public string Examine(Vector3 worldPos = default(Vector3))
+		{
+			return StateExamineMessage();
+		}
+
+		public string HoverTip()
+		{
+			return StateExamineMessage();
+		}
+
+		public Sprite CustomIcon() => Sprites[0].sprite;
+		public string CustomTitle() => null;
+		public List<Sprite> IconIndicators() => null;
+		public List<TextColor> InteractionsStrings() => null;
 	}
 }


### PR DESCRIPTION
### Purpose
This was suggested on Discord. The gateway now has examine messages that hint at its state, including having no power, being currently disconnected and having a stablished connection with an away site.

![image](https://github.com/unitystation/unitystation/assets/43683714/a444ba71-2ad3-45e9-8ab7-f7da5d40a5b6)

![image](https://github.com/unitystation/unitystation/assets/43683714/ae08d60a-e6b8-4f9a-a5ef-301ff6ae89a5)

![image](https://github.com/unitystation/unitystation/assets/43683714/395f9ebb-750c-4842-bbe9-ce20903d31fa)


### Changelog:
CL: [New] Gateway now displays its current state when examined, including the away site it is connected to.
