### PR TITLE
Several Fixes and improvements

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Food/Drinks/SodaCans/MonkeyEnergy.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Drinks/SodaCans/MonkeyEnergy.prefab
@@ -108,6 +108,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3342215226231398706, guid: b04d0f9770ef17c459a1af178889e3ba,
         type: 3}
+      propertyPath: _assetId
+      value: 3818612438
+      objectReference: {fileID: 0}
+    - target: {fileID: 3342215226231398706, guid: b04d0f9770ef17c459a1af178889e3ba,
+        type: 3}
       propertyPath: m_AssetId
       value: 2e464f403424dbd409a91b0abbb4121c
       objectReference: {fileID: 0}
@@ -174,12 +179,12 @@ PrefabInstance:
     - target: {fileID: 4530569950825010222, guid: b04d0f9770ef17c459a1af178889e3ba,
         type: 3}
       propertyPath: initialReagentMix.reagents.m_keys.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4530569950825010222, guid: b04d0f9770ef17c459a1af178889e3ba,
         type: 3}
       propertyPath: initialReagentMix.reagents.m_values.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4530569950825010222, guid: b04d0f9770ef17c459a1af178889e3ba,
         type: 3}
@@ -189,8 +194,19 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 4530569950825010222, guid: b04d0f9770ef17c459a1af178889e3ba,
         type: 3}
+      propertyPath: initialReagentMix.reagents.m_keys.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 5e2a5c76d1bce6144b8b1aac987b2751,
+        type: 2}
+    - target: {fileID: 4530569950825010222, guid: b04d0f9770ef17c459a1af178889e3ba,
+        type: 3}
       propertyPath: initialReagentMix.reagents.m_values.Array.data[0]
       value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 4530569950825010222, guid: b04d0f9770ef17c459a1af178889e3ba,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_values.Array.data[1]
+      value: 0.25
       objectReference: {fileID: 0}
     - target: {fileID: 8597199573883621611, guid: b04d0f9770ef17c459a1af178889e3ba,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Food/Drinks/SodaCans/PwrGame.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Drinks/SodaCans/PwrGame.prefab
@@ -111,6 +111,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3342215226231398706, guid: b04d0f9770ef17c459a1af178889e3ba,
         type: 3}
+      propertyPath: _assetId
+      value: 2791413300
+      objectReference: {fileID: 0}
+    - target: {fileID: 3342215226231398706, guid: b04d0f9770ef17c459a1af178889e3ba,
+        type: 3}
       propertyPath: m_AssetId
       value: e0be282d3112cf044b7f9ddc40f04655
       objectReference: {fileID: 0}
@@ -177,12 +182,12 @@ PrefabInstance:
     - target: {fileID: 4530569950825010222, guid: b04d0f9770ef17c459a1af178889e3ba,
         type: 3}
       propertyPath: initialReagentMix.reagents.m_keys.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4530569950825010222, guid: b04d0f9770ef17c459a1af178889e3ba,
         type: 3}
       propertyPath: initialReagentMix.reagents.m_values.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4530569950825010222, guid: b04d0f9770ef17c459a1af178889e3ba,
         type: 3}
@@ -192,8 +197,19 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 4530569950825010222, guid: b04d0f9770ef17c459a1af178889e3ba,
         type: 3}
+      propertyPath: initialReagentMix.reagents.m_keys.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 5e2a5c76d1bce6144b8b1aac987b2751,
+        type: 2}
+    - target: {fileID: 4530569950825010222, guid: b04d0f9770ef17c459a1af178889e3ba,
+        type: 3}
       propertyPath: initialReagentMix.reagents.m_values.Array.data[0]
       value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 4530569950825010222, guid: b04d0f9770ef17c459a1af178889e3ba,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_values.Array.data[1]
+      value: 0.35
       objectReference: {fileID: 0}
     - target: {fileID: 8597199573883621611, guid: b04d0f9770ef17c459a1af178889e3ba,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/BreadSnacks/Baguette.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/BreadSnacks/Baguette.prefab
@@ -112,6 +112,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
+      propertyPath: _assetId
+      value: 2705804230
+      objectReference: {fileID: 0}
+    - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
       propertyPath: m_AssetId
       value: 04970687af9a8114db43f25200a13676
       objectReference: {fileID: 0}
@@ -170,6 +175,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
+      propertyPath: maxBites
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
       propertyPath: NutritionLevel
       value: 263
       objectReference: {fileID: 0}
@@ -198,6 +208,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8e15827970984ba78808f03bc3f01586, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   allClothingData:

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/BreadSnacks/BananaNutBreadLoaf.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/BreadSnacks/BananaNutBreadLoaf.prefab
@@ -9,6 +9,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1209025498235043164, guid: 1c2bdc503ea85964dbb86ef10991bef8,
         type: 3}
+      propertyPath: maxBites
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 1209025498235043164, guid: 1c2bdc503ea85964dbb86ef10991bef8,
+        type: 3}
       propertyPath: NutritionLevel
       value: 800
       objectReference: {fileID: 0}
@@ -27,6 +32,11 @@ PrefabInstance:
         type: 3}
       propertyPath: foreverID
       value: 4f9805413b48329458d0ffcfc031e65b
+      objectReference: {fileID: 0}
+    - target: {fileID: 6954729823044027032, guid: 1c2bdc503ea85964dbb86ef10991bef8,
+        type: 3}
+      propertyPath: _assetId
+      value: 3910524817
       objectReference: {fileID: 0}
     - target: {fileID: 6954729823044027032, guid: 1c2bdc503ea85964dbb86ef10991bef8,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/BreadSnacks/ButterBiscuit.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/BreadSnacks/ButterBiscuit.prefab
@@ -101,6 +101,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
+      propertyPath: _assetId
+      value: 3447075132
+      objectReference: {fileID: 0}
+    - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
       propertyPath: m_AssetId
       value: 8ab0c6744d91e854cb5bac5412e13efb
       objectReference: {fileID: 0}
@@ -124,6 +129,11 @@ PrefabInstance:
         type: 3}
       propertyPath: foreverID
       value: 8ab0c6744d91e854cb5bac5412e13efb
+      objectReference: {fileID: 0}
+    - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
+      propertyPath: timeToEat
+      value: 0.1
       objectReference: {fileID: 0}
     - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/BreadSnacks/Butterdog.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/BreadSnacks/Butterdog.prefab
@@ -101,6 +101,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
+      propertyPath: _assetId
+      value: 555012681
+      objectReference: {fileID: 0}
+    - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
       propertyPath: m_AssetId
       value: eca930a3661e5954dbca94bd2f4e7d29
       objectReference: {fileID: 0}
@@ -151,6 +156,11 @@ PrefabInstance:
         type: 3}
       propertyPath: foreverID
       value: eca930a3661e5954dbca94bd2f4e7d29
+      objectReference: {fileID: 0}
+    - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
+      propertyPath: timeToEat
+      value: 0.35
       objectReference: {fileID: 0}
     - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/BreadSnacks/GarlicBread.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/BreadSnacks/GarlicBread.prefab
@@ -123,6 +123,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
+      propertyPath: _assetId
+      value: 2687238568
+      objectReference: {fileID: 0}
+    - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
       propertyPath: m_AssetId
       value: 7c5fd468505b27b4fab084f06135430b
       objectReference: {fileID: 0}
@@ -146,6 +151,11 @@ PrefabInstance:
         type: 3}
       propertyPath: foreverID
       value: 7c5fd468505b27b4fab084f06135430b
+      objectReference: {fileID: 0}
+    - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
+      propertyPath: timeToEat
+      value: 0.25
       objectReference: {fileID: 0}
     - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/BreadSnacks/_BreadBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/BreadSnacks/_BreadBase.prefab
@@ -14,6 +14,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3800308598080693593, guid: 15c2e5750e27b0c4b8faf56ad3e06f46,
         type: 3}
+      propertyPath: timeToEat
+      value: 0.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 3800308598080693593, guid: 15c2e5750e27b0c4b8faf56ad3e06f46,
+        type: 3}
       propertyPath: EatFoodA.AssetAddress
       value: Assets/Prefabs/Effects/EatFood.prefab
       objectReference: {fileID: 0}
@@ -28,6 +33,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: c3d4d535a3d0c5948a29bc462aeb55fb,
         type: 2}
+    - target: {fileID: 4971432123339430557, guid: 15c2e5750e27b0c4b8faf56ad3e06f46,
+        type: 3}
+      propertyPath: _assetId
+      value: 1285540650
+      objectReference: {fileID: 0}
     - target: {fileID: 4971432123339430557, guid: 15c2e5750e27b0c4b8faf56ad3e06f46,
         type: 3}
       propertyPath: m_AssetId

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/BreadSnacks/_BreadSliceBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/BreadSnacks/_BreadSliceBase.prefab
@@ -90,6 +90,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
+      propertyPath: _assetId
+      value: 2044211547
+      objectReference: {fileID: 0}
+    - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
       propertyPath: m_AssetId
       value: d2991f5505400ab479c5262137eed380
       objectReference: {fileID: 0}
@@ -113,6 +118,11 @@ PrefabInstance:
         type: 3}
       propertyPath: foreverID
       value: d2991f5505400ab479c5262137eed380
+      objectReference: {fileID: 0}
+    - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
+      propertyPath: timeToEat
+      value: 0.15
       objectReference: {fileID: 0}
     - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
@@ -144,12 +154,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e7c30ca55ffa4467a421abf7a832a6a1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   initialAmount: 5
   maxAmount: 5
   stacksWith:
   - {fileID: 3772583389644969066}
+  isRepresentationOfStack: 0
   stackNames: []
   stackSprites: []
   autoStackOnSpawn: 1
@@ -166,6 +178,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8e15827970984ba78808f03bc3f01586, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   allClothingData: []

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/BubblegumGum.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/BubblegumGum.prefab
@@ -49,6 +49,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7354706488053939195, guid: bda3a92c3bab16e4cb40374111199080,
         type: 3}
+      propertyPath: _assetId
+      value: 999332435
+      objectReference: {fileID: 0}
+    - target: {fileID: 7354706488053939195, guid: bda3a92c3bab16e4cb40374111199080,
+        type: 3}
       propertyPath: m_AssetId
       value: 02665510a45e3414ab662e4bb60dcc46
       objectReference: {fileID: 0}
@@ -110,6 +115,16 @@ PrefabInstance:
     - target: {fileID: 7464326250923653947, guid: bda3a92c3bab16e4cb40374111199080,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8552077044633063143, guid: bda3a92c3bab16e4cb40374111199080,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_keys.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8552077044633063143, guid: bda3a92c3bab16e4cb40374111199080,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_values.Array.size
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8552077044633063143, guid: bda3a92c3bab16e4cb40374111199080,

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/BurgerSnacks/SpellBurger.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/BurgerSnacks/SpellBurger.prefab
@@ -7,6 +7,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1628471418149378888, guid: 4bf8c38cb85116e4babedf03228412de,
+        type: 3}
+      propertyPath: timeToEat
+      value: 7
+      objectReference: {fileID: 0}
     - target: {fileID: 3605183359545615039, guid: 4bf8c38cb85116e4babedf03228412de,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/BurgerSnacks/_BurgerBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/BurgerSnacks/_BurgerBase.prefab
@@ -112,6 +112,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
+      propertyPath: _assetId
+      value: 2161197381
+      objectReference: {fileID: 0}
+    - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
       propertyPath: m_AssetId
       value: 4bf8c38cb85116e4babedf03228412de
       objectReference: {fileID: 0}
@@ -130,6 +135,11 @@ PrefabInstance:
         type: 3}
       propertyPath: maxBites
       value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
+      propertyPath: timeToEat
+      value: 0.6
       objectReference: {fileID: 0}
     - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/Burrito.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/Burrito.prefab
@@ -112,6 +112,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
+      propertyPath: _assetId
+      value: 3142836359
+      objectReference: {fileID: 0}
+    - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
       propertyPath: m_AssetId
       value: adb93c946c3a55c47ae3c87e5353e63d
       objectReference: {fileID: 0}
@@ -135,6 +140,11 @@ PrefabInstance:
         type: 3}
       propertyPath: foreverID
       value: adb93c946c3a55c47ae3c87e5353e63d
+      objectReference: {fileID: 0}
+    - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
+      propertyPath: timeToEat
+      value: 0.45
       objectReference: {fileID: 0}
     - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/CakeSnacks/_CakeBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/CakeSnacks/_CakeBase.prefab
@@ -14,6 +14,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3800308598080693593, guid: 15c2e5750e27b0c4b8faf56ad3e06f46,
         type: 3}
+      propertyPath: timeToEat
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3800308598080693593, guid: 15c2e5750e27b0c4b8faf56ad3e06f46,
+        type: 3}
       propertyPath: NutritionLevel
       value: 938
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/CakeSnacks/_CakeSliceBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/CakeSnacks/_CakeSliceBase.prefab
@@ -101,6 +101,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
+      propertyPath: _assetId
+      value: 3758621436
+      objectReference: {fileID: 0}
+    - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
       propertyPath: m_AssetId
       value: 7f29641ac1b06c74a932d09fff95856c
       objectReference: {fileID: 0}
@@ -108,6 +113,11 @@ PrefabInstance:
         type: 3}
       propertyPath: foreverID
       value: 7f29641ac1b06c74a932d09fff95856c
+      objectReference: {fileID: 0}
+    - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
+      propertyPath: timeToEat
+      value: 0.4
       objectReference: {fileID: 0}
     - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
@@ -139,12 +149,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e7c30ca55ffa4467a421abf7a832a6a1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   initialAmount: 5
   maxAmount: 5
   stacksWith:
   - {fileID: 9111318539336604283}
+  isRepresentationOfStack: 0
   stackNames: []
   stackSprites: []
   autoStackOnSpawn: 1

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/MeatSnacks/FishAndChips.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/MeatSnacks/FishAndChips.prefab
@@ -101,6 +101,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
+      propertyPath: _assetId
+      value: 4126704071
+      objectReference: {fileID: 0}
+    - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
       propertyPath: m_AssetId
       value: 845d84b426e36bc4095f7c85997c1d9f
       objectReference: {fileID: 0}
@@ -134,6 +139,11 @@ PrefabInstance:
         type: 3}
       propertyPath: foreverID
       value: 845d84b426e36bc4095f7c85997c1d9f
+      objectReference: {fileID: 0}
+    - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
+      propertyPath: timeToEat
+      value: 0.76
       objectReference: {fileID: 0}
     - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/MeatSnacks/FishFingers.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/MeatSnacks/FishFingers.prefab
@@ -101,6 +101,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
+      propertyPath: _assetId
+      value: 304241994
+      objectReference: {fileID: 0}
+    - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
       propertyPath: m_AssetId
       value: cf52cab2d76aefa4296adbe1bb2a0fd3
       objectReference: {fileID: 0}
@@ -124,6 +129,11 @@ PrefabInstance:
         type: 3}
       propertyPath: foreverID
       value: cf52cab2d76aefa4296adbe1bb2a0fd3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
+      propertyPath: timeToEat
+      value: 0.45
       objectReference: {fileID: 0}
     - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/MeatSnacks/KebabBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/MeatSnacks/KebabBase.prefab
@@ -101,6 +101,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
+      propertyPath: _assetId
+      value: 13530793
+      objectReference: {fileID: 0}
+    - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
       propertyPath: m_AssetId
       value: 36fc7777ec7adb649b33688a3fde3e67
       objectReference: {fileID: 0}
@@ -126,6 +131,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 7198241665461443898, guid: 5dce4d3e01518474bb9bb8085b718980,
         type: 3}
+    - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
+      propertyPath: timeToEat
+      value: 0.85
+      objectReference: {fileID: 0}
     - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
       propertyPath: NutritionLevel

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/MeatSnacks/KebabRat.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/MeatSnacks/KebabRat.prefab
@@ -19,6 +19,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 324054398724280581, guid: 36fc7777ec7adb649b33688a3fde3e67,
         type: 3}
+      propertyPath: _assetId
+      value: 1141619020
+      objectReference: {fileID: 0}
+    - target: {fileID: 324054398724280581, guid: 36fc7777ec7adb649b33688a3fde3e67,
+        type: 3}
       propertyPath: m_AssetId
       value: 61e2b60df4f12c5409b1d382b94a6e8b
       objectReference: {fileID: 0}
@@ -124,6 +129,11 @@ PrefabInstance:
         type: 3}
       propertyPath: foreverID
       value: 61e2b60df4f12c5409b1d382b94a6e8b
+      objectReference: {fileID: 0}
+    - target: {fileID: 8375638023034351297, guid: 36fc7777ec7adb649b33688a3fde3e67,
+        type: 3}
+      propertyPath: timeToEat
+      value: 4
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 36fc7777ec7adb649b33688a3fde3e67, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/MeatSnacks/KebabRatDouble.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/MeatSnacks/KebabRatDouble.prefab
@@ -20,6 +20,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2763800934617118261, guid: 61e2b60df4f12c5409b1d382b94a6e8b,
         type: 3}
+      propertyPath: timeToEat
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 2763800934617118261, guid: 61e2b60df4f12c5409b1d382b94a6e8b,
+        type: 3}
       propertyPath: NutritionLevel
       value: 600
       objectReference: {fileID: 0}
@@ -49,6 +54,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 421194c22305f8544845159b63f51240,
         type: 3}
+    - target: {fileID: 6204137207525296625, guid: 61e2b60df4f12c5409b1d382b94a6e8b,
+        type: 3}
+      propertyPath: _assetId
+      value: 712403793
+      objectReference: {fileID: 0}
     - target: {fileID: 6204137207525296625, guid: 61e2b60df4f12c5409b1d382b94a6e8b,
         type: 3}
       propertyPath: m_AssetId

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/MeatSnacks/KebabTofu.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/MeatSnacks/KebabTofu.prefab
@@ -19,6 +19,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 324054398724280581, guid: 36fc7777ec7adb649b33688a3fde3e67,
         type: 3}
+      propertyPath: _assetId
+      value: 3837074952
+      objectReference: {fileID: 0}
+    - target: {fileID: 324054398724280581, guid: 36fc7777ec7adb649b33688a3fde3e67,
+        type: 3}
       propertyPath: m_AssetId
       value: 359aae2e5fc4b394fb9869391977d25b
       objectReference: {fileID: 0}
@@ -86,6 +91,11 @@ PrefabInstance:
         type: 3}
       propertyPath: foreverID
       value: 359aae2e5fc4b394fb9869391977d25b
+      objectReference: {fileID: 0}
+    - target: {fileID: 8375638023034351297, guid: 36fc7777ec7adb649b33688a3fde3e67,
+        type: 3}
+      propertyPath: timeToEat
+      value: 0.2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 36fc7777ec7adb649b33688a3fde3e67, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/MeatSnacks/RawKhinkali.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/MeatSnacks/RawKhinkali.prefab
@@ -123,6 +123,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
+      propertyPath: _assetId
+      value: 3007279674
+      objectReference: {fileID: 0}
+    - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
       propertyPath: m_AssetId
       value: 322da2df62f4aeb41a45d3730bf7755c
       objectReference: {fileID: 0}
@@ -157,6 +162,11 @@ PrefabInstance:
         type: 3}
       propertyPath: foreverID
       value: 322da2df62f4aeb41a45d3730bf7755c
+      objectReference: {fileID: 0}
+    - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
+      propertyPath: timeToEat
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/MeatSnacks/RawSausage.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/MeatSnacks/RawSausage.prefab
@@ -112,6 +112,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
+      propertyPath: _assetId
+      value: 4117602512
+      objectReference: {fileID: 0}
+    - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
       propertyPath: m_AssetId
       value: b719d2d5c55edec43b1e770960a9c795
       objectReference: {fileID: 0}
@@ -151,6 +156,11 @@ PrefabInstance:
         type: 3}
       propertyPath: foreverID
       value: b719d2d5c55edec43b1e770960a9c795
+      objectReference: {fileID: 0}
+    - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
+      propertyPath: timeToEat
+      value: 0.7
       objectReference: {fileID: 0}
     - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/MeatSnacks/Tofu.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/MeatSnacks/Tofu.prefab
@@ -112,6 +112,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
+      propertyPath: _assetId
+      value: 309440682
+      objectReference: {fileID: 0}
+    - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
       propertyPath: m_AssetId
       value: 2751f86e853d6dd43a2b3614c3e6c24c
       objectReference: {fileID: 0}
@@ -266,6 +271,11 @@ PrefabInstance:
         type: 3}
       propertyPath: foreverID
       value: 2751f86e853d6dd43a2b3614c3e6c24c
+      objectReference: {fileID: 0}
+    - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
+      propertyPath: timeToEat
+      value: 0.3
       objectReference: {fileID: 0}
     - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/MeatSnacks/TofuSoggy.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/MeatSnacks/TofuSoggy.prefab
@@ -7,10 +7,41 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 14392067318378820, guid: 2751f86e853d6dd43a2b3614c3e6c24c,
+        type: 3}
+      propertyPath: timeToEat
+      value: 0.1
+      objectReference: {fileID: 0}
     - target: {fileID: 2981055692647399257, guid: 2751f86e853d6dd43a2b3614c3e6c24c,
         type: 3}
       propertyPath: foreverID
       value: 5104ef3fc2afa334387312f504d9a0f4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6975623305099590556, guid: 2751f86e853d6dd43a2b3614c3e6c24c,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_keys.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6975623305099590556, guid: 2751f86e853d6dd43a2b3614c3e6c24c,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_values.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6975623305099590556, guid: 2751f86e853d6dd43a2b3614c3e6c24c,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_keys.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 5e2a5c76d1bce6144b8b1aac987b2751,
+        type: 2}
+    - target: {fileID: 6975623305099590556, guid: 2751f86e853d6dd43a2b3614c3e6c24c,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_values.Array.data[1]
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8102074855839682176, guid: 2751f86e853d6dd43a2b3614c3e6c24c,
+        type: 3}
+      propertyPath: _assetId
+      value: 4085417900
       objectReference: {fileID: 0}
     - target: {fileID: 8102074855839682176, guid: 2751f86e853d6dd43a2b3614c3e6c24c,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/SandwichAndToastSnacks/Sandwich.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/SandwichAndToastSnacks/Sandwich.prefab
@@ -112,6 +112,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
+      propertyPath: _assetId
+      value: 296637070
+      objectReference: {fileID: 0}
+    - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
       propertyPath: m_AssetId
       value: b27d4769e571a0f40bb338759d431f76
       objectReference: {fileID: 0}
@@ -153,6 +158,11 @@ PrefabInstance:
         type: 3}
       propertyPath: maxBites
       value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
+      propertyPath: timeToEat
+      value: 0.6
       objectReference: {fileID: 0}
     - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/SandwichAndToastSnacks/ToastedSandwich.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/SandwichAndToastSnacks/ToastedSandwich.prefab
@@ -112,6 +112,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
+      propertyPath: _assetId
+      value: 3902652514
+      objectReference: {fileID: 0}
+    - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
       propertyPath: m_AssetId
       value: 612d13472373fc74ca2537309cd5f345
       objectReference: {fileID: 0}
@@ -142,6 +147,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 2717702614898470369, guid: b7f9ffc5f19a51546bc9474d372c12c4,
         type: 3}
+    - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
+      propertyPath: timeToEat
+      value: 0.55
+      objectReference: {fileID: 0}
     - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
       propertyPath: NutritionLevel

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/SandwichAndToastSnacks/TwoBread.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/SandwichAndToastSnacks/TwoBread.prefab
@@ -112,6 +112,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
+      propertyPath: _assetId
+      value: 711620762
+      objectReference: {fileID: 0}
+    - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
       propertyPath: m_AssetId
       value: eba5b6be9b9eaf44ca93c9a270c642cc
       objectReference: {fileID: 0}
@@ -140,6 +145,11 @@ PrefabInstance:
         type: 3}
       propertyPath: maxBites
       value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
+      propertyPath: timeToEat
+      value: 0.35
       objectReference: {fileID: 0}
     - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/SoupSnacks/ClownsTears.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/SoupSnacks/ClownsTears.prefab
@@ -31,12 +31,12 @@ PrefabInstance:
     - target: {fileID: 7174761012728533436, guid: 09d98d684f3dbe544a3f54331019cba1,
         type: 3}
       propertyPath: initialReagentMix.reagents.m_keys.Array.size
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 7174761012728533436, guid: 09d98d684f3dbe544a3f54331019cba1,
         type: 3}
       propertyPath: initialReagentMix.reagents.m_values.Array.size
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 7174761012728533436, guid: 09d98d684f3dbe544a3f54331019cba1,
         type: 3}
@@ -49,6 +49,12 @@ PrefabInstance:
       propertyPath: initialReagentMix.reagents.m_keys.Array.data[4]
       value: 
       objectReference: {fileID: 11400000, guid: 403cb38ddbdf64937800405bb674f292,
+        type: 2}
+    - target: {fileID: 7174761012728533436, guid: 09d98d684f3dbe544a3f54331019cba1,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_keys.Array.data[5]
+      value: 
+      objectReference: {fileID: 11400000, guid: 5e2a5c76d1bce6144b8b1aac987b2751,
         type: 2}
     - target: {fileID: 7174761012728533436, guid: 09d98d684f3dbe544a3f54331019cba1,
         type: 3}
@@ -69,6 +75,11 @@ PrefabInstance:
         type: 3}
       propertyPath: initialReagentMix.reagents.m_values.Array.data[4]
       value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7174761012728533436, guid: 09d98d684f3dbe544a3f54331019cba1,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_values.Array.data[5]
+      value: 0.1
       objectReference: {fileID: 0}
     - target: {fileID: 8091316462478551624, guid: 09d98d684f3dbe544a3f54331019cba1,
         type: 3}
@@ -140,6 +151,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: ClownsTears
+      objectReference: {fileID: 0}
+    - target: {fileID: 8300100540400329888, guid: 09d98d684f3dbe544a3f54331019cba1,
+        type: 3}
+      propertyPath: _assetId
+      value: 2849610325
       objectReference: {fileID: 0}
     - target: {fileID: 8300100540400329888, guid: 09d98d684f3dbe544a3f54331019cba1,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/SpaghettiSnacks/_SpaghettiBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/SpaghettiSnacks/_SpaghettiBase.prefab
@@ -99,6 +99,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
+      propertyPath: timeToEat
+      value: 0.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
       propertyPath: NutritionLevel
       value: 75
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/_CannedSnackBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/_CannedSnackBase.prefab
@@ -112,6 +112,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
+      propertyPath: _assetId
+      value: 2114845498
+      objectReference: {fileID: 0}
+    - target: {fileID: 1400446589329289331, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
       propertyPath: m_AssetId
       value: e291198bb131d49469d0b57ae983bd32
       objectReference: {fileID: 0}
@@ -145,6 +150,11 @@ PrefabInstance:
         type: 3}
       propertyPath: maxBites
       value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
+      propertyPath: timeToEat
+      value: 0.45
       objectReference: {fileID: 0}
     - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/_SnackBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/_SnackBase.prefab
@@ -69,6 +69,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 825558115691839795, guid: 6eb9748e1eaf8dc4598a50e5b09df3b3,
         type: 3}
+      propertyPath: _assetId
+      value: 1905384318
+      objectReference: {fileID: 0}
+    - target: {fileID: 825558115691839795, guid: 6eb9748e1eaf8dc4598a50e5b09df3b3,
+        type: 3}
       propertyPath: m_AssetId
       value: eaf8c1f2a0f9374488e16061fd5b4dcd
       objectReference: {fileID: 0}
@@ -183,13 +188,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 45e06ddb12acf47158b8cccf9289fd75, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   consumeTime: 0.1
   leavings: {fileID: 0}
   currentBites: 0
   maxBites: 3
-  setCurrentBitesToMaxBitesOnAwake: 1
+  timeToEat: 0.25
+  forceFeedTime: 3
+  setCurrentBitesToMaxBitesOnServerSpawn: 1
   sound:
     SetLoadSetting: 0
     AssetAddress: Assets/Prefabs/Effects/EatFood.prefab

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Body/BadFoodinBody.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Body/BadFoodinBody.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
     - {fileID: 11400000, guid: b2b053728f3f52c1fb6ce25bb6bc03f1, type: 2}
     m_values: 01000000
   useExactAmounts: 0
+  MinimumReactionMultiple: 0
   catalysts:
     m_keys: []
     m_values: 

--- a/UnityProject/Assets/Scripts/Items/Food/Consumable.cs
+++ b/UnityProject/Assets/Scripts/Items/Food/Consumable.cs
@@ -16,7 +16,7 @@ using Player;
 /// </summary>
 public abstract class Consumable : NetworkBehaviour, ICheckedInteractable<HandApply>
 {
-	[SerializeField] private float consumeTime = 0.1f;
+	[SerializeField] protected float consumeTime = 0.1f;
 
 	public void ServerPerformInteraction(HandApply interaction)
 	{

--- a/UnityProject/Assets/Scripts/Items/Food/Edible.cs
+++ b/UnityProject/Assets/Scripts/Items/Food/Edible.cs
@@ -9,6 +9,7 @@ using Messages.Server.SoundMessages;
 using Mirror;
 using Systems.Score;
 using UI.Systems.Tooltips.HoverTooltips;
+using UnityEngine.Serialization;
 
 namespace Items.Food
 {
@@ -18,12 +19,13 @@ namespace Items.Food
 	[RequireComponent(typeof(RegisterItem))]
 	[RequireComponent(typeof(ItemAttributesV2))]
 	[RequireComponent(typeof(ReagentContainer))]
-	public class Edible : Consumable, ICheckedInteractable<HandActivate>, IHoverTooltip
+	public class Edible : Consumable, ICheckedInteractable<HandActivate>, IHoverTooltip, IServerSpawn
 	{
 		public GameObject leavings;
 		[SerializeField, SyncVar] private int currentBites;
 		[SerializeField] private int maxBites = 1;
-		[SerializeField] private bool setCurrentBitesToMaxBitesOnAwake = true;
+		[SerializeField] private float forceFeedTime = 3f;
+		[SerializeField] private bool setCurrentBitesToMaxBitesOnServerSpawn = true;
 
 		[SerializeField] private AddressableAudioSource sound = null;
 
@@ -54,8 +56,11 @@ namespace Items.Food
 			{
 				Logger.LogErrorFormat("{0} prefab is missing ItemAttributes", Category.Objects, name);
 			}
+		}
 
-			if (setCurrentBitesToMaxBitesOnAwake) currentBites = maxBites;
+		public void OnSpawnServer(SpawnInfo info)
+		{
+			if (setCurrentBitesToMaxBitesOnServerSpawn) currentBites = maxBites;
 		}
 
 		public bool WillInteract(HandActivate interaction, NetworkSide side)
@@ -112,28 +117,24 @@ namespace Items.Food
 
 			if (feeder != eater) //If you're feeding it to someone else.
 			{
-				//Wait 3 seconds before you can feed
 				StandardProgressAction.Create(ProgressConfig, () =>
 				{
 					ConsumableTextUtils.SendGenericForceFeedMessage(feeder, eater, eaterHungerState, Name, "eat");
 					Eat(eater, feeder);
-				}).ServerStartProgress(eater.RegisterPlayer, 3f, feeder.gameObject);
+				}).ServerStartProgress(eater.RegisterPlayer, forceFeedTime, feeder.gameObject);
 				return;
 			}
-			else
-			{
-				Eat(eater, feeder);
-			}
+			StandardProgressAction.Create(ProgressConfig, () =>
+				{
+					Eat(eater, feeder);
+				}).ServerStartProgress(eater.RegisterPlayer, consumeTime, feeder.gameObject);
 		}
 
 		protected virtual void Eat(PlayerScript eater, PlayerScript feeder)
 		{
 			//TODO: Reimplement metabolism.
-			AudioSourceParameters eatSoundParameters = new AudioSourceParameters(pitch: RandomPitch);
-			SoundManager.PlayNetworkedAtPos(sound, eater.WorldPos, eatSoundParameters, sourceObj: eater.gameObject);
-
-			var Stomachs = eater.playerHealth.GetStomachs();
-			if (Stomachs.Count == 0)
+			var stomachs = eater.playerHealth.GetStomachs();
+			if (stomachs.Count == 0)
 			{
 				//No stomachs?!
 				return;
@@ -141,9 +142,9 @@ namespace Items.Food
 
 			float SpareSpace = 0;
 
-			foreach (var Stomach in Stomachs)
+			foreach (var stomach in stomachs)
 			{
-				SpareSpace += Stomach.StomachContents.SpareCapacity;
+				SpareSpace += stomach.StomachContents.SpareCapacity;
 			}
 
 			if (SpareSpace < 0.5f)
@@ -172,11 +173,13 @@ namespace Items.Food
 
 			ReagentMix incomingFood = GetMixForBite(feeder);
 
-			foreach (var Stomach in Stomachs)
+			foreach (var stomach in stomachs)
 			{
-				Stomach.StomachContents.Add(incomingFood.Clone());
+				stomach.StomachContents.Add(incomingFood.Clone());
 			}
 
+			AudioSourceParameters eatSoundParameters = new AudioSourceParameters(pitch: RandomPitch);
+			SoundManager.PlayNetworkedAtPos(sound, eater.WorldPos, eatSoundParameters, sourceObj: eater.gameObject);
 			ScoreMachine.AddToScoreInt(1, RoundEndScoreBuilder.COMMON_SCORE_FOODEATEN);
 		}
 
@@ -219,7 +222,7 @@ namespace Items.Food
 							ToDropOn.GetComponent<UniversalObjectPhysics>());
 					}
 				}
-				_ = Inventory.ServerDespawn(gameObject);
+				if (currentBites <= 0) _ = Inventory.ServerDespawn(gameObject);
 			}
 
 			return incomingFood;

--- a/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
+++ b/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
@@ -941,7 +941,15 @@ public class MovementSynchronisation : UniversalObjectPhysics, IPlayerControllab
 		{
 			var dummyMind = PlayerSpawn.NewSpawnCharacterV2(OccupationList.Instance.Occupations.PickRandom(),
 				CharacterSheet.GenerateRandomCharacter());
-			dummyMind.Body.GetComponent<UniversalObjectPhysics>()?.AppearAtWorldPositionServer(this.transform.position);
+			if (dummyMind == null || dummyMind.Body == null ||
+			    dummyMind.Body.TryGetComponent<UniversalObjectPhysics>(out var physics) == false)
+			{
+				Logger.LogError("Something went wrong while spawning a dummy player.");
+			}
+			else
+			{
+				physics.AppearAtWorldPositionServer(transform.position);
+			}
 		}
 
 

--- a/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
+++ b/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
@@ -939,9 +939,9 @@ public class MovementSynchronisation : UniversalObjectPhysics, IPlayerControllab
 		if (UIManager.IsInputFocus) return;
 		if (CommonInput.GetKeyDown(KeyCode.F7) && gameObject == PlayerManager.LocalPlayerObject)
 		{
-			var DummyMind = PlayerSpawn.NewSpawnCharacterV2(OccupationList.Instance.Occupations.PickRandom(),
+			var dummyMind = PlayerSpawn.NewSpawnCharacterV2(OccupationList.Instance.Occupations.PickRandom(),
 				CharacterSheet.GenerateRandomCharacter());
-			DummyMind.Body.GetComponent<UniversalObjectPhysics>().AppearAtWorldPositionServer(this.transform.position);
+			dummyMind.Body.GetComponent<UniversalObjectPhysics>()?.AppearAtWorldPositionServer(this.transform.position);
 		}
 
 

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_GhostOptions.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_GhostOptions.cs
@@ -97,6 +97,7 @@ namespace UI.Systems.Ghost
 
 		public void NewGhostRoleAvailable(GhostRoleData role)
 		{
+			if (gameObject.activeSelf == false) return;
 			ghostRoleSpriteHandler.SetSpriteSO(role.Sprite, networked: false);
 			if (roleBtnAnimating) return; // Drop rapid subsequent notifications
 


### PR DESCRIPTION
CL: [Improvement] Several edible/drinkable items utilize the vomit mechanics now.
CL: [Fix] Fixed an error that popped up when the ghost UI would attempt to update itself while inactive.
CL: [Fix] Fixed an NRE when pressing F7 to spawn test characters that caused inputs to misbehave for a few frames.
CL: [Fix] Fixed an issue with edible items that resulted in their bite mechanics to disappear due to an oversight while adding Slimes.
