### PR TITLE
better quick load handle in editor

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Editor/CheckmarkMenuItems/CheckmarkMenuItems.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/CheckmarkMenuItems/CheckmarkMenuItems.cs
@@ -8,7 +8,7 @@ namespace Core.Editor
 	public static class QuickLoad
 	{
 		private const string MenuName = "Tools/Quick Load";
-		private const string SettingName = "QuickLoad";
+		private const string SettingName = "quickLoad";
 
 		/// <summary>
 		/// If checked, prevents nonessential scenes from loading, in addition to removing the roundstart countdown.
@@ -24,7 +24,6 @@ namespace Core.Editor
 		public static void Toggle()
 		{
 			IsEnabled = !IsEnabled;
-			UpdateGameManager(IsEnabled);
 		}
 
 
@@ -35,119 +34,84 @@ namespace Core.Editor
 			Menu.SetChecked(MenuName, IsEnabled);
 			return true;
 		}
-		private static void UpdateGameManager(bool isQuickLoad)
-		{
-			var gameManager = AssetDatabase.LoadAssetAtPath<GameManager>
-					("Assets/Prefabs/SceneConstruction/NestedManagers/GameManager.prefab");
-			if (gameManager == null)
-			{
-				Logger.LogWarning($"{nameof(GameManager)} not found! Cannot set {nameof(GameManager.QuickLoad)} property.");
-				return;
-			}
 
-			if (gameManager.QuickLoad != isQuickLoad)
-			{
-				gameManager.QuickLoad = isQuickLoad;
-				EditorUtility.SetDirty(gameManager);
-				AssetDatabase.SaveAssets();
-			}
-		}
-
-
-		private static void UpdateGameManagerQuickJobSelect(bool isQuickLoad)
-		{
-			var gameManager = AssetDatabase.LoadAssetAtPath<GameManager>
-				("Assets/Prefabs/SceneConstruction/NestedManagers/GameManager.prefab");
-			if (gameManager == null)
-			{
-				Logger.LogWarning($"{nameof(GameManager)} not found! Cannot set {nameof(GameManager.QuickJoinLoad)} property.");
-				return;
-			}
-
-			if (gameManager.QuickJoinLoad != isQuickLoad)
-			{
-				gameManager.QuickJoinLoad = isQuickLoad;
-				EditorUtility.SetDirty(gameManager);
-				AssetDatabase.SaveAssets();
-			}
-		}
-	}
-
-	/// <summary>
-	/// If checked, hides prefab-related fields from scene mode, and mapping-related fields from prefab mode.
-	/// </summary>
-	public static class HideIrrelevantFields
-	{
-		private const string MenuName = "Tools/Inspector/Hide Irrelevant Fields";
-		private const string SettingName = "HideIrrelevantFields";
-
-		public static bool IsEnabled
-		{
-			get => EditorPrefs.GetBool(SettingName, true);
-			set => EditorPrefs.SetBool(SettingName, value);
-		}
-
-		[MenuItem(MenuName)]
-		private static void Toggle()
-		{
-			IsEnabled = !IsEnabled;
-		}
-
-		[MenuItem(MenuName, true)]
-		private static bool ToggleValidate()
-		{
-			Menu.SetChecked(MenuName, IsEnabled);
-			return true;
-		}
-	}
-
-	public static class QuickJobSelect
-	{
-		private const string MenuName = "Tools/Quick Job Select";
-		private const string SettingName = "QuickJobSelect";
-
-
-		/// <summary
-		/// If checked, prevents nonessential scenes from loading, in addition to removing the roundstart countdown.
+		/// <summary>
+		/// If checked, hides prefab-related fields from scene mode, and mapping-related fields from prefab mode.
 		/// </summary>
-		public static bool IsEnabled
+		public static class HideIrrelevantFields
 		{
-			get => EditorPrefs.GetBool(SettingName, true);
-			set => EditorPrefs.SetBool(SettingName, value);
-		}
+			private const string MenuName = "Tools/Inspector/Hide Irrelevant Fields";
+			private const string SettingName = "HideIrrelevantFields";
 
-		[MenuItem(MenuName, priority = 1)]
-		public static void Toggle()
-		{
-			IsEnabled = !IsEnabled;
-			UpdateGameManager(IsEnabled);
-		}
-
-
-
-		[MenuItem(MenuName, true, 1)]
-		private static bool ToggleValidate()
-		{
-			Menu.SetChecked(MenuName, IsEnabled);
-			return true;
-		}
-
-
-		private static void UpdateGameManager(bool isQuickLoad)
-		{
-			var gameManager = AssetDatabase.LoadAssetAtPath<GameManager>
-					("Assets/Prefabs/SceneConstruction/NestedManagers/GameManager.prefab");
-			if (gameManager == null)
+			public static bool IsEnabled
 			{
-				Logger.LogWarning($"{nameof(GameManager)} not found! Cannot set {nameof(GameManager.QuickLoad)} property.");
-				return;
+				get => EditorPrefs.GetBool(SettingName, true);
+				set => EditorPrefs.SetBool(SettingName, value);
 			}
 
-			if (gameManager.QuickJoinLoad != isQuickLoad)
+			[MenuItem(MenuName)]
+			private static void Toggle()
 			{
-				gameManager.QuickJoinLoad = isQuickLoad;
-				EditorUtility.SetDirty(gameManager);
-				AssetDatabase.SaveAssets();
+				IsEnabled = !IsEnabled;
+			}
+
+			[MenuItem(MenuName, true)]
+			private static bool ToggleValidate()
+			{
+				Menu.SetChecked(MenuName, IsEnabled);
+				return true;
+			}
+		}
+
+		public static class QuickJobSelect
+		{
+			private const string MenuName = "Tools/Quick Job Select";
+			private const string SettingName = "QuickJobSelect";
+
+
+			/// <summary
+			/// If checked, prevents nonessential scenes from loading, in addition to removing the roundstart countdown.
+			/// </summary>
+			public static bool IsEnabled
+			{
+				get => EditorPrefs.GetBool(SettingName, true);
+				set => EditorPrefs.SetBool(SettingName, value);
+			}
+
+			[MenuItem(MenuName, priority = 1)]
+			public static void Toggle()
+			{
+				IsEnabled = !IsEnabled;
+				UpdateGameManager(IsEnabled);
+			}
+
+
+
+			[MenuItem(MenuName, true, 1)]
+			private static bool ToggleValidate()
+			{
+				Menu.SetChecked(MenuName, IsEnabled);
+				return true;
+			}
+
+
+			private static void UpdateGameManager(bool isQuickLoad)
+			{
+				var gameManager = AssetDatabase.LoadAssetAtPath<GameManager>
+					("Assets/Prefabs/SceneConstruction/NestedManagers/GameManager.prefab");
+				if (gameManager == null)
+				{
+					Logger.LogWarning(
+						$"{nameof(GameManager)} not found! Cannot set {nameof(GameManager.QuickLoad)} property.");
+					return;
+				}
+
+				if (gameManager.QuickJoinLoad != isQuickLoad)
+				{
+					gameManager.QuickJoinLoad = isQuickLoad;
+					EditorUtility.SetDirty(gameManager);
+					AssetDatabase.SaveAssets();
+				}
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Core/Editor/PropertyDrawers/PropertyDrawers.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/PropertyDrawers/PropertyDrawers.cs
@@ -1,14 +1,12 @@
 ﻿using UnityEngine;
 using UnityEditor;
 
-
-
 namespace Core.Editor.Attributes
 {
 	[CustomPropertyDrawer(typeof(PrefabModeOnlyAttribute))]
 	public class PrefabModeOnlyDrawer : PropertyDrawer
 	{
-		private bool HideProperty => HideIrrelevantFields.IsEnabled && UnityEditor.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage() == null;
+		private bool HideProperty => QuickLoad.HideIrrelevantFields.IsEnabled && UnityEditor.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage() == null;
 
 		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
 		{
@@ -25,7 +23,7 @@ namespace Core.Editor.Attributes
 	[CustomPropertyDrawer(typeof(SceneModeOnlyAttribute))]
 	public class SceneModeOnlyDrawer : PropertyDrawer
 	{
-		private bool HideProperty => HideIrrelevantFields.IsEnabled && UnityEditor.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage() != null;
+		private bool HideProperty => QuickLoad.HideIrrelevantFields.IsEnabled && UnityEditor.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage() != null;
 
 		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
 		{

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -26,6 +26,7 @@ using Systems.Cargo;
 using ScriptableObjects.Characters;
 using TileManagement;
 using UI.Core;
+using UnityEditor;
 using UnityEngine.Serialization;
 using UnityEngine.Tilemaps;
 using Random = System.Random;
@@ -210,6 +211,12 @@ public partial class GameManager : MonoBehaviour, IInitialise
 			{
 				loadedDirectlyToStation = true;
 			}
+
+#if UNITY_EDITOR
+			var editorLoadPref = EditorPrefs.GetBool("quickLoad", false);
+			QuickLoad = editorLoadPref;
+			Logger.Log($"Currently using editor pref for quick-load checkup. Current value is {editorLoadPref}. To change this, please head to tools -> Enable QuickLoad.");
+#endif
 		}
 		else
 		{


### PR DESCRIPTION
Are you tired of accidentally uploading the GameManager prefab while submitting a PR?
Is waiting 30 seconds for unity to reimport a single prefab is too annoying?
Forgot to switch on quick load after opening a fresh new branch and now unity is taking forever to load all scenes which is slowing down your old PC?

Well I got the solution here my friend.
From now on, while in editor; `QuickLoad` is read and set as an editor pref rather, which will persist when switching between branches. However, outside the editor, the `QuickLoad` variable stays the same until you manually set it inside the prefab yourself.