### PR TITLE
Filth Score + Some Round End Score Tweaks

### DIFF
--- a/UnityProject/Assets/Scripts/Effects/FloorEffect/LeaveFootprints.cs
+++ b/UnityProject/Assets/Scripts/Effects/FloorEffect/LeaveFootprints.cs
@@ -1,15 +1,5 @@
-using System;
-using System.Collections.Generic;
-using NaughtyAttributes;
-using AddressableReferences;
-using Chemistry;
 using Chemistry.Components;
 using Effects.FloorEffect;
-using HealthV2;
-using Systems.Clothing;
-
-
-using UnityEngine;
 
 namespace Objects.Other
 {

--- a/UnityProject/Assets/Scripts/Systems/FilthGenerator/FilthGenerator.cs
+++ b/UnityProject/Assets/Scripts/Systems/FilthGenerator/FilthGenerator.cs
@@ -24,6 +24,9 @@ namespace Systems.FilthGenerator
 
 		[SerializeField] private List<GameObject> filthDecalsAndObjects = new List<GameObject>();
 
+		private int filthGenerated = 0;
+		public int FilthCleanGoal { get; private set; } = 0;
+
 		public override void Awake()
 		{
 			RegisteredToLegacySubsystemManager = false;
@@ -85,10 +88,13 @@ namespace Systems.FilthGenerator
 				var chosenLocation = EmptyTiled[Random.Next(EmptyTiled.Count)];
 				DetermineFilthToSpawn(chosenLocation);
 			}
+
+			FilthCleanGoal = filthGenerated / Random.Next(3, 8);
 		}
 
 		private void DetermineFilthToSpawn(Vector3Int chosenLocation)
 		{
+			filthGenerated++;
 			// Make this a local void to avoid code duplication.
 			void ReagentSpawn()
 			{

--- a/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.Data.cs
+++ b/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.Data.cs
@@ -22,9 +22,12 @@ namespace Systems.Score
 		public const string COMMON_HUG_SCORE_ENTRY = "hugsGiven";
 		public const string COMMON_TAIL_SCORE_ENTRY = "tailsPulled";
 		public const string COMMON_DOOR_ELECTRIC_ENTRY = "electricDoors";
+		public const string FILTH_ENTRY = "filth";
 		public const int HUG_SCORE_VALUE = 2;
 		public const int TAIL_SCORE_VALUE = -2;
 		private const int DEAD_CREW_SCORE = -250;
 		private const int HURT_CREW_MINIMUM_SCORE = 50;
+		private const int CLEAN_STATION_SCORE = 1250;
+		private const int DIRTY_STATION_SCORE = -350;
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.cs
+++ b/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.cs
@@ -93,7 +93,7 @@ namespace Systems.Score
 			if (string.IsNullOrEmpty(lowestHealthCrewMemberName)) return;
 			var lowestHealthWinner = $"{lowestHealthCrewMemberName} - {lowestHealthCrewMemberNumber}HP";
 			ScoreMachine.AddNewScoreEntry("worstBatteredCrewMemeber", "Crewmember with the lowest health", ScoreMachine.ScoreType.String, ScoreCategory.StationScore, ScoreAlignment.Bad);
-			ScoreMachine.AddToScoreString(lowestHealthWinner, lowestHealthCrewMemberNumber > 25f ? 0 : -5, "worstBatteredCrewMemeber");
+			ScoreMachine.AddToScoreString(lowestHealthWinner, lowestHealthCrewMemberNumber > 25f ? 100 : -5, "worstBatteredCrewMemeber");
 		}
 
 		private static void FindHarmfulDoors()

--- a/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.cs
+++ b/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.cs
@@ -152,42 +152,27 @@ namespace Systems.Score
 			var finalStationScore = 0;
 			var finalAntagScore = 0;
 
-			foreach (var entry in ScoreMachine.Instance.Scores)
+			foreach (var pair in ScoreMachine.Instance.Scores)
 			{
-				switch (entry.Value.Category)
+				var entry = pair.Value;
+				var score = entry switch
+				{
+					ScoreEntryInt a => a.Score,
+					ScoreEntryBool m => m.Score ? boolScore : -boolScore,
+					_ => 0,
+				};
+				entry.ScoreValue = score;
+				switch (entry.Category)
 				{
 					case ScoreCategory.StationScore:
-						stationScoreEntries.Add(entry.Value);
-						switch (entry.Value)
-						{
-							case ScoreEntryInt a:
-								finalStationScore += a.Score;
-								entry.Value.ScoreValue = a.Score;
-								break;
-							case ScoreEntryBool m:
-								finalStationScore += m.Score ? boolScore : -boolScore;
-								entry.Value.ScoreValue = m.Score ? boolScore : -boolScore;
-								break;
-						}
+						stationScoreEntries.Add(entry);
+						finalStationScore += score;
 						break;
 					//TODO: Add Antag Score UI.
 					case ScoreCategory.AntagScore:
-						antagScoreEntries.Add(entry.Value);
-						switch (entry.Value)
-						{
-							case ScoreEntryInt o:
-								finalAntagScore += o.Score;
-								entry.Value.ScoreValue = o.Score;
-								break;
-							case ScoreEntryBool g:
-								entry.Value.ScoreValue = g.Score ? boolScore : -boolScore;
-								break;
-						}
+						antagScoreEntries.Add(entry);
+						finalAntagScore += score;
 						break;
-					case
-						ScoreCategory.MiscScore :
-						default:
-							break;
 				}
 			}
 

--- a/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.cs
+++ b/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.cs
@@ -1,11 +1,8 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Doors;
 using Doors.Modules;
-using Managers;
 using Objects.Construction;
-using Objects.Other;
 using Shared.Managers;
 
 namespace Systems.Score
@@ -118,7 +115,7 @@ namespace Systems.Score
 
 		private void CheckMainStationFilth()
 		{
-			var dirtyness= 0;
+			var dirtyness = 0;
 			foreach (var decal in MatrixManager.MainStationMatrix.Objects.GetComponentsInChildren<FloorDecal>())
 			{
 				if (decal.Cleanable) dirtyness++;

--- a/UnityProject/Assets/Scripts/Systems/Score/ScoreEntry/ScoreEntry.cs
+++ b/UnityProject/Assets/Scripts/Systems/Score/ScoreEntry/ScoreEntry.cs
@@ -6,6 +6,8 @@ namespace Systems.Score
 		private ScoreCategory category;
 		private ScoreAlignment alignment;
 
+		public int ScoreValue { get; set; }
+
 		public string ScoreName
 		{
 			get => scoreName;

--- a/UnityProject/Assets/Scripts/Systems/Score/ScoreMachine.cs
+++ b/UnityProject/Assets/Scripts/Systems/Score/ScoreMachine.cs
@@ -45,7 +45,6 @@ namespace Systems.Score
 		{
 			if (Instance.Scores.ContainsKey(ID))
 			{
-				Logger.LogWarning($"[ScoreMachine] - Attempting to add new entry with id ({ID}) but it already exists!");
 				return;
 			}
 			switch (type)
@@ -123,7 +122,7 @@ namespace Systems.Score
 		/// <summary>
 		/// whats the new string for this score?
 		/// </summary>
-		public static void AddToScoreString(String newValue, string ID)
+		public static void AddToScoreString(String newValue, int givenScore, string ID)
 		{
 			if (Instance.Scores.ContainsKey(ID) == false)
 			{

--- a/UnityProject/Assets/Scripts/UI/Systems/EndRound/RoundEndScoreScreen.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/EndRound/RoundEndScoreScreen.cs
@@ -24,40 +24,41 @@ namespace UI.Systems.EndRound
 			// Based on the context and content
 			// NOTE //
 			StringBuilder theGoodList = new StringBuilder();
-			theGoodList.AppendLine("<i><u><b>The Good:</b></u></i>");
+			theGoodList.AppendLine("<align=\"center\"><i><u><b>The Good:</b></u></i></align>");
 			StringBuilder theBadList = new StringBuilder();
-			theBadList.AppendLine("<i><u><b>The Bad:</b></u></i>");
+			theBadList.AppendLine("<align=\"center\"><i><u><b>The Bad:</b></u></i></align>");
 			StringBuilder theWeirdList = new StringBuilder();
-			theWeirdList.AppendLine("<i><u><b>The Weird:</b></u></i>");
+			theWeirdList.AppendLine("<align=\"center\"><i><u><b>The Weird:</b></u></i></align>");
 
 			StringBuilder finalResult = new StringBuilder();
 
 			entries.Shuffle(); //Randomize the positions of all entries.
 
-			foreach (var Entry in entries)
+			foreach (ScoreEntry entry in entries)
 			{
-				if (Entry.Alignment == ScoreAlignment.Unspecified || Entry.Category == ScoreCategory.MiscScore) continue;
-				var result = ScoreMachine.ScoreTypeResultAsString(Entry);
+				if (entry.Alignment == ScoreAlignment.Unspecified || entry.Category == ScoreCategory.MiscScore) continue;
+				var result = ScoreMachine.ScoreTypeResultAsString(entry);
 				if (result == null)
 				{
 					Logger.LogError("[ScoreMachine] - Unidentified score entry type detected while building UI text for round end.");
 					continue;
 				}
-				if (result.ToLower().Contains("true")) result = "<color=green>Success!</color>";
-				if (result.ToLower().Contains("false")) result = "<color=red>Failed!</color>";
-				switch (Entry.Alignment)
+				if (result.ToLower().Contains("true")) result = $"<color=green>Success! ({entry.ScoreValue})</color>";
+				if (result.ToLower().Contains("false")) result = $"<color=red>Failed! ({entry.ScoreValue})</color>";
+				switch (entry.Alignment)
 				{
 					case ScoreAlignment.Good:
-						theGoodList.AppendLine($"<b>{Entry.ScoreName}</b> : {result}");
+						theGoodList.AppendLine($"<b>{entry.ScoreName}</b> : {result}");
 						break;
 					case ScoreAlignment.Bad:
-						theBadList.AppendLine($"<b>{Entry.ScoreName}</b> : {result}");
+						theBadList.AppendLine($"<b>{entry.ScoreName}</b> : {result}");
 						break;
 					case ScoreAlignment.Weird:
-						theWeirdList.AppendLine($"<b>{Entry.ScoreName}</b> : {result}");
+						theWeirdList.AppendLine($"<b>{entry.ScoreName}</b> : {result}");
 						break;
 					default:
-						throw new NotImplementedException();
+						Logger.LogError("[RoundEndScoreScreen/ShowScore] - Undefined Alignment for score entry.");
+						break;
 				}
 			}
 
@@ -88,13 +89,13 @@ namespace UI.Systems.EndRound
 
 		private string RatePerformance(int finalScore)
 		{
-			if (finalScore <= -1500) return "Expunge from records";
-			if (finalScore <= -1000) return "Singularity Fodder";
-			if (finalScore <= -500) return "Clown Station";
-			if (finalScore <= 0) return "Disaster";
+			if (finalScore.IsBetween(int.MinValue, -1500)) return "Expunge from records";
+			if (finalScore.IsBetween(-1500, -1000)) return "Singularity Fodder";
+			if (finalScore.IsBetween(-1000, -500)) return "Clown Station";
+			if (finalScore.IsBetween(-500, 0)) return "Disaster";
 			if (finalScore.IsBetween(0, 500)) return "Decent Shift";
 			if (finalScore.IsBetween(500, 1000)) return "Net Profit";
-			return finalScore.IsBetween(1000, 1500) ? "Robust Station" : "N/A";
+			return finalScore.IsBetween(1000, int.MaxValue) ? "Robust Station" : "N/A";
 		}
 	}
 


### PR DESCRIPTION
CL: [New] The station's filth state will be evaluated at the end of the round now. Giving 1250 score to the station if it is deemed sufficiently clean and -350 if it is left in a dirty state.
CL: [Improvement] Objective (bool) based scores will now report how much points they award to the station.
CL: [Improvement] Having a crewmate with the lowest HP being greater than 25 will net the station 100 points to their evaluation score now.
CL: [Improvement] Made some naming of score entries much clearer for the differences between "Numbers of X happening" and "Score of X"
CL: [Improvement] To make categories much clearer, their titles have been centered in the score UI screen.
CL: [Fix] Fixed an issue with score titles reporting N/A due to a coding error when checking for scores that go above 1500 and -1500.
CL: [Fix] Antags will no longer be accounted for in the "Dead Crew" score.
