### PR TITLE
Fixed bugs and balance with flashes

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Construction/Assemblies/FlashHandheld.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Construction/Assemblies/FlashHandheld.prefab
@@ -13,6 +13,21 @@ PrefabInstance:
       propertyPath: foreverID
       value: 7885c3ef269a1bb49870f7fb6d8f904d
       objectReference: {fileID: 0}
+    - target: {fileID: 6031154819312805203, guid: e77ad8336ea71364c9ec01faad07f5f4,
+        type: 3}
+      propertyPath: flashTime
+      value: 3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6031154819312805203, guid: e77ad8336ea71364c9ec01faad07f5f4,
+        type: 3}
+      propertyPath: flashRadius
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 6031154819312805203, guid: e77ad8336ea71364c9ec01faad07f5f4,
+        type: 3}
+      propertyPath: stunExtraTime
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 9115576831223235532, guid: e77ad8336ea71364c9ec01faad07f5f4,
         type: 3}
       propertyPath: customNetTransform
@@ -61,17 +76,17 @@ PrefabInstance:
     - target: {fileID: 9153242923020361508, guid: e77ad8336ea71364c9ec01faad07f5f4,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9153242923020361508, guid: e77ad8336ea71364c9ec01faad07f5f4,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9153242923020361508, guid: e77ad8336ea71364c9ec01faad07f5f4,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9153242923020361508, guid: e77ad8336ea71364c9ec01faad07f5f4,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Construction/Assemblies/_FlashBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Construction/Assemblies/_FlashBase.prefab
@@ -168,13 +168,12 @@ MonoBehaviour:
   syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
-  maximumDistance: 12
-  flashRadius: 12
+  maximumDistance: 6
+  flashRadius: 6
   flashTime: 4
   weakDuration: 12
-  stunExtraTime: 4
+  stunExtraTime: 9
   flashCooldown: 12
-  sunglassesTrait: {fileID: 11400000, guid: 4f5b7ce1cca0a644cba934af14ea4b2c, type: 2}
   flashSound:
     SetLoadSetting: 0
     AssetAddress: Assets/Prefabs/Effects/Flash.prefab

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/FlashbangGrenade.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/FlashbangGrenade.prefab
@@ -219,11 +219,10 @@ MonoBehaviour:
   syncInterval: 0.1
   maximumDistance: 20
   flashRadius: 20
-  flashTime: 6
+  flashTime: 5
   weakDuration: 4
-  stunExtraTime: 3
+  stunExtraTime: 8
   flashCooldown: 24
-  sunglassesTrait: {fileID: 0}
   flashSound:
     SetLoadSetting: 0
     AssetAddress: Assets/Prefabs/Effects/FlashbangBoom.prefab

--- a/UnityProject/Assets/Scripts/Items/Tool/FlasherItem.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/FlasherItem.cs
@@ -22,14 +22,12 @@ namespace Items.Tool
 				$"{interaction.PerformerPlayerScript.visibleName} flashes {player.PlayerScript.visibleName}!");
 			if (stunsPlayers)
 			{
-				FlashTarget(player.gameObject, flashTime, flashTime+ stunExtraTime);
+				FlashTarget(player.gameObject, flashTime, flashTime + stunExtraTime);
 			}
 			else
 			{
 				FlashTarget(player.gameObject, flashTime, 0);
 			}
-
-
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Weapons/FlashbangGrenadeLogic.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/FlashbangGrenadeLogic.cs
@@ -1,5 +1,6 @@
 ﻿using NaughtyAttributes;
 using Objects;
+using Systems.Explosions;
 using UnityEngine;
 
 namespace Items.Weapons
@@ -15,6 +16,7 @@ namespace Items.Weapons
 			FlashInRadius();
 
 			if (flashSound != null) SoundManager.PlayNetworkedAtPos(flashSound, gameObject.AssumedWorldPosServer());
+			SparkUtil.TrySpark(gameObject);
 			if (despawnOnInvoke) _ = Despawn.ServerSingle(gameObject);
 		}
 	}

--- a/UnityProject/Assets/Scripts/Items/Weapons/FlashbangGrenadeLogic.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/FlashbangGrenadeLogic.cs
@@ -1,7 +1,5 @@
-﻿using AddressableReferences;
-using NaughtyAttributes;
+﻿using NaughtyAttributes;
 using Objects;
-using Player;
 using UnityEngine;
 
 namespace Items.Weapons

--- a/UnityProject/Assets/Scripts/Objects/FlasherBase.cs
+++ b/UnityProject/Assets/Scripts/Objects/FlasherBase.cs
@@ -11,13 +11,15 @@ namespace Objects
 {
 	public class FlasherBase : NetworkBehaviour
 	{
-		[SerializeField] private float maximumDistance = 12f;
+		[SerializeField] protected float maximumDistance = 12f;
 		[SerializeField] protected float flashRadius = 12f;
 		[SerializeField] protected float flashTime = 12f;
-		[SerializeField] protected float weakDuration  = 12f;
+
+		[SerializeField, Tooltip("Duration used for when players are standing further away from the flash distance")]
+		protected float weakDuration  = 6f;
+
 		[SerializeField, ShowIf(nameof(stunsPlayers))] protected float stunExtraTime = 3f;
 		[SerializeField] protected float flashCooldown = 24f;
-		[SerializeField] protected ItemTrait sunglassesTrait;
 		[SerializeField] protected AddressableAudioSource flashSound;
 		[SerializeField] protected bool stunsPlayers = true;
 		[SyncVar] private bool onCooldown = false;
@@ -27,7 +29,6 @@ namespace Objects
 
 		private void Start()
 		{
-			//(Max) : How would this work when we get to the mind rework? Will we force all objects that inherit from player to change their mask to "Players"? Or will we make a new one?
 			pLayerMask = LayerMask.GetMask("Players");
 			layerMask = LayerMask.GetMask("Door Closed"); //I copied this from ChatRelay.cs
 		}
@@ -63,24 +64,22 @@ namespace Objects
 		}
 
 		[Server]
-		public void FlashTarget(GameObject target, float time, float stunnedtime)
+		public void FlashTarget(GameObject target, float time, float stunnedtime, bool checkForProtectiveGear = true)
 		{
 			if (onCooldown) return;
 			if (flashSound != null) _ = SoundManager.PlayNetworkedAtPosAsync(flashSound, gameObject.AssumedWorldPosServer());
 			StartCoroutine(Cooldown());
-			PerformFlash(target,time, stunnedtime);
+			PerformFlash(target, time, stunnedtime, checkForProtectiveGear);
 		}
 
 		[Server]
-		private void PerformFlash(GameObject target, float time, float stunnedtime)
+		private void PerformFlash(GameObject target, float time, float stunnedTime, bool checkForProtectiveGear = true)
 		{
-			//TODO Stun flashTime + stunExtraTime
 			if (target.gameObject.TryGetComponentCustom<LivingHealthMasterBase>(out var livingHealthMasterBase) == false) return;
-			if (stunnedtime > 0)
+			if (stunnedTime > 0 && livingHealthMasterBase.TryFlash(time, checkForProtectiveGear))
 			{
-				livingHealthMasterBase.GetComponent<RegisterPlayer>().ServerStun(stunnedtime);
+				livingHealthMasterBase.GetComponent<RegisterPlayer>()?.ServerStun(stunnedTime);
 			}
-			livingHealthMasterBase.TryFlash(time, true);
 		}
 
 


### PR DESCRIPTION
CL: [New] Flashbangs will leave a spark before despawning to make their disappearance more visually appealing for those wearing sunglasses.
CL: [Improvement] Flashbangs and handheld flashers will now blind players for shorter amounts of time, but their stun durations have been buffed as a result.
CL: [Fix] Fixed an issue where players would get stunned by flashing entities even when wearing protective gear that would prevent stuns from happening.
CL: [Fix] Fixed an NRE when attempting to flash a HealthV2 character that did not have a `RegisterPlayer` component
