### PR TITLE
Makes slime hit detection more reliable while they're eating players

### DIFF
--- a/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
+++ b/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
@@ -2141,11 +2141,10 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 
 	// netid of the game object we are buckled to, NetId.Empty if not buckled
 	[SyncVar(hook = nameof(SyncBuckledToObject))]
-	protected UniversalObjectPhysics ObjectIsBuckling = null;
+	public UniversalObjectPhysics ObjectIsBuckling = null;
 
 	public CheckedComponent<UniversalObjectPhysics> ObjectIsBucklingChecked =
 		new CheckedComponent<UniversalObjectPhysics>();
-
 
 	public UniversalObjectPhysics BuckledToObject;
 

--- a/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
+++ b/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
@@ -2140,8 +2140,8 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 	#region Buckling
 
 	// netid of the game object we are buckled to, NetId.Empty if not buckled
-	[SyncVar(hook = nameof(SyncBuckledToObject))]
-	public UniversalObjectPhysics ObjectIsBuckling = null;
+	[field: SyncVar(hook = nameof(SyncBuckledToObject))]
+	public UniversalObjectPhysics ObjectIsBuckling { get; protected set; }
 
 	public CheckedComponent<UniversalObjectPhysics> ObjectIsBucklingChecked =
 		new CheckedComponent<UniversalObjectPhysics>();

--- a/UnityProject/Assets/Scripts/Items/Weapons/Meleeable.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Meleeable.cs
@@ -108,7 +108,7 @@ namespace Systems.Interaction
 			wna.ServerPerformMeleeAttack(gameObject, interaction.TargetVector, interaction.TargetBodyPart, layerType);
 			if (Validations.HasItemTrait(handObject, CommonTraits.Instance.Breakable))
 			{
-				handObject.GetComponent<ItemBreakable>().AddDamage();
+				handObject.GetComponent<ItemBreakable>()?.AddDamage();
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
@@ -84,7 +84,7 @@ public class WeaponNetworkActions : NetworkBehaviour
 	public void ServerPerformMeleeAttack(GameObject victim, Vector2 attackDirection, BodyPartType damageZone, LayerType layerType)
 	{
 		if (victim == null) return;
-		if (playerMove.ObjectIsBuckling.OrNull()?.gameObject != null)
+		if (playerMove.ObjectIsBuckling.OrNull()?.gameObject != null && playerMove.ObjectIsBuckling is MovementSynchronisation)
 		{
 			victim = playerMove.ObjectIsBuckling.gameObject;
 		}

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
@@ -84,6 +84,10 @@ public class WeaponNetworkActions : NetworkBehaviour
 	public void ServerPerformMeleeAttack(GameObject victim, Vector2 attackDirection, BodyPartType damageZone, LayerType layerType)
 	{
 		if (victim == null) return;
+		if (playerMove.ObjectIsBuckling.OrNull()?.gameObject != null)
+		{
+			victim = playerMove.ObjectIsBuckling.gameObject;
+		}
 		if (Cooldowns.IsOnServer(playerScript, CommonCooldowns.Instance.Melee)) return;
 		if (playerMove.AllowInput == false) return;
 		if (playerScript.PlayerTypeSettings.CanMelee == false) return;


### PR DESCRIPTION
fixes #9962

CL: [Fix] Fixed an issue where the server and client would constantly disagree with each other when deciding who to hit when targeting slimes that are buckled to players. This fix applies to all future mobs and objects that use `MovementSync` as well.