### PR TITLE
Revert default font change

### DIFF
--- a/UnityProject/Assets/Standard Assets/TextMesh Pro/Resources/TMP Settings.asset
+++ b/UnityProject/Assets/Standard Assets/TextMesh Pro/Resources/TMP Settings.asset
@@ -21,7 +21,7 @@ MonoBehaviour:
   m_GetFontFeaturesAtRuntime: 1
   m_missingGlyphCharacter: 0
   m_warningsDisabled: 1
-  m_defaultFontAsset: {fileID: 11400000, guid: 86cc3cba78717ad48a40abf01295cd8b, type: 2}
+  m_defaultFontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_defaultFontAssetPath: Fonts & Materials/
   m_defaultFontSize: 36
   m_defaultAutoSizeMinRatio: 0.5
@@ -31,7 +31,8 @@ MonoBehaviour:
   m_autoSizeTextContainer: 1
   m_IsTextObjectScaleStatic: 0
   m_fallbackFontAssets:
-  - {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  - {fileID: 11400000, guid: 06163af7308fb7345b59dc7e46b231d7, type: 2}
+  - {fileID: 11400000, guid: 86cc3cba78717ad48a40abf01295cd8b, type: 2}
   m_matchMaterialPreset: 1
   m_defaultSpriteAsset: {fileID: 11400000, guid: c41005c129ba4d66911b75229fd70b45,
     type: 2}


### PR DESCRIPTION
Reverts default font change to use LiberaltionSans again as the default font as Ubuntu was supposed to be the fallback font, not the default.

CL: [Fix] Revert back to using LiberaltionSans as the default font to fix issues with papers having missing characters.