### PR TITLE
Some quick staging fixes of issues I found during today's playtests

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Lighting/LightsHolder.cs
+++ b/UnityProject/Assets/Scripts/Core/Lighting/LightsHolder.cs
@@ -145,7 +145,10 @@ namespace Core.Lighting
 		{
 			lightSprite.Color = data.lightColor;
 			lightSprite.Shape = data.lightShape;
-			lightSprite.Sprite = data.lightSpriteObject.GetComponent<ItemLightControl>().ObjectLightSprite.Sprite;
+			if (data.lightSpriteObject != null)
+			{
+				lightSprite.Sprite = data.lightSpriteObject.GetComponent<ItemLightControl>()?.ObjectLightSprite.Sprite;
+			}
 			lightSprite.transform.localScale = new Vector3(data.size, data.size, data.size);
 			if (data.Id != 0)
 			{

--- a/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
+++ b/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
@@ -576,7 +576,14 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 			}
 
 			if (this is not MovementSynchronisation c) return;
-			c.playerScript.RegisterPlayer.LayDownBehavior.ServerEnsureCorrectState();
+			if (CustomNetworkManager.IsServer)
+			{
+				c.playerScript.RegisterPlayer.LayDownBehavior.ServerEnsureCorrectState();
+			}
+			else
+			{
+				c.playerScript.RegisterPlayer.LayDownBehavior.ClientEnsureCorrectState();
+			}
 		}
 		else
 		{

--- a/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
@@ -199,7 +199,7 @@ namespace ScriptableObjects.RP
 		{
 			//TODO : This sort of thing should be checked on the player script when reworking telecomms and adding a proper silencing system
 			if(player.TryGetComponent<PlayerScript>(out var script) == false) return false;
-			if (script.Mind?.occupation != null && script.Mind.occupation.JobType == JobType.MIME) return true; //FIXME : Find a way to check if vow of silence is broken
+			if (script.Mind.OrNull()?.occupation != null && script.Mind.occupation.JobType == JobType.MIME) return true; //FIXME : Find a way to check if vow of silence is broken
 			foreach (var slot in script.Equipment.ItemStorage.GetItemSlots())
 			{
 				if(slot.IsEmpty) continue;
@@ -214,6 +214,11 @@ namespace ScriptableObjects.RP
 			    && allowedPlayerTypes.HasFlag(playerScript.PlayerType) == false)
 			{
 				FailText(player, FailType.Normal);
+				return false;
+			}
+
+			if (playerScript.playerHealth.IsDead)
+			{
 				return false;
 			}
 


### PR DESCRIPTION
CL: [Fix] Fixed an issue where you could emote while dead.
CL: [Fix] Fixed an issue where spawned light holders would throw an NRE at the start due to missing data that hasn't loaded yet.
CL: [Fix] Fixed an issue where the client would attempt to call server code for the `laydown` component by accident.
