### PR TITLE
feat: fluent utility to create Rich texts with TMP

### DIFF
--- a/UnityProject/App.config
+++ b/UnityProject/App.config
@@ -25,6 +25,34 @@
         <assemblyIdentity name="System.Xml" publicKeyToken="b77a5c561934e089" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Resources.ResourceManager" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/UnityProject/Assets/Resources/ScriptableObjectsSingletons/SpriteCatalogueSingleton.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjectsSingletons/SpriteCatalogueSingleton.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5dfdde502469175448989e7bc58e5c03
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c8db7bae4d9d41908c791746e831c246
+timeCreated: 1696660916

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/RichText.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/RichText.cs
@@ -1,0 +1,484 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Util.Independent.FluentRichText.Styles;
+
+namespace Util.Independent.FluentRichText
+{
+	/// <summary>
+	/// This utility class helps with creating formatted text in TMP.
+	/// </summary>
+	public class RichText
+	{
+		private readonly StringBuilder builder;
+		private readonly List<IStyleStrategy> styles = new();
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="RichText"/> class with an empty content.
+		/// </summary>
+		public RichText()
+		{
+			builder = new StringBuilder();
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="RichText"/> class with the specified initial text.
+		/// </summary>
+		/// <param name="text">The initial text to set in the RichText.</param>
+		public RichText(string text)
+		{
+			builder = new StringBuilder(text);
+		}
+
+		public static implicit operator string(RichText richText)
+		{
+			return richText.ToString();
+		}
+
+		/// <summary>
+		/// Aligns the text according to the specified alignment.
+		/// </summary>
+		/// <param name="alignment">The desired text alignment (e.g., left, right, center).</param>
+		/// <returns>The current RichText instance to allow method chaining.</returns>
+		public RichText Align(Alignment alignment)
+		{
+			styles.Add(new AlignStrategy(alignment));
+			return this;
+		}
+
+		/// <summary>
+		/// Makes the text bold.
+		/// </summary>
+		/// <returns>The current RichText instance to allow method chaining.</returns>
+		public RichText Bold()
+		{
+			styles.Add(new BoldStrategy());
+			return this;
+		}
+
+		/// <summary>
+		/// Makes the text italic.
+		/// </summary>
+		/// <returns>The current RichText instance to allow method chaining.</returns>
+		public RichText Italic()
+		{
+			styles.Add(new ItalicStrategy());
+			return this;
+		}
+
+		/// <summary>
+		/// Adjusts the spacing between characters based on the given amount. This spacing can be specified in pixels, font units, or percentages.
+		/// A positive value increases the spacing, separating the characters, whereas a negative value decreases it, bringing them closer together.
+		/// </summary>
+		/// <param name="amount">The desired spacing value. Accepts pixel values (e.g., "12", "12.4"), font unit values (e.g., "12em", "12.4em"), or percentages (e.g., "12%", "12.4%").</param>
+		/// <returns>The current RichText instance to allow for method chaining.</returns>
+		public RichText Spacing(string amount)
+		{
+			styles.Add(new SpacingStrategy(amount));
+			return this;
+		}
+
+		/// <summary>
+		/// Makes the text colored according to the specified named color.
+		/// </summary>
+		/// <param name="namedColor">What color to use.</param>
+		/// <returns>The current RichText instance to allow for method chaining.</returns>
+		public RichText Color(Color namedColor)
+		{
+			styles.Add(new ColorStrategy(namedColor));
+			return this;
+		}
+
+		/// <summary>
+		/// Makes the text colored according to the specified named color.
+		/// </summary>
+		/// <param name="hexColor">What color to use in hexadecimal format. It should start with a #</param>
+		/// <returns>The current RichText instance to allow for method chaining.</returns>
+		public RichText Color(string hexColor)
+		{
+			styles.Add(new ColorStrategy(hexColor));
+			return this;
+		}
+
+		/// <summary>
+		/// Sets the font for the text based on the provided font name.
+		/// </summary>
+		/// <param name="fontName">The name of the font to apply to the text.</param>
+		/// <returns>The current RichText instance to allow for method chaining.</returns>
+		public RichText Font(string fontName)
+		{
+			styles.Add(new FontStrategy(fontName));
+			return this;
+		}
+
+		/// <summary>
+		/// Indents the text by the specified amount, which persists across lines. Useful for creating layouts like bullet points compatible with word-wrapping.
+		/// </summary>
+		/// <param name="amount">The indentation value. Accepts pixel values (e.g., "12", "12.4"), font unit values (e.g., "12em", "12.4em"), or percentages (e.g., "12%", "12.4%").</param>
+		public RichText Indent(string amount)
+		{
+			styles.Add(new IndentStrategy(amount));
+			return this;
+		}
+
+		/// <summary>
+		/// Adjusts the line height for the text based on the specified amount, affecting the vertical spacing between lines.
+		/// </summary>
+		/// <param name="amount">The desired line height value. Accepts pixel values (e.g., "12", "12.4"), font unit values (e.g., "12em", "12.4em"), or percentages (e.g., "12%", "12.4%").</param>
+		/// <returns>The current RichText instance to allow for method chaining.</returns>
+		public RichText LineHeight(string amount)
+		{
+			styles.Add(new LineHeightStrategy(amount));
+			return this;
+		}
+
+		/// <summary>
+		/// Inserts horizontal space directly after it, and before the start of each new line. It only affects manual line breaks, not word-wrapped lines. You can use pixels, font units, or percentages.
+		/// </summary>
+		/// <param name="amount">Amount of line indentation. Accepts pixel values (e.g., "12", "12.4"), font unit values (e.g., "12em", "12.4em"), or percentages (e.g., "12%", "12.4%").</param>
+		/// <returns></returns>
+		public RichText LineIndentation(string amount)
+		{
+			styles.Add(new LineIndentationStrategy(amount));
+			return this;
+		}
+
+		/// <summary>
+		/// Adds an unstyled hyperlink to the current content using the provided URL.
+		/// </summary>
+		/// <param name="url">The URL to which the hyperlink will point.</param>
+		/// <returns>The current RichText instance to allow for method chaining.</returns>
+		public RichText UnStyledLink(string url)
+		{
+			styles.Add(new LinkStrategy(url));
+			return this;
+		}
+
+		/// <summary>
+		/// Makes the text lowercase
+		/// </summary>
+		/// <returns></returns>
+		public RichText LowerCase()
+		{
+			styles.Add(new LowerCaseStrategy());
+			return this;
+		}
+
+		/// <summary>
+		/// Makes the text uppercase
+		/// </summary>
+		/// <returns></returns>
+		public RichText UpperCase()
+		{
+			styles.Add(new UpperCaseStrategy());
+			return this;
+		}
+
+		/// <summary>
+		/// Makes the text small caps. This means that all characters will be uppercase but the ones that were lowercase will be smaller in font size.
+		/// </summary>
+		/// <returns></returns>
+		public RichText SmallCaps()
+		{
+			styles.Add(new SmallCapsStrategy());
+			return this;
+		}
+
+		/// <summary>
+		///	adds an overlay on top of the text. You can use this to highlight portions of your text.
+		/// Because the markings lay on top of the text, you have to give them a semitransparent color to still be able
+		/// to see the text.
+		///
+		/// Marks tags don't stack, they replace each other.
+		/// </summary>
+		/// <param name="hexColor">Color in hexadecimal format.</param>
+		/// <returns></returns>
+		public RichText Mark(string hexColor)
+		{
+			styles.Add(new MarkStrategy(hexColor));
+			return this;
+		}
+
+		/// <summary>
+		///  This will force all characters to claim the same horizontal space. You can use pixels or font units to set the monospace character width.
+		/// </summary>
+		/// <param name="characterWidth">Horizontal space the character will use. Accepts pixels (eg. 1, 1.2) or font units (eg. 1em, 1.2em)</param>
+		/// <returns></returns>
+		public RichText Monospace(string characterWidth)
+		{
+			styles.Add(new MonospaceStrategy(characterWidth));
+			return this;
+		}
+
+		/// <summary>
+		/// Wraps the text in a tag that will make it so any inner tag isn't parsed by TMP interpreter.
+		/// Useful if there are things that might be interpreted as tags but you don't want them to be.
+		/// </summary>
+		/// <returns></returns>
+		public RichText NoParse()
+		{
+			styles.Add(new NoParseStrategy());
+			return this;
+		}
+
+		/// <summary>
+		/// Wraps the text in a tag that will prevent the word wrapper from separating the word into different lines.
+		/// </summary>
+		/// <returns></returns>
+		public RichText NonBreakingSpaces()
+		{
+			styles.Add(new NonBreakingSpacesStrategy());
+			return this;
+		}
+
+		/// <summary>
+		/// Gives you direct control over the horizontal caret position. You can put it anywhere on the same line,
+		/// regardless where it started. You can use either pixels, font units, or percentages.
+		/// This tags is best used with left alignment.
+		/// </summary>
+		/// <param name="position"></param>
+		/// <returns></returns>
+		public RichText HorizontalPosition(string position)
+		{
+			styles.Add(new HorizontalPositionStrategy(position));
+			return this;
+		}
+
+		/// <summary>
+		/// Changes the size of the font. You can use pixels, font units, or percentages.
+		/// </summary>
+		/// <param name="size"></param>
+		/// <returns></returns>
+		public RichText FontSize(string size)
+		{
+			styles.Add(new FontSizeStrategy(size));
+			return this;
+		}
+
+		/// <summary>
+		/// Appends a space tag to the current content. You can use pixels, font units, or percentages.
+		/// </summary>
+		/// <param name="amount"></param>
+		/// <remarks>Note this style doesn't get added to the stack and immediately appends the tag instead.</remarks>
+		/// <returns></returns>
+		public RichText Space(string amount)
+		{
+			builder.Append(new SpaceStrategy(amount).ApplyStyle(string.Empty));
+			return this;
+		}
+
+		/// <summary>
+		/// Appends a sprite tag to the current content.
+		/// </summary>
+		/// <param name="index">Index of the sprite in the default atlas.</param>
+		/// <remarks>Note this style doesn't get added to the stack and immediately appends the tag instead.</remarks>
+		/// <returns></returns>
+		public RichText Sprite(int index)
+		{
+			builder.Append(new SpriteStrategy(index).ApplyStyle(string.Empty));
+			return this;
+		}
+
+		/// <summary>
+		/// Appends a sprite tag to the current content.
+		/// </summary>
+		/// <param name="name">name of the sprite in the default atlas.</param>
+		/// <remarks>Note this style doesn't get added to the stack and immediately appends the tag instead.</remarks>
+		/// <returns></returns>
+		public RichText Sprite(string name)
+		{
+			builder.Append(new SpriteStrategy(name).ApplyStyle(string.Empty));
+			return this;
+		}
+
+		/// <summary>
+		/// Appends a sprite tag to the current content.
+		/// </summary>
+		/// <param name="atlas">asset name of the atlas from which we will take the sprite</param>
+		/// <param name="index">Index of the sprite in the selected atlas.</param>
+		/// <remarks>Note this style doesn't get added to the stack and immediately appends the tag instead.</remarks>
+		/// <returns></returns>
+		public RichText Sprite(string atlas, int index)
+		{
+			builder.Append(new SpriteStrategy(atlas, index).ApplyStyle(string.Empty));
+			return this;
+		}
+
+		/// <summary>
+		/// Appends a sprite tag to the current content.
+		/// </summary>
+		/// <param name="atlas">asset name of the atlas from which we will take the sprite</param>
+		/// <param name="name">name of the sprite in the selected atlas.</param>
+		/// <remarks>Note this style doesn't get added to the stack and immediately appends the tag instead.</remarks>
+		/// <returns></returns>
+		public RichText Sprite(string atlas, string name)
+		{
+			builder.Append(new SpriteStrategy(atlas, name).ApplyStyle(string.Empty));
+			return this;
+		}
+
+		/// <summary>
+		/// Adds a horizontal line that crosses the text.
+		/// </summary>
+		/// <returns></returns>
+		public RichText Strikethrough()
+		{
+			styles.Add(new StrikethroughStrategy());
+			return this;
+		}
+
+		/// <summary>
+		/// Adds an underline to the text.
+		/// </summary>
+		/// <returns></returns>
+		public RichText Underline()
+		{
+			styles.Add(new UnderlineStrategy());
+			return this;
+		}
+
+		/// <summary>
+		/// Wraps the text in a tag that will apply the specified style to it.
+		/// </summary>
+		/// <param name="style"></param>
+		/// <returns></returns>
+		public RichText CustomStyle(string style)
+		{
+			styles.Add(new CustomStyleStrategy(style));
+			return this;
+		}
+
+		/// <summary>
+		/// Wraps the text in the subscript tag. This will make the text smaller and lower than the rest of the text.
+		/// </summary>
+		/// <returns></returns>
+		public RichText Subscript()
+		{
+			styles.Add(new SubscriptStrategy());
+			return this;
+		}
+
+		/// <summary>
+		/// Wraps the text in the superscript tag. This will make the text smaller and higher than the rest of the text.
+		/// </summary>
+		/// <returns></returns>
+		public RichText SuperScript()
+		{
+			styles.Add(new SuperscriptStrategy());
+			return this;
+		}
+
+		/// <summary>
+		/// Adds an offset to the vertical position of the text. You can use pixels, font units, or percentages.
+		/// </summary>
+		/// <param name="amount"></param>
+		/// <returns></returns>
+		public RichText VerticalOffset(string amount)
+		{
+			styles.Add(new VerticalOffsetStrategy(amount));
+			return this;
+		}
+
+		/// <summary>
+		/// Modifies the width of the text. You can use pixels, font units, or percentages.
+		/// </summary>
+		/// <param name="amount"></param>
+		/// <returns></returns>
+		public RichText Width(string amount)
+		{
+			styles.Add(new WidthStrategy(amount));
+			return this;
+		}
+
+		/// <summary>
+		/// Applies accumulated styles to the specified text and then appends it to the current content. After application, the style stack is cleared.
+		/// </summary>
+		/// <param name="text">The text to which the accumulated styles will be applied.</param>
+		/// <returns>The current RichText instance to allow for method chaining.</returns>
+		public RichText ApplyTo(string text)
+		{
+			foreach (IStyleStrategy style in styles)
+			{
+				text = style.ApplyStyle(text);
+			}
+
+			builder.Append(text);
+			styles.Clear();
+			return this;
+		}
+
+		/// <summary>
+		/// Appends the provided text to the current content without applying any additional styles.
+		/// </summary>
+		/// <param name="text">The text to be appended.</param>
+		/// <returns>The current RichText instance to allow for method chaining.</returns>
+		public RichText Add(string text)
+		{
+			builder.Append(text);
+			return this;
+		}
+
+		/// <summary>
+		/// Appends a formatted string to the current content using the specified format template and arguments.
+		/// </summary>
+		/// <param name="template">A composite format string.</param>
+		/// <param name="text">An array of objects to format and then append.</param>
+		/// <returns>The current RichText instance to allow for method chaining.</returns>
+		public RichText AddFormat(string template, params object[] text)
+		{
+			builder.AppendFormat(template, text.ToArray());
+			return this;
+		}
+
+		/// <summary>
+		/// Same as <see cref="Add"/> but adds a newline character before the text.
+		/// </summary>
+		///
+		/// <param name="text"></param>
+		/// <returns></returns>
+		public RichText AddOnNewLine(string text)
+		{
+			builder.Append("\n").Append(text);
+			return this;
+		}
+
+		/// <summary>
+		/// Same as <see cref="AddFormat"/> but adds a newline character before the text.
+		/// </summary>
+		/// <param name="template"></param>
+		/// <param name="text"></param>
+		/// <returns></returns>
+		public RichText AddFormatOnNewLine(string template, params object[] text)
+		{
+			builder.Append("\n").AppendFormat(template, text.ToArray());
+			return this;
+		}
+	}
+
+	public enum Alignment
+	{
+		Left,
+		Center,
+		Right
+	}
+
+	public enum Color
+	{
+		NoColor,
+		Black,
+		Blue,
+		Green,
+		Orange,
+		Purple,
+		Red,
+		White,
+		Yellow
+	}
+
+	public enum MarginDirection
+	{
+		All,
+		Left,
+		Right
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/RichText.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/RichText.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 53f83b99428f48bd9169cd0a1809b895
+timeCreated: 1696530570

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/StringExtensions.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/StringExtensions.cs
@@ -1,0 +1,39 @@
+﻿using Util.Independent.FluentRichText.Styles;
+
+namespace Util.Independent.FluentRichText
+{
+	public static class StringExtensions
+	{
+		public static string Align(this string text, Alignment alignment) => new AlignStrategy(alignment).ApplyStyle(text);
+		public static string Bold(this string text) => new BoldStrategy().ApplyStyle(text);
+		public static string Italic(this string text) => new ItalicStrategy().ApplyStyle(text);
+		public static string Spacing(this string text, string amount) => new SpacingStrategy(amount).ApplyStyle(text);
+		public static string Color(this string text, Color namedColor) => new ColorStrategy(namedColor).ApplyStyle(text);
+		public static string Color(this string text, string hexColor) => new ColorStrategy(hexColor).ApplyStyle(text);
+		public static string Font(this string text, string fontName) => new FontStrategy(fontName).ApplyStyle(text);
+		public static string Indent(this string text, string amount) => new IndentStrategy(amount).ApplyStyle(text);
+		public static string LineHeight(this string text, string amount) => new LineHeightStrategy(amount).ApplyStyle(text);
+		public static string UnStyledLink(this string text, string url) => new LinkStrategy(url).ApplyStyle(text);
+		public static string TmpLowercase(this string text) => new LowerCaseStrategy().ApplyStyle(text);
+		public static string TmpUppercase(this string text) => new UpperCaseStrategy().ApplyStyle(text);
+		public static string SmallCaps(this string text) => new SmallCapsStrategy().ApplyStyle(text);
+		public static string Mark(this string text, string hexColor) => new MarkStrategy(hexColor).ApplyStyle(text);
+		public static string Monospace(this string text, string characterWidth) => new MonospaceStrategy(characterWidth).ApplyStyle(text);
+		public static string NoParse(this string text) => new NoParseStrategy().ApplyStyle(text);
+		public static string NonBreakingSpaces(this string text) => new NonBreakingSpacesStrategy().ApplyStyle(text);
+		public static string HorizontalPosition(this string text, string position) => new HorizontalPositionStrategy(position).ApplyStyle(text);
+		public static string FontSize(this string text, string size) => new FontStrategy(size).ApplyStyle(text);
+		public static string Space(this string text, string amount) => new SpaceStrategy(amount).ApplyStyle(text);
+		public static string Sprite(this string text, int index) => new SpriteStrategy(index).ApplyStyle(text);
+		public static string Sprite(this string text, string name) => new SpriteStrategy(name).ApplyStyle(text);
+		public static string Sprite(this string text, string atlas, int index) => new SpriteStrategy(atlas, index).ApplyStyle(text);
+		public static string Sprite(this string text, string atlas, string name) => new SpriteStrategy(atlas, name).ApplyStyle(text);
+		public static string Strikethrough(this string text) => new StrikethroughStrategy().ApplyStyle(text);
+		public static string Underline(this string text) => new UnderlineStrategy().ApplyStyle(text);
+		public static string CustomStyle(this string text, string style) => new CustomStyleStrategy(style).ApplyStyle(text);
+		public static string Subscript(this string text) => new SubscriptStrategy().ApplyStyle(text);
+		public static string Superscript(this string text) => new SuperscriptStrategy().ApplyStyle(text);
+		public static string VerticalOffset(this string text, string amount) => new VerticalOffsetStrategy(amount).ApplyStyle(text);
+		public static string Width(this string text, string amount) => new WidthStrategy(amount).ApplyStyle(text);
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/StringExtensions.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/StringExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 66de20b5af4c4f9cb8abbf7778eaf50e
+timeCreated: 1697052226

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 516087634e894e7cb3fc12953c4d8fa2
+timeCreated: 1696736630

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/AlignStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/AlignStrategy.cs
@@ -1,0 +1,14 @@
+﻿namespace Util.Independent.FluentRichText.Styles
+{
+	public class AlignStrategy : IStyleStrategy
+	{
+		private readonly Alignment alignment;
+
+		public AlignStrategy(Alignment alignment)
+		{
+			this.alignment = alignment;
+		}
+
+		public string ApplyStyle(string text) => $"<align=\"{alignment}\">{text}</align>";
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/AlignStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/AlignStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f1839f7eae3544e396ed5ae4ea01383b
+timeCreated: 1696736844

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/AlphaStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/AlphaStrategy.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Logs;
+
+namespace Util.Independent.FluentRichText.Styles
+{
+	public class AlphaStrategy : IStyleStrategy
+	{
+		private readonly int percentage;
+
+		public AlphaStrategy(int percentage)
+		{
+			if (percentage is < 0 or > 100)
+			{
+				Loggy.LogError("RichText received invalid percentage for alpha. Percentage must be between 0 and 100.");
+				this.percentage = -1;
+				return;
+			}
+
+			this.percentage = percentage;
+		}
+
+		public string ApplyStyle(string text)
+		{
+			if (percentage == -1)
+			{
+				return text;
+			}
+
+			int alphaValue = (int)Math.Round(255 * (percentage / 100.0), MidpointRounding.AwayFromZero);
+			return $"<alpha=#{alphaValue:X2}>{text}</alpha>";
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/AlphaStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/AlphaStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9897d2b84dd84706ae41b52ce05aa0ae
+timeCreated: 1696737208

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/BoldStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/BoldStrategy.cs
@@ -1,0 +1,7 @@
+﻿namespace Util.Independent.FluentRichText.Styles
+{
+	public class BoldStrategy : IStyleStrategy
+	{
+		public string ApplyStyle(string text) => $"<b>{text}</b>";
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/BoldStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/BoldStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 36038ac7192046d9a58da73c265d62a4
+timeCreated: 1696736880

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/ColorStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/ColorStrategy.cs
@@ -1,0 +1,49 @@
+﻿using Logs;
+
+namespace Util.Independent.FluentRichText.Styles
+{
+	public class ColorStrategy : IStyleStrategy
+	{
+		private readonly string hexColor;
+		private readonly Color color = Color.NoColor;
+
+		public ColorStrategy(string hexColor)
+		{
+			if (CommonValidations.IsValidHexColor(hexColor) == false)
+			{
+				Loggy.LogError($"RichText received invalid hexadecimal color: {hexColor}.");
+				this.hexColor = null;
+				return;
+			}
+
+			this.hexColor = hexColor;
+		}
+
+		public ColorStrategy(Color color)
+		{
+			this.color = color;
+		}
+
+		public string ApplyStyle(string text)
+		{
+			string colorString;
+
+			if (!string.IsNullOrEmpty(hexColor))
+			{
+				// If it's a hexadecimal color, use it as is.
+				colorString = hexColor;
+			}
+			else if (color != Color.NoColor)
+			{
+				// If it's a named color, convert to lowercase and wrap in quotes.
+				colorString = $"\"{color.ToString().ToLower()}\"";
+			}
+			else
+			{
+				colorString = null;
+			}
+
+			return string.IsNullOrEmpty(colorString) ? text : $"<color={colorString}>{text}</color>";
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/ColorStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/ColorStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: abf5c13e46884148888e2b5809460189
+timeCreated: 1696737238

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/CommonValidations.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/CommonValidations.cs
@@ -1,0 +1,27 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Util.Independent.FluentRichText.Styles
+{
+	public static class CommonValidations
+	{
+		public static bool IsValidPixelValue(string value)
+		{
+			return Regex.IsMatch(value, @"^-?\+?\d+(\.\d+)?$");
+		}
+
+		public static  bool IsValidFontUnitValue(string value)
+		{
+			return Regex.IsMatch(value, @"^-?\+?\d+(\.\d+)?em$");
+		}
+
+		public static bool IsValidPercentageValue(string value)
+		{
+			return Regex.IsMatch(value, @"^-?\+?\d+(\.\d+)?%$");
+		}
+
+		public static bool IsValidHexColor(string hexColor)
+		{
+			return Regex.IsMatch(hexColor, @"^#([a-fA-F0-9]{6}|[a-fA-F0-9]{8})$");
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/CommonValidations.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/CommonValidations.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d9dcea82f6e04eaeae09d643408b775f
+timeCreated: 1696736704

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/CustomStyleStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/CustomStyleStrategy.cs
@@ -1,0 +1,14 @@
+﻿namespace Util.Independent.FluentRichText.Styles
+{
+	public class CustomStyleStrategy: IStyleStrategy
+	{
+		private readonly string style;
+
+		public CustomStyleStrategy(string style)
+		{
+			this.style = style;
+		}
+
+		public string ApplyStyle(string text) => $"<style=\"{style}\">{text}</style>";
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/CustomStyleStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/CustomStyleStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 31b76aecb57c428583a95046ec52383d
+timeCreated: 1697057814

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/FontSizeStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/FontSizeStrategy.cs
@@ -1,0 +1,27 @@
+﻿using Logs;
+
+namespace Util.Independent.FluentRichText.Styles
+{
+	public class FontSizeStrategy: IStyleStrategy
+	{
+		private readonly string size;
+
+		public FontSizeStrategy(string size)
+		{
+			if (CommonValidations.IsValidPixelValue(size) == false &&
+			    CommonValidations.IsValidFontUnitValue(size) == false &&
+			    CommonValidations.IsValidPercentageValue(size) == false)
+			{
+				Loggy.LogError($"RichText received invalid font size value: {size}");
+				return;
+			}
+
+			this.size = size;
+		}
+
+		public string ApplyStyle(string text)
+		{
+			return string.IsNullOrEmpty(size) ? text : $"<size={size}>{text}</size>";
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/FontSizeStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/FontSizeStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 12321808a70e4e2ba8de4acd3aef9df8
+timeCreated: 1696740268

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/FontStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/FontStrategy.cs
@@ -1,0 +1,14 @@
+﻿namespace Util.Independent.FluentRichText.Styles
+{
+	public class FontStrategy : IStyleStrategy
+	{
+		private readonly string fontName;
+
+		public FontStrategy(string fontName)
+		{
+			this.fontName = fontName;
+		}
+
+		public string ApplyStyle(string text) => $"<font=\"{fontName}\">{text}</font>";
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/FontStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/FontStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 24e0117dbdf44b93ac3ffbd5659e0ba0
+timeCreated: 1696736966

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/HorizontalPositionStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/HorizontalPositionStrategy.cs
@@ -1,0 +1,28 @@
+﻿using C5;
+using Logs;
+
+namespace Util.Independent.FluentRichText.Styles
+{
+	public class HorizontalPositionStrategy: IStyleStrategy
+	{
+		private readonly string position;
+
+		public HorizontalPositionStrategy(string position)
+		{
+			if (CommonValidations.IsValidPixelValue(position) == false &&
+			    CommonValidations.IsValidFontUnitValue(position) == false &&
+			    CommonValidations.IsValidPercentageValue(position) == false)
+			{
+				Loggy.LogError($"RichText received invalid horizontal position value: {position}" );
+				return;
+			}
+
+			this.position = position;
+		}
+
+		public string ApplyStyle(string text)
+		{
+			return string.IsNullOrEmpty(position) ? text : $"<pos={position}>{text}</pos>";
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/HorizontalPositionStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/HorizontalPositionStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9a2fbe9f713e4cc0823840602f73bf3b
+timeCreated: 1696739691

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/IStyleStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/IStyleStrategy.cs
@@ -1,0 +1,7 @@
+﻿namespace Util.Independent.FluentRichText.Styles
+{
+	public interface IStyleStrategy
+	{
+		string ApplyStyle(string text);
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/IStyleStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/IStyleStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 81b87b98dadc466e80a6e981ec9ed9e8
+timeCreated: 1696736675

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/IndentStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/IndentStrategy.cs
@@ -1,0 +1,28 @@
+﻿using Logs;
+
+namespace Util.Independent.FluentRichText.Styles
+{
+	public class IndentStrategy : IStyleStrategy
+	{
+		private readonly string indentValue;
+
+		public IndentStrategy(string indentValue)
+		{
+			if (CommonValidations.IsValidPixelValue(indentValue) == false
+			    && CommonValidations.IsValidFontUnitValue(indentValue) == false
+			    && CommonValidations.IsValidPercentageValue(indentValue) == false)
+			{
+				Loggy.LogError("RichText received invalid indent. Indent must be a pixel value (e.g., \"1\", \"2.5\"), a font unit value (e.g., \"1em\", \"-0.5em\"), or a percentage value (e.g., \"10%\", \"2.5%\").");
+				this.indentValue = null;
+				return;
+			}
+
+			this.indentValue = indentValue;
+		}
+
+		public string ApplyStyle(string text)
+		{
+			return string.IsNullOrEmpty(indentValue) ? text : $"<indent={indentValue}>{text}</indent>";
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/IndentStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/IndentStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 07769c97fde64335b399352bee73bc2c
+timeCreated: 1696737270

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/ItalicStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/ItalicStrategy.cs
@@ -1,0 +1,7 @@
+﻿namespace Util.Independent.FluentRichText.Styles
+{
+	public class ItalicStrategy : IStyleStrategy
+	{
+		public string ApplyStyle(string text) => $"<i>{text}</i>";
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/ItalicStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/ItalicStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6d3d6358a6f74840add455d844df16f5
+timeCreated: 1696736911

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/LineHeightStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/LineHeightStrategy.cs
@@ -1,0 +1,27 @@
+﻿using Logs;
+
+namespace Util.Independent.FluentRichText.Styles
+{
+	public class LineHeightStrategy : IStyleStrategy
+	{
+		private readonly string amount;
+
+		public LineHeightStrategy(string amount)
+		{
+			if (CommonValidations.IsValidPixelValue(amount) == false
+			    && CommonValidations.IsValidFontUnitValue(amount) == false
+			    && CommonValidations.IsValidPercentageValue(amount) == false)
+			{
+				Loggy.LogError("RichText received invalid line height. Line height must be a pixel value (e.g., \"1\", \"2.5\"), a font unit value (e.g., \"1em\", \"-0.5em\"), or a percentage value (e.g., \"10%\", \"2.5%\").");
+				return;
+			}
+
+			this.amount = amount;
+		}
+
+		public string ApplyStyle(string text)
+		{
+			return string.IsNullOrEmpty(amount) ? text : $"<line-height={amount}>{text}</line-height>";
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/LineHeightStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/LineHeightStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1c8080d8c4f7477296b5970794534e62
+timeCreated: 1696737309

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/LineIndentationStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/LineIndentationStrategy.cs
@@ -1,0 +1,27 @@
+﻿using Logs;
+
+namespace Util.Independent.FluentRichText.Styles
+{
+	public class LineIndentationStrategy : IStyleStrategy
+	{
+		private readonly string amount;
+
+		public LineIndentationStrategy(string amount)
+		{
+			if (CommonValidations.IsValidPixelValue(amount) == false
+			    && CommonValidations.IsValidFontUnitValue(amount) == false
+			    && CommonValidations.IsValidPercentageValue(amount) == false)
+			{
+				Loggy.LogError("RichText received invalid line indentation. Line indentation must be a pixel value (e.g., \"1\", \"2.5\"), a font unit value (e.g., \"1em\", \"-0.5em\"), or a percentage value (e.g., \"10%\", \"2.5%\").");
+				return;
+			}
+
+			this.amount = amount;
+		}
+
+		public string ApplyStyle(string text)
+		{
+			return string.IsNullOrEmpty(amount) ? text : $"<line-indentation={amount}>{text}</line-indentation>";
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/LineIndentationStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/LineIndentationStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 51a70d5234e04b178bed3c104024482a
+timeCreated: 1696737342

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/LinkStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/LinkStrategy.cs
@@ -1,0 +1,14 @@
+﻿namespace Util.Independent.FluentRichText.Styles
+{
+	public class LinkStrategy : IStyleStrategy
+	{
+		private readonly string url;
+
+		public LinkStrategy(string url)
+		{
+			this.url = url;
+		}
+
+		public string ApplyStyle(string text) => $"<link=\"{url}\">{text}</link>";
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/LinkStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/LinkStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: db55d8c2f876483598d8574866fbe3f5
+timeCreated: 1696737366

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/LowerCaseStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/LowerCaseStrategy.cs
@@ -1,0 +1,7 @@
+﻿namespace Util.Independent.FluentRichText.Styles
+{
+	public class LowerCaseStrategy : IStyleStrategy
+	{
+		public string ApplyStyle(string text) => $"<lowercase>{text}</lowercase>";
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/LowerCaseStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/LowerCaseStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e9608f3de53f4eb0a4540897cf9b9985
+timeCreated: 1696737385

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/MarginStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/MarginStrategy.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Logs;
+
+namespace Util.Independent.FluentRichText.Styles
+{
+	public class MarginStrategy : IStyleStrategy
+	{
+		private readonly MarginDirection direction;
+		private readonly string amount;
+
+		public MarginStrategy(string amount)
+		{
+			if (ValidateAmount(amount) == false) return;
+
+			this.amount = amount;
+			direction = MarginDirection.All;
+		}
+
+		public MarginStrategy(string amount, MarginDirection direction)
+		{
+			if (ValidateAmount(amount) == false) return;
+
+			this.amount = amount;
+			this.direction = direction;
+		}
+
+		private static bool ValidateAmount(string amount)
+		{
+			if (CommonValidations.IsValidPixelValue(amount) ||
+			    CommonValidations.IsValidFontUnitValue(amount) ||
+			    CommonValidations.IsValidPercentageValue(amount))
+			{
+				return true;
+			}
+
+			Loggy.LogError(
+				"RichText received invalid margin. Margin must be a pixel value (e.g., \"1\", \"2.5\"), a font unit value (e.g., \"1em\", \"-0.5em\"), or a percentage value (e.g., \"10%\", \"2.5%\").");
+			return false;
+		}
+
+		public string ApplyStyle(string text)
+		{
+			if (string.IsNullOrEmpty(amount)) return text;
+
+			const string allDirectionTemplate = "<margin={0}>{1}</margin>";
+			const string directionTemplate = "<margin-{0}={1}>{2}</margin-{0}>";
+
+			return direction switch
+			{
+				MarginDirection.All => string.Format(allDirectionTemplate, amount, text),
+				MarginDirection.Right => string.Format(directionTemplate, "right", amount, text),
+				MarginDirection.Left => string.Format(directionTemplate, "left", amount, text),
+				_ => throw new ArgumentOutOfRangeException()
+			};
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/MarginStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/MarginStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: bdfd12070d9b41f090a20fc8a229c102
+timeCreated: 1696737448

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/MarkStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/MarkStrategy.cs
@@ -1,0 +1,26 @@
+﻿using Logs;
+
+namespace Util.Independent.FluentRichText.Styles
+{
+	public class MarkStrategy : IStyleStrategy
+	{
+		private readonly string hexColor;
+
+		public MarkStrategy(string hexColor)
+		{
+			if (CommonValidations.IsValidHexColor(hexColor) == false)
+			{
+				Loggy.LogError($"RichText received invalid hexadecimal color: {hexColor}.");
+				this.hexColor = null;
+				return;
+			}
+
+			this.hexColor = hexColor;
+		}
+
+		public string ApplyStyle(string text)
+		{
+			return string.IsNullOrEmpty(hexColor) ? text : $"<mark={hexColor}>{text}</mark>";
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/MarkStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/MarkStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0146c365fdb243de82e7016b006e2a20
+timeCreated: 1696737470

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/MonospaceStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/MonospaceStrategy.cs
@@ -1,0 +1,32 @@
+﻿using Logs;
+
+namespace Util.Independent.FluentRichText.Styles
+{
+	public class MonospaceStrategy: IStyleStrategy
+	{
+		private readonly string characterWidth;
+
+		public MonospaceStrategy(string characterWidth)
+		{
+			if (characterWidth.StartsWith("-"))
+			{
+				Loggy.LogError("RichText received a negative character width for monospace. This is not allowed.");
+				return;
+			}
+
+			if (CommonValidations.IsValidPixelValue(characterWidth) == false &&
+			    CommonValidations.IsValidFontUnitValue(characterWidth) == false)
+			{
+				Loggy.LogError($"RichText received an invalid character width for monospace: {characterWidth}");
+				return;
+			}
+
+			this.characterWidth = characterWidth;
+		}
+
+		public string ApplyStyle(string text)
+		{
+			return string.IsNullOrWhiteSpace(characterWidth) ? text : $"<mspace={characterWidth}>{text}</mspace>";
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/MonospaceStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/MonospaceStrategy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a2b028ece7e1497db6c3a565f27bbec9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/NoParseStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/NoParseStrategy.cs
@@ -1,0 +1,7 @@
+﻿namespace Util.Independent.FluentRichText.Styles
+{
+	public class NoParseStrategy: IStyleStrategy
+	{
+		public string ApplyStyle(string text) => $"<noparse>{text}</noparse>";
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/NoParseStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/NoParseStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0e1128e8d6074a2e9ba8b236b4184014
+timeCreated: 1696738386

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/NonBreakingSpacesStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/NonBreakingSpacesStrategy.cs
@@ -1,0 +1,7 @@
+﻿namespace Util.Independent.FluentRichText.Styles
+{
+	public class NonBreakingSpacesStrategy: IStyleStrategy
+	{
+		public string ApplyStyle(string text) => $"<nobr>{text}</nobr>";
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/NonBreakingSpacesStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/NonBreakingSpacesStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b2d5dc8c6b0d4c4c9316cd28e065ccd9
+timeCreated: 1696739249

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/SmallCapsStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/SmallCapsStrategy.cs
@@ -1,0 +1,7 @@
+﻿namespace Util.Independent.FluentRichText.Styles
+{
+	public class SmallCapsStrategy : IStyleStrategy
+	{
+		public string ApplyStyle(string text) => $"<smallcaps>{text}</smallcaps>";
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/SmallCapsStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/SmallCapsStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 031cf3200e0b48a887d4e7fdda501102
+timeCreated: 1696737427

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/SpaceStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/SpaceStrategy.cs
@@ -1,0 +1,27 @@
+﻿using Logs;
+
+namespace Util.Independent.FluentRichText.Styles
+{
+	public class SpaceStrategy: IStyleStrategy
+	{
+		private readonly string amount;
+
+		public SpaceStrategy(string amount)
+		{
+			if (CommonValidations.IsValidPixelValue(amount) == false &&
+			    CommonValidations.IsValidFontUnitValue(amount) == false &&
+			    CommonValidations.IsValidPercentageValue(amount) == false)
+			{
+				Loggy.LogError($"RichText received invalid space amount value: {amount}");
+				return;
+			}
+
+			this.amount = amount;
+		}
+
+		public string ApplyStyle(string text)
+		{
+			return string.IsNullOrEmpty(amount) ? text : $"{text}<space={amount}>";
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/SpaceStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/SpaceStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5fcce6f369ad4a60a6efa20a6d0b54d3
+timeCreated: 1697053737

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/SpacingStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/SpacingStrategy.cs
@@ -1,0 +1,28 @@
+﻿using Logs;
+
+namespace Util.Independent.FluentRichText.Styles
+{
+	public class SpacingStrategy : IStyleStrategy
+	{
+		private readonly string spacing;
+
+		public SpacingStrategy(string spacing)
+		{
+			if (CommonValidations.IsValidPixelValue(spacing) == false &&
+			    CommonValidations.IsValidFontUnitValue(spacing) == false)
+			{
+				Loggy.LogError(
+					$"RichText received invalid spacing: {spacing}. Spacing must be a pixel value (e.g., \"1\", \"2.5\") or a font unit value (e.g., \"1em\", \"-0.5em\").");
+				this.spacing = null;
+				return;
+			}
+
+			this.spacing = spacing;
+		}
+
+		public string ApplyStyle(string text)
+		{
+			return string.IsNullOrEmpty(spacing) ? text : $"<cspace={spacing}>{text}</cspace>";
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/SpacingStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/SpacingStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: affb4ba4efc146ffb5fae9941bbbc64f
+timeCreated: 1696736930

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/SpriteStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/SpriteStrategy.cs
@@ -1,0 +1,102 @@
+﻿using System.Text;
+using JetBrains.Annotations;
+using Logs;
+
+namespace Util.Independent.FluentRichText.Styles
+{
+	public class SpriteStrategy: IStyleStrategy
+	{
+		[CanBeNull] private readonly string atlas;
+		private readonly int? index;
+		[CanBeNull] private readonly string name;
+
+		/// <summary>
+		/// The instance has index value or name value, but not both.
+		/// </summary>
+		private bool HasValidParameters => index.HasValue ^ string.IsNullOrEmpty(name) == false;
+
+		private bool HasAtlas => string.IsNullOrEmpty(atlas) == false;
+
+		/// <summary>
+		/// Sprite from default atlas by index position
+		/// </summary>
+		/// <param name="index"></param>
+		public SpriteStrategy(int index)
+		{
+			if (index < 0)
+			{
+				Loggy.LogError("Rich text sprite index must be greater than or equal to 0.");
+				return;
+			}
+
+			this.index = index;
+		}
+
+		/// <summary>
+		/// Sprite from default atlas by name
+		/// </summary>
+		/// <param name="name"></param>
+		public SpriteStrategy(string name)
+		{
+			this.name = name;
+		}
+
+		/// <summary>
+		/// Sprite from custom atlas by index
+		/// </summary>
+		/// <param name="atlas"></param>
+		/// <param name="index"></param>
+		public SpriteStrategy(string atlas, int index)
+		{
+			if (index < 0)
+			{
+				Loggy.LogError("Rich text sprite index must be greater than or equal to 0.");
+				return;
+			}
+
+			this.atlas = atlas;
+			this.index = index;
+		}
+
+		/// <summary>
+		/// Sprite from custom atlas by name
+		/// </summary>
+		/// <param name="atlas"></param>
+		/// <param name="name"></param>
+		public SpriteStrategy(string atlas, string name)
+		{
+			this.atlas = atlas;
+			this.name = name;
+		}
+
+		public string ApplyStyle(string text)
+		{
+			if (HasValidParameters == false)
+			{
+				Loggy.LogError("Rich text sprite must have either an index or a name, not both.");
+				return text;
+			}
+
+			StringBuilder sb = new($"{text}<sprite");
+
+			// Append atlas if present
+			if (HasAtlas)
+			{
+				sb.Append($"=\"{atlas}\"");
+			}
+
+			// Decide between index and name
+			if (index.HasValue)
+			{
+				sb.Append(HasAtlas ? $" index={index}" : $"={index}");
+			}
+			else if (string.IsNullOrEmpty(name) == false)
+			{
+				sb.Append($" name=\"{name}\"");
+			}
+
+			sb.Append(">");
+			return sb.ToString();
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/SpriteStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/SpriteStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4035ae22079941f78bf3c41307755b92
+timeCreated: 1697054671

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/StrikethroughStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/StrikethroughStrategy.cs
@@ -1,0 +1,7 @@
+﻿namespace Util.Independent.FluentRichText.Styles
+{
+	public class StrikethroughStrategy: IStyleStrategy
+	{
+		public string ApplyStyle(string text) => $"<s>{text}</s>";
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/StrikethroughStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/StrikethroughStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 28ab1b47262e42d0995af1fca0bbbc04
+timeCreated: 1697057091

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/SubscriptStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/SubscriptStrategy.cs
@@ -1,0 +1,7 @@
+﻿namespace Util.Independent.FluentRichText.Styles
+{
+	public class SubscriptStrategy: IStyleStrategy
+	{
+		public string ApplyStyle(string text) => $"<sub>{text}</sub>";
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/SubscriptStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/SubscriptStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1e06e8198169469398278b19ce3bb05b
+timeCreated: 1697058434

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/SuperscriptStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/SuperscriptStrategy.cs
@@ -1,0 +1,7 @@
+﻿namespace Util.Independent.FluentRichText.Styles
+{
+	public class SuperscriptStrategy: IStyleStrategy
+	{
+		public string ApplyStyle(string text) => $"<sup>{text}</sup>";
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/SuperscriptStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/SuperscriptStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f870c18cd2784e249a4ec035db39a820
+timeCreated: 1697059627

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/UnderlineStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/UnderlineStrategy.cs
@@ -1,0 +1,7 @@
+﻿namespace Util.Independent.FluentRichText.Styles
+{
+	public class UnderlineStrategy: IStyleStrategy
+	{
+		public string ApplyStyle(string text) => $"<u>{text}</u>";
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/UnderlineStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/UnderlineStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b72d90773c3f4d78946a668b6d931df0
+timeCreated: 1697057402

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/UpperCaseStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/UpperCaseStrategy.cs
@@ -1,0 +1,7 @@
+﻿namespace Util.Independent.FluentRichText.Styles
+{
+	public class UpperCaseStrategy : IStyleStrategy
+	{
+		public string ApplyStyle(string text) => $"<uppercase>{text}</uppercase>";
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/UpperCaseStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/UpperCaseStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 39acd688423c46dc989a4e0d07092ca1
+timeCreated: 1696737409

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/VerticalOffsetStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/VerticalOffsetStrategy.cs
@@ -1,0 +1,27 @@
+﻿using Logs;
+
+namespace Util.Independent.FluentRichText.Styles
+{
+	public class VerticalOffsetStrategy: IStyleStrategy
+	{
+		private readonly string amount;
+
+		public VerticalOffsetStrategy(string amount)
+		{
+			if (CommonValidations.IsValidPixelValue(amount) == false &&
+			    CommonValidations.IsValidFontUnitValue(amount) == false &&
+			    CommonValidations.IsValidPercentageValue(amount) == false)
+			{
+				Loggy.LogError($"RichText received invalid vertical offset amount: {amount}");
+				return;
+			}
+
+			this.amount = amount;
+		}
+
+		public string ApplyStyle(string text)
+		{
+			return string.IsNullOrEmpty(amount) ? text : $"<voffset={amount}>{text}</voffset>";
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/VerticalOffsetStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/VerticalOffsetStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2c021da72bec47999f66be2b612807e9
+timeCreated: 1697061811

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/WidthStrategy.cs
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/WidthStrategy.cs
@@ -1,0 +1,27 @@
+﻿using Logs;
+
+namespace Util.Independent.FluentRichText.Styles
+{
+	public class WidthStrategy: IStyleStrategy
+	{
+		private readonly string amount;
+
+		public WidthStrategy(string amount)
+		{
+			if (CommonValidations.IsValidPixelValue(amount) == false &&
+			    CommonValidations.IsValidFontUnitValue(amount) == false &&
+			    CommonValidations.IsValidPercentageValue(amount) == false)
+			{
+				Loggy.LogError($"RichText received invalid width amount: {amount}");
+				return;
+			}
+
+			this.amount = amount;
+		}
+
+		public string ApplyStyle(string text)
+		{
+			return string.IsNullOrEmpty(amount) ? text : $"<width={amount}>{text}</width>";
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/WidthStrategy.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/Independent/FluentRichText/Styles/WidthStrategy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cbf2b11e249a4d5da02bdd9b8346a123
+timeCreated: 1697062442

--- a/UnityProject/Assets/Scripts/Util/Independent/Utils.asmdef
+++ b/UnityProject/Assets/Scripts/Util/Independent/Utils.asmdef
@@ -1,3 +1,16 @@
-﻿{
-	"name": "Utils"
+{
+    "name": "Utils",
+    "rootNamespace": "",
+    "references": [
+        "GUID:7c9a27d2b43f1ac479d159329c7eb9e6"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/UnityProject/Assets/Tests/RichTextTests.meta
+++ b/UnityProject/Assets/Tests/RichTextTests.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9d960b8b9633447a91d9d66232090ff6
+timeCreated: 1696531266

--- a/UnityProject/Assets/Tests/RichTextTests/StylesTests.cs
+++ b/UnityProject/Assets/Tests/RichTextTests/StylesTests.cs
@@ -1,0 +1,595 @@
+﻿using System;
+using NUnit.Framework;
+using Shouldly;
+using UnityEngine.TestTools;
+using Util.Independent.FluentRichText;
+using Util.Independent.FluentRichText.Styles;
+
+namespace Tests.RichTextTests
+{
+	public class StylesTests
+	{
+		[Test]
+		[TestCase(Alignment.Left)]
+		[TestCase(Alignment.Center)]
+		[TestCase(Alignment.Right)]
+		public void AlignStrategyReturnsAlignedText(Alignment alignment)
+		{
+			AlignStrategy strategy = new(alignment);
+			const string text = "text";
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<align=\"{alignment}\">{text}</align>");
+		}
+
+		[Test]
+		public void BoldStrategyReturnsBoldText()
+		{
+			BoldStrategy strategy = new();
+			const string text = "text";
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<b>{text}</b>");
+		}
+
+		[Test]
+		public void ItalicStrategyReturnsItalicText()
+		{
+			ItalicStrategy strategy = new();
+			const string text = "text";
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<i>{text}</i>");
+		}
+
+		[Test]
+		public void FontStrategyReturnsTextWithFontName()
+		{
+			const string text = "text";
+			const string font = "Arial";
+			FontStrategy strategy = new(font);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<font=\"{font}\">{text}</font>");
+		}
+
+		[Test]
+		[TestCase("1")]
+		[TestCase("2.5")]
+		[TestCase("1em")]
+		[TestCase("-0.5em")]
+		public void ValidSpacingShouldReturnSpacedText(string validSpacing)
+		{
+			SpacingStrategy strategy = new(validSpacing);
+			const string text = "text";
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<cspace={validSpacing}>{text}</cspace>");
+		}
+
+		[Test]
+		[TestCase("1.0.0")]
+		[TestCase("not a number")]
+		[TestCase("1.0.0em")]
+		public void InvalidSpacingShouldReturnUnmodifiedText(string invalidSpacing)
+		{
+			LogAssert.ignoreFailingMessages = true;
+			SpacingStrategy strategy = new(invalidSpacing);
+			const string text = "text";
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe(text);
+		}
+
+		[Test]
+		[TestCase(0)]
+		[TestCase(1)]
+		[TestCase(99)]
+		[TestCase(100)]
+		public void ValidAlphaShouldReturnTextWithAlpha(int validAlpha)
+		{
+			const string text = "text";
+			AlphaStrategy strategy = new(validAlpha);
+			string actual = strategy.ApplyStyle(text);
+			int alphaValue = (int)Math.Round(255 * (validAlpha / 100.0), MidpointRounding.AwayFromZero);
+			actual.ShouldBe($"<alpha=#{alphaValue:X2}>{text}</alpha>");
+		}
+
+		[Test]
+		[TestCase(-1)]
+		[TestCase(101)]
+		public void InvalidAlphaShouldReturnUnmodifiedText(int invalidAlpha)
+		{
+			LogAssert.ignoreFailingMessages = true;
+			const string text = "text";
+			AlphaStrategy strategy = new(invalidAlpha);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe(text);
+		}
+
+		[Test]
+		[TestCase(Color.Black)]
+		[TestCase(Color.Blue)]
+		[TestCase(Color.Green)]
+		[TestCase(Color.Red)]
+		[TestCase(Color.Orange)]
+		[TestCase(Color.Purple)]
+		[TestCase(Color.White)]
+		[TestCase(Color.Yellow)]
+		public void NamedColorShouldReturnColoredText(Color namedColor)
+		{
+			const string text = "text";
+			ColorStrategy strategy = new(namedColor);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<color=\"{namedColor.ToString().ToLower()}\">{text}</color>");
+		}
+
+		[Test]
+		[TestCase("#FF000088")]
+		[TestCase("#005500")]
+		[TestCase("#000000")]
+		public void ValidHexColorShouldReturnColoredText(string validHexColor)
+		{
+			const string text = "text";
+			ColorStrategy strategy = new(validHexColor);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<color={validHexColor}>{text}</color>");
+		}
+
+		[Test]
+		[TestCase("not a color")]
+		[TestCase("FF0000")]
+		[TestCase("#FF0000F")]
+		public void InvalidHexColorShouldReturnUnmodifiedText(string invalidHexColor)
+		{
+			LogAssert.ignoreFailingMessages = true;
+			const string text = "text";
+			ColorStrategy strategy = new(invalidHexColor);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe(text);
+		}
+
+		[Test]
+		[TestCase("1")]
+		[TestCase("2.5")]
+		[TestCase("1em")]
+		[TestCase("-0.5em")]
+		[TestCase("15%")]
+		public void ValidIndentShouldReturnIndentedText(string validIndent)
+		{
+			const string text = "text";
+			IndentStrategy strategy = new(validIndent);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<indent={validIndent}>{text}</indent>");
+		}
+
+		[Test]
+		[TestCase("not a number")]
+		[TestCase("1.0.0")]
+		[TestCase("1.0.0em")]
+		[TestCase("%15")]
+		public void InvalidIndentShouldReturnUnmodifiedText(string invalidIndent)
+		{
+			LogAssert.ignoreFailingMessages = true;
+			const string text = "text";
+			IndentStrategy strategy = new(invalidIndent);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe(text);
+		}
+
+		[Test]
+		[TestCase("1")]
+		[TestCase("2.5")]
+		[TestCase("1em")]
+		[TestCase("-0.5em")]
+		[TestCase("15%")]
+		public void ValidLineHeightShouldReturnTextWithLineHeight(string validLineHeight)
+		{
+			const string text = "text";
+			LineHeightStrategy strategy = new(validLineHeight);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<line-height={validLineHeight}>{text}</line-height>");
+		}
+
+		[Test]
+		[TestCase("not a number")]
+		[TestCase("1.0.0")]
+		[TestCase("1.0.0em")]
+		[TestCase("%15")]
+		public void InvalidLineHeightShouldReturnUnmodifiedText(string invalidLineHeight)
+		{
+			LogAssert.ignoreFailingMessages = true;
+			const string text = "text";
+			LineHeightStrategy strategy = new(invalidLineHeight);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe(text);
+		}
+
+		[Test]
+		[TestCase("1")]
+		[TestCase("2.5")]
+		[TestCase("1em")]
+		[TestCase("-0.5em")]
+		[TestCase("15%")]
+		public void ValidLineIndentationReturnsIndentedText(string validLineIndentation)
+		{
+			const string text = "text";
+			LineIndentationStrategy strategy = new(validLineIndentation);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<line-indentation={validLineIndentation}>{text}</line-indentation>");
+		}
+
+		[Test]
+		[TestCase("not a number")]
+		[TestCase("1.0.0")]
+		[TestCase("1.0.0em")]
+		[TestCase("%15")]
+		public void InvalidLineIndentationShouldReturnUnmodifiedText(string invalidLineIndentation)
+		{
+			LogAssert.ignoreFailingMessages = true;
+			const string text = "text";
+			LineIndentationStrategy strategy = new(invalidLineIndentation);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe(text);
+		}
+
+		[Test]
+		public void LinkShouldReturnTextWithLink()
+		{
+			const string text = "text";
+			const string url = "https://www.google.com";
+			LinkStrategy strategy = new(url);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<link=\"{url}\">{text}</link>");
+		}
+
+		[Test]
+		public void LowerCaseShouldReturnTextInLowerCase()
+		{
+			const string text = "TEXT";
+			LowerCaseStrategy strategy = new();
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<lowercase>{text}</lowercase>");
+		}
+
+		[Test]
+		public void UpperCaseShouldReturnTextInUpperCase()
+		{
+			const string text = "text";
+			UpperCaseStrategy strategy = new();
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<uppercase>{text}</uppercase>");
+		}
+
+		[Test]
+		public void SmallCapsShouldReturnTextInSmallCaps()
+		{
+			const string text = "text";
+			SmallCapsStrategy strategy = new();
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<smallcaps>{text}</smallcaps>");
+		}
+
+		[Test]
+		[TestCase("1")]
+		[TestCase("2.5")]
+		[TestCase("1em")]
+		[TestCase("-0.5em")]
+		[TestCase("15%")]
+		public void ValidMarginShouldReturnTextWithMargin(string validMargin)
+		{
+			const string text = "text";
+			MarginStrategy strategy = new(validMargin);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<margin={validMargin}>{text}</margin>");
+		}
+
+		[Test]
+		[TestCase("not a number")]
+		[TestCase("1.0.0")]
+		[TestCase("1.0.0em")]
+		[TestCase("%15")]
+		public void InvalidMarginShouldReturnUnmodifiedText(string invalidMargin)
+		{
+			LogAssert.ignoreFailingMessages = true;
+			const string text = "text";
+			MarginStrategy strategy = new(invalidMargin);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe(text);
+		}
+
+		[Test]
+		[TestCase(MarginDirection.Right)]
+		[TestCase(MarginDirection.Left)]
+		public void MarginWithDirectionShouldReturnTextWithMargin(MarginDirection direction)
+		{
+			const string text = "text";
+			const string validMargin = "15%";
+			MarginStrategy strategy = new(validMargin, direction);
+			string actual = strategy.ApplyStyle(text);
+			string stringDirection = direction.ToString().ToLower();
+			actual.ShouldBe($"<margin-{stringDirection}={validMargin}>{text}</margin-{stringDirection}>");
+		}
+
+		[Test]
+		public void MarginWithAllDirectionReturnsTextWithMargin()
+		{
+			const string text = "text";
+			const string validMargin = "15%";
+			MarginStrategy strategy = new(validMargin, MarginDirection.All);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<margin={validMargin}>{text}</margin>");
+		}
+
+		[Test]
+		[TestCase("#FF000088")]
+		[TestCase("#005500")]
+		[TestCase("#000000")]
+		public void ValidMarkColorReturnsMarkedText(string hexColor)
+		{
+			const string text = "text";
+			MarkStrategy strategy = new(hexColor);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<mark={hexColor}>{text}</mark>");
+		}
+
+		[Test]
+		[TestCase("1")]
+		[TestCase("2.5")]
+		[TestCase("1em")]
+		public void ValidCharacterWidthReturnsMonospacedText(string validCharacterWidth)
+		{
+			const string text = "text";
+			MonospaceStrategy strategy = new(validCharacterWidth);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<mspace={validCharacterWidth}>{text}</mspace>");
+		}
+
+		[Test]
+		[TestCase("not a number")]
+		[TestCase("1.0.0")]
+		[TestCase("1.0.0em")]
+		[TestCase("15%")]
+		[TestCase("-1")]
+		public void InvalidCharacterWidthReturnsUnmodifiedText(string invalidCharacterWidth)
+		{
+			LogAssert.ignoreFailingMessages = true;
+			const string text = "text";
+			MonospaceStrategy strategy = new(invalidCharacterWidth);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe(text);
+		}
+
+		[Test]
+		public void NoParseShouldReturnNotParsedText()
+		{
+			const string text = "text";
+			NoParseStrategy strategy = new();
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<noparse>{text}</noparse>");
+		}
+
+		[Test]
+		public void NonBreakingSpacesShouldReturnWrappedText()
+		{
+			const string text = "text";
+			NonBreakingSpacesStrategy strategy = new();
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<nobr>{text}</nobr>");
+		}
+
+		[Test]
+		[TestCase("1")]
+		[TestCase("2.5")]
+		[TestCase("1em")]
+		[TestCase("10%")]
+		public void ValidHorizontalPositionReturnsPositionedText(string validPosition)
+		{
+			const string text = "text";
+			HorizontalPositionStrategy strategy = new(validPosition);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<pos={validPosition}>{text}</pos>");
+
+		}
+
+		[Test]
+		[TestCase("not a number")]
+		[TestCase("1.0.0")]
+		[TestCase("1.0.0em")]
+		[TestCase("%15")]
+		public void InvalidHorizontalPositionReturnsUnmodifiedText(string invalidPosition)
+		{
+			LogAssert.ignoreFailingMessages = true;
+			const string text = "text";
+			HorizontalPositionStrategy strategy = new(invalidPosition);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe(text);
+		}
+
+		[Test]
+		[TestCase("1")]
+		[TestCase("2.5")]
+		[TestCase("1em")]
+		[TestCase("10%")]
+		public void ValidFontSizeReturnsTextWithSize(string validFontSize)
+		{
+			LogAssert.ignoreFailingMessages = true;
+			const string text = "text";
+			FontSizeStrategy strategy = new(validFontSize);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<size={validFontSize}>{text}</size>");
+		}
+
+		[Test]
+		[TestCase("not a number")]
+		[TestCase("1.0.0")]
+		[TestCase("1.0.0em")]
+		[TestCase("%15")]
+		public void InvalidFontSizeReturnsUnmodifiedText(string invalidFontSize)
+		{
+			LogAssert.ignoreFailingMessages = true;
+			const string text = "text";
+			FontSizeStrategy strategy = new(invalidFontSize);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe(text);
+		}
+
+		[Test]
+		[TestCase("1")]
+		[TestCase("2.5")]
+		[TestCase("1em")]
+		[TestCase("10%")]
+		public void ValidSpaceAddsSpaceTag(string validSpace)
+		{
+			const string text = "text";
+			SpaceStrategy strategy = new(validSpace);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"{text}<space={validSpace}>");
+		}
+
+		[Test]
+		[TestCase("not a number")]
+		[TestCase("1.0.0")]
+		[TestCase("1.0.0em")]
+		[TestCase("%15")]
+		public void InvalidSpaceReturnsUnmodifiedText(string invalidSpace)
+		{
+			LogAssert.ignoreFailingMessages = true;
+			const string text = "text";
+			SpaceStrategy strategy = new(invalidSpace);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe(text);
+		}
+
+		[Test]
+		public void InsertingSpriteByIndexReturnsTextWithSpriteIndex()
+		{
+			SpriteStrategy spriteStrategy = new(1);
+			const string expected = "<sprite=1>";
+			string actual = spriteStrategy.ApplyStyle("");
+			actual.ShouldBe(expected);
+		}
+
+		[Test]
+		public void InsertingSpriteByNameFromDefaultAssetReturnsTextWithNamedSprite()
+		{
+			SpriteStrategy spriteStrategy = new("clown");
+			const string expected = "<sprite name=\"clown\">";
+			string actual = spriteStrategy.ApplyStyle("");
+			actual.ShouldBe(expected);
+		}
+
+		[Test]
+		public void InsertingSpriteFromAtlasWithIndexReturnsTextWithAtlasAndIndex()
+		{
+			SpriteStrategy spriteStrategy = new("atlas", 1);
+			const string expected = "<sprite=\"atlas\" index=1>";
+			string actual = spriteStrategy.ApplyStyle("");
+			actual.ShouldBe(expected);
+		}
+
+		[Test]
+		public void InsertingSpriteFromAtlasWithNameReturnsTextWIthAtlasAndNamedSprite()
+		{
+			SpriteStrategy spriteStrategy = new("atlas", "clown");
+			const string expected = "<sprite=\"atlas\" name=\"clown\">";
+			string actual = spriteStrategy.ApplyStyle("");
+			actual.ShouldBe(expected);
+		}
+
+		[Test]
+		public void StrikethroughReturnsTextWithStrikethrough()
+		{
+			StrikethroughStrategy strategy = new();
+			const string text = "text";
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<s>{text}</s>");
+		}
+
+		[Test]
+		public void UnderlineReturnsTextWithUnderline()
+		{
+			UnderlineStrategy strategy = new();
+			const string text = "text";
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<u>{text}</u>");
+		}
+
+		[Test]
+		public void CustomStyleReturnsStyledText()
+		{
+			const string text = "text";
+			const string style = "my-style";
+			CustomStyleStrategy strategy = new(style);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<style=\"my-style\">{text}</style>");
+		}
+
+		[Test]
+		public void SubscriptShouldReturnTextWithSubscript()
+		{
+			SubscriptStrategy strategy = new();
+			const string text = "text";
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<sub>{text}</sub>");
+		}
+
+		[Test]
+		public void SuperscriptShouldReturnTextWithSuperscript()
+		{
+			SuperscriptStrategy strategy = new();
+			const string text = "text";
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<sup>{text}</sup>");
+		}
+
+		[Test]
+		[TestCase("1")]
+		[TestCase("2.5")]
+		[TestCase("1em")]
+		[TestCase("10%")]
+		public void ValidVerticalOffsetShouldReturn(string amount)
+		{
+			const string text = "text";
+			VerticalOffsetStrategy strategy = new(amount);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<voffset={amount}>{text}</voffset>");
+		}
+
+		[Test]
+		[TestCase("not a number")]
+		[TestCase("1.0.0")]
+		[TestCase("1.0.0em")]
+		[TestCase("%15")]
+		public void InvalidVerticalOffsetShouldReturnUnmodifiedText(string invalidAmount)
+		{
+			LogAssert.ignoreFailingMessages = true;
+			const string text = "text";
+			VerticalOffsetStrategy strategy = new(invalidAmount);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe(text);
+		}
+
+		[Test]
+		[TestCase("1")]
+		[TestCase("2.5")]
+		[TestCase("1em")]
+		[TestCase("10%")]
+		public void ValidWidthShouldReturnTextWithWidth(string validWidth)
+		{
+			const string text = "text";
+			WidthStrategy strategy = new(validWidth);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe($"<width={validWidth}>{text}</width>");
+		}
+
+		[Test]
+		[TestCase("not a number")]
+		[TestCase("1.0.0")]
+		[TestCase("1.0.0em")]
+		[TestCase("%15")]
+		public void InvalidWidthShouldReturnUnmodifiedText(string invalidWidth)
+		{
+			LogAssert.ignoreFailingMessages = true;
+			const string text = "text";
+			WidthStrategy strategy = new(invalidWidth);
+			string actual = strategy.ApplyStyle(text);
+			actual.ShouldBe(text);
+		}
+
+	}
+}

--- a/UnityProject/Assets/Tests/RichTextTests/StylesTests.cs.meta
+++ b/UnityProject/Assets/Tests/RichTextTests/StylesTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3494ab7adcdb4aeb9e1cc80a51e5d730
+timeCreated: 1696662734

--- a/UnityProject/Assets/Tests/Tests.asmdef
+++ b/UnityProject/Assets/Tests/Tests.asmdef
@@ -14,7 +14,8 @@
         "NaughtyAttributes.Editor",
         "NaughtyAttributes.Core",
         "Shared",
-        "Permissions"
+        "Permissions",
+        "Utils"
     ],
     "includePlatforms": [
         "Editor"
@@ -23,7 +24,8 @@
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "nunit.framework.dll"
+        "nunit.framework.dll",
+        "Shouldly.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [

--- a/UnityProject/Assets/packages.config
+++ b/UnityProject/Assets/packages.config
@@ -1,4 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="DiffEngine" version="11.3.0" />
+  <package id="EmptyFiles" version="4.4.0" />
+  <package id="Shouldly" version="4.2.1" />
+  <package id="System.CodeDom" version="6.0.0" />
+  <package id="System.Management" version="6.0.1" />
   <package id="Tomlyn" version="0.16.2" />
 </packages>

--- a/UnityProject/Packages/manifest.json
+++ b/UnityProject/Packages/manifest.json
@@ -11,7 +11,7 @@
     "com.unity.2d.tilemap.extras": "4.0.1",
     "com.unity.addressables": "1.19.19",
     "com.unity.editorcoroutines": "1.0.0",
-    "com.unity.ide.rider": "3.0.24",
+    "com.unity.ide.rider": "3.0.25",
     "com.unity.ide.visualstudio": "2.0.20",
     "com.unity.memoryprofiler": "1.0.0",
     "com.unity.multiplayer.playmode": "0.1.1",

--- a/UnityProject/Packages/packages-lock.json
+++ b/UnityProject/Packages/packages-lock.json
@@ -83,34 +83,6 @@
       },
       "url": "https://packages.unity.com"
     },
-    "com.unity.ai.navigation": {
-      "version": "1.1.4",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.modules.ai": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.burst": {
-      "version": "1.8.7",
-      "depth": 2,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.mathematics": "1.2.1"
-      },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.collections": {
-      "version": "1.2.4",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.burst": "1.6.6",
-        "com.unity.test-framework": "1.1.31"
-      },
-      "url": "https://packages.unity.com"
-    },
     "com.unity.editorcoroutines": {
       "version": "1.0.0",
       "depth": 0,
@@ -126,7 +98,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.24",
+      "version": "3.0.25",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -141,13 +113,6 @@
       "dependencies": {
         "com.unity.test-framework": "1.1.9"
       },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.mathematics": {
-      "version": "1.2.6",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.memoryprofiler": {
@@ -167,26 +132,6 @@
         "nuget.moq": "1.0.0",
         "com.unity.nuget.newtonsoft-json": "2.0.2"
       },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.multiplayer.tools": {
-      "version": "1.1.0",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.profiling.core": "1.0.0-pre.1",
-        "com.unity.nuget.newtonsoft-json": "2.0.0",
-        "com.unity.nuget.mono-cecil": "1.10.1",
-        "com.unity.collections": "1.1.0",
-        "com.unity.modules.uielements": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.nuget.mono-cecil": {
-      "version": "1.11.4",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.nuget.newtonsoft-json": {
@@ -210,13 +155,6 @@
       "dependencies": {
         "com.unity.modules.physics": "1.0.0"
       },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.profiling.core": {
-      "version": "1.0.2",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.scriptablebuildpipeline": {
@@ -297,16 +235,6 @@
         "com.unity.modules.unitywebrequest": "1.0.0",
         "com.unity.modules.unitywebrequesttexture": "1.0.0",
         "com.unity.modules.unitywebrequestwww": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.visualscripting": {
-      "version": "1.8.0",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.ugui": "1.0.0",
-        "com.unity.modules.jsonserialize": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },


### PR DESCRIPTION
### Purpose
When merged this PR will add the ``RichText`` utility class that will hopefully aid developers when doing fancy text with TMP.

Usage example:

```cs
RichText myText = new()
	.Size(40).Color(Color.Red).Center()
	.ApplyTo("Captain Announcement")
	.AddOnNewLine("Vital announcement for ")
	.Bold().ApplyTo("ALL CREWMEMBERS").Append(".");
```

And it would produce: 
```
<size=40><color="red"><align="center">Captain Announcement</align></color</size>
Vital announcement for <b>ALL CREWMEMBERS</b>.
```

Since ``RichText`` is implicity converted to string, you can use your instance anywhere it takes an string as argument, like the chat API for example.
	
The entire TMP api has been implemented with the following exceptions:
- Sprite is partially implemented. It is missing the tint and color optional properties.
- Page break doesn't have an example of usage, which makes it hard to know how to implement it.

