### PR TITLE
Fixes soap not being accepted in janitor toolbelts

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Belts/JanibeltCapacity.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Belts/JanibeltCapacity.asset
@@ -21,5 +21,6 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 3bc88a6fd0eb5cd49a3295a04e1ca62d, type: 2}
   - {fileID: 11400000, guid: 6bbea9c4e0a1b4840bde0835b8db0b2a, type: 2}
   - {fileID: 11400000, guid: de743c06b981846cb8d8457970385934, type: 2}
+  - {fileID: 11400000, guid: 8a70d98a964167745acd6533f6dbd8cf, type: 2}
   Required: []
   Blacklist: []


### PR DESCRIPTION

CL: [Fix] Fixed an issue with toolbelts that caused it to refuse accepting soap items when they already spawn with one.