### PR TITLE
Faiths - Part 3

### DIFF
--- a/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
+++ b/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
@@ -481,6 +481,7 @@ GameObject:
   - component: {fileID: 5754329967401393357}
   - component: {fileID: 4201909151401612127}
   - component: {fileID: 5323151696653614753}
+  - component: {fileID: 6182295504772674896}
   m_Layer: 8
   m_Name: Player_V4(uNet)
   m_TagString: Untagged
@@ -592,6 +593,7 @@ MonoBehaviour:
   playerName: ' '
   visibleName: ' '
   PlayerSync: {fileID: 0}
+  <PlayerFaith>k__BackingField: {fileID: 6182295504772674896}
   RTT: 0
   RcsMode: 0
   RcsMatrixMove: {fileID: 0}
@@ -1488,6 +1490,8 @@ MonoBehaviour:
   CrawlSpeed: 0
   needsWalking: {fileID: 11400000, guid: 06d78d19774fe204489d635ddb501f83, type: 2}
   needsRunning: {fileID: 11400000, guid: 79263d379ff044244a9baa143471a268, type: 2}
+  CachedPreviousMove: {x: 0, y: 0}
+  CachedMove: {x: 0, y: 0}
   actionData: {fileID: 11400000, guid: 967a13d2ea206e9448f6c6e2af11a3cf, type: 2}
   IsBumping: 0
 --- !u!114 &3901833431230868314
@@ -1730,6 +1734,22 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   scaleTransform: {x: 1, y: 1, z: 1}
+--- !u!114 &6182295504772674896
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1133514949248654}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 82def04b61e1483f8a1f4032486d0d97, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0.1
+  player: {fileID: 114617133355526680}
 --- !u!1 &1147423205297840
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scenes/ActiveScenes/Lobby.unity
+++ b/UnityProject/Assets/Scenes/ActiveScenes/Lobby.unity
@@ -354,6 +354,36 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 252153304076729325, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 252153304076729325, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 252153304076729325, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 252153304076729325, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 252153304076729325, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 252153304076729325, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 604346653308370519, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchorMax.x
@@ -439,6 +469,26 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -45.65
       objectReference: {fileID: 0}
+    - target: {fileID: 992538979044950145, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 992538979044950145, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 992538979044950145, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 992538979044950145, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1031530482342011089, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -485,6 +535,26 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1074479757314985835, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1082554281695473575, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1082554281695473575, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1082554281695473575, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1082554281695473575, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
@@ -634,6 +704,26 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -45.65
       objectReference: {fileID: 0}
+    - target: {fileID: 1878025610426000139, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1878025610426000139, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1878025610426000139, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1878025610426000139, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1988014472101492628, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -759,6 +849,26 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2970664891730648836, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2970664891730648836, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2970664891730648836, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2970664891730648836, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3034338390223825030, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -819,6 +929,26 @@ PrefabInstance:
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3176504860838396169, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3176504860838396169, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3176504860838396169, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3176504860838396169, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3296864213575753617, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -858,6 +988,36 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -45.65
+      objectReference: {fileID: 0}
+    - target: {fileID: 3662905105139174173, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3662905105139174173, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3672752177168391779, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3672752177168391779, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3672752177168391779, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3672752177168391779, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3696942991969360864, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
@@ -898,6 +1058,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -45.65
+      objectReference: {fileID: 0}
+    - target: {fileID: 4147125179588738938, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4147125179588738938, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4199685495035560006, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
@@ -1064,6 +1234,16 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5013526283225713844, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5013526283225713844, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5152818265451557039, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -1134,6 +1314,21 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -45.65
       objectReference: {fileID: 0}
+    - target: {fileID: 5566628679138717838, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5566628679138717838, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5566628679138717838, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5621985496395139001, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_SizeDelta.x
@@ -1184,6 +1379,26 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -45.65
       objectReference: {fileID: 0}
+    - target: {fileID: 5747882439573765586, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5747882439573765586, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5747882439573765586, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5747882439573765586, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5813106762567308439, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -1239,6 +1454,51 @@ PrefabInstance:
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6048442913564239499, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6048442913564239499, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6071882965284253461, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6071882965284253461, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6071882965284253461, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6071882965284253461, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6074955334508597406, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6074955334508597406, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6074955334508597406, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6222646843013961890, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -1262,6 +1522,16 @@ PrefabInstance:
     - target: {fileID: 6222646843013961890, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6302189356873220767, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6302189356873220767, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6436963250147515523, guid: 829f4ca992b848d6bb4d007fb9c112e1,
@@ -1414,6 +1684,26 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -45.65
       objectReference: {fileID: 0}
+    - target: {fileID: 6938441099956916736, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6938441099956916736, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6938441099956916736, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6938441099956916736, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7343168600905245221, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -1462,6 +1752,21 @@ PrefabInstance:
     - target: {fileID: 7750728929600624244, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7804995832386823833, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7804995832386823833, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7804995832386823833, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8033701211907213671, guid: 829f4ca992b848d6bb4d007fb9c112e1,
@@ -1573,6 +1878,26 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -45.65
+      objectReference: {fileID: 0}
+    - target: {fileID: 8219930580886435770, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8219930580886435770, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8219930580886435770, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8219930580886435770, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8281039574217415454, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
@@ -1649,6 +1974,36 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8746595423935741167, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8746595423935741167, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8746595423935741167, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8746595423935741167, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8776496734455370650, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8776496734455370650, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8800622826614355687, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -1717,6 +2072,16 @@ PrefabInstance:
     - target: {fileID: 8920117486637346770, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9164456083301456429, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9164456083301456429, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []

--- a/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
@@ -1301,8 +1301,11 @@ namespace AdminCommands
 		public void CmdFreeFaithPoints(NetworkConnectionToClient conn = null)
 		{
 			if (IsAdmin(conn, out var player) == false) return;
-			FaithManager.AwardPoints(500);
-			Chat.AddGameWideSystemMsgToChat("<color=blue>An admin has given the current faith 500 points</color>");
+			foreach (var faith in FaithManager.Instance.CurrentFaiths)
+			{
+				FaithManager.AwardPoints(500, faith.Faith.FaithName);
+				Chat.AddGameWideSystemMsgToChat($"<color=blue>An admin has given the '{faith.Faith.FaithName}' faith 500 points</color>");
+			}
 		}
 
 		#endregion

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -1049,25 +1049,4 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		playerScript.playerMove.ResetEverything();
 		playerScript.playerMove.ResetLocationOnClients();
 	}
-
-	[Command]
-	public void CmdJoinFaith(string faith)
-	{
-		playerScript.JoinReligion(faith);
-	}
-
-	[Command]
-	public void CmdSetMainFaith()
-	{
-		if (FaithManager.Instance.FaithLeaders.Contains(playerScript) == false) return;
-		FaithManager.Instance.SetMainFaith(playerScript.CurrentFaith);
-		FaithManager.Instance.FaithMembers.Add(playerScript);
-	}
-
-	
-	[TargetRpc]
-	public void RpcShowFaithSelectScreen(NetworkConnection target)
-	{
-		UIManager.Instance.ChaplainFirstTimeSelectScreen.gameObject.SetActive(true);
-	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Faith/FaithData.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/FaithData.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+
+namespace Systems.Faith
+{
+	public class FaithData
+	{
+		public Faith Faith { get; set; }
+		public int Points { get; set; }
+		public List<PlayerScript> FaithMembers { get; set; }
+		public List<PlayerScript> FaithLeaders { get; set; }
+
+		public void AddMember(PlayerScript newMember)
+		{
+			RemoveMember(newMember);
+			FaithMembers.Add(newMember);
+			foreach (var property in Faith.FaithProperties)
+			{
+				property.OnJoinFaith(newMember);
+			}
+		}
+
+		public void RemoveMember(PlayerScript member)
+		{
+			FaithMembers.Remove(member);
+			foreach (var property in Faith.FaithProperties)
+			{
+				property.OnLeaveFaith(member);
+			}
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/Faith/FaithData.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/Faith/FaithData.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0b59a14e987747b9899eb35356df7a69
+timeCreated: 1699206042

--- a/UnityProject/Assets/Scripts/Systems/Faith/FaithProperties/Darkness.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/FaithProperties/Darkness.cs
@@ -31,14 +31,17 @@ namespace Systems.Faith.FaithProperties
 			set => propertyIcon = value;
 		}
 
-		public void Setup()
+		public FaithData AssociatedFaith { get; set; }
+
+		public void Setup(FaithData associatedFaith)
 		{
 			FaithManager.Instance.FaithPropertiesEventUpdate.Add(CheckNearbyLights);
+			AssociatedFaith = associatedFaith;
 		}
 
 		private void CheckNearbyLights()
 		{
-			foreach (var member in FaithManager.Instance.FaithMembers)
+			foreach (var member in AssociatedFaith.FaithMembers)
 			{
 				if (member.IsDeadOrGhost) continue;
 				var overlapBox = Physics2D.OverlapBoxAll(member.gameObject.AssumedWorldPosServer(), new Vector2(6, 6), 0);
@@ -52,18 +55,18 @@ namespace Systems.Faith.FaithProperties
 					{
 						if (lightSource.CurrentOnColor.a <= minimumAlphaForDarkness)
 						{
-							FaithManager.AwardPoints(15);
+							FaithManager.AwardPoints(15, AssociatedFaith.Faith.FaithName);
 							if(Application.isEditor) Loggy.Log("Awarded points for having low darkness value.");
 							continue;
 						}
 						else
 						{
-							FaithManager.TakePoints(25);
+							FaithManager.TakePoints(25, AssociatedFaith.Faith.FaithName);
 							Chat.AddExamineMsg(member.GameObject, $"The nearby {collider.gameObject.ExpensiveName()} is too bright..");
 							continue;
 						}
 					}
-					FaithManager.AwardPoints(25);
+					FaithManager.AwardPoints(25, AssociatedFaith.Faith.FaithName);
 				}
 			}
 		}

--- a/UnityProject/Assets/Scripts/Systems/Faith/FaithProperties/Gluttony.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/FaithProperties/Gluttony.cs
@@ -30,39 +30,42 @@ namespace Systems.Faith.FaithProperties
 			set => propertyIcon = value;
 		}
 
+		public FaithData AssociatedFaith { get; set; }
+
 		[SerializeField] private Sickness starvationSickness;
 		[SerializeField] private Sprite propertyIcon;
 
-		public void Setup()
+		public void Setup(FaithData associatedFaith)
 		{
 			FaithManager.Instance.FaithPropertiesEventUpdate.Add(CheckHungerLevels);
+			AssociatedFaith = associatedFaith;
 		}
 
 		private void CheckHungerLevels()
 		{
-			foreach (var member in FaithManager.Instance.FaithMembers)
+			foreach (var member in AssociatedFaith.FaithMembers)
 			{
 				if (member.playerHealth.TryGetSystem<HungerSystem>(out var hungerSystem) == false) return;
 				switch (hungerSystem.CashedHungerState)
 				{
 					case HungerState.Full:
 						Chat.AddExamineMsg(member.gameObject, "<color=green>My belly is full! I'm quite happy.</color>");
-						FaithManager.AwardPoints(25);
+						FaithManager.AwardPoints(25, AssociatedFaith.Faith.FaithName);
 						break;
 					case HungerState.Normal:
 						Chat.AddExamineMsg(member.gameObject, "I feel like I can grab a bite or two..");
 						break;
 					case HungerState.Hungry:
 						Chat.AddExamineMsg(member.gameObject, "<i><color=yellow>I haven't ate anything in a while! I need to find something with high fat!</color></i>");
-						FaithManager.TakePoints(10);
+						FaithManager.TakePoints(10, AssociatedFaith.Faith.FaithName);
 						break;
 					case HungerState.Malnourished:
 						Chat.AddExamineMsg(member.gameObject, "<i><color=yellow><size+=9>I must consume something! Anything!</size></color></i>");
-						FaithManager.TakePoints(25);
+						FaithManager.TakePoints(25, AssociatedFaith.Faith.FaithName);
 						break;
 					case HungerState.Starving:
 						Chat.AddExamineMsg(member.gameObject, "<i><color=red><size+=12>I'M STARVING, THIS IS UNACCEPTABLE.</size></color></i>");
-						FaithManager.TakePoints(45);
+						FaithManager.TakePoints(45, AssociatedFaith.Faith.FaithName);
 						StarvationProblem(member);
 						break;
 					default:

--- a/UnityProject/Assets/Scripts/Systems/Faith/FaithProperties/HighLife.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/FaithProperties/HighLife.cs
@@ -15,9 +15,12 @@ namespace Systems.Faith.FaithProperties
 			set => propertyIcon = value;
 		}
 
-		public void Setup()
+		public FaithData AssociatedFaith { get; set; }
+
+		public void Setup(FaithData associatedFaith)
 		{
 			//Todo: add high checks.
+			AssociatedFaith = associatedFaith;
 		}
 
 		public void OnJoinFaith(PlayerScript newMember)

--- a/UnityProject/Assets/Scripts/Systems/Faith/FaithProperties/PainIsVirtue.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/FaithProperties/PainIsVirtue.cs
@@ -13,9 +13,12 @@ namespace Systems.Faith.FaithProperties
 			set => propertyIcon = value;
 		}
 
-		public void Setup()
+		public FaithData AssociatedFaith { get; set; }
+
+		public void Setup(FaithData associatedFaith)
 		{
 			//Todo: add discomfort checks.
+			AssociatedFaith = associatedFaith;
 		}
 
 		public void OnJoinFaith(PlayerScript newMember)
@@ -27,7 +30,7 @@ namespace Systems.Faith.FaithProperties
 		{
 			if (damageType.HasFlag(DamageType.Stamina) || damageType.HasFlag(DamageType.Clone)) return;
 			if (damage < 4) return;
-			FaithManager.AwardPoints((int)damage * 2);
+			FaithManager.AwardPoints((int)damage * 2, AssociatedFaith.Faith.FaithName);
 		}
 
 		public void OnLeaveFaith(PlayerScript member)

--- a/UnityProject/Assets/Scripts/Systems/Faith/FaithProperties/RockAndStone.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/FaithProperties/RockAndStone.cs
@@ -14,15 +14,18 @@ namespace Systems.Faith.FaithProperties
 			set => propertyIcon = value;
 		}
 
-		public void Setup()
+		public FaithData AssociatedFaith { get; set; }
+
+		public void Setup(FaithData associatedFaith)
 		{
 			ScoreMachine.Instance.OnScoreChanged.AddListener(UpdatePoints);
+			AssociatedFaith = associatedFaith;
 		}
 
 		private void UpdatePoints(string ID, int points)
 		{
 			if (ID != RoundEndScoreBuilder.COMMON_SCORE_LABORPOINTS) return;
-			FaithManager.AwardPoints(points);
+			FaithManager.AwardPoints(points, AssociatedFaith.Faith.FaithName);
 		}
 
 		public void OnJoinFaith(PlayerScript newMember)

--- a/UnityProject/Assets/Scripts/Systems/Faith/FaithProperties/ScienceComesFirst.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/FaithProperties/ScienceComesFirst.cs
@@ -16,15 +16,18 @@ namespace Systems.Faith.FaithProperties
 			set => propertyIcon = value;
 		}
 
-		public void Setup()
+		public FaithData AssociatedFaith { get; set; }
+
+		public void Setup(FaithData associatedFaith)
 		{
 			ScoreMachine.Instance.OnScoreChanged.AddListener(TrackScore);
+			AssociatedFaith = associatedFaith;
 		}
 
 		private void TrackScore(string name, int score)
 		{
 			if (name != RoundEndScoreBuilder.COMMON_SCORE_SCIENCEPOINTS || score < 1) return;
-			FaithManager.AwardPoints(score);
+			FaithManager.AwardPoints(score, AssociatedFaith.Faith.FaithName);
 		}
 
 		public void OnJoinFaith(PlayerScript newMember) { /* intentionally left empty */ }

--- a/UnityProject/Assets/Scripts/Systems/Faith/FaithProperties/Transhumanist.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/FaithProperties/Transhumanist.cs
@@ -38,9 +38,12 @@ namespace Systems.Faith.FaithProperties
 			set => propertyIcon = value;
 		}
 
-		public void Setup()
+		public FaithData AssociatedFaith { get; set; }
+
+		public void Setup(FaithData associatedFaith)
 		{
 			//Todo: Finish transhumanist setup to include checks for body status
+			((IFaithProperty)this).AssociatedFaith = associatedFaith;
 		}
 
 		public void OnJoinFaith(PlayerScript newMember)

--- a/UnityProject/Assets/Scripts/Systems/Faith/FaithProperties/Xenophobia.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/FaithProperties/Xenophobia.cs
@@ -15,29 +15,32 @@ namespace Systems.Faith.FaithProperties
 			get => propertyIcon;
 			set => propertyIcon = value;
 		}
+		FaithData IFaithProperty.AssociatedFaith { get; set; }
+		private FaithData Faith => ((IFaithProperty)this).AssociatedFaith;
 
 		[SerializeField] private int nonMemberTakePoints = 10;
 		[SerializeField] private int memberGivePoints = 15;
 
-		public void Setup()
+		public void Setup(FaithData associatedFaith)
 		{
 			FaithManager.Instance.FaithPropertiesEventUpdate.Add(CheckForMemberRaces);
+			((IFaithProperty)this).AssociatedFaith = associatedFaith;
 		}
 
 		private void CheckForMemberRaces()
 		{
-			if (FaithManager.Instance.FaithLeaders.Count == 0) return;
-			var leaderRaces = FaithManager.Instance.FaithLeaders.Select(leader => leader.characterSettings.GetRaceSo().name).ToList();
-			foreach (var member in FaithManager.Instance.FaithMembers)
+			if (Faith.FaithLeaders.Count == 0) return;
+			var leaderRaces = Faith.FaithLeaders.Select(leader => leader.characterSettings.GetRaceSo().name).ToList();
+			foreach (var member in Faith.FaithMembers)
 			{
-				if(member.IsDeadOrGhost) continue;
+				if (member.IsDeadOrGhost) continue;
 				if (leaderRaces.Contains(member.characterSettings.GetRaceSo().name) == false)
 				{
-					FaithManager.TakePoints(nonMemberTakePoints);
+					FaithManager.TakePoints(nonMemberTakePoints, Faith.Faith.FaithName);
 					Chat.AddExamineMsg(member.gameObject, "<i>You feel like you don't belong here..</i>");
 					continue;
 				}
-				FaithManager.AwardPoints(memberGivePoints);
+				FaithManager.AwardPoints(memberGivePoints, Faith.Faith.FaithName);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Systems/Faith/FaithProperty.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/FaithProperty.cs
@@ -7,7 +7,8 @@ namespace Systems.Faith
 		public string FaithPropertyName { get; protected set; }
 		public string FaithPropertyDesc { get; protected set; }
 		public Sprite PropertyIcon { get; protected set; }
-		public void Setup();
+		public FaithData AssociatedFaith { get; set; }
+		public void Setup(FaithData data);
 		public void OnJoinFaith(PlayerScript newMember);
 		public void OnLeaveFaith(PlayerScript member);
 		public void RandomEvent();

--- a/UnityProject/Assets/Scripts/Systems/Faith/IFaithMiracle.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/IFaithMiracle.cs
@@ -9,6 +9,6 @@ namespace Systems.Faith
 		public SpriteDataSO MiracleIcon { get; protected set; }
 
 		public int MiracleCost { get; set; }
-		public void DoMiracle();
+		public void DoMiracle(FaithData associatedFaith, PlayerScript invoker = null);
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Faith/Miracles/BestowThePowerOfGod.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/Miracles/BestowThePowerOfGod.cs
@@ -32,7 +32,7 @@ namespace Systems.Faith.Miracles
 		}
 
 		public int MiracleCost { get; set; } = 690;
-		public void DoMiracle()
+		public void DoMiracle(FaithData associatedFaith, PlayerScript invoker = null)
 		{
 			string msg = new RichText().Color(RichTextColor.Yellow).Italic().Add("You feel... Power..");
 			foreach (var dong in PlayerList.Instance.GetAlivePlayers())

--- a/UnityProject/Assets/Scripts/Systems/Faith/Miracles/BlessCrops.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/Miracles/BlessCrops.cs
@@ -30,9 +30,9 @@ namespace Systems.Faith.Miracles
 		}
 
 		public int MiracleCost { get; set; } = 375;
-		public void DoMiracle()
+		public void DoMiracle(FaithData associatedFaith, PlayerScript invoker = null)
 		{
-			foreach (var farmer in FaithManager.Instance.FaithMembers)
+			foreach (var farmer in associatedFaith.FaithMembers)
 			{
 				Chat.AddLocalMsgToChat($"{farmer.visibleName}'s eyes become white as they start chanting some words loudly while small vines ever so slowly wrap around them..", farmer.gameObject);
 				Chat.AddChatMsgToChatServer(farmer.PlayerInfo, "..Banana... ro-TA-te..", ChatChannel.Local, Loudness.LOUD);

--- a/UnityProject/Assets/Scripts/Systems/Faith/Miracles/CurseWithDrunkness.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/Miracles/CurseWithDrunkness.cs
@@ -30,9 +30,9 @@ namespace Systems.Faith.Miracles
 
 		public int MiracleCost { get; set; } = 350;
 
-		public void DoMiracle()
+		public void DoMiracle(FaithData associatedFaith, PlayerScript invoker = null)
 		{
-			foreach (var leader in FaithManager.Instance.FaithLeaders)
+			foreach (var leader in associatedFaith.FaithLeaders)
 			{
 				Chat.AddLocalMsgToChat($"{leader.visibleName}'s eyes become white as they start chanting some words loudly..", leader.gameObject);
 				Chat.AddChatMsgToChatServer(leader.PlayerInfo, "..Gin-La tok.. Ja-kra-ko..", ChatChannel.Local, Loudness.LOUD);

--- a/UnityProject/Assets/Scripts/Systems/Faith/Miracles/DarkifyAllLightSources.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/Miracles/DarkifyAllLightSources.cs
@@ -34,7 +34,7 @@ namespace Systems.Faith.Miracles
 		}
 
 		public int MiracleCost { get; set; } = 180;
-		public void DoMiracle()
+		public void DoMiracle(FaithData associatedFaith, PlayerScript invoker = null)
 		{
 			GameManager.Instance.StartCoroutine(ChangeLights());
 			string msg = new RichText().Italic().Color(RichTextColor.Red)

--- a/UnityProject/Assets/Scripts/Systems/Faith/Miracles/FreeBooze.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/Miracles/FreeBooze.cs
@@ -33,7 +33,7 @@ namespace Systems.Faith.Miracles
 
 		public int MiracleCost { get; set; } = 150;
 
-		public void DoMiracle()
+		public void DoMiracle(FaithData associatedFaith, PlayerScript invoker = null)
 		{
 			string msg = new RichText().Color(RichTextColor.Yellow).Italic().Add("You hear bottles of glass fall..");
 			Chat.AddGameWideSystemMsgToChat(msg);

--- a/UnityProject/Assets/Scripts/Systems/Faith/Miracles/GhostOfCarmenMiranda.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/Miracles/GhostOfCarmenMiranda.cs
@@ -42,7 +42,7 @@ namespace Systems.Faith.Miracles
 		}
 
 		public int MiracleCost { get; set; } = 200;
-		public void DoMiracle()
+		public void DoMiracle(FaithData associatedFaith, PlayerScript invoker = null)
 		{
 			GameManager.Instance.StartCoroutine(SongEvents());
 		}

--- a/UnityProject/Assets/Scripts/Systems/Faith/Miracles/HealFaithMembers.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/Miracles/HealFaithMembers.cs
@@ -31,9 +31,9 @@ namespace Systems.Faith.Miracles
 		public int MiracleCost { get; set; } = 1500;
 
 
-		public void DoMiracle()
+		public void DoMiracle(FaithData associatedFaith, PlayerScript invoker = null)
 		{
-			foreach (var member in FaithManager.Instance.FaithMembers)
+			foreach (var member in associatedFaith.FaithMembers)
 			{
 				if (member.IsDeadOrGhost) continue;
 				member.playerHealth.FullyHeal();

--- a/UnityProject/Assets/Scripts/Systems/Faith/Miracles/MakeFoodBigger.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/Miracles/MakeFoodBigger.cs
@@ -35,9 +35,9 @@ namespace Systems.Faith.Miracles
 
 		public int MiracleCost { get; set; } = 500;
 
-		public void DoMiracle()
+		public void DoMiracle(FaithData associatedFaith, PlayerScript invoker = null)
 		{
-			foreach (var foodGobbler in FaithManager.Instance.FaithLeaders)
+			foreach (var foodGobbler in associatedFaith.FaithLeaders)
 			{
 				Chat.AddLocalMsgToChat($"{foodGobbler.visibleName}'s eyes become white as they start chanting some words loudly..", foodGobbler.gameObject);
 				Chat.AddChatMsgToChatServer(foodGobbler.PlayerInfo, "..Eathem.. Wish-ha-pig..", ChatChannel.Local, Loudness.LOUD);

--- a/UnityProject/Assets/Scripts/Systems/Faith/Miracles/MakeLeadersBigger.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/Miracles/MakeLeadersBigger.cs
@@ -28,9 +28,9 @@ namespace Systems.Faith.Miracles
 		}
 
 		public int MiracleCost { get; set; } = 100;
-		public void DoMiracle()
+		public void DoMiracle(FaithData associatedFaith, PlayerScript invoker = null)
 		{
-			foreach (var leader in FaithManager.Instance.FaithLeaders)
+			foreach (var leader in associatedFaith.FaithLeaders)
 			{
 				if (leader.TryGetComponent<ScaleSync>(out var scale) == false) continue;
 				int scaleNew = Random.Range(2, 3);

--- a/UnityProject/Assets/Scripts/Systems/Faith/Miracles/RigObjects.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/Miracles/RigObjects.cs
@@ -28,9 +28,9 @@ namespace Systems.Faith.Miracles
 		}
 
 		public int MiracleCost { get; set; } = 300;
-		public void DoMiracle()
+		public void DoMiracle(FaithData associatedFaith, PlayerScript invoker = null)
 		{
-			foreach (var member in FaithManager.Instance.FaithMembers)
+			foreach (var member in associatedFaith.FaithLeaders)
 			{
 				Chat.AddLocalMsgToChat($"A red tether appears from {member.visibleName} to nearby objects..", member.gameObject);
 				var overlapBox =

--- a/UnityProject/Assets/Scripts/Systems/Faith/PlayerFaith.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/PlayerFaith.cs
@@ -1,0 +1,138 @@
+﻿using Logs;
+using Mirror;
+
+namespace Systems.Faith
+{
+	public class PlayerFaith : NetworkBehaviour, IRightClickable
+	{
+		public PlayerScript player;
+		private Faith currentFaith = null;
+
+		public Faith CurrentFaith
+		{
+			get => currentFaith;
+			private set => currentFaith = value;
+		}
+
+		[field: SyncVar] public string FaithName { get; private set; } = "None";
+
+		[Server]
+		public void JoinReligion(Faith newFaith)
+		{
+			if (newFaith == null)
+			{
+				Loggy.LogError("[PlayerFaith] - Cannot join a null faith.");
+				return;
+			}
+			currentFaith = newFaith;
+			FaithName = currentFaith.FaithName;
+			FaithManager.JoinFaith(newFaith, player);
+		}
+
+		[Command]
+		public void JoinReligion(string newFaith)
+		{
+			JoinReligion(FaithManager.Instance.AllFaiths.Find(x => x.Faith.FaithName == newFaith).Faith);
+		}
+
+		[Command]
+		public void LeaveReligion()
+		{
+			currentFaith = null;
+			FaithName = "None";
+			FaithManager.LeaveFaith(player);
+		}
+
+		[Command]
+		public void AddNewFaithLeader()
+		{
+			if (currentFaith == null) return;
+			FaithManager.AddLeaderToFaith(CurrentFaith.FaithName, player);
+		}
+
+		[Command]
+		public void CreateNewFaith(string selectedFaith)
+		{
+			FaithManager.Instance.AddFaithToActiveList(FaithManager.Instance.AllFaiths
+				.Find(x => x.Faith.FaithName == selectedFaith).Faith);
+		}
+
+		[TargetRpc]
+		public void RpcShowFaithSelectScreen(NetworkConnection target)
+		{
+			UIManager.Instance.ChaplainFirstTimeSelectScreen.gameObject.SetActive(true);
+		}
+
+		public RightClickableResult GenerateRightClickOptions()
+		{
+			RightClickableResult result = new RightClickableResult();
+			if (FaithName != "None")
+			{
+				result.AddElement("Join Faith",
+					() => PlayerManager.LocalPlayerScript.PlayerFaith.JoinReligion(FaithName));
+			}
+
+			return result;
+		}
+
+		public string ToleranceCheckForReligion()
+		{
+			//This is client trickery, anything we want to check on the client itself is from PlayerManager
+			//while things on the other player is done directly from within this class
+			if (PlayerManager.LocalPlayerScript.PlayerFaith.currentFaith == null) return "";
+			string finalText = "";
+			if (FaithName == "None")
+			{
+				finalText = "This person does not appear to be a part of any faith.";
+			}
+			else
+			{
+				switch (PlayerManager.LocalPlayerScript.PlayerFaith.currentFaith.ToleranceToOtherFaiths)
+				{
+					case ToleranceToOtherFaiths.Accepting:
+						finalText = "";
+						break;
+					case ToleranceToOtherFaiths.Neutral:
+						if (PlayerManager.LocalPlayerScript.PlayerFaith.FaithName != FaithName)
+						{
+							finalText = $"This person appears to have faith in {FaithName}.";
+						}
+						else
+						{
+							finalText = $"<color=green>This person appears to share the same faith as me!</color>";
+						}
+
+						break;
+					case ToleranceToOtherFaiths.Rejecting:
+						if (PlayerManager.LocalPlayerScript.PlayerFaith.FaithName != FaithName)
+						{
+							finalText =
+								$"<color=red>This person appears to have faith in {FaithName} which goes against what I believe.</color>";
+						}
+						else
+						{
+							finalText = $"<color=green>This person appears to share the same faith as me!</color>";
+						}
+
+						break;
+					case ToleranceToOtherFaiths.Violent:
+						if (PlayerManager.LocalPlayerScript.PlayerFaith.FaithName != FaithName)
+						{
+							finalText =
+								$"<color=red>This person appears to not share the same beliefs as me, and I don't like that.</color>";
+						}
+						else
+						{
+							finalText = $"<color=green>This person appears to share the same faith as me!</color>";
+						}
+
+						break;
+					default:
+						finalText = "";
+						break;
+				}
+			}
+			return finalText;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/Faith/PlayerFaith.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/Faith/PlayerFaith.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 82def04b61e1483f8a1f4032486d0d97
+timeCreated: 1699202224

--- a/UnityProject/Assets/Scripts/Systems/Faith/UI/ChaplainFirstTimeSelectScreen.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/UI/ChaplainFirstTimeSelectScreen.cs
@@ -54,8 +54,9 @@ namespace Systems.Faith.UI
 		public void OnChooseFaith()
 		{
 			gameObject.SetActive(false);
-			PlayerManager.LocalPlayerScript.PlayerNetworkActions.CmdJoinFaith(currentSelectedFaith.FaithName);
-			PlayerManager.LocalPlayerScript.PlayerNetworkActions.CmdSetMainFaith();
+			PlayerManager.LocalPlayerScript.PlayerFaith.CreateNewFaith(currentSelectedFaith.FaithName);
+			PlayerManager.LocalPlayerScript.PlayerFaith.JoinReligion(currentSelectedFaith.FaithName);
+			PlayerManager.LocalPlayerScript.PlayerFaith.AddNewFaithLeader();
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Faith/UI/GUI_ChaplainPointShopScreen.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/UI/GUI_ChaplainPointShopScreen.cs
@@ -17,8 +17,8 @@ namespace Systems.Faith.UI
 		[SerializeField] private NetSpriteHandler image;
 
 		private HolyBook provider;
-
 		private ShopItemButton currentlySelectedMiracle;
+		public FaithData HolderFaith { get; private set; }
 
 		private void Start()
 		{
@@ -39,9 +39,12 @@ namespace Systems.Faith.UI
 		private void RefreshShop()
 		{
 			if (IsMasterTab == false) return;
-			balanceText.MasterSetValue($"Current Balance: <b>{FaithManager.Instance.FaithPoints.ToString()}</b>");
+			if (provider == null) return;
+			if (provider.lastTouchedBy == null) return;
+			HolderFaith = FaithManager.Instance.CurrentFaiths.Find(x => x.Faith.FaithName == provider.lastTouchedBy.CurrentFaith.FaithName);
+			balanceText.MasterSetValue($"Current Balance: <b>{HolderFaith.Points.ToString()}</b>");
 			shopListTransform.Clear();
-			foreach (var miracle in FaithManager.Instance.CurrentFaith.FaithMiracles)
+			foreach (var miracle in HolderFaith.Faith.FaithMiracles)
 			{
 				var newItem = shopListTransform.AddItem() as ShopItemButton;
 				if (newItem == null)
@@ -72,7 +75,7 @@ namespace Systems.Faith.UI
 
 		public void OnMasterBuy()
 		{
-			if (FaithManager.Instance.FaithPoints < currentlySelectedMiracle.Miracle.MiracleCost)
+			if (HolderFaith.Points < currentlySelectedMiracle.Miracle.MiracleCost)
 			{
 				foreach (var peeper in Peepers)
 				{
@@ -80,7 +83,7 @@ namespace Systems.Faith.UI
 				}
 				return;
 			}
-			FaithManager.TakePoints(currentlySelectedMiracle.Miracle.MiracleCost);
+			FaithManager.TakePoints(currentlySelectedMiracle.Miracle.MiracleCost, HolderFaith.Faith.FaithName);
 			currentlySelectedMiracle.DoMiracle();
 			foreach (var peeper in Peepers)
 			{

--- a/UnityProject/Assets/Scripts/Systems/Faith/UI/ShopItemButton.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/UI/ShopItemButton.cs
@@ -25,7 +25,7 @@ namespace Systems.Faith.UI
 
 		public void DoMiracle()
 		{
-			Miracle.DoMiracle();
+			Miracle.DoMiracle(screen.HolderFaith);
 		}
 
 		public void OnCategoryChosen()


### PR DESCRIPTION
CL: [New] Lifted a hard-coded restriction that prevented multiple faiths from existing at the same time in the faith manager for testing.
CL: [New] Enabled faith events checks once again.
CL: [Improvement] Faith events only occur when a faith has less than -250 or more than 250 points.
CL: [Improvement] Holy books are now aware of the holder's faith.
CL: [Fix] Improved the order and reliability of how faith properties are set up for new and leaving faith members.
CL: [Fix] Ensured that players cannot co-exist in multiple faiths at the same time when leaving or entering faiths.
CL: [Fix] Faith leaders can no longer lead multiple faiths at the same time. This was not intended and resulted in multiple issues even before the faith limit was removed.
