### PR TITLE
Allow admins to select tiles from the map using middle click

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Lighting/HighlightScan.cs
+++ b/UnityProject/Assets/Scripts/Core/Lighting/HighlightScan.cs
@@ -1,10 +1,6 @@
-using System;
 using System.Collections;
-using Core.Factories;
 using Logs;
-using Mirror;
 using UnityEngine;
-using Util;
 
 namespace Core.Lighting
 {
@@ -40,7 +36,7 @@ namespace Core.Lighting
 			HighlightScanManager.Instance.OrNull()?.HighlightScans.Remove(this);
 		}
 
-		public void Setup(Sprite sprite)
+		public void Setup(Sprite sprite, bool disableAlphaChangeOnAwake = false)
 		{
 			if (sprite == null)
 			{
@@ -48,6 +44,14 @@ namespace Core.Lighting
 				return;
 			}
 			spriteRenderer.sprite = sprite;
+			if (disableAlphaChangeOnAwake)
+			{
+				Color alpha = spriteRenderer.color;
+				alpha.a = 0.65f;
+				spriteRenderer.color = alpha;
+				gameObject.layer = 10;
+				spriteRenderer.gameObject.layer = 10;
+			}
 		}
 
 		public IEnumerator Highlight()

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/GUI_DevTileChanger.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/GUI_DevTileChanger.cs
@@ -258,6 +258,9 @@ namespace UI.Systems.AdminTools.DevTools
 			selectedButton = button.GetComponentInChildren<Image>();
 			selectedButton.color = Color.green;
 			Cursor.SetCursor(selectedButton.sprite.texture, Vector2.zero, CursorMode.Auto);
+			var buttonText = selectedButton.GetComponentInChildren<TMP_Text>();
+			if (buttonText == null) return;
+			Chat.AddExamineMsg(PlayerManager.LocalPlayerObject, $"You will paint now with a '{buttonText.text}'");
 		}
 
 		#endregion


### PR DESCRIPTION
closes #10099

CL: [New] Admins/Future mappers can now use their middle mouse button as a dropper to quickly select tiles from the map to paint with.