### PR TITLE
Some Faith fixes

### DIFF
--- a/UnityProject/Assets/Prefabs/UI/Faiths/FaithPlayerInfoUI.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Faiths/FaithPlayerInfoUI.prefab
@@ -2260,6 +2260,140 @@ RectTransform:
   m_AnchoredPosition: {x: 0.0025024, y: -0.000076294}
   m_SizeDelta: {x: 1187.1, y: 678.19}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &5964040280979122603
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7309247535280381295}
+  - component: {fileID: 3838024352558169378}
+  - component: {fileID: 5026016717278867566}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7309247535280381295
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5964040280979122603}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2415377146391473351}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.000034332, y: 0}
+  m_SizeDelta: {x: 45.769, y: 40.22}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3838024352558169378
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5964040280979122603}
+  m_CullTransparentMesh: 1
+--- !u!114 &5026016717278867566
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5964040280979122603}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: X
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &5991663143452941184
 GameObject:
   m_ObjectHideFlags: 0
@@ -3072,81 +3206,6 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!1 &9021139764718895181
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7929388111780526790}
-  - component: {fileID: 2996063656271409042}
-  - component: {fileID: 4391614831754420025}
-  m_Layer: 5
-  m_Name: Image
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &7929388111780526790
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9021139764718895181}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2415377146391473351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.0000066757, y: -0.0000066757}
-  m_SizeDelta: {x: 48.772, y: 43.325}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &2996063656271409042
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9021139764718895181}
-  m_CullTransparentMesh: 1
---- !u!114 &4391614831754420025
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9021139764718895181}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: a1e2921eff2065542be6ac778f4c8569, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &9063019182433633147
 GameObject:
   m_ObjectHideFlags: 0
@@ -3178,7 +3237,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 7929388111780526790}
+  - {fileID: 7309247535280381295}
   m_Father: {fileID: 224120160830574892}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -3207,7 +3266,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 1, b: 0.06733799, a: 1}
+  m_Color: {r: 1, g: 0.1608387, b: 0, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -3268,11 +3327,10 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Systems.Faith.UI.ChaplainFirstTimeSelectScreen,
-          Assets
-        m_MethodName: OnChooseFaith
-        m_Mode: 1
+      - m_Target: {fileID: 1502172408805726}
+        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+        m_MethodName: SetActive
+        m_Mode: 6
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine

--- a/UnityProject/Assets/Scripts/Systems/Faith/FaithData.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/FaithData.cs
@@ -27,5 +27,21 @@ namespace Systems.Faith
 				property.OnLeaveFaith(member);
 			}
 		}
+
+		public void RemoveAllMembers()
+		{
+			foreach (var member in FaithMembers)
+			{
+				RemoveMember(member);
+			}
+		}
+
+		public void SetupFaith()
+		{
+			foreach (var property in Faith.FaithProperties)
+			{
+				property.Setup(this);
+			}
+		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Faith/PlayerFaith.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/PlayerFaith.cs
@@ -1,6 +1,5 @@
 ﻿using System.Text;
 using Logs;
-using Messages.Server;
 using Mirror;
 using Systems.Faith.UI;
 using UI.Core.Action;

--- a/UnityProject/Assets/Scripts/Systems/Faith/PlayerFaith.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/PlayerFaith.cs
@@ -104,7 +104,7 @@ namespace Systems.Faith
 		public RightClickableResult GenerateRightClickOptions()
 		{
 			RightClickableResult result = new RightClickableResult();
-			if (FaithName == "None")
+			if (FaithName != "None")
 			{
 				result.AddElement("Join Faith",
 					() => PlayerManager.LocalPlayerScript.PlayerFaith.JoinReligion(FaithName));

--- a/UnityProject/Assets/Scripts/Systems/Faith/PlayerFaith.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/PlayerFaith.cs
@@ -39,6 +39,7 @@ namespace Systems.Faith
 			currentFaith = newFaith;
 			FaithName = currentFaith.FaithName;
 			FaithManager.JoinFaith(newFaith, player);
+			Chat.AddExamineMsg(gameObject, $"You've joined the {FaithName} faith.");
 		}
 
 		[Command]
@@ -103,10 +104,16 @@ namespace Systems.Faith
 		public RightClickableResult GenerateRightClickOptions()
 		{
 			RightClickableResult result = new RightClickableResult();
-			if (FaithName != "None")
+			if (FaithName == "None")
 			{
 				result.AddElement("Join Faith",
 					() => PlayerManager.LocalPlayerScript.PlayerFaith.JoinReligion(FaithName));
+			}
+
+			if (gameObject == PlayerManager.LocalPlayerObject && FaithName is not "None")
+			{
+				result.AddElement("Leave Faith",
+					() => PlayerManager.LocalPlayerScript.PlayerFaith.LeaveReligion());
 			}
 
 			return result;

--- a/UnityProject/Assets/Scripts/Systems/Faith/UI/FaithInfoUI.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/UI/FaithInfoUI.cs
@@ -105,6 +105,7 @@ namespace Systems.Faith.UI
 					Loggy.LogError("No such page exists");
 					break;
 			}
+			Refresh();
 		}
 	}
 }


### PR DESCRIPTION
Note: There are still some issues that only appear on headless that require more time to investigate, specifically with how the Faith Properties that interact with the `ScoreManager` stop working once a round ends. This PR only fixes cross-round issues with the faith manager only.


CL: [Improvement] Faiths that do not contain any leaders are automatically disbanded.
CL: [Balance] Random events now occur at 75 and -75 points instead of 200 to quickly investigate issues with random faith events.  
CL: [Fix] The ability to leave faiths was missing, it has been re-added again.
CL: [Fix] Faith events and periodic updates should not stop working after a round has ended now.
CL: [Fix] The faith info UI had its close button broken, but it is now fixed.
CL: [Fix] The faith info UI never updated its info, which led people to get confused on why their points were stuck at the time. This has been fixed, and the UI will update now every time the player switches pages.

