### PR TITLE
Shuttle Race

### DIFF
--- a/UnityProject/Assets/Scenes/AwaySites/ShuttleRace.unity.meta
+++ b/UnityProject/Assets/Scenes/AwaySites/ShuttleRace.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 17677b279f2906f549eba48f29897185
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/SubScenes/AwayWorldList.asset
+++ b/UnityProject/Assets/ScriptableObjects/SubScenes/AwayWorldList.asset
@@ -20,3 +20,4 @@ MonoBehaviour:
   - DarkJungle
   - Backrooms
   - Valley
+  - ShuttleRace

--- a/UnityProject/ProjectSettings/EditorBuildSettings.asset
+++ b/UnityProject/ProjectSettings/EditorBuildSettings.asset
@@ -134,6 +134,9 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/AwaySites/Valley.unity
     guid: c46d2794e7b009499a603aa68ca526bb
+  - enabled: 1
+    path: Assets/Scenes/AwaySites/ShuttleRace.unity
+    guid: 17677b279f2906f549eba48f29897185
   m_configObjects:
     com.unity.addressableassets: {fileID: 11400000, guid: 7ac8cd75382a23042b1a13021adfae5d,
       type: 2}


### PR DESCRIPTION
### Purpose
Adds a Shuttle Race Course awaysite

### Notes:
Come on down to Shuttle Race Course, where totally untrained pilots and medical personnel give their all to create a totally entertained audience!

Features:
- Garage with space suits and 10 race pods
- Viewing areas along the track for the audience, linked by quantum pads
- A control area where shutters can be lifted by an operator to start the race
- A medical bay with cloner and medical shuttle (all staffing on a volunteer basis)
- 
![Shuttle Race Map](https://github.com/unitystation/unitystation/assets/33767950/427293a1-d6ed-4065-829e-ca27fdcc9e4b)

![image](https://github.com/unitystation/unitystation/assets/33767950/37f3cb3b-6401-42c5-91a0-fbc08b15e25d)

![image](https://github.com/unitystation/unitystation/assets/33767950/5e219822-f718-4ebf-ab71-d99e06da92eb)

### Changelog:
CL: [New] Shuttle Race awaysite