### PR TITLE
Some atmos fixes for mining station

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Atmos/RoomGasSetters/AirRoomGasSetter.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Atmos/RoomGasSetters/AirRoomGasSetter.prefab
@@ -75,6 +75,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7720728262316129163, guid: 4be0b953627cfaa4d9e7713cd25f19a0,
         type: 3}
+      propertyPath: m_Icon
+      value: 
+      objectReference: {fileID: 4422084297763085224, guid: 0000000000000000d000000000000000,
+        type: 0}
+    - target: {fileID: 7720728262316129163, guid: 4be0b953627cfaa4d9e7713cd25f19a0,
+        type: 3}
       propertyPath: m_Name
       value: AirRoomGasSetter
       objectReference: {fileID: 0}
@@ -106,17 +112,17 @@ PrefabInstance:
     - target: {fileID: 7723740124206480721, guid: 4be0b953627cfaa4d9e7713cd25f19a0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7723740124206480721, guid: 4be0b953627cfaa4d9e7713cd25f19a0,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7723740124206480721, guid: 4be0b953627cfaa4d9e7713cd25f19a0,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7723740124206480721, guid: 4be0b953627cfaa4d9e7713cd25f19a0,
         type: 3}


### PR DESCRIPTION
CL: [Fix] Fixed some air gabs in mining station that caused lavaland air to invade the cleaner station air.
CL: [Fix] Some walls were using the wrong wall types on mining station, this has been fixed.