### PR TITLE
Fixes gas containers exploading before destruction

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/ClosetsAndCrates/ClosetBase.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/ClosetsAndCrates/ClosetBase.prefab
@@ -905,7 +905,7 @@ MonoBehaviour:
   MaximumMoles: 1013.25
   ReleasePressure: 101.325
   CargoSealApproved: 0
-  exploadOnTooMuchDamage: 0
+  explodeOnTooMuchDamage: 0
 --- !u!114 &6872015153723498109
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Objects/ClosetsAndCrates/ClosetBase.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/ClosetsAndCrates/ClosetBase.prefab
@@ -529,6 +529,41 @@ PrefabInstance:
       propertyPath: initialIntegrity
       value: 200
       objectReference: {fileID: 0}
+    - target: {fileID: 1140667517167752775, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
+      propertyPath: OnDestruction.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140667517167752775, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
+      propertyPath: OnDestruction.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140667517167752775, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
+      propertyPath: OnDestruction.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 5739732223049864694}
+    - target: {fileID: 1140667517167752775, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
+      propertyPath: OnDestruction.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140667517167752775, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
+      propertyPath: OnDestruction.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: ExplodeContainer
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140667517167752775, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
+      propertyPath: OnDestruction.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: Objects.Atmospherics.GasContainer, Assets
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140667517167752775, guid: a7af28adb717b4c44b8b2002b27670bd,
+        type: 3}
+      propertyPath: OnDestruction.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     - target: {fileID: 1197192003336439530, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
       propertyPath: exportCost
@@ -870,6 +905,7 @@ MonoBehaviour:
   MaximumMoles: 1013.25
   ReleasePressure: 101.325
   CargoSealApproved: 0
+  exploadOnTooMuchDamage: 0
 --- !u!114 &6872015153723498109
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -53,6 +53,7 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 	public DamagedEvent OnApplyDamage = new DamagedEvent();
 
 	public UnityEvent OnDamaged = new UnityEvent();
+	public UnityEvent OnDestruction = new UnityEvent();
 
 	/// <summary>
 	/// event for hotspots
@@ -322,6 +323,7 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 	{
 		if (!destroyed && integrity <= 0)
 		{
+			OnDestruction?.Invoke();
 			var destructInfo = new DestructionInfo(lastDamageType, this);
 			OnWillDestroyServer.Invoke(destructInfo);
 

--- a/UnityProject/Assets/Scripts/Objects/GasContainer.cs
+++ b/UnityProject/Assets/Scripts/Objects/GasContainer.cs
@@ -68,8 +68,7 @@ namespace Objects.Atmospherics
 		[Tooltip("If true : Cargo will accept gases found within this container and can be sold.")]
 		public bool CargoSealApproved = false;
 
-		[FormerlySerializedAs("exploadOnTooMuchDamage")] [SerializeField]
-		private bool explodeOnTooMuchDamage = true;
+		[SerializeField] private bool explodeOnTooMuchDamage = true;
 
 		#region Lifecycle
 

--- a/UnityProject/Assets/Scripts/Objects/GasContainer.cs
+++ b/UnityProject/Assets/Scripts/Objects/GasContainer.cs
@@ -68,7 +68,8 @@ namespace Objects.Atmospherics
 		[Tooltip("If true : Cargo will accept gases found within this container and can be sold.")]
 		public bool CargoSealApproved = false;
 
-		[SerializeField] private bool exploadOnTooMuchDamage = true;
+		[FormerlySerializedAs("exploadOnTooMuchDamage")] [SerializeField]
+		private bool explodeOnTooMuchDamage = true;
 
 		#region Lifecycle
 
@@ -105,7 +106,7 @@ namespace Objects.Atmospherics
 
 		private void OnServerDamage(DamageInfo info)
 		{
-			if (integrity.integrity - info.Damage <= 0 && exploadOnTooMuchDamage)
+			if (integrity.integrity - info.Damage <= 0 && explodeOnTooMuchDamage)
 			{
 				ExplodeContainer();
 				integrity.RestoreIntegrity(integrity.initialIntegrity);

--- a/UnityProject/Assets/Scripts/Objects/GasContainer.cs
+++ b/UnityProject/Assets/Scripts/Objects/GasContainer.cs
@@ -5,6 +5,8 @@ using UnityEditor;
 using NaughtyAttributes;
 using Systems.Atmospherics;
 using Systems.Explosions;
+using UnityEngine.Events;
+using UnityEngine.Serialization;
 
 namespace Objects.Atmospherics
 {
@@ -66,6 +68,8 @@ namespace Objects.Atmospherics
 		[Tooltip("If true : Cargo will accept gases found within this container and can be sold.")]
 		public bool CargoSealApproved = false;
 
+		[SerializeField] private bool exploadOnTooMuchDamage = true;
+
 		#region Lifecycle
 
 		private void Awake()
@@ -101,7 +105,7 @@ namespace Objects.Atmospherics
 
 		private void OnServerDamage(DamageInfo info)
 		{
-			if (integrity.integrity - info.Damage <= 0)
+			if (integrity.integrity - info.Damage <= 0 && exploadOnTooMuchDamage)
 			{
 				ExplodeContainer();
 				integrity.RestoreIntegrity(integrity.initialIntegrity);
@@ -138,7 +142,7 @@ namespace Objects.Atmospherics
 		}
 
 		[Server]
-		private void ExplodeContainer()
+		public void ExplodeContainer()
 		{
 			var shakeIntensity = (byte) Mathf.Lerp(
 				byte.MinValue, byte.MaxValue / 2, GasMix.Pressure / MAX_EXPLOSION_EFFECT_PRESSURE);


### PR DESCRIPTION
fixes  #10198

CL: [New] Mappers and designers now have the ability to hook up functions to when an object/item get destroyed.
CL: [Fix] Fixed containers exploding before they are actually destroyed by explicitly asking if gas containers are meant to release their content due to excessive damage or when they are getting destroyed.
