### PR TITLE
Buckling to an object makes you face their direction again

### DIFF
--- a/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
+++ b/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
@@ -2299,6 +2299,7 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 			if (directionalObject != null)
 			{
 				directionalObject.OnRotationChange.AddListener(newBuckledTo.OnBuckledObjectDirectionChange);
+				rotatable.OrNull()?.FaceDirection(directionalObject.CurrentDirection);
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
+++ b/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
@@ -2295,11 +2295,15 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 		{
 			ObjectIsBuckling.BuckledToObject = this;
 			ObjectIsBuckling.BuckleToChange(this);
-			var directionalObject = this.GetComponent<Rotatable>();
+			var directionalObject = GetComponent<Rotatable>();
 			if (directionalObject != null)
 			{
 				directionalObject.OnRotationChange.AddListener(newBuckledTo.OnBuckledObjectDirectionChange);
-				rotatable.OrNull()?.FaceDirection(directionalObject.CurrentDirection);
+			}
+			var directionalBuckledObject = ObjectIsBuckling.GetComponent<Rotatable>();
+			if (directionalBuckledObject != null)
+			{
+				directionalBuckledObject.FaceDirection(rotatable.CurrentDirection);
 			}
 		}
 	}


### PR DESCRIPTION
CL: [Fix] Re-added a missing behavior that caused players to not face the direction of the object they're being buckled to, which made chairs feel off when buckling and rotating on.
