### PR TITLE
Improve space movement

### DIFF
--- a/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
+++ b/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
@@ -520,6 +520,8 @@ public class MovementSynchronisation : UniversalObjectPhysics, IPlayerControllab
 
 	public struct MoveData
 	{
+		//TODO Send over momentum as well? Before move
+
 		public Vector3 LocalPosition;
 
 		//The current location of the player (  just in case they are desynchronised )
@@ -666,9 +668,8 @@ public class MovementSynchronisation : UniversalObjectPhysics, IPlayerControllab
 		resetSmooth = false;
 		if (IsFlyingSliding)
 		{
-			if ((transform.position - entry.LocalPosition.ToWorld(MatrixManager.Get(entry.MatrixID)))
-			    .magnitude <
-			    0.24f) //TODO Maybe not needed if needed can be used is when Move request comes in before player has quite reached tile in space flight
+			var PositionDifference = (transform.position - entry.LocalPosition.ToWorld(MatrixManager.Get(entry.MatrixID))).magnitude;
+ 			if (PositionDifference < 0.50f) //TODO Maybe not needed if needed can be used is when Move request comes in before player has quite reached tile in space flight
 			{
 				stored = transform.localPosition;
 				transform.localPosition = entry.LocalPosition;
@@ -677,9 +678,9 @@ public class MovementSynchronisation : UniversalObjectPhysics, IPlayerControllab
 				SetMatrixCache.ResetNewPosition(transform.position, registerTile);
 				fudged = true;
 			}
-			else
+			else if (entry.IsNotMove == false)
 			{
-				//Logger.LogError(" Fail the Range floating check ");
+				//Loggy.LogError($" Fail the Range floating check with Distance {PositionDifference}");
 				ResetLocationOnClients();
 				MoveQueue.Clear();
 				return;
@@ -907,7 +908,7 @@ public class MovementSynchronisation : UniversalObjectPhysics, IPlayerControllab
 
 
 
-						//Logger.LogError("Failed TryMove");
+						// //Logger.LogError("Failed TryMove");
 						if (fudged)
 						{
 							transform.localPosition = stored;

--- a/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
+++ b/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
@@ -669,7 +669,9 @@ public class MovementSynchronisation : UniversalObjectPhysics, IPlayerControllab
 		if (IsFlyingSliding)
 		{
 			var PositionDifference = (transform.position - entry.LocalPosition.ToWorld(MatrixManager.Get(entry.MatrixID))).magnitude;
- 			if (PositionDifference < 0.50f) //TODO Maybe not needed if needed can be used is when Move request comes in before player has quite reached tile in space flight
+ 			if (PositionDifference < 0.50f)
+			    //TODO Maybe not needed if needed can be used is when Move request comes in before player has quite reached tile in space flight
+				//TODO it Can be manipulated
 			{
 				stored = transform.localPosition;
 				transform.localPosition = entry.LocalPosition;

--- a/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
+++ b/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
@@ -113,6 +113,8 @@ public class MovementSynchronisation : UniversalObjectPhysics, IPlayerControllab
 
 	private LayerType tileBumpables = LayerType.Grills | LayerType.Walls;
 
+	public float FudgeThresholdFlyingSliding = 0.5f;
+
 	/// <summary>
 	/// Event which fires when movement type changes (run/walk)
 	/// </summary>
@@ -669,7 +671,7 @@ public class MovementSynchronisation : UniversalObjectPhysics, IPlayerControllab
 		if (IsFlyingSliding)
 		{
 			var PositionDifference = (transform.position - entry.LocalPosition.ToWorld(MatrixManager.Get(entry.MatrixID))).magnitude;
- 			if (PositionDifference < 0.50f)
+ 			if (PositionDifference < FudgeThresholdFlyingSliding)
 			    //TODO Maybe not needed if needed can be used is when Move request comes in before player has quite reached tile in space flight
 				//TODO it Can be manipulated
 			{

--- a/UnityProject/Assets/Scripts/Systems/Chemistry/ReagentMix.cs
+++ b/UnityProject/Assets/Scripts/Systems/Chemistry/ReagentMix.cs
@@ -309,7 +309,6 @@ namespace Chemistry
 
 			if (float.IsNormal(amount) == false)
 			{
-				Loggy.LogError($"Trying to add {amount} amount of {reagent}", Category.Chemistry);
 				return;
 			}
 


### PR DESCRIPTION
still not perfect but a lot better than it was
Details,
The one issue was the Synchronise check to make sure your floating in the right direction and all that stuff, doesn't account for
latency if you have network prediction, so added that check into account for the latency,

Next made it so When you get in range of a tile you round to the position of the tile, this helps with the annoying issue with server and client slightly disagreeing on where the players, and since then the request is sent on write the edge of the tile it would cause issues so, now it's a bit more resilient


### Changelog:

CL: [Improvement] Improve space movement by making server and client agree more in where players are when space jogging.

