### PR TITLE
Allows gamemodes to define their own maps

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/GameModes/Blob.asset
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/Blob.asset
@@ -29,3 +29,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 4e33e3c5bcb99b34cbab164bcfa68951, type: 2}
   allocateJobsToAntags: 1
   nonAntagJobTypes: 0600000016000000170000002300000021000000110000000d0000001e0000000100000010000000
+  mainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/GameModes/BloodBrothers.asset
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/BloodBrothers.asset
@@ -31,3 +31,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: c060c33698c0f81449f0735a800740ca, type: 2}
   allocateJobsToAntags: 1
   nonAntagJobTypes: 0600000016000000170000002300000021000000110000000100000010000000
+  mainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/GameModes/Cargonia.asset
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/Cargonia.asset
@@ -32,3 +32,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 6eb4b2c2fcd1e8f4bba13a622f480144, type: 2}
   allocateJobsToAntags: 1
   nonAntagJobTypes: 0600000016000000170000002300000021000000110000000100000010000000
+  mainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/GameModes/Changeling.asset
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/Changeling.asset
@@ -28,3 +28,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 7977e2d7465279a419fe55b27ecca5df, type: 2}
   allocateJobsToAntags: 1
   nonAntagJobTypes: 0600000016000000170000002300000021000000110000000d0000001e00000001000000
+  mainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/GameModes/Extended.asset
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/Extended.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
   possibleAntags: []
   allocateJobsToAntags: 0
   nonAntagJobTypes: 060000001600000017000000230000002100000011000000
+  mainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/GameModes/Highlander.asset
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/Highlander.asset
@@ -33,3 +33,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 0f19f9b747ac2ee499c57e02517aed37, type: 2}
   allocateJobsToAntags: 0
   nonAntagJobTypes: 06000000160000001700000023000000210000001100000001000000
+  mainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/GameModes/NukeOps.asset
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/NukeOps.asset
@@ -29,3 +29,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 4bc36e6d8aa946c4081073eabc2472eb, type: 2}
   allocateJobsToAntags: 0
   nonAntagJobTypes: 060000001600000017000000230000002100000011000000
+  mainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/GameModes/Traitor.asset
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/Traitor.asset
@@ -29,3 +29,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: c060c33698c0f81449f0735a800740ca, type: 2}
   allocateJobsToAntags: 1
   nonAntagJobTypes: 06000000160000001700000023000000210000001100000010000000
+  mainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/GameModes/Wizard.asset
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/Wizard.asset
@@ -33,3 +33,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 7325a4893b19676439a5fdb39d2cc069, type: 2}
   allocateJobsToAntags: 0
   nonAntagJobTypes: 060000001600000017000000230000002100000011000000
+  mainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -571,21 +571,7 @@ public partial class GameManager : MonoBehaviour, IInitialise
 			Loggy.LogError("Failed to log Players antagonist preferences" + e.ToString());
 		}
 
-
-		if (string.IsNullOrEmpty(NextGameMode) || NextGameMode == "Random")
-		{
-			SetRandomGameMode();
-		}
-		else
-		{
-			//Set game mode to the selected game mode
-			SetGameMode(NextGameMode);
-			//Then reset it to the default game mode set in the config for next round.
-			NextGameMode = InitialGameMode;
-		}
-
-		DiscordWebhookMessage.Instance.AddWebHookMessageToQueue(DiscordWebhookURLs.DiscordWebhookAdminLogURL,
-			$"{GameMode.Name} chosen", "[GameMode]");
+		ChooseGameMode();
 
 		try
 		{
@@ -610,6 +596,23 @@ public partial class GameManager : MonoBehaviour, IInitialise
 		UpdateCountdownMessage.Send(true, 0);
 		EventManager.Broadcast(Event.PostRoundStarted, true);
 		CleanupUtil.RoundStartCleanup();
+	}
+
+	public void ChooseGameMode()
+	{
+		if (string.IsNullOrEmpty(NextGameMode) || NextGameMode == "Random")
+		{
+			SetRandomGameMode();
+		}
+		else
+		{
+			//Set game mode to the selected game mode
+			SetGameMode(NextGameMode);
+			//Then reset it to the default game mode set in the config for next round.
+			NextGameMode = InitialGameMode;
+		}
+		DiscordWebhookMessage.Instance.AddWebHookMessageToQueue(DiscordWebhookURLs.DiscordWebhookAdminLogURL,
+			$"{GameMode.Name} chosen", "[GameMode]");
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -571,8 +571,6 @@ public partial class GameManager : MonoBehaviour, IInitialise
 			Loggy.LogError("Failed to log Players antagonist preferences" + e.ToString());
 		}
 
-		ChooseGameMode();
-
 		try
 		{
 			// Game mode specific setup

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/MainStationListSO.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/MainStationListSO.cs
@@ -16,13 +16,13 @@ public class MainStationListSO : ScriptableObject
 	[Scene]
 	public List<string> MainStations = new();
 
+	public string mapsConfig = "maps.json";
+
 	public string GetRandomMainStation()
 	{
-		var mapConfigPath = "maps.json";
-
-		if (AccessFile.Exists(mapConfigPath))
+		if (AccessFile.Exists(mapsConfig))
 		{
-			var maps = JsonConvert.DeserializeObject<MapList>(AccessFile.Load("maps.json"));
+			var maps = JsonConvert.DeserializeObject<MapList>(AccessFile.Load(mapsConfig));
 			return maps.GetRandomMap();
 		}
 
@@ -39,11 +39,9 @@ public class MainStationListSO : ScriptableObject
 
 	public List<string> GetMaps()
 	{
-		var mapConfigPath =  "maps.json";
-
-		if (AccessFile.Exists(mapConfigPath))
+		if (AccessFile.Exists(mapsConfig))
 		{
-			var maps = JsonConvert.DeserializeObject<MapList>(AccessFile.Load(mapConfigPath));
+			var maps = JsonConvert.DeserializeObject<MapList>(AccessFile.Load(mapsConfig));
 
 			return maps.highPopMaps.Union(maps.medPopMaps).Union(maps.lowPopMaps).ToList();
 		}

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.SceneList.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.SceneList.cs
@@ -119,7 +119,7 @@ public partial class SubSceneManager
 		}
 		else
 		{
-			serverChosenMainStation = mainStationList.GetRandomMainStation();
+			serverChosenMainStation = GameManager.Instance.GameMode.mainStations.GetRandomMainStation();
 		}
 
 		//Reset map selector

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManagerNetworked.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManagerNetworked.cs
@@ -9,7 +9,7 @@ public class SubSceneManagerNetworked : NetworkBehaviour
 
 	public SubSceneManager SubSceneManager;
 
-	//Note: This is the first thing ever that gets called on the server.
+	//Note: This is the first thing ever that gets called on the server after managers finish setting up.
 	//This is where life blooms.
 	public override void OnStartServer()
 	{

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManagerNetworked.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManagerNetworked.cs
@@ -1,7 +1,4 @@
-using System.Collections;
-using System.Collections.Generic;
 using Mirror;
-using UnityEngine;
 
 public class SubSceneManagerNetworked : NetworkBehaviour
 {
@@ -16,6 +13,7 @@ public class SubSceneManagerNetworked : NetworkBehaviour
 	{
 		NetworkServer.observerSceneList.Clear();
 		// Determine a Main station subscene and away site
+		GameManager.Instance.ChooseGameMode();
 		StartCoroutine(SubSceneManager.RoundStartServerLoadSequence());
 		base.OnStartServer();
 	}

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManagerNetworked.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManagerNetworked.cs
@@ -9,6 +9,8 @@ public class SubSceneManagerNetworked : NetworkBehaviour
 
 	public SubSceneManager SubSceneManager;
 
+	//Note: This is the first thing ever that gets called on the server.
+	//This is where life blooms.
 	public override void OnStartServer()
 	{
 		NetworkServer.observerSceneList.Clear();

--- a/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
+++ b/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
@@ -169,6 +169,9 @@ namespace GameModes
 		/// </summary>
 		public List<JobType> NonAntagJobTypes => nonAntagJobTypes;
 
+
+		public MainStationListSO mainStations;
+
 		#endregion
 
 		#region Game Mode Methods


### PR DESCRIPTION
This PR is related to #10271

It changes the order on how maps and game modes are loaded to allow for game modes to define the specific maps that can be loaded in the future to allow for things like shiptest to be added.

# Changelog

CL: [Improvement] Game modes can now define their own map pools.