### PR TITLE
Workaround for @FuntimeDudeski

### DIFF
--- a/UnityProject/Assets/Scripts/NPC/AI/MobController.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobController.cs
@@ -7,6 +7,7 @@ using UnityEngine.SceneManagement;
 
 namespace Systems.MobAIs
 {
+	[Obsolete]
 	public class MobController : MonoBehaviour
 	{
 		public RegisterTile RegisterTile;
@@ -42,7 +43,7 @@ namespace Systems.MobAIs
 
 		public void UpdateMe()
 		{
-			if (RegisterTile.Matrix.PresentPlayers.Count == 0) return;
+			if (RegisterTile.Matrix.PresentPlayers.Count == 0 && DMMath.Prob(75)) return;
 
 			if (RegisterTile.Matrix.IsMainStation == false)
 			{

--- a/UnityProject/Assets/Scripts/NPC/AI/MobController.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobController.cs
@@ -58,7 +58,7 @@ namespace Systems.MobAIs
 					}
 				}
 
-				if (playerNearby == false && DMMath.Prob(75)) return;
+				if (playerNearby == false && DMMath.Prob(90)) return;
 			}
 
 			foreach (var _MobObjective in MobObjectives)

--- a/UnityProject/Assets/Scripts/NPC/AI/MobController.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobController.cs
@@ -43,22 +43,22 @@ namespace Systems.MobAIs
 
 		public void UpdateMe()
 		{
-			if (RegisterTile.Matrix.PresentPlayers.Count == 0 && DMMath.Prob(75)) return;
+			if (RegisterTile.Matrix.PresentPlayers.Count == 0) return;
 
+			var position = transform.localPosition;
 			if (RegisterTile.Matrix.IsMainStation == false)
 			{
-				var Position = this.transform.localPosition;
-				bool PlayerNearby = false;
-				foreach (var Player in RegisterTile.Matrix.PresentPlayers)
+				bool playerNearby = false;
+				foreach (var player in RegisterTile.Matrix.PresentPlayers)
 				{
-					if ((Player.transform.localPosition - Position).magnitude < 20f)
+					if ((player.transform.localPosition - position).magnitude < 20f)
 					{
-						PlayerNearby = true;
+						playerNearby = true;
 						break;
 					}
 				}
 
-				if (PlayerNearby == false) return;
+				if (playerNearby == false && DMMath.Prob(75)) return;
 			}
 
 			foreach (var _MobObjective in MobObjectives)


### PR DESCRIPTION
This adds a 35% chance for V1 mobs to have the ability to move around when there are no players present nearby them
