### PR TITLE
Fixed ant hills being too dangerous than intended

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Alien/SpaceAnts/AntHill.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Alien/SpaceAnts/AntHill.prefab
@@ -27,7 +27,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 5f1191fd1d99098479009df2b219606f,
+      objectReference: {fileID: 21300000, guid: f0eedf49dc445c64681c9de05e79ce97,
         type: 3}
     - target: {fileID: 4116897424394887774, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
@@ -202,11 +202,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   routineDelay: 30
-  minMaxAntDamage: {x: 2, y: 7}
+  minMaxAntDamage: {x: 2, y: 4}
   biteType: 0
   damageType: 0
   state: 0
   filthTrait: {fileID: 11400000, guid: 4c7b190bc2ad57c459127fbcb49ff7e3, type: 2}
+  flySwatterTrait: {fileID: 11400000, guid: 748d6170e42aa074f8d475e4713f573f, type: 2}
   stateSprites:
   - {fileID: 11400000, guid: 5f6799e004291954ca50cd72085d20cd, type: 2}
   - {fileID: 11400000, guid: b29614733ffd58d45afbdd006ea5ba5a, type: 2}

--- a/UnityProject/Assets/Prefabs/Objects/Alien/SpaceAnts/AntHill.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Alien/SpaceAnts/AntHill.prefab
@@ -27,7 +27,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: f0eedf49dc445c64681c9de05e79ce97,
+      objectReference: {fileID: 21300000, guid: 5f1191fd1d99098479009df2b219606f,
         type: 3}
     - target: {fileID: 4116897424394887774, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/FaithManager.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/FaithManager.prefab
@@ -44,18 +44,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b443ed0adc9240759fb8b842c3156b3b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  DefaultFaith:
-    <FaithName>k__BackingField: None
-    <FaithDesc>k__BackingField: Ambious connection to God
-    <FaithIcon>k__BackingField: {fileID: 0}
-    <GodName>k__BackingField: God
-    <NanotrasenProgressMessage>k__BackingField: Nanotrasen's public mental health
-      department reminds all crew members that a healthy spirtual connection is good
-      to overcome hardships and stay motivated.
-    <ToleranceToOtherFaiths>k__BackingField: 0
-    FaithProperties: []
-  FaithEventsCheckTimeInSeconds: 390
-  FaithPerodicCheckTimeInSeconds: 12
+  FaithEventsCheckTimeInSeconds: 490
+  FaithPerodicCheckTimeInSeconds: 16
   <AllFaiths>k__BackingField:
   - {fileID: 11400000, guid: fb70b54dd325b7f4682b54eab09129e1, type: 2}
   - {fileID: 11400000, guid: a38d74f25d037be42a07c9f2d018cee6, type: 2}
@@ -64,6 +54,3 @@ MonoBehaviour:
   - {fileID: 11400000, guid: c365d32821407944992dae8cbe92eb2c, type: 2}
   - {fileID: 11400000, guid: b0e69e6f903a51241ab1e880d69e59c9, type: 2}
   - {fileID: 11400000, guid: 37a5db04667712a4eb120ece7e1db7fd, type: 2}
-  references:
-    version: 2
-    RefIds: []

--- a/UnityProject/Assets/Scripts/Objects/Alien/SpaceAnts/AntHill.cs
+++ b/UnityProject/Assets/Scripts/Objects/Alien/SpaceAnts/AntHill.cs
@@ -91,7 +91,7 @@ namespace Objects.Alien.SpaceAnts
 				mob.ApplyDamageAll(gameObject, damage, biteType, damageType);
 				Chat.AddExamineMsg(mob.gameObject, "you feel itchy all over yourself.");
 				PlayStepAudio(mob.gameObject);
-				if (DMMath.Prob(50)) mobsToDispel.Add(mob);
+				if (DMMath.Prob(90)) mobsToDispel.Add(mob);
 			}
 			foreach (var mobToRemove in mobsToDispel)
 			{

--- a/UnityProject/Assets/Scripts/Objects/Alien/SpaceAnts/AntHill.cs
+++ b/UnityProject/Assets/Scripts/Objects/Alien/SpaceAnts/AntHill.cs
@@ -70,7 +70,7 @@ namespace Objects.Alien.SpaceAnts
 
 		public void InflictMob(GameObject mob)
 		{
-			if (mob.TryGetComponent<LivingHealthMasterBase>(out var health) == false) return;
+			if (DMMath.Prob(75) || mob.TryGetComponent<LivingHealthMasterBase>(out var health) == false) return;
 			inflictedMobs.Add(health);
 		}
 

--- a/UnityProject/Assets/Scripts/Systems/Faith/FaithProperties/Germaphobe.cs
+++ b/UnityProject/Assets/Scripts/Systems/Faith/FaithProperties/Germaphobe.cs
@@ -88,37 +88,49 @@ namespace Systems.Faith.FaithProperties
 
 		private void SpawnStuff(ref List<Attributes> filth)
 		{
-			if (FilthScore > 150)
+			if (FilthScore > 175)
 			{
-				var spotsToPick = filth.PickRandom(2);
-				foreach (var spot in spotsToPick)
-				{
-					Spawn.ServerPrefab(antHills.PickRandom(), spot.gameObject.AssumedWorldPosServer());
-				}
+				SpawnAnts(ref filth);
 			}
-			if (FilthScore > 300)
+			if (FilthScore > 400)
 			{
-				var bread =
-					ComponentsTracker<Attributes>.Instances.Where(x
-						=> x.InitialTraits.Contains(breadLoafTrait) &&
-						   x.gameObject.RegisterTile().Matrix == MatrixManager.MainStationMatrix.Matrix).ToList();
-				if (bread.Count != 0)
-				{
-					foreach (var breadItem in bread)
-					{
-						Spawn.ServerPrefab(KillerBread.PickRandom(), breadItem.gameObject.AssumedWorldPosServer());
-						_ = Despawn.ServerSingle(breadItem.gameObject);
-					}
-				}
+				MoldBread();
 			}
-			if (FilthScore >= 550)
+			if (FilthScore >= 650)
 			{
-				var spotsToPick = filth.PickRandom(3);
-				foreach (var spot in spotsToPick)
-				{
-					Spawn.ServerPrefab(spores.PickRandom(), spot.gameObject.AssumedWorldPosServer());
-				}
+				SpawnSpores(ref filth);
 			}
 		}
+
+		private void SpawnAnts(ref List<Attributes> filth)
+		{
+			var spotsToPick = filth.PickRandom(2);
+			foreach (var spot in spotsToPick)
+			{
+				Spawn.ServerPrefab(antHills.PickRandom(), spot.gameObject.AssumedWorldPosServer());
+			}
+		}
+
+		private void SpawnSpores(ref List<Attributes> filth)
+		{
+			var spotsToPick = filth.PickRandom(3);
+			foreach (var spot in spotsToPick)
+			{
+				Spawn.ServerPrefab(spores.PickRandom(), spot.gameObject.AssumedWorldPosServer());
+			}
+		}
+
+		private void MoldBread()
+		{
+			var bread =
+				ComponentsTracker<Attributes>.Instances.Where(x => x.InitialTraits.Contains(breadLoafTrait)).ToList();
+			if (bread.Count == 0) return;
+			foreach (var breadItem in bread)
+			{
+				Spawn.ServerPrefab(KillerBread.PickRandom(), breadItem.gameObject.AssumedWorldPosServer());
+				_ = Despawn.ServerSingle(breadItem.gameObject);
+			}
+		}
+
 	}
 }


### PR DESCRIPTION
CL: [Fix] Increased the chance for ant bite inflications to be dispeled from 50% to 90%
CL: [Fix] Lowered the random damage done by ants when inflicted.
CL: [Fix] Ants now have a 35% chance to inflict players
CL: [Fix] Fixed a missing trait that caused an NRE when attempting to interact with ant hills with an object in hand. 
CL: [Fix] Ants will now only spawn 175 filth score instead of 150.
CL: [Improvement] Long updates for faith events now take 490 seconds to happen instead of 390.