### PR TITLE
Fixes cable placement and ants eating everything

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Electricity/HighCableCoil.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Electricity/HighCableCoil.prefab
@@ -42,7 +42,7 @@ PrefabInstance:
     - target: {fileID: 5205735185705106531, guid: c3e6805b264a935428b0de415ea57943,
         type: 3}
       propertyPath: initialTraits.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 5205735185705106531, guid: c3e6805b264a935428b0de415ea57943,
         type: 3}
@@ -55,6 +55,12 @@ PrefabInstance:
       propertyPath: 'initialTraits.Array.data[0]'
       value: 
       objectReference: {fileID: 11400000, guid: 6e46c3fa979e00940a50dbb3c0a4ac0c,
+        type: 2}
+    - target: {fileID: 5205735185705106531, guid: c3e6805b264a935428b0de415ea57943,
+        type: 3}
+      propertyPath: 'initialTraits.Array.data[1]'
+      value: 
+      objectReference: {fileID: 11400000, guid: e39c048ec864b47a495a40f9c76af764,
         type: 2}
     - target: {fileID: 5205735185705106531, guid: c3e6805b264a935428b0de415ea57943,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Electricity/LowCableCoil.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Electricity/LowCableCoil.prefab
@@ -42,7 +42,7 @@ PrefabInstance:
     - target: {fileID: 5205735185705106531, guid: c3e6805b264a935428b0de415ea57943,
         type: 3}
       propertyPath: initialTraits.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 5205735185705106531, guid: c3e6805b264a935428b0de415ea57943,
         type: 3}
@@ -55,6 +55,12 @@ PrefabInstance:
       propertyPath: 'initialTraits.Array.data[0]'
       value: 
       objectReference: {fileID: 11400000, guid: 6e46c3fa979e00940a50dbb3c0a4ac0c,
+        type: 2}
+    - target: {fileID: 5205735185705106531, guid: c3e6805b264a935428b0de415ea57943,
+        type: 3}
+      propertyPath: 'initialTraits.Array.data[1]'
+      value: 
+      objectReference: {fileID: 11400000, guid: e39c048ec864b47a495a40f9c76af764,
         type: 2}
     - target: {fileID: 5205735185705106531, guid: c3e6805b264a935428b0de415ea57943,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Electricity/MachineConnectorLowItem.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Electricity/MachineConnectorLowItem.prefab
@@ -124,13 +124,19 @@ PrefabInstance:
     - target: {fileID: 2679066993449747652, guid: d88c145d60cabfd4092f839650cea997,
         type: 3}
       propertyPath: initialTraits.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 2679066993449747652, guid: d88c145d60cabfd4092f839650cea997,
         type: 3}
       propertyPath: 'initialTraits.Array.data[0]'
       value: 
       objectReference: {fileID: 11400000, guid: 6e46c3fa979e00940a50dbb3c0a4ac0c,
+        type: 2}
+    - target: {fileID: 2679066993449747652, guid: d88c145d60cabfd4092f839650cea997,
+        type: 3}
+      propertyPath: 'initialTraits.Array.data[1]'
+      value: 
+      objectReference: {fileID: 11400000, guid: e39c048ec864b47a495a40f9c76af764,
         type: 2}
     - target: {fileID: 3016429826770117312, guid: d88c145d60cabfd4092f839650cea997,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Electricity/MachineConnectorMediumItem.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Electricity/MachineConnectorMediumItem.prefab
@@ -550,13 +550,25 @@ PrefabInstance:
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: initialTraits.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: 'initialTraits.Array.data[0]'
       value: 
       objectReference: {fileID: 11400000, guid: 6e46c3fa979e00940a50dbb3c0a4ac0c,
+        type: 2}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: 'initialTraits.Array.data[1]'
+      value: 
+      objectReference: {fileID: 11400000, guid: e39c048ec864b47a495a40f9c76af764,
+        type: 2}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: 'initialTraits.Array.data[2]'
+      value: 
+      objectReference: {fileID: 11400000, guid: e39c048ec864b47a495a40f9c76af764,
         type: 2}
     - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Electricity/MediumCableCoil.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Electricity/MediumCableCoil.prefab
@@ -159,7 +159,7 @@ PrefabInstance:
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: initialTraits.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
@@ -177,7 +177,7 @@ PrefabInstance:
         type: 3}
       propertyPath: 'initialTraits.Array.data[1]'
       value: 
-      objectReference: {fileID: 11400000, guid: 5eafba0d7388d428c8e08ed1b5d5d260,
+      objectReference: {fileID: 11400000, guid: e39c048ec864b47a495a40f9c76af764,
         type: 2}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Electricity/SingleHighCableCoil.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Electricity/SingleHighCableCoil.prefab
@@ -86,13 +86,19 @@ PrefabInstance:
     - target: {fileID: 1527742535114383235, guid: 288980126acf5f441841169958c31630,
         type: 3}
       propertyPath: initialTraits.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 1527742535114383235, guid: 288980126acf5f441841169958c31630,
         type: 3}
       propertyPath: 'initialTraits.Array.data[0]'
       value: 
       objectReference: {fileID: 11400000, guid: 6e46c3fa979e00940a50dbb3c0a4ac0c,
+        type: 2}
+    - target: {fileID: 1527742535114383235, guid: 288980126acf5f441841169958c31630,
+        type: 3}
+      propertyPath: 'initialTraits.Array.data[1]'
+      value: 
+      objectReference: {fileID: 11400000, guid: e39c048ec864b47a495a40f9c76af764,
         type: 2}
     - target: {fileID: 3377645697590253390, guid: 288980126acf5f441841169958c31630,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Electricity/SingleLowCableCoil.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Electricity/SingleLowCableCoil.prefab
@@ -107,11 +107,17 @@ PrefabInstance:
     - target: {fileID: 7830631383878543262, guid: 7f32e42309899114b9c122f261161bc5,
         type: 3}
       propertyPath: initialTraits.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 7830631383878543262, guid: 7f32e42309899114b9c122f261161bc5,
         type: 3}
       propertyPath: 'initialTraits.Array.data[0]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 6e46c3fa979e00940a50dbb3c0a4ac0c,
+        type: 2}
+    - target: {fileID: 7830631383878543262, guid: 7f32e42309899114b9c122f261161bc5,
+        type: 3}
+      propertyPath: 'initialTraits.Array.data[1]'
       value: 
       objectReference: {fileID: 11400000, guid: 6e46c3fa979e00940a50dbb3c0a4ac0c,
         type: 2}

--- a/UnityProject/Assets/Prefabs/Items/Electricity/SingleMediumCableCoil.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Electricity/SingleMediumCableCoil.prefab
@@ -16,13 +16,19 @@ PrefabInstance:
     - target: {fileID: 5205735185705106531, guid: c3e6805b264a935428b0de415ea57943,
         type: 3}
       propertyPath: initialTraits.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 5205735185705106531, guid: c3e6805b264a935428b0de415ea57943,
         type: 3}
       propertyPath: 'initialTraits.Array.data[0]'
       value: 
       objectReference: {fileID: 11400000, guid: 6e46c3fa979e00940a50dbb3c0a4ac0c,
+        type: 2}
+    - target: {fileID: 5205735185705106531, guid: c3e6805b264a935428b0de415ea57943,
+        type: 3}
+      propertyPath: 'initialTraits.Array.data[1]'
+      value: 
+      objectReference: {fileID: 11400000, guid: e39c048ec864b47a495a40f9c76af764,
         type: 2}
     - target: {fileID: 5674645506955800181, guid: c3e6805b264a935428b0de415ea57943,
         type: 3}

--- a/UnityProject/Assets/Scripts/Objects/Alien/SpaceAnts/AntHill.cs
+++ b/UnityProject/Assets/Scripts/Objects/Alien/SpaceAnts/AntHill.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using AddressableReferences;
 using Core;
 using HealthV2;
@@ -117,8 +118,9 @@ namespace Objects.Alien.SpaceAnts
 
 		private void LookForFilth()
 		{
-			var edibles = ComponentsTracker<Attributes>.GetAllNearbyTypesToTarget(gameObject, 32, eatsYourLiver);
-			if(edibles.Count == 0) return;
+			var edibles = ComponentsTracker<Attributes>.GetAllNearbyTypesToTarget(gameObject, 32, eatsYourLiver)
+				.Where(x => x.InitialTraits.Contains(filthTrait)).ToList();
+			if (edibles.Count == 0) return;
 			var edible = edibles.PickRandom();
 			if (DMMath.Prob(5) && state is AntHillState.Large or AntHillState.Swarm)
 			{


### PR DESCRIPTION
CL: [Fix] fixed a small oversight that made ants go goblin mode on the station infrastructure.
CL: [Fix] fixed a regression caused by unity that prevented players from placing/connecting cables.
