### PR TITLE
Makes sure that `CharacterSheet` does not fail on reteriving empty lists

### DIFF
--- a/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
+++ b/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
@@ -563,7 +563,7 @@ namespace IngameDebugConsole
 				foreach (var worldPos in playerScript.WorldPos.BoundsAround().allPositionsWithin)
 				{
 					var localPos = MatrixManager.WorldToLocalInt(worldPos, matrix);
-					var gasMix = matrix.MetaDataLayer.Get(localPos).GasMix;
+					var gasMix = matrix.MetaDataLayer.Get(localPos).GasMixLocal;
 					gasMix.AddGas(Gas.Plasma, 100);
 					gasMix.AddGas(Gas.Oxygen, 100);
 					matrix.ReactionManager.ExposeHotspot(localPos, 500);

--- a/UnityProject/Assets/Scripts/Core/Editor/Matrix/Views/MetaDataView.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/Matrix/Views/MetaDataView.cs
@@ -205,7 +205,7 @@ public class MetaDataView : BasicView
 			if (node.Exists)
 			{
 				Vector3 p = LocalToWorld(source, position);
-				GizmoUtils.DrawText($"{node.GasMix.Pressure:0.###}", p, false);
+				GizmoUtils.DrawText($"{node.GasMixLocal.Pressure:0.###}", p, false);
 			}
 		}
 	}
@@ -221,7 +221,7 @@ public class MetaDataView : BasicView
 			if (node.Exists)
 			{
 				Vector3 p = LocalToWorld(source, position);
-				GizmoUtils.DrawText($"{(node.GasMix.Temperature):0.##}", p, false);
+				GizmoUtils.DrawText($"{(node.GasMixLocal.Temperature):0.##}", p, false);
 			}
 		}
 	}
@@ -255,7 +255,7 @@ public class MetaDataView : BasicView
 			if (node.Exists)
 			{
 				Vector3 p = LocalToWorld(source, position);
-				GizmoUtils.DrawText($"{node.GasMix.Moles:0.###}", p, false);
+				GizmoUtils.DrawText($"{node.GasMixLocal.Moles:0.###}", p, false);
 			}
 		}
 	}
@@ -271,7 +271,7 @@ public class MetaDataView : BasicView
 			if (node.Exists)
 			{
 				Vector3 p = LocalToWorld(source, position);
-				GizmoUtils.DrawText($"{node.GasMix.Volume:0.###}", p, false);
+				GizmoUtils.DrawText($"{node.GasMixLocal.Volume:0.###}", p, false);
 			}
 		}
 	}
@@ -422,7 +422,7 @@ public class MetaDataView : BasicView
 			if (node.Exists)
 			{
 				Vector3 p = LocalToWorld(source, position);
-				GizmoUtils.DrawText($"{node.GasMix.GetMoles(Gas.Plasma):0.###}", p, false);
+				GizmoUtils.DrawText($"{node.GasMixLocal.GetMoles(Gas.Plasma):0.###}", p, false);
 			}
 		}
 	}
@@ -438,7 +438,7 @@ public class MetaDataView : BasicView
 			if (node.Exists)
 			{
 				Vector3 p = LocalToWorld(source, position);
-				GizmoUtils.DrawText($"{node.GasMix.GetMoles(Gas.Oxygen):0.###}", p, false);
+				GizmoUtils.DrawText($"{node.GasMixLocal.GetMoles(Gas.Oxygen):0.###}", p, false);
 			}
 		}
 	}
@@ -454,7 +454,7 @@ public class MetaDataView : BasicView
 			if (node.Exists)
 			{
 				Vector3 p = LocalToWorld(source, position);
-				GizmoUtils.DrawText($"{node.GasMix.GetMoles(Gas.Nitrogen):0.###}", p, false);
+				GizmoUtils.DrawText($"{node.GasMixLocal.GetMoles(Gas.Nitrogen):0.###}", p, false);
 			}
 		}
 	}
@@ -470,7 +470,7 @@ public class MetaDataView : BasicView
 			if (node.Exists)
 			{
 				Vector3 p = LocalToWorld(source, position);
-				GizmoUtils.DrawText($"{node.GasMix.GetMoles(Gas.CarbonDioxide):0.###}", p, false);
+				GizmoUtils.DrawText($"{node.GasMixLocal.GetMoles(Gas.CarbonDioxide):0.###}", p, false);
 			}
 		}
 	}
@@ -486,7 +486,7 @@ public class MetaDataView : BasicView
 			if (node.Exists)
 			{
 				Vector3 p = LocalToWorld(source, position);
-				GizmoUtils.DrawText($"{node.GasMix.GasesArray.Count}", p, false);
+				GizmoUtils.DrawText($"{node.GasMixLocal.GasesArray.Count}", p, false);
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Health/FireExposure.cs
+++ b/UnityProject/Assets/Scripts/Health/FireExposure.cs
@@ -104,7 +104,7 @@ public class FireExposure
 			                      " will occur. This is likely a coding error.", Category.Atmos, hotspotNode.LocalPosition);
 			return;
 		}
-		Update(hotspotNode.GasMix.Temperature, hotspotNode.LocalPosition, atLocalPosition, atWorldPosition, hotspotWorldPosition);
+		Update(hotspotNode.GasMixLocal.Temperature, hotspotNode.LocalPosition, atLocalPosition, atWorldPosition, hotspotWorldPosition);
 	}
 
 	/// <summary>
@@ -124,6 +124,6 @@ public class FireExposure
 			                      " will occur. This is likely a coding error.", Category.Atmos, hotspotNode.LocalPosition);
 			return null;
 		}
-		return new FireExposure(hotspotNode.GasMix.Temperature, hotspotNode.LocalPosition, atLocalPosition, atWorldPosition, hotspotWorldPosition);
+		return new FireExposure(hotspotNode.GasMixLocal.Temperature, hotspotNode.LocalPosition, atLocalPosition, atWorldPosition, hotspotWorldPosition);
 	}
 }

--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -467,7 +467,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 			SyncFireStacks(fireStacks, fireStacks - 0.1f);
 			//instantly stop burning if there's no oxygen at this location
 			MetaDataNode node = registerTile.Matrix.MetaDataLayer.Get(registerTile.LocalPositionClient);
-			if (node.GasMix.GetMoles(Gas.Oxygen) < 1)
+			if (node.GasMixLocal.GetMoles(Gas.Oxygen) < 1)
 			{
 				SyncFireStacks(fireStacks, 0);
 			}
@@ -630,12 +630,12 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 		MetaDataNode node = registerTile.Matrix.MetaDataLayer.Get(registerTile.LocalPositionClient);
 
 		//Space or below -10 degrees celsius is safe from miasma creation
-		if (node.IsSpace || node.GasMix.Temperature <= Reactions.KOffsetC - 10) return;
+		if (node.IsSpace || node.GasMixLocal.Temperature <= Reactions.KOffsetC - 10) return;
 
 		//If we are in a container then don't produce miasma
 		if (objectBehaviour.ContainedInObjectContainer != null) return;
 
-		node.GasMix.AddGas(Gas.Miasma, AtmosDefines.MIASMA_CORPSE_MOLES);
+		node.GasMixLocal.AddGas(Gas.Miasma, AtmosDefines.MIASMA_CORPSE_MOLES);
 	}
 
 	private bool NotSuitableForDeath()

--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -280,7 +280,7 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 	{
 		//Instantly stop burning if there's no oxygen at this location
 		MetaDataNode node = RegisterTile.Matrix.MetaDataLayer.Get(RegisterTile.LocalPositionServer);
-		if (node?.GasMix.GetMoles(Gas.Oxygen) < 1)
+		if (node?.GasMixLocal.GetMoles(Gas.Oxygen) < 1)
 		{
 			SyncOnFire(true, false);
 			return;
@@ -288,7 +288,7 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 
 		ApplyDamage(BURNING_DAMAGE, AttackType.Fire, DamageType.Burn);
 
-		node?.GasMix.AddGas(Gas.Smoke, BURNING_DAMAGE * 100);
+		node?.GasMixLocal.AddGas(Gas.Smoke, BURNING_DAMAGE * 100);
 	}
 
 	private void SyncOnFire(bool wasOnFire, bool onFire)

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -892,7 +892,7 @@ namespace HealthV2
 			MetaDataNode
 				node = RegisterTile.Matrix.MetaDataLayer.Get(RegisterTile
 					.LocalPositionClient); //TODO Account for containers
-			if (node.GasMix.GetMoles(Gas.Oxygen) < 1)
+			if (node.GasMixLocal.GetMoles(Gas.Oxygen) < 1)
 			{
 				fireStacks = 0;
 				return;
@@ -1666,7 +1666,7 @@ namespace HealthV2
 			MetaDataNode node = RegisterTile.Matrix.MetaDataLayer.Get(RegisterTile.LocalPositionClient);
 
 			//Space or below -10 degrees celsius is safe from miasma creation
-			if (node.IsSpace || node.GasMix.Temperature <= Reactions.KOffsetC - 10) return;
+			if (node.IsSpace || node.GasMixLocal.Temperature <= Reactions.KOffsetC - 10) return;
 
 			//If we are in a container then don't produce miasma
 			//TODO: make this only happen with coffins, body bags and other body containers (morgue, etc)
@@ -1675,9 +1675,9 @@ namespace HealthV2
 			//TODO: check for formaldehyde in body, prevent if more than 15u
 
 			//Don't continuously produce miasma, only produce max 4 moles on the tile
-			if (node.GasMix.GetMoles(Gas.Miasma) > 4) return;
+			if (node.GasMixLocal.GetMoles(Gas.Miasma) > 4) return;
 
-			node.GasMix.AddGas(Gas.Miasma, AtmosDefines.MIASMA_CORPSE_MOLES);
+			node.GasMixLocal.AddGas(Gas.Miasma, AtmosDefines.MIASMA_CORPSE_MOLES);
 		}
 
 		#region Examine

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Respiration/RespiratorySystemBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Respiration/RespiratorySystemBase.cs
@@ -128,7 +128,7 @@ namespace HealthV2
 				if(implant.isEMPed)
 				{
 					GasContainer gasContainer = new GasContainer();
-					gasContainer.GasMix = new GasMix();
+					gasContainer.GasMixLocal = new GasMix();
 					return gasContainer;
 				}
 			}

--- a/UnityProject/Assets/Scripts/Items/Glass/IceShard.cs
+++ b/UnityProject/Assets/Scripts/Items/Glass/IceShard.cs
@@ -80,12 +80,12 @@ namespace Items
 
 			if (metaDataNode == null) return;
 
-			if (isHotIce == false && metaDataNode.GasMix.Temperature > AtmosDefines.WATER_VAPOR_FREEZE)
+			if (isHotIce == false && metaDataNode.GasMixLocal.Temperature > AtmosDefines.WATER_VAPOR_FREEZE)
 			{
 				MeltIce(metaDataNode);
 			}
 
-			if (isHotIce && metaDataNode.GasMix.Temperature > 373.15)
+			if (isHotIce && metaDataNode.GasMixLocal.Temperature > 373.15)
 			{
 				MeltHotIce(metaDataNode);
 			}
@@ -95,7 +95,7 @@ namespace Items
 
 		private void MeltIce(MetaDataNode node)
 		{
-			node.GasMix.AddGas(Gas.WaterVapor, stackable.Amount * 2f);
+			node.GasMixLocal.AddGas(Gas.WaterVapor, stackable.Amount * 2f);
 			_ = Despawn.ServerSingle(gameObject);
 		}
 
@@ -103,8 +103,8 @@ namespace Items
 		{
 			if (node == null) return;
 
-			node.GasMix.AddGas(Gas.Plasma, stackable.Amount * 150);
-			node.GasMix.ChangeTemperature(stackable.Amount * 20 + 300);
+			node.GasMixLocal.AddGas(Gas.Plasma, stackable.Amount * 150);
+			node.GasMixLocal.ChangeTemperature(stackable.Amount * 20 + 300);
 			_ = Despawn.ServerSingle(gameObject);
 		}
 

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Ears.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Ears.cs
@@ -100,7 +100,7 @@ namespace Items.Implants.Organs
 			var pressure =
 				RelatedPart.HealthMaster.playerScript.playerMove.GetRootObject.RegisterTile()
 					.Matrix.GetMetaDataNode(localPosition)
-					.GasMix.Pressure;
+					.GasMixLocal.Pressure;
 
 			if (pressure > 80)
 			{

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
@@ -157,7 +157,7 @@ namespace Items.Implants.Organs
 
 			// Try to get internal breathing if possible, otherwise get from the surroundings
 			IGasMixContainer container = RelatedPart.HealthMaster.RespiratorySystem.GetInternalGasMix();
-			var gasMixSink = node.GasMix; // Where to dump lung exhaust
+			var gasMixSink = node.GasMixLocal; // Where to dump lung exhaust
 			if (container == null)
 			{
 				// Could be in a container that has an internal gas mix, else use the tile's gas mix.
@@ -165,7 +165,7 @@ namespace Items.Implants.Organs
 				if (parentContainer != null && parentContainer.TryGetComponent<GasContainer>(out var gasContainer))
 				{
 					container = gasContainer;
-					gasMixSink = container.GasMix;
+					gasMixSink = container.GasMixLocal;
 				}
 				else
 				{
@@ -188,7 +188,7 @@ namespace Items.Implants.Organs
 			}
 
 			bool tryExhale = BreatheOut(gasMixSink, availableBlood);
-			bool tryInhale = BreatheIn(container.GasMix, availableBlood, efficiency);
+			bool tryInhale = BreatheIn(container.GasMixLocal, availableBlood, efficiency);
 			ReagentCirculatedComponent.AssociatedSystem.BloodPool.Add(availableBlood);
 			return tryExhale || tryInhale;
 		}

--- a/UnityProject/Assets/Scripts/Items/Others/Jetpack.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/Jetpack.cs
@@ -64,7 +64,7 @@ namespace Items.Others
 		private void PushUpdate()
 		{
 			if (isOn == false || compatibleSlot == false) return;
-			if (gasContainer.GasMix.Moles <= 0) return;
+			if (gasContainer.GasMixLocal.Moles <= 0) return;
 			if (player.PlayerSync.IsPressedServer) //Is a movement key pressed?
 			{
 				PushPlayerInFacedDirection(player, gasContainer, gasReleaseOnUse, moveQueueBuildUp);
@@ -137,8 +137,8 @@ namespace Items.Others
 		{
 			if (playerScript.ObjectPhysics.CanPush(playerScript.CurrentDirection.ToLocalVector2Int()) == false) return;
 			playerScript.ObjectPhysics.NewtonianPush(playerScript.CurrentDirection.ToLocalVector2Int(), speed);
-			var domGas = gasContainer.GasMix.GetBiggestGasSOInMix();
-			if (domGas != null) gasContainer.GasMix.RemoveGas(domGas, gasRelease);
+			var domGas = gasContainer.GasMixLocal.GetBiggestGasSOInMix();
+			if (domGas != null) gasContainer.GasMixLocal.RemoveGas(domGas, gasRelease);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Tool/AtmosphericAnalyser/AtmosphericAnalyser.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/AtmosphericAnalyser/AtmosphericAnalyser.cs
@@ -25,7 +25,7 @@ namespace Items.Atmospherics
 				    .TryGetComponent<GasContainer>(
 					    out var container))
 			{
-				Chat.AddExamineMsgFromServer(interaction.Performer, GetGasMixInfo(container.GasMix));
+				Chat.AddExamineMsgFromServer(interaction.Performer, GetGasMixInfo(container.GasMixLocal));
 				return;
 			}
 
@@ -35,7 +35,7 @@ namespace Items.Atmospherics
 				var node = metaDataLayer.Get(interaction.Performer.transform.localPosition.RoundToInt());
 				if (node != null)
 				{
-					Chat.AddExamineMsgFromServer(interaction.Performer, GetGasMixInfo(node.GasMix));
+					Chat.AddExamineMsgFromServer(interaction.Performer, GetGasMixInfo(node.GasMixLocal));
 				}
 			}
 		}
@@ -55,7 +55,7 @@ namespace Items.Atmospherics
 			{
 				if (interaction.TargetObject.TryGetComponent(out GasContainer container))
 				{
-					Chat.AddExamineMsgFromServer(interaction.Performer, GetGasMixInfo(container.GasMix));
+					Chat.AddExamineMsgFromServer(interaction.Performer, GetGasMixInfo(container.GasMixLocal));
 					return;
 				}
 
@@ -99,7 +99,7 @@ namespace Items.Atmospherics
 		{
 			if (interaction.TargetObject.TryGetComponent<GasContainer>(out var container) == false) return;
 
-			Chat.AddExamineMsgFromServer(interaction.Performer, GetGasMixInfo(container.GasMix));
+			Chat.AddExamineMsgFromServer(interaction.Performer, GetGasMixInfo(container.GasMixLocal));
 		}
 
 

--- a/UnityProject/Assets/Scripts/Items/Weapons/Projectiles/Behaviours/ProjectileKineticDamageCalculation.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Projectiles/Behaviours/ProjectileKineticDamageCalculation.cs
@@ -18,7 +18,7 @@ namespace Weapons.Projectiles.Behaviours
 
 			float pressure = MatrixManager.AtPoint(
 				localPosition.RoundToInt(), true
-			).MetaDataLayer.Get(localPosition.RoundToInt()).GasMix.Pressure;
+			).MetaDataLayer.Get(localPosition.RoundToInt()).GasMixLocal.Pressure;
 
 			return pressure;
 		}

--- a/UnityProject/Assets/Scripts/Managers/CargoManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/CargoManager.cs
@@ -399,9 +399,9 @@ namespace Systems.Cargo
 			{
 				var stringBuilder = new StringBuilder(export.ExportMessage);
 
-				lock (gasContainer.GasMix.GasesArray) //no Double lock
+				lock (gasContainer.GasMixLocal.GasesArray) //no Double lock
 				{
-					foreach (var gas in gasContainer.GasMix.GasesArray)  //doesn't appear to modify list while iterating
+					foreach (var gas in gasContainer.GasMixLocal.GasesArray)  //doesn't appear to modify list while iterating
 					{
 						int gasValue = (int)gas.Moles * gas.GasSO.ExportPrice;
 						stringBuilder.AppendLine($"Exported {gas.Moles} moles of {gas.GasSO.Name} for {gasValue} credits");

--- a/UnityProject/Assets/Scripts/Objects/Atmospherics/AcuSensor.cs
+++ b/UnityProject/Assets/Scripts/Objects/Atmospherics/AcuSensor.cs
@@ -8,7 +8,7 @@ namespace Objects.Atmospherics
 	/// </summary>
 	public class AcuSensor : MonoBehaviour, IServerSpawn, IAcuControllable
 	{
-		public AcuSample AtmosphericSample => atmosphericSample.FromGasMix(metaNode.GasMix);
+		public AcuSample AtmosphericSample => atmosphericSample.FromGasMix(metaNode.GasMixLocal);
 
 		private readonly AcuSample atmosphericSample = new AcuSample();
 		private MetaDataNode metaNode;

--- a/UnityProject/Assets/Scripts/Objects/Atmospherics/AirController.cs
+++ b/UnityProject/Assets/Scripts/Objects/Atmospherics/AirController.cs
@@ -158,7 +158,7 @@ namespace Objects.Atmospherics
 
 			if (acuSamplesAir)
 			{
-				acuSample.FromGasMix(facingMetaNode.GasMix);
+				acuSample.FromGasMix(facingMetaNode.GasMixLocal);
 				AtmosphericAverage.AddSample(acuSample);
 			}
 		}

--- a/UnityProject/Assets/Scripts/Objects/Canisters/Canister.cs
+++ b/UnityProject/Assets/Scripts/Objects/Canisters/Canister.cs
@@ -340,7 +340,7 @@ namespace Objects.Atmospherics
 		{
 			if (canisterTier > 0)
 			{
-				GasContainer.GasMix.MultiplyGas(Mathf.Pow(10, canisterTier));
+				GasContainer.GasMixLocal.MultiplyGas(Mathf.Pow(10, canisterTier));
 				canisterTierOverlay.SetCatalogueIndexSprite(canisterTier - 1); // Tier 0 has no overlay.
 			}
 		}
@@ -361,10 +361,10 @@ namespace Objects.Atmospherics
 
 			GasContainer canisterTank = GetComponent<GasContainer>();
 			GasContainer externalTank = InsertedContainer.GetComponent<GasContainer>();
-			GasMix canisterGas = canisterTank.GasMix;
-			GasMix tankGas = externalTank.GasMix;
-			canisterTank.GasMix = tankGas.MergeGasMix(canisterGas);
-			externalTank.GasMix = tankGas;
+			GasMix canisterGas = canisterTank.GasMixLocal;
+			GasMix tankGas = externalTank.GasMixLocal;
+			canisterTank.GasMixLocal = tankGas.MergeGasMix(canisterGas);
+			externalTank.GasMixLocal = tankGas;
 		}
 
 		public void RefreshPressureIndicator()

--- a/UnityProject/Assets/Scripts/Objects/Canisters/PlasmaAddable.cs
+++ b/UnityProject/Assets/Scripts/Objects/Canisters/PlasmaAddable.cs
@@ -47,14 +47,14 @@ namespace Objects.Atmospherics
 				return;
 			}
 
-			if (gasContainer.GasMix.Pressure >= maxPressure)
+			if (gasContainer.GasMixLocal.Pressure >= maxPressure)
 			{
 				Chat.AddExamineMsg(interaction.Performer, " The gas canister is too high pressure for you to fit the plasma into ");
 				return;
 			}
 
 			interaction.HandObject.GetComponent<Stackable>().ServerConsume(1);
-			gasContainer.GasMix.AddGasWithTemperature(Gas.Plasma, molesAdded, temperatureKelvin);
+			gasContainer.GasMixLocal.AddGasWithTemperature(Gas.Plasma, molesAdded, temperatureKelvin);
 		}
 
 		public RightClickableResult GenerateRightClickOptions()

--- a/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
@@ -165,8 +165,6 @@ namespace Objects
 			{
 				CollectObjects();
 			}
-
-			if (gasContainer != null) gasContainer.EqualiseWithTile();
 		}
 
 		private void OnWillDestroyServer(DestructionInfo arg0)

--- a/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
@@ -165,6 +165,8 @@ namespace Objects
 			{
 				CollectObjects();
 			}
+
+			if (gasContainer != null) gasContainer.EqualiseWithTile();
 		}
 
 		private void OnWillDestroyServer(DestructionInfo arg0)
@@ -228,11 +230,9 @@ namespace Objects
 
 		private void UpdateGasContainer()
 		{
-			if (gasContainer != null)
-			{
-				gasContainer.IsSealed = IsOpen == false && (isOnlySealedWhenWelded == false || IsWelded);
-				gasContainer.EqualiseWithTile();
-			}
+			if (gasContainer == null) return;
+			gasContainer.IsSealed = IsOpen == false && (isOnlySealedWhenWelded == false || IsWelded);
+			gasContainer.EqualiseWithTile();
 		}
 
 		public void BreakLock()

--- a/UnityProject/Assets/Scripts/Objects/Disposals/DisposalBin.cs
+++ b/UnityProject/Assets/Scripts/Objects/Disposals/DisposalBin.cs
@@ -495,15 +495,15 @@ namespace Objects.Disposals
 		private void OperateAirPump()
 		{
 			MetaDataLayer metadata = registerObject.Matrix.MetaDataLayer;
-			GasMix tileMix = metadata.Get(registerObject.LocalPositionServer, false).GasMix;
+			GasMix tileMix = metadata.Get(registerObject.LocalPositionServer, false).GasMixLocal;
 
-			var molesToTransfer = (tileMix.Moles - (tileMix.Moles * (CHARGED_PRESSURE / gasContainer.GasMix.Pressure))) * -1;
+			var molesToTransfer = (tileMix.Moles - (tileMix.Moles * (CHARGED_PRESSURE / gasContainer.GasMixLocal.Pressure))) * -1;
 			molesToTransfer *= 0.5f;
 
-			GasMix.TransferGas(gasContainer.GasMix, tileMix, molesToTransfer.Clamp(0, 8));
+			GasMix.TransferGas(gasContainer.GasMixLocal, tileMix, molesToTransfer.Clamp(0, 8));
 			metadata.UpdateSystemsAt(registerObject.LocalPositionServer, SystemType.AtmosSystem);
 
-			chargePressure = gasContainer.GasMix.Pressure;
+			chargePressure = gasContainer.GasMixLocal.Pressure;
 		}
 
 		private IEnumerator RunFlushSequence()

--- a/UnityProject/Assets/Scripts/Objects/Doors/DoorController.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/DoorController.cs
@@ -499,11 +499,11 @@ namespace Doors
 			var horzPressureDiff = 0.0;
 			if (upMetaNode.IsOccupied == false || downMetaNode.IsOccupied == false)
 			{
-				vertPressureDiff = Math.Abs(upMetaNode.GasMix.Pressure - downMetaNode.GasMix.Pressure);
+				vertPressureDiff = Math.Abs(upMetaNode.GasMixLocal.Pressure - downMetaNode.GasMixLocal.Pressure);
 			}
 			if (leftMetaNode.IsOccupied == false || rightMetaNode.IsOccupied == false)
 			{
-				horzPressureDiff = Math.Abs(leftMetaNode.GasMix.Pressure - rightMetaNode.GasMix.Pressure);
+				horzPressureDiff = Math.Abs(leftMetaNode.GasMixLocal.Pressure - rightMetaNode.GasMixLocal.Pressure);
 			}
 
 			// Set pressureLevel according to the pressure difference found.

--- a/UnityProject/Assets/Scripts/Objects/Doors/Modules/PressureModule.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/Modules/PressureModule.cs
@@ -96,11 +96,11 @@ namespace Doors.Modules
 			var horzPressureDiff = 0.0;
 			if (!upMetaNode.IsOccupied || !downMetaNode.IsOccupied)
 			{
-				vertPressureDiff = Math.Abs(upMetaNode.GasMix.Pressure - downMetaNode.GasMix.Pressure);
+				vertPressureDiff = Math.Abs(upMetaNode.GasMixLocal.Pressure - downMetaNode.GasMixLocal.Pressure);
 			}
 			if (!leftMetaNode.IsOccupied || !rightMetaNode.IsOccupied)
 			{
-				horzPressureDiff = Math.Abs(leftMetaNode.GasMix.Pressure - rightMetaNode.GasMix.Pressure);
+				horzPressureDiff = Math.Abs(leftMetaNode.GasMixLocal.Pressure - rightMetaNode.GasMixLocal.Pressure);
 			}
 
 			// Set pressureLevel according to the pressure difference found.

--- a/UnityProject/Assets/Scripts/Objects/Engineering/Reactor/ReactorGraphiteChamber.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/Reactor/ReactorGraphiteChamber.cs
@@ -163,7 +163,7 @@ namespace Objects.Engineering
 		{
 			if (PoppedPipes)
 			{
-				return (registerObject.Matrix.GetMetaDataNode(this.registerObject.LocalPosition).GasMix.Temperature);
+				return (registerObject.Matrix.GetMetaDataNode(this.registerObject.LocalPosition).GasMixLocal.Temperature);
 			}
 			else
 			{
@@ -280,19 +280,19 @@ namespace Objects.Engineering
 			if (PoppedPipes)
 			{
 				var GasNode = registerObject.Matrix.GetMetaDataNode(this.registerObject.LocalPosition);
-				if (GasNode.GasMix.Temperature < 5000)
+				if (GasNode.GasMixLocal.Temperature < 5000)
 				{
-					if (GasNode.GasMix.WholeHeatCapacity != 0)
+					if (GasNode.GasMixLocal.WholeHeatCapacity != 0)
 					{
-						GasNode.GasMix.InternalEnergy += ExtraEnergyGained * 0.000001f;
-						if (GasNode.GasMix.Temperature > 5000)
+						GasNode.GasMixLocal.InternalEnergy += ExtraEnergyGained * 0.000001f;
+						if (GasNode.GasMixLocal.Temperature > 5000)
 						{
-							GasNode.GasMix.Temperature = 5000;
+							GasNode.GasMixLocal.Temperature = 5000;
 						}
 					}
 				}
 
-				CurrentPressure = (decimal) GasNode.GasMix.Pressure;
+				CurrentPressure = (decimal) GasNode.GasMixLocal.Pressure;
 			}
 			else
 			{

--- a/UnityProject/Assets/Scripts/Objects/Engineering/SuperMatter.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/SuperMatter.cs
@@ -391,7 +391,7 @@ namespace Objects.Engineering
 			var gasNode = registerTile.Matrix.GetMetaDataNode(registerTile.LocalPositionServer, false);
 			if(gasNode == null) return;
 
-			var gasMix = gasNode.GasMix;
+			var gasMix = gasNode.GasMixLocal;
 
 			GasMix.TransferGas(removeMix, gasMix, 0.15f * gasMix.Moles);
 
@@ -1287,7 +1287,7 @@ namespace Objects.Engineering
 
 			if (node == null) return SuperMatterStatus.Error;
 
-			var gas = node.GasMix;
+			var gas = node.GasMixLocal;
 
 			var integrityPercentage = GetIntegrityPercentage();
 

--- a/UnityProject/Assets/Scripts/Objects/Other/CrawlingVirtualContainer.cs
+++ b/UnityProject/Assets/Scripts/Objects/Other/CrawlingVirtualContainer.cs
@@ -93,7 +93,7 @@ namespace Objects.Other
 			if(pipeToMove == null) return;
 
 			//Equalise our gasmix on move
-			pipeToMove.GetMixAndVolume.EqualiseWithExternal(gasContainer.GasMix);
+			pipeToMove.GetMixAndVolume.EqualiseWithExternal(gasContainer.GasMixLocal);
 
 			objectContainer.registerTile.
 				ObjectPhysics.Component

--- a/UnityProject/Assets/Scripts/Objects/Pipes/Devices/AirInjector.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/Devices/AirInjector.cs
@@ -130,10 +130,10 @@ namespace Objects.Atmospherics
 				default:
 				case Mode.Injecting:
 					sourceMix = pipeMix;
-					targetMix = metaNode.GasMix;
+					targetMix = metaNode.GasMixLocal;
 					break;
 				case Mode.Extracting:
-					sourceMix = metaNode.GasMix;
+					sourceMix = metaNode.GasMixLocal;
 					targetMix = pipeMix;
 					break;
 			}

--- a/UnityProject/Assets/Scripts/Objects/Pipes/Devices/AirVent.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/Devices/AirVent.cs
@@ -104,10 +104,10 @@ namespace Objects.Atmospherics
 		private void Operate()
 		{
 			GasMix sourceGasMix = pipeMix;
-			GasMix targetGasMix = metaNode.GasMix;
+			GasMix targetGasMix = metaNode.GasMixLocal;
 			if (OperatingMode == Mode.In)
 			{
-				sourceGasMix = metaNode.GasMix;
+				sourceGasMix = metaNode.GasMixLocal;
 				targetGasMix = pipeMix;
 			}
 
@@ -143,9 +143,9 @@ namespace Objects.Atmospherics
 
 			// Evaluate External pressure regulator - want to match pressure in the tile to the regulator value
 			float externalMolLimit = maxTransfer;
-			if (ExternalEnabled && metaNode.GasMix.Pressure.Approx(0) == false)
+			if (ExternalEnabled && metaNode.GasMixLocal.Pressure.Approx(0) == false)
 			{
-				externalMolLimit = sourceMix.Moles - (sourceMix.Moles * (ExternalTarget / metaNode.GasMix.Pressure));
+				externalMolLimit = sourceMix.Moles - (sourceMix.Moles * (ExternalTarget / metaNode.GasMixLocal.Pressure));
 				externalMolLimit *= -direction;
 			}
 
@@ -333,7 +333,7 @@ namespace Objects.Atmospherics
 		#region IAcuControllable
 
 		private readonly AcuSample atmosphericSample = new AcuSample();
-		AcuSample IAcuControllable.AtmosphericSample => atmosphericSample.FromGasMix(metaNode.GasMix);
+		AcuSample IAcuControllable.AtmosphericSample => atmosphericSample.FromGasMix(metaNode.GasMixLocal);
 
 		public void SetOperatingMode(AcuMode mode)
 		{

--- a/UnityProject/Assets/Scripts/Objects/Pipes/Devices/Connector.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/Devices/Connector.cs
@@ -17,8 +17,8 @@ namespace Objects.Atmospherics
 			base.TickUpdate();
 			if (canister != null && canister.ValveIsOpen)
 			{
-				pipeData.mixAndVolume.GetGasMix().MergeGasMix(canister.GasContainer.GasMix);
-				canister.GasContainer.GasMix = pipeData.mixAndVolume.EqualiseWithExternal(canister.GasContainer.GasMix);
+				pipeData.mixAndVolume.GetGasMix().MergeGasMix(canister.GasContainer.GasMixLocal);
+				canister.GasContainer.GasMixLocal = pipeData.mixAndVolume.EqualiseWithExternal(canister.GasContainer.GasMixLocal);
 			}
 			pipeData.mixAndVolume.EqualiseWithOutputs(pipeData.Outputs);
 		}

--- a/UnityProject/Assets/Scripts/Objects/Pipes/Devices/PeriodicGasSetter.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/Devices/PeriodicGasSetter.cs
@@ -39,14 +39,14 @@ public class PeriodicGasSetter : MonoBehaviour
 	public void UpdateLoop()
 	{
 		var node = RegisterTile.Matrix.MetaDataLayer.Get(transform.localPosition.RoundToInt());
-		var nodeGasMix =  node.GasMix;
+		var nodeGasMix =  node.GasMixLocal;
 
 		var gas = GasMix.GasData.CopyTo(nodeGasMix.GasData);
 		nodeGasMix.GasData = gas;
 		nodeGasMix.Temperature = GasMix.Temperature;
 		nodeGasMix.Temperature = GasMix.Pressure;
 		nodeGasMix.Volume = GasMix.Volume;
-		node.GasMix = nodeGasMix;
+		node.GasMixLocal = nodeGasMix;
 	}
 
 

--- a/UnityProject/Assets/Scripts/Objects/Pipes/Devices/PortableScrubber.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/Devices/PortableScrubber.cs
@@ -134,7 +134,7 @@ public class PortableScrubber : MonoBehaviour, ICheckedInteractable<HandApply>
 			return;
 		}
 
-		var gasMix = canister.GasContainer.GasMix;
+		var gasMix = canister.GasContainer.GasMixLocal;
 		if (gasMix.Pressure > 15000)
 		{
 			Toggle(false);
@@ -148,13 +148,13 @@ public class PortableScrubber : MonoBehaviour, ICheckedInteractable<HandApply>
 		foreach (var offsetPosition in RelativePositionsToScrub)
 		{
 			var tile = UniversalObjectPhysics.registerTile.Matrix.MetaDataLayer.Get(localPosition + offsetPosition);
-			var moles = tile.GasMix.GetMoles(TargetGas) * ScrubberEfficiency;
+			var moles = tile.GasMixLocal.GetMoles(TargetGas) * ScrubberEfficiency;
 			moles = moles.Clamp(0, 10); //max 25 Presumes it's only one
 			if (moles == 0)
 			{
 				continue;
 			}
-			energyTotal += tile.GasMix.TakeGasReturnEnergy(TargetGas, moles);
+			energyTotal += tile.GasMixLocal.TakeGasReturnEnergy(TargetGas, moles);
 			totalMoles += moles;
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/Pipes/Devices/Scrubber.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/Devices/Scrubber.cs
@@ -141,7 +141,7 @@ namespace Objects.Atmospherics
 		private bool CanTransfer()
 		{
 			// No external gas to take
-			if (metaNode.GasMix.Pressure.Approx(0)) return false;
+			if (metaNode.GasMixLocal.Pressure.Approx(0)) return false;
 			if (selfSufficient == false)
 			{
 				// No room in internal pipe to push to
@@ -160,9 +160,9 @@ namespace Objects.Atmospherics
 
 			float scrubbableMolesAvailable = 0;
 
-			lock (metaNode.GasMix.GasesArray) //no Double lock
+			lock (metaNode.GasMixLocal.GasesArray) //no Double lock
 			{
-				foreach (GasValues gas in metaNode.GasMix.GasesArray) //doesn't appear to modify list while iterating
+				foreach (GasValues gas in metaNode.GasMixLocal.GasesArray) //doesn't appear to modify list while iterating
 				{
 					if (FilteredGases.Contains(gas.GasSO))
 					{
@@ -186,7 +186,7 @@ namespace Objects.Atmospherics
 				float transferAmount = scrubbingGasMoles[i] * ratio;
 				if (transferAmount.Approx(0)) continue;
 
-				metaNode.GasMix.RemoveGas(gas, transferAmount);
+				metaNode.GasMixLocal.RemoveGas(gas, transferAmount);
 				if (selfSufficient == false)
 				{
 					pipeMix.AddGas(gas, transferAmount);
@@ -198,12 +198,12 @@ namespace Objects.Atmospherics
 
 		private void ModeSiphon()
 		{
-			float moles = metaNode.GasMix.Moles * (IsExpandedRange ? ExpandedRangeNumber : NormalRangeNumber ) * Effectiveness * SiphonMultiplier; // siphon a portion
+			float moles = metaNode.GasMixLocal.Moles * (IsExpandedRange ? ExpandedRangeNumber : NormalRangeNumber ) * Effectiveness * SiphonMultiplier; // siphon a portion
 			moles = moles.Clamp(0, nominalMolesTransferCap);
 
 			if (moles.Approx(0)) return;
 
-			GasMix.TransferGas(pipeMix, metaNode.GasMix, moles);
+			GasMix.TransferGas(pipeMix, metaNode.GasMixLocal, moles);
 		}
 
 		#endregion
@@ -347,7 +347,7 @@ namespace Objects.Atmospherics
 		};
 
 		private AcuSample atmosphericSample = new AcuSample();
-		AcuSample IAcuControllable.AtmosphericSample => atmosphericSample.FromGasMix(metaNode.GasMix);
+		AcuSample IAcuControllable.AtmosphericSample => atmosphericSample.FromGasMix(metaNode.GasMixLocal);
 
 		public void SetOperatingMode(AcuMode mode)
 		{

--- a/UnityProject/Assets/Scripts/Objects/Pipes/MonoPipe.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/MonoPipe.cs
@@ -249,7 +249,7 @@ namespace Objects.Atmospherics
 			}
 			if (container.GameObject.TryGetComponent<GasContainer>(out var gasContainer))
 			{
-				GasMix.TransferGas(gasContainer.GasMix, pipeMix, pipeMix.Moles);
+				GasMix.TransferGas(gasContainer.GasMixLocal, pipeMix, pipeMix.Moles);
 			}
 
 			Chat.AddActionMsgToChat(gameObject, $"You enter the {gameObject.ExpensiveName()}",

--- a/UnityProject/Assets/Scripts/Objects/Research/Artifacts/Artifact.cs
+++ b/UnityProject/Assets/Scripts/Objects/Research/Artifacts/Artifact.cs
@@ -413,7 +413,7 @@ namespace Objects.Research
 
 			Matrix matrix = integrity.RegisterTile.Matrix;
 			Vector3Int localPosition = MatrixManager.WorldToLocalInt(objectPhysics.registerTile.WorldPosition, matrix);
-			GasMix ambientGasMix = matrix.MetaDataLayer.Get(localPosition).GasMix;
+			GasMix ambientGasMix = matrix.MetaDataLayer.Get(localPosition).GasMixLocal;
 
 			ambientGasMix.GasData.GetGasMoles(gastype, out var moles);
 

--- a/UnityProject/Assets/Scripts/Objects/Wallmounts/FireAlarm.cs
+++ b/UnityProject/Assets/Scripts/Objects/Wallmounts/FireAlarm.cs
@@ -107,7 +107,7 @@ namespace Objects.Wallmounts
 
 			if(metaNode.MetaDataSystem.SetUpDone == false) return;
 
-			if (metaNode.GasMix.Pressure < AtmosConstants.WARNING_LOW_PRESSURE || metaNode.GasMix.Pressure > AtmosConstants.WARNING_HIGH_PRESSURE)
+			if (metaNode.GasMixLocal.Pressure < AtmosConstants.WARNING_LOW_PRESSURE || metaNode.GasMixLocal.Pressure > AtmosConstants.WARNING_HIGH_PRESSURE)
 			{
 				SendCloseAlerts();
 			}

--- a/UnityProject/Assets/Scripts/ScriptableObjects/Research/Artifacts/Effects/AreaEffects/GasAreaEffect.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/Research/Artifacts/Effects/AreaEffects/GasAreaEffect.cs
@@ -28,11 +28,11 @@ namespace Systems.Research
 
 			MetaDataNode node = MatrixManager.GetMetaDataAt(position);
 
-			if(RemoveGas) node.GasMix.RemoveGas(GasToRemove, MolesToRemove);
+			if(RemoveGas) node.GasMixLocal.RemoveGas(GasToRemove, MolesToRemove);
 
-			if(ChangeTemperature) node.GasMix.ChangeTemperature(TemperatureChange);
+			if(ChangeTemperature) node.GasMixLocal.ChangeTemperature(TemperatureChange);
 
-			if(AddGas) node.GasMix.AddGas(GasToAdd, MolesToAdd);
+			if(AddGas) node.GasMixLocal.AddGas(GasToAdd, MolesToAdd);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Shuttles/ShuttleFuelSystem.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/ShuttleFuelSystem.cs
@@ -60,7 +60,7 @@ namespace Systems.Shuttles
 				{
 					MatrixMove.IsFueled = true;
 				}
-				FuelLevel = Connector.canister.GasContainer.GasMix.GetMoles(Gas.Plasma) / Connector.canister.GasContainer.MaximumMoles;
+				FuelLevel = Connector.canister.GasContainer.GasMixLocal.GetMoles(Gas.Plasma) / Connector.canister.GasContainer.MaximumMoles;
 			}
 			else
 			{
@@ -80,8 +80,8 @@ namespace Systems.Shuttles
 
 		bool IsFuelledOptimum()
 		{
-			var Plasma = Connector.canister.GasContainer.GasMix.GetMoles(Gas.Plasma);
-			var Oxygen = Connector.canister.GasContainer.GasMix.GetMoles(Gas.Oxygen);
+			var Plasma = Connector.canister.GasContainer.GasMixLocal.GetMoles(Gas.Plasma);
+			var Oxygen = Connector.canister.GasContainer.GasMixLocal.GetMoles(Gas.Oxygen);
 			var Ratio = ((Plasma / Oxygen) / (7f / 3f));
 			//Logger.Log("Ratio > " + Ratio);
 			Ratio = Ratio * 2f;
@@ -123,13 +123,13 @@ namespace Systems.Shuttles
 			if (IsFuelledOptimum())
 			{
 				//Logger.Log("CalculatedMassConsumption > " + CalculatedMassConsumption*MassConsumption);
-				Connector.canister.GasContainer.GasMix.RemoveGas(Gas.Plasma, CalculatedMassConsumption * MassConsumption * (0.7f));
-				Connector.canister.GasContainer.GasMix.RemoveGas(Gas.Oxygen, CalculatedMassConsumption * MassConsumption * (0.3f));
+				Connector.canister.GasContainer.GasMixLocal.RemoveGas(Gas.Plasma, CalculatedMassConsumption * MassConsumption * (0.7f));
+				Connector.canister.GasContainer.GasMixLocal.RemoveGas(Gas.Oxygen, CalculatedMassConsumption * MassConsumption * (0.3f));
 			}
-			else if (Connector.canister.GasContainer.GasMix.GetMoles(Gas.Plasma) > MassConsumption * FuelConsumption)
+			else if (Connector.canister.GasContainer.GasMixLocal.GetMoles(Gas.Plasma) > MassConsumption * FuelConsumption)
 			{
 				//Logger.Log("Full-back > " + (FuelConsumption * MassConsumption));
-				Connector.canister.GasContainer.GasMix.RemoveGas(Gas.Plasma, (MassConsumption * FuelConsumption));
+				Connector.canister.GasContainer.GasMixLocal.RemoveGas(Gas.Plasma, (MassConsumption * FuelConsumption));
 			}
 			else
 			{
@@ -145,7 +145,7 @@ namespace Systems.Shuttles
 			{
 				return (true);
 			}
-			else if (Connector.canister.GasContainer.GasMix.GetMoles(Gas.Plasma) > MassConsumption * FuelConsumption)
+			else if (Connector.canister.GasContainer.GasMixLocal.GetMoles(Gas.Plasma) > MassConsumption * FuelConsumption)
 			{
 				return (true);
 			}

--- a/UnityProject/Assets/Scripts/Systems/Chemistry/Effects/ReleaseGas.cs
+++ b/UnityProject/Assets/Scripts/Systems/Chemistry/Effects/ReleaseGas.cs
@@ -21,11 +21,11 @@ namespace Chemistry.Effects
 			
 			var	metaNode = Matrix.MetaDataLayer.Get(onObject.gameObject.AssumedWorldPosServer().ToLocalInt(Matrix));
 
-			lock (metaNode.GasMix.GasesArray) //no Double lock
+			lock (metaNode.GasMixLocal.GasesArray) //no Double lock
 			{
 				var mix = new GasMix(2.5f, TemperatureK);
 				mix.AddGas(ToRelease,AmountToRelease );
-				GasMix.TransferGas(metaNode.GasMix,mix, mix.Moles );
+				GasMix.TransferGas(metaNode.GasMixLocal,mix, mix.Moles );
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Systems/Disposals/DisposalsManager.cs
+++ b/UnityProject/Assets/Scripts/Systems/Disposals/DisposalsManager.cs
@@ -108,15 +108,15 @@ namespace Systems.Disposals
 			}
 			if (sourceObject.TryGetComponent<GasContainer>(out var gasContainer))
 			{
-				GasMix.TransferGas(disposalContainer.GetComponent<GasContainer>().GasMix, gasContainer.GasMix, gasContainer.GasMix.Moles);
+				GasMix.TransferGas(disposalContainer.GetComponent<GasContainer>().GasMixLocal, gasContainer.GasMixLocal, gasContainer.GasMixLocal.Moles);
 			}
 			else
 			{
 				var tile = sourceObject.RegisterTile();
-				var gasMix = tile.Matrix.MetaDataLayer.Get(tile.LocalPositionServer)?.GasMix;
+				var gasMix = tile.Matrix.MetaDataLayer.Get(tile.LocalPositionServer)?.GasMixLocal;
 				if (gasMix != null)
 				{
-					GasMix.TransferGas(disposalContainer.GetComponent<GasContainer>().GasMix, gasMix, gasMix.Moles);
+					GasMix.TransferGas(disposalContainer.GetComponent<GasContainer>().GasMixLocal, gasMix, gasMix.Moles);
 				}
 			}
 

--- a/UnityProject/Assets/Scripts/Systems/Fluids/PipeData.cs
+++ b/UnityProject/Assets/Scripts/Systems/Fluids/PipeData.cs
@@ -226,11 +226,11 @@ namespace Systems.Pipes
 			MetaDataLayer metaDataLayer = matrixInfo.MetaDataLayer;
 			if (pipeNode != null)
 			{
-				GasMix.TransferGas(pipeNode.IsOn.GasMix, ToSpill.Item2, ToSpill.Item2.Moles);
+				GasMix.TransferGas(pipeNode.IsOn.GasMixLocal, ToSpill.Item2, ToSpill.Item2.Moles);
 			}
 			else
 			{
-				GasMix.TransferGas(Matrix.GetMetaDataNode(ZeroedLocation).GasMix, ToSpill.Item2, ToSpill.Item2.Moles);
+				GasMix.TransferGas(Matrix.GetMetaDataNode(ZeroedLocation).GasMixLocal, ToSpill.Item2, ToSpill.Item2.Moles);
 			}
 			metaDataLayer.UpdateSystemsAt(ZeroedLocation, SystemType.AtmosSystem);
 		}

--- a/UnityProject/Assets/Scripts/Systems/Lobby/CharacterSheet.cs
+++ b/UnityProject/Assets/Scripts/Systems/Lobby/CharacterSheet.cs
@@ -316,22 +316,15 @@ public class CharacterSheet : ICloneable
 	{
 		CharacterSheet character = new CharacterSheet();
 
-
-		if (speciesToChooseFrom == null)
+		if (speciesToChooseFrom == null || speciesToChooseFrom.Count == 0)
 		{
 			speciesToChooseFrom = RaceSOSingleton.Instance.Races;
 		}
 		PlayerHealthData race = speciesToChooseFrom.PickRandom();
 
 		character.Species = race.name;
-		if (race.Base.bodyTypeSettings.AvailableBodyTypes.Count != 0)
-		{
-			character.BodyType = race.Base.bodyTypeSettings.AvailableBodyTypes.PickRandom().bodyType;
-		}
-		else
-		{
-			character.BodyType = BodyType.NonBinary;
-		}
+		character.BodyType = race.Base.bodyTypeSettings.AvailableBodyTypes.Count != 0
+			? race.Base.bodyTypeSettings.AvailableBodyTypes.PickRandom().bodyType : BodyType.NonBinary;
 
 		character.Age = Random.Range(19, 84); // TODO should be a race characteristic, literally 1984
 		character.SkinTone = GetRandomSkinTone(race);

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSimulation.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSimulation.cs
@@ -134,11 +134,11 @@ namespace Systems.Atmospherics
 				//If its not space then share otherwise it is space so set to empty
 				if (node.IsSpace == false)
 				{
-					node.GasMix.CopyFrom(meanGasMix);
+					node.GasMixLocal.CopyFrom(meanGasMix);
 				}
 				else
 				{
-					node.GasMix.SetToEmpty();
+					node.GasMixLocal.SetToEmpty();
 				}
 			}
 		}
@@ -163,8 +163,8 @@ namespace Systems.Atmospherics
 				//Block transfer if wall / closed door or windoor / directional passable
 				if(doEqualise)
 				{
-					meanGasMix.Volume += node.GasMix.Volume;
-					GasMix.TransferGas(meanGasMix, node.GasMix, node.GasMix.Moles, true);
+					meanGasMix.Volume += node.GasMixLocal.Volume;
+					GasMix.TransferGas(meanGasMix, node.GasMixLocal, node.GasMixLocal.Moles, true);
 					targetCount++;
 				}
 				else if(node.IsOccupied && node.IsIsolatedNode == false)
@@ -207,7 +207,7 @@ namespace Systems.Atmospherics
 				//Block pressure check if wall / closed door or windoor / directional passable
 				if(doEqualise == false) continue;
 
-				float pressureDifference = node.GasMix.Pressure - neighbor.GasMix.Pressure;
+				float pressureDifference = node.GasMixLocal.Pressure - neighbor.GasMixLocal.Pressure;
 				float absoluteDifference = Mathf.Abs(pressureDifference);
 
 				//Check to see if theres a large pressure difference
@@ -248,13 +248,13 @@ namespace Systems.Atmospherics
 				//Only need to check if false
 				if (result == false)
 				{
-					lock (neighbor.GasMix.GasesArray) //no Double lock
+					lock (neighbor.GasMixLocal.GasesArray) //no Double lock
 					{
-						for (int j = node.GasMix.GasesArray.Count - 1; j >= 0; j--)
+						for (int j = node.GasMixLocal.GasesArray.Count - 1; j >= 0; j--)
 						{
-							var gas = node.GasMix.GasesArray[j];
-							float moles = node.GasMix.GasData.GetGasMoles(gas.GasSO);
-							float molesNeighbor = neighbor.GasMix.GasData.GetGasMoles(gas.GasSO);
+							var gas = node.GasMixLocal.GasesArray[j];
+							float moles = node.GasMixLocal.GasData.GetGasMoles(gas.GasSO);
+							float molesNeighbor = neighbor.GasMixLocal.GasData.GetGasMoles(gas.GasSO);
 
 							if (Mathf.Abs(moles - molesNeighbor) > AtmosConstants.MinPressureDifference)
 							{
@@ -271,12 +271,12 @@ namespace Systems.Atmospherics
 				//Only need to check if false
 				if (result == false)
 				{
-					lock (neighbor.GasMix.GasesArray) //no Double lock
+					lock (neighbor.GasMixLocal.GasesArray) //no Double lock
 					{
-						foreach (var gas in neighbor.GasMix.GasesArray) //doesn't appear to modify list while iterating
+						foreach (var gas in neighbor.GasMixLocal.GasesArray) //doesn't appear to modify list while iterating
 						{
-							float moles = node.GasMix.GasData.GetGasMoles(gas.GasSO);
-							float molesNeighbor = neighbor.GasMix.GasData.GetGasMoles(gas.GasSO);
+							float moles = node.GasMixLocal.GasData.GetGasMoles(gas.GasSO);
+							float molesNeighbor = neighbor.GasMixLocal.GasData.GetGasMoles(gas.GasSO);
 
 							if (Mathf.Abs(moles - molesNeighbor) > AtmosConstants.MinPressureDifference)
 							{
@@ -461,12 +461,12 @@ namespace Systems.Atmospherics
 		//If needed, sends them to a queue in ReactionManager so that main thread will apply them
 		public static void GasVisualEffects(MetaDataNode node)
 		{
-			foreach (var gasData in node.GasMix.GasesArray) //doesn't appear to modify list while iterating
+			foreach (var gasData in node.GasMixLocal.GasesArray) //doesn't appear to modify list while iterating
 			{
 				var gas = gasData.GasSO;
 				if(gas.HasOverlay == false) continue;
 
-				var gasAmount = node.GasMix.GetMoles(gas);
+				var gasAmount = node.GasMixLocal.GetMoles(gas);
 
 				if(gasAmount > gas.MinMolesToSee)
 				{
@@ -525,7 +525,7 @@ namespace Systems.Atmospherics
 				return;
 			}
 
-			var gasMix = node.GasMix;
+			var gasMix = node.GasMixLocal;
 
 			foreach (var gasReaction in GasReactions.All)
 			{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSystem.cs
@@ -96,7 +96,7 @@ namespace Systems.Atmospherics
 					//node.ChangeGasMix(GasMix.NewGasMix(gasSetter.GasMixToSpawn));
 
 					//TODO: above commented out due to performance on load for lavaland, remove line below if solution is found
-					node.GasMix = GasMix.NewGasMix(roomGasSetter.GasMixToSpawn);
+					node.GasMixLocal = GasMix.NewGasMix(roomGasSetter.GasMixToSpawn);
 				}
 				//Check to see if theres a special occupied mix
 				else if (node.IsOccupied && toSetOccupied.Count > 0 &&
@@ -107,7 +107,7 @@ namespace Systems.Atmospherics
 					//node.ChangeGasMix(GasMix.NewGasMix(gasSetter.GasMixToSpawn));
 
 					//TODO: above commented out due to performance on load for lavaland, remove line below if solution is found
-					node.GasMix = GasMix.NewGasMix(occupiedGasSetter.GasMixToSpawn);
+					node.GasMixLocal = GasMix.NewGasMix(occupiedGasSetter.GasMixToSpawn);
 				}
 				//See if the whole matrix has a custom mix
 				else if (hasCustomMix)
@@ -116,17 +116,17 @@ namespace Systems.Atmospherics
 					//node.ChangeGasMix(GasMix.NewGasMix(defaultRoomGasMixOverride.BaseGasMix));
 
 					//TODO: above commented out due to performance on load for lavaland, remove line below if solution is found
-					node.GasMix = GasMix.NewGasMix(defaultRoomGasMixOverride.BaseGasMix);
+					node.GasMixLocal = GasMix.NewGasMix(defaultRoomGasMixOverride.BaseGasMix);
 				}
 				//Default to air mix otherwise
 				else
 				{
-					node.GasMix = GasMix.NewGasMix(GasMixes.BaseAirMix);
+					node.GasMixLocal = GasMix.NewGasMix(GasMixes.BaseAirMix);
 				}
 			}
 			else
 			{
-				node.GasMix = GasMix.NewGasMix(GasMixes.BaseSpaceMix);
+				node.GasMixLocal = GasMix.NewGasMix(GasMixes.BaseSpaceMix);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
@@ -552,13 +552,13 @@ namespace Systems.Atmospherics
 			if (gameObject.ContainedInObjectContainer != null && //Make generic function
 			    gameObject.ContainedInObjectContainer.TryGetComponent<GasContainer>(out var gasContainer))
 			{
-				ambientGasMix = gasContainer.GasMix;
+				ambientGasMix = gasContainer.GasMixLocal;
 			}
 			else
 			{
 				var matrix = gameObject.registerTile.Matrix;
 				Vector3Int localPosition = MatrixManager.WorldToLocalInt(gameObject.OfficialPosition, matrix);
-				ambientGasMix = matrix.MetaDataLayer.Get(localPosition).GasMix;
+				ambientGasMix = matrix.MetaDataLayer.Get(localPosition).GasMixLocal;
 			}
 
 			return ambientGasMix;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Hotspot.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Hotspot.cs
@@ -88,7 +88,7 @@ namespace Systems.Atmospherics
 			if(timer < 7) return;
 			timer = 0;
 
-			var temperature = node.GasMix.Temperature;
+			var temperature = node.GasMixLocal.Temperature;
 			var temp2Colour = Temp2Colour(temperature);
 			var heatR = temp2Colour.r * 255;
 			var heatG = temp2Colour.g * 255;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/IGasMixContainer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/IGasMixContainer.cs
@@ -2,6 +2,6 @@ namespace Systems.Atmospherics
 {
 	public interface IGasMixContainer
 	{
-		GasMix GasMix { get; set; }
+		GasMix GasMixLocal { get; set; }
 	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
@@ -320,9 +320,9 @@ namespace Systems.Atmospherics
 			}
 
 			//If we are already a hotspot try to increase temperature if allowed to
-			if (changeTemp && hotspot.GasMix.Temperature < exposeTemperature)
+			if (changeTemp && hotspot.GasMixLocal.Temperature < exposeTemperature)
 			{
-				hotspot.GasMix.SetTemperature(exposeTemperature);
+				hotspot.GasMixLocal.SetTemperature(exposeTemperature);
 			}
 
 			//Only do expose if allowed, prevents thread errors when being called off of main thread
@@ -355,7 +355,7 @@ namespace Systems.Atmospherics
 			//Only need to check stuff which has nodes as we are checking gas contents afterwards
 			if(node == null) return false;
 
-			GasMix gasMix = node.GasMix;
+			GasMix gasMix = node.GasMixLocal;
 
 			if (exposeTemperature < 0)
 			{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataNode.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataNode.cs
@@ -99,7 +99,7 @@ public class MetaDataNode : IGasMixContainer
 	/// <summary>
 	/// The mixture of gases currently on this node.
 	/// </summary>
-	public GasMix GasMix
+	public GasMix GasMixLocal
 	{
 		get
 		{
@@ -399,7 +399,7 @@ public class MetaDataNode : IGasMixContainer
 	{
 		AtmosSimulation.RemovalAllGasOverlays(this);
 
-		GasMix = newGasMix;
+		GasMixLocal = newGasMix;
 
 		AtmosSimulation.GasVisualEffects(this);
 	}

--- a/UnityProject/Assets/Scripts/UI/Core/OptionsMenu/SoundOptions.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/OptionsMenu/SoundOptions.cs
@@ -91,9 +91,9 @@ namespace Unitystation.Options
 
 		void Refresh()
 		{
-			musicSlider.value = PlayerPrefs.GetFloat(PlayerPrefKeys.MusicVolumeKey);
-			soundFXSlider.value = PlayerPrefs.GetFloat(PlayerPrefKeys.SoundFXVolumeKey);
-			ambientSlider.value = PlayerPrefs.GetFloat(PlayerPrefKeys.AmbientVolumeKey);
+			musicSlider.value = PlayerPrefs.GetFloat(PlayerPrefKeys.MusicVolumeKey, 0.75f);
+			soundFXSlider.value = PlayerPrefs.GetFloat(PlayerPrefKeys.SoundFXVolumeKey, 1f);
+			ambientSlider.value = PlayerPrefs.GetFloat(PlayerPrefKeys.AmbientVolumeKey, 0.35f);
 			TTSSlider.value = PlayerPrefs.GetFloat(PlayerPrefKeys.TtsVolumeKey);
 			ttsToggle.isOn = PlayerPrefs.GetInt(PlayerPrefKeys.TTSToggleKey) == 1;
 			audioReflectionsToggle.isOn = !PlayerPrefs.HasKey(PlayerPrefKeys.AudioReflectionsToggleKey) || PlayerPrefs.GetInt(PlayerPrefKeys.AudioReflectionsToggleKey) == 1;


### PR DESCRIPTION
CL: [Fix] Fixed an issue that would cause Character Sheets to fail on retrieving empty species lists