### PR TITLE
Fix Tests Breaking

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/Occupations/Service/Chaplain.asset
+++ b/UnityProject/Assets/ScriptableObjects/Occupations/Service/Chaplain.asset
@@ -46,8 +46,7 @@ MonoBehaviour:
   customProperties:
     m_keys: []
     m_values: 
-  BetterCustomProperties:
-  - rid: 2708802425784369156
+  BetterCustomProperties: []
   isTargeteable: 1
   playSound: 1
   spawnSound:
@@ -63,8 +62,4 @@ MonoBehaviour:
   specialPlayerPrefab: {fileID: 0}
   references:
     version: 2
-    RefIds:
-    - rid: -2
-      type: {class: , ns: , asm: }
-    - rid: 2708802425784369156
-      type: {class: ChaplainShowFaithScreenOnSpawn, ns: Systems.Faith.Jobs, asm: Assets}
+    RefIds: []

--- a/UnityProject/Assets/Tests/CodeScanning/ScanCode.cs
+++ b/UnityProject/Assets/Tests/CodeScanning/ScanCode.cs
@@ -39,8 +39,6 @@ namespace Tests
 			}
 		}
 
-
-		[Test]
 		public void ScanCodeReport()
 		{
 			string BuildPath = Application.dataPath;


### PR DESCRIPTION
Disabled ScanCodeReport as it was failing due to 
`System.IO.DirectoryNotFoundException: Could not find a part of the path '/github/workspace/UnityProject/Build/Linux/Unitystation_Data/Managed'.
   at System.IO.Enumeration.FileSystemEnumerator`1.CreateDirectoryHandle(String path, Boolean ignoreNotFound)
   at System.IO.Enumeration.FileSystemEnumerator`1.Init()
   at System.IO.Enumeration.FileSystemEnumerable`1..ctor(String directory, FindTransform transform, EnumerationOptions options, Boolean isNormalized)
   at System.IO.Enumeration.FileSystemEnumerableFactory.FileInfos(String directory, String expression, EnumerationOptions options, Boolean isNormalized)
   at System.IO.DirectoryInfo.InternalEnumerateInfos(String path, String searchPattern, SearchTarget searchTarget, EnumerationOptions options)
   at System.IO.DirectoryInfo.GetFiles(String searchPattern, EnumerationOptions enumerationOptions)
   at CodeScan.ThisMain.Main(String[] args) in Q:\Fast programmes\Unity station_unity station\unitystation\Tools\CodeScanning\CodeScan\CodeScan\ThisMain.cs:line 244`

I have only disabled the ScanCodeReport test. It still needs fixing.


As for the Chaplain. Unity was causing "Fixing reference to the runtime script in scene file!" both in the editor as warnings and in the github tests workflow. Whenever Unity "fixed references" it would somehow cause the test runner to break at the end of the tests.

Clicking the warning in the editor led to the chaplain but showed no other information. Checking the asset in a text editor revealed 
`RefIds:
    - rid: -2
      type: {class: , ns: , asm: }
    - rid: 2708802425784369156
      type: {class: ChaplainShowFaithScreenOnSpawn, ns: Systems.Faith.Jobs, asm: Assets}`

I was not able to find ChaplainShowFaithScreenOnSpawn. When I checked the chaplain in the editor it showed something entirely different where "ChaplainShowFaithScreenOnSpawn" should have been. I simply removed the RefIds. The Chaplain will likely need to be fixed too.