### PR TITLE
Stunned/Input alert indicator

### DIFF
--- a/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
+++ b/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
@@ -604,8 +604,6 @@ MonoBehaviour:
   <PlayerFaith>k__BackingField: {fileID: 6182295504772674896}
   <Particles>k__BackingField: {fileID: 6835177244151955954}
   RTT: 0
-  RcsMode: 0
-  RcsMatrixMove: {fileID: 0}
   playerChatLocation: {fileID: 1133514949248654}
   canVentCrawl: 0
   <OnBodyPossesedByPlayer>k__BackingField:
@@ -812,6 +810,7 @@ MonoBehaviour:
   CurrentsortingGroup: {fileID: 0}
   <LayDownBehavior>k__BackingField: {fileID: 8176686349149668929}
   networkedLean: {fileID: -8106636780342977062}
+  stunAlert: {fileID: 11400000, guid: bb846b67e8fe7174a9259cac094036c9, type: 2}
 --- !u!114 &114449635359748350
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -833,6 +832,7 @@ MonoBehaviour:
   CurrentDirection: 3
   SynchroniseCurrentDirection: 3
   IgnoreServerUpdatesIfLocalPlayer: 1
+  MatrixRotateUpdate: 1
   IsAtmosphericDevice: 0
   doNotResetOtherSpriteOptions: 0
 --- !u!50 &50851566022184656
@@ -1183,6 +1183,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   LivingHealthMasterBase: {fileID: 1354417930896543338}
+  ProcedureInProgress: 0
   InitiateSurgeryItemTraits:
   - {fileID: 11400000, guid: 30127bfedd67541a3afa2a5582daa98c, type: 2}
   - {fileID: 11400000, guid: 1e5559e895a286845ae6c1d616f3f26d, type: 2}
@@ -13641,7 +13642,7 @@ SpriteRenderer:
   m_SortingLayerID: -902452607
   m_SortingLayer: 22
   m_SortingOrder: 20
-  m_Sprite: {fileID: 7660122581263827943, guid: 2adbceb9cc674484cb9a2c58b41d5493,
+  m_Sprite: {fileID: 8165807964432903219, guid: 2adbceb9cc674484cb9a2c58b41d5493,
     type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -14143,6 +14144,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 5e6cf56e407117e4faa5cbed4663a515, type: 2}
   - {fileID: 11400000, guid: 8edd9df57e0eca742973f14d8e27ff52, type: 2}
   - {fileID: 11400000, guid: ddf681d078c0be44eaa104e2c182b78a, type: 2}
+  timeBetweenAmbience: 135
 --- !u!1 &7706745016017648645
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/Alert/Alert.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/Alert/Alert.prefab
@@ -62,7 +62,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:

--- a/UnityProject/Assets/Resources/ScriptableObjectsSingletons/AlertSOs.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjectsSingletons/AlertSOs.asset
@@ -41,3 +41,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 73f14bb661d06e14b927be321458c28c, type: 2}
   - {fileID: 11400000, guid: 2c812669f183287449afa3e620bfcef6, type: 2}
   - {fileID: 11400000, guid: 2cacc34a5e9de974f9f8f4274ffaf54f, type: 2}
+  - {fileID: 11400000, guid: bb846b67e8fe7174a9259cac094036c9, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/UIAlerts/Bleeding/Bleeding_High.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIAlerts/Bleeding/Bleeding_High.asset
@@ -13,6 +13,6 @@ MonoBehaviour:
   m_Name: Bleeding_High
   m_EditorClassIdentifier: 
   AssociatedSprite: {fileID: 11400000, guid: 37a78136eb9b5964da0b5714dcb339e1, type: 2}
-  HoverToolTip: 
+  HoverToolTip: tis but a scratch
   PlayerProtip: {fileID: 11400000, guid: 15b39b0191818c04cb098b5ff0848cb8, type: 2}
   DoNotShowIfPresent: []

--- a/UnityProject/Assets/ScriptableObjects/UIAlerts/Bleeding/Bleeding_Low.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIAlerts/Bleeding/Bleeding_Low.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: Bleeding_Low
   m_EditorClassIdentifier: 
   AssociatedSprite: {fileID: 11400000, guid: 08feaf33c8c046540a684ad249951ef7, type: 2}
-  HoverToolTip: 
+  HoverToolTip: You are bleeding a bit. It will take awhile for the wound to close
+    itself, consider applying a gauze to yourself.
   PlayerProtip: {fileID: 11400000, guid: 674dd66c6a6ff5f40a52d8b8b9e742bf, type: 2}
   DoNotShowIfPresent: []

--- a/UnityProject/Assets/ScriptableObjects/UIAlerts/Bleeding/Bleeding_Medium.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIAlerts/Bleeding/Bleeding_Medium.asset
@@ -13,6 +13,6 @@ MonoBehaviour:
   m_Name: Bleeding_Medium
   m_EditorClassIdentifier: 
   AssociatedSprite: {fileID: 11400000, guid: 952db7d501a8fd542a2dfa25a32bd07d, type: 2}
-  HoverToolTip: 
+  HoverToolTip: Get a gauze!
   PlayerProtip: {fileID: 0}
   DoNotShowIfPresent: []

--- a/UnityProject/Assets/ScriptableObjects/UIAlerts/Bleeding/Bleeding_UhOh.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIAlerts/Bleeding/Bleeding_UhOh.asset
@@ -13,6 +13,6 @@ MonoBehaviour:
   m_Name: Bleeding_UhOh
   m_EditorClassIdentifier: 
   AssociatedSprite: {fileID: 11400000, guid: 24a29b81dc8ee06428825496216466aa, type: 2}
-  HoverToolTip: 
+  HoverToolTip: tis but a scratch
   PlayerProtip: {fileID: 11400000, guid: 1160df88f3c00344fac0d74d818b3907, type: 2}
   DoNotShowIfPresent: []

--- a/UnityProject/Assets/ScriptableObjects/UIAlerts/Bleeding/Bleeding_VeryLow.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIAlerts/Bleeding/Bleeding_VeryLow.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: Bleeding_VeryLow
   m_EditorClassIdentifier: 
   AssociatedSprite: {fileID: 11400000, guid: 7088ea7c29cc06d4bb3324ead7224353, type: 2}
-  HoverToolTip: 
+  HoverToolTip: You are dripping a bit of blood. Your wound will heal itself over
+    time.
   PlayerProtip: {fileID: 11400000, guid: 9840743232461594d952b82560fe1eeb, type: 2}
   DoNotShowIfPresent: []

--- a/UnityProject/Assets/ScriptableObjects/UIAlerts/HasFiresStacks.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIAlerts/HasFiresStacks.asset
@@ -13,6 +13,6 @@ MonoBehaviour:
   m_Name: HasFiresStacks
   m_EditorClassIdentifier: 
   AssociatedSprite: {fileID: 11400000, guid: 3f47bc037773af441aa80843e9bdf31c, type: 2}
-  HoverToolTip: 
+  HoverToolTip: You're on fire! Resist to attempt to put yourself out.
   PlayerProtip: {fileID: 11400000, guid: 343cbe9dec8d8fc41898fceda8c13083, type: 2}
   DoNotShowIfPresent: []

--- a/UnityProject/Assets/ScriptableObjects/UIAlerts/Hunger/Full.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIAlerts/Hunger/Full.asset
@@ -13,6 +13,6 @@ MonoBehaviour:
   m_Name: Full
   m_EditorClassIdentifier: 
   AssociatedSprite: {fileID: 11400000, guid: 22c33e84c50386f4198414f6cbf71c6a, type: 2}
-  HoverToolTip: you ate too much
+  HoverToolTip: You ate too much, fatass. You will run/walk slower now.
   PlayerProtip: {fileID: 11400000, guid: fbc620038f7c4204cbed8c766fabd086, type: 2}
   DoNotShowIfPresent: []

--- a/UnityProject/Assets/ScriptableObjects/UIAlerts/Hunger/Hungry.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIAlerts/Hunger/Hungry.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Hungry
   m_EditorClassIdentifier: 
   AssociatedSprite: {fileID: 11400000, guid: 677174ad3cd85614cbadda134fbf1576, type: 2}
-  HoverToolTip: 
+  HoverToolTip: You are feeling a bit hungry, get something to eat.
   PlayerProtip: {fileID: 11400000, guid: 2849afa5708d7b445b7eccab05c2826c, type: 2}
   DoNotShowIfPresent:
   - {fileID: 11400000, guid: 756fa4a7b0404794a9db193e0514e2b5, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/UIAlerts/Hunger/Malnourished.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIAlerts/Hunger/Malnourished.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Malnourished
   m_EditorClassIdentifier: 
   AssociatedSprite: {fileID: 11400000, guid: 677174ad3cd85614cbadda134fbf1576, type: 2}
-  HoverToolTip: 
+  HoverToolTip: You are feeling a bit hungry, get something to eat.
   PlayerProtip: {fileID: 0}
   DoNotShowIfPresent:
   - {fileID: 11400000, guid: 37880884910e549479c706e04e015105, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/UIAlerts/Hunger/Starving.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIAlerts/Hunger/Starving.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: Starving
   m_EditorClassIdentifier: 
   AssociatedSprite: {fileID: 11400000, guid: c2eb52a045882a94f8b173af25daf354, type: 2}
-  HoverToolTip: you are starving get some food and you
+  HoverToolTip: You are starving! You will expierence some health debuffs, and will
+    generate new blood much slower!
   PlayerProtip: {fileID: 11400000, guid: f83cd98cc385fbc4ca7371e70e9f9604, type: 2}
   DoNotShowIfPresent: []

--- a/UnityProject/Assets/ScriptableObjects/UIAlerts/LockedDown.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIAlerts/LockedDown.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: LockedDown
   m_EditorClassIdentifier: 
   AssociatedSprite: {fileID: 11400000, guid: d2d38a7255feccc4eb70cf02a2785c30, type: 2}
-  HoverToolTip: You have been remotely locked by the RD's Robotics console you are
-    unable to move
+  HoverToolTip: You have been remotely locked by the RD's Robotics console. You are
+    unable to move.
   PlayerProtip: {fileID: 0}
   DoNotShowIfPresent: []

--- a/UnityProject/Assets/ScriptableObjects/UIAlerts/Pressure/PressureLow.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIAlerts/Pressure/PressureLow.asset
@@ -13,6 +13,6 @@ MonoBehaviour:
   m_Name: PressureLow
   m_EditorClassIdentifier: 
   AssociatedSprite: {fileID: 11400000, guid: a7b6f5771f4073540b2e5dc084429322, type: 2}
-  HoverToolTip: 
+  HoverToolTip: Pressure is low! You will receive damage over-time.
   PlayerProtip: {fileID: 0}
   DoNotShowIfPresent: []

--- a/UnityProject/Assets/ScriptableObjects/UIAlerts/Pressure/PressureTooHigher.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIAlerts/Pressure/PressureTooHigher.asset
@@ -13,6 +13,6 @@ MonoBehaviour:
   m_Name: PressureTooHigher
   m_EditorClassIdentifier: 
   AssociatedSprite: {fileID: 11400000, guid: f0fbd0ecf9740694d9a94b2a7c1df5aa, type: 2}
-  HoverToolTip: 
+  HoverToolTip: nah bruh, you getting crushed.
   PlayerProtip: {fileID: 11400000, guid: 4b51b193b167eec4ea3108add75e852a, type: 2}
   DoNotShowIfPresent: []

--- a/UnityProject/Assets/ScriptableObjects/UIAlerts/Pressure/PressureTooLow.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIAlerts/Pressure/PressureTooLow.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: PressureTooLow
   m_EditorClassIdentifier: 
   AssociatedSprite: {fileID: 11400000, guid: 8120f4db743b42c41bb73e07e3731183, type: 2}
-  HoverToolTip: 
+  HoverToolTip: Pressure is dangerously low! You will receive heavy damage over-time,
+    wear a hard-suit.
   PlayerProtip: {fileID: 11400000, guid: 03a097741db78a648a4cb07a947ddeff, type: 2}
   DoNotShowIfPresent: []

--- a/UnityProject/Assets/ScriptableObjects/UIAlerts/Stunned.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIAlerts/Stunned.asset
@@ -10,9 +10,9 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b1055f6767b8d254fb6634c7bbb32cda, type: 3}
-  m_Name: Suffocating
+  m_Name: Stunned
   m_EditorClassIdentifier: 
-  AssociatedSprite: {fileID: 11400000, guid: afa6fdd6b679c454ba8ab690ebab896c, type: 2}
-  HoverToolTip: Suffocation is caused by a lack of air or low blood saturation.
-  PlayerProtip: {fileID: 11400000, guid: 963f6a6de169c484bad0d08fbdf230ce, type: 2}
+  AssociatedSprite: {fileID: 11400000, guid: ca01c9b80e4811f47b252dbe3c68df3a, type: 2}
+  HoverToolTip: You're unable to move!
+  PlayerProtip: {fileID: 0}
   DoNotShowIfPresent: []

--- a/UnityProject/Assets/ScriptableObjects/UIAlerts/Stunned.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/UIAlerts/Stunned.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bb846b67e8fe7174a9259cac094036c9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/UIAlerts/Temperature/Temperature_Cold.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIAlerts/Temperature/Temperature_Cold.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: Temperature_Cold
   m_EditorClassIdentifier: 
   AssociatedSprite: {fileID: 11400000, guid: 20bc58cf81ebf534984b3da65d0d669c, type: 2}
-  HoverToolTip: 
+  HoverToolTip: You're in a cold environment. This environment is not lethal, but
+    it is best to put on something warm.
   PlayerProtip: {fileID: 0}
   DoNotShowIfPresent: []

--- a/UnityProject/Assets/ScriptableObjects/UIAlerts/Temperature/Temperature_Hot.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIAlerts/Temperature/Temperature_Hot.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: Temperature_Hot
   m_EditorClassIdentifier: 
   AssociatedSprite: {fileID: 11400000, guid: 027bff019bdc5c74885235c901db6b63, type: 2}
-  HoverToolTip: 
+  HoverToolTip: This is a hot environment. Get to a colder place or wear something
+    like an explorer's suit.
   PlayerProtip: {fileID: 0}
   DoNotShowIfPresent: []

--- a/UnityProject/Assets/ScriptableObjects/UIAlerts/Temperature/Temperature_TooCold.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIAlerts/Temperature/Temperature_TooCold.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: Temperature_TooCold
   m_EditorClassIdentifier: 
   AssociatedSprite: {fileID: 11400000, guid: 2b20c75b8e382ce4aaaa95d8e359b552, type: 2}
-  HoverToolTip: 
+  HoverToolTip: This is a dangerously cold environment. Wear a hardsuit or warmer
+    clothes.
   PlayerProtip: {fileID: 11400000, guid: 95ef98c8f385f7b4382a1d283224cfee, type: 2}
   DoNotShowIfPresent: []

--- a/UnityProject/Assets/ScriptableObjects/UIAlerts/Temperature/Temperature_TooHot.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIAlerts/Temperature/Temperature_TooHot.asset
@@ -13,6 +13,6 @@ MonoBehaviour:
   m_Name: Temperature_TooHot
   m_EditorClassIdentifier: 
   AssociatedSprite: {fileID: 11400000, guid: 1706c35d54a2eae4a93bfa430c19538c, type: 2}
-  HoverToolTip: 
+  HoverToolTip: This environment is dangerously hot! Get to safety!
   PlayerProtip: {fileID: 11400000, guid: 76b1fee33a8e5334aafd5f6c95d3aedd, type: 2}
   DoNotShowIfPresent: []

--- a/UnityProject/Assets/ScriptableObjects/UIAlerts/Toxin.asset
+++ b/UnityProject/Assets/ScriptableObjects/UIAlerts/Toxin.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: Toxin
   m_EditorClassIdentifier: 
   AssociatedSprite: {fileID: 11400000, guid: 384ba6ec110ef874aa79c9c9b5a50865, type: 2}
-  HoverToolTip: 
+  HoverToolTip: You are receiving a toxin damage. Toxin lingers even after you stop
+    taking toxin damage.
   PlayerProtip: {fileID: 11400000, guid: 3b38af0357f6fa44399a8b14f539a581, type: 2}
   DoNotShowIfPresent: []

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -230,7 +230,7 @@ namespace HealthV2
 		public List<HealthSystemBase> ActiveSystems = new List<HealthSystemBase>();
 
 
-		private BodyAlertManager BodyAlertManager;
+		public BodyAlertManager BodyAlertManager { get; protected set; }
 
 
 		public BleedingState BleedingState => CalculateBleedingState();

--- a/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
+++ b/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
@@ -313,6 +313,7 @@ public class MovementSynchronisation : UniversalObjectPhysics, IPlayerControllab
 	private void SyncInput(bool oldInput, bool newInput)
 	{
 		allowInput = newInput;
+		playerScript.RegisterPlayer.ServerUpdateStunStatus(newInput == false);
 	}
 
 	private void SyncIntent(Intent oldIntent, Intent newIntent)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
@@ -33,7 +33,7 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 	public bool IsLayingDown => LayDownBehavior.IsLayingDown;
 
 	/// <summary>
-	/// True when the player is slipping
+	/// True when the player is slipping (or stunned)
 	/// </summary>
 	public bool IsSlippingServer { get; private set; }
 
@@ -66,6 +66,7 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 	public bool IsBlockingServer => !playerScript.IsGhost && !IsLayingDown && !IsSlippingServer;
 	private Coroutine unstunHandle;
 
+	[SerializeField] private AlertSO stunAlert;
 
 	protected override void Awake()
 	{
@@ -344,8 +345,8 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 			playerScript.playerMove.ServerAllowInput.RecordPosition(this, false);
 		}
 
-
 		this.RestartCoroutine(StunTimer(stunDuration), ref unstunHandle);
+		ServerUpdateStunStatus(true);
 	}
 	private IEnumerator StunTimer(float stunTime)
 	{
@@ -376,6 +377,20 @@ public class RegisterPlayer : RegisterTile, IServerSpawn, RegisterPlayer.IContro
 			 || playerScript.playerHealth.ConsciousState == ConsciousState.BARELY_CONSCIOUS)
 		{
 			playerScript.playerMove.ServerAllowInput.RemovePosition(this);
+		}
+
+		ServerUpdateStunStatus(false);
+	}
+
+	public void ServerUpdateStunStatus(bool isStunned)
+	{
+		if (isStunned)
+		{
+			playerScript.playerHealth.BodyAlertManager.RegisterAlert(stunAlert);
+		}
+		else
+		{
+			playerScript.playerHealth.BodyAlertManager.UnRegisterAlert(stunAlert);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/UI/Core/Alerts/AlertSO.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/Alerts/AlertSO.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using Learning;
 using UnityEngine;

--- a/UnityProject/Assets/Scripts/UI/Core/Alerts/AlertUIElement.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/Alerts/AlertUIElement.cs
@@ -1,11 +1,13 @@
-using System.Collections;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using Learning;
 using Learning.ProtipObjectTypes;
 using Logs;
+using UI.Systems.Tooltips.HoverTooltips;
 using UnityEngine;
+using UnityEngine.EventSystems;
 
-public class AlertUIElement : MonoBehaviour
+public class AlertUIElement : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler, IHoverTooltip
 {
 	public AlertSO AlertSO;
 	public SpriteHandler SpriteHandler;
@@ -118,5 +120,47 @@ public class AlertUIElement : MonoBehaviour
 	{
 		PlayerManager.LocalPlayerObject.OrNull()?.GetComponentInChildren<ProtipObjectOnHealthStateChange>()
 			?.StandardTrigger(protipSo);
+	}
+
+	public void OnPointerEnter(PointerEventData eventData)
+	{
+		UIManager.SetHoverToolTip = gameObject;
+		//thanks stack overflow!
+		Regex r = new Regex(@"
+                (?<=[A-Z])(?=[A-Z][a-z]) |
+                 (?<=[^A-Z])(?=[A-Z]) |
+                 (?<=[A-Za-z])(?=[^A-Za-z])", RegexOptions.IgnorePatternWhitespace);
+		UIManager.SetToolTip = r.Replace(AlertSO.name, " ");
+	}
+
+	public void OnPointerExit(PointerEventData eventData)
+	{
+		UIManager.SetToolTip = "";
+		UIManager.SetHoverToolTip = null;
+	}
+
+	public string HoverTip()
+	{
+		return AlertSO.HoverToolTip;
+	}
+
+	public string CustomTitle()
+	{
+		return AlertSO.name;
+	}
+
+	public Sprite CustomIcon()
+	{
+		return null;
+	}
+
+	public List<Sprite> IconIndicators()
+	{
+		return null;
+	}
+
+	public List<TextColor> InteractionsStrings()
+	{
+		return null;
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Core/Alerts/BodyAlertManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/Alerts/BodyAlertManager.cs
@@ -17,10 +17,14 @@ public class BodyAlertManager : NetworkBehaviour, IClientPlayerLeaveBody, IClien
 	}
 
 
-	public void RegisterAlert(AlertSO AlertSO)
+	public void RegisterAlert(AlertSO AlertSO, bool noDuplicates = true)
 	{
 		var List = JsonConvert.DeserializeObject<List<int>>(PresentAlertsJson); //TODO Make this more optimal sometime
-		List.Add(AlertSO.GetIndexed());
+		var alertToAdd = AlertSO.GetIndexed();
+		if (noDuplicates && List.Contains(alertToAdd) == false)
+		{
+			List.Add(AlertSO.GetIndexed());
+		}
 		SyncActiTheons(PresentAlertsJson, PresentAlertsJson = JsonConvert.SerializeObject(List));
 	}
 

--- a/UnityProject/Assets/Scripts/UI/Core/Alerts/ClientAlertManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/Alerts/ClientAlertManager.cs
@@ -1,8 +1,6 @@
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Logs;
-using Shared.Managers;
 using UnityEngine;
 
 public class ClientAlertManager : MonoBehaviour

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemSlot.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemSlot.cs
@@ -1,23 +1,23 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Items;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 using UnityEngine.Serialization;
 using UnityEngine.UI;
-using HealthV2;
 using Items.Implants.Organs;
 using Logs;
 using Managers;
 using UI;
+using UI.Systems.Tooltips.HoverTooltips;
+using UnityEngine.EventSystems;
 
 /// <summary>
 /// Represents an item slot rendered in the UI.
 /// </summary>
 [Serializable]
-public class UI_ItemSlot : TooltipMonoBehaviour
+public class UI_ItemSlot : TooltipMonoBehaviour, IPointerEnterHandler, IPointerExitHandler
 {
 	[SerializeField]
 	[FormerlySerializedAs("NamedSlot")]
@@ -501,6 +501,24 @@ public class UI_ItemSlot : TooltipMonoBehaviour
 				placeholderImage.color = new Color(1, 1, 1, 0);
 			}
 		}
+	}
+
+	public void OnPointerEnter(PointerEventData eventData)
+	{
+		if (ItemObject == null) return;
+		UIManager.SetHoverToolTip = ItemObject;
+		//thanks stack overflow!
+		Regex r = new Regex(@"
+                (?<=[A-Z])(?=[A-Z][a-z]) |
+                 (?<=[^A-Z])(?=[A-Z]) |
+                 (?<=[A-Za-z])(?=[^A-Za-z])", RegexOptions.IgnorePatternWhitespace);
+		UIManager.SetToolTip = r.Replace(ItemObject.ExpensiveName(), " ");
+	}
+
+	public void OnPointerExit(PointerEventData eventData)
+	{
+		UIManager.SetToolTip = "";
+		UIManager.SetHoverToolTip = null;
 	}
 }
 

--- a/UnityProject/Assets/Scripts/UI/Systems/Tooltips/HoverTooltips/HoverTooltipUI.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Tooltips/HoverTooltips/HoverTooltipUI.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using Learning;
-using Logs;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -33,10 +32,12 @@ namespace UI.Systems.Tooltips.HoverTooltips
 
 		private bool animating = false;
 		private bool showing = false;
+		private RectTransform contentRect;
 
 		private void Awake()
 		{
 			HoverDelay = GetSavedTooltipDelay();
+			contentRect = content.GetComponent<RectTransform>();
 		}
 
 		public float GetSavedTooltipDelay()
@@ -53,9 +54,19 @@ namespace UI.Systems.Tooltips.HoverTooltips
 
 		private void UpdatePosition()
 		{
-			var newPosition = new Vector3(Input.mousePosition.x + MOUSE_OFFSET_X, Input.mousePosition.y + MOUSE_OFFSET_Y,
-				Input.mousePosition.z);
-			transform.position = newPosition;
+			Vector3 newPosition = new Vector3(
+				Input.mousePosition.x + MOUSE_OFFSET_X, Input.mousePosition.y + MOUSE_OFFSET_Y, Input.mousePosition.z);
+
+			float contentWidth = contentRect.rect.width * content.transform.localScale.x;
+			float contentHeight = contentRect.rect.height * content.transform.localScale.y;
+
+			float padding = 10f;
+
+			// makes sure that the tooltip doesn't go offscreen.
+			newPosition.x = Mathf.Clamp(newPosition.x, contentWidth / 2, Screen.width - contentWidth / 2);
+			newPosition.y = Mathf.Clamp(newPosition.y, contentHeight / 2, Screen.height - contentHeight / 2);
+
+			content.transform.position = newPosition;
 		}
 
 		private void CheckForInput()


### PR DESCRIPTION
CL: [New] Alerts now have hover-tooltips.
CL: [New] When input is disabled server-side, you will receive an indication that you're unable to move.
CL: [Improvement] Tooltips are now accessible from item-slot UIs.
CL: [Fix] Tooltips can no longer go off screen.
