### PR TITLE
ID Access Fixes

### DIFF
--- a/UnityProject/Assets/Scripts/Items/PDA/PDALogic.cs
+++ b/UnityProject/Assets/Scripts/Items/PDA/PDALogic.cs
@@ -103,6 +103,9 @@ namespace Items.PDA
 		private ItemSlot IDSlot = default;
 		private ItemSlot CartridgeSlot = default;
 
+		public IEnumerable<Clearance> IssuedClearance => IDCard.OrNull()?.ClearanceSource.IssuedClearance;
+		public IEnumerable<Clearance> LowPopIssuedClearance => IDCard.OrNull()?.ClearanceSource.LowPopIssuedClearance;
+
 		#region Lifecycle
 
 		private void Awake()
@@ -544,8 +547,5 @@ namespace Items.PDA
 		}
 
 		#endregion IDAccess
-
-		public IEnumerable<Clearance> IssuedClearance => IDCard.OrNull()?.ClearanceSource.IssuedClearance;
-		public IEnumerable<Clearance> LowPopIssuedClearance => IDCard.OrNull()?.ClearanceSource.LowPopIssuedClearance;
 	}
 }

--- a/UnityProject/Assets/Scripts/Mobs/Equipment/Equipment.cs
+++ b/UnityProject/Assets/Scripts/Mobs/Equipment/Equipment.cs
@@ -3,11 +3,13 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 using Items;
+using Items.PDA;
 using UnityEngine;
 using Mirror;
 using Objects.Atmospherics;
 using Systems.Clothing;
 using Messages.Server;
+using Systems.Clearance;
 
 /// <summary>
 /// Component which manages all the equipment on a player.
@@ -169,35 +171,21 @@ public class Equipment : NetworkBehaviour
 	/// <returns>Unknown if an identity couldn't be found.</returns>
 	public string GetPlayerNameByEquipment()
 	{
-		if (IsOccupied(idSlot))
+		var clearanceObject = ClearanceRestricted.GrabClearanceObject(script.gameObject);
+		if (clearanceObject == null)
 		{
-			foreach (var itemSlot in idSlot)
-			{
-				if (itemSlot.Item.TryGetComponent<IDCard>(out var idCard))
-				{
-					if (string.IsNullOrEmpty(idCard.RegisteredName) == false)
-					{
-						return idCard.RegisteredName;
-					}
-				}
-			}
+			return "Unknown";
 		}
-
-		if (IsOccupied(idSlot))
+		var playerName = "Unknown";
+		if (clearanceObject.TryGetComponent<IDCard>(out var card))
 		{
-			foreach (var itemSlot in idSlot)
-			{
-				if (itemSlot.Item.TryGetComponent<Items.PDA.PDALogic>(out var pda))
-				{
-					if (string.IsNullOrEmpty(pda.RegisteredPlayerName) == false)
-					{
-						return pda.RegisteredPlayerName;
-					}
-				}
-			}
+			playerName = card.RegisteredName;
 		}
-
-		return "Unknown";
+		else if (clearanceObject.TryGetComponent<PDALogic>(out var pda))
+		{
+			playerName = pda.RegisteredPlayerName;
+		}
+		return playerName;
 	}
 
 	#endregion Identity

--- a/UnityProject/Assets/Scripts/Objects/Atmospherics/AirController.cs
+++ b/UnityProject/Assets/Scripts/Objects/Atmospherics/AirController.cs
@@ -262,7 +262,7 @@ namespace Objects.Atmospherics
 		{
 			if (DefaultWillInteract.Default(interaction, side) == false) return false;
 
-			return Validations.HasItemTrait(interaction, CommonTraits.Instance.Id);
+			return interaction.HandObject != null;
 		}
 
 		public void ServerPerformInteraction(HandApply interaction)

--- a/UnityProject/Assets/Scripts/Objects/Vendor.cs
+++ b/UnityProject/Assets/Scripts/Objects/Vendor.cs
@@ -221,7 +221,7 @@ namespace Objects
 					}
 				}
 
-				var  Hand = playerStorage.OrNull()?.GetActiveHandSlot();
+				var Hand = playerStorage.OrNull()?.GetActiveHandSlot();
 				if (Hand.ItemObject)
 				{
 					var idCard = AccessRestrictions.GetIDCard(Hand.ItemObject);

--- a/UnityProject/Assets/Scripts/Systems/Clearance/ClearanceRestricted.cs
+++ b/UnityProject/Assets/Scripts/Systems/Clearance/ClearanceRestricted.cs
@@ -124,7 +124,7 @@ namespace Systems.Clearance
 			if (playerStorage != null)
 			{
 				List<ItemSlot> slotsToSearch = new List<ItemSlot>();
-				slotsToSearch.Add(playerStorage.GetActiveHandSlot());
+				slotsToSearch.AddRange(playerStorage.GetHandSlots());
 				slotsToSearch.AddRange(playerStorage.GetNamedItemSlots(NamedSlot.id));
 				slotsToSearch.AddRange(playerStorage.GetNamedItemSlots(NamedSlot.belt));
 				slotsToSearch.AddRange(playerStorage.GetNamedItemSlots(NamedSlot.suitStorage));


### PR DESCRIPTION
CL: [New] There's a low chance that you can assume the identity of someone by holding up their ID card in your active hand while naked.
CL: [New] Items with `IClearanceSource` inside storage containers can now be checked for clearance.
CL: [Fix] Fixed an issue with the `ClearanceRestricted` API blocking access checks for cyborgifed players who don't have access on their new bodyParts.
CL: [Fix] `ClearanceRestricted` will always check clothing first now before anything else.
CL: [Fix] Belts and suit storages were not checked at all before for clearance.
CL: [Fix] Fixed an issue with player names reporting "unknown" despite the existence of an ID somewhere on the player.