### PR TITLE
Fixes a few NREs related to setting up names for aliens that completely broke them

### DIFF
--- a/UnityProject/Assets/Scripts/Player/Mind.cs
+++ b/UnityProject/Assets/Scripts/Player/Mind.cs
@@ -341,6 +341,13 @@ public class Mind : NetworkBehaviour, IActionGUI
 		{
 			CurrentCharacterSettings.Name = newName;
 		}
+		else
+		{
+			CurrentCharacterSettings = CharacterSheet.GenerateRandomCharacter();
+			CurrentCharacterSettings.PlayerPronoun = PlayerPronoun.They_them;
+			CurrentCharacterSettings.Species = ""; //(Max): This will cause some issues. Too bad!
+			CurrentCharacterSettings.Name = newName;
+		}
 
 		this.name = newName;
 	}

--- a/UnityProject/Assets/Scripts/Player/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerScript.cs
@@ -605,7 +605,6 @@ public class PlayerScript : NetworkBehaviour, IAdminInfo, IPlayerPossessable, IH
 		}
 
 		SyncVisibleName(newVisibleName, newVisibleName);
-
 	}
 
 	// Tooltips inspector bar
@@ -771,7 +770,7 @@ public class PlayerScript : NetworkBehaviour, IAdminInfo, IPlayerPossessable, IH
 		if (characterSettings == null) return finalText.ToString();
 		finalText.Append($"A {characterSettings.Species}.");
 		finalText.Append($" {characterSettings.TheyPronoun(this)}/{characterSettings.TheirPronoun(this)}.");
-		finalText.AppendLine($"\n{PlayerFaith.ToleranceCheckForReligion()}");
+		finalText.AppendLine($"\n{PlayerFaith?.ToleranceCheckForReligion()}");
 		return finalText.ToString();
 	}
 

--- a/UnityProject/Assets/Scripts/Systems/Inventory/DynamicItemStorage.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/DynamicItemStorage.cs
@@ -799,10 +799,9 @@ public class DynamicItemStorage : NetworkBehaviour, IOnPlayerRejoin, IOnControlP
 						{
 							DIS.ProcessChangeClient(NewST, LocalTries);
 						}
-					}, 30);
+					}, 60);
 					return;
 				}
-
 
 				bool Contain = false;
 				foreach (var ID in ClientUIBodyPartsToSerialise)

--- a/UnityProject/Assets/Scripts/Systems/Lobby/CharacterSheet.cs
+++ b/UnityProject/Assets/Scripts/Systems/Lobby/CharacterSheet.cs
@@ -162,7 +162,8 @@ public class CharacterSheet : ICloneable
 	/// </summary>
 	public string TheyPronoun(PlayerScript script)
 	{
-		if (script.Equipment.GetPlayerNameByEquipment() == "Unknown" && script.Equipment.IsIdentityObscured())
+		if (script == null) return "they";
+		if (script.Equipment != null && script.Equipment.GetPlayerNameByEquipment() == "Unknown" && script.Equipment.IsIdentityObscured())
 		{
 			return "they";
 		}

--- a/UnityProject/Assets/Scripts/UI/Core/Action/UIActionManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/Action/UIActionManager.cs
@@ -140,18 +140,17 @@ namespace UI.Core.Action
 
 		private void InstantToggleServer(GameObject Body, IActionGUI iActionGUI, bool show)
 		{
-			if (CustomNetworkManager.IsServer == false) return;
+			if (CustomNetworkManager.IsServer == false || Body == null) return;
 			if (ActivePlayerActions.ContainsKey(Body) == false)
 			{
 				ActivePlayerActions[Body] = new List<IActionGUI>();
 			}
 
-
 			if (show)
 			{
 				if (ActivePlayerActions[Body].Contains(iActionGUI))
 				{
-					Loggy.LogError("iActionGUI Already present on mind");
+					Loggy.LogWarning($"[UIActionManager/InstantToggleServer()] - iActionGUI Already present on mind for {Body.name}");
 					return;
 				}
 
@@ -169,7 +168,7 @@ namespace UI.Core.Action
 			{
 				if (ActivePlayerActions[Body].Contains(iActionGUI) == false)
 				{
-					Loggy.LogError($"iActionGUI {iActionGUI?.ActionData.OrNull()?.Name}, not present on mind", Category.UI);
+					Loggy.LogWarning($"iActionGUI {iActionGUI?.ActionData.OrNull()?.Name}, not present on mind", Category.UI);
 					return;
 				}
 

--- a/UnityProject/Assets/Tests/PlayModeTests/RunTests/TestSingleton.cs
+++ b/UnityProject/Assets/Tests/PlayModeTests/RunTests/TestSingleton.cs
@@ -3,11 +3,8 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using NUnit.Framework;
-using ScriptableObjects;
 using UnityEditor;
-using UnityEditor.SceneManagement;
 using UnityEngine;
 
 namespace GameRunTests


### PR DESCRIPTION
fixes #9691

I've spent all day debugging this issue, and I'm tired now..

![myreactionsadtoinfo](https://github.com/unitystation/unitystation/assets/34368774/6bdcc391-48a7-45b6-9db3-4578c72b4905)


### Changelog:

CL: [Fix] Fixed an issue with aliens disappearing into thin air when evolving due to an NRE that did not complete their spawn process.
CL: [Fix] Fixed an issue where mindless Aliens would NRE while attempting to give them their names.
CL: [Fix] Fixed an issue where alien names were never updated when evolved.
CL: [Fix] Fixed an issue where aliens would attempt accessing Faith scripts when hovering over them with your mouse because they forget that they're godless creatures. This also fixes an issue where tooltips for Aliens would not work.
CL: [Fix] Fixed an issue where Aliens did not spawn with character sheets. This subsequently fixes an issue where several parts of the game would NRE when attempting to access the Aliens' pronouns, by default all aliens go by They/Them now.
CL: [Fix] The UIAction logs have been moved to the warnings section instead of Errors because they were getting annoying.