### PR TITLE
Fix an issue with hand slots blocking ID/Belt slots

### DIFF
--- a/UnityProject/Assets/Scripts/Systems/Clearance/ClearanceRestricted.cs
+++ b/UnityProject/Assets/Scripts/Systems/Clearance/ClearanceRestricted.cs
@@ -124,7 +124,7 @@ namespace Systems.Clearance
 			if (playerStorage != null)
 			{
 				List<ItemSlot> slotsToSearch = new List<ItemSlot>();
-				slotsToSearch.AddRange(playerStorage.GetHandSlots());
+				slotsToSearch.Add(playerStorage.GetActiveHandSlot());
 				slotsToSearch.AddRange(playerStorage.GetNamedItemSlots(NamedSlot.id));
 				slotsToSearch.AddRange(playerStorage.GetNamedItemSlots(NamedSlot.belt));
 				slotsToSearch.AddRange(playerStorage.GetNamedItemSlots(NamedSlot.suitStorage));

--- a/UnityProject/Assets/Scripts/Systems/Clearance/ClearanceRestricted.cs
+++ b/UnityProject/Assets/Scripts/Systems/Clearance/ClearanceRestricted.cs
@@ -124,6 +124,8 @@ namespace Systems.Clearance
 			if (playerStorage != null)
 			{
 				List<ItemSlot> slotsToSearch = new List<ItemSlot>();
+				// Only check the hand in use for a clearance item to avoid blocking other slots.
+				// That way players can still hold other PDAs in their hands without it blocking their access until they switch to that hand as their active.
 				slotsToSearch.Add(playerStorage.GetActiveHandSlot());
 				slotsToSearch.AddRange(playerStorage.GetNamedItemSlots(NamedSlot.id));
 				slotsToSearch.AddRange(playerStorage.GetNamedItemSlots(NamedSlot.belt));


### PR DESCRIPTION
CL: [Fix] When using doors, access checks will only scan for your active hand now when holding an item that has an `IClearanceSource` (such as a PDA) to prevent doors from blocking you completely by just doing the act of holding the item.
