### PR TITLE
Ashwalker Nest balance changes

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Lavaland/AshwalkerNest.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Lavaland/AshwalkerNest.prefab
@@ -331,5 +331,7 @@ MonoBehaviour:
       m_SubObjectName: 
       m_SubObjectType: 
       m_EditorAssetChanged: 0
-  meatCost: 2
-  timeBetweenEating: 30
+  edibleTraitForTheNest: {fileID: 11400000, guid: e9640fc5a465def458cfff48c65df282,
+    type: 2}
+  meatCost: 4
+  timeBetweenEating: 120

--- a/UnityProject/Assets/ScriptableObjects/Spells/HellSpawn/GibbusMaximus.asset
+++ b/UnityProject/Assets/ScriptableObjects/Spells/HellSpawn/GibbusMaximus.asset
@@ -26,14 +26,14 @@ MonoBehaviour:
   PreventBeingControlledBy: 
   DisableOnEvent: 
   isAimable: 1
-  useCustomCursor: 0
-  cursorTexture: {fileID: 0}
+  useCustomCursor: 1
+  cursorTexture: {fileID: 2800000, guid: 49419f465bddca3449f0e806194ba1b1, type: 3}
   cursorOffsetType: 0
   cursorOffset: {x: 0, y: 0}
   spellImplementation: {fileID: 7469762742606550612, guid: cef1589efbcdad64489278278893b3f4,
     type: 3}
   chargeType: 0
-  cooldownTime: 195
+  cooldownTime: 400
   startingCharges: 10
   castSound:
     SetLoadSetting: 0

--- a/UnityProject/Assets/ScriptableObjects/Systems/GhostRoles/Occupations/Ashwalker Priest.asset
+++ b/UnityProject/Assets/ScriptableObjects/Systems/GhostRoles/Occupations/Ashwalker Priest.asset
@@ -13,9 +13,9 @@ MonoBehaviour:
   m_Name: Ashwalker Priest
   m_EditorClassIdentifier: 
   name: Ashwalker Priest
-  description: "The holy medium of the Lavalands. \n\nGuide and ensure the survival
+  description: "The holy medium of the Lavalands. \nGuide and ensure the survival
     and prosperity of your tribe. \n\nBut watch out for the people from the sky.
-    They mean to exploit your lands."
+    \nThey mean to exploit your lands."
   descriptionAdmin: 
   sprite: {fileID: 11400000, guid: e05313ec04d17d34fb4806360f1886b8, type: 2}
   respawnType: 2

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -1566,21 +1566,30 @@ namespace HealthV2
 
 			reagentPoolSystem?.Bleed(reagentPoolSystem.GetTotalBlood());
 
-			if (InitialSpecies != null)
-			{
-				Spawn.ServerPrefab(InitialSpecies.Base.MeatProduce,
-					gameObject.AssumedWorldPosServer(), count: Random.Range(1, 3),
-					scatterRadius: 0.5f);
-				Spawn.ServerPrefab(InitialSpecies.Base.SkinProduce,
-					gameObject.AssumedWorldPosServer(), count: Random.Range(1, 3),
-					scatterRadius: 0.5f);
-			}
+			SpawnSpeciesProduce(3);
 
 			Death();
 			for (int i = BodyPartList.Count - 1; i >= 0; i--)
 			{
 				if (BodyPartList[i].BodyPartType == BodyPartType.Chest) continue;
 				BodyPartList[i].TryRemoveFromBody(true, PreventGibb_Death: true);
+			}
+		}
+
+		public void SpawnSpeciesProduce(int maximumProduce)
+		{
+			if (InitialSpecies == null) return;
+			if (InitialSpecies.Base.MeatProduce != null)
+			{
+				Spawn.ServerPrefab(InitialSpecies.Base.MeatProduce,
+					gameObject.AssumedWorldPosServer(), count: Random.Range(1, maximumProduce),
+					scatterRadius: 0.5f);
+			}
+			if (InitialSpecies.Base.SkinProduce != null)
+			{
+				Spawn.ServerPrefab(InitialSpecies.Base.SkinProduce,
+					gameObject.AssumedWorldPosServer(), count: Random.Range(1, maximumProduce),
+					scatterRadius: 0.5f);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/Lavaland/AshwalkerNest.cs
+++ b/UnityProject/Assets/Scripts/Objects/Lavaland/AshwalkerNest.cs
@@ -149,7 +149,7 @@ namespace Objects
 				if (creature.InitialSpecies == ashwalkerRaceData || creature.InitialSpecies == tieflingRaceData)
 				{
 					Chat.AddActionMsgToChat(gameObject,
-						$"The nest grumples violently as it first tries snatching up {creature.gameObject.ExpensiveName()}, " +
+						$"The nest grumples violently as it first tries snatching up {creature.playerScript.visibleName}, " +
 						$"but it puts them down as it notices that they're a {creature.InitialSpecies.name}");
 					continue;
 				}


### PR DESCRIPTION
CL: [New] Ashwalker nests can now directly consume meat produce, for a 5% chance to satiate the nest's hunger.
CL: [New] Ashwalker nests now have hover-tooltips that report when was the last meal the nest had, and some instructions on how to feed it.
CL: [Balance] Ashwalker nests now search for food every 120 seconds, instead of 30 seconds.
CL: [Balance] Ashwalker nests now require 5 successful hunger reductions to produce 1 egg.
CL: [Balance] Ashwalker priests have had their Gibbus Maximus spell's cooldown increased to 400 seconds.
CL: [Balance] Ashwalker nests will never attempt to feed on Ashwalkers or Tieflings.
CL: [Fix] Fixed an NRE that would happen when players without a meat/skin produce (e.g: Cyborgs) would get gibbed.
CL: [Fix] Removed support for consuming MobV1 corpses, as they're obsolete; and are being phased out slowly for MobV2.
CL: [Fix] Fixed ashwalker priest description not aligning properly inside the ghost role menu.
