### PR TITLE
Fix an issue where objects would attempt to store themselves within themselves

### DIFF
--- a/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
+++ b/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
@@ -21,6 +21,7 @@ using UnityEditor;
 using UnityEngine;
 using UnityEngine.Events;
 using Util;
+using Util.Independent.FluentRichText;
 using Random = UnityEngine.Random;
 
 public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegisterTileInitialised
@@ -530,11 +531,10 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 		if (newParent.OrNull()?.gameObject == this.gameObject)
 		{
 			Chat.AddGameWideSystemMsgToChat(
-				" Something doesn't feel right? **BBBBBBBBBBBBBOOOOOOOOOOOOOOOOOOOMMMMMMMMMMMEMMEEEEE** ");
+				$"Anomoly Detected.. {gameObject.ExpensiveName()} has attempted to store itself within itself".Color(Color.red));
 			Loggy.LogError("Tried to store object within itself");
 			return; //Storing something inside of itself what?
 		}
-
 
 		PullSet(null, false); //Presume you can't Pulling stuff inside container
 		//TODO Handle non-disappearing containers like Cart riding

--- a/UnityProject/Assets/Scripts/Objects/ObjectContainer.cs
+++ b/UnityProject/Assets/Scripts/Objects/ObjectContainer.cs
@@ -295,6 +295,7 @@ namespace Objects
 		{
 			foreach (var obj in target)
 			{
+				if (obj == gameObject) continue;
 				StoreObject(obj, obj.transform.position - transform.position);
 			}
 			onGrab?.Invoke();


### PR DESCRIPTION
CL: [Fix] Items will no longer attempt to store themselves within themselves when the round is starting.
CL: [Improvement] improved the text regrading someone attempting to store an object within itself.
