### PR TITLE
Adds in health descriptions for integrity

### DIFF
--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -366,24 +366,7 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 
 	public string Examine(Vector3 worldPos)
 	{
-		string str = "";
-		if (integrity < 0.2f * initialIntegrity)
-		{
-			str = "it's falling apart";
-		}
-		else if (integrity < 0.4f * initialIntegrity)
-		{
-			str = "It appears very badly damaged.";
-		}
-		else if (integrity < 0.6f * initialIntegrity)
-		{
-			str = "It appears substantially damaged.";
-		}
-		else if (integrity < 0.8f * initialIntegrity)
-		{
-			str = "It appears damaged.";
-		}
-		return str;
+		return GetDamageDesc();
 	}
 
 	[Server]
@@ -467,9 +450,9 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 		BeingDestroyed = null;
 	}
 
-	public string HoverTip()
+	public string GetDamageDesc()
 	{
-		string damageDesc = "Integrity: " + PercentageDamaged switch
+		return "Integrity: " + PercentageDamaged switch
 		{
 			< 10 => "Crumbling".Color(Color.red),
 			< 30 => "Heavily Damaged".Color(Color.red),
@@ -480,7 +463,11 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 			>= 100 => "In Perfect Condition".Color(Color.green),
 			_ => "Unknown Condition"
 		};
-		return damageDesc;
+	}
+
+	public string HoverTip()
+	{
+		return GetDamageDesc();
 	}
 
 	public string CustomTitle()

--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -457,10 +457,10 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 			< 10 => "Crumbling".Color(Color.red),
 			< 30 => "Heavily Damaged".Color(Color.red),
 			< 40 => "Significantly Damaged".Color(Color.yellow),
-			< 60 => "Worn out Condition".Color(Color.yellow),
+			< 60 => "Worn Out Condition".Color(Color.yellow),
 			< 80 => "Slightly Damaged".Color(Color.green),
 			< 95 => "Scratched Condition".Color(Color.green),
-			>= 100 => "In Perfect Condition".Color(Color.green),
+			>= 100 => "Perfect Condition".Color(Color.green),
 			_ => "Unknown Condition"
 		};
 	}

--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -366,7 +366,7 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 
 	public string Examine(Vector3 worldPos)
 	{
-		return GetDamageDesc();
+		return GetDamageDesc().Italic();
 	}
 
 	[Server]

--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -452,16 +452,16 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 
 	public string GetDamageDesc()
 	{
-		return "Integrity: " + PercentageDamaged switch
+		return "It is " + PercentageDamaged switch
 		{
 			< 10 => "Crumbling".Color(Color.red),
 			< 30 => "Heavily Damaged".Color(Color.red),
 			< 40 => "Significantly Damaged".Color(Color.yellow),
-			< 60 => "Worn Out Condition".Color(Color.yellow),
+			< 60 => "in a " + "Worn Out Condition".Color(Color.yellow),
 			< 80 => "Slightly Damaged".Color(Color.green),
-			< 95 => "Scratched Condition".Color(Color.green),
-			>= 100 => "Perfect Condition".Color(Color.green),
-			_ => "Unknown Condition"
+			< 95 => "in a " + "Scratched Condition".Color(Color.green),
+			>= 100 => "in a " + "Perfect Condition".Color(Color.green),
+			_ => "in an unknown condition"
 		};
 	}
 

--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -469,7 +469,7 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 
 	public string HoverTip()
 	{
-		string damageDesc = PercentageDamaged switch
+		string damageDesc = "Health: " + PercentageDamaged switch
 		{
 			< 10 => "Crumbling".Color(Color.red),
 			< 30 => "Heavily Damaged".Color(Color.red),

--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -469,7 +469,7 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 
 	public string HoverTip()
 	{
-		string damageDesc = "Health: " + PercentageDamaged switch
+		string damageDesc = "Integrity: " + PercentageDamaged switch
 		{
 			< 10 => "Crumbling".Color(Color.red),
 			< 30 => "Heavily Damaged".Color(Color.red),

--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -4,18 +4,17 @@ using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.Profiling;
 using Mirror;
-using Core.Editor.Attributes;
 using AddressableReferences;
 using AdminCommands;
-using DatabaseAPI;
 using Effects.Overlays;
-using InGameEvents;
 using Logs;
 using Messages.Client.DevSpawner;
 using ScriptableObjects;
 using Systems.Atmospherics;
 using Systems.Explosions;
 using Systems.Interaction;
+using UI.Systems.Tooltips.HoverTooltips;
+using Util.Independent.FluentRichText;
 
 
 /// <summary>
@@ -28,7 +27,7 @@ using Systems.Interaction;
 /// </summary>
 ///
 [RequireComponent(typeof(RegisterTile))]
-public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClickable, IServerSpawn, IExaminable, IServerDespawn
+public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClickable, IServerSpawn, IExaminable, IServerDespawn, IHoverTooltip
 {
 
 	/// <summary>
@@ -132,7 +131,7 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 
 	private static readonly float BURN_RATE = 1f;
 
-	public float integrity { get; private set; } = 100f;
+	[field: SyncVar] public float integrity { get; private set; } = 100f;
 	private bool destroyed = false;
 	private DamageType lastDamageType;
 	private RegisterTile registerTile;
@@ -143,7 +142,7 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 	public Meleeable Meleeable => meleeable;
 
 	//The current integrity divided by the initial integrity
-	public float PercentageDamaged => integrity.Approx(0) ? 0 : integrity / initialIntegrity;
+	public float PercentageDamaged => integrity.Approx(0) ? 0 : integrity / initialIntegrity * 100f;
 
 	//whether this is a large object (meaning we would use the large ash pile and large burning sprite)
 	private bool isLarge;
@@ -466,6 +465,42 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 	{
 		BeingDestroyed?.Invoke();
 		BeingDestroyed = null;
+	}
+
+	public string HoverTip()
+	{
+		string damageDesc = PercentageDamaged switch
+		{
+			< 10 => "Crumbling".Color(Color.red),
+			< 30 => "Heavily Damaged".Color(Color.red),
+			< 40 => "Significantly Damaged".Color(Color.yellow),
+			< 60 => "Worn out Condition".Color(Color.yellow),
+			< 80 => "Slightly Damaged".Color(Color.green),
+			< 95 => "Scratched Condition".Color(Color.green),
+			>= 100 => "In Perfect Condition".Color(Color.green),
+			_ => "Unknown Condition"
+		};
+		return damageDesc;
+	}
+
+	public string CustomTitle()
+	{
+		return null;
+	}
+
+	public Sprite CustomIcon()
+	{
+		return null;
+	}
+
+	public List<Sprite> IconIndicators()
+	{
+		return null;
+	}
+
+	public List<TextColor> InteractionsStrings()
+	{
+		return null;
 	}
 }
 

--- a/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestExamineMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestExamineMessage.cs
@@ -56,8 +56,7 @@ namespace Messages.Client.Interaction
 				}
 
 				var examinableMsg = examinable.Examine(netMsg.mousePosition);
-				if (string.IsNullOrEmpty(examinableMsg))
-					continue;
+				if (string.IsNullOrEmpty(examinableMsg)) continue;
 
 				msg += examinableMsg;
 


### PR DESCRIPTION
![image](https://github.com/unitystation/unitystation/assets/34368774/2764d210-3f30-440c-923c-7385d030dfa2)
![image](https://github.com/unitystation/unitystation/assets/34368774/a5aaafb8-427b-42d9-8091-dc2940a78174)
![image](https://github.com/unitystation/unitystation/assets/34368774/63ce90c1-4275-4bd7-8d5c-d45b39a4b686)
![image](https://github.com/unitystation/unitystation/assets/34368774/bd306bb1-c745-4e05-ae84-c0daa0843ae0)
![image](https://github.com/unitystation/unitystation/assets/34368774/6070cb56-1097-4c6a-ab0f-684dc455f41f)


CL: [New] Hover-tooltips now display the health of items/objects.
CL: [Improvement] Updated the examine text for integrity health slightly to make them color-coded and shorter.