### PR TITLE
Priority for IExaminable

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Interfaces/IExaminable.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Interfaces/IExaminable.cs
@@ -7,7 +7,12 @@ using UnityEngine;
 /// </summary>
 public interface IExaminable
 {
-	string Examine(Vector3 worldPos = default(Vector3));
+	string Examine(Vector3 worldPos = default);
+
+	/// <summary>
+	/// Higher priority will ensure this text is displayed first when constructing the examine message.
+	/// </summary>
+	int ExaminablePriority => 1;
 }
 
 [Flags]

--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -454,14 +454,14 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 	{
 		return "It is " + PercentageDamaged switch
 		{
-			< 10 => "Crumbling".Color(Color.red),
-			< 30 => "Heavily Damaged".Color(Color.red),
-			< 40 => "Significantly Damaged".Color(Color.yellow),
-			< 60 => "in a " + "Worn Out Condition".Color(Color.yellow),
-			< 80 => "Slightly Damaged".Color(Color.green),
-			< 95 => "in a " + "Scratched Condition".Color(Color.green),
-			>= 100 => "in a " + "Perfect Condition".Color(Color.green),
-			_ => "in an unknown condition"
+			< 10 => "crumbling.".Color(Color.red),
+			< 30 => "heavily damaged.".Color(Color.red),
+			< 40 => "significantly damaged.".Color(Color.yellow),
+			< 60 => "in a " + "worn out condition.".Color(Color.yellow),
+			< 80 => "slightly damaged.".Color(Color.green),
+			< 95 => "in a " + "scratched condition.".Color(Color.green),
+			>= 100 => "in " + "perfect condition.".Color(Color.green),
+			_ => "in an unknown condition."
 		};
 	}
 

--- a/UnityProject/Assets/Scripts/Items/Attributes.cs
+++ b/UnityProject/Assets/Scripts/Items/Attributes.cs
@@ -32,6 +32,9 @@ public class Attributes : NetworkBehaviour, IRightClickable, IExaminable, IServe
 
 	public string InitialDescription => initialDescription;
 
+	// This examine message has priority over everything. If you make yours have higher priority, I will cut your ears.
+	public int ExaminablePriority => 10_000_000;
+
 	[Tooltip("Description of this item when spawned.")]
 	[SerializeField]
 	[TextArea(3,5)]

--- a/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestExamineMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestExamineMessage.cs
@@ -1,3 +1,4 @@
+using System;
 using Mirror;
 using Player;
 using Shuttles;
@@ -39,7 +40,10 @@ namespace Messages.Client.Interaction
 			// Here we build the message to send, by looking at the target's components.
 			// anyone extending IExaminable gets a say in it.
 			// Look for examinables.
-			var examinables = NetworkObject.GetComponents<IExaminable>();
+			IExaminable[] examinables = NetworkObject.GetComponents<IExaminable>();
+
+			// modifying this line can make the tests fail, please update accordingly.
+			Array.Sort(examinables, (first, other) => other.ExaminablePriority.CompareTo(first.ExaminablePriority));
 			string msg = "";
 			IExaminable examinable;
 

--- a/UnityProject/Assets/Tests/Examinables.meta
+++ b/UnityProject/Assets/Tests/Examinables.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 403ae36df6fe4fa5a4bbd21516618eff
+timeCreated: 1714784402

--- a/UnityProject/Assets/Tests/Examinables/PriorityTest.cs
+++ b/UnityProject/Assets/Tests/Examinables/PriorityTest.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Tests.Examinables
+{
+	public class MockExaminable : IExaminable
+	{
+		public string Message { get; }
+		private readonly int _priority;
+		public int ExaminablePriority => _priority;
+
+		public MockExaminable(string message, int priority)
+		{
+			Message = message;
+			_priority = priority;
+		}
+
+		public string Examine(Vector3 worldPos = default) => Message;
+	}
+
+	public class PriorityTest
+	{
+		[Test]
+		public void Examinables_SortedByDescendingPriority()
+		{
+			var examinables = new IExaminable[]
+			{
+				new MockExaminable("Low", 1),
+				new MockExaminable("Medium", 5),
+				new MockExaminable("High", 10)
+			};
+
+			// we are assuming this is how RequestExamineMessage will always sort the list. Please update the test if the algo changes.
+			Array.Sort(examinables, (first, other) => other.ExaminablePriority.CompareTo(first.ExaminablePriority));
+
+			Assert.AreEqual("High", examinables[0].Examine());
+			Assert.AreEqual("Medium", examinables[1].Examine());
+			Assert.AreEqual("Low", examinables[2].Examine());
+		}
+
+		[Test]
+		public void Examinables_WithEqualPriority_RemainInOriginalOrder()
+		{
+			var examinables = new IExaminable[]
+			{
+				new MockExaminable("First", 3),
+				new MockExaminable("Second", 3),
+				new MockExaminable("Third", 3)
+			};
+
+			Array.Sort(examinables, (first, other) => other.ExaminablePriority.CompareTo(first.ExaminablePriority));
+
+			Assert.AreEqual("First", examinables[0].Examine());
+			Assert.AreEqual("Second", examinables[1].Examine());
+			Assert.AreEqual("Third", examinables[2].Examine());
+		}
+	}
+}

--- a/UnityProject/Assets/Tests/Examinables/PriorityTest.cs.meta
+++ b/UnityProject/Assets/Tests/Examinables/PriorityTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5aecb41d32584069a8f4b78548bb5799
+timeCreated: 1714784420


### PR DESCRIPTION
### Purpose
Adds a new property to IExaminable with a default value of 1, representing the priority of this examine text to be considered when building the final examination text. Higher priority means the text appears first.

I also added tests to make sure this functionality works as intended.

