### PR TITLE
Fixes two issues with the flammable component

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Mining/Ore/GibtoniteOre.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Mining/Ore/GibtoniteOre.prefab
@@ -28,6 +28,21 @@ PrefabInstance:
       propertyPath: stackNames.Array.data[1].OverAmount
       value: 2
       objectReference: {fileID: 0}
+    - target: {fileID: 3530973717534294305, guid: fdb2f97a13e5b31468c170e6847a8d15,
+        type: 3}
+      propertyPath: chanceToSpread
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 3530973717534294305, guid: fdb2f97a13e5b31468c170e6847a8d15,
+        type: 3}
+      propertyPath: skipFlammableCheck
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3530973717534294305, guid: fdb2f97a13e5b31468c170e6847a8d15,
+        type: 3}
+      propertyPath: minimumFireDamageForStack
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4039560752263721574, guid: fdb2f97a13e5b31468c170e6847a8d15,
         type: 3}
       propertyPath: m_RootOrder
@@ -87,6 +102,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: GibtoniteOre
+      objectReference: {fileID: 0}
+    - target: {fileID: 4145377823770582758, guid: fdb2f97a13e5b31468c170e6847a8d15,
+        type: 3}
+      propertyPath: Resistances.Flammable
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4145792851350106790, guid: fdb2f97a13e5b31468c170e6847a8d15,
         type: 3}

--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/LavaStepInteraction.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/LavaStepInteraction.cs
@@ -68,19 +68,13 @@ namespace Systems.Interaction
 
 		private void DamageObject(GameObject objectToBurn)
 		{
-			if (objectToBurn.TryGetComponent<PlayerHealthV2>(out var playerHealth))
+			if (objectToBurn.TryGetComponent<LivingHealthMasterBase>(out var playerHealth))
 			{
 				playerHealth.ChangeFireStacks(playerMobFireStacks);
 				return;
 			}
 
-			if (objectToBurn.TryGetComponent<Flammable>(out var flammable))
-			{
-				flammable.AddFireStacks(5);
-				return;
-			}
-
-			if (objectToBurn.TryGetComponent<Integrity>(out var integrity) && integrity.Resistances.LavaProof == false)
+			if (objectToBurn.TryGetComponent<Integrity>(out var integrity) && (integrity.Resistances.LavaProof == false || integrity.Resistances.Flammable))
 			{
 				integrity.ApplyDamage(objectFireDamage, AttackType.Fire, DamageType.Burn);
 			}

--- a/UnityProject/Assets/Scripts/Health/Objects/Flammable.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Flammable.cs
@@ -46,6 +46,7 @@ namespace Health.Objects
 		[SerializeField] private float minimumFireDamageForStack = 12;
 		[SerializeField, SyncVar] private float chanceToSpread = 20;
 		[SerializeField] private int maxStacks = 20;
+		[SerializeField, SyncVar] private bool skipFlammableCheck = false;
 
 		[SyncVar] private long lastBurnStackTickTime = 0;
 		private const long BURN_STACK_TICK_INTERVAL = 60 * TimeSpan.TicksPerSecond; // 60 seconds in ticks
@@ -118,9 +119,12 @@ namespace Health.Objects
 				SyncOnFire(fireStacks, 0);
 				return;
 			}
-
-			integrity.ApplyDamage(BURNING_DAMAGE_PER_STACK * fireStacks, AttackType.Fire, DamageType.Burn);
 			node?.GasMixLocal.AddGas(Gas.Smoke, BURNING_DAMAGE_PER_STACK * 100);
+
+			if (integrity.Resistances.Flammable || skipFlammableCheck)
+			{
+				integrity.ApplyDamage(BURNING_DAMAGE_PER_STACK * fireStacks, AttackType.Fire, DamageType.Burn);
+			}
 
 			long currentTickTime = DateTime.UtcNow.Ticks;
 			long timeElapsed = currentTickTime - lastBurnStackTickTime;
@@ -209,6 +213,7 @@ namespace Health.Objects
 			isUpdating = newState;
 			if (newState == true && oldState == false)
 			{
+				lastBurnStackTickTime = DateTime.UtcNow.Ticks;
 				UpdateManager.Add(PeriodicUpdateBurn, BURN_RATE);
 				Chat.AddLocalMsgToChat($"The {gameObject.ExpensiveName()} catches on fire!".Color(Color.red), gameObject);
 				registerTile = gameObject.RegisterTile();
@@ -292,6 +297,11 @@ namespace Health.Objects
 			chanceToSpread = 100;
 		}
 
+		private void DebugSkipFlammableCheck()
+		{
+			skipFlammableCheck = true;
+		}
+
 		public RightClickableResult GenerateRightClickOptions()
 		{
 			if (string.IsNullOrEmpty(PlayerList.Instance.AdminToken) || KeyboardInputManager.Instance.CheckKeyAction(KeyAction.ShowAdminOptions, KeyboardInputManager.KeyEventType.Hold) == false)
@@ -299,17 +309,25 @@ namespace Health.Objects
 				return null;
 			}
 
-			if (IsOnFire)
+			var result = RightClickableResult.Create();
+
+			if (integrity.Resistances.Flammable || skipFlammableCheck)
 			{
-				return RightClickableResult.Create()
-					.AddAdminElement("[Debug] - Set firestacks to 0", ResetFireStacks)
+				result.AddAdminElement("[Debug] - Add 20 fire stacks", DebugAddStacks)
 					.AddAdminElement("[Debug] - Set fire spread chance to 100%", DebugMakeItAlwaysSpread);
 			}
 			else
 			{
-				return RightClickableResult.Create()
-					.AddAdminElement("[Debug] - Add 20 fire stacks", DebugAddStacks);
+				result.AddElement("[Debug] -  Force Flammable", DebugSkipFlammableCheck);
 			}
+
+			if (IsOnFire)
+			{
+				return RightClickableResult.Create()
+					.AddAdminElement("[Debug] - Set firestacks to 0", ResetFireStacks);
+			}
+
+			return result;
 		}
 
 		public string HoverTip()


### PR DESCRIPTION
CL: [Fix] Fixed an issue where flammable objects would immediately extinguish themselves.
CL: [Fix] Fixed an issue where lava tiles would always set everything it touches on fire regardless if they were flammable/lava proof or not.
CL: [Fix] Fire stacks will not damage objects that are flameproof, even if they got a max fire stack through any means.
CL: [Fix] Fixed an issue with Gibtonite not responding to fire/burn damage.
CL: [Improvement] Improved admin commands for flammables a bit to not clutter them when they're not needed.