### PR TITLE
Prevent headless servers from spawning and running particles for flammables

### DIFF
--- a/UnityProject/Assets/Scripts/Health/Objects/Flammable.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Flammable.cs
@@ -187,6 +187,7 @@ namespace Health.Objects
 
 		private void HandleFireParticles()
 		{
+			if (CustomNetworkManager.IsHeadless) return;
 			if (fireParticlePrefab == null) return;
 			if (fireStacks == maxStacks)
 			{


### PR DESCRIPTION
CL: [Improvement] Headless servers will not attempt to spawn dynamic particles on their end to save on performance.
