### PR TITLE
Add a hover tooltip description for when an object is indestructable

### DIFF
--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -327,7 +327,7 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 
 	public string GetDamageDesc()
 	{
-		if (Resistances.Indestructable) return "This object is indestructable!".Color(RichTextColor.Green).Bold();
+		if (Resistances.Indestructable) return "This object is indestructible!".Color(RichTextColor.Green).Bold();
 		return "It is " + PercentageDamaged switch
 		{
 			< 10 => "crumbling.".Color(Color.red),

--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -327,6 +327,7 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 
 	public string GetDamageDesc()
 	{
+		if (Resistances.Indestructable) return "This object is indestructable!".Color(RichTextColor.Green).Bold();
 		return "It is " + PercentageDamaged switch
 		{
 			< 10 => "crumbling.".Color(Color.red),


### PR DESCRIPTION
CL: [Improvement] Objects that cannot receive any damage or be destroyed will report that they're indestructible in hover tooltips to help players not get confused when objects never change their damage descriptions, and help testers and devs know when an object that isn't supposed to be destroyed gets destroyed.
