### PR TITLE
More flammable fixes

### DIFF
--- a/UnityProject/Assets/Prefabs/Effects/FireParticle.prefab
+++ b/UnityProject/Assets/Prefabs/Effects/FireParticle.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 532734834970881050}
   - component: {fileID: 2905733220475948552}
   - component: {fileID: 8840793728698598884}
+  - component: {fileID: 2555330160969562780}
   m_Layer: 11
   m_Name: FireParticle
   m_TagString: Untagged
@@ -4833,3 +4834,15 @@ ParticleSystemRenderer:
   m_MeshWeighting2: 1
   m_MeshWeighting3: 1
   m_MaskInteraction: 0
+--- !u!114 &2555330160969562780
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2178958902703507295}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ba33d849f244521b86f761617ebd4a2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Prefabs/Effects/Resources/BurningLarge.prefab
+++ b/UnityProject/Assets/Prefabs/Effects/Resources/BurningLarge.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 1682087833536344853}
   - component: {fileID: -1894424199744463202}
   - component: {fileID: 8746195124161956548}
+  - component: {fileID: 6597004941106633304}
   m_Layer: 10
   m_Name: BurningLarge
   m_TagString: Untagged
@@ -51,6 +52,8 @@ SpriteRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -107,9 +110,6 @@ MonoBehaviour:
   pushTextureOnStartUp: 1
   initialVariantIndex: 0
   palette: []
-  OnSpriteUpdated:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!114 &8746195124161956548
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -120,5 +120,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dec6e9c0f1454b1a90892bc8915e6c16, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &6597004941106633304
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1558421102126524431}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ba33d849f244521b86f761617ebd4a2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Prefabs/Effects/Resources/BurningSmall.prefab
+++ b/UnityProject/Assets/Prefabs/Effects/Resources/BurningSmall.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 1682087833536344853}
   - component: {fileID: 6485798593100464536}
   - component: {fileID: 8746195124161956548}
+  - component: {fileID: 7698622354138618556}
   m_Layer: 10
   m_Name: BurningSmall
   m_TagString: Untagged
@@ -51,6 +52,8 @@ SpriteRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -107,9 +110,6 @@ MonoBehaviour:
   pushTextureOnStartUp: 1
   initialVariantIndex: 0
   palette: []
-  OnSpriteUpdated:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!114 &8746195124161956548
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -120,5 +120,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dec6e9c0f1454b1a90892bc8915e6c16, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &7698622354138618556
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1558421102126524431}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ba33d849f244521b86f761617ebd4a2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Prefabs/Items/Bureaucracy/Book.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Bureaucracy/Book.prefab
@@ -57,6 +57,11 @@ PrefabInstance:
       propertyPath: _assetId
       value: 2972389857
       objectReference: {fileID: 0}
+    - target: {fileID: 114883521337486670, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: Resistances.Flammable
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Prefabs/Items/Bureaucracy/BookOnSimplicity.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Bureaucracy/BookOnSimplicity.prefab
@@ -23,6 +23,11 @@ PrefabInstance:
       propertyPath: hitSound.AssetAddress
       value: Assets/Prefabs/Effects/Tap.prefab
       objectReference: {fileID: 0}
+    - target: {fileID: 1461123374050772007, guid: 8332fa075a02a824eaf1162a1650b259,
+        type: 3}
+      propertyPath: Resistances.Flammable
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1461827644208326759, guid: 8332fa075a02a824eaf1162a1650b259,
         type: 3}
       propertyPath: _assetId

--- a/UnityProject/Assets/Prefabs/Items/Bureaucracy/HandLabelerRoll.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Bureaucracy/HandLabelerRoll.prefab
@@ -122,6 +122,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: b32ca0cccde16ef428f4f164dc1f884a
       objectReference: {fileID: 0}
+    - target: {fileID: 114883521337486670, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: Resistances.Flammable
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Prefabs/Items/Bureaucracy/Paper Bin1.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Bureaucracy/Paper Bin1.prefab
@@ -152,6 +152,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 3edf81f4a32c4c348bad5bfe43e263fd
       objectReference: {fileID: 0}
+    - target: {fileID: 114883521337486670, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: Resistances.Flammable
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Prefabs/Items/Bureaucracy/Paper.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Bureaucracy/Paper.prefab
@@ -34,15 +34,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -70,6 +70,11 @@ PrefabInstance:
         type: 3}
       propertyPath: customNetTransform
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 114883521337486670, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: Resistances.Flammable
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
@@ -227,6 +232,11 @@ PrefabInstance:
     - target: {fileID: 542829611148227948, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: relatedRecipes.Array.data[0].ingredientIndex
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 657520313027932809, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: minimumFireDamageForStack
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Backpack.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Backpack.prefab
@@ -8,6 +8,11 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 3580462755915700728, guid: 2d25908ce8ab84cda986faf02dd3c84c,
+        type: 3}
+      propertyPath: minimumFireDamageForStack
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 4083699647597369291, guid: 2d25908ce8ab84cda986faf02dd3c84c,
         type: 3}
       propertyPath: m_Name
@@ -72,6 +77,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4122910363020740159, guid: 2d25908ce8ab84cda986faf02dd3c84c,
+        type: 3}
+      propertyPath: Resistances.Flammable
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4123048385342335615, guid: 2d25908ce8ab84cda986faf02dd3c84c,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Uniform.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Uniform.prefab
@@ -8,6 +8,16 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 2374489609720019985, guid: 6b5f74a79e023479cb5b30a2879621da,
+        type: 3}
+      propertyPath: minimumFireDamageForStack
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2915024616253055958, guid: 6b5f74a79e023479cb5b30a2879621da,
+        type: 3}
+      propertyPath: Resistances.Flammable
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 2917128564446547862, guid: 6b5f74a79e023479cb5b30a2879621da,
         type: 3}
       propertyPath: _assetId

--- a/UnityProject/Assets/Prefabs/Items/Economy/Cash/SpaceCash.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Economy/Cash/SpaceCash.prefab
@@ -8,6 +8,11 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1279403570093724512, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: minimumFireDamageForStack
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: m_RootOrder
@@ -67,6 +72,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: SpaceCash
+      objectReference: {fileID: 0}
+    - target: {fileID: 1821288291537931431, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: Resistances.Flammable
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1821991397738242279, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}

--- a/UnityProject/Assets/Scripts/UI/Core/MapSaverIgnoreObject.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/MapSaverIgnoreObject.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+namespace UI.Core
+{
+	public class MapSaverIgnoreObject : MonoBehaviour
+	{
+
+	}
+}

--- a/UnityProject/Assets/Scripts/UI/Core/MapSaverIgnoreObject.cs.meta
+++ b/UnityProject/Assets/Scripts/UI/Core/MapSaverIgnoreObject.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4ba33d849f244521b86f761617ebd4a2
+timeCreated: 1715317773


### PR DESCRIPTION
this PR adds a way for the MapSaver to ignore specific objects that shouldn't be saved (like effects), also some fixes

Changelog:

CL: [Fix] Papers were flameproof for some odd reason.
CL: [Fix] Fixed an issue where flame sprites would take a couple of seconds to appear.
CL: [Fix] The game will only attempt to pre-load flame sprites on objects that actually need it
CL: [Fix] Fixed an issue where sprites would only appear on the server, but not on clients.
