### PR TITLE
Cremator and Cookable upgrades

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Food/_FoodBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/_FoodBase.prefab
@@ -23,6 +23,11 @@ PrefabInstance:
       propertyPath: <AlternativePrefabName>k__BackingField
       value: food
       objectReference: {fileID: 0}
+    - target: {fileID: 7282479286934092243, guid: f866b44bcdd7d734885f7c49999d85c9,
+        type: 3}
+      propertyPath: minimumFireDamageForStack
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 7701549257419364482, guid: f866b44bcdd7d734885f7c49999d85c9,
         type: 3}
       propertyPath: exportCost

--- a/UnityProject/Assets/Prefabs/Objects/Drawers/Cremator.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Drawers/Cremator.prefab
@@ -121,6 +121,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4732959556644653524, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
+      propertyPath: damageDeflection
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732959556644653524, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
       propertyPath: Resistances.FireProof
       value: 1
       objectReference: {fileID: 0}
@@ -251,6 +256,10 @@ PrefabInstance:
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 6751178667305699581}
+    - targetCorrespondingSourceObject: {fileID: 4197940402254186057, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 3363206456413499409}
   m_SourcePrefab: {fileID: 100100000, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
 --- !u!1 &1876053485803257813 stripped
 GameObject:
@@ -277,7 +286,7 @@ MonoBehaviour:
   ChangeSprites: 0
   isChangingSO: 0
   CurrentDirection: 3
-  SynchroniseCurrentDirection: 0
+  SynchroniseCurrentDirection: 3
   IgnoreServerUpdatesIfLocalPlayer: 0
   MatrixRotateUpdate: 1
   IsAtmosphericDevice: 0
@@ -397,7 +406,7 @@ MonoBehaviour:
       m_SubObjectName: 
       m_SubObjectType: 
       m_EditorAssetChanged: 0
-  burningDamage: 23
+  creamationStorage: {fileID: 3363206456413499409}
 --- !u!114 &6751178667305699581
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -413,6 +422,56 @@ MonoBehaviour:
   initialContents: {fileID: 0}
   spawnContentsAtRoundstart: 1
   registerTile: {fileID: 0}
+  OnObjectStored:
+    m_PersistentCalls:
+      m_Calls: []
+  OnObjectRetrieved:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &3363206456413499409
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1876053485803257813}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2c6659195fcc603488ef56e50c1ebd88, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Storage: {fileID: 6751178667305699581}
+  burningDamage: 8
+  fireStacksForCreaturePerSecond: 2
+  secondsBeforeEachDamage: 1.55
+  turnOffWhenAllContentsDestroyed: 1
+  OnTurnOff:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6751178667305699581}
+        m_TargetAssemblyTypeName: Objects.ObjectContainer, Assets
+        m_MethodName: RetrieveObjects
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 5820822380738713605}
+        m_TargetAssemblyTypeName: Objects.Drawers.Cremator, Assets
+        m_MethodName: PlayCremationSound
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!210 &3802493308368489317 stripped
 SortingGroup:
   m_CorrespondingSourceObject: {fileID: 1481169419180323577, guid: ebb08cf966efc084aa918bd8d9429604,

--- a/UnityProject/Assets/Scripts/Core/GameGizmos/GameGizmomanager.cs
+++ b/UnityProject/Assets/Scripts/Core/GameGizmos/GameGizmomanager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Logs;
 using Shared.Managers;
 using UnityEngine;
 
@@ -34,7 +35,15 @@ namespace InGameGizmos
 
 	public void OnDisable()
 	{
-		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
+		if (UpdateManager.Instance != null)
+		{
+			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
+		}
+		else
+		{
+			Loggy.LogWarning("[GameGizmoManager/OnDisable()] - Tried adding a function to the UpdateManager, " +
+				"but UpdateManager is missing! Make sure you're not calling this when loading scenes. Or Ignore this if you're exiting playmode inside the Unity Editor.");
+		}
 	}
 
 	public void UpdateMe()

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -2176,6 +2176,13 @@ namespace HealthV2
 			StartCoroutine(ScreamCooldown());
 		}
 
+		public void IndicatePain()
+		{
+			if (EmoteActionManager.Instance == null || screamEmote == null
+													|| ConsciousState == ConsciousState.UNCONSCIOUS || IsDead) return;
+			EmoteActionManager.DoEmote(screamEmote, playerScript.gameObject);
+		}
+
 		private IEnumerator ScreamCooldown()
 		{
 			canScream = false;

--- a/UnityProject/Assets/Scripts/Items/Dice/RollDie.cs
+++ b/UnityProject/Assets/Scripts/Items/Dice/RollDie.cs
@@ -64,7 +64,7 @@ namespace Items.Dice
 			ObjectPhysics.OnThrowEnd.AddListener(ThrowEndOld);
 			if (cookable != null && isRiggable)
 			{
-				cookable.OnCooked += Cook;
+				cookable.OnCooked.AddListener( Cook );
 			}
 		}
 
@@ -75,7 +75,7 @@ namespace Items.Dice
 			ObjectPhysics.OnThrowEnd.RemoveListener(ThrowEndOld);
 			if (cookable != null)
 			{
-				cookable.OnCooked -= Cook;
+				cookable.OnCooked.RemoveListener( Cook );
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/Disposals/DisposalVirtualContainer.cs
+++ b/UnityProject/Assets/Scripts/Objects/Disposals/DisposalVirtualContainer.cs
@@ -35,7 +35,7 @@ namespace Objects.Disposals
 		private void Awake()
 		{
 			ObjectContainer = GetComponent<ObjectContainer>();
-			ObjectContainer.ObjectStored += ObjectStored;
+			ObjectContainer.OnObjectStored.AddListener(ObjectStored);
 			gasContainer = GetComponent<GasContainer>();
 #if UNITY_EDITOR
 			struggleChance = 90f;

--- a/UnityProject/Assets/Scripts/Objects/Drawers/Cremator.cs
+++ b/UnityProject/Assets/Scripts/Objects/Drawers/Cremator.cs
@@ -1,18 +1,21 @@
-﻿using System.Collections;
+﻿using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using AddressableReferences;
 using HealthV2;
+using Objects.Production;
 using Systems.Clearance;
+using UI.Systems.Tooltips.HoverTooltips;
+using Util.Independent.FluentRichText;
 
 namespace Objects.Drawers
 {
 	/// <summary>
 	/// Cremator component for cremator objects, for use in crematorium rooms. Adds additional function to the base Drawer component.
-	/// TODO: Implement activation via button when buttons can be assigned a generic component instead of only a DoorController component
 	/// and remove the activation by right-click option.
 	/// </summary>
-	public class Cremator : Drawer, IRightClickable, ICheckedInteractable<ContextMenuApply>
+	[RequireComponent(typeof(BurningStorage))]
+	public class Cremator : Drawer, IRightClickable, ICheckedInteractable<ContextMenuApply>, IHoverTooltip
 	{
 		[Tooltip("Sound used for cremation.")]
 		[SerializeField] private AddressableAudioSource CremationSound = null;
@@ -28,17 +31,15 @@ namespace Objects.Drawers
 
 		private ClearanceRestricted clearanceRestricted;
 
-		private const float BURNING_DURATION = 5f;
-
-		[SerializeField] private float burningDamage = 25f;
+		[SerializeField] private BurningStorage creamationStorage;
 
 		protected override void Awake()
 		{
 			base.Awake();
 			clearanceRestricted = GetComponent<ClearanceRestricted>();
+			creamationStorage ??= GetComponent<BurningStorage>();
 		}
 
-		// This region (Interaction-RightClick) shouldn't exist once TODO in class summary is done.
 		#region Interaction-RightClick
 
 		public RightClickableResult GenerateRightClickOptions()
@@ -49,7 +50,7 @@ namespace Objects.Drawers
 			if (clearanceRestricted.HasClearance(PlayerManager.LocalPlayerObject) == false) return result;
 
 			var cremateInteraction = ContextMenuApply.ByLocalPlayer(gameObject, null);
-			if (!WillInteract(cremateInteraction, NetworkSide.Client)) return result;
+			if (WillInteract(cremateInteraction, NetworkSide.Client) == false) return result;
 
 			return result.AddElement("Activate", () => OnCremateClicked(cremateInteraction));
 		}
@@ -88,6 +89,7 @@ namespace Objects.Drawers
 			if (interaction.IsAltClick && drawerState != DrawerState.Open)
 			{
 				Cremate();
+				return;
 			}
 			base.ServerPerformInteraction(interaction);
 		}
@@ -101,14 +103,13 @@ namespace Objects.Drawers
 			base.CloseDrawer();
 			// Note: the sprite setting done in base.CloseDrawer() would be overridden (an unnecessary sprite call).
 			// "Not great, not terrible."
-
 			UpdateCloseState();
 		}
 
 		public override void OpenDrawer()
 		{
 			base.OpenDrawer();
-			if(drawerState == (DrawerState)CrematorState.ShutAndActive) StopCoroutine(BurnContent());
+			creamationStorage.TurnOff();
 		}
 
 		private void UpdateCloseState()
@@ -123,49 +124,65 @@ namespace Objects.Drawers
 
 		private void Cremate()
 		{
-			SoundManager.PlayNetworkedAtPos(CremationSound, DrawerWorldPosition, sourceObj: gameObject);
+			PlayCremationSound();
 			SetDrawerState((DrawerState)CrematorState.ShutAndActive);
 			UpdateCloseState();
 			OnStartPlayerCremation();
-			StartCoroutine(nameof(BurnContent));
+			creamationStorage.TurnOn();
 		}
 
-		private IEnumerator BurnContent()
+		public void PlayCremationSound()
 		{
-			foreach (var obj in container.GetStoredObjects())
-			{
-				if(obj.TryGetComponent<Integrity>(out var integrity)) //For items
-					integrity.ApplyDamage(burningDamage, AttackType.Fire, DamageType.Burn, true);
-				if (obj.TryGetComponent<LivingHealthBehaviour>(out var healthBehaviour)) //For NPCs
-					healthBehaviour.ApplyDamage(gameObject, burningDamage, AttackType.Fire, DamageType.Burn);
-				if (obj.TryGetComponent<PlayerHealthV2>(out var playerHealthV2)) //For Players
-					playerHealthV2.ApplyDamageAll(gameObject, burningDamage, AttackType.Fire, DamageType.Burn, false, TraumaticDamageTypes.BURN);
-			}
-
-			yield return WaitFor.Seconds(BURNING_DURATION);
-			//if it's just closed but not active don't start this again.
-			if (drawerState == DrawerState.Shut || drawerState == DrawerState.Open) yield break;
-			StartCoroutine(nameof(BurnContent));
+			SoundManager.PlayNetworkedAtPos(CremationSound, DrawerWorldPosition, sourceObj: gameObject);
 		}
 
 		private void OnStartPlayerCremation()
 		{
-
 			var objectsInContainer = container.GetStoredObjects();
 			foreach (var player in objectsInContainer)
 			{
-				if (player.TryGetComponent<PlayerHealthV2>(out var healthBehaviour))
+				if (player.TryGetComponent<PlayerHealthV2>(out var healthBehaviour) == false) continue;
+				if (healthBehaviour.ConsciousState is ConsciousState.CONSCIOUS)
 				{
-					if(healthBehaviour.ConsciousState == ConsciousState.CONSCIOUS ||
-					   healthBehaviour.ConsciousState == ConsciousState.BARELY_CONSCIOUS)
-						EntityTryEscape(player, null, MoveAction.NoMove);
-					// TODO: This is an incredibly brutal SFX... it also needs chopping up.
-					// (Max): We should use the scream emote from the emote system when sounds are added for them
-					// codacy ignore this ->SoundManager.PlayNetworkedAtPos("ShyguyScream", DrawerWorldPosition, sourceObj: gameObject);
+					EntityTryEscape(player, null, MoveAction.NoMove);
+					healthBehaviour.IndicatePain();
 				}
 			}
 		}
-
 		#endregion
+
+		public string HoverTip()
+		{
+			var status = creamationStorage.IsBurning ? "on".Color(Color.red) : "off".Color(Color.gray);
+			return $"It is currently {status}";
+		}
+
+		public string CustomTitle()
+		{
+			return null;
+		}
+
+		public Sprite CustomIcon()
+		{
+			return null;
+		}
+
+		public List<Sprite> IconIndicators()
+		{
+			return null;
+		}
+
+		public List<TextColor> InteractionsStrings()
+		{
+			var interactions = new List<TextColor>();
+			interactions.Add(creamationStorage.IsBurning
+				? new TextColor() { Color = Color.green, Text = $"Left Click to open and stop the cremation process." }
+				: new TextColor() { Color = Color.green, Text = $"Left Click to open/close it." });
+			if (drawerState == DrawerState.Shut && creamationStorage.IsBurning == false)
+			{
+				interactions.Add(new TextColor(){ Color = Color.green, Text = $"Alt + Left Click to quickly activate it."});
+			}
+			return interactions;
+		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Objects/Production.meta
+++ b/UnityProject/Assets/Scripts/Objects/Production.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 28719955c785828419308fe241c42401
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Objects/Production/BurningStorage.cs
+++ b/UnityProject/Assets/Scripts/Objects/Production/BurningStorage.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+using System.Linq;
+using HealthV2;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace Objects.Production
+{
+	[RequireComponent(typeof(ObjectContainer))]
+	public class BurningStorage : MonoBehaviour
+	{
+		public ObjectContainer Storage;
+		public bool IsBurning { get; private set; } = false;
+		private Dictionary<GameObject, BurningStorageData> storedObjects = new Dictionary<GameObject, BurningStorageData>();
+
+		[SerializeField] private float burningDamage = 10;
+		[SerializeField] private float fireStacksForCreaturePerSecond = 2;
+		[SerializeField] private float secondsBeforeEachDamage = 1.25f;
+		[SerializeField] private bool turnOffWhenAllContentsDestroyed = true;
+
+		public UnityEvent OnTurnOff;
+
+		private void Awake()
+		{
+			if (CustomNetworkManager.IsServer == false) return;
+			Storage.OnObjectStored.AddListener(CheckStoredObject);
+			Storage.OnObjectRetrieved.AddListener(RemoveStoredObject);
+		}
+
+		private void CheckStoredObject(GameObject obj)
+		{
+			BurningStorageData data = new BurningStorageData();
+			if (obj.TryGetComponent<LivingHealthMasterBase>(out var creature))
+			{
+				data.creature = creature;
+				storedObjects.Add(obj, data);
+			}
+			if (obj.TryGetComponent<Integrity>(out var item))
+			{
+				data.item = item;
+				storedObjects.Add(obj, data);
+			}
+			ContentCountCheck();
+		}
+
+		private void RemoveStoredObject(GameObject obj)
+		{
+			storedObjects.Remove(obj);
+			ContentCountCheck();
+		}
+
+		private void ContentCountCheck()
+		{
+			if (Storage.StoredObjectsCount == 0 && turnOffWhenAllContentsDestroyed)
+			{
+				TurnOff();
+			}
+		}
+
+		private void BurnContent()
+		{
+			var objectsToBurn = new List<KeyValuePair<GameObject, BurningStorageData>>(storedObjects);
+			foreach (var obj in objectsToBurn.ToList())
+			{
+				if (obj.Key == null)
+				{
+					objectsToBurn.Remove(obj);
+					continue;
+				}
+				if (obj.Value.creature != null)
+				{
+					obj.Value.creature.ApplyDamageAll(gameObject, burningDamage, AttackType.Fire, DamageType.Burn, false, TraumaticDamageTypes.BURN);
+					obj.Value.creature.ChangeFireStacks(obj.Value.creature.FireStacks + fireStacksForCreaturePerSecond);
+				}
+				obj.Value.item.OrNull()?.ApplyDamage(burningDamage, AttackType.Fire, DamageType.Burn, true);
+			}
+			ContentCountCheck();
+		}
+
+		public void TurnOn()
+		{
+			UpdateManager.Add(BurnContent, secondsBeforeEachDamage);
+			IsBurning = true;
+		}
+
+		public void TurnOff()
+		{
+			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, BurnContent);
+			storedObjects.Clear();
+			IsBurning = false;
+			OnTurnOff?.Invoke();
+		}
+
+		struct BurningStorageData
+		{
+			public LivingHealthMasterBase creature;
+			public Integrity item;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Objects/Production/BurningStorage.cs.meta
+++ b/UnityProject/Assets/Scripts/Objects/Production/BurningStorage.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2c6659195fcc603488ef56e50c1ebd88


### PR DESCRIPTION
Ported from the forge PR.


### Changelog:

CL: [New] Cremators have received contextual hover tooltips to help users understand how to operate it.
CL: [New] Victims shoved inside cremators will attempt to scream regardless of their health state, as long as they're still conscious.
CL: [New] Fire stacks and heat damage can now cook food.
CL: [New] Cookable items will now report how long an object requires to be cooked. No more tears shall be shed by chefs now after accidently burning dough in the oven because they overcooked the dough for 1 extra second.
CL: [New] Cremators will now play sounds when they turn on/off. The current sound is a place holder for the time being.
CL: [Improvement] Improved the performance of cremators, as they were previously suboptimal and caused issues when attempting to burn several hundred objects. 
CL: [Fix] Fixed an NRE related to cremators attempting to access objects that were turned to ash at some point.
CL: [Fix] Fixed an issue where MobV2 creatures were ignored previously by the cremator, as it only checked for player health instead of `LivingHealthMasterBase`.
CL: [Fix] Removed checks for MobV1 NPCs, as they deprecated and are being slowly phased out in favor of MobV2.
CL: [Fix] Fixed a broken interaction with cremators that caused cremators to immediately open up as soon as they close. 