### PR TITLE
Fixes blinding being disabled from explosions

### DIFF
--- a/UnityProject/Assets/Scripts/Core/ITrackableType.cs
+++ b/UnityProject/Assets/Scripts/Core/ITrackableType.cs
@@ -21,24 +21,7 @@ namespace Core
 			var stopwatch = new Stopwatch();
 			stopwatch.Start();
 #endif
-			List<T> components = new List<T>();
-			foreach (var stationObject in Instances)
-			{
-				var obj = stationObject as Component;
-				if (obj == null || obj.gameObject == null || obj.gameObject.OrNull() == null) continue;
-				if (bypassInventories == false && obj.gameObject.IsAtHiddenPos())
-				{
-					continue;
-				}
-				if (Vector3.Distance(obj.gameObject.AssumedWorldPosServer(), target.AssumedWorldPosServer()) > maximumDistance)
-				{
-					continue;
-				}
-				else
-				{
-					components.Add(stationObject);
-				}
-			}
+			List<T> components = GetNearbyComponents(bypassInventories, target.AssumedWorldPosServer(), maximumDistance);
 #if UNITY_EDITOR
 			stopwatch.Stop();
 			Loggy.Log($"[GameObject/FindAllComponentsNearestToTarget<T>()] - Operation took {stopwatch.Elapsed.Milliseconds}ms");
@@ -57,7 +40,28 @@ namespace Core
 			var stopwatch = new Stopwatch();
 			stopwatch.Start();
 #endif
-			List<T> components = new List<T>();
+			List<T> components = GetNearbyComponents(bypassInventories, target, maximumDistance);
+#if UNITY_EDITOR
+			stopwatch.Stop();
+			Loggy.Log($"[GameObject/FindAllComponentsNearestToTarget<T>()] - Operation took {stopwatch.Elapsed.Milliseconds}ms");
+#endif
+			return components;
+		}
+
+		public static List<ItemTrait> GetNearbyTraits(GameObject target, float searchRadius, bool bypassInventories = true)
+		{
+			var items = ComponentsTracker<Attributes>.GetAllNearbyTypesToTarget(target, searchRadius, bypassInventories);
+			var traits = new List<ItemTrait>();
+			foreach (var item in items)
+			{
+				traits.AddRange(item.InitialTraits);
+			}
+			return traits.Distinct().ToList();
+		}
+
+		private static List<T> GetNearbyComponents(bool bypassInventories, Vector3 target, float maximumDistance)
+		{
+			var components = new List<T>();
 			foreach (var stationObject in Instances)
 			{
 				var obj = stationObject as Component;
@@ -75,22 +79,7 @@ namespace Core
 					components.Add(stationObject);
 				}
 			}
-#if UNITY_EDITOR
-			stopwatch.Stop();
-			Loggy.Log($"[GameObject/FindAllComponentsNearestToTarget<T>()] - Operation took {stopwatch.Elapsed.Milliseconds}ms");
-#endif
 			return components;
-		}
-
-		public static List<ItemTrait> GetNearbyTraits(GameObject target, float searchRadius, bool bypassInventories = true)
-		{
-			var items = ComponentsTracker<Attributes>.GetAllNearbyTypesToTarget(target, searchRadius, bypassInventories);
-			var traits = new List<ItemTrait>();
-			foreach (var item in items)
-			{
-				traits.AddRange(item.InitialTraits);
-			}
-			return traits.Distinct().ToList();
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Core/ITrackableType.cs
+++ b/UnityProject/Assets/Scripts/Core/ITrackableType.cs
@@ -46,6 +46,42 @@ namespace Core
 			return components;
 		}
 
+		public static List<T> GetAllNearbyTypesToLocation(Vector3 target, float maximumDistance, bool bypassInventories = true)
+		{
+			if (Instances == null || Instances.Count == 0)
+			{
+				Loggy.Log($"No elements found for Type {nameof(T)}, are you sure you have ITrackableType<T> added to your class?");
+				return null;
+			}
+#if UNITY_EDITOR
+			var stopwatch = new Stopwatch();
+			stopwatch.Start();
+#endif
+			List<T> components = new List<T>();
+			foreach (var stationObject in Instances)
+			{
+				var obj = stationObject as Component;
+				if (obj == null || obj.gameObject == null || obj.gameObject.OrNull() == null) continue;
+				if (bypassInventories == false && obj.gameObject.IsAtHiddenPos())
+				{
+					continue;
+				}
+				if (Vector3.Distance(obj.gameObject.AssumedWorldPosServer(), target) > maximumDistance)
+				{
+					continue;
+				}
+				else
+				{
+					components.Add(stationObject);
+				}
+			}
+#if UNITY_EDITOR
+			stopwatch.Stop();
+			Loggy.Log($"[GameObject/FindAllComponentsNearestToTarget<T>()] - Operation took {stopwatch.Elapsed.Milliseconds}ms");
+#endif
+			return components;
+		}
+
 		public static List<ItemTrait> GetNearbyTraits(GameObject target, float searchRadius, bool bypassInventories = true)
 		{
 			var items = ComponentsTracker<Attributes>.GetAllNearbyTypesToTarget(target, searchRadius, bypassInventories);

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -9,6 +9,7 @@ using UnityEngine.Events;
 using Mirror;
 using Systems.Atmospherics;
 using Chemistry;
+using Core;
 using Core.Chat;
 using Core.Utils;
 using Health.Sickness;
@@ -355,6 +356,12 @@ namespace HealthV2
 			BodyAlertManager = GetComponent<BodyAlertManager>();
 			//Needs to be in awake so the mobId is set before mind transfer (OnSpawnServer happens after that so cannot be used)
 			mobID = PlayerManager.Instance.GetMobID();
+			ComponentsTracker<LivingHealthMasterBase>.Instances.Add(this);
+		}
+
+		public void OnDestroy()
+		{
+			ComponentsTracker<LivingHealthMasterBase>.Instances.Remove(this);
 		}
 
 		public void OnSpawnServer(SpawnInfo info)
@@ -1314,6 +1321,7 @@ namespace HealthV2
 				if (EyeFlash != null && EyeFlash.TryFlash(flashDuration, checkForProtectiveCloth))
 				{
 					didFlash = true;
+					ScoreMachine.AddToScoreInt(1, RoundEndScoreBuilder.COMMON_SCORE_FLASHED);
 				}
 			}
 

--- a/UnityProject/Assets/Scripts/Items/Others/Gibtonite.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/Gibtonite.cs
@@ -112,7 +112,7 @@ namespace Items.Others
 		{
 			var pos = gameObject.AssumedWorldPosServer().CutToInt();
 			_ = Despawn.ServerSingle(gameObject);
-			Explosion.StartExplosion(pos, explosionStrength, damageIgnoreAttributes: itemTraitsToIgnoreOnExplosion);
+			Explosion.StartExplosion(pos, explosionStrength, damageIgnoreAttributes: itemTraitsToIgnoreOnExplosion, stunNearbyPlayers: true);
 		}
 
 		public void ServerPerformInteraction(HandApply interaction)

--- a/UnityProject/Assets/Scripts/Items/Weapons/BulkyExplosive.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/BulkyExplosive.cs
@@ -1,6 +1,4 @@
 ﻿using System.Collections;
-using AddressableReferences;
-using Communications;
 using Mirror;
 using UnityEngine;
 

--- a/UnityProject/Assets/Scripts/Items/Weapons/ExplosiveBase.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/ExplosiveBase.cs
@@ -10,7 +10,6 @@ using Scripts.Core.Transform;
 using UI.Items;
 using UnityEngine.Events;
 using Chemistry;
-using Random = UnityEngine.Random;
 
 namespace Items.Weapons
 {

--- a/UnityProject/Assets/Scripts/Items/Weapons/ExplosiveBase.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/ExplosiveBase.cs
@@ -97,7 +97,7 @@ namespace Items.Weapons
 			blastData.BlastYield = explosiveStrength;
 
 			ExplosionEvent.Invoke(worldPos, blastData);
-			Explosion.StartExplosion(worldPos, explosiveStrength, null, explosiveRadius);
+			Explosion.StartExplosion(worldPos, explosiveStrength, null, explosiveRadius, stunNearbyPlayers: true);
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/Items/Weapons/PowerSink.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/PowerSink.cs
@@ -139,7 +139,7 @@ namespace Items.Weapons
 			var worldPos = gameObject.AssumedWorldPosServer();
 			// Despawn the explosive
 			_ = Despawn.ServerSingle(gameObject);
-			Explosion.StartExplosion(worldPos.RoundToInt(), currentCharge * explosionAmplifer);
+			Explosion.StartExplosion(worldPos.RoundToInt(), currentCharge * explosionAmplifer, stunNearbyPlayers: true);
 		}
 
 		public void CheckForVoltage()

--- a/UnityProject/Assets/Scripts/Items/Weapons/Projectiles/Behaviours/ProjectileExplode.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Projectiles/Behaviours/ProjectileExplode.cs
@@ -47,7 +47,7 @@ namespace Weapons.Projectiles.Behaviours
 				return;
 			}
 
-			Explosion.StartExplosion(worldTilePosition, explosionStrength);
+			Explosion.StartExplosion(worldTilePosition, explosionStrength, stunNearbyPlayers: explosionStrength > 400);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Objects/Engineering/SuperMatter.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/SuperMatter.cs
@@ -892,7 +892,7 @@ namespace Objects.Engineering
 
 			RadiationManager.Instance.RequestPulse( registerTile.LocalPositionServer, detonationRads, GetInstanceID());
 
-			Explosion.StartExplosion(registerTile.WorldPositionServer, explosionStrength);
+			Explosion.StartExplosion(registerTile.WorldPositionServer, explosionStrength, stunNearbyPlayers: true);
 
 			_ = Despawn.ServerSingle(gameObject);
 		}

--- a/UnityProject/Assets/Scripts/Objects/FuelTank.cs
+++ b/UnityProject/Assets/Scripts/Objects/FuelTank.cs
@@ -82,11 +82,11 @@ namespace Objects.Engineering
 
 			if (registerObject == null)
 			{
-				Explosion.StartExplosion(objectBehaviour.registerTile.WorldPositionServer, strength);
+				Explosion.StartExplosion(objectBehaviour.registerTile.WorldPositionServer, strength, stunNearbyPlayers: true);
 			}
 			else
 			{
-				Explosion.StartExplosion(registerObject.WorldPositionServer, strength);
+				Explosion.StartExplosion(registerObject.WorldPositionServer, strength, stunNearbyPlayers: true);
 			}
 
 			reagentContainerObjectInteractionScript.OnHandApply.RemoveListener(TryServerPerformInteraction);

--- a/UnityProject/Assets/Scripts/ScriptableObjects/Research/Artifacts/Effects/DamageEffect/ExplosiveDamageEffect.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/Research/Artifacts/Effects/DamageEffect/ExplosiveDamageEffect.cs
@@ -22,7 +22,7 @@ namespace Systems.Research
 
 			var worldPos = objectPhysics.registerTile.WorldPosition;
 
-			Explosion.StartExplosion(worldPos, explosiveStrength, null, explosiveRadius);
+			Explosion.StartExplosion(worldPos, explosiveStrength, null, explosiveRadius, stunNearbyPlayers: true);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Chemistry/Effects/ChemExplosion.cs
+++ b/UnityProject/Assets/Scripts/Systems/Chemistry/Effects/ChemExplosion.cs
@@ -79,12 +79,12 @@ namespace Chemistry.Effects
 					else
 					{
 						//Otherwise, if it's not inside of a player, we consider it just an item
-						Explosion.StartExplosion(objectBehaviour.registerTile.WorldPosition, strength, node);
+						Explosion.StartExplosion(objectBehaviour.registerTile.WorldPosition, strength, node, stunNearbyPlayers: strength > 400);
 					}
 				}
 				else
 				{
-					Explosion.StartExplosion(registerObject.WorldPosition, strength, node);
+					Explosion.StartExplosion(registerObject.WorldPosition, strength, node, stunNearbyPlayers: strength > 400);
 				}
 			}
 

--- a/UnityProject/Assets/Scripts/Systems/Explosions/Explosion.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/Explosion.cs
@@ -101,7 +101,7 @@ namespace Systems.Explosions
 				// for performance reasons, if we have a big enough explosion: skip physics line checks as they're expensive.
 				// large explosions are slow enough as is because it has to damage/check hundreds of objects which all trigger
 				// different behaviors and events. We shouldn't strain the server with extra physics check ontop of that.
-				if (distance < 23)
+				if (distance < 16)
 				{
 					if (IsStunReachable(startingPos, obj) == false) continue;
 				}

--- a/UnityProject/Assets/Scripts/Systems/Explosions/Explosion.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/Explosion.cs
@@ -173,13 +173,10 @@ namespace Systems.Explosions
 
 		private static int GetDistanceFromStrength(float strength)
 		{
-			if (strength < 1000000)
+			if (strength < 92000)
 			{
-				var result = (int)Math.Ceiling(Math.Log(strength / 100.0) * 2);
-				Loggy.Log(result.ToString());
-				return result;
+				return (int)Math.Ceiling(Math.Log(strength / 100.0) * 2);
 			}
-
 			return NUKE_FLASH_DISTANCE;
 		}
 	}

--- a/UnityProject/Assets/Scripts/Systems/Explosions/Explosion.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/Explosion.cs
@@ -97,7 +97,7 @@ namespace Systems.Explosions
 			var s = ComponentsTracker<LivingHealthMasterBase>.GetAllNearbyTypesToLocation(startingPos.To3(), distance);
 			foreach (var obj in s)
 			{
-				if (distance < 12)
+				if (distance < 23)
 				{
 					if (IsStunReachable(startingPos, obj) == false) continue;
 				}

--- a/UnityProject/Assets/Scripts/Systems/Explosions/Explosion.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/Explosion.cs
@@ -16,6 +16,7 @@ namespace Systems.Explosions
 		public const int EXPLOSION_STRENGTH_LOW = 800;
 		public const int EXPLOSION_STRENGTH_MEDIUM = 8000;
 		public const int EXPLOSION_STRENGTH_HIGH = 80000;
+		public const int NUKE_FLASH_DISTANCE = 12580;
 
 		public class ExplosionData
 		{
@@ -172,23 +173,14 @@ namespace Systems.Explosions
 
 		private static int GetDistanceFromStrength(float strength)
 		{
-			return strength switch
+			if (strength < 1000000)
 			{
-				< 100 => 2, // fairly smol explosion
-				< 400 => 3,
-				< 800 => 6,
-				< 4000 => 8,
-				< 12000 => 12, // gernade
-				< 22000 => 14,
-				< 62000 => 16,
-				< 80000 => 24, // why do I hear loud beeping?
-				< 120000 => 48,
-				< 166000 => 64, // powersink with high energy siphon
-				< 248000 => 128, // powersink with maxcap bypass
-				< 648000 => 256, // someone is trying to be funny or is trying to crash the server
-				< 1000000 => 512, // nuke
-				_ => 6
-			};
+				var result = (int)Math.Ceiling(Math.Log(strength / 100.0) * 2);
+				Loggy.Log(result.ToString());
+				return result;
+			}
+
+			return NUKE_FLASH_DISTANCE;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Explosions/Explosion.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/Explosion.cs
@@ -101,7 +101,7 @@ namespace Systems.Explosions
 				// for performance reasons, if we have a big enough explosion: skip physics line checks as they're expensive.
 				// large explosions are slow enough as is because it has to damage/check hundreds of objects which all trigger
 				// different behaviors and events. We shouldn't strain the server with extra physics check ontop of that.
-				if (distance < 16)
+				if (distance < 12)
 				{
 					if (IsStunReachable(startingPos, obj) == false) continue;
 				}

--- a/UnityProject/Assets/Scripts/Systems/Explosions/Explosion.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/Explosion.cs
@@ -1,178 +1,21 @@
 ﻿using System;
 using System.Collections.Generic;
+using Core;
 using HealthV2;
-using Player;
+using Logs;
 using Systems.Score;
 using UnityEngine;
 
 namespace Systems.Explosions
 {
-	public class ExplosionPropagationLine
-	{
-		public static List<ExplosionPropagationLine> PooledThis = new List<ExplosionPropagationLine>();
-
-		public static ExplosionPropagationLine Getline()
-		{
-			if (PooledThis.Count > 0)
-			{
-				ExplosionPropagationLine line = PooledThis[0];
-				PooledThis.RemoveAt(0);
-				return (line);
-			}
-			else
-			{
-				return (new ExplosionPropagationLine());
-			}
-		}
-
-		//Gets an XY direction of magnitude from a radian angle relative to the x axis
-		//Simple version
-		public static Vector2 GetXYDirection(float angle, float magnitude)
-		{
-			return new Vector2(Mathf.Cos(angle), Mathf.Sin(angle)) * magnitude;
-		}
-
-
-		int x0 = 0;
-		int y0 = 0;
-		int x1 = 0;
-		int y1 = 0;
-		private float Angle = 0;
-
-		int dx = 0;
-		int sx = 0;
-		int dy = 0;
-		int sy = 0;
-		int err = 0;
-		int e2 = 0;
-		public float ExplosionStrength = 0;
-		private bool InitialStep = true;
-
-		private ExplosionNode NodeType;
-
-		private bool IsAnyMatchingType(ExplosionNode[] expNodes, ExplosionNode nodeType)
-		{
-			foreach(ExplosionNode expNode in expNodes)
-			{
-				if (IsMatchingType(expNode, nodeType)) return true;
-			}
-			return false;
-		}
-
-		private bool IsMatchingType(ExplosionNode expNode, ExplosionNode nodeType)
-		{
-			if (expNode != null && nodeType != null) return expNode.GetType() == NodeType.GetType();
-			return false;
-		}
-
-		private int FirstNullValue(ExplosionNode[] expNodes)
-		{
-			int count = 0;
-			foreach(var val in expNodes)
-			{
-				if(val == null)
-				{
-					return count;
-				}
-				count++;
-			}
-			return -1;
-		}
-
-		public void SetUp(int X0, int Y0, int X1, int Y1, float InExplosionStrength, ExplosionNode nodeType)
-		{
-			x0 = X0;
-			y0 = Y0;
-
-
-			x1 = X1;
-			y1 = Y1;
-
-			Angle = 0; // (float) (Math.Atan2(x1 - x0, y1 - y0));
-			InitialStep = true;
-			dx = Math.Abs(x1 - x0);
-			sx = x0 < x1 ? 1 : -1;
-
-			dy = Math.Abs(y1 - y0);
-			sy = y0 < y1 ? 1 : -1;
-
-			err = (dx > dy ? dx : -dy) / 2;
-			ExplosionStrength = InExplosionStrength;
-
-			NodeType = nodeType;
-		}
-
-		public void Step()
-		{
-			if (ExplosionStrength <= 0)
-			{
-				Pool();
-				return;
-			}
-
-			if (x0 == x1 && y0 == y1)
-			{
-				Pool();
-				return;
-			}
-
-			Vector3Int WorldPSos = new Vector3Int(x0, y0, 0);
-			MatrixInfo Matrix = MatrixManager.AtPoint(WorldPSos, CustomNetworkManager.IsServer);
-			Vector3Int Local = WorldPSos.ToLocal(Matrix.Matrix).RoundToInt();
-			MetaDataNode NodePoint = Matrix.MetaDataLayer.Get(Local); //Explosion node
-
-			if (NodePoint != null)
-			{
-				if (IsAnyMatchingType(NodePoint.ExplosionNodes, NodeType) == false)
-				{
-					ExplosionNode expNode = NodeType.GenInstance();
-					int fnull = FirstNullValue(NodePoint.ExplosionNodes);
-					if (fnull >= 0) NodePoint.ExplosionNodes[fnull] = expNode;
-					expNode.Initialise(Local, Matrix.Matrix);
-				}
-
-				foreach (ExplosionNode expNode in NodePoint.ExplosionNodes) //separating explosion nodes of our type from others, so we dont interfere with EMPs or whatever
-				{
-					if (IsMatchingType(expNode, NodeType))
-					{
-						expNode.AngleAndIntensity += GetXYDirection(Angle, ExplosionStrength);
-						expNode.PresentLines.Add(this);
-						ExplosionManager.CheckLocations.Add(expNode);
-					}
-				}
-			}
-
-			e2 = err;
-			if (e2 > -dx)
-			{
-				err -= dy;
-				x0 += sx;
-			}
-
-			if (e2 < dy)
-			{
-				err += dx;
-				y0 += sy;
-			}
-
-
-			ExplosionManager.CheckLines.Add(this);
-			if (InitialStep)
-			{
-				InitialStep = false;
-				Angle = (float) (Math.Atan2(x1 - x0, y1 - y0));
-			}
-		}
-
-		public void Pool()
-		{
-			PooledThis.Add(this);
-		}
-	}
-
 	public class Explosion
 	{
-		//Function to check CheckLocations
+
+		// (Max) - why were these numbers choosen before?
+		// They may look less like magic numbers now, but there is no explanation for why they multiples of 8.
+		public const int EXPLOSION_STRENGTH_LOW = 800;
+		public const int EXPLOSION_STRENGTH_MEDIUM = 8000;
+		public const int EXPLOSION_STRENGTH_HIGH = 80000;
 
 		public class ExplosionData
 		{
@@ -207,15 +50,15 @@ namespace Systems.Explosions
 			if (fixedShakingStrength <= 0 || fixedShakingStrength > 255)
 			{
 				ShakingStrength = 25;
-				if (strength > 800)
+				if (strength > EXPLOSION_STRENGTH_LOW)
 				{
 					ShakingStrength = 75;
 				}
-				else if (strength > 8000)
+				else if (strength > EXPLOSION_STRENGTH_MEDIUM)
 				{
 					ShakingStrength = 125;
 				}
-				else if (strength > 80000)
+				else if (strength > EXPLOSION_STRENGTH_HIGH)
 				{
 					ShakingStrength = 255;
 				}
@@ -239,32 +82,44 @@ namespace Systems.Explosions
 				Line.Step();
 			}
 
-			if (stunNearbyPlayers)
+			// we assume that the explosion isn't something small like an EMP gernade or
+			if (stunNearbyPlayers || strength > EXPLOSION_STRENGTH_HIGH)
 			{
-				StunAndFlashPlayers(WorldPOS.To2Int());
+				StunAndFlashPlayers(WorldPOS.To2Int(), strength);
 			}
-
 
 			ScoreMachine.AddToScoreInt(1, RoundEndScoreBuilder.COMMON_SCORE_EXPLOSION);
 		}
 
-		private static void StunAndFlashPlayers(Vector2Int startingPos)
+		public static void StunAndFlashPlayers(Vector2Int startingPos, float strength)
 		{
-			var s = Physics2D.OverlapCircleAll(startingPos, 5, LayerMask.GetMask("Players"));
-			Debug.Log(s.Length);
-			foreach (Collider2D obj in s)
+			var distance = GetDistanceFromStrength(strength);;
+			var s = ComponentsTracker<LivingHealthMasterBase>.GetAllNearbyTypesToLocation(startingPos.To3(), distance);
+			foreach (var obj in s)
 			{
-				var result = MatrixManager.Linecast(
-					startingPos.To3Int(), LayerTypeSelection.Walls, null,
-					obj.gameObject.AssumedWorldPosServer(), true);
-				if (result.ItHit) continue;
-				if (obj.gameObject.TryGetComponentCustom<LivingHealthMasterBase>(out var livingHealthMasterBase) == false) continue;
-				//TODO Stun , result.Distance <= 3, 9
-				//GameObject client, float flashDuration, bool checkForProtectiveCloth, bool stunPlayer = true, float stunDuration = 4f
-				livingHealthMasterBase.TryFlash(5, true);
+				if (distance < 23)
+				{
+					if (IsStunReachable(startingPos, obj) == false) continue;
+				}
+				obj.TryFlash(5, true);
 			}
 		}
 
+		private static bool IsStunReachable(Vector2Int startingPos, LivingHealthMasterBase obj)
+		{
+			var result = MatrixManager.Linecast(
+				startingPos.To3Int(), LayerTypeSelection.Walls, null,
+				obj.gameObject.AssumedWorldPosServer(), true);
+			if (result.ItHit)
+			{
+#if UNITY_EDITOR
+				Loggy.Log($"[Explosion/StunAndFlashPlayers()] - " +
+				          $"We hit {result.CollisionHit.GameObject?.ExpensiveName()} when using MatrixManger.Linecraft().", Category.TileMaps);
+#endif
+				return false;
+			}
+			return true;
+		}
 
 		//https://www.geeksforgeeks.org/bresenhams-circle-drawing-algorithm/
 		// Function for circle-generation
@@ -309,6 +164,27 @@ namespace Systems.Explosions
 			explosionData.CircleCircumference.Add(new Vector2Int(xc - y, yc + x));
 			explosionData.CircleCircumference.Add(new Vector2Int(xc + y, yc - x));
 			explosionData.CircleCircumference.Add(new Vector2Int(xc - y, yc - x));
+		}
+
+		private static int GetDistanceFromStrength(float strength)
+		{
+			return strength switch
+			{
+				< 100 => 2, // fairly smol explosion
+				< 400 => 3,
+				< 800 => 6,
+				< 4000 => 8,
+				< 12000 => 12, // gernade
+				< 22000 => 14,
+				< 62000 => 16,
+				< 80000 => 24, // why do I hear loud beeping?
+				< 120000 => 48,
+				< 166000 => 64, // powersink with high energy siphon
+				< 248000 => 128, // powersink with maxcap bypass
+				< 648000 => 256, // someone is trying to be funny or is trying to crash the server
+				< 1000000 => 512, // nuke
+				_ => 6
+			};
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Explosions/Explosion.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/Explosion.cs
@@ -97,11 +97,11 @@ namespace Systems.Explosions
 			var s = ComponentsTracker<LivingHealthMasterBase>.GetAllNearbyTypesToLocation(startingPos.To3(), distance);
 			foreach (var obj in s)
 			{
-				if (distance < 23)
+				if (distance < 12)
 				{
 					if (IsStunReachable(startingPos, obj) == false) continue;
 				}
-				obj.TryFlash(5, true);
+				obj.TryFlash(5, strength < EXPLOSION_STRENGTH_HIGH);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Systems/Explosions/Explosion.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/Explosion.cs
@@ -12,7 +12,7 @@ namespace Systems.Explosions
 	{
 
 		// (Max) - why were these numbers choosen before?
-		// They may look less like magic numbers now, but there is no explanation for why they multiples of 8.
+		// They may look less like magic numbers now, but there is no explanation for why they are multiples of 8.
 		public const int EXPLOSION_STRENGTH_LOW = 800;
 		public const int EXPLOSION_STRENGTH_MEDIUM = 8000;
 		public const int EXPLOSION_STRENGTH_HIGH = 80000;
@@ -97,10 +97,14 @@ namespace Systems.Explosions
 			var s = ComponentsTracker<LivingHealthMasterBase>.GetAllNearbyTypesToLocation(startingPos.To3(), distance);
 			foreach (var obj in s)
 			{
+				// for performance reasons, if we have a big enough explosion: skip physics line checks as they're expensive.
+				// large explosions are slow enough as is because it has to damage/check hundreds of objects which all trigger
+				// different behaviors and events. We shouldn't strain the server with extra physics check ontop of that.
 				if (distance < 23)
 				{
 					if (IsStunReachable(startingPos, obj) == false) continue;
 				}
+				// if the explosion is too strong, skip flash protection check.
 				obj.TryFlash(5, strength < EXPLOSION_STRENGTH_HIGH);
 			}
 		}

--- a/UnityProject/Assets/Scripts/Systems/Explosions/ExplosionPropagationLine.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/ExplosionPropagationLine.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Systems.Explosions
+{
+	public class ExplosionPropagationLine
+	{
+		public static List<ExplosionPropagationLine> PooledThis = new List<ExplosionPropagationLine>();
+
+		public static ExplosionPropagationLine Getline()
+		{
+			if (PooledThis.Count > 0)
+			{
+				ExplosionPropagationLine line = PooledThis[0];
+				PooledThis.RemoveAt(0);
+				return (line);
+			}
+			else
+			{
+				return (new ExplosionPropagationLine());
+			}
+		}
+
+		//Gets an XY direction of magnitude from a radian angle relative to the x axis
+		//Simple version
+		public static Vector2 GetXYDirection(float angle, float magnitude)
+		{
+			return new Vector2(Mathf.Cos(angle), Mathf.Sin(angle)) * magnitude;
+		}
+
+
+		int x0 = 0;
+		int y0 = 0;
+		int x1 = 0;
+		int y1 = 0;
+		private float Angle = 0;
+
+		int dx = 0;
+		int sx = 0;
+		int dy = 0;
+		int sy = 0;
+		int err = 0;
+		int e2 = 0;
+		public float ExplosionStrength = 0;
+		private bool InitialStep = true;
+
+		private ExplosionNode NodeType;
+
+		private bool IsAnyMatchingType(ExplosionNode[] expNodes, ExplosionNode nodeType)
+		{
+			foreach(ExplosionNode expNode in expNodes)
+			{
+				if (IsMatchingType(expNode, nodeType)) return true;
+			}
+			return false;
+		}
+
+		private bool IsMatchingType(ExplosionNode expNode, ExplosionNode nodeType)
+		{
+			if (expNode != null && nodeType != null) return expNode.GetType() == NodeType.GetType();
+			return false;
+		}
+
+		private int FirstNullValue(ExplosionNode[] expNodes)
+		{
+			int count = 0;
+			foreach(var val in expNodes)
+			{
+				if(val == null)
+				{
+					return count;
+				}
+				count++;
+			}
+			return -1;
+		}
+
+		public void SetUp(int X0, int Y0, int X1, int Y1, float InExplosionStrength, ExplosionNode nodeType)
+		{
+			x0 = X0;
+			y0 = Y0;
+
+
+			x1 = X1;
+			y1 = Y1;
+
+			Angle = 0; // (float) (Math.Atan2(x1 - x0, y1 - y0));
+			InitialStep = true;
+			dx = Math.Abs(x1 - x0);
+			sx = x0 < x1 ? 1 : -1;
+
+			dy = Math.Abs(y1 - y0);
+			sy = y0 < y1 ? 1 : -1;
+
+			err = (dx > dy ? dx : -dy) / 2;
+			ExplosionStrength = InExplosionStrength;
+
+			NodeType = nodeType;
+		}
+
+		public void Step()
+		{
+			if (ExplosionStrength <= 0)
+			{
+				Pool();
+				return;
+			}
+
+			if (x0 == x1 && y0 == y1)
+			{
+				Pool();
+				return;
+			}
+
+			Vector3Int WorldPSos = new Vector3Int(x0, y0, 0);
+			MatrixInfo Matrix = MatrixManager.AtPoint(WorldPSos, CustomNetworkManager.IsServer);
+			Vector3Int Local = WorldPSos.ToLocal(Matrix.Matrix).RoundToInt();
+			MetaDataNode NodePoint = Matrix.MetaDataLayer.Get(Local); //Explosion node
+
+			if (NodePoint != null)
+			{
+				if (IsAnyMatchingType(NodePoint.ExplosionNodes, NodeType) == false)
+				{
+					ExplosionNode expNode = NodeType.GenInstance();
+					int fnull = FirstNullValue(NodePoint.ExplosionNodes);
+					if (fnull >= 0) NodePoint.ExplosionNodes[fnull] = expNode;
+					expNode.Initialise(Local, Matrix.Matrix);
+				}
+
+				foreach (ExplosionNode expNode in NodePoint.ExplosionNodes) //separating explosion nodes of our type from others, so we dont interfere with EMPs or whatever
+				{
+					if (IsMatchingType(expNode, NodeType))
+					{
+						expNode.AngleAndIntensity += GetXYDirection(Angle, ExplosionStrength);
+						expNode.PresentLines.Add(this);
+						ExplosionManager.CheckLocations.Add(expNode);
+					}
+				}
+			}
+
+			e2 = err;
+			if (e2 > -dx)
+			{
+				err -= dy;
+				x0 += sx;
+			}
+
+			if (e2 < dy)
+			{
+				err += dx;
+				y0 += sy;
+			}
+
+
+			ExplosionManager.CheckLines.Add(this);
+			if (InitialStep)
+			{
+				InitialStep = false;
+				Angle = (float) (Math.Atan2(x1 - x0, y1 - y0));
+			}
+		}
+
+		public void Pool()
+		{
+			PooledThis.Add(this);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/Explosions/ExplosionPropagationLine.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/ExplosionPropagationLine.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e8ec36e1a290456e9d16535cf1bc59bf
+timeCreated: 1716135738

--- a/UnityProject/Assets/Scripts/Systems/GameModes/BloodBrothers.cs
+++ b/UnityProject/Assets/Scripts/Systems/GameModes/BloodBrothers.cs
@@ -40,7 +40,7 @@ namespace GameModes
 				if (possibleBrother.Owner.CurrentPlayScript.IsDeadOrGhost == false) possibleBrother.Owner.CurrentPlayScript.playerHealth.Death(false);
 				if (DMMath.Prob(15))
 				{
-					Explosion.StartExplosion(possibleBrother.Owner.Body.gameObject.AssumedWorldPosServer().CutToInt(), 750);
+					Explosion.StartExplosion(possibleBrother.Owner.Body.gameObject.AssumedWorldPosServer().CutToInt(), 750, stunNearbyPlayers: true);
 				}
 			}
 

--- a/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.Data.cs
+++ b/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.Data.cs
@@ -19,6 +19,7 @@ namespace Systems.Score
 		public const string COMMON_SCORE_HEALING = "healing";
 		public const string COMMON_SCORE_FOODEATEN = "foodeaten";
 		public const string COMMON_SCORE_EXPLOSION = "explosions";
+		public const string COMMON_SCORE_FLASHED = "flashed";
 		public const string COMMON_SCORE_CLOWNABUSE = "clownBeaten";
 		public const string COMMON_HUG_SCORE_ENTRY = "hugsGiven";
 		public const string COMMON_TAIL_SCORE_ENTRY = "tailsPulled";

--- a/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.cs
+++ b/UnityProject/Assets/Scripts/Systems/Score/RoundEndScoreBuilder.cs
@@ -39,6 +39,7 @@ namespace Systems.Score
 			ScoreMachine.AddNewScoreEntry(COMMON_SCORE_FOODEATEN, "Food Eaten", ScoreMachine.ScoreType.Int, ScoreCategory.StationScore, ScoreAlignment.Weird);
 			ScoreMachine.AddNewScoreEntry(COMMON_TAIL_SCORE_ENTRY, "Tails Pulled", ScoreMachine.ScoreType.Int, ScoreCategory.StationScore, ScoreAlignment.Weird);
 			ScoreMachine.AddNewScoreEntry(COMMON_SCORE_EXPLOSION, "Number of explosions this round", ScoreMachine.ScoreType.Int, ScoreCategory.StationScore, ScoreAlignment.Weird);
+			ScoreMachine.AddNewScoreEntry(COMMON_SCORE_FLASHED, "Number of times a Player or NPC was blinded by a flash", ScoreMachine.ScoreType.Int, ScoreCategory.StationScore, ScoreAlignment.Weird);
 			ScoreMachine.AddNewScoreEntry(COMMON_SCORE_CLOWNABUSE, "Clown Abused", ScoreMachine.ScoreType.Int, ScoreCategory.StationScore, ScoreAlignment.Bad);
 		}
 


### PR DESCRIPTION
CL: [New] Added a new entry to the score machine. It will now track how many times a player/MobV2 has been flashed throughout the round.
CL: [Improvement] Improved performance significantly of explosions while they're trying to scan for nearby players.
CL: [Improvement] The distance for explosions stunning nearby players is no longer hardcoded, and dynamically expands the stronger the explosion becomes.
CL: [Improvement] Chemical explosions will now only stun players if the explosion strength is higher than 400.
CL: [Improvement] Explosions that are considered "too strong" will now skip the line-cast check for performance reasons.
CL: [Fix] Fixed flash-by-explosion being disabled at some point.