### PR TITLE
Fixes camera being offset

### DIFF
--- a/UnityProject/Assets/Prefabs/SceneConstruction/Camera.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/Camera.prefab
@@ -320,7 +320,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 53e3142adc76418db1fe76b4e22c2035, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  yOffSet: -0.5
+  yOffSet: 0
   starScroll: -0.8
   damping: 0
   listenerObj: {fileID: 1187200688554218}


### PR DESCRIPTION

![image](https://github.com/unitystation/unitystation/assets/34368774/fe796cf7-5fff-4144-acf3-3b75f8600977)



CL: [Fix] The camera is no longer offset on the y axis for players.
