### PR TITLE
Unarmed damage and Hearing range from bodyparts

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightArm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/HumanRightArm.prefab
@@ -515,6 +515,12 @@ MonoBehaviour:
   RelatedPart: {fileID: 0}
   armEfficiency: 1
   crawlingSpeed: 0.3
+  ArmMeleeDamage: 5
+  ArmDamageType: 0
+  ArmDamageVerbs:
+  - punched
+  ArmTraumaticDamage: 0
+  ArmTraumaticChance: 0
 --- !u!114 &5756682103643324902
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/Special Organs/The Welder's Organs/WelderLeftArm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/Special Organs/The Welder's Organs/WelderLeftArm.prefab
@@ -41,17 +41,17 @@ PrefabInstance:
     - target: {fileID: 1770294262758372903, guid: 719377fefb0114b448fc6ca9f7a5a6df,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1770294262758372903, guid: 719377fefb0114b448fc6ca9f7a5a6df,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1770294262758372903, guid: 719377fefb0114b448fc6ca9f7a5a6df,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1770294262758372903, guid: 719377fefb0114b448fc6ca9f7a5a6df,
         type: 3}
@@ -132,6 +132,11 @@ PrefabInstance:
         type: 3}
       propertyPath: foreverID
       value: 108b23bf3284b1f43ab5f046ac57fc35
+      objectReference: {fileID: 0}
+    - target: {fileID: 5747680921802428440, guid: 719377fefb0114b448fc6ca9f7a5a6df,
+        type: 3}
+      propertyPath: ArmMeleeDamage
+      value: 10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/UnityProject/Assets/Prefabs/Items/Implants/Organs/Special Organs/The Welder's Organs/WelderRightArm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Organs/Special Organs/The Welder's Organs/WelderRightArm.prefab
@@ -8,6 +8,11 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 3523244764140818517, guid: ba9a875c31908af4ab3749cd127a2edb,
+        type: 3}
+      propertyPath: ArmMeleeDamage
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 4548261438558078835, guid: ba9a875c31908af4ab3749cd127a2edb,
         type: 3}
       propertyPath: parentID
@@ -106,17 +111,17 @@ PrefabInstance:
     - target: {fileID: 7473600891628779114, guid: ba9a875c31908af4ab3749cd127a2edb,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7473600891628779114, guid: ba9a875c31908af4ab3749cd127a2edb,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7473600891628779114, guid: ba9a875c31908af4ab3749cd127a2edb,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7473600891628779114, guid: ba9a875c31908af4ab3749cd127a2edb,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
+++ b/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
@@ -123,7 +123,7 @@ MonoBehaviour:
   randomInitialSprite: 0
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
-  initialVariantIndex: 0
+  variantIndex: 0
   palette: []
 --- !u!1 &1051931730128558
 GameObject:
@@ -282,7 +282,7 @@ MonoBehaviour:
   randomInitialSprite: 0
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
-  initialVariantIndex: 0
+  variantIndex: 0
   palette: []
 --- !u!1 &1106181757792460
 GameObject:
@@ -407,7 +407,7 @@ MonoBehaviour:
   randomInitialSprite: 0
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
-  initialVariantIndex: 0
+  variantIndex: 0
   palette: []
 --- !u!1 &1133514949248654
 GameObject:
@@ -483,6 +483,7 @@ GameObject:
   - component: {fileID: 6097234027102085964}
   - component: {fileID: 8039750332941386657}
   - component: {fileID: 3794334480808639130}
+  - component: {fileID: 3483459317486548442}
   m_Layer: 8
   m_Name: Player_V4(uNet)
   m_TagString: Untagged
@@ -1870,6 +1871,21 @@ MonoBehaviour:
       m_SubObjectName: 
       m_SubObjectType: 
       m_EditorAssetChanged: 0
+--- !u!114 &3483459317486548442
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1133514949248654}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a7027a6940e1b35eabeff5fee703cbda, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0.1
 --- !u!1 &1147423205297840
 GameObject:
   m_ObjectHideFlags: 0
@@ -1993,7 +2009,7 @@ MonoBehaviour:
   randomInitialSprite: 0
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
-  initialVariantIndex: 0
+  variantIndex: 0
   palette: []
 --- !u!1 &1332325770335918
 GameObject:
@@ -2118,7 +2134,7 @@ MonoBehaviour:
   randomInitialSprite: 0
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
-  initialVariantIndex: 0
+  variantIndex: 0
   palette: []
 --- !u!1 &1392646042361530
 GameObject:
@@ -2243,7 +2259,7 @@ MonoBehaviour:
   randomInitialSprite: 0
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
-  initialVariantIndex: 0
+  variantIndex: 0
   palette: []
 --- !u!1 &1442926995363424
 GameObject:
@@ -2368,7 +2384,7 @@ MonoBehaviour:
   randomInitialSprite: 0
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
-  initialVariantIndex: 0
+  variantIndex: 0
   palette: []
 --- !u!1 &1456517064699986
 GameObject:
@@ -2493,7 +2509,7 @@ MonoBehaviour:
   randomInitialSprite: 0
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
-  initialVariantIndex: 0
+  variantIndex: 0
   palette: []
 --- !u!1 &1562215114468348
 GameObject:
@@ -2618,7 +2634,7 @@ MonoBehaviour:
   randomInitialSprite: 0
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
-  initialVariantIndex: 0
+  variantIndex: 0
   palette: []
 --- !u!1 &1626073062007556
 GameObject:
@@ -2743,7 +2759,7 @@ MonoBehaviour:
   randomInitialSprite: 0
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
-  initialVariantIndex: 0
+  variantIndex: 0
   palette: []
 --- !u!1 &1653009388007362
 GameObject:
@@ -2868,7 +2884,7 @@ MonoBehaviour:
   randomInitialSprite: 0
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
-  initialVariantIndex: 0
+  variantIndex: 0
   palette: []
 --- !u!1 &1660669868818532
 GameObject:
@@ -2993,7 +3009,7 @@ MonoBehaviour:
   randomInitialSprite: 0
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
-  initialVariantIndex: 0
+  variantIndex: 0
   palette: []
 --- !u!1 &1889549945948160
 GameObject:
@@ -3118,7 +3134,7 @@ MonoBehaviour:
   randomInitialSprite: 0
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
-  initialVariantIndex: 0
+  variantIndex: 0
   palette: []
 --- !u!1 &1894933337466704
 GameObject:
@@ -3533,7 +3549,7 @@ MonoBehaviour:
   randomInitialSprite: 0
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
-  initialVariantIndex: 0
+  variantIndex: 0
   palette: []
 --- !u!1 &1243472505666966351
 GameObject:
@@ -13731,7 +13747,7 @@ MonoBehaviour:
   randomInitialSprite: 0
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
-  initialVariantIndex: 0
+  variantIndex: 0
   palette: []
 --- !u!1 &4006269813396621170
 GameObject:
@@ -13856,7 +13872,7 @@ MonoBehaviour:
   randomInitialSprite: 0
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
-  initialVariantIndex: 0
+  variantIndex: 0
   palette: []
 --- !u!1 &4560473325844253165
 GameObject:

--- a/UnityProject/Assets/Scripts/Core/Chat/ChatRelay.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/ChatRelay.cs
@@ -10,6 +10,7 @@ using Managers;
 using Systems.Ai;
 using Messages.Server;
 using Messages.Server.SoundMessages;
+using Player;
 using Player.Language;
 using Systems.Communications;
 using TMPro;
@@ -76,9 +77,9 @@ public class ChatRelay : NetworkBehaviour
 		List<PlayerInfo> players = PlayerList.Instance.AllPlayers;
 		if (chatEvent.originator != null) WhisperCheck(chatEvent);
 
-		bool DistanceCheck(Vector3 playerPos)
+		bool DistanceCheck(Vector3 playerPos, float distancevalue)
 		{
-			if (Vector2.Distance(chatEvent.position, playerPos) > 14f)
+			if (Vector2.Distance(chatEvent.position, playerPos) > distancevalue)
 			{
 				//Player in the list is too far away for local chat, remove them:
 				return false;
@@ -131,9 +132,10 @@ public class ChatRelay : NetworkBehaviour
 				//Send chat to PlayerChatLocation pos, usually just the player object but for AI is its vessel
 				var playerPosition = players[i].Script.PlayerChatLocation.OrNull()?.AssumedWorldPosServer()
 				                     ?? players[i].Script.gameObject.AssumedWorldPosServer();
-
+				//Get chatrange stat from playerstats
+				var playerhearing = players[i].Script.PlayerStats.GetTotalStat(PlayerStats.Stat.LocalChatRange);
 				//Do player position to originator distance check
-				if (DistanceCheck(playerPosition) == false)
+				if (DistanceCheck(playerPosition, playerhearing) == false)
 				{
 					//Distance check failed so if we are Ai, then try send action and combat messages to their camera location
 					//as well as if possible
@@ -145,7 +147,8 @@ public class ChatRelay : NetworkBehaviour
 						playerPosition = players[i].Script.gameObject.AssumedWorldPosServer();
 
 						//Check camera pos
-						if (DistanceCheck(playerPosition))
+						//AI doesnt have ears so just pass 14f
+						if (DistanceCheck(playerPosition, 14f))
 						{
 							//Camera can see player, allow Ai to see action/combat messages
 							continue;

--- a/UnityProject/Assets/Scripts/Items/Implants/Limbs/HumanoidArm.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Limbs/HumanoidArm.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Player.Movement;
 using UnityEngine;
 
@@ -19,12 +20,18 @@ namespace HealthV2.Limbs
 		private float crawlingSpeed = 0.3f;
 		public float CrawlingSpeed => crawlingSpeed;
 
+		[Header("Arm Damage Stats")]
+		[SerializeField] public float ArmMeleeDamage = 5f;
+		[SerializeField] public DamageType ArmDamageType = DamageType.Brute;
+		[SerializeField] public List<string> ArmDamageVerbs;
+		[SerializeField] public TraumaticDamageTypes ArmTraumaticDamage;
+		[SerializeField] public float ArmTraumaticChance = 0;
+
+
 		public override void OnAddedToBody(LivingHealthMasterBase livingHealth)
 		{
 			base.OnAddedToBody(livingHealth);
 			playerHealth.OrNull()?.PlayerMove.AddModifier(this);
-
-
 		}
 
 		public override void OnRemovedFromBody(LivingHealthMasterBase livingHealth)

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Ears.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Ears.cs
@@ -1,12 +1,16 @@
 using Audio.Containers;
 using HealthV2;
 using Mirror;
+using Player;
 using UnityEngine;
 
 namespace Items.Implants.Organs
 {
 	public class Ears : BodyPartFunctionality, IItemInOutMovedPlayer, IClientSynchronisedEffect
 	{
+
+		[SerializeField]
+		private float localChatRange = 14;
 
 		public float DefaultHearing = 1;
 
@@ -82,11 +86,13 @@ namespace Items.Implants.Organs
 		public override void OnRemovedFromBody(LivingHealthMasterBase livingHealth)
 		{
 			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, CheckPressure);
+			(livingHealth as PlayerHealthV2).OrNull()?.playerScript.PlayerStats.RemoveModifier(PlayerStats.Stat.LocalChatRange, gameObject.name);
 		}
 
 		public override void OnAddedToBody(LivingHealthMasterBase livingHealth)
 		{
 			UpdateManager.Add(CheckPressure, 1);
+			(livingHealth as PlayerHealthV2).OrNull()?.playerScript.PlayerStats.AddModifier(PlayerStats.Stat.LocalChatRange, gameObject.name, localChatRange);
 		}
 
 		private void CheckPressure()

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
@@ -29,6 +29,8 @@ public class WeaponNetworkActions : NetworkBehaviour
 	[SerializeField]
 	private DamageType damageType = DamageType.Brute;
 
+	private bool damageOverwritten = false;
+
 	private float traumaDamageChance = 0;
 	private TraumaticDamageTypes tramuticDamageType;
 
@@ -71,6 +73,7 @@ public class WeaponNetworkActions : NetworkBehaviour
 		handDamage = newAttackDamage;
 		damageType = newDamageType;
 		chanceToHit = newChanceToHit;
+		damageOverwritten = true;
 	}
 
 	/// <summary>
@@ -124,7 +127,8 @@ public class WeaponNetworkActions : NetworkBehaviour
 			weaponSound = weaponAttributes.hitSoundSettings == SoundItemSettings.OnlyObject ? null : weaponAttributes.ServerHitSound;
 			tramuticDamageType = weaponAttributes.TraumaticDamageType;
 			traumaDamageChance = weaponAttributes.TraumaDamageChance;
-		} else
+		}
+		else if (damageOverwritten == false)
 		{
 			//weaponAttributes is null so we are punching
 			GameObject activeArm = playerScript.PlayerNetworkActions.activeHand;

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
@@ -6,7 +6,9 @@ using TileManagement;
 using Mirror;
 using AddressableReferences;
 using HealthV2;
+using HealthV2.Limbs;
 using Items;
+using Logs;
 using Messages.Server.SoundMessages;
 using Player.Movement;
 using Systems.Interaction;
@@ -122,6 +124,19 @@ public class WeaponNetworkActions : NetworkBehaviour
 			weaponSound = weaponAttributes.hitSoundSettings == SoundItemSettings.OnlyObject ? null : weaponAttributes.ServerHitSound;
 			tramuticDamageType = weaponAttributes.TraumaticDamageType;
 			traumaDamageChance = weaponAttributes.TraumaDamageChance;
+		} else
+		{
+			//weaponAttributes is null so we are punching
+			GameObject activeArm = playerScript.PlayerNetworkActions.activeHand;
+			HumanoidArm armStats = activeArm.GetComponent<HumanoidArm>();
+			if (armStats != null)
+			{
+				damage = armStats.ArmMeleeDamage;
+				currentDamageType = armStats.ArmDamageType;
+				attackVerb = armStats.ArmDamageVerbs.PickRandom();
+				tramuticDamageType = armStats.ArmTraumaticDamage;
+				traumaDamageChance = armStats.ArmTraumaticChance;
+			}
 		}
 
 		LayerTile attackedTile = null;

--- a/UnityProject/Assets/Scripts/Player/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerScript.cs
@@ -102,6 +102,8 @@ public class PlayerScript : NetworkBehaviour, IAdminInfo, IPlayerPossessable, IH
 
 	[field: SerializeField] public DimPlayerLightController DimPlayerLightController { get; private set; }
 
+	public PlayerStats PlayerStats { get; private set; }
+
 	/// <summary>
 	/// Serverside world position.
 	/// Outputs correct world position even if you're hidden (e.g. in a locker)
@@ -203,6 +205,7 @@ public class PlayerScript : NetworkBehaviour, IAdminInfo, IPlayerPossessable, IH
 		PlayerFaith ??= GetComponent<PlayerFaith>();
 		Particles ??= GetComponent<PlayerParticle>();
 		DimPlayerLightController ??= GetComponent<DimPlayerLightController>();
+		PlayerStats = GetComponent<PlayerStats>();
 	}
 
 	public override void OnStartClient()

--- a/UnityProject/Assets/Scripts/Player/PlayerStats.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerStats.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using Logs;
+using Mirror;
+using UnityEngine;
+
+namespace Player
+{
+	public class PlayerStats : NetworkBehaviour {
+
+		private Dictionary<Stat, Dictionary<string, float>> stats;
+		
+		public enum Stat
+		{
+			MeleeDamage,
+			LocalChatRange,
+		}
+		
+		private void Awake()
+		{
+			stats = new();
+			foreach (Stat stat in Enum.GetValues(typeof(Stat)))
+			{
+				stats.Add(stat, new());
+			}
+		}
+				
+		public float GetTotalStat(Stat stat)
+		{
+			var val = 0f;
+			foreach (var value in stats[stat])
+			{
+				val += value.Value;
+			}
+			return val;
+		}
+		
+		public void AddModifier(Stat stat, string source, float value)
+		{
+			stats[stat].Add(source, value);
+		}
+		
+		public void RemoveModifier(Stat stat, string source)
+		{
+			stats[stat].Remove(source);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Player/PlayerStats.cs.meta
+++ b/UnityProject/Assets/Scripts/Player/PlayerStats.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a7027a6940e1b35eabeff5fee703cbda


### PR DESCRIPTION

### Notes:
<!-- Please enter any other relevant information here -->
adds a generic component for tracking stats
if something is meleeing and doesnt have human arms it should fallback to whatever value(s) are defined in weaponnetworkactions

as a result of getting localchat range from ears, if you have no ears you cant hear local chat (but can still hear the radio and ooc)

### Changelog:
<!-- Add here individual lines with all your remarkable changes using the prefix ``CL:`` -->
<!-- Mind that the changes meant to be logged in the in changelog are those that are remarkable for the end user, so things like new features and fixes of known bugs are perfect for this section -->
CL: [Improvement] Players cannot hear local chat without ears.

<!-- CL: [New] For new features, things that didn't exist before the PR. -->

<!-- CL: [Improvement] For any change on any existing feature. -->

<!-- CL: [Balance] For any change on an existing feature done in the sake of improving game balance. It's the only exception to the rule above. -->

<!-- CL: [Fix] For any change that fixes a bug. -->
