### PR TITLE
WorldSpace Imaging Tool QoL Update

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Editor/Tools/WorldSpaceCamera.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/Tools/WorldSpaceCamera.cs
@@ -32,14 +32,19 @@ public class WorldSpaceCamera : EditorWindow
 		EditorGUILayout.LabelField("Image path: " + path);
 		if (GUILayout.Button("Browse"))
 		{
-			path = EditorUtility.OpenFilePanel("Show all images (.png)", "", "png");
+			path = EditorUtility.SaveFilePanel("Show all images (.png)", "", "Worldspace Screenshot", "png");
 		}
 
 		EditorGUILayout.Space(10);
-		if(GUILayout.Button("Take Snapshot"))
+
+		bool validPath = path != null && path != "";
+		string buttonTest = validPath ? "Take Snapshot" : "Please select a valid directory!";
+
+		if (GUILayout.Button(buttonTest))
 		{
-			TakeSnapshot();
+			if(validPath == true) TakeSnapshot();
 		}
+
 	}
 
 	async Task TakeSnapshot()


### PR DESCRIPTION
The world space imaging tool (used to take High-Res screenshots of maps and environments) previously had an issue where you had to select an existing file to save to, making it slight inconvenient to use.

This PR fixes that, and also prevents users from saving screenshots prior to having selected a valid directory.
