### PR TITLE
Implement Deconstructing Damaged Base Plating, also bugfix Scorched Plating to be Repairable

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/DeconstructWhenCrowbarUsedBase.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/DeconstructWhenCrowbarUsedBase.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f0627a4860741578ec35e4340e83cc6, type: 3}
+  m_Name: DeconstructWhenCrowbarUsedBase
+  m_EditorClassIdentifier: 
+  requiredTrait: {fileID: 11400000, guid: 5524008e9372c468aacfb95c83179a91, type: 2}
+  performerStartActionMessage: You begin prying up the floor plating...
+  othersStartActionMessage: '{performer} begins prying up the floor plating...'
+  seconds: 30
+  objectsToSpawn: {fileID: 0}
+  performerFinishActionMessage: You pry up the floor plating.
+  othersFinishActionMessage: '{performer} pries up the floor plating.'

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/DeconstructWhenCrowbarUsedBase.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/DeconstructWhenCrowbarUsedBase.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 26cde2c683404c491be3a9225eb5aafc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/PlatingScorched.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/PlatingScorched.asset
@@ -58,12 +58,14 @@ MonoBehaviour:
     TemperatureProtectionInK: {x: 268.15, y: 313.15}
     PressureProtectionInKpa: {x: 30, y: 300}
   tileInteractions:
-  - {fileID: 11400000, guid: f06f99d9e8bc5454a8df89a2a387ff77, type: 2}
+  - {fileID: 11400000, guid: 20594944fdc1e8c4f926faf5d0653dae, type: 2}
+  - {fileID: 11400000, guid: 26cde2c683404c491be3a9225eb5aafc, type: 2}
   <OnTileStartMining>k__BackingField: []
   <OnTileFinishMining>k__BackingField: []
   tileStepInteractions: []
-  spawnOnDeconstruct: {fileID: 0}
-  spawnAmountOnDeconstruct: 0
+  spawnOnDeconstruct: {fileID: 5331286249588652700, guid: 29ecbf5a1d918574cbcf5853927e0944,
+    type: 3}
+  spawnAmountOnDeconstruct: 1
   lootOnDespawn: {fileID: 0}
   toTileWhenDestroyed: {fileID: 11400000, guid: 8ef47dcbc2f72784797fb63f33a0ac36,
     type: 2}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/platingdmg1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/platingdmg1.asset
@@ -26,7 +26,7 @@ MonoBehaviour:
   SpawnWithNoAir: 0
   passable: 1
   mineable: 0
-  miningTime: 5
+  miningTime: -4.02
   miningHardness: 1
   constructable: 1
   RadiationPassability: 1
@@ -59,11 +59,13 @@ MonoBehaviour:
     PressureProtectionInKpa: {x: 30, y: 300}
   tileInteractions:
   - {fileID: 11400000, guid: 20594944fdc1e8c4f926faf5d0653dae, type: 2}
+  - {fileID: 11400000, guid: 26cde2c683404c491be3a9225eb5aafc, type: 2}
   <OnTileStartMining>k__BackingField: []
   <OnTileFinishMining>k__BackingField: []
   tileStepInteractions: []
-  spawnOnDeconstruct: {fileID: 0}
-  spawnAmountOnDeconstruct: 0
+  spawnOnDeconstruct: {fileID: 5331286249588652700, guid: 29ecbf5a1d918574cbcf5853927e0944,
+    type: 3}
+  spawnAmountOnDeconstruct: 1
   lootOnDespawn: {fileID: 0}
   toTileWhenDestroyed: {fileID: 11400000, guid: 28455114dec364442b57e2ae77a4b06e,
     type: 2}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/platingdmg2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/platingdmg2.asset
@@ -59,11 +59,13 @@ MonoBehaviour:
     PressureProtectionInKpa: {x: 30, y: 300}
   tileInteractions:
   - {fileID: 11400000, guid: 20594944fdc1e8c4f926faf5d0653dae, type: 2}
+  - {fileID: 11400000, guid: 26cde2c683404c491be3a9225eb5aafc, type: 2}
   <OnTileStartMining>k__BackingField: []
   <OnTileFinishMining>k__BackingField: []
   tileStepInteractions: []
-  spawnOnDeconstruct: {fileID: 0}
-  spawnAmountOnDeconstruct: 0
+  spawnOnDeconstruct: {fileID: 5331286249588652700, guid: 29ecbf5a1d918574cbcf5853927e0944,
+    type: 3}
+  spawnAmountOnDeconstruct: 1
   lootOnDespawn: {fileID: 0}
   toTileWhenDestroyed: {fileID: 0}
   spawnOnDestroy: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/platingdmg3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/platingdmg3.asset
@@ -59,11 +59,13 @@ MonoBehaviour:
     PressureProtectionInKpa: {x: 30, y: 300}
   tileInteractions:
   - {fileID: 11400000, guid: 20594944fdc1e8c4f926faf5d0653dae, type: 2}
+  - {fileID: 11400000, guid: 26cde2c683404c491be3a9225eb5aafc, type: 2}
   <OnTileStartMining>k__BackingField: []
   <OnTileFinishMining>k__BackingField: []
   tileStepInteractions: []
-  spawnOnDeconstruct: {fileID: 0}
-  spawnAmountOnDeconstruct: 0
+  spawnOnDeconstruct: {fileID: 5331286249588652700, guid: 29ecbf5a1d918574cbcf5853927e0944,
+    type: 3}
+  spawnAmountOnDeconstruct: 1
   lootOnDespawn: {fileID: 0}
   toTileWhenDestroyed: {fileID: 11400000, guid: b023eb05939afe049ac7dd121a82b054,
     type: 2}


### PR DESCRIPTION
<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->

### Purpose
<!-- Describe the problem the PR fixes or the feature it introduces. --> <br>
<!-- Don't forget to use "Fixes #issuenumber" to select issues and auto close them on merge. -->
Implements a way to deconstruct a station's base plating, without using high explosives to make a massive hull breach.
The interaction has a 30 second long progress timer; please let me know if this time should be lengthened or shortened.
Fixes ScorchedPlatings to be repairable, so explosions no longer create permanent marks.

### Notes:
<!-- Please enter any other relevant information here -->
This change is part of my plan to implement the Thermite reaction (Thermite would damage base plating, which would allow for the interaction implemented here.) 

### Changelog:
<!-- Add here individual lines with all your remarkable changes using the prefix ``CL:`` -->
<!-- Mind that the changes meant to be logged in the in changelog are those that are remarkable for the end user, so things like new features and fixes of known bugs are perfect for this section -->
CL: [Improvement] Changes Base Plating to allow for Deconstruction
CL: [Fix] Scorched Plating can now be Repaired

<!-- CL: [New] For new features, things that didn't exist before the PR. -->

<!-- CL: [Improvement] For any change on any existing feature. -->

<!-- CL: [Balance] For any change on an existing feature done in the sake of improving game balance. It's the only exception to the rule above. -->

<!-- CL: [Fix] For any change that fixes a bug. -->
