### PR TITLE
Proper grenade fuses

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/EMPGrenade.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/EMPGrenade.prefab
@@ -34,15 +34,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -180,6 +180,10 @@ PrefabInstance:
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 9197874253917913631}
+    - targetCorrespondingSourceObject: {fileID: 1011433845357754, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 200530619557270262}
   m_SourcePrefab: {fileID: 100100000, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
 --- !u!114 &2450954382432651964 stripped
 MonoBehaviour:
@@ -230,6 +234,8 @@ MonoBehaviour:
     type: 3}
   unstableFuse: 0
   fuseLength: 3
+  fuseMinimum: 3
+  fuseMaximum: 5
   armbomb:
     SetLoadSetting: 0
     AssetAddress: Assets/Prefabs/Weapons/armbomb.prefab
@@ -240,6 +246,36 @@ MonoBehaviour:
       m_EditorAssetChanged: 0
   spriteHandler: {fileID: 2450954382432651964}
   pickupable: {fileID: 8561795974084681285}
+  destroyGrenade: 1
+  allowReuse: 0
   OnExpload:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &200530619557270262
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8594439505056330043}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fdce8a163088453ca593c0e98f2c5f07, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemStorageStructure: {fileID: 11400000, guid: 263bf834f99424f12bda19d67c3ab5fc,
+    type: 2}
+  itemStorageCapacity: {fileID: 11400000, guid: 58888e96aba983b30b1a5b57ec762151,
+    type: 2}
+  itemStoragePopulator: {fileID: 11400000, guid: 8c7626bab82fb2a24bcace3c04c92ba6,
+    type: 2}
+  forceSpawnContents: 0
+  ManuallySpawnContent: 0
+  dropItemsOnDespawn: 0
+  UesAddlistPopulater: 0
+  Populater:
+    SlotContents: []
+    DeprecatedContents: []
+  SetSlotItemNotRemovableOnStartUp: 0
+  ashPrefab: {fileID: 2957035178188790827, guid: 9ac6968a3f3ed54428662c9aae5a4b32,
+    type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/EMPGrenade.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/EMPGrenade.prefab
@@ -269,7 +269,7 @@ MonoBehaviour:
     type: 2}
   itemStoragePopulator: {fileID: 11400000, guid: 8c7626bab82fb2a24bcace3c04c92ba6,
     type: 2}
-  forceSpawnContents: 0
+  forceSpawnContents: 1
   ManuallySpawnContent: 0
   dropItemsOnDespawn: 0
   UesAddlistPopulater: 0

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/Grenade.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/Grenade.prefab
@@ -34,15 +34,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -191,6 +191,10 @@ PrefabInstance:
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 9197874253917913631}
+    - targetCorrespondingSourceObject: {fileID: 1011433845357754, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 200530619557270262}
   m_SourcePrefab: {fileID: 100100000, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
 --- !u!114 &2450954382432651964 stripped
 MonoBehaviour:
@@ -241,6 +245,8 @@ MonoBehaviour:
     type: 3}
   unstableFuse: 0
   fuseLength: 3
+  fuseMinimum: 3
+  fuseMaximum: 5
   armbomb:
     SetLoadSetting: 0
     AssetAddress: Assets/Prefabs/Weapons/armbomb.prefab
@@ -251,6 +257,36 @@ MonoBehaviour:
       m_EditorAssetChanged: 0
   spriteHandler: {fileID: 2450954382432651964}
   pickupable: {fileID: 8561795974084681285}
+  destroyGrenade: 1
+  allowReuse: 0
   OnExpload:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &200530619557270262
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8594439505056330043}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fdce8a163088453ca593c0e98f2c5f07, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemStorageStructure: {fileID: 11400000, guid: 263bf834f99424f12bda19d67c3ab5fc,
+    type: 2}
+  itemStorageCapacity: {fileID: 11400000, guid: 58888e96aba983b30b1a5b57ec762151,
+    type: 2}
+  itemStoragePopulator: {fileID: 11400000, guid: 8c7626bab82fb2a24bcace3c04c92ba6,
+    type: 2}
+  forceSpawnContents: 0
+  ManuallySpawnContent: 0
+  dropItemsOnDespawn: 0
+  UesAddlistPopulater: 0
+  Populater:
+    SlotContents: []
+    DeprecatedContents: []
+  SetSlotItemNotRemovableOnStartUp: 0
+  ashPrefab: {fileID: 2957035178188790827, guid: 9ac6968a3f3ed54428662c9aae5a4b32,
+    type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/Grenade.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/Grenade.prefab
@@ -280,7 +280,7 @@ MonoBehaviour:
     type: 2}
   itemStoragePopulator: {fileID: 11400000, guid: 8c7626bab82fb2a24bcace3c04c92ba6,
     type: 2}
-  forceSpawnContents: 0
+  forceSpawnContents: 1
   ManuallySpawnContent: 0
   dropItemsOnDespawn: 0
   UesAddlistPopulater: 0

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Items/Grenades.meta
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Items/Grenades.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e7ff1d66aacf8a3129b2469d09dbb73f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Items/Grenades/GrenadeWireFuse.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Items/Grenades/GrenadeWireFuse.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4dcdd86e87cc447d94b99df8b1a383b3, type: 3}
+  m_Name: GrenadeWireFuse
+  m_EditorClassIdentifier: 
+  SlotContents: []
+  DeprecatedContents:
+  - {fileID: 4435676122793348777, guid: c567e6c3b003a2b488534a8766866cb0, type: 3}

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Items/Grenades/GrenadeWireFuse.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Items/Grenades/GrenadeWireFuse.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8c7626bab82fb2a24bcace3c04c92ba6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Grenade.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Grenade.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7c909446621c41cd975e26eab73860a6, type: 3}
+  m_Name: Grenade
+  m_EditorClassIdentifier: 
+  maxSize: 5
+  Whitelist:
+  - {fileID: 11400000, guid: e39c048ec864b47a495a40f9c76af764, type: 2}
+  Required: []
+  Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Grenade.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Grenade.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 58888e96aba983b30b1a5b57ec762151
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Items/Weapons/Grenade.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Grenade.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 using Mirror;
 using Systems.Explosions;
@@ -7,6 +8,7 @@ using AddressableReferences;
 using Objects;
 using UnityEngine.Events;
 using NaughtyAttributes;
+using UI.Systems.Tooltips.HoverTooltips;
 using Random = UnityEngine.Random;
 
 namespace Items.Weapons
@@ -16,7 +18,7 @@ namespace Items.Weapons
 	/// </summary>
 	[RequireComponent(typeof(Pickupable))]
 	[RequireComponent(typeof(ItemStorage))]
-	public class Grenade : NetworkBehaviour, IPredictedInteractable<HandActivate>, ICheckedInteractable<InventoryApply>, IServerDespawn, ITrapComponent, IExaminable
+	public class Grenade : NetworkBehaviour, IPredictedInteractable<HandActivate>, ICheckedInteractable<InventoryApply>, IServerDespawn, ITrapComponent, IExaminable, IHoverTooltip
 
 	{
 		[Tooltip("Explosion effect prefab, which creates when timer ends")]
@@ -147,7 +149,7 @@ namespace Items.Weapons
 			}
 			else if (Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.Cable) && TriggerSlot.IsEmpty)
 			{
-				if (interaction.UsedObject.TryGetComponent<Stackable>(out var stackable))
+				if (interaction.UsedObject.TryGetComponent<Stackable>(out var stackable) && stackable.Amount > 1)
 				{
 					Inventory.ServerAdd(stackable.ServerRemoveOne(), TriggerSlot);
 				} else
@@ -293,9 +295,39 @@ namespace Items.Weapons
 
 		}
 
+		private string ExamineText()
+		{
+			return TriggerSlot.IsOccupied ? $"Uses a {TriggerSlot.ItemObject.ExpensiveName()} trigger." : "It lacks a trigger." ;
+		}
+
+		public string HoverTip()
+		{
+			return ExamineText();
+		}
+
+		public string CustomTitle()
+		{
+			return null;
+		}
+
+		public Sprite CustomIcon()
+		{
+			return null;
+		}
+
+		public List<Sprite> IconIndicators()
+		{
+			return null;
+		}
+
+		public List<TextColor> InteractionsStrings()
+		{
+			return null;
+		}
+
 		public string Examine(Vector3 pos)
 		{
-			return TriggerSlot.IsOccupied ? $"Uses a {TriggerSlot.ItemObject.ExpensiveName()} trigger" : "It lacks a trigger." ;
+			return ExamineText();
 		}
 
 		[ContextMenu("Pull a pin")]


### PR DESCRIPTION
### Notes:
<!-- Please enter any other relevant information here -->
Adds proper wire fuses to grenades
Fuses can be cut using wirecutters, which will defuse active grenades and requires a replacement wire to be inserted for the grenade to be usable again
Also adds the ability to change the timer on the grenade using the mutlitool, by default the min time is 3s and max is 5s

None of this applies to chemical grenades because they use a different script


### Changelog:
<!-- Add here individual lines with all your remarkable changes using the prefix ``CL:`` -->
<!-- Mind that the changes meant to be logged in the in changelog are those that are remarkable for the end user, so things like new features and fixes of known bugs are perfect for this section -->
CL: [New] Grenades can now be defused using wirecutters.
CL: [New] Grenade detonation timer can now be adjusted using the multitool.
<!-- CL: [New] For new features, things that didn't exist before the PR. -->

<!-- CL: [Improvement] For any change on any existing feature. -->

<!-- CL: [Balance] For any change on an existing feature done in the sake of improving game balance. It's the only exception to the rule above. -->

<!-- CL: [Fix] For any change that fixes a bug. -->
