### PR TITLE
Fix items spawning inside lights on asteroid scenes

### DIFF
--- a/UnityProject/Assets/Scenes/AdditionalScenes/AncientStation.unity
+++ b/UnityProject/Assets/Scenes/AdditionalScenes/AncientStation.unity
@@ -630,6 +630,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 9630316}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &19171002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &20932869
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -714,6 +726,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 20932869}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &29406201
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &30727806
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1252,18 +1276,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b795fd3e621e742b0aafdb501b9d36cf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &38085164
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &38591606
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1445,7 +1457,7 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 40459526}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &42278300
+--- !u!114 &43322226
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1880,6 +1892,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 63139286}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &64601175
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &66982662
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2230,6 +2254,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 71178516}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &77705208
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &81310912
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2634,7 +2670,7 @@ PrefabInstance:
     - target: {fileID: 3546756579768976802, guid: 517c48fc4fc1cba48908d11ec58451ce,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 28
+      value: 27
       objectReference: {fileID: 0}
     - target: {fileID: 3546756579768976802, guid: 517c48fc4fc1cba48908d11ec58451ce,
         type: 3}
@@ -2697,18 +2733,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 96660723}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &97717052
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &98272051
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3203,6 +3227,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 109366430}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &110159428
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &110976292
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3292,6 +3328,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 110976292}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &114180002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &114649855
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3376,18 +3424,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 114649855}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &115536856
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &115702118
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3557,7 +3593,7 @@ PrefabInstance:
     - target: {fileID: 6524792663699463651, guid: aea6ac6f49bb5e443ac179f2e10caae0,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 6524792663699463651, guid: aea6ac6f49bb5e443ac179f2e10caae0,
         type: 3}
@@ -3976,18 +4012,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 132125481}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &132391281
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &133013513
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4087,18 +4111,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &134573138
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &134809286
@@ -4286,6 +4298,30 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 137581192}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &140975452
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &142487264
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &142980105
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4375,18 +4411,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 142980105}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &144867510
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &145858472
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5213,12 +5237,12 @@ PrefabInstance:
     - target: {fileID: 4413554447041905189, guid: 20a3d1857d5f66c4aa945129302471a7,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 4.9902344
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 4413554447041905189, guid: 20a3d1857d5f66c4aa945129302471a7,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 23.880117
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 4413554447041905189, guid: 20a3d1857d5f66c4aa945129302471a7,
         type: 3}
@@ -5997,18 +6021,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 174202485}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &175846894
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &179118863
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6452,12 +6464,12 @@ PrefabInstance:
     - target: {fileID: 2727044552519519286, guid: f366188e22a01984c8789be3304661c9,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 2.993
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2727044552519519286, guid: f366188e22a01984c8789be3304661c9,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 24.023
+      value: 26
       objectReference: {fileID: 0}
     - target: {fileID: 2727044552519519286, guid: f366188e22a01984c8789be3304661c9,
         type: 3}
@@ -6717,6 +6729,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 194257114}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &196183608
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &196305286
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6899,7 +6923,7 @@ PrefabInstance:
     - target: {fileID: 2778777903733453973, guid: e41afb7979b591443b008859f958eca6,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2778777903733453973, guid: e41afb7979b591443b008859f958eca6,
         type: 3}
@@ -7333,18 +7357,6 @@ SortingGroup:
     type: 3}
   m_PrefabInstance: {fileID: 213634168}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &213987878
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &214062765
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7797,18 +7809,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 223045268}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &229942556
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &231449873
 GameObject:
   m_ObjectHideFlags: 0
@@ -8359,6 +8359,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &232864792
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &233787166
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8431,6 +8443,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 233787166}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &240290994
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &247436632
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9559,6 +9583,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8cd47c8a7b3ca4905983be3a08c1caf0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &262538577
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &269575866
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10444,6 +10480,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8cd47c8a7b3ca4905983be3a08c1caf0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &292343511
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &294148828
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10967,6 +11015,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 298829239}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &299125859
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &312115500
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -11619,7 +11679,7 @@ PrefabInstance:
     - target: {fileID: 3650718730568828686, guid: b35a262356250504fbfa735d183f9998,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3650718730568828686, guid: b35a262356250504fbfa735d183f9998,
         type: 3}
@@ -11853,18 +11913,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 342703637}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &344127042
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &349426246
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -11881,12 +11929,12 @@ PrefabInstance:
     - target: {fileID: 6524792663699463651, guid: aea6ac6f49bb5e443ac179f2e10caae0,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 4.9902344
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 6524792663699463651, guid: aea6ac6f49bb5e443ac179f2e10caae0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 24.020117
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 6524792663699463651, guid: aea6ac6f49bb5e443ac179f2e10caae0,
         type: 3}
@@ -12219,6 +12267,18 @@ SortingGroup:
     type: 3}
   m_PrefabInstance: {fileID: 362817549}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &364808549
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &366926084
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -12336,7 +12396,7 @@ PrefabInstance:
     - target: {fileID: 4245844695371101720, guid: 650450916815dfb4ba0aa087a3006beb,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 4245844695371101720, guid: 650450916815dfb4ba0aa087a3006beb,
         type: 3}
@@ -12801,7 +12861,7 @@ PrefabInstance:
     - target: {fileID: 3283716107216258734, guid: 4f7ce98391b8ec54493a831134aa65be,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3283716107216258734, guid: 4f7ce98391b8ec54493a831134aa65be,
         type: 3}
@@ -12960,18 +13020,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 388604159}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &392673623
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &393862674
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -13442,18 +13490,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 400493354}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &405454669
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &406892952
 GameObject:
   m_ObjectHideFlags: 0
@@ -14338,7 +14374,7 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 431360064}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &440467271
+--- !u!114 &435459271
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -14451,7 +14487,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &454454090
+--- !u!114 &455159050
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -14460,7 +14496,19 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &456146155
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &456360291
@@ -15882,18 +15930,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &472521170
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &473558841
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -15910,7 +15946,7 @@ PrefabInstance:
     - target: {fileID: 5674645506955800181, guid: c3e6805b264a935428b0de415ea57943,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 28
+      value: 27
       objectReference: {fileID: 0}
     - target: {fileID: 5674645506955800181, guid: c3e6805b264a935428b0de415ea57943,
         type: 3}
@@ -16889,6 +16925,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 505307664}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &515003390
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &518740061
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -16915,7 +16963,7 @@ PrefabInstance:
     - target: {fileID: 1846153452591548922, guid: 397461e981e81df4c8983f127dbabae6,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 1846153452591548922, guid: 397461e981e81df4c8983f127dbabae6,
         type: 3}
@@ -17095,7 +17143,7 @@ PrefabInstance:
     - target: {fileID: 4412732363476520148, guid: d6495a017b1b4634697738270d87d354,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 28.001
+      value: 27
       objectReference: {fileID: 0}
     - target: {fileID: 4412732363476520148, guid: d6495a017b1b4634697738270d87d354,
         type: 3}
@@ -17258,18 +17306,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 528436170}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &529689627
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &529858407
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -18247,7 +18283,7 @@ PrefabInstance:
     - target: {fileID: 6024195123704426206, guid: 871c3d9267933674894b9bfb2f956c56,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 6024195123704426206, guid: 871c3d9267933674894b9bfb2f956c56,
         type: 3}
@@ -18326,7 +18362,7 @@ PrefabInstance:
     - target: {fileID: 7662282495583499656, guid: 7f32e42309899114b9c122f261161bc5,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 28
+      value: 27
       objectReference: {fileID: 0}
     - target: {fileID: 7662282495583499656, guid: 7f32e42309899114b9c122f261161bc5,
         type: 3}
@@ -18600,7 +18636,7 @@ PrefabInstance:
     - target: {fileID: 114644025392430031, guid: a096b50447bc34448ab67474a463eaef,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 114644025392430031, guid: a096b50447bc34448ab67474a463eaef,
         type: 3}
@@ -18848,19 +18884,7 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 574718215}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &575662334
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &579206275
+--- !u!114 &579030245
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -19713,6 +19737,18 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
+--- !u!114 &589310979
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &590243638
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -20206,6 +20242,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8cd47c8a7b3ca4905983be3a08c1caf0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &593322050
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &593908189
@@ -21265,18 +21313,6 @@ SortingGroup:
     type: 3}
   m_PrefabInstance: {fileID: 621435714}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &624962070
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &631408057
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -21575,7 +21611,7 @@ PrefabInstance:
     - target: {fileID: 114644025392430031, guid: a096b50447bc34448ab67474a463eaef,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 114644025392430031, guid: a096b50447bc34448ab67474a463eaef,
         type: 3}
@@ -21633,18 +21669,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 645939475}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &647468096
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &647568349
 GameObject:
   m_ObjectHideFlags: 0
@@ -23981,6 +24005,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 692799257}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &700605817
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &701850605
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -24080,18 +24116,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &702597201
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &704384332
@@ -24541,6 +24565,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 708332467}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &709398264
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &709924480
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -25770,6 +25806,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 725271500}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &725624159
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &728604310
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -26028,6 +26076,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b795fd3e621e742b0aafdb501b9d36cf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &742111119
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &742591939
@@ -26674,12 +26734,12 @@ PrefabInstance:
     - target: {fileID: 7866763346833693135, guid: a8b053482da561b4eba3bd81d8fe51ab,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 4.9902344
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 7866763346833693135, guid: a8b053482da561b4eba3bd81d8fe51ab,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 23.960117
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 7866763346833693135, guid: a8b053482da561b4eba3bd81d8fe51ab,
         type: 3}
@@ -27150,6 +27210,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 791874170}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &794527114
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &802527885
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -27569,6 +27641,30 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 820852856}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &828480676
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &828556480
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &829055180
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -27733,7 +27829,7 @@ SortingGroup:
     type: 3}
   m_PrefabInstance: {fileID: 829598838}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &833386525
+--- !u!114 &831092252
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -28506,6 +28602,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 845471974}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &845659905
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &846230862
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -28839,7 +28947,7 @@ PrefabInstance:
     - target: {fileID: 2778777903733453973, guid: e41afb7979b591443b008859f958eca6,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2778777903733453973, guid: e41afb7979b591443b008859f958eca6,
         type: 3}
@@ -28902,6 +29010,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 851348871}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &853724068
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &854105952
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -29425,18 +29545,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 864329586}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &874224185
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &874269397
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -29940,6 +30048,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 879240203}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &881490396
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &891620306
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -33597,18 +33717,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 981721530}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &986255582
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &988249961
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -34475,30 +34583,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &1010891506
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1011407712
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1011518187
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -34806,7 +34890,7 @@ PrefabInstance:
     - target: {fileID: 1846153452591548922, guid: 397461e981e81df4c8983f127dbabae6,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 1846153452591548922, guid: 397461e981e81df4c8983f127dbabae6,
         type: 3}
@@ -35586,18 +35670,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1024823456}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1027788984
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1029327374
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -36180,7 +36252,7 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1042626434}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1044283221
+--- !u!114 &1046512692
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -36394,18 +36466,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1049552429}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1049609306
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1055722814
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -36963,6 +37023,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1063167952}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1068199761
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1072529459
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -37069,18 +37141,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1075472236
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &1081456470
@@ -37501,6 +37561,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1089750923}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1097009938
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1108351091
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -38371,18 +38443,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1136105646}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1145276167
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1146427748
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -38992,18 +39052,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1169129140}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1170634443
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1173026244
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -39538,7 +39586,7 @@ PrefabInstance:
     - target: {fileID: 1846153452591548922, guid: 397461e981e81df4c8983f127dbabae6,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 1846153452591548922, guid: 397461e981e81df4c8983f127dbabae6,
         type: 3}
@@ -40213,6 +40261,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1205045848}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1206403743
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1208070341
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -40503,6 +40563,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1213483931}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1220103620
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1220232165
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -40701,30 +40773,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1220401355}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1222403035
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1224920268
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1225845385
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -41869,18 +41917,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1254932969}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1260913026
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1270321808
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -43664,6 +43700,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1333079736
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1334024568
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -43749,6 +43797,18 @@ Transform:
   m_PrefabInstance: {fileID: 1334024568}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &1334714947
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1338500824
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -44590,7 +44650,7 @@ PrefabInstance:
     - target: {fileID: 4245844695371101720, guid: 650450916815dfb4ba0aa087a3006beb,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 4245844695371101720, guid: 650450916815dfb4ba0aa087a3006beb,
         type: 3}
@@ -44742,6 +44802,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1367974407}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1369855876
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1374353899
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -45245,18 +45317,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1386949856}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1390875028
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1391010751
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -45447,18 +45507,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1391076298}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1394486684
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1408350728
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -46567,7 +46615,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8cd47c8a7b3ca4905983be3a08c1caf0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &1432018176
+--- !u!114 &1436433289
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -46577,6 +46625,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1436589093
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &1441884402
@@ -46743,18 +46803,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8cd47c8a7b3ca4905983be3a08c1caf0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1449264924
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &1454223586
@@ -46974,7 +47022,7 @@ PrefabInstance:
     - target: {fileID: 2778777903733453973, guid: e41afb7979b591443b008859f958eca6,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2778777903733453973, guid: e41afb7979b591443b008859f958eca6,
         type: 3}
@@ -47938,18 +47986,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1506207025}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1511803632
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1512476824
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -47976,7 +48012,7 @@ PrefabInstance:
     - target: {fileID: 1846153452591548922, guid: 397461e981e81df4c8983f127dbabae6,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 1846153452591548922, guid: 397461e981e81df4c8983f127dbabae6,
         type: 3}
@@ -49133,6 +49169,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1541257130}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1554371506
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1554490277
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -49222,6 +49270,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1554490277}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1564680165
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1570690944
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -49311,7 +49371,7 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1570690944}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1574192899
+--- !u!114 &1571154413
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -49321,6 +49381,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1572956958
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &1574873115
@@ -49590,18 +49662,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1582351501}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1583686418
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1583894991
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -49623,12 +49683,12 @@ PrefabInstance:
     - target: {fileID: 4413554447041905189, guid: 20a3d1857d5f66c4aa945129302471a7,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 4.99
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 4413554447041905189, guid: 20a3d1857d5f66c4aa945129302471a7,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 23.94
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 4413554447041905189, guid: 20a3d1857d5f66c4aa945129302471a7,
         type: 3}
@@ -50593,18 +50653,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1622150891}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1627737941
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1637354464
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -50854,18 +50902,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8cd47c8a7b3ca4905983be3a08c1caf0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1644476983
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &1645777818
@@ -51288,6 +51324,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1646479481}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1650439299
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1650820439
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -51589,18 +51637,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1655136989}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1656128935
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1658125717
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -53048,6 +53084,30 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1686144801}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1686876710
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1689112445
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1693346265
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -53431,6 +53491,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1696460839
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1697476656
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -53654,18 +53726,6 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
---- !u!114 &1699958611
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1700063233
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -54488,7 +54548,7 @@ PrefabInstance:
     - target: {fileID: 3650718730568828686, guid: b35a262356250504fbfa735d183f9998,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3650718730568828686, guid: b35a262356250504fbfa735d183f9998,
         type: 3}
@@ -54854,6 +54914,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1730604781
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1736551748
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -54953,6 +55025,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1740794056
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &1741683743
@@ -55257,7 +55341,7 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1744447348}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1748064981
+--- !u!114 &1745212692
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -55266,7 +55350,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &1748333004
@@ -55988,7 +56072,7 @@ PrefabInstance:
     - target: {fileID: 4245844695371101720, guid: 650450916815dfb4ba0aa087a3006beb,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 4245844695371101720, guid: 650450916815dfb4ba0aa087a3006beb,
         type: 3}
@@ -56140,18 +56224,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1764626439}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1766755420
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1770467960
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -56523,11 +56595,16 @@ PrefabInstance:
     - target: {fileID: 2089160542943999880, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: CurrentDirection
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2089160542943999880, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: InitialDirection
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2089160542943999880, guid: c937e0abe85aca9499d09951de736ec6,
+        type: 3}
+      propertyPath: SynchroniseCurrentDirection
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2561115454955776467, guid: c937e0abe85aca9499d09951de736ec6,
@@ -56572,7 +56649,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 33.98
+      value: 35
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -56587,7 +56664,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -56602,7 +56679,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.7071068
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -57418,18 +57495,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1786221647}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1786755374
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1786806495
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -57753,12 +57818,12 @@ PrefabInstance:
     - target: {fileID: 3238057358945659066, guid: f93f1ab0ed9820742b43e07cb9375aec,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 4.9902344
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3238057358945659066, guid: f93f1ab0ed9820742b43e07cb9375aec,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 23.900116
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 3238057358945659066, guid: f93f1ab0ed9820742b43e07cb9375aec,
         type: 3}
@@ -59211,18 +59276,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b795fd3e621e742b0aafdb501b9d36cf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &1833581647
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1847509013
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -59503,7 +59556,7 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1848403329}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1848478749
+--- !u!114 &1849394951
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -59512,7 +59565,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &1849713346
@@ -59623,18 +59676,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1849713346}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1849960089
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1850723244
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -60121,18 +60162,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1864589585}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1865082607
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1866910196
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -60584,18 +60613,6 @@ SortingGroup:
     type: 3}
   m_PrefabInstance: {fileID: 1887332250}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1893712010
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1894410037
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -61540,7 +61557,7 @@ PrefabInstance:
     - target: {fileID: 3283716107216258734, guid: 4f7ce98391b8ec54493a831134aa65be,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3283716107216258734, guid: 4f7ce98391b8ec54493a831134aa65be,
         type: 3}
@@ -61927,6 +61944,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1927769340}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1930086448
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1932944529
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -62454,18 +62483,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1941444677}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1943768771
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1945989989
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -62631,6 +62648,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8cd47c8a7b3ca4905983be3a08c1caf0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1953559360
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &1955827786
@@ -63101,18 +63130,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1967890384}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1972779495
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1981086898
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -63735,7 +63752,7 @@ PrefabInstance:
     - target: {fileID: 3283716107216258734, guid: 4f7ce98391b8ec54493a831134aa65be,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3283716107216258734, guid: 4f7ce98391b8ec54493a831134aa65be,
         type: 3}
@@ -63877,18 +63894,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1987970524}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1990941399
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1993081778
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -64054,18 +64059,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8cd47c8a7b3ca4905983be3a08c1caf0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1993576772
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &1994250933
@@ -65434,18 +65427,6 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
---- !u!114 &2024565471
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &2027910242
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -66255,6 +66236,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2038291500}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2039582666
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2039769977
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -66791,6 +66784,18 @@ SortingGroup:
     type: 3}
   m_PrefabInstance: {fileID: 2048301282}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2048955465
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2049263164
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -67085,7 +67090,7 @@ PrefabInstance:
     - target: {fileID: 1427000246303903125, guid: 288980126acf5f441841169958c31630,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 28
+      value: 27
       objectReference: {fileID: 0}
     - target: {fileID: 1427000246303903125, guid: 288980126acf5f441841169958c31630,
         type: 3}
@@ -67331,6 +67336,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2066003539}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2070357596
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2070430885
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -67403,6 +67420,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2070430885}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2070936164
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2078210546
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -67571,18 +67600,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2081744465}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &2082831786
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &2086551558
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -67860,7 +67877,7 @@ PrefabInstance:
     - target: {fileID: 1846153452591548922, guid: 397461e981e81df4c8983f127dbabae6,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 1846153452591548922, guid: 397461e981e81df4c8983f127dbabae6,
         type: 3}
@@ -68163,19 +68180,7 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2097929269}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &2098121336
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &2099230165
+--- !u!114 &2099731827
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -68405,18 +68410,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2111543442}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &2112088582
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &2120879462
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -72492,6 +72485,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2140578774}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2141389021
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2142004859
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scenes/AsteroidScenes/Ruin02.unity
+++ b/UnityProject/Assets/Scenes/AsteroidScenes/Ruin02.unity
@@ -120,18 +120,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!114 &28478
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &333859
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -529,6 +517,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 43395991}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &77113525
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &80674190
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -865,6 +865,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 118286355}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &126282880
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &126439066
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1589,18 +1601,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 240872013}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &243726599
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &282894986
 GameObject:
   m_ObjectHideFlags: 0
@@ -2573,30 +2573,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 448517646}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &448517648 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2409827327891946488, guid: 3fdd9b0cc7f8f344585d7ff27eb83dc6,
-    type: 3}
-  m_PrefabInstance: {fileID: 448517646}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 817f11041af626f49bdae27be1c0fb60, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &455512111
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &458465947
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3283,13 +3259,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2288eee7139e28942a7c0163c3e507f4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  FuelLevel: 0
-  Connector: {fileID: 448517648}
-  MatrixMove: {fileID: 0}
-  FuelConsumption: 0
-  MassConsumption: 0.5
-  CalculatedMassConsumption: 0
-  optimumMassConsumption: 0.05
 --- !u!114 &528075262
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3713,18 +3682,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 573871355}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &591458937
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &602230136
 GameObject:
   m_ObjectHideFlags: 0
@@ -5029,12 +4986,12 @@ PrefabInstance:
     - target: {fileID: 7445965954836857213, guid: a6be4f14190d70d4ead5531b5e15d5f9,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 19.15
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 7445965954836857213, guid: a6be4f14190d70d4ead5531b5e15d5f9,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 6.09
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 7445965954836857213, guid: a6be4f14190d70d4ead5531b5e15d5f9,
         type: 3}
@@ -5049,17 +5006,17 @@ PrefabInstance:
     - target: {fileID: 7445965954836857213, guid: a6be4f14190d70d4ead5531b5e15d5f9,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7445965954836857213, guid: a6be4f14190d70d4ead5531b5e15d5f9,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7445965954836857213, guid: a6be4f14190d70d4ead5531b5e15d5f9,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7445965954836857213, guid: a6be4f14190d70d4ead5531b5e15d5f9,
         type: 3}
@@ -6862,7 +6819,7 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
---- !u!114 &1070694038
+--- !u!114 &1080589225
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -6963,6 +6920,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1090233217}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1108798354
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1115833382
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7688,18 +7657,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1276051602}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1283995843
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1321253403
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7863,7 +7820,7 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1326957340}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1332926348
+--- !u!114 &1333683387
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -7872,7 +7829,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &1400562272
@@ -8402,18 +8359,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1462603654}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1469156046
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1472818979
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8762,6 +8707,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1523209410}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1536439790
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1557410376
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -11450,6 +11407,7 @@ MonoBehaviour:
   IsSpaceMatrix: 0
   IsMainStation: 0
   IsLavaLand: 0
+  MatrixMove: {fileID: 0}
   AIShuttleShouldAvoid: 1
   PresentPlayers: []
   UpdatedPlayerFrame: 0
@@ -12062,6 +12020,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1879846654}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1916394905
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1922422982
 GameObject:
   m_ObjectHideFlags: 0
@@ -14282,6 +14252,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d007c14d2939f4fb2a1121b89c7a030e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1944936144
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1954254928
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -14706,18 +14688,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 44c43d3fd88f44c684f0d47dbaee2bfa, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &1994677379
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &2001457677
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -14827,18 +14797,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2001457677}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &2014956042
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &2020203370
 GameObject:
   m_ObjectHideFlags: 0
@@ -15434,7 +15392,12 @@ PrefabInstance:
     - target: {fileID: 2883810215281542680, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: CurrentDirection
-      value: 2
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2883810215281542680, guid: fde32c02abddc814f9366ff1fb21f234,
+        type: 3}
+      propertyPath: SynchroniseCurrentDirection
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 6807309527984598602, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -15459,12 +15422,12 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 19
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 6.99
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -15474,7 +15437,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: -0.7071068
+      value: -0.00000004371139
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -15489,7 +15452,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.7071068
+      value: -1
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -15541,6 +15504,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2105898520}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2110234003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2126097628
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -15630,6 +15605,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2126097628}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2129724631
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2133821958
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Items mapped to the same tile as lights spawn the items inside the lights, this pr fixes the only instances of this occurring on asteroids

Moves light from ontop of the lower table to the wall above on ruins02
![2024-06-25-04:43:44](https://github.com/unitystation/unitystation/assets/55225562/43f0bb67-b299-4f4f-ae51-1d15f1c14664)

Moves container full of seeds left so its not under the lightbulb on ancientstation
![2024-06-25-04:44:06](https://github.com/unitystation/unitystation/assets/55225562/063fe572-72fd-421a-81f3-ccceb84ecc19)

Moves lightbulb from above the lower left rack to the bottom wall on ancientstation
![2024-06-25-04:44:15](https://github.com/unitystation/unitystation/assets/55225562/c3590bec-8aae-4331-ae97-492a34f7d02d)

