### PR TITLE
Adds sorting for named slots for clothing UI

### DIFF
--- a/UnityProject/Assets/Prefabs/UI/Panel_Hud_Bottom.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Panel_Hud_Bottom.prefab
@@ -190,78 +190,6 @@ MonoBehaviour:
   m_Spacing: {x: 7, y: 7}
   m_Constraint: 1
   m_ConstraintCount: 2
---- !u!1 &243854348625914256
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4233983702166074482}
-  - component: {fileID: 672440398184173801}
-  - component: {fileID: 1227188888283216636}
-  - component: {fileID: 1184713778972888216}
-  m_Layer: 5
-  m_Name: Shoes (1)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &4233983702166074482
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 243854348625914256}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 3286557468392014776}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0, y: 0}
---- !u!222 &672440398184173801
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 243854348625914256}
-  m_CullTransparentMesh: 0
---- !u!114 &1227188888283216636
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 243854348625914256}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 38a02f32610d09c4aaefe46dec0d0d0f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  baseTooltip: 
-  baseExitTooltip: 
---- !u!114 &1184713778972888216
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 243854348625914256}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cd0ae0d927c244ce7bafe7759bdaebfb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &266574511538156855
 GameObject:
   m_ObjectHideFlags: 0
@@ -1084,13 +1012,12 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4233983702166074482}
+  m_Children: []
   m_Father: {fileID: 1824531136933978597}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: 93.7, y: 40.6}
+  m_AnchoredPosition: {x: 99, y: 113.100006}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 1, y: 0}
 --- !u!222 &4857016711109714905
@@ -1168,7 +1095,7 @@ MonoBehaviour:
   m_CellSize: {x: 66, y: 66}
   m_Spacing: {x: 7, y: 7}
   m_Constraint: 1
-  m_ConstraintCount: 2
+  m_ConstraintCount: 3
 --- !u!1 &854580475937671771
 GameObject:
   m_ObjectHideFlags: 0
@@ -8842,7 +8769,6 @@ MonoBehaviour:
   OpenSlots: []
   Pockets: {fileID: 187606637373623070}
   SuitStorage: {fileID: 2028057056706002670}
-  Hands: {fileID: 0}
   BeltPDABackpack: {fileID: 6048557527970446322}
   Clothing: {fileID: 676099764615448730}
   SlotPrefab: {fileID: 1797031250616714, guid: 31a7e33d28b1bc54682ad8da4173418a, type: 3}
@@ -10142,6 +10068,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7070938846388989243, guid: 77692e85c2a37aa49b42216dec43c3d0,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []


### PR DESCRIPTION
closes #10114

![image](https://github.com/unitystation/unitystation/assets/34368774/e0e32113-109f-4c83-991b-3609963f5ad6)


CL: [Improvement] The clothing UI has been updated to sort slots based on their characteristics.
CL: [Improvement] The clothing UI will now display slots in 3 columns instead of two.
