### PR TITLE
Add Pump examine/tooltip text and pipe action messages

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Binary/GasTemperatureGateOff.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Atmos/PipeObjects/Binary/GasTemperatureGateOff.prefab
@@ -216,6 +216,16 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: b0acb51e1d67bac48a3d15a157fef8bb,
         type: 3}
+    - target: {fileID: 8163608160046166977, guid: 40b91fa71481bb54cbec1e89fa1ff1d2,
+        type: 3}
+      propertyPath: initialName
+      value: temperature gate
+      objectReference: {fileID: 0}
+    - target: {fileID: 8163608160046166977, guid: 40b91fa71481bb54cbec1e89fa1ff1d2,
+        type: 3}
+      propertyPath: initialDescription
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 8913505815451129662, guid: 40b91fa71481bb54cbec1e89fa1ff1d2,
         type: 3}
       propertyPath: variantIndex

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/WrenchPipeDeconstruction.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/WrenchPipeDeconstruction.asset
@@ -13,5 +13,8 @@ MonoBehaviour:
   m_Name: WrenchPipeDeconstruction
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 024541a41c4ab42a499f8e49374496d4, type: 2}
-  performerStartActionMessage: ' you unwrench the pipe '
-  othersStartActionMessage: '{performer} unwrenches the pipe '
+  performerStartActionMessage: You start to unfasten the pipe...
+  othersStartActionMessage: '{performer} starts to unfasten the pipe...'
+  seconds: 1
+  performerFinishActionMessage: You unfasten the pipe.
+  othersFinishActionMessage: '{performer} unfastens the pipe.'

--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/PipeDeconstruction.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/PipeDeconstruction.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 using Objects.Atmospherics;
 
 
@@ -18,11 +17,24 @@ namespace Tiles.Pipes
 
 		[Tooltip("Action message to performer when they begin this interaction.")]
 		[SerializeField]
-		private string performerStartActionMessage = " you unwrench the pipe ";
+		private string performerStartActionMessage = null;
 
 		[Tooltip("Use {performer} for performer name. Action message to others when the performer begins this interaction.")]
 		[SerializeField]
-		private string othersStartActionMessage = "{performer} unwrenches the pipe ";
+		private string othersStartActionMessage = null;
+
+		[Tooltip("Seconds taken to perform this action. Leave at 0 for instant.")]
+		[SerializeField]
+		private float seconds = 0;
+
+		[Tooltip("Action message to performer when they finish this interaction.")]
+		[SerializeField]
+		private string performerFinishActionMessage = null;
+
+		[Tooltip("Use {performer} for performer name. Action message to others when performer finishes this interaction.")]
+		[SerializeField]
+		private string othersFinishActionMessage = null;
+
 
 		public override bool WillInteract(TileApply interaction, NetworkSide side)
 		{
@@ -37,9 +49,6 @@ namespace Tiles.Pipes
 
 		public override void ServerPerformInteraction(TileApply interaction)
 		{
-			string othersMessage = Chat.ReplacePerformer(othersStartActionMessage, interaction.Performer);
-			Chat.AddActionMsgToChat(interaction.Performer, performerStartActionMessage, othersMessage);
-
 			if (interaction.BasicTile.LayerType != LayerType.Pipe) return;
 
 			var pipeTile = interaction.BasicTile as PipeTile;
@@ -50,13 +59,12 @@ namespace Tiles.Pipes
 			{
 				if (metaDataNode.PipeData[i].RelatedTile != pipeTile) continue; //TODO Stuff like layers and stuff can be included
 
-				ToolUtils.ServerUseToolWithActionMessages(interaction, 1f,
-						"You start to deconstruct the pipe..",
-						$"{interaction.Performer.ExpensiveName()} starts to deconstruct the pipe...",
-						"You deconstruct the pipe",
-						$"{interaction.Performer.ExpensiveName()} deconstructs the pipe.",
-						() => { metaDataNode.PipeData[i].pipeData.Remove(); });
-
+				ToolUtils.ServerUseToolWithActionMessages(interaction, seconds,
+					performerStartActionMessage,
+					Chat.ReplacePerformer(othersStartActionMessage, interaction.Performer),
+					performerFinishActionMessage,
+					Chat.ReplacePerformer(othersFinishActionMessage, interaction.Performer),
+					() => { metaDataNode.PipeData[i].pipeData.Remove(); });
 				return;
 				// var Transform =  matrix.UnderFloorLayer.GetMatrix4x4(metaDataNode.PipeData[i].NodeLocation, metaDataNode.PipeData[i].RelatedTile);
 				// var pipe = Spawn.ServerPrefab(PipeTile.SpawnOnDeconstruct, interaction.WorldPositionTarget, localRotation : QuaternionFromMatrix(Transform)).GameObject;

--- a/UnityProject/Assets/Scripts/Items/Pipes/PipeItem.cs
+++ b/UnityProject/Assets/Scripts/Items/Pipes/PipeItem.cs
@@ -58,8 +58,12 @@ namespace Items.Atmospherics
 				{
 					return;
 				}
-				ToolUtils.ServerPlayToolSound(interaction);
-				BuildPipe();
+				ToolUtils.ServerUseToolWithActionMessages(interaction, 0,
+						string.Empty,
+						string.Empty,
+						$"You fasten the {gameObject.ExpensiveName()}.",
+						$"{interaction.Performer} fastens the {gameObject.ExpensiveName()}",
+						BuildPipe);
 			}
 			else
 			{

--- a/UnityProject/Assets/Scripts/Objects/Pipes/Devices/PassiveGate.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/Devices/PassiveGate.cs
@@ -1,12 +1,14 @@
 using System;
+using System.Collections.Generic;
 using Messages.Server;
 using UnityEngine;
 using Systems.Interaction;
 using Systems.Pipes;
+using UI.Systems.Tooltips.HoverTooltips;
 
 namespace Objects.Atmospherics
 {
-	public class PassivePump : MonoPipe
+	public class PassivePump : MonoPipe, IHoverTooltip
 	{
 		public SpriteHandler spriteHandlerOverlay = null;
 
@@ -94,6 +96,36 @@ namespace Objects.Atmospherics
 			};
 			
 			inputPipe.GetMixAndVolume.TransferTo(pipeData.mixAndVolume, transferValue);
+		}
+
+		public string HoverTip()
+		{
+			return null;
+		}
+
+		public string CustomTitle()
+		{
+			return null;
+		}
+
+		public Sprite CustomIcon()
+		{
+			return null;
+		}
+
+		public List<Sprite> IconIndicators()
+		{
+			return null;
+		}
+
+		public List<TextColor> InteractionsStrings()
+		{
+			var list = new List<TextColor>
+			{
+				new() { Color = Color.green, Text = "Left Click: Toggle Power." },
+				new() { Color = Color.green, Text = "Alt Click: Open GUI." }
+			};
+			return list;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Objects/Pipes/Devices/PressureValve.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/Devices/PressureValve.cs
@@ -1,12 +1,14 @@
 using System;
+using System.Collections.Generic;
 using Messages.Server;
 using UnityEngine;
 using Systems.Interaction;
 using Systems.Pipes;
+using UI.Systems.Tooltips.HoverTooltips;
 
 namespace Objects.Atmospherics
 {
-	public class PressureValve: MonoPipe
+	public class PressureValve: MonoPipe, IHoverTooltip
 	{
 		public SpriteHandler spriteHandlerOverlay = null;
 
@@ -86,6 +88,36 @@ namespace Objects.Atmospherics
 			{
 				pipeData.mixAndVolume.EqualiseWithOutputs(pipeData.ConnectedPipes);
 			}
+		}
+
+		public string HoverTip()
+		{
+			return null;
+		}
+
+		public string CustomTitle()
+		{
+			return null;
+		}
+
+		public Sprite CustomIcon()
+		{
+			return null;
+		}
+
+		public List<Sprite> IconIndicators()
+		{
+			return null;
+		}
+
+		public List<TextColor> InteractionsStrings()
+		{
+			var list = new List<TextColor>
+			{
+				new() { Color = Color.green, Text = "Left Click: Toggle Power." },
+				new() { Color = Color.green, Text = "Alt Click: Open GUI." }
+			};
+			return list;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Objects/Pipes/Devices/Pump.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/Devices/Pump.cs
@@ -1,12 +1,14 @@
-﻿using Messages.Server;
+﻿using System.Collections.Generic;
+using Messages.Server;
 using UnityEngine;
 using Systems.Interaction;
 using Systems.Pipes;
+using UI.Systems.Tooltips.HoverTooltips;
 
 
 namespace Objects.Atmospherics
 {
-	public class Pump : MonoPipe
+	public class Pump : MonoPipe, IHoverTooltip
 	{
 		public SpriteHandler spriteHandlerOverlay = null;
 
@@ -114,6 +116,36 @@ namespace Objects.Atmospherics
 			}
 
 			pipeData.mixAndVolume.EqualiseWithOutputs(pipeData.Outputs);
+		}
+
+		public string HoverTip()
+		{
+			return null;
+		}
+
+		public string CustomTitle()
+		{
+			return null;
+		}
+
+		public Sprite CustomIcon()
+		{
+			return null;
+		}
+
+		public List<Sprite> IconIndicators()
+		{
+			return null;
+		}
+
+		public List<TextColor> InteractionsStrings()
+		{
+			var list = new List<TextColor>
+			{
+				new() { Color = Color.green, Text = "Left Click: Toggle Power." },
+				new() { Color = Color.green, Text = "Alt Click: Open GUI." }
+			};
+			return list;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Objects/Pipes/Devices/TemperatureGate.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/Devices/TemperatureGate.cs
@@ -1,12 +1,14 @@
 using System;
+using System.Collections.Generic;
 using Messages.Server;
 using UnityEngine;
 using Systems.Interaction;
 using Systems.Pipes;
+using UI.Systems.Tooltips.HoverTooltips;
 
 namespace Objects.Atmospherics
 {
-	public class TemperatureGate: MonoPipe
+	public class TemperatureGate: MonoPipe, IHoverTooltip, IExaminable
 	{
 		public SpriteHandler spriteHandlerOverlay = null;
 
@@ -94,6 +96,43 @@ namespace Objects.Atmospherics
 			{
 				pipeData.mixAndVolume.EqualiseWithOutputs(pipeData.ConnectedPipes);
 			}
+		}
+
+
+		public string Examine(Vector3 worldPos = default)
+		{
+			return $"The gate has been set to let gas flow when the input gas temp is {(isInverted ? "higher" : "lower")} than set threshold.";
+		}
+
+		public string HoverTip()
+		{
+			return null;
+		}
+
+		public string CustomTitle()
+		{
+			return null;
+		}
+
+		public Sprite CustomIcon()
+		{
+			return null;
+		}
+
+		public List<Sprite> IconIndicators()
+		{
+			return null;
+		}
+
+		public List<TextColor> InteractionsStrings()
+		{
+			var list = new List<TextColor>
+			{
+				new() { Color = Color.green, Text = "Left Click: Toggle Power." },
+				new() { Color = Color.green, Text = $"Left Click with screwdriver: {(isInverted ? "Reset" : "Invert" )} temperature sensor." },
+				new() { Color = Color.green, Text = "Alt Click: Open GUI." }
+			};
+			return list;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Objects/Pipes/Devices/VolumePump.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/Devices/VolumePump.cs
@@ -1,13 +1,15 @@
 using System;
+using System.Collections.Generic;
 using Messages.Server;
 using Systems.Atmospherics;
 using UnityEngine;
 using Systems.Interaction;
 using Systems.Pipes;
+using UI.Systems.Tooltips.HoverTooltips;
 
 namespace Objects.Atmospherics
 {
-	public class VolumePump : MonoPipe
+	public class VolumePump : MonoPipe, IHoverTooltip, IExaminable
 	{
 		public SpriteHandler spriteHandlerOverlay = null;
 		public SpriteHandler spriteHandlerOverclockedOverlay = null;
@@ -148,6 +150,42 @@ namespace Objects.Atmospherics
 		public static float FiniteOrDefault(float value)
 		{
 		    return float.IsNaN(value) == false && float.IsInfinity(value) == false ? value : default;
+		}
+
+		public string Examine(Vector3 worldPos = default)
+		{
+			return $"The volume pump pressure limiters are {(isOverclocked ? "disabled" : "enabled")}";
+		}
+
+		public string HoverTip()
+		{
+			return null;
+		}
+
+		public string CustomTitle()
+		{
+			return null;
+		}
+
+		public Sprite CustomIcon()
+		{
+			return null;
+		}
+
+		public List<Sprite> IconIndicators()
+		{
+			return null;
+		}
+
+		public List<TextColor> InteractionsStrings()
+		{
+			var list = new List<TextColor>
+			{
+				new() { Color = Color.green, Text = "Left Click: Toggle Power." },
+				new() { Color = Color.green, Text = "Left Click with screwdriver: Toggle pressure limiters." },
+				new() { Color = Color.green, Text = "Alt Click: Open GUI." }
+			};
+			return list;
 		}
 	}	
 }

--- a/UnityProject/Assets/Scripts/Objects/Pipes/MonoPipe.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/MonoPipe.cs
@@ -180,8 +180,15 @@ namespace Objects.Atmospherics
 			}
 			else
 			{
-				ToolUtils.ServerPlayToolSound(interaction);
-				Unwrench(interaction);
+				ToolUtils.ServerUseToolWithActionMessages(interaction, 0,
+					string.Empty,
+					string.Empty,
+					$"You unfasten the {gameObject.ExpensiveName()}.",
+					$"{interaction.Performer} unfastens the {gameObject.ExpensiveName()}",
+					() =>
+					{
+						Unwrench(interaction);
+					});
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Systems/Construction/Machine.cs
+++ b/UnityProject/Assets/Scripts/Systems/Construction/Machine.cs
@@ -96,7 +96,7 @@ namespace Objects.Machines
 				if (panelopen)
 				{
 					Chat.AddActionMsgToChat(interaction.Performer,
-						$"You unscrews the {gameObject.ExpensiveName()}'s cable panel.",
+						$"You unscrew the {gameObject.ExpensiveName()}'s cable panel.",
 						$"{interaction.Performer.ExpensiveName()} unscrews {gameObject.ExpensiveName()}'s cable panel.");
 					return;
 				}


### PR DESCRIPTION
Fixes the temperature gate item name
Adds interaction strings for the hover tooltip to all pumps and examine text to the volume pump and temperature gate
Fixes pipes having two different action messages shown in chat at the same time when unsecuring them
Adds action messages for securing and unsecuring pumps (You fasten/unfasten the {name})
Adds action messages for securing a pipe (You fasten/ufasten the pipe)
Fixes the action message for unscrewing the cable panel on machines 

### Changelog:
<!-- Add here individual lines with all your remarkable changes using the prefix ``CL:`` -->
<!-- Mind that the changes meant to be logged in the in changelog are those that are remarkable for the end user, so things like new features and fixes of known bugs are perfect for this section -->

CL: [Improvement] Hover tooltips and examine text for pumps.

<!-- CL: [New] For new features, things that didn't exist before the PR. -->

<!-- CL: [Improvement] For any change on any existing feature. -->

<!-- CL: [Balance] For any change on an existing feature done in the sake of improving game balance. It's the only exception to the rule above. -->

<!-- CL: [Fix] For any change that fixes a bug. -->
