### PR TITLE
FIx syndicate uplink not having the new prefab entries in it

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/PDA/UplinkCategoryList.asset
+++ b/UnityProject/Assets/ScriptableObjects/PDA/UplinkCategoryList.asset
@@ -223,11 +223,13 @@ MonoBehaviour:
       name: Syndicate Minibomb
       isNukeOps: 0
     - cost: 1
-      item: {fileID: 896716891640034833, guid: 0a45eeafcc7b5164bb139db7bf25c0a8, type: 3}
+      item: {fileID: 6621940020426841340, guid: 55e7ca4ce21d0bb4b816d936646959b7,
+        type: 3}
       name: C4
       isNukeOps: 0
     - cost: 4
-      item: {fileID: 896716891640034833, guid: 9ca978c567f2e5c4bb8a6be3190717f7, type: 3}
+      item: {fileID: 5706955965134215350, guid: de353c0b5bf1ce64ab77542efc42ed8e,
+        type: 3}
       name: X4
       isNukeOps: 0
     - cost: 24
@@ -246,12 +248,12 @@ MonoBehaviour:
       name: EMP grenade box
       isNukeOps: 0
     - cost: 15
-      item: {fileID: 1011433845357754, guid: 2354313a50efe2543862cb92150a5388, type: 3}
+      item: {fileID: 6285642168130081169, guid: 6cf09f0799c28cf4eb34908ccab8122a,
+        type: 3}
       name: Power Sink
       isNukeOps: 0
     - cost: 20
-      item: {fileID: 4761250752494374682, guid: 00265c28041a8b84f9012e430f772f08,
-        type: 3}
+      item: {fileID: 342081685440327241, guid: 1f5b619819c7bd44eb9f1f1f45d08e4d, type: 3}
       name: Syndicate Bomb
       isNukeOps: 0
     - cost: 2


### PR DESCRIPTION
CL: [Fix] Fix the syndicate uplink not letting you buy the c4, x4, power sink and the syndi bomb.