### PR TITLE
Items can cause damage when thrown at players again

### DIFF
--- a/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
+++ b/UnityProject/Assets/Scripts/Core/UniversalObjectPhysics.cs
@@ -1718,8 +1718,7 @@ public class UniversalObjectPhysics : NetworkBehaviour, IRightClickable, IRegist
 			{
 				integrity.ApplyDamage(damage, AttackType.Melee, iav2.ServerDamageType);
 			}
-			//TODO: Catching
-			//(Max): Catching what?
+			//TODO: Add the ability to catch thrown objects if the player has the "throw" state enabled on them.
 			if (hit.TryGetComponent<LivingHealthMasterBase>(out var livingHealthMasterBase) && isServer)
 			{
 				var randomHitZone = aim.Randomize();

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/StomachExpulsion.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Vomit/StomachExpulsion.cs
@@ -50,7 +50,7 @@ namespace Items.Implants.Organs.Vomit
 				vomitSound, LivingHealthMaster.gameObject.AssumedWorldPosServer());
 		}
 
-		private bool WillDryHeave()
+		public bool WillDryHeave()
 		{
 			if (dryHeavingEmote == null) return false;
 			if (stomach.StomachContents.IsEmpty == false || stomach.StomachContents.CurrentReagentMix.Total > 0.09f) return false;

--- a/UnityProject/Assets/Scripts/Player/EmoteScripts/Vomit.cs
+++ b/UnityProject/Assets/Scripts/Player/EmoteScripts/Vomit.cs
@@ -34,11 +34,12 @@ namespace Player.EmoteScripts
 			foreach (var part in bodyParts)
 			{
 				if (part.TryGetComponent<StomachExpulsion>(out var stomach) == false) continue;
+				if (stomach.WillDryHeave()) continue;
 				stomach.Vomit();
 				base.Do(player);
 				return;
 			}
-			if(instant == false) Chat.AddExamineMsg(player, "You do not have a stomach to do this...");
+			if (instant == false) Chat.AddExamineMsg(player, "You do not have a stomach to do this...");
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
+++ b/UnityProject/Assets/Scripts/Player/MovementV2/MovementSynchronisation.cs
@@ -340,7 +340,7 @@ public class MovementSynchronisation : UniversalObjectPhysics, IPlayerControllab
 	public void ImpactVomit(UniversalObjectPhysics ob, Vector2 Newtonian)
 	{
 		if (VomitEmote == null) return;
-		if (Newtonian.magnitude > 6.5f)
+		if (Newtonian.magnitude > 7f && DMMath.Prob(75))
 		{
 			EmoteActionManager.DoEmote(VomitEmote, gameObject);
 		}


### PR DESCRIPTION
CL: [Improvement] Players vomiting from being thrown around is now locked behind a 75% roll to avoid players from abusing the vomit stuns more frequently.
CL: [Fix] Fixed an issue where players did not receive damage upon getting hit by an object. This will make spears useable again.
CL: [Fix] Fixed an issue where the vomit emote would force the player to dry heave twice.
