### PR TITLE
Adds character speech limit to tounges

### DIFF
--- a/UnityProject/Assets/Prefabs/Chat/ChatSystem.prefab
+++ b/UnityProject/Assets/Prefabs/Chat/ChatSystem.prefab
@@ -58,6 +58,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 5431052916838343998, guid: 94208a0928046438d9b8a00796e7a5a7,
     type: 2}
   m_audioClip: {fileID: 0}
+  m_Resource: {fileID: 0}
   m_PlayOnAwake: 0
   m_Volume: 0.72
   m_Pitch: 1
@@ -247,7 +248,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bce6ebc820bc96f41b4b46c9e60cf195, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  cpmMax: 500
+  cpmMax: 700
   cpmMinCharacters: 5
   cpmWarning: You ran out of breath before you finished speaking.
   cpmWarningOOC: Your messages have been too long, please slow down.

--- a/UnityProject/Assets/Prefabs/Items/Implants/cyborg/Artificial Brain.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/cyborg/Artificial Brain.prefab
@@ -244,8 +244,9 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 873b362aa82d0274eb311c8003a29a2b, type: 2}
   - {fileID: 11400000, guid: 47efbe39a7009d9419eb48769a2409c3, type: 2}
   - {fileID: 11400000, guid: 94628fa641ba01342a5db9ad420c45e6, type: 2}
-  speechModifiers: 0
+  speechModifiers: 16777216
   <CannotSpeak>k__BackingField: 0
+  maximumCharactersCanBeSpokenInOneMessage: 64
 --- !u!114 &5156403850238146881
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -313,19 +313,14 @@ namespace HealthV2
 		public GameObject MeatProduce => meatProduce;
 		public GameObject SkinProduce => skinProduce;
 
-
 		[NonSerialized] public MultiInterestBool IsMute = new MultiInterestBool(true,
 			MultiInterestBool.RegisterBehaviour.RegisterFalse,
 			MultiInterestBool.BoolBehaviour.ReturnOnTrue);
-
+		[NonSerialized] public MultiInterestFloat SpeakCharacterLimit = new MultiInterestFloat(-1f);
+		[NonSerialized] public PlayerHealthData InitialSpecies = null;
 		[SerializeField, Range(1, 60f)] private float updateTime = 1f;
 
-		[NonSerialized] public PlayerHealthData InitialSpecies = null;
-
-
 		private IGib gibBehavior;
-
-		//Default is mute yes
 
 		public bool HasCoreBodyPart()
 		{

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Tongue.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Tongue.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using HealthV2;
 using Player.Language;
-using ScriptableObjects;
 using UnityEngine;
 
 namespace Items.Implants.Organs
@@ -12,7 +11,9 @@ namespace Items.Implants.Organs
 
 		[SerializeField] private List<LanguageSO> languages = new List<LanguageSO>();
 		[SerializeField] private ChatModifier speechModifiers = ChatModifier.None;
-		[field: SerializeField] public bool CannotSpeak {get; private set; }
+		[field: SerializeField] public bool CannotSpeak { get; private set; }
+
+		[SerializeField] private float maximumCharactersCanBeSpokenInOneMessage = 1600;
 
 		public override void OnAddedToBody(LivingHealthMasterBase livingHealth)
 		{
@@ -26,19 +27,20 @@ namespace Items.Implants.Organs
 				mobLanguages.LearnLanguage(language, true);
 			}
 			livingHealth.IsMute.RecordPosition(this, CannotSpeak);
+			livingHealth.SpeakCharacterLimit.RecordPosition(this, maximumCharactersCanBeSpokenInOneMessage);
 			LivingHealthMaster.playerScript.inventorySpeechModifiers = LivingHealthMaster.playerScript.inventorySpeechModifiers | speechModifiers;
 		}
 
 		public override void OnRemovedFromBody(LivingHealthMasterBase livingHealth)
 		{
-			if(CustomNetworkManager.IsServer == false) return;
+			if (CustomNetworkManager.IsServer == false) return;
 			livingHealth.IsMute.RemovePosition(this);
+			livingHealth.SpeakCharacterLimit.RemovePosition(this);
 			foreach (var language in languages)
 			{
 				//Don't remove the language if it is in the default list
-				if(mobLanguages.DefaultLanguages != null && mobLanguages.DefaultLanguages.UnderstoodLanguages.Contains(language)) continue;
-
-				if(language.Flags.HasFlag(LanguageFlags.TonguelessSpeech)) continue;
+				if (mobLanguages.DefaultLanguages != null && mobLanguages.DefaultLanguages.UnderstoodLanguages.Contains(language)) continue;
+				if (language.Flags.HasFlag(LanguageFlags.TonguelessSpeech)) continue;
 
 				//Can no longer speak, but can still understand
 				mobLanguages.RemoveLanguage(language);

--- a/UnityProject/Assets/Scripts/Player/Mind.cs
+++ b/UnityProject/Assets/Scripts/Player/Mind.cs
@@ -191,8 +191,6 @@ public class Mind : NetworkBehaviour, IActionGUI
 	/// </summary>
 	private Dictionary<string, object> properties = new Dictionary<string, object>();
 
-
-
 	public bool IsMute
 	{
 		get
@@ -207,6 +205,15 @@ public class Mind : NetworkBehaviour, IActionGUI
 			}
 
 			return IsMiming;
+		}
+	}
+
+	public float SpeechCharacterLimit
+	{
+		get
+		{
+			var health = GetDeepestBody().GetComponent<LivingHealthMasterBase>();
+			return health != null ? health.SpeakCharacterLimit : 1600f;
 		}
 	}
 


### PR DESCRIPTION
CL: [New] Added speech limits that are influenced by tongues and brains.
CL: [New] Players possessing artificial brains/cyborgs will now speak in a robotic tone.
CL: [New] Artificial brains are no longer talkative. As they can only speak 64 characters at a time.
