### PR TITLE
New Machine connector and conveyor fixes

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Construction/New ConveyorBelt.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Construction/New ConveyorBelt.prefab
@@ -19,10 +19,30 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: b741542666fee104e85d1e45811c983b,
         type: 3}
+    - target: {fileID: 4116897424394887774, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_SortingLayer
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4116897424394887774, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 200
+      objectReference: {fileID: 0}
+    - target: {fileID: 4116897424394887774, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_SortingLayerID
+      value: 322132419
+      objectReference: {fileID: 0}
     - target: {fileID: 4197940402254186057, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
       propertyPath: m_Name
       value: New ConveyorBelt
+      objectReference: {fileID: 0}
+    - target: {fileID: 4197940402254186057, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_Layer
+      value: 23
       objectReference: {fileID: 0}
     - target: {fileID: 4204006106222477459, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Construction/New ConveyorSwitch.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Construction/New ConveyorSwitch.prefab
@@ -24,6 +24,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: New ConveyorSwitch
       objectReference: {fileID: 0}
+    - target: {fileID: 4197940402254186057, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_Layer
+      value: 23
+      objectReference: {fileID: 0}
     - target: {fileID: 4204006106222477459, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -73,6 +78,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4800765294880679425, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: initialPassable
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4800765294880679425, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: initialCrawlPassable
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5737521361753715499, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/Electricity/New Medium Machine Connector.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Electricity/New Medium Machine Connector.prefab
@@ -496,6 +496,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: New Medium Machine Connector
       objectReference: {fileID: 0}
+    - target: {fileID: 4197940402254186057, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_Layer
+      value: 22
+      objectReference: {fileID: 0}
     - target: {fileID: 4204006106222477459, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -553,6 +558,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4800765294880679425, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
+      propertyPath: objectType
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4800765294880679425, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
       propertyPath: initialPassable
       value: 1
       objectReference: {fileID: 0}
@@ -565,6 +575,11 @@ PrefabInstance:
         type: 3}
       propertyPath: initialCrawlPassable
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5388634654466307187, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_Layer
+      value: 29
       objectReference: {fileID: 0}
     - target: {fileID: 5737521361753715499, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
@@ -584,6 +599,7 @@ PrefabInstance:
         type: 2}
     m_RemovedComponents:
     - {fileID: 1481169419180323577, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
+    - {fileID: 7474997010728688467, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: 83141582606814714, guid: ebb08cf966efc084aa918bd8d9429604,


### PR DESCRIPTION
Sets the machine connector object to the floor layer
Sets the conveyor and conveyer switch to the unshootable machines layer
Adjusts the conveyor sprite layer to the floor layer with sorting order set to 200, identical to the old conveyer prefab sprite
Sets the conveyor switch to also be passable and crawl passable, same as the old conveyor switch prefab