### PR TITLE
Remove offset from camera & FOV rendering

### DIFF
--- a/UnityProject/Assets/Prefabs/SceneConstruction/Camera.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/Camera.prefab
@@ -320,7 +320,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 53e3142adc76418db1fe76b4e22c2035, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  yOffSet: -0.5
+  yOffSet: 0
   starScroll: -0.8
   damping: 0
   listenerObj: {fileID: 1187200688554218}
@@ -436,7 +436,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eba83ad86d60dc1478d96b6283f32732, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  fovCenterOffset: {x: 0, y: 0.6, z: 0}
+  fovCenterOffset: {x: 0, y: 0, z: 0}
   fovDistance: 13
   renderSettings:
     viewMode: 0


### PR DESCRIPTION
<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->

### Purpose
Fix this:
![](https://transfur.science/lu7onl9w)

### Notes:
Please review and test this on your own, I'm pretty sure this doesn't introduce any issues but we know what happened *[the last time](https://github.com/unitystation/unitystation/pull/10375)*

### Changelog:
CL: [Fix] Camera is now centered on the player now instead of their feet.