### PR TITLE
Fix missing references to apc component on firelocks/blastdoors/windoors

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Firelocks/Firelock.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Firelocks/Firelock.prefab
@@ -94,6 +94,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c423f5e51deb46791afaa4439d14b4ee, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  apc: {fileID: 5998305020639520956}
 --- !u!1 &3537565085596052285
 GameObject:
   m_ObjectHideFlags: 0
@@ -1122,6 +1123,18 @@ SortingGroup:
     type: 3}
   m_PrefabInstance: {fileID: 2351700664918873728}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &5998305020639520956 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8330720231993589308, guid: 1291a5cb15d008c41bf0a373403f56b2,
+    type: 3}
+  m_PrefabInstance: {fileID: 2351700664918873728}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7092266194031920784}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &7092266194031920784 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4813822218561835024, guid: 1291a5cb15d008c41bf0a373403f56b2,

--- a/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/PodDoors/BlastDoor.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/PodDoors/BlastDoor.prefab
@@ -664,6 +664,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c423f5e51deb46791afaa4439d14b4ee, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  apc: {fileID: 7279317671276405710}
 --- !u!1 &7901964432939451919
 GameObject:
   m_ObjectHideFlags: 0
@@ -1316,3 +1317,15 @@ MonoBehaviour:
       m_SubObjectName: 
       m_SubObjectType: 
       m_EditorAssetChanged: 0
+--- !u!114 &7279317671276405710 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8330720231993589308, guid: 1291a5cb15d008c41bf0a373403f56b2,
+    type: 3}
+  m_PrefabInstance: {fileID: 1628611137711136242}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6077569209427463650}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/WindowDoors/WinDoorLeft.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/WindowDoors/WinDoorLeft.prefab
@@ -307,6 +307,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c423f5e51deb46791afaa4439d14b4ee, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  apc: {fileID: 345023311217890025}
 --- !u!1 &4532754454576057609
 GameObject:
   m_ObjectHideFlags: 0
@@ -1149,6 +1150,18 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 8642803761611812381}
   m_SourcePrefab: {fileID: 100100000, guid: 1291a5cb15d008c41bf0a373403f56b2, type: 3}
+--- !u!114 &345023311217890025 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8330720231993589308, guid: 1291a5cb15d008c41bf0a373403f56b2,
+    type: 3}
+  m_PrefabInstance: {fileID: 8598899142623505621}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3862765748506000581}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &3859295922778749471 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4817606987798484682, guid: 1291a5cb15d008c41bf0a373403f56b2,


### PR DESCRIPTION
I remembered to do this for regular airlocks, but not the rest I guess