### PR TITLE
Fix new nuke prefabs and redo detonation behaviour

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Nuke/New Nuke.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Nuke/New Nuke.prefab
@@ -8,6 +8,11 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 643326484729671418, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: isNotPushable
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 676721839806558615, guid: b06b702714bab49b9ad949eab1ca4534,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Scenes/AdditionalScenes/Fallstation Syndicate.unity
+++ b/UnityProject/Assets/Scenes/AdditionalScenes/Fallstation Syndicate.unity
@@ -916,6 +916,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 47914694}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &62363223
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &119763186
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1947,18 +1959,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 187029211}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &208868950
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &214646308
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2498,12 +2498,12 @@ PrefabInstance:
         type: 3}
       propertyPath: 'runningInterfaces.Array.data[0]'
       value: 
-      objectReference: {fileID: 1024070983}
+      objectReference: {fileID: 802320410}
     - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
         type: 3}
       propertyPath: 'runningInterfaces.Array.data[1]'
       value: 
-      objectReference: {fileID: 1937624972}
+      objectReference: {fileID: 1860488859}
     - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
         type: 3}
       propertyPath: 'NewdoorControllers.Array.data[0]'
@@ -2528,6 +2528,11 @@ PrefabInstance:
         type: 3}
       propertyPath: requiredClearance.Array.size
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8004372364847621320, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'requiredClearance.Array.data[0]'
+      value: 73
       objectReference: {fileID: 0}
     - target: {fileID: 8558682525055023016, guid: ea7280b49083dfa469fb176f6a7e4772,
         type: 3}
@@ -2649,6 +2654,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 279977272}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &290057513
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &315397764
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2733,6 +2750,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 315397764}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &315519666
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &324938620
 GameObject:
   m_ObjectHideFlags: 0
@@ -3691,6 +3720,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 381735214}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &394971687
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &397682264
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3785,6 +3826,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 397682264}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &405645947
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &412397065
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6673,6 +6726,18 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
+--- !u!114 &491939560
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &511507096
 GameObject:
   m_ObjectHideFlags: 0
@@ -8849,18 +8914,6 @@ Grid:
   m_CellGap: {x: 0, y: 0, z: 0}
   m_CellLayout: 0
   m_CellSwizzle: 0
---- !u!114 &639656398
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &641870176
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9227,6 +9280,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 646818841}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &650548562
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &661703969
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9587,18 +9652,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 663230475}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &668783274
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &687637453
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10091,15 +10144,19 @@ Transform:
   - {fileID: 986699494}
   - {fileID: 854191583}
   - {fileID: 257206379}
+  - {fileID: 1315953172}
   - {fileID: 956626198}
   - {fileID: 641870178}
   - {fileID: 1233106253}
   - {fileID: 1968258197}
   - {fileID: 687637454}
   - {fileID: 1945147448}
+  - {fileID: 1319675656}
   - {fileID: 1156855525}
   - {fileID: 1219299329}
   - {fileID: 1957956043}
+  - {fileID: 1462967002}
+  - {fileID: 962840819}
   - {fileID: 2140217041}
   - {fileID: 1447856999}
   - {fileID: 1698766363}
@@ -10131,6 +10188,30 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   LayerType: 2
+--- !u!114 &761105938
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &762600338
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &780032690
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -11779,6 +11860,18 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
+--- !u!114 &802320410
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &814361116
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -12027,6 +12120,18 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
+--- !u!114 &840528348
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &843667052
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -12274,12 +12379,12 @@ PrefabInstance:
         type: 3}
       propertyPath: 'runningInterfaces.Array.data[0]'
       value: 
-      objectReference: {fileID: 208868950}
+      objectReference: {fileID: 62363223}
     - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
         type: 3}
       propertyPath: 'runningInterfaces.Array.data[1]'
       value: 
-      objectReference: {fileID: 1589997693}
+      objectReference: {fileID: 290057513}
     - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
         type: 3}
       propertyPath: 'NewdoorControllers.Array.data[0]'
@@ -12289,6 +12394,11 @@ PrefabInstance:
         type: 3}
       propertyPath: requiredClearance.Array.size
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8004372364847621320, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'requiredClearance.Array.data[0]'
+      value: 73
       objectReference: {fileID: 0}
     - target: {fileID: 8558682525055023016, guid: ea7280b49083dfa469fb176f6a7e4772,
         type: 3}
@@ -12328,18 +12438,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 854191581}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &854921978
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &873577538
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -13896,6 +13994,135 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 956896426}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &962840818
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 757063120}
+    m_Modifications:
+    - target: {fileID: 1443270592161478253, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: isSelfPowered
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -22.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2690072642478446657, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_Name
+      value: ButtonDoor
+      objectReference: {fileID: 0}
+    - target: {fileID: 5803133425061211427, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: sceneId
+      value: 1281339647
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: runningInterfaces.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: NewdoorControllers.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'runningInterfaces.Array.data[0]'
+      value: 
+      objectReference: {fileID: 491939560}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'runningInterfaces.Array.data[1]'
+      value: 
+      objectReference: {fileID: 761105938}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'NewdoorControllers.Array.data[0]'
+      value: 
+      objectReference: {fileID: 956626197}
+    - target: {fileID: 8004372364847621320, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: requiredClearance.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8004372364847621320, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'requiredClearance.Array.data[0]'
+      value: 73
+      objectReference: {fileID: 0}
+    - target: {fileID: 8558682525055023016, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: CurrentDirection
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8558682525055023016, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: SynchroniseCurrentDirection
+      value: 2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ea7280b49083dfa469fb176f6a7e4772, type: 3}
+--- !u!4 &962840819 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+    type: 3}
+  m_PrefabInstance: {fileID: 962840818}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &986699493
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -14054,18 +14281,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 986699493}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1024070983
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1025696546
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -15029,6 +15244,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1120072009}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1121690925
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1132370692
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -19286,7 +19513,7 @@ PrefabInstance:
     - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -23.16
+      value: -23.12
       objectReference: {fileID: 0}
     - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
         type: 3}
@@ -19402,12 +19629,12 @@ PrefabInstance:
         type: 3}
       propertyPath: 'runningInterfaces.Array.data[0]'
       value: 
-      objectReference: {fileID: 854921978}
+      objectReference: {fileID: 650548562}
     - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
         type: 3}
       propertyPath: 'runningInterfaces.Array.data[1]'
       value: 
-      objectReference: {fileID: 639656398}
+      objectReference: {fileID: 1768734580}
     - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
         type: 3}
       propertyPath: 'NewdoorControllers.Array.data[0]'
@@ -19417,6 +19644,11 @@ PrefabInstance:
         type: 3}
       propertyPath: requiredClearance.Array.size
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8004372364847621320, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'requiredClearance.Array.data[0]'
+      value: 73
       objectReference: {fileID: 0}
     - target: {fileID: 8558682525055023016, guid: ea7280b49083dfa469fb176f6a7e4772,
         type: 3}
@@ -19786,6 +20018,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1268977777}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1278275256
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1296461649
 GameObject:
   m_ObjectHideFlags: 0
@@ -21494,6 +21738,210 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
+--- !u!1001 &1315953171
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 757063120}
+    m_Modifications:
+    - target: {fileID: 1443270592161478253, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: isSelfPowered
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2175373348901770226, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2175373348901770226, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2175373348901770226, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 68
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -21
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2690072642478446657, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_Name
+      value: ButtonDoor
+      objectReference: {fileID: 0}
+    - target: {fileID: 5803133425061211427, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: sceneId
+      value: 248807664
+      objectReference: {fileID: 0}
+    - target: {fileID: 6739818006514333705, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: customNetTransform
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: access
+      value: 71
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: restricted
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: doorControllers.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: runningInterfaces.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: NewdoorControllers.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'doorControllers.Array.data[0]'
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'doorControllers.Array.data[1]'
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'doorControllers.Array.data[2]'
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'runningInterfaces.Array.data[0]'
+      value: 
+      objectReference: {fileID: 394971687}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'runningInterfaces.Array.data[1]'
+      value: 
+      objectReference: {fileID: 405645947}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'NewdoorControllers.Array.data[0]'
+      value: 
+      objectReference: {fileID: 1968258198}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'NewdoorControllers.Array.data[1]'
+      value: 
+      objectReference: {fileID: 641870177}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'NewdoorControllers.Array.data[2]'
+      value: 
+      objectReference: {fileID: 1968258198}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'NewdoorControllers.Array.data[3]'
+      value: 
+      objectReference: {fileID: 528758084}
+    - target: {fileID: 8004372364847621320, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: requiredClearance.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8004372364847621320, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'requiredClearance.Array.data[0]'
+      value: 73
+      objectReference: {fileID: 0}
+    - target: {fileID: 8558682525055023016, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: CurrentDirection
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8558682525055023016, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: InitialDirection
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8558682525055023016, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: SynchroniseCurrentDirection
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ea7280b49083dfa469fb176f6a7e4772, type: 3}
+--- !u!4 &1315953172 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+    type: 3}
+  m_PrefabInstance: {fileID: 1315953171}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1319297724
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -21577,6 +22025,210 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5826037586392917993, guid: d8021268b3b5bed46ab286a22a7110c9,
     type: 3}
   m_PrefabInstance: {fileID: 1319297724}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1319675655
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 757063120}
+    m_Modifications:
+    - target: {fileID: 1443270592161478253, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: isSelfPowered
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2175373348901770226, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2175373348901770226, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2175373348901770226, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 74
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -21
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2690072642478446657, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_Name
+      value: ButtonDoor
+      objectReference: {fileID: 0}
+    - target: {fileID: 5803133425061211427, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: sceneId
+      value: 3179101870
+      objectReference: {fileID: 0}
+    - target: {fileID: 6739818006514333705, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: customNetTransform
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: access
+      value: 71
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: restricted
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: doorControllers.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: runningInterfaces.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: NewdoorControllers.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'doorControllers.Array.data[0]'
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'doorControllers.Array.data[1]'
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'doorControllers.Array.data[2]'
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'runningInterfaces.Array.data[0]'
+      value: 
+      objectReference: {fileID: 762600338}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'runningInterfaces.Array.data[1]'
+      value: 
+      objectReference: {fileID: 315519666}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'NewdoorControllers.Array.data[0]'
+      value: 
+      objectReference: {fileID: 1156855526}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'NewdoorControllers.Array.data[1]'
+      value: 
+      objectReference: {fileID: 1219299328}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'NewdoorControllers.Array.data[2]'
+      value: 
+      objectReference: {fileID: 1156855526}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'NewdoorControllers.Array.data[3]'
+      value: 
+      objectReference: {fileID: 1405663710}
+    - target: {fileID: 8004372364847621320, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: requiredClearance.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8004372364847621320, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'requiredClearance.Array.data[0]'
+      value: 73
+      objectReference: {fileID: 0}
+    - target: {fileID: 8558682525055023016, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: CurrentDirection
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8558682525055023016, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: InitialDirection
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8558682525055023016, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: SynchroniseCurrentDirection
+      value: 2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ea7280b49083dfa469fb176f6a7e4772, type: 3}
+--- !u!4 &1319675656 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+    type: 3}
+  m_PrefabInstance: {fileID: 1319675655}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1323861708
 PrefabInstance:
@@ -22098,18 +22750,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1389807240}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1393796425
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1398147676
 GameObject:
   m_ObjectHideFlags: 0
@@ -23631,6 +24271,135 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 7310038869089225508, guid: f59ae305481bbc4419d66c692d312e36,
     type: 3}
   m_PrefabInstance: {fileID: 1454956927}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1462967001
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 757063120}
+    m_Modifications:
+    - target: {fileID: 1443270592161478253, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: isSelfPowered
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -22.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2690072642478446657, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: m_Name
+      value: ButtonDoor
+      objectReference: {fileID: 0}
+    - target: {fileID: 5803133425061211427, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: sceneId
+      value: 1203845745
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: runningInterfaces.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: NewdoorControllers.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'runningInterfaces.Array.data[0]'
+      value: 
+      objectReference: {fileID: 1278275256}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'runningInterfaces.Array.data[1]'
+      value: 
+      objectReference: {fileID: 1121690925}
+    - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'NewdoorControllers.Array.data[0]'
+      value: 
+      objectReference: {fileID: 1957956042}
+    - target: {fileID: 8004372364847621320, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: requiredClearance.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8004372364847621320, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'requiredClearance.Array.data[0]'
+      value: 73
+      objectReference: {fileID: 0}
+    - target: {fileID: 8558682525055023016, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: CurrentDirection
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8558682525055023016, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: SynchroniseCurrentDirection
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ea7280b49083dfa469fb176f6a7e4772, type: 3}
+--- !u!4 &1462967002 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
+    type: 3}
+  m_PrefabInstance: {fileID: 1462967001}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1469303776
 GameObject:
@@ -25815,18 +26584,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1581701972}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1589997693
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1591448571
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -26497,6 +27254,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1748195032}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1768734580
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1777256292
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -27207,6 +27976,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1826314979}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1860488859
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1894580876
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -27497,6 +28278,11 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 757063120}
     m_Modifications:
+    - target: {fileID: 1230102468423824115, guid: a0435651e9a40f54ea02c119de299b0f,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.00000014901144
+      objectReference: {fileID: 0}
     - target: {fileID: 3054269849306578842, guid: a0435651e9a40f54ea02c119de299b0f,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -27568,18 +28354,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1913587825}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1937624972
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1f2bad5f99f9f54da626bf73a043ac5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1945147447
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -27616,7 +28390,7 @@ PrefabInstance:
     - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 16.019
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 2684351100681019035, guid: ea7280b49083dfa469fb176f6a7e4772,
         type: 3}
@@ -27722,12 +28496,12 @@ PrefabInstance:
         type: 3}
       propertyPath: 'runningInterfaces.Array.data[0]'
       value: 
-      objectReference: {fileID: 1393796425}
+      objectReference: {fileID: 2031557641}
     - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
         type: 3}
       propertyPath: 'runningInterfaces.Array.data[1]'
       value: 
-      objectReference: {fileID: 668783274}
+      objectReference: {fileID: 840528348}
     - target: {fileID: 7470765398914834986, guid: ea7280b49083dfa469fb176f6a7e4772,
         type: 3}
       propertyPath: 'NewdoorControllers.Array.data[0]'
@@ -27752,6 +28526,11 @@ PrefabInstance:
         type: 3}
       propertyPath: requiredClearance.Array.size
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8004372364847621320, guid: ea7280b49083dfa469fb176f6a7e4772,
+        type: 3}
+      propertyPath: 'requiredClearance.Array.data[0]'
+      value: 73
       objectReference: {fileID: 0}
     - target: {fileID: 8558682525055023016, guid: ea7280b49083dfa469fb176f6a7e4772,
         type: 3}
@@ -29259,6 +30038,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2026427429}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2031557641
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18ed50c2381e55498365c3cf9b34433, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2037799637
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Objects/Nuke.cs
+++ b/UnityProject/Assets/Scripts/Objects/Nuke.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿﻿using System;
+using Core;
 using System.Collections;
 using Audio.Managers;
 using UnityEngine;
@@ -137,8 +138,7 @@ namespace Objects.Command
 				Detonated = true;
 				//if yes, blow up the nuke
 				RpcDetonate();
-				//Kill Everyone in the universe
-				//FIXME kill only people on the station matrix that the nuke was detonated on
+				//Kills everyone on the matrix the nuke is currently on
 				StartCoroutine(WaitForDeath());
 				GameManager.Instance.RespawnCurrentlyAllowed = false;
 				DetonateVideo();
@@ -300,20 +300,35 @@ namespace Objects.Command
 		IEnumerator WaitForDeath()
 		{
 			yield return WaitFor.Seconds(2.5f);
-			var worldPos = gameObject.GetComponent<RegisterTile>().WorldPosition;
-			foreach (LivingHealthMasterBase livingHealth in FindObjectsOfType<LivingHealthMasterBase>())
+
+			//Grab the bounds of the matrix, grab all living creatures that are close-ish
+			//to the center of the matrix and gib them if they are within the bounds
+			//This is done instead of iterating over PresentPlayers on that matrix so that if a player is
+			//nearby but over a space tile or on a seperate matrix they still get gibbed
+			
+			var matrix = gameObject.GetMatrixRoot();
+
+			//Prevent shenanigans caused by removal of the tile below the nuke
+			if (matrix.IsSpaceMatrix && MatrixManager.MainStationMatrix.WorldBounds.Contains(gameObject.AssumedWorldPosServer()))
 			{
-				var dist = Vector3.Distance(worldPos, livingHealth.GetComponent<RegisterTile>().WorldPosition);
-				if (dist < explosionRadius)
+				matrix = MatrixManager.MainStationMatrix.Matrix;
+			}
+
+			var matrixbounds = matrix.MatrixInfo.WorldBounds;
+			float searchradius = Mathf.Max(matrixbounds.size.x, matrixbounds.size.y);
+			var grabEntities = ComponentsTracker<LivingHealthMasterBase>.GetAllNearbyTypesToLocation(matrixbounds.center, searchradius, bypassInventories:true);
+			foreach (LivingHealthMasterBase livingHealth in grabEntities)
+			{
+				if (matrixbounds.Contains(livingHealth.GetComponent<RegisterTile>().WorldPosition))
 				{
-					livingHealth.Death();
+					//Cyborgs wont actually die from livingHealth.Death() so gib everything instead
+					livingHealth.GetComponent<IGib>()?.OnGib(true);
 				}
 			}
 			yield return WaitFor.Seconds(10f);
 			// Trigger end of round
 			GameManager.Instance.RoundEndTime = 10;
 			GameManager.Instance.EndRound();
-
 		}
 
 		IEnumerator TickTimer()


### PR DESCRIPTION
Fixes the new station nuke and syndicate nuke so they are anchored by default
Adds some extra buttons to the syndicate shuttle on fallstation so the shutters are less of a pain to deal with
Also changes the behaviour of the nuke exploding

The new behaviour will grab all players and npcs on the matrix the nuke is attached to and gib them all
Will default to the station matrix if on space and within the bounds of the station matrix, just to prevent shenanigans involving removal of the tile the nuke is on

### Changelog:
CL: [Fix] Fix nukes being pushable when anchored.
CL: [Improvement] Redone nuke detonation behaviour