### PR TITLE
Add Internal gas tank toggling

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/AtmosGrenade.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/AtmosGrenade.prefab
@@ -314,7 +314,7 @@ MonoBehaviour:
   ReleasePressure: 101.325
   CargoSealApproved: 0
   explodeOnTooMuchDamage: 1
-  ignoreInternals: 1
+  canToggleIgnoreInternals: 0
 --- !u!4 &1278750111789472313 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8599085903787527247, guid: 838a4732b2dece64497d074b7a700be6,

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Respiration/RespiratorySystemBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Respiration/RespiratorySystemBase.cs
@@ -157,7 +157,7 @@ namespace HealthV2
 				{
 					if (gasSlot.Item == null) continue;
 					var gasContainer = gasSlot.Item.GetComponent<GasContainer>();
-					if (gasContainer && gasContainer.ignoreInternals == false)
+					if (gasContainer && gasContainer.IgnoreInternals == false)
 					{
 						return gasContainer;
 					}

--- a/UnityProject/Assets/Scripts/Objects/GasContainer.cs
+++ b/UnityProject/Assets/Scripts/Objects/GasContainer.cs
@@ -275,7 +275,11 @@ namespace Objects.Atmospherics
 
 		public string HoverTip()
 		{
-			return pickupable != null && canToggleIgnoreInternals ? $"A tank full of gas, its valve is {(IgnoreInternals ? "closed" : "open")} and it {(IgnoreInternals ? "will" : "won't")} be used by your internals" : "";
+			if (pickupable != null && canToggleIgnoreInternals)
+			{
+				return $"A tank full of gas, its valve is {(IgnoreInternals ? "closed" : "open")} and it {(IgnoreInternals ? "won't" : "will")} be used by your internals";
+			}
+			return null;
 		}
 
 		public string CustomTitle()
@@ -295,12 +299,15 @@ namespace Objects.Atmospherics
 
 		public List<TextColor> InteractionsStrings()
 		{
-			var list = new List<TextColor>
+			if (pickupable != null && canToggleIgnoreInternals)
 			{
-				new() { Color = Color.green, Text = pickupable != null && canToggleIgnoreInternals ? "Alt Click: Toggle usage of tank with internals" : "" },
-			};
-			return list;
+				var list = new List<TextColor>
+				{
+					new() { Color = Color.green, Text = "Alt Click: Toggle usage of tank with internals" },
+				};
+				return list;
+			}
+			return null;
 		}
-
 	}
 }

--- a/UnityProject/Assets/Scripts/Objects/GasContainer.cs
+++ b/UnityProject/Assets/Scripts/Objects/GasContainer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 using Mirror;
 using UnityEditor;
@@ -6,9 +7,11 @@ using NaughtyAttributes;
 using Systems.Atmospherics;
 using Systems.Explosions;
 using ScriptableObjects.Atmospherics;
+using UI.Systems.Tooltips.HoverTooltips;
+
 namespace Objects.Atmospherics
 {
-	public class GasContainer : NetworkBehaviour, IGasMixContainer, IServerSpawn, IServerInventoryMove, ICheckedInteractable<InventoryApply>
+	public class GasContainer : NetworkBehaviour, IGasMixContainer, IServerSpawn, IServerInventoryMove, ICheckedInteractable<InventoryApply>, IHoverTooltip
 	{
 		//max pressure for determining explosion effects - effects will be maximum at this contained pressure
 		private static readonly float MAX_EXPLOSION_EFFECT_PRESSURE = 148517f;
@@ -269,5 +272,35 @@ namespace Objects.Atmospherics
 				SyncIgnoreInternals(ignoreInternals, !ignoreInternals);
 			}
 		}
+
+		public string HoverTip()
+		{
+			return pickupable != null && canToggleIgnoreInternals ? $"A tank full of gas, its valve is {(IgnoreInternals ? "closed" : "open")} and it {(IgnoreInternals ? "will" : "won't")} be used by your internals" : "";
+		}
+
+		public string CustomTitle()
+		{
+			return null;
+		}
+
+		public Sprite CustomIcon()
+		{
+			return null;
+		}
+
+		public List<Sprite> IconIndicators()
+		{
+			return null;
+		}
+
+		public List<TextColor> InteractionsStrings()
+		{
+			var list = new List<TextColor>
+			{
+				new() { Color = Color.green, Text = pickupable != null && canToggleIgnoreInternals ? "Alt Click: Toggle usage of tank with internals" : "" },
+			};
+			return list;
+		}
+
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/ControlInternals.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/ControlInternals.cs
@@ -151,7 +151,7 @@ namespace UI
 					{
 						if (itemSlot.ItemObject != null && itemSlot.ItemObject.TryGetComponent(out GasContainer gasContainer))
 						{
-							if (gasContainer.ignoreInternals == false)
+							if (gasContainer.IgnoreInternals == false)
 							{
 								Tank = itemSlot.ItemObject;
 								this.gasContainer = gasContainer;
@@ -176,7 +176,7 @@ namespace UI
 
 			if (Tank != null)
 			{
-				if (PlayerManager.LocalPlayerScript.DynamicItemStorage.InventoryHasObject(Tank) == false)
+				if (PlayerManager.LocalPlayerScript.DynamicItemStorage.InventoryHasObject(Tank) == false || gasContainer.IgnoreInternals)
 				{
 					gasContainer = null;
 					Tank = null;

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemSlot.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemSlot.cs
@@ -9,6 +9,7 @@ using UnityEngine.UI;
 using Items.Implants.Organs;
 using Logs;
 using Managers;
+using Objects.Atmospherics;
 using UI;
 using UI.Systems.Tooltips.HoverTooltips;
 using UnityEngine.EventSystems;
@@ -239,9 +240,14 @@ public class UI_ItemSlot : TooltipMonoBehaviour, IPointerEnterHandler, IPointerE
 			if (MoreInventoryImage != null)
 			{
 				var Storage = item.GetComponent<InteractableStorage>();
+				var canister = item.GetComponent<GasContainer>();
 				if (Storage != null && Storage.DoNotShowInventoryOnUI == false)
 				{
 					HasSubInventory.itemStorage = Storage.ItemStorage;
+					MoreInventoryImage.enabled = true;
+				}
+				else if (canister != null && canister.IgnoreInternals == false)
+				{
 					MoreInventoryImage.enabled = true;
 				}
 				else


### PR DESCRIPTION
Adds the ability to toggle using a gas tank for internals via alt-click
All gas tanks have been changed to not be used for internals by default
A held gas tank that has been enabled for usage with your internals will disable itself if dropped or transfered to a gas tank dispenser.

### Changelog:
CL: [Improvement] Add the ability to toggle a gas tanks usage for internals, all gas tanks have been set to not be used for internals by default.