### PR TITLE
Fix healing item double action message and healing item behaviour

### DIFF
--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -1486,16 +1486,18 @@ namespace HealthV2
 		public void HealDamage(GameObject healingItem, float healAmt,
 			DamageType damageTypeToHeal, BodyPartType bodyPartAim, bool ExternalHealing = false)
 		{
+			var healingLeft = healAmt;
 			foreach (var bodyPart in SurfaceBodyParts)
 			{
-				if (bodyPart.BodyPartType == bodyPartAim)
+				if (bodyPart.BodyPartType == bodyPartAim && healingLeft > 0)
 				{
 					if (ExternalHealing && bodyPart.CanNotBeHealedByExternalHealingPack)
 					{
 						continue;
 					}
-
-					bodyPart.HealDamage(healingItem, healAmt, damageTypeToHeal);
+					var healingDamage = bodyPart.Damages[(int) damageTypeToHeal];
+					bodyPart.HealDamage(healingItem, Mathf.Max(0, healingLeft), damageTypeToHeal);
+					healingLeft -= healingDamage;
 				}
 			}
 

--- a/UnityProject/Assets/Scripts/Items/Medical/HealsTheLiving.cs
+++ b/UnityProject/Assets/Scripts/Items/Medical/HealsTheLiving.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using HealthV2;
+﻿using HealthV2;
 using UnityEngine;
 using Items;
 using Util.Independent.FluentRichText;
@@ -76,12 +75,15 @@ public class HealsTheLiving : MonoBehaviour, ICheckedInteractable<HandApply>
 		if (HasTrauma(LHB)) HealTrauma(LHB, interaction);
 	}
 
-	private void ServerApplyHeal(LivingHealthMasterBase livingHealth, HandApply interaction)
+	private void ServerApplyHeal(LivingHealthMasterBase livingHealth, HandApply interaction, bool skipActionMessage = false)
 	{
-		Chat.AddActionMsgToChat(interaction,
-			$"You apply the {this.gameObject.ExpensiveName()} to {livingHealth.gameObject.ExpensiveName()} healing them.".Color(Color.green),
-			$"{interaction.Performer.gameObject.ExpensiveName()} applies the {this.gameObject.ExpensiveName()} to {livingHealth.gameObject.ExpensiveName()}, healing them.".Color(Color.green)
-		);
+		if (skipActionMessage == false)
+		{
+			Chat.AddActionMsgToChat(interaction,
+				$"You apply the {this.gameObject.ExpensiveName()} to {livingHealth.gameObject.ExpensiveName()} healing them.".Color(Color.green),
+				$"{interaction.Performer.gameObject.ExpensiveName()} applies the {this.gameObject.ExpensiveName()} to {livingHealth.gameObject.ExpensiveName()}, healing them.".Color(Color.green)
+			);
+		}
 		livingHealth.HealDamage(null, 40, healType, interaction.TargetBodyPart, true);
 		if (StopsExternalBleeding)
 		{
@@ -98,7 +100,7 @@ public class HealsTheLiving : MonoBehaviour, ICheckedInteractable<HandApply>
 				$"You apply the {this.gameObject.ExpensiveName()} to yourself, healing yourself.".Color(Color.green),
 				$"{originator.gameObject.ExpensiveName()} applies the {this.gameObject.ExpensiveName()} to themselves, healing them self.".Color(Color.green)
 				);
-			ServerApplyHeal(livingHealth, interaction);
+			ServerApplyHeal(livingHealth, interaction, true);
 		}
 
 		StandardProgressAction.Create(ProgressConfig, ProgressComplete)


### PR DESCRIPTION
Fixes the double action messages when using bruise packs (or similar) on yourself
Also changes the healing behaviour of bruise packs (etc) to be more consistent

Prior behaviour would heal 40 damage per limb
e.g: if you had 2 left legs, one with 42 damage and one with 38 damage, one leg would be fully healed and the other would be left with 2 remaining damage

This new behaviour would heal 40 damage total between both legs, resulting in either one leg fully healed and the other with 40 damage left, or one leg with 2 damage left and the other with 38 damage left.
This also means that the amount of healing items used to healing any given amount of damage should be identical no matter how many limbs the damage is split between

### Changelog:
CL: [Fix] Fix double action message when healing with bruise packs.
CL: [Improvement] More consistent healing with bruise packs.