### PR TITLE
Fix some antag objs

### DIFF
--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/EscapeObjectives/Escape.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/EscapeObjectives/Escape.cs
@@ -51,7 +51,7 @@ namespace Antagonists
 
 			return !Owner.Body.playerHealth.IsDead &&
 				ValidShuttles.Any( shuttle => shuttle.MatrixInfo != null
-					&& (CheckOnShip(Owner.Body.RegisterPlayer, shuttle.MatrixInfo.Matrix)) && shuttle.HasWorkingThrusters);
+					&& CheckOnShip(Owner.Body.RegisterPlayer, shuttle.MatrixInfo.Matrix));
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/EscapeObjectives/Hijack.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/EscapeObjectives/Hijack.cs
@@ -58,7 +58,7 @@ namespace Antagonists
 
 			//Shuttle must be functional and player be on it
 			if (!ValidShuttles.Any( shuttle => shuttle.MatrixInfo != null
-				&& Owner.Body.RegisterPlayer.Matrix.Id == shuttle.MatrixInfo.Id && shuttle.HasWorkingThrusters))
+				&& Owner.Body.RegisterPlayer.Matrix.Id == shuttle.MatrixInfo.Id))
 			{
 				return false;
 			}

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/Maroon.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/Maroon.cs
@@ -107,8 +107,7 @@ namespace Antagonists
 			}
 
 			//If target is on functional escape shuttle, we failed
-			return ValidShuttles.Any( shuttle => shuttle
-				&& shuttle.MatrixInfo.Matrix.PresentPlayers.Contains(Owner.Body.RegisterPlayer) && shuttle.HasWorkingThrusters) == false;
+			return ValidShuttles.Any( shuttle => shuttle.MatrixInfo != null && shuttle.MatrixInfo.Matrix.PresentPlayers.Contains(Target.Body.RegisterPlayer) == false);
 		}
 	}
 }


### PR DESCRIPTION
HasWorkingThrusters will always return false, so it has been removed as a check in all antag objs
Additionally marooned was checking the owner of the objective instead of the target, which has also been fixed


### Changelog:
CL: [Fix] Fix some antag objs.