### PR TITLE
Weapon attachments

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Mining/ProtoKineticAccelerator.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Mining/ProtoKineticAccelerator.prefab
@@ -95,17 +95,17 @@ PrefabInstance:
     - target: {fileID: 4450321759764526106, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4450321759764526106, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4450321759764526106, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4450321759764526106, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
@@ -253,8 +253,9 @@ MonoBehaviour:
     RecoveryDuration: 0
   WeaponType: 1
   allowPinSwap: 1
+  allowedAttachments: 6
+  attributes: {fileID: 0}
   isSuppressed: 0
-  isSuppressible: 0
   projectile: {fileID: 7081206667275519994, guid: a4c2debd67d612549b05801d1e37121a,
     type: 3}
   rechargeTime: 2

--- a/UnityProject/Assets/Prefabs/Items/Tools/Lights/Seclite.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/Lights/Seclite.prefab
@@ -112,7 +112,7 @@ PrefabInstance:
     - target: {fileID: 5295069687449651132, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
       propertyPath: initialTraits.Array.size
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 5295069687449651132, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
@@ -124,7 +124,8 @@ PrefabInstance:
         type: 3}
       propertyPath: 'initialTraits.Array.data[2]'
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5,
+        type: 2}
     - target: {fileID: 5295069687449651132, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
       propertyPath: itemSprites.SpriteRightHand

--- a/UnityProject/Assets/Prefabs/Items/Tools/Lights/Seclite.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/Lights/Seclite.prefab
@@ -314,5 +314,27 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 5734849685452875998, guid: 6f371050bff8b32438f91c7c680900bb,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1703491430305322530}
   m_SourcePrefab: {fileID: 100100000, guid: 6f371050bff8b32438f91c7c680900bb, type: 3}
+--- !u!1 &1524261696040241017 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5734849685452875998, guid: 6f371050bff8b32438f91c7c680900bb,
+    type: 3}
+  m_PrefabInstance: {fileID: 6535009517738618791}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1703491430305322530
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1524261696040241017}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d2006f80a5f4f87a89c5073fe3316ad, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Knives/CombatKnife.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Knives/CombatKnife.prefab
@@ -68,17 +68,17 @@ PrefabInstance:
     - target: {fileID: 7777312831022217093, guid: 229f1c93e0e4ada439cfe4b781f65997,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7777312831022217093, guid: 229f1c93e0e4ada439cfe4b781f65997,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7777312831022217093, guid: 229f1c93e0e4ada439cfe4b781f65997,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7777312831022217093, guid: 229f1c93e0e4ada439cfe4b781f65997,
         type: 3}
@@ -134,5 +134,27 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 7781396554342910705, guid: 229f1c93e0e4ada439cfe4b781f65997,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 4728819406054140152}
   m_SourcePrefab: {fileID: 100100000, guid: 229f1c93e0e4ada439cfe4b781f65997, type: 3}
+--- !u!1 &4908574526498763258 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7781396554342910705, guid: 229f1c93e0e4ada439cfe4b781f65997,
+    type: 3}
+  m_PrefabInstance: {fileID: 3450830945449655051}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4728819406054140152
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4908574526498763258}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0b0a407a2abf5e83f964fc3fb96e63f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Knives/CombatKnife.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Knives/CombatKnife.prefab
@@ -120,6 +120,17 @@ PrefabInstance:
       propertyPath: initialDescription
       value: A military combat utility survival knife.
       objectReference: {fileID: 0}
+    - target: {fileID: 7858931176587863443, guid: 229f1c93e0e4ada439cfe4b781f65997,
+        type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7858931176587863443, guid: 229f1c93e0e4ada439cfe4b781f65997,
+        type: 3}
+      propertyPath: 'initialTraits.Array.data[3]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5,
+        type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Pistols/MakarovPistol.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Pistols/MakarovPistol.prefab
@@ -105,7 +105,7 @@ MonoBehaviour:
   randomInitialSprite: 0
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
-  initialVariantIndex: 0
+  variantIndex: 0
   palette: []
 --- !u!1 &5963240411708656045
 GameObject:
@@ -212,7 +212,7 @@ MonoBehaviour:
   randomInitialSprite: 0
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
-  initialVariantIndex: 0
+  variantIndex: 0
   palette: []
 --- !u!1 &7641977024500047899
 GameObject:
@@ -321,7 +321,7 @@ MonoBehaviour:
   randomInitialSprite: 0
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
-  initialVariantIndex: 0
+  variantIndex: 0
   palette: []
 --- !u!1001 &7482822103900389266
 PrefabInstance:
@@ -371,6 +371,11 @@ PrefabInstance:
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
       propertyPath: isSuppressible
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
+      propertyPath: allowedAttachments
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
@@ -447,17 +452,17 @@ PrefabInstance:
     - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/Misc/SpellBlade.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/Misc/SpellBlade.prefab
@@ -21,6 +21,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 177576810467860530, guid: ad527ba4de069794796e314f236794f4,
         type: 3}
+      propertyPath: allowedAttachments
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 177576810467860530, guid: ad527ba4de069794796e314f236794f4,
+        type: 3}
       propertyPath: shootSound.AssetAddress
       value: null
       objectReference: {fileID: 0}
@@ -77,17 +82,17 @@ PrefabInstance:
     - target: {fileID: 4128444937792741979, guid: ad527ba4de069794796e314f236794f4,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4128444937792741979, guid: ad527ba4de069794796e314f236794f4,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4128444937792741979, guid: ad527ba4de069794796e314f236794f4,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4128444937792741979, guid: ad527ba4de069794796e314f236794f4,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/Suppressor.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/Suppressor.prefab
@@ -105,13 +105,19 @@ PrefabInstance:
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: initialTraits.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: 'initialTraits.Array.data[0]'
       value: 
       objectReference: {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23,
+        type: 2}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: 'initialTraits.Array.data[1]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5,
         type: 2}
     - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/Suppressor.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/Suppressor.prefab
@@ -34,15 +34,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -138,5 +138,27 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1011433845357754, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7510823456575629365}
   m_SourcePrefab: {fileID: 100100000, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+--- !u!1 &5065923221907874056 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1011433845357754, guid: a7abba22164ce49f0bf9b9b219f39298,
+    type: 3}
+  m_PrefabInstance: {fileID: 5066076450384797106}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7510823456575629365
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5065923221907874056}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: de6c5bd82140a9a90a65ce31838665ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/_GunBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/_GunBase.prefab
@@ -223,7 +223,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fdce8a163088453ca593c0e98f2c5f07, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  itemStorageStructure: {fileID: 11400000, guid: ee76ba24a0cd443b1a308dd04cdb3678,
+  itemStorageStructure: {fileID: 11400000, guid: 54cbb4402f813441cb503dcd1d440082,
     type: 2}
   itemStorageCapacity: {fileID: 0}
   itemStoragePopulator: {fileID: 0}
@@ -235,6 +235,7 @@ MonoBehaviour:
     SlotContents: []
     DeprecatedContents: []
   SetSlotItemNotRemovableOnStartUp: 0
+  ignoreRoundstartGrabObjects: 0
   ashPrefab: {fileID: 0}
 --- !u!114 &4644871529314044369
 MonoBehaviour:

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/_GunBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/_GunBase.prefab
@@ -312,5 +312,6 @@ MonoBehaviour:
     RecoveryDuration: 0
   WeaponType: 0
   allowPinSwap: 1
+  allowedAttachments: 6
+  attributes: {fileID: 0}
   isSuppressed: 0
-  isSuppressible: 0

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Populators/ExplorerBagPopulator.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Populators/ExplorerBagPopulator.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   DeprecatedContents:
   - {fileID: 3335297197175331277, guid: 6e4c73588ba228a4ebb9c538180c8000, type: 3}
   - {fileID: 1524261696040241017, guid: 06fa88552c4d5c84a9356cc79c6d43c6, type: 3}
+  - {fileID: 5542859664017978807, guid: 26a8b018cf8f8e444850eea5715bc58e, type: 3}

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/10mmPistolMagazine.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/10mmPistolMagazine.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: 85a90a4e0aadf0fedb21ebc836bc40d2, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/10mmRifleMagazine.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/10mmRifleMagazine.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: 8d0e6068e86aa7749948cfed4fb1703f, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/357.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/357.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: 5efceb855c11841ad9af3f0510b3dbb8, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/38.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/38.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: ef9ed56250b41426baa5a3e5b16b8f34, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/4.6x30mmMagazine.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/4.6x30mmMagazine.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: b09c7c40bd36f463b8900c204dd54498, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/44PistolMagazine.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/44PistolMagazine.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: 21c6d37a63316cc2c8d9d9bccd508864, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/45PistolMagazine.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/45PistolMagazine.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: f2bf71ce8896794a4ac5541cdb0f3f98, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/45StalkerMagazine.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/45StalkerMagazine.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: 403b6d15f1cbe104fbb2f9ed44bdfa24, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/45ThompsonMagazine.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/45ThompsonMagazine.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: ee3c13405dec6bd11b66dd9bac9aa3a5, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/5.56RifleMagazine.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/5.56RifleMagazine.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: 4e7a28935887b42c0abbb43cc4370604, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/50SniperMagazine.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/50SniperMagazine.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: 11fdd80d232c34c3c9f74a96e3c0b0e3, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/7.62mmBoxMagazine.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/7.62mmBoxMagazine.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: 5344f7d34a67046a19f7955f984f8ea0, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/75Magazine.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/75Magazine.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: 79fc83824a2609e4dbe4604da0f5d554, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/762.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/762.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: 40d2c518784e9aa99abd08d9e7252555, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/9mmPistolMagazine.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/9mmPistolMagazine.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: 4fbd68bd00efb44529aea7a89057a257, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/9mmPistolMagazineAPS.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/9mmPistolMagazineAPS.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: 809c3ab737dc0d242898b5fec1498488, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/9mmSaberMagazine.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/9mmSaberMagazine.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: f605405b9b89d45e4afc2dd22eea1c64, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/9mmUziMagazine.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/9mmUziMagazine.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: d10d36b83632643b381b5fb3a41e294e, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/DonksoftBoxMagazine.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/DonksoftBoxMagazine.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: c9b4f25cf60b46d45a68f92dcb3d3913, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/DonksoftSMGMagazine.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/DonksoftSMGMagazine.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: f02f4727098495d4c85a13aefe478b8d, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/FoamForcePistolMagazine.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/FoamForcePistolMagazine.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: b16ae3645633b9d4d88ad96b045060e3, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/FoamForceSMGMagazine.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/FoamForceSMGMagazine.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: 751b9c896c516ec48a674f4e0a5f219d, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/Gasoline.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/Gasoline.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: 88902b2707563fec69e7f1d586e7c03d, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/InternalMagazine.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/InternalMagazine.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: 1ada82b29ea18174d8b349f1563393b0, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/ShotgunDrumMagazine.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/ShotgunDrumMagazine.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: d278ba3e6b9d66a4489c0bf23557cb31, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/ShotgunShellCapacity.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/ShotgunShellCapacity.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: c5ea118354e234f9fa2e1e18ce0adff8, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/Syringe.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/Syringe.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: 8f46f13d516624e6883db235a840f575, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/WeaponCell.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/WeaponCell.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: e73f3e53735c02e4c94c5c57e59a1579, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/WeaponCellExtraLarge.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/WeaponCellExtraLarge.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: 34a7e72690b7ea4409007d6ac6928525, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/WeaponCellMiniature.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Structure/Magazines/WeaponCellMiniature.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   Whitelist:
   - {fileID: 11400000, guid: ba5f29ab4428f254587e3b9ec94addda, type: 2}
   - {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
-  - {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  - {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/ScriptableObjects/Traits/CommonTraitsSingleton.asset
+++ b/UnityProject/Assets/ScriptableObjects/Traits/CommonTraitsSingleton.asset
@@ -14,6 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Gun: {fileID: 11400000, guid: 0ed64735be8ec47f99cd4c93bce388ac, type: 2}
   Suppressor: {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
+  WeaponAttachable: {fileID: 11400000, guid: 8c15c57c64195bdd284ef85535d84ad5, type: 2}
   WeaponCell: {fileID: 11400000, guid: e73f3e53735c02e4c94c5c57e59a1579, type: 2}
   FiringPin: {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
   Ingredient: {fileID: 11400000, guid: f4bf367b42a325c4dbf26b76591e0ef1, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Traits/Usage/WeaponAttachment.asset
+++ b/UnityProject/Assets/ScriptableObjects/Traits/Usage/WeaponAttachment.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ccfe138752d4b66bcb7c56a0c9769c7, type: 3}
+  m_Name: WeaponAttachment
+  m_EditorClassIdentifier: 
+  foreverID: 8c15c57c64195bdd284ef85535d84ad5
+  traitDescription: An Item that can be attached to a firearm

--- a/UnityProject/Assets/ScriptableObjects/Traits/Usage/WeaponAttachment.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Traits/Usage/WeaponAttachment.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8c15c57c64195bdd284ef85535d84ad5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Core/Input System/MouseInputController.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/MouseInputController.cs
@@ -195,9 +195,9 @@ public class MouseInputController : MonoBehaviour
 
 			if (loadedGun != null)
 			{
-				//if we are on harm intent with loaded gun,
+				//if we are on help intent with loaded gun,
 				//don't do anything else, just shoot (trigger the AimApply).
-				if (UIManager.CurrentIntent == Intent.Harm)
+				if (UIManager.CurrentIntent == Intent.Help)
 				{
 					CheckAimApply(MouseButtonState.PRESS);
 				}

--- a/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
@@ -330,10 +330,10 @@ namespace Items
 					returnS =  "would do some damage";
 					break;
 				case < 7:
-					returnS =  "an okay damage";
+					returnS =  "okay damage";
 					break;
 				case < 11:
-					returnS =  "a decent damage";
+					returnS =  "decent damage";
 					break;
 				case < 13:
 					returnS =  "robust damage.";

--- a/UnityProject/Assets/Scripts/Items/Others/Knife.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/Knife.cs
@@ -73,6 +73,9 @@ public class Knife : MonoBehaviour, ICheckedInteractable<InventoryApply>,  IChec
 		//if the item isn't a butcher knife, no go.
 		if (!Validations.HasItemTrait(interaction, CommonTraits.Instance.Knife)) return false;
 
+		//Exception to allow for firearm weapon attachments to work
+		if (Validations.HasItemTrait(interaction.TargetObject, CommonTraits.Instance.Gun)) return false;
+
 
 		//TargetSlot must not be empty.
 		if (interaction.TargetSlot.Item == null) return false;

--- a/UnityProject/Assets/Scripts/Items/Traits/CommonTraits.cs
+++ b/UnityProject/Assets/Scripts/Items/Traits/CommonTraits.cs
@@ -15,6 +15,7 @@ public class CommonTraits : SingletonScriptableObject<CommonTraits>
 {
 	[BoxGroup("Guns")] public ItemTrait Gun;
 	[BoxGroup("Guns")] public ItemTrait Suppressor;
+	[BoxGroup("Guns")] public ItemTrait WeaponAttachable;
 	[BoxGroup("Guns")] public ItemTrait WeaponCell;
 	[BoxGroup("Guns")] public ItemTrait FiringPin;
 

--- a/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
@@ -193,7 +193,7 @@ namespace Weapons
 		/// If true, displays a message whenever a gun is shot
 		/// </summary>
 		[SerializeField, SyncVar(hook = nameof(SyncIsSuppressed)), Tooltip("If the gun displays a shooter message")]
-		public bool isSuppressed;
+		private bool isSuppressed;
 
 		public bool IsSuppressed => isSuppressed;
 

--- a/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -285,7 +285,9 @@ namespace Weapons
 				}
 
 				Inventory.ServerAdd(Spawn.ServerPrefab(prefab).GameObject, slot);
-				slot.ItemObject.GetComponent<WeaponAttachment>().AttachBehaviour(this);
+				var attachment = slot.ItemObject.GetComponent<WeaponAttachment>();
+				weaponAttachments.Add(attachment);
+				attachment.AttachBehaviour(this);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
@@ -470,6 +470,12 @@ namespace Weapons
 		{
 			if (!DefaultWillInteract.Default(interaction, side)) return false;
 
+			//Melee behaviour for things like bayonets
+			if (interaction.Intent == Intent.Harm && (interaction.TargetPosition - interaction.Performer.RegisterTile().LocalPosition.To2()).magnitude <= 1.5f)
+			{
+				return false;
+			}
+
 			if (CurrentMagazine == null)
 			{
 				PlayEmptySfx();
@@ -674,7 +680,7 @@ namespace Weapons
 		//Go through all the other comments and check blame to see if they are still relevant, the first few in display shot probably arent
 		//Register tile var is unused, throw that out after triple checking where it was previously used and making sure that change hasnt broken shit
 		//Recoil needs to be looked at and probably fixed or replaced, additionally a pass on guneletrical and gunpka needs to be done but neither are as much as a mess as this has become
-		//Unfuck the ability to shoot over downed players, also give the player a method to melee with a loaded gun so bayonets arent next to useless
+		//Unfuck the ability to shoot over downed players
 		//Firing pin clumsy needs to be actually reimplemented sometime this century and also redo examine text, probably also add hover tooltip stuff
 		//Do a pass on Examine Messages and Action messages, also see if the progress bar for firing pins should be converted into the utils one maybe
 		//And then after all of thats fixed do a balance pass on all firearms, plus finally actually implement shit for all the guns that dont have projectiles done

--- a/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
@@ -187,8 +187,6 @@ namespace Weapons
 		private readonly List<WeaponAttachment> weaponAttachments = new();
 		private readonly List<ItemSlot> weaponAttachmentSlots = new();
 
-		public ItemAttributesV2 attributes;
-
 		protected const float PinRemoveTime = 10f;
 
 		/// <summary>
@@ -204,8 +202,7 @@ namespace Weapons
 		private void Awake()
 		{
 			//init weapon with missing settings
-			attributes = GetComponent<ItemAttributesV2>();
-			attributes.AddTrait(CommonTraits.Instance.Gun);
+			GetComponent<ItemAttributesV2>().AddTrait(CommonTraits.Instance.Gun);
 
 			itemStorage = GetComponent<ItemStorage>();
 			magSlot = itemStorage.GetIndexedItemSlot(0);

--- a/UnityProject/Assets/Scripts/Items/Weapons/SawnOff.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/SawnOff.cs
@@ -64,7 +64,7 @@ namespace Weapons
 		public void ServerPerformInteraction(InventoryApply interaction)
 		{
 			//TODO: switch this trait to the circular saw when that is implemented
-			if (Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.Welder) && gunComp.FireOnCooldowne == false)
+			if (Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.Welder) && gunComp.ShotCooldown == false)
 			{
 				if (isSawn)
 				{

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments.meta
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0bee12675dd77c80f887c20d3d17d8ef
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/Bayonet.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/Bayonet.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using Items;
+
+namespace Weapons.WeaponAttachments
+{
+	public class Bayonet : WeaponAttachment
+	{
+		private float defaultHitDamage;
+		private DamageType defaultDamageType;
+		private IEnumerable<string> defaultAttackVerbs;
+
+		protected void Awake()
+		{
+			InteractionKey = "Remove Bayonet";
+			AttachmentType = AttachmentType.Bayonet;
+			AttachmentSlot = AttachmentSlot.Suppressor;
+		}
+		
+		public override void AttachBehaviour(InventoryApply interaction, Gun gun)
+		{
+			defaultHitDamage = gun.attributes.ServerHitDamage;
+			defaultDamageType = gun.attributes.ServerDamageType;
+			defaultAttackVerbs = gun.attributes.ServerAttackVerbs;
+			var melee = GetComponent<ItemAttributesV2>();
+			gun.attributes.ServerHitDamage = melee.ServerHitDamage;
+			gun.attributes.ServerDamageType = melee.ServerDamageType;
+			gun.attributes.ServerAttackVerbs = melee.ServerAttackVerbs;
+		}
+		
+		public override void DetachBehaviour(ContextMenuApply interaction, Gun gun)
+		{
+			gun.attributes.ServerHitDamage = defaultHitDamage;
+			gun.attributes.ServerDamageType = defaultDamageType;
+			gun.attributes.ServerAttackVerbs = defaultAttackVerbs;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/Bayonet.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/Bayonet.cs
@@ -9,6 +9,8 @@ namespace Weapons.WeaponAttachments
 		private DamageType defaultDamageType;
 		private IEnumerable<string> defaultAttackVerbs;
 
+		private ItemAttributesV2 gunAttributes;
+
 		protected void Awake()
 		{
 			InteractionKey = "Remove Bayonet";
@@ -17,20 +19,21 @@ namespace Weapons.WeaponAttachments
 		
 		public override void AttachBehaviour(Gun gun)
 		{
-			defaultHitDamage = gun.attributes.ServerHitDamage;
-			defaultDamageType = gun.attributes.ServerDamageType;
-			defaultAttackVerbs = gun.attributes.ServerAttackVerbs;
+			gunAttributes = gun.GetComponent<ItemAttributesV2>();
+			defaultHitDamage = gunAttributes.ServerHitDamage;
+			defaultDamageType = gunAttributes.ServerDamageType;
+			defaultAttackVerbs = gunAttributes.ServerAttackVerbs;
 			var melee = GetComponent<ItemAttributesV2>();
-			gun.attributes.ServerHitDamage = melee.ServerHitDamage;
-			gun.attributes.ServerDamageType = melee.ServerDamageType;
-			gun.attributes.ServerAttackVerbs = melee.ServerAttackVerbs;
+			gunAttributes.ServerHitDamage = melee.ServerHitDamage;
+			gunAttributes.ServerDamageType = melee.ServerDamageType;
+			gunAttributes.ServerAttackVerbs = melee.ServerAttackVerbs;
 		}
 		
 		public override void DetachBehaviour(Gun gun)
 		{
-			gun.attributes.ServerHitDamage = defaultHitDamage;
-			gun.attributes.ServerDamageType = defaultDamageType;
-			gun.attributes.ServerAttackVerbs = defaultAttackVerbs;
+			gunAttributes.ServerHitDamage = defaultHitDamage;
+			gunAttributes.ServerDamageType = defaultDamageType;
+			gunAttributes.ServerAttackVerbs = defaultAttackVerbs;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/Bayonet.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/Bayonet.cs
@@ -13,10 +13,9 @@ namespace Weapons.WeaponAttachments
 		{
 			InteractionKey = "Remove Bayonet";
 			AttachmentType = AttachmentType.Bayonet;
-			AttachmentSlot = AttachmentSlot.Suppressor;
 		}
 		
-		public override void AttachBehaviour(InventoryApply interaction, Gun gun)
+		public override void AttachBehaviour(Gun gun)
 		{
 			defaultHitDamage = gun.attributes.ServerHitDamage;
 			defaultDamageType = gun.attributes.ServerDamageType;
@@ -27,7 +26,7 @@ namespace Weapons.WeaponAttachments
 			gun.attributes.ServerAttackVerbs = melee.ServerAttackVerbs;
 		}
 		
-		public override void DetachBehaviour(ContextMenuApply interaction, Gun gun)
+		public override void DetachBehaviour(Gun gun)
 		{
 			gun.attributes.ServerHitDamage = defaultHitDamage;
 			gun.attributes.ServerDamageType = defaultDamageType;

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/Bayonet.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/Bayonet.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0b0a407a2abf5e83f964fc3fb96e63f0

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/Flashlight.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/Flashlight.cs
@@ -7,15 +7,14 @@ namespace Weapons.WeaponAttachments
 		{
 			InteractionKey = "Remove Flashlight";
 			AttachmentType = AttachmentType.Flashlight;
-			AttachmentSlot = AttachmentSlot.Flashlight;
 		}
 
-		public override void AttachBehaviour(InventoryApply interaction, Gun gun)
+		public override void AttachBehaviour(Gun gun)
 		{
 			//TODO: itemActionButton for flashlight?
 		}
 		
-		public override void DetachBehaviour(ContextMenuApply interaction, Gun gun)
+		public override void DetachBehaviour(Gun gun)
 		{
 			//TODO: itemActionButton for flashlight?
 		}

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/Flashlight.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/Flashlight.cs
@@ -1,0 +1,23 @@
+
+namespace Weapons.WeaponAttachments
+{
+	public class Flashlight : WeaponAttachment
+	{
+		protected void Awake()
+		{
+			InteractionKey = "Remove Flashlight";
+			AttachmentType = AttachmentType.Flashlight;
+			AttachmentSlot = AttachmentSlot.Flashlight;
+		}
+
+		public override void AttachBehaviour(InventoryApply interaction, Gun gun)
+		{
+			//TODO: itemActionButton for flashlight?
+		}
+		
+		public override void DetachBehaviour(ContextMenuApply interaction, Gun gun)
+		{
+			//TODO: itemActionButton for flashlight?
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/Flashlight.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/Flashlight.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5d2006f80a5f4f87a89c5073fe3316ad

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/Suppressor.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/Suppressor.cs
@@ -7,7 +7,6 @@ namespace Weapons.WeaponAttachments
 		{
 			InteractionKey = "Remove Suppressor";
 			AttachmentType = AttachmentType.Suppressor;
-			AttachmentSlot = AttachmentSlot.Suppressor;
 		}
 
 		public override bool AttachCheck(Gun gun)
@@ -20,12 +19,12 @@ namespace Weapons.WeaponAttachments
 			return gun.isSuppressed;
 		}
 		
-		public override void AttachBehaviour(InventoryApply interaction, Gun gun)
+		public override void AttachBehaviour(Gun gun)
 		{
 			gun.SyncIsSuppressed(gun.isSuppressed, true);
 		}
 		
-		public override void DetachBehaviour(ContextMenuApply interaction, Gun gun)
+		public override void DetachBehaviour(Gun gun)
 		{
 			gun.SyncIsSuppressed(gun.isSuppressed, false);
 		}

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/Suppressor.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/Suppressor.cs
@@ -1,0 +1,33 @@
+
+namespace Weapons.WeaponAttachments
+{
+	public class Suppressor : WeaponAttachment
+	{
+		protected void Awake()
+		{
+			InteractionKey = "Remove Suppressor";
+			AttachmentType = AttachmentType.Suppressor;
+			AttachmentSlot = AttachmentSlot.Suppressor;
+		}
+
+		public override bool AttachCheck(Gun gun)
+		{
+			return !gun.isSuppressed;
+		}
+		
+		public override bool DetachCheck(Gun gun)
+		{
+			return gun.isSuppressed;
+		}
+		
+		public override void AttachBehaviour(InventoryApply interaction, Gun gun)
+		{
+			gun.SyncIsSuppressed(gun.isSuppressed, true);
+		}
+		
+		public override void DetachBehaviour(ContextMenuApply interaction, Gun gun)
+		{
+			gun.SyncIsSuppressed(gun.isSuppressed, false);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/Suppressor.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/Suppressor.cs
@@ -11,22 +11,22 @@ namespace Weapons.WeaponAttachments
 
 		public override bool AttachCheck(Gun gun)
 		{
-			return !gun.isSuppressed;
+			return !gun.IsSuppressed;
 		}
 		
 		public override bool DetachCheck(Gun gun)
 		{
-			return gun.isSuppressed;
+			return gun.IsSuppressed;
 		}
 		
 		public override void AttachBehaviour(Gun gun)
 		{
-			gun.SyncIsSuppressed(gun.isSuppressed, true);
+			gun.SyncIsSuppressed(gun.IsSuppressed, true);
 		}
 		
 		public override void DetachBehaviour(Gun gun)
 		{
-			gun.SyncIsSuppressed(gun.isSuppressed, false);
+			gun.SyncIsSuppressed(gun.IsSuppressed, false);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/Suppressor.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/Suppressor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: de6c5bd82140a9a90a65ce31838665ba

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/WeaponAttachment.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/WeaponAttachment.cs
@@ -1,0 +1,44 @@
+using System;
+using UnityEngine;
+
+namespace Weapons.WeaponAttachments
+{
+	public abstract class WeaponAttachment : MonoBehaviour
+	{
+		
+		[NonSerialized] public string InteractionKey;
+		[NonSerialized] public AttachmentType AttachmentType;
+		[NonSerialized] public AttachmentSlot AttachmentSlot;
+
+		public virtual bool AttachCheck(Gun gun)
+		{
+			return true;
+		}
+		
+		public virtual bool DetachCheck(Gun gun)
+		{
+			return true;
+		}
+		
+		public abstract void AttachBehaviour(InventoryApply interaction, Gun gun);
+		public abstract void DetachBehaviour(ContextMenuApply interaction, Gun gun);
+	}
+	
+	[Flags]
+	public enum AttachmentType
+	{
+		//None exists for Gun allowed attachment selection, do not set the attachment type of a weaponattachment to it.
+		None = 0,
+		Suppressor = 1 << 0,
+		Flashlight = 1 << 1,
+		Bayonet = 1 << 2
+	}
+	
+	public enum AttachmentSlot
+	{
+		Suppressor = 2,
+		Flashlight = 3,
+		Bayonet = 4,
+	}
+	
+}

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/WeaponAttachment.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/WeaponAttachment.cs
@@ -5,10 +5,10 @@ namespace Weapons.WeaponAttachments
 {
 	public abstract class WeaponAttachment : MonoBehaviour
 	{
-		
 		[NonSerialized] public string InteractionKey;
 		[NonSerialized] public AttachmentType AttachmentType;
-		[NonSerialized] public AttachmentSlot AttachmentSlot;
+
+		[NonSerialized] public bool AllowDuplicateAttachments = false;
 
 		public virtual bool AttachCheck(Gun gun)
 		{
@@ -20,8 +20,8 @@ namespace Weapons.WeaponAttachments
 			return true;
 		}
 		
-		public abstract void AttachBehaviour(InventoryApply interaction, Gun gun);
-		public abstract void DetachBehaviour(ContextMenuApply interaction, Gun gun);
+		public abstract void AttachBehaviour(Gun gun);
+		public abstract void DetachBehaviour(Gun gun);
 	}
 	
 	[Flags]
@@ -33,12 +33,5 @@ namespace Weapons.WeaponAttachments
 		Flashlight = 1 << 1,
 		Bayonet = 1 << 2
 	}
-	
-	public enum AttachmentSlot
-	{
-		Suppressor = 2,
-		Flashlight = 3,
-		Bayonet = 4,
-	}
-	
+
 }

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/WeaponAttachment.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/WeaponAttachment.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cd450a78828bab4b0b245e70678a3729


### PR DESCRIPTION
yep, thats it
Combat knife and survival knife are the only bayonets and Seclight is the only flashlight that are attachable right now
Rightclick menu used to detach em because any other approach would be a ux nightmare
IsSupressible has also been thrown out, an enum flag option for allowed attachments has been added instead
Similarly, the supressorPrefab var has been replaced with a generic attachments list, which will be added to the weapon at roundstart

Currently the pka every ballistic weapon except for the bow can have a flashlight and bayonet attachment
The makarov remains the only firearm compatible with the suppressor 
Firearm meleeing has been added and only functions on harm intent

Also fixes a statusdisplay on fallstation that had its channel set to doortimer for whatever reason
And adds the survival knife to the explorers bags, for slappin onto your pka, also so the bayonet interactions actually get tested.

### Changelog:
CL: [Improvement] Combat Knife, survival knife and Seclight weapon attachments