### PR TITLE
Interaction and examine text for weapon attachments

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/Energy/_GunEnergyBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/Energy/_GunEnergyBase.prefab
@@ -667,11 +667,29 @@ MonoBehaviour:
   syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
+  AllowSuicide: 0
+  pinPrefab: {fileID: 6004521592186936485, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+    type: 3}
+  allowPinSwap: 1
+  FireDelay: 0.5
+  isSuppressed: 0
+  WeaponType: 0
+  MaxRecoilVariance: 0
+  ProjectileVelocity: 20
+  CameraRecoilConfig:
+    Distance: 0
+    RecoilDuration: 0
+    RecoveryDuration: 0
   ammoPrefab: {fileID: 5999901686547831408, guid: bd07fb3945875634685790190ea8decc,
     type: 3}
-  casingPrefabOverride: {fileID: 0}
-  allowMagazineRemoval: 0
   ammoType: 14
+  casingPrefabOverride: {fileID: 0}
+  SpawnsCasing: 0
+  MagInternal: 0
+  SmartGun: 0
+  allowMagazineRemoval: 0
+  attachmentPrefabs: []
+  allowedAttachments: 6
   loadMagSound:
     SetLoadSetting: 0
     AssetAddress: Assets/Prefabs/Weapons/KineticReload.prefab
@@ -688,12 +706,6 @@ MonoBehaviour:
       m_SubObjectName: 
       m_SubObjectType: 
       m_EditorAssetChanged: 0
-  pinPrefab: {fileID: 6004521592186936485, guid: 0c0328cbf94ffe648a0903cfc375ab91,
-    type: 3}
-  suppressorPrefab: {fileID: 0}
-  SpawnsCasing: 0
-  MagInternal: 0
-  SmartGun: 0
   FiringSoundA:
     SetLoadSetting: 0
     AssetAddress: null
@@ -718,18 +730,6 @@ MonoBehaviour:
       m_SubObjectName: 
       m_SubObjectType: 
       m_EditorAssetChanged: 0
-  FireDelay: 0.5
-  AllowSuicide: 0
-  MaxRecoilVariance: 0
-  ProjectileVelocity: 20
-  CameraRecoilConfig:
-    Distance: 0
-    RecoilDuration: 0
-    RecoveryDuration: 0
-  WeaponType: 0
-  allowPinSwap: 1
-  isSuppressed: 0
-  isSuppressible: 0
   firemodeProjectiles:
   - {fileID: 3294328072042417454, guid: 49a8364f6515be34bac52c48c9214d85, type: 3}
   firemodeFiringSound:
@@ -743,7 +743,6 @@ MonoBehaviour:
   firemodeName:
   - Kill
   firemodeUsage: 3e030000
-  hasChargeSprites: 0
-  chargeSprites: []
-  pickupable: {fileID: 0}
+  chargeSprite: {fileID: 0}
+  ammoSprite: {fileID: 0}
   allowScrewdriver: 1

--- a/UnityProject/Assets/Scripts/Items/Weapons/FiringPins/ClownPin.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/FiringPins/ClownPin.cs
@@ -24,22 +24,5 @@ namespace Weapons
 				$"{interaction.Performer.ExpensiveName()} somehow manages to shoot themself in the face!");
 			}
 		}
-
-		public override void ClientBehaviour(AimApply interaction, bool isSuicide)
-		{
-			//TODO Commented out as client doesnt sync job, after mind rework see if job is now sync'd
-			// JobType job = GetJobClient();
-			//
-			// if (clusmyMisfire && job == JobType.CLOWN)
-			// {
-			// 	CallShotClient(interaction, isSuicide);
-			// }
-			// else
-			// {
-			// 	CallShotClient(interaction, true);
-			// }
-
-			CallShotClient(interaction, true);
-		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Weapons/FiringPins/GenericPin.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/FiringPins/GenericPin.cs
@@ -20,17 +20,5 @@ namespace Weapons
 				CallShotServer(interaction, isSuicide);
 			}
 		}
-
-		public override void ClientBehaviour(AimApply interaction, bool isSuicide)
-		{
-			//TODO Commented out as client doesnt sync job, after mind rework see if job is now sync'd
-			// JobType job = GetJobClient();
-			// if ((clusmyMisfire && job == JobType.CLOWN) == false)
-			// {
-			// 	CallShotClient(interaction, isSuicide);
-			// }
-
-			CallShotClient(interaction, isSuicide);
-		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Weapons/FiringPins/HonkPin.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/FiringPins/HonkPin.cs
@@ -11,9 +11,5 @@ namespace Weapons
 			SoundManager.PlayNetworkedAtPos(CommonSounds.Instance.ClownHonk, interaction.Performer.AssumedWorldPosServer(),
 			hornParameters, true, sourceObj: interaction.Performer);
 		}
-
-		public override void ClientBehaviour(AimApply interaction, bool isSuicide)
-		{
-		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Weapons/FiringPins/IDLockedPin.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/FiringPins/IDLockedPin.cs
@@ -24,40 +24,21 @@ namespace Weapons
 		{
 			if (clearanceRestricted.HasClearance(interaction.Performer))
 			{
-				//TODO Commented out as client doesnt sync job, after mind rework see if job is now sync'd
-				// JobType job = GetJobServer(interaction.Performer);
-				//
-				// if (clusmyMisfire && job == JobType.CLOWN)
-				// {
-				// 	ClumsyShotServer(interaction, isSuicide);
-				// }
-				// else
-				// {
-				// 	CallShotServer(interaction, isSuicide);
-				// }
+				JobType job = GetJobServer(interaction.Performer);
 
-				CallShotServer(interaction, isSuicide);
+				if (clusmyMisfire && job == JobType.CLOWN)
+				{
+					ClumsyShotServer(interaction, isSuicide);
+				}
+				else
+				{
+					CallShotServer(interaction, isSuicide);
+				}
+
 				return;
 			}
 
 			Chat.AddExamineMsg(interaction.Performer, deniedMessage);
-		}
-
-		public override void ClientBehaviour(AimApply interaction, bool isSuicide)
-		{
-			if (clearanceRestricted.HasClearance(interaction.Performer))
-			{
-				//TODO Commented out as client doesnt sync job, after mind rework see if job is now sync'd
-				// JobType job = GetJobClient();
-				//
-				// if ((clusmyMisfire && job == JobType.CLOWN) == false)
-				// {
-				// 	CallShotClient(interaction, isSuicide);
-				// }
-
-				CallShotClient(interaction, isSuicide);
-
-			}
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Weapons/FiringPins/PinBase.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/FiringPins/PinBase.cs
@@ -8,29 +8,15 @@ namespace Weapons
 		public Gun gunComp;
 
 		public abstract void ServerBehaviour(AimApply interaction, bool isSuicide);
-		public abstract void ClientBehaviour(AimApply interaction, bool isSuicide);
 
 		protected void CallShotServer(AimApply interaction, bool isSuicide)
 		{
 			gunComp.ServerShoot(interaction.Performer, interaction.TargetVector.normalized, interaction.TargetBodyPart, isSuicide);
 		}
 
-		protected void CallShotClient(AimApply interaction, bool isSuicide)
-		{
-			var dir = gunComp.ApplyRecoil(interaction.TargetVector.normalized);
-		 	gunComp.DisplayShot(PlayerManager.LocalPlayerObject, dir, interaction.TargetBodyPart, isSuicide, gunComp.CurrentMagazine.containedBullets[0], gunComp.CurrentMagazine.containedProjectilesFired[0]);
-
-		}
-
 		protected JobType GetJobServer(GameObject player)
 		{
 			return PlayerList.Instance.GetOnline(player).Job;
-		}
-
-		protected JobType GetJobClient()
-		{
-			//TODO Client doesnt sync job, after mind rework see if job is now sync'd
-			return PlayerManager.LocalMindScript.occupation.JobType;
 		}
 
 		protected void ClumsyShotServer(AimApply interaction, bool isSuicide)

--- a/UnityProject/Assets/Scripts/Items/Weapons/GunPKA.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/GunPKA.cs
@@ -1,9 +1,7 @@
 ﻿using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using AddressableReferences;
 using HealthV2;
-using Messages.Server.SoundMessages;
 
 namespace Weapons
 {
@@ -51,14 +49,14 @@ namespace Weapons
 			CurrentMagazine.LoadProjectile(projectile, 1);
 			if (IsSuppressed)
 			{
-				if (serverHolder != null)
+				if (ServerHolder != null)
 				{
-					Chat.AddExamineMsgFromServer(serverHolder, $"The {gameObject.ExpensiveName()} silently recharges.");
+					Chat.AddExamineMsgFromServer(ServerHolder, $"The {gameObject.ExpensiveName()} silently recharges.");
 				}
 			}
 			else
 			{
-				SoundManager.PlayNetworkedAtPos(rechargeSound, gameObject.AssumedWorldPosServer(), sourceObj: serverHolder);
+				SoundManager.PlayNetworkedAtPos(rechargeSound, gameObject.AssumedWorldPosServer(), sourceObj: ServerHolder);
 			}
 			allowRecharge = true;
 		}

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/Bayonet.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponAttachments/Bayonet.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using AddressableReferences;
 using Items;
 
 namespace Weapons.WeaponAttachments
@@ -8,6 +10,7 @@ namespace Weapons.WeaponAttachments
 		private float defaultHitDamage;
 		private DamageType defaultDamageType;
 		private IEnumerable<string> defaultAttackVerbs;
+		[NonSerialized] private AddressableAudioSource defaultHitSound;
 
 		private ItemAttributesV2 gunAttributes;
 
@@ -23,10 +26,12 @@ namespace Weapons.WeaponAttachments
 			defaultHitDamage = gunAttributes.ServerHitDamage;
 			defaultDamageType = gunAttributes.ServerDamageType;
 			defaultAttackVerbs = gunAttributes.ServerAttackVerbs;
+			defaultHitSound = gunAttributes.ServerHitSound;
 			var melee = GetComponent<ItemAttributesV2>();
 			gunAttributes.ServerHitDamage = melee.ServerHitDamage;
 			gunAttributes.ServerDamageType = melee.ServerDamageType;
 			gunAttributes.ServerAttackVerbs = melee.ServerAttackVerbs;
+			gunAttributes.ServerHitSound = melee.ServerHitSound;
 		}
 		
 		public override void DetachBehaviour(Gun gun)
@@ -34,6 +39,7 @@ namespace Weapons.WeaponAttachments
 			gunAttributes.ServerHitDamage = defaultHitDamage;
 			gunAttributes.ServerDamageType = defaultDamageType;
 			gunAttributes.ServerAttackVerbs = defaultAttackVerbs;
+			gunAttributes.ServerHitSound = defaultHitSound;
 		}
 	}
 }


### PR DESCRIPTION
Adds interaction messages for attaching/detaching attachments and also a message if an attachment cannot be put on a weapon
Adds the ability to attach weapon attachments to energy weapons
Adds an examine text string listing which weapon attachments can be put onto a weapon
Bayonets now change the sound of melee attacks with a firearm if they are attached to one
Removes a bunch of unused methods left over from shotqueue stuff
Reorganizes the ordering of inspector editable variables for gun.cs, also adds headers
Removes a bunch of redundant xml comments
Update a few comments to reflect what things actually do now
Reorganizes a few functions into the correct regions
ID Locked pins now actually do clumsy shots as they should

Guncode still sucks, but hopefully this makes it a tiny bit less awful? eh

### Changelog:
CL: [Fix] Firearms with bayonets attached now play the correct melee sound
CL: [Improvement] Energy weapons can now use attachments
CL: [Improvement] firearms now list which attachments can be used on them in their examine text