### PR TITLE
Better firearm melee behaviour

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Input System/MouseInputController.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/MouseInputController.cs
@@ -195,11 +195,14 @@ public class MouseInputController : MonoBehaviour
 
 			if (loadedGun != null)
 			{
-				//if we are on help intent with loaded gun,
-				//don't do anything else, just shoot (trigger the AimApply).
-				if (UIManager.CurrentIntent == Intent.Help)
+				//if we are on harm intent with loaded gun,
+				//Do the aim apply first and then check other interactions
+				//This is to allow both not interacting with things that a player probably wants to shoot
+				//While also letting bayonet interactions for firearms work
+				if (UIManager.CurrentIntent == Intent.Harm)
 				{
 					CheckAimApply(MouseButtonState.PRESS);
+					CheckClick();
 				}
 				else
 				{

--- a/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
@@ -516,7 +516,7 @@ namespace Weapons
 			if (!DefaultWillInteract.Default(interaction, side)) return false;
 
 			//Melee behaviour for things like bayonets
-			if (interaction.Intent == Intent.Harm && (interaction.TargetPosition - interaction.Performer.RegisterTile().LocalPosition.To2()).magnitude <= 1.5f)
+			if (interaction.Intent == Intent.Harm && BayonetCheck(interaction.Performer.RegisterTile().LocalPosition.To2(), interaction.TargetPosition))
 			{
 				return false;
 			}
@@ -559,6 +559,21 @@ namespace Weapons
 				}
 			}
 
+			return false;
+		}
+
+		//.magnitude leaves out small area in the outer corner of tiles diagonal to the player pos
+		//Doing it this way prevents that
+		private bool BayonetCheck(Vector2 playerPos, Vector2 targetPos)
+		{
+			const float checkRange = 1.5f;
+			if (playerPos.x >= targetPos.x - checkRange  && playerPos.x <= targetPos.x + checkRange)
+			{
+				if (playerPos.y >= targetPos.y - checkRange && playerPos.y <= targetPos.y + checkRange)
+				{
+					return true;
+				}
+			}
 			return false;
 		}
 


### PR DESCRIPTION
Fixes the firearm melee range to cover the entirety of the adjacent tiles to the player, instead of just most of them
Tweaks the firearm interactions to run the aimapply check first and then all other interaction checks afterwards which should be more intuitive behaviour

Still toying with the idea of making the melee check only work if there is something that can be melee'd under the clients mousecursor, so you would still be able to shoot if you clicked in the tiles adjacent to the player, but Ive not found a good way to do that yet

### Changelog:
CL: [Improvement] More consistent firearm melee behaviour
