### PR TITLE
Fixes AI interaction with displays and making sure Dev Spawner doesn't randomly break in the future

### DIFF
--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/AdminTools/DevSpawnerMenu.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/AdminTools/DevSpawnerMenu.prefab
@@ -1224,6 +1224,7 @@ MonoBehaviour:
   StackAmountBox: {fileID: 1561518914433867185}
   DEBUGToggle: {fileID: 7206237559797441369}
   MappingToggle: {fileID: 3229891491055718626}
+  Menu: {fileID: 4113884316881524652}
   alwaysWildcard: 1
   searchWhileTyping: 1
   minCharactersForSearch: 2

--- a/UnityProject/Assets/Scripts/Objects/StatusDisplay.cs
+++ b/UnityProject/Assets/Scripts/Objects/StatusDisplay.cs
@@ -12,6 +12,7 @@ using Managers;
 using Doors;
 using Logs;
 using Shared.Systems.ObjectConnection;
+using Systems.Ai;
 using Systems.Clearance;
 
 
@@ -271,17 +272,7 @@ namespace Objects.Wallmounts
 				{
 					if (channel == StatusDisplayChannel.DoorTimer)
 					{
-						if (Restricted == null || Restricted.HasClearance(interaction.Performer))
-						{
-							AddTime(60);
-						}
-						else
-						{
-							Chat.AddExamineMsg(interaction.Performer, "Access Denied.");
-							// Play sound
-							SoundManager.PlayNetworkedAtPos(CommonSounds.Instance.AccessDenied,
-								gameObject.AssumedWorldPosServer(), sourceObj: gameObject);
-						}
+						UpdateCellTimer(interaction);
 					}
 					else
 					{
@@ -289,6 +280,24 @@ namespace Objects.Wallmounts
 						stateSync = MountedMonitorState.Image;
 					}
 				}
+			}
+		}
+
+		private void UpdateCellTimer(HandApply interaction)
+		{
+			if (interaction.PerformerPlayerScript.gameObject.HasComponent<AiPlayer>())
+			{
+				return;
+			}
+			if (Restricted == null || Restricted.HasClearance(interaction.Performer))
+			{
+				AddTime(60);
+			}
+			else
+			{
+				Chat.AddExamineMsg(interaction.Performer, "Access Denied.");
+				SoundManager.PlayNetworkedAtPos(CommonSounds.Instance.AccessDenied,
+					gameObject.AssumedWorldPosServer(), sourceObj: gameObject);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/GUI_DevSpawner.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/GUI_DevSpawner.cs
@@ -20,12 +20,11 @@ public class GUI_DevSpawner : MonoBehaviour
 	[Tooltip("content panel into which the list items should be placed")]
 	public GameObject contentPanel;
 	public InputField searchBox;
-
 	public InputField StackAmountBox;
-
 	public Toggle DEBUGToggle;
-
 	public Toggle MappingToggle;
+
+	public GameObject Menu;
 
 	public int StackAmount
 	{
@@ -161,7 +160,7 @@ public class GUI_DevSpawner : MonoBehaviour
 	{
 		_ = SoundManager.Play(CommonSounds.Instance.Click01);
 		Loggy.Log("Opening dev spawner menu", Category.NetUI);
-		transform.GetChild(0).gameObject.SetActive(true);
+		Menu.gameObject.SetActive(true);
 		transform.SetAsLastSibling();
 	}
 
@@ -169,6 +168,6 @@ public class GUI_DevSpawner : MonoBehaviour
 	{
 		_ = SoundManager.Play(CommonSounds.Instance.Click01);
 		Loggy.Log("Closing dev spawner menu", Category.NetUI);
-		transform.GetChild(0).gameObject.SetActive(false);
+		Menu.SetActive(false);
 	}
 }


### PR DESCRIPTION
fixes #10473

CL: [Fix] AIs will no longer be allowed to break status displays.
