### PR TITLE
Add Dual wielding

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
@@ -621,6 +621,20 @@ namespace Weapons
 			{
 				FiringPin.ServerBehaviour(interaction, isSuicide);
 			}
+
+			if (interaction.Intent == Intent.Harm && interaction.UsedObject == gameObject)
+			{
+				List<ItemSlot> hands = interaction.PerformerPlayerScript.DynamicItemStorage.GetHandSlots();
+				hands.Remove(interaction.PerformerPlayerScript.DynamicItemStorage.GetActiveHandSlot());
+				foreach (var hand in hands)
+				{
+					if (hand.ItemObject != null && hand.ItemObject.TryGetComponent<Gun>(out var gun)
+						&& gun.WillInteract(interaction, NetworkSide.Server))
+					{
+						gun.ServerPerformInteraction(interaction);
+					}
+				}
+			}
 		}
 
 		#endregion


### PR DESCRIPTION
Adds dual wielding, only works on harm intent
It should be noted that wielding a fullauto weapon in your main hand and a semiauto weapon in your offhand will not let you fire the semi weapon as if it was a fullauto weapon, additionally the weapon in your offhand will only ever fire as fast as the weapon in your main hand
The way this is implemented does mean you can tri-wield with 3 arms, quad wield if with 4 arms (etc), which leads to some interesting results

https://github.com/user-attachments/assets/f73f522c-3e92-4e8e-a3d5-f2fd96196560




### Changelog:
CL: [New] Add Dual wielding