### PR TITLE
Add melee blocking

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Item.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Item.prefab
@@ -81,6 +81,7 @@ MonoBehaviour:
   throwDamage: 0
   traumaDamageChance: 0
   TraumaticDamageType: 0
+  blockChance: 0
   throwSpeed: 2
   throwRange: 7
   hitSound:
@@ -92,6 +93,14 @@ MonoBehaviour:
       m_SubObjectType: 
       m_EditorAssetChanged: 0
   hitSoundSettings: 0
+  blockSound:
+    SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/Effects/smash.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
   inventoryMoveSound:
     SetLoadSetting: 0
     AssetAddress: 
@@ -251,6 +260,7 @@ MonoBehaviour:
   HeatResistance: 100
   ExplosionsDamage: 100
   doDamageMessage: 1
+  logDamage: 0
 --- !u!114 &657520313027932809
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Items/Mining/ProtoKineticCrusher.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Mining/ProtoKineticCrusher.prefab
@@ -16,6 +16,11 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 177576810467860530, guid: ad527ba4de069794796e314f236794f4,
         type: 3}
+      propertyPath: allowPinSwap
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 177576810467860530, guid: ad527ba4de069794796e314f236794f4,
+        type: 3}
       propertyPath: rechargeTime
       value: 1.5
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Mining/ProtoKineticMachete.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Mining/ProtoKineticMachete.prefab
@@ -53,12 +53,13 @@ PrefabInstance:
     - target: {fileID: 2952853855190462870, guid: 3f3c69eb80c13d439a7659f6834b091a,
         type: 3}
       propertyPath: initialDescription
-      value: Recent breakthroughs with proto-kinetic technology have led to improved
+      value: 'Recent breakthroughs with proto-kinetic technology have led to improved
         designs for the early proto-kinetic crusher, namely the ability to pack all
         the same technology into a smaller more portable package. The machete design
         was chosen as to make a much easier to handle and less cumbersome frame.
         Of course the smaller package means that the power is not as high as the
-        original crusher design.
+        original crusher design, but the different shell makes it capable of blocking
+        basic attacks. '
       objectReference: {fileID: 0}
     - target: {fileID: 2952853855190462870, guid: 3f3c69eb80c13d439a7659f6834b091a,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Mining/ProtoKineticMachete.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Mining/ProtoKineticMachete.prefab
@@ -37,6 +37,11 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 2952853855190462870, guid: 3f3c69eb80c13d439a7659f6834b091a,
         type: 3}
+      propertyPath: blockChance
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 2952853855190462870, guid: 3f3c69eb80c13d439a7659f6834b091a,
+        type: 3}
       propertyPath: initialName
       value: proto-kinetic machete
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/OfficersSabre.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/OfficersSabre.prefab
@@ -62,17 +62,17 @@ PrefabInstance:
     - target: {fileID: 5847001516606818509, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5847001516606818509, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5847001516606818509, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5847001516606818509, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}
@@ -125,6 +125,11 @@ PrefabInstance:
         type: 3}
       propertyPath: hitDamage
       value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
+        type: 3}
+      propertyPath: blockChance
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Shields/WoodenBuckler.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Shields/WoodenBuckler.prefab
@@ -15,6 +15,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3554597231095268504, guid: 5f9896c0cca80e14f8144be44d05e0a0,
         type: 3}
+      propertyPath: blockChance
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 3554597231095268504, guid: 5f9896c0cca80e14f8144be44d05e0a0,
+        type: 3}
       propertyPath: initialName
       value: wooden buckler
       objectReference: {fileID: 0}
@@ -105,17 +110,17 @@ PrefabInstance:
     - target: {fileID: 4011141344954996366, guid: 5f9896c0cca80e14f8144be44d05e0a0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4011141344954996366, guid: 5f9896c0cca80e14f8144be44d05e0a0,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4011141344954996366, guid: 5f9896c0cca80e14f8144be44d05e0a0,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4011141344954996366, guid: 5f9896c0cca80e14f8144be44d05e0a0,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Shields/_ShieldBase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Shields/_ShieldBase.prefab
@@ -103,6 +103,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
+      propertyPath: blockChance
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
       propertyPath: initialName
       value: shield
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/Energy/EnergyCrossbow.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/Energy/EnergyCrossbow.prefab
@@ -20,6 +20,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 64326933076804260, guid: ead12d91b06d1d84faa1c6fd90a76059,
         type: 3}
+    - target: {fileID: 505096979424067052, guid: ba0d71e0e5bfbac4e974fefc4ad1e300,
+        type: 3}
+      propertyPath: rechargeSpriteHandler
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 4233841553354124691, guid: ba0d71e0e5bfbac4e974fefc4ad1e300,
         type: 3}
       propertyPath: exportCost
@@ -73,17 +78,17 @@ PrefabInstance:
     - target: {fileID: 4341391846075563909, guid: ba0d71e0e5bfbac4e974fefc4ad1e300,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4341391846075563909, guid: ba0d71e0e5bfbac4e974fefc4ad1e300,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4341391846075563909, guid: ba0d71e0e5bfbac4e974fefc4ad1e300,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4341391846075563909, guid: ba0d71e0e5bfbac4e974fefc4ad1e300,
         type: 3}
@@ -132,6 +137,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: fd0144fbc9ebcee42b83a02150853b11,
         type: 2}
+    - target: {fileID: 8604005227905372315, guid: ba0d71e0e5bfbac4e974fefc4ad1e300,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/Misc/SpellBlade.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Guns/Misc/SpellBlade.prefab
@@ -26,6 +26,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 177576810467860530, guid: ad527ba4de069794796e314f236794f4,
         type: 3}
+      propertyPath: rechargeSpriteHandler
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 177576810467860530, guid: ad527ba4de069794796e314f236794f4,
+        type: 3}
       propertyPath: shootSound.AssetAddress
       value: null
       objectReference: {fileID: 0}
@@ -233,6 +238,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: e113b73fcd84c9e408ec928cd7453fee,
         type: 2}
+    - target: {fileID: 8219921471277780293, guid: ad527ba4de069794796e314f236794f4,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using Mirror;
 using AddressableReferences;
 using Core;
+using Core.Utils;
 using Systems.Clothing;
 using UI.Systems.Tooltips.HoverTooltips;
 using Util.Independent.FluentRichText;
@@ -92,15 +93,14 @@ namespace Items
 		public TraumaticDamageTypes TraumaticDamageType;
 
 		[SerializeField,
-			Range(0, 100),
-			Tooltip("How likely a player is to block an attack if they are holding this item in their active hand, 0% for never.")]
+		Range(0, 100),
+		Tooltip("How likely a player is to block an attack if they are holding this item in their active hand, 0% for never.")]
 		private float blockChance = 0;
 
-		public float BlockChance
-		{
-			get => blockChance;
-			set => blockChance = value;
-		}
+		/// <summary>
+		/// MultiInterestFloat listing all sources that are effecting block chance, tracked server side only.
+		/// </summary>
+		public MultiInterestFloat ServerBlockChance = new();
 
 		[Header("Sprites/Sounds/Flags/Misc.")]
 
@@ -216,11 +216,13 @@ namespace Items
 		{
 			EnsureInit();
 			ComponentsTracker<ItemAttributesV2>.Instances.Add(this);
+			ServerBlockChance.RecordPosition(this, blockChance);
 		}
 
 		private void OnDestroy()
 		{
 			ComponentsTracker<ItemAttributesV2>.Instances.Remove(this);
+			ServerBlockChance.RemovePosition(this);
 		}
 
 		private void EnsureInit()

--- a/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
@@ -91,6 +91,17 @@ namespace Items
 		[EnumFlag]
 		public TraumaticDamageTypes TraumaticDamageType;
 
+		[SerializeField,
+			Range(0, 100),
+			Tooltip("How likely a player is to block an attack if they are holding this item in their active hand, 0% for never.")]
+		private float blockChance = 0;
+
+		public float BlockChance
+		{
+			get => blockChance;
+			set => blockChance = value;
+		}
+
 		[Header("Sprites/Sounds/Flags/Misc.")]
 
 		[Tooltip("How many tiles to move per 0.1s when being thrown")]
@@ -124,6 +135,18 @@ namespace Items
 		{
 			get => hitSound;
 			set => hitSound = value;
+		}
+
+		[Tooltip("Sound to be played when we block someone elses attack")]
+		[SerializeField]
+		private AddressableAudioSource blockSound = null;
+		/// <summary>
+		/// Sound to be played when we block someone elses attack, tracked server side only
+		/// </summary>
+		public AddressableAudioSource ServerBlockSound
+		{
+			get => blockSound;
+			set => blockSound = value;
 		}
 
 		[Tooltip("Sound to be played when object gets added to storage.")]

--- a/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
@@ -176,7 +176,9 @@ namespace Weapons
 
 		private ItemStorage itemStorage;
 
+		//Note that this is only populated on the server
 		private readonly List<WeaponAttachment> weaponAttachments = new();
+
 		private readonly List<ItemSlot> weaponAttachmentSlots = new();
 
 		#region Init Logic
@@ -453,13 +455,22 @@ namespace Weapons
 
 			if (!WillInteract(ContextMenuApply.ByLocalPlayer(gameObject, null), NetworkSide.Client)) return result;
 
-			foreach (var attachment in weaponAttachments)
+			foreach (var slot in weaponAttachmentSlots)
 			{
-				//If an attachment is already stored and we dont have the flag, assume its intended to be iremovable
-				if (allowedAttachments.HasFlag(attachment.AttachmentType))
+				if (slot.ItemObject == null)
 				{
-					var interaction = ContextMenuApply.ByLocalPlayer(gameObject, attachment.InteractionKey);
-					result.AddElement(attachment.InteractionKey, () => ContextMenuOptionClicked(interaction));
+					continue;
+				}
+
+				var att = slot.ItemObject.GetComponent<WeaponAttachment>();
+				if (att != null)
+				{
+					//If an attachment is already stored and we dont have the flag, assume its intended to be iremovable
+					if (allowedAttachments.HasFlag(att.AttachmentType))
+					{
+						var interaction = ContextMenuApply.ByLocalPlayer(gameObject, att.InteractionKey);
+						result.AddElement(att.InteractionKey, () => ContextMenuOptionClicked(interaction));
+					}
 				}
 			}
 			return result;

--- a/UnityProject/Assets/Scripts/Items/Weapons/Melee/EnergySword.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Melee/EnergySword.cs
@@ -35,6 +35,11 @@ public class EnergySword : NetworkBehaviour, ICheckedInteractable<HandActivate>,
 	private float offThrowDamage;
 
 	[SerializeField]
+	[Range(0, 100)]
+	private float activatedBlockChance = 50;
+	private float offBlockChance;
+
+	[SerializeField]
 	[Tooltip("The verbs to use when the energy sword being used to attack something while activated.")]
 	private List<string> activatedVerbs = new List<string>();
 	private List<string> offAttackVerbs;
@@ -68,6 +73,7 @@ public class EnergySword : NetworkBehaviour, ICheckedInteractable<HandActivate>,
 		offHitSound = itemAttributes.ServerHitSound;
 		offHitDamage = itemAttributes.ServerHitDamage;
 		offThrowDamage = itemAttributes.ServerThrowDamage;
+		offBlockChance = itemAttributes.BlockChance;
 		offAttackVerbs = new List<string>(itemAttributes.ServerAttackVerbs);
 		if (color == SwordColor.Random)
 		{
@@ -213,6 +219,7 @@ public class EnergySword : NetworkBehaviour, ICheckedInteractable<HandActivate>,
 		itemAttributes.ServerHitSound = activatedHitSound;
 		itemAttributes.ServerHitDamage = activatedHitDamage;
 		itemAttributes.ServerThrowDamage = activatedThrowDamage;
+		itemAttributes.BlockChance = activatedBlockChance;
 		itemAttributes.ServerAttackVerbs = activatedVerbs;
 	}
 

--- a/UnityProject/Assets/Scripts/Items/Weapons/Melee/EnergySword.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Melee/EnergySword.cs
@@ -37,7 +37,6 @@ public class EnergySword : NetworkBehaviour, ICheckedInteractable<HandActivate>,
 	[SerializeField]
 	[Range(0, 100)]
 	private float activatedBlockChance = 50;
-	private float offBlockChance;
 
 	[SerializeField]
 	[Tooltip("The verbs to use when the energy sword being used to attack something while activated.")]
@@ -73,7 +72,6 @@ public class EnergySword : NetworkBehaviour, ICheckedInteractable<HandActivate>,
 		offHitSound = itemAttributes.ServerHitSound;
 		offHitDamage = itemAttributes.ServerHitDamage;
 		offThrowDamage = itemAttributes.ServerThrowDamage;
-		offBlockChance = itemAttributes.BlockChance;
 		offAttackVerbs = new List<string>(itemAttributes.ServerAttackVerbs);
 		if (color == SwordColor.Random)
 		{
@@ -210,6 +208,7 @@ public class EnergySword : NetworkBehaviour, ICheckedInteractable<HandActivate>,
 		itemAttributes.ServerHitSound = offHitSound;
 		itemAttributes.ServerHitDamage = offHitDamage;
 		itemAttributes.ServerThrowDamage = offThrowDamage;
+		itemAttributes.ServerBlockChance.RemovePosition(this);
 		itemAttributes.ServerAttackVerbs = offAttackVerbs;
 	}
 
@@ -219,7 +218,7 @@ public class EnergySword : NetworkBehaviour, ICheckedInteractable<HandActivate>,
 		itemAttributes.ServerHitSound = activatedHitSound;
 		itemAttributes.ServerHitDamage = activatedHitDamage;
 		itemAttributes.ServerThrowDamage = activatedThrowDamage;
-		itemAttributes.BlockChance = activatedBlockChance;
+		itemAttributes.ServerBlockChance.RecordPosition(this, activatedBlockChance);
 		itemAttributes.ServerAttackVerbs = activatedVerbs;
 	}
 

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
@@ -250,6 +250,7 @@ public class WeaponNetworkActions : NetworkBehaviour
 		Cooldowns.TryStartServer(playerScript, CommonCooldowns.Instance.Melee);
 	}
 
+	[Server]
 	private bool BlockCheck(GameObject victim)
 	{
 		float blockChance = 100f;

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
@@ -265,7 +265,7 @@ public class WeaponNetworkActions : NetworkBehaviour
 				var attribs = hand.ItemAttributes;
 				if (attribs != null)
 				{
-					blockChance -= attribs.BlockChance;
+					blockChance -= attribs.ServerBlockChance;
 					blockSound = attribs.ServerBlockSound;
 					blockName = hand.ItemObject.ExpensiveName();
 				}


### PR DESCRIPTION
Adds the block chance stat to itemattributesv2, which dictates the odds of a melee attack being blocked if a player is holding that item in their active hand, 0% being never and 100% being always
Adds a block chance of 25 to the proto kinetic machete, 30 to the buckler, 50 to all other shields, the officers sabre and (activated) energy swords

Also prevents removal of firingpins from proto kinetic crushers (and variants)
Additionally fixes a bug where the right click removal options for weapon attachments wouldnt appear

### Changelog:
CL: [New] Adds the ability for shields to block melee attacks