### PR TITLE
AI can jukebox and players cant breath atmosgrenades

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/AtmosGrenade.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/AtmosGrenade.prefab
@@ -314,6 +314,7 @@ MonoBehaviour:
   ReleasePressure: 101.325
   CargoSealApproved: 0
   explodeOnTooMuchDamage: 1
+  ignoreInternals: 1
   canToggleIgnoreInternals: 0
 --- !u!4 &1278750111789472313 stripped
 Transform:

--- a/UnityProject/Assets/Scripts/Objects/Machines/Jukebox.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/Jukebox.cs
@@ -12,13 +12,14 @@ using Items.Bar;
 using Messages.Server;
 using Messages.Server.SoundMessages;
 using Systems.Explosions;
+using Systems.Interaction;
 
 namespace Objects
 {
 	/// <summary>
 	/// A machine that plays music choosen by it's user's tastes in a cool place like a lounge or a bar.
 	/// </summary>
-	public class Jukebox : NetworkBehaviour, IAPCPowerable, ICheckedInteractable<HandApply>
+	public class Jukebox : NetworkBehaviour, IAPCPowerable, ICheckedInteractable<HandApply>, ICheckedInteractable<AiActivate>
 	{
 		/// <summary>
 		/// How many watts at 240 V the Jukebox uses when not in use
@@ -426,6 +427,27 @@ namespace Objects
 				ItemSlot from = isRemoving ? targetSlot : interaction.HandSlot;
 				ItemSlot to = isRemoving ? interaction.HandSlot : targetSlot;
 				Inventory.ServerTransfer(from, to);
+			}
+		}
+
+		public bool WillInteract(AiActivate interaction, NetworkSide side)
+		{
+			if (interaction.ClickType != AiActivate.ClickTypes.NormalClick) return false;
+
+			if (DefaultWillInteract.AiActivate(interaction, side) == false) return false;
+
+			return true;
+		}
+
+		public void ServerPerformInteraction(AiActivate interaction)
+		{
+			if (isOpened == false && vinylStorage.HasAnyOccupied() && musics.Count > 0)
+			{
+				TabUpdateMessage.Send(interaction.Performer, gameObject, NetTabType.Jukebox, TabAction.Open );
+			}
+			else
+			{
+				Chat.AddExamineMsg(interaction.Performer, "The jukebox is silent. A red LED labeled \"No Records\" blinks.");
 			}
 		}
 	}


### PR DESCRIPTION
Lets the AI open the jukebox UI again, the AI still is bound by the same conditions as regular players and cannot open the jukebox UI if the jukebox storage is open or lacks any vinyls because that would cause a lot of errors

Also sets ignore internals on the atmos grenade to be 1, so people dont almost die from breathing its contents (again)


### Changelog:
CL: [Fix] AI can open the jukebox ui (when theres vinyls in the jukebox)
CL: [Fix] Players will nolonger breath in the contents of held atmos grenades instead of from their oxygen tank