### PR TITLE
Surgery Hover Tips, Flashlight buff and rotation fix, and Surgery causes bleeding.

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Tools/Lights/Flashlight.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/Lights/Flashlight.prefab
@@ -151,6 +151,11 @@ PrefabInstance:
       propertyPath: <AlternativePrefabName>k__BackingField
       value: light
       objectReference: {fileID: 0}
+    - target: {fileID: 4349193172791428265, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
+      propertyPath: rotationTarget
+      value: 
+      objectReference: {fileID: 5730203012241659306}
     - target: {fileID: 8139896980434582913, guid: c9c58a9243d494537abcb4ee470efab0,
         type: 3}
       propertyPath: relatedRecipes.Array.size
@@ -594,11 +599,11 @@ MonoBehaviour:
   LightEmission: {fileID: 0}
   objectLightEmission: {fileID: 3320711171919508498}
   IsOn: 0
-  colour: {r: 1, g: 0.90938777, b: 0.6839622, a: 0.28235295}
+  colour: {r: 1, g: 0.90938777, b: 0.6839622, a: 0.21960784}
   objectLightSprite: {fileID: 0}
   commonComponents: {fileID: 0}
   SpriteShape: 0
-  Size: 8
+  Size: 11
   weakenOnGround: 0
   revertToOldConsistencyBehavior: 0
   weakenStrength: 1.25

--- a/UnityProject/Assets/ScriptableObjects/Surgery/Cyborg/CyborgAttachItem.asset
+++ b/UnityProject/Assets/ScriptableObjects/Surgery/Cyborg/CyborgAttachItem.asset
@@ -24,6 +24,7 @@ MonoBehaviour:
     SuccessOther: '{performer} unscrews the cover on {WhoOn}''s {OnPart}'
     FailSelf: 
     FailOther: 
+    BleedStacksToAdd: 1
   - RequiredTrait: {fileID: 11400000, guid: 024541a41c4ab42a499f8e49374496d4, type: 2}
     Time: 0
     FailChance: 0
@@ -33,6 +34,7 @@ MonoBehaviour:
     SuccessOther: '{performer} unfastens the bolts on {WhoOn}''s {OnPart}'
     FailSelf: 
     FailOther: 
+    BleedStacksToAdd: 1
   - RequiredTrait: {fileID: 11400000, guid: d859938ed34564a4a932f3beb902e34c, type: 2}
     Time: 0
     FailChance: 0
@@ -42,5 +44,6 @@ MonoBehaviour:
     SuccessOther: '{performer} attaches the {Using} to {WhoOn}''s {OnPart}'
     FailSelf: 
     FailOther: 
+    BleedStacksToAdd: -5
   RequiredImplantTrait: {fileID: 11400000, guid: d859938ed34564a4a932f3beb902e34c,
     type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Surgery/Cyborg/CyborgCloseProcedure.asset
+++ b/UnityProject/Assets/ScriptableObjects/Surgery/Cyborg/CyborgCloseProcedure.asset
@@ -24,6 +24,7 @@ MonoBehaviour:
     SuccessOther: '{performer} fastens the bolts on {WhoOn}''s {OnPart}'
     FailSelf: 
     FailOther: 
+    BleedStacksToAdd: -5
   - RequiredTrait: {fileID: 11400000, guid: 5524008e9372c468aacfb95c83179a91, type: 2}
     Time: 0
     FailChance: 0
@@ -33,6 +34,7 @@ MonoBehaviour:
     SuccessOther: '{performer} successfully prys the cover closed on {WhoOn}''s {OnPart}'
     FailSelf: 
     FailOther: 
+    BleedStacksToAdd: -5
   - RequiredTrait: {fileID: 11400000, guid: 98ad76bb152404a11aed28bf6fa703d6, type: 2}
     Time: 0
     FailChance: 0
@@ -42,3 +44,4 @@ MonoBehaviour:
     SuccessOther: '{performer} screws in the cover on {WhoOn}''s {OnPart}'
     FailSelf: 
     FailOther: 
+    BleedStacksToAdd: -5

--- a/UnityProject/Assets/ScriptableObjects/Surgery/GenericAttachProcedure.asset
+++ b/UnityProject/Assets/ScriptableObjects/Surgery/GenericAttachProcedure.asset
@@ -24,6 +24,7 @@ MonoBehaviour:
     SuccessOther: '{performer} uses {Using} to cut open {WhoOn}''s {OnPart}'
     FailSelf: you miscut with {Using}, cutting into {WhoOn}'s {OnPart}
     FailOther: '{performer} miscuts with {Using}. cutting into {WhoOn}''s {OnPart}'
+    BleedStacksToAdd: 10
   - RequiredTrait: {fileID: 11400000, guid: fc51d63cf9b06574ca78a62da76969e5, type: 2}
     Time: 2
     FailChance: 0
@@ -33,6 +34,7 @@ MonoBehaviour:
     SuccessOther: '{performer} uses {Using} to clamp {WhoOn}''s {OnPart}'
     FailSelf: you misuse {Using} failing to clamp {WhoOn}'s {OnPart}
     FailOther: '{performer} misuses {Using} failing to clamp {WhoOn}''s {OnPart}'
+    BleedStacksToAdd: 5
   - RequiredTrait: {fileID: 11400000, guid: 1e5559e895a286845ae6c1d616f3f26d, type: 2}
     Time: 2
     FailChance: 0
@@ -42,6 +44,7 @@ MonoBehaviour:
     SuccessOther: '{performer} uses {Using} to hold open {WhoOn}''s {OnPart}'
     FailSelf: you misuse {Using} failing to hold open {WhoOn}'s {OnPart}
     FailOther: '{performer} misuses {Using} failing to hold open {WhoOn}''s {OnPart}'
+    BleedStacksToAdd: 2
   - RequiredTrait: {fileID: 0}
     Time: 3
     FailChance: 0
@@ -51,5 +54,6 @@ MonoBehaviour:
     SuccessOther: '{performer} successfully inserts {Using} into {WhoOn}''s {OnPart}'
     FailSelf: you fail to fit {Using} into {WhoOn}'s {OnPart}
     FailOther: '{performer} fails to fit {Using} into {WhoOn}''s {OnPart}'
+    BleedStacksToAdd: 0
   RequiredImplantTrait: {fileID: 11400000, guid: d859938ed34564a4a932f3beb902e34c,
     type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Surgery/GenericCloseProcedure.asset
+++ b/UnityProject/Assets/ScriptableObjects/Surgery/GenericCloseProcedure.asset
@@ -24,3 +24,4 @@ MonoBehaviour:
     SuccessOther: '{performer} uses {Using} to seal up {WhoOn}''s {OnPart}'
     FailSelf: you misplace {Using} messing up {WhoOn}'s {OnPart}
     FailOther: '{performer} misplaces {Using} messing up {WhoOn}''s {OnPart}'
+    BleedStacksToAdd: -25

--- a/UnityProject/Assets/ScriptableObjects/Surgery/GenericImplantProcedure.asset
+++ b/UnityProject/Assets/ScriptableObjects/Surgery/GenericImplantProcedure.asset
@@ -24,6 +24,7 @@ MonoBehaviour:
     SuccessOther: '{performer} uses {Using} to cut open {WhoOn}''s {OnPart}'
     FailSelf: you miscut with {Using}, cutting into {WhoOn}'s {OnPart}
     FailOther: '{performer} miscuts with {Using}. cutting into {WhoOn}''s {OnPart}'
+    BleedStacksToAdd: 5
   - RequiredTrait: {fileID: 11400000, guid: fc51d63cf9b06574ca78a62da76969e5, type: 2}
     Time: 1
     FailChance: 0
@@ -33,6 +34,7 @@ MonoBehaviour:
     SuccessOther: '{performer} uses {Using} to clamp {WhoOn}''s {OnPart}'
     FailSelf: you misuse {Using} failing to clamp {WhoOn}'s {OnPart}
     FailOther: '{performer} misuses {Using} failing to clamp {WhoOn}''s {OnPart}'
+    BleedStacksToAdd: 4
   - RequiredTrait: {fileID: 11400000, guid: 1e5559e895a286845ae6c1d616f3f26d, type: 2}
     Time: 1
     FailChance: 0
@@ -42,6 +44,7 @@ MonoBehaviour:
     SuccessOther: '{performer} uses {Using} to hold open {WhoOn}''s {OnPart}'
     FailSelf: you misuse {Using} failing to hold open {WhoOn}'s {OnPart}
     FailOther: '{performer} misuses {Using} failing to hold open {WhoOn}''s {OnPart}'
+    BleedStacksToAdd: 2
   - RequiredTrait: {fileID: 0}
     Time: 3
     FailChance: 0
@@ -51,5 +54,6 @@ MonoBehaviour:
     SuccessOther: '{performer} successfully inserts {Using} into {WhoOn}''s {OnPart}'
     FailSelf: you fail to fit {Using} into {WhoOn}'s {OnPart}
     FailOther: '{performer} fails to fit {Using} into {WhoOn}''s {OnPart}'
+    BleedStacksToAdd: 0
   RequiredImplantTrait: {fileID: 11400000, guid: d859938ed34564a4a932f3beb902e34c,
     type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Surgery/GenericRemoveProcedure.asset
+++ b/UnityProject/Assets/ScriptableObjects/Surgery/GenericRemoveProcedure.asset
@@ -24,6 +24,7 @@ MonoBehaviour:
     SuccessOther: '{performer} uses {Using} to cut open {WhoOn}''s {OnPart}'
     FailSelf: you miss cut with {Using} cutting into {WhoOn}'s {OnPart}
     FailOther: '{performer} miss cutts with {Using} cutting into{WhoOn}''s {OnPart}'
+    BleedStacksToAdd: 5
   - RequiredTrait: {fileID: 11400000, guid: fc51d63cf9b06574ca78a62da76969e5, type: 2}
     Time: 0
     FailChance: 0
@@ -33,6 +34,7 @@ MonoBehaviour:
     SuccessOther: '{performer} uses {Using} to clamp {WhoOn}''s {OnPart}'
     FailSelf: you misuse {Using} failing to clamp {WhoOn}'s {OnPart}
     FailOther: '{performer} misuses {Using} failing to clamp {WhoOn}''s {OnPart}'
+    BleedStacksToAdd: 5
   - RequiredTrait: {fileID: 11400000, guid: 30127bfedd67541a3afa2a5582daa98c, type: 2}
     Time: 0
     FailChance: 0
@@ -42,3 +44,4 @@ MonoBehaviour:
     SuccessOther: '{performer} cuts out {WhoOn}''s {OnPart} using {Using}'
     FailSelf: you fail to cut out {WhoOn}'s {OnPart} using {Using}
     FailOther: '{performer} fails to cut out {WhoOn}''s {OnPart} using {Using}'
+    BleedStacksToAdd: 15

--- a/UnityProject/Assets/ScriptableObjects/Surgery/genericOpenProcedure.asset
+++ b/UnityProject/Assets/ScriptableObjects/Surgery/genericOpenProcedure.asset
@@ -24,6 +24,7 @@ MonoBehaviour:
     SuccessOther: '{performer} uses {Using} to cut open {WhoOn}''s {OnPart}'
     FailSelf: you miss cut with {Using} cutting into{WhoOn}'s {OnPart}
     FailOther: '{performer} miss cutts with {Using} cutting into{WhoOn}''s {OnPart}'
+    BleedStacksToAdd: 5
   - RequiredTrait: {fileID: 11400000, guid: 1e5559e895a286845ae6c1d616f3f26d, type: 2}
     Time: 1
     FailChance: 0
@@ -33,6 +34,7 @@ MonoBehaviour:
     SuccessOther: '{performer} uses {Using} to hold open {WhoOn}''s {OnPart}'
     FailSelf: you misuse {Using} failing to hold open {WhoOn}'s {OnPart}
     FailOther: '{performer} misuses {Using} failing to hold open {WhoOn}''s {OnPart}'
+    BleedStacksToAdd: 5
   - RequiredTrait: {fileID: 11400000, guid: fc51d63cf9b06574ca78a62da76969e5, type: 2}
     Time: 1
     FailChance: 0
@@ -42,3 +44,4 @@ MonoBehaviour:
     SuccessOther: '{performer} uses {Using} to clamp {WhoOn}''s {OnPart}'
     FailSelf: you misuse {Using} failing to clamp {WhoOn}'s {OnPart}
     FailOther: '{performer} misuses {Using} failing to clamp {WhoOn}''s {OnPart}'
+    BleedStacksToAdd: 5

--- a/UnityProject/Assets/Scripts/Core/RootSillys/SOTracker.cs
+++ b/UnityProject/Assets/Scripts/Core/RootSillys/SOTracker.cs
@@ -1,15 +1,12 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using SecureStuff;
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
 using UnityEngine;
-using Random = UnityEngine.Random;
 
 namespace ScriptableObjects
 {
+	[Serializable]
 	public class SOTracker : ScriptableObject, ISOTracker
 	{
 		public virtual SpriteDataSO Sprite => null;

--- a/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPartSurgery.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/BodyParts/BodyPartSurgery.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using HealthV2.Living.Surgery;
 using NaughtyAttributes;
 using UnityEngine;
 
@@ -11,12 +12,12 @@ namespace HealthV2
 		public List<SurgeryProcedureBase> SurgeryProcedureBase = new List<SurgeryProcedureBase>();
 
 
-		public virtual void SuccessfulProcedure(HandApply interaction, Dissectible.PresentProcedure PresentProcedure)
+		public virtual void SuccessfulProcedure(HandApply interaction, PresentProcedure PresentProcedure)
 		{
 			//Do you whatever you would like
 		}
 
-		public virtual void UnsuccessfulStep(HandApply interaction, Dissectible.PresentProcedure PresentProcedure)
+		public virtual void UnsuccessfulStep(HandApply interaction, PresentProcedure PresentProcedure)
 		{
 			//DO dmg
 			//Do you whatever you would like
@@ -37,7 +38,7 @@ namespace HealthV2
 		public string SuccessOther = "";
 		public string FailSelf = "";
 		public string FailOther = "";
-
+		public float BleedStacksToAdd = 0;
 	}
 
 }

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -1661,6 +1661,15 @@ namespace HealthV2
 			BleedStacks = Mathf.Clamp((BleedStacks + deltaValue), 0, maxBleedStacks);
 		}
 
+		public void AddBleedStacks(float deltaValue)
+		{
+			BleedStacks += Mathf.Clamp((BleedStacks + deltaValue), -1000, maxBleedStacks);
+			if (BleedStacks < 0)
+			{
+				BleedStacks = 0;
+			}
+		}
+
 		/// <summary>
 		/// Forces a number of bleed stacks on the creature.
 		/// </summary>

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Dissectible.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Dissectible.cs
@@ -1,13 +1,15 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using HealthV2.Living.Surgery;
 using UnityEngine;
 using Mirror;
 using Player;
+using UI.Systems.Tooltips.HoverTooltips;
 
 namespace HealthV2
 {
 	public class Dissectible : NetworkBehaviour, IClientInteractable<HandApply>,
-		ICheckedInteractable<HandApply>
+		ICheckedInteractable<HandApply>, IExaminable, IHoverTooltip
 	{
 		public LivingHealthMasterBase LivingHealthMasterBase;
 
@@ -50,8 +52,9 @@ namespace HealthV2
 		[SyncVar(hook = nameof(SetBodyPartID))]
 		private uint BodyPartID;
 
-		public PresentProcedure ThisPresentProcedure = new PresentProcedure();
+		[field: SyncVar] public string NextTraitToUse { get; set; } = "";
 
+		public PresentProcedure ThisPresentProcedure = new PresentProcedure();
 		public List<ItemTrait> InitiateSurgeryItemTraits = new List<ItemTrait>(); //Make sure to include implantable stuff
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)
@@ -283,181 +286,63 @@ namespace HealthV2
 
 		public void ReceivedSurgery(List<BodyPart> Options)
 		{
-			if (ProcedureInProgress == false)
+			if (ProcedureInProgress) return;
+			if (BodyPartIsOn != null)
 			{
-				if (BodyPartIsOn != null)
-				{
-					if (BodyPartIsopen)
-					{
-						UIManager.Instance.SurgeryDialogue.ShowDialogue(this, Options);
-					}
-					else
-					{
-						UIManager.Instance.SurgeryDialogue.ShowDialogue(this, Options);
-					}
-				}
-				else
-				{
-					UIManager.Instance.SurgeryDialogue.ShowDialogue(this, Options, true);
-				}
+				UIManager.Instance.SurgeryDialogue.ShowDialogue(this, Options);
+			}
+			else
+			{
+				UIManager.Instance.SurgeryDialogue.ShowDialogue(this, Options, true);
 			}
 		}
 
-		public class PresentProcedure
+		public string Examine(Vector3 worldPos = default)
 		{
-			System.Random RNG = new System.Random();
+			if (BodyPartIsopen == false) return null;
+			return "<color=red>This body is open.</color>";
+		}
 
-			public Dissectible isOn;
+		public string HoverTip()
+		{
+			return Examine();
+		}
 
-			public SurgeryProcedureBase SurgeryProcedureBase;
-			public int CurrentStep = 0;
-			public BodyPart RelatedBodyPart;
+		public string CustomTitle()
+		{
+			return null;
+		}
 
-			//Used for when surgeries are cancelled
-			public BodyPart PreviousBodyPart;
+		public Sprite CustomIcon()
+		{
+			return null;
+		}
 
+		public List<Sprite> IconIndicators()
+		{
+			return null;
+		}
 
-			public HandApply Stored;
-			public SurgeryStep ThisSurgeryStep;
-
-
-			public void TryTool(HandApply interaction)
+		public List<TextColor> InteractionsStrings()
+		{
+			List<TextColor> interactions = new List<TextColor>();
+			if (ProcedureInProgress && string.IsNullOrEmpty(NextTraitToUse) == false)
 			{
-				Stored = interaction;
-				ThisSurgeryStep = null;
-
-				ThisSurgeryStep = SurgeryProcedureBase.SurgerySteps[CurrentStep];
-
-				if (ThisSurgeryStep != null)
+				interactions.Add(new TextColor
 				{
-					if (Validations.HasItemTrait(interaction.HandObject, ThisSurgeryStep.RequiredTrait))
-					{
-						string StartSelf = ApplyChatModifiers(ThisSurgeryStep.StartSelf);
-						string StartOther = ApplyChatModifiers(ThisSurgeryStep.StartOther);
-						string SuccessSelf = ApplyChatModifiers(ThisSurgeryStep.SuccessSelf);
-						string SuccessOther = ApplyChatModifiers(ThisSurgeryStep.SuccessOther);
-						string FailSelf = ApplyChatModifiers(ThisSurgeryStep.FailSelf);
-						string FailOther = ApplyChatModifiers(ThisSurgeryStep.FailOther);
-						ToolUtils.ServerUseToolWithActionMessages(interaction.Performer, interaction.HandObject,
-							ActionTarget.Object(interaction.TargetObject.RegisterTile()), ThisSurgeryStep.Time,
-							StartSelf, StartOther,
-							SuccessSelf, SuccessOther,
-							SuccessfulProcedure,
-							FailSelf, FailOther,
-							UnsuccessfulProcedure);
-						return;
-					}
-					else
-					{
-						//RelatedBodyPart can be null
-						var pokelimbtext = RelatedBodyPart != null ? $"'s {RelatedBodyPart.name}" : "";
-							Chat.AddActionMsgToChat(interaction, $" You poke {this.isOn.LivingHealthMasterBase.playerScript.visibleName}{pokelimbtext} with the {interaction.UsedObject.name} ",
-								$"{interaction.PerformerPlayerScript.visibleName} pokes {this.isOn.LivingHealthMasterBase.playerScript.visibleName}{pokelimbtext} with the {interaction.UsedObject.name} ");
-					}
-				}
-
-				if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Cautery))
-				{
-					Chat.AddActionMsgToChat(interaction, $" You use the {interaction.HandObject.ExpensiveName()} to close up {this.isOn.LivingHealthMasterBase.playerScript.visibleName}'s {RelatedBodyPart.name} ",
-						$"{interaction.PerformerPlayerScript.visibleName} uses a {interaction.UsedObject.ExpensiveName()} to close up  {this.isOn.LivingHealthMasterBase.playerScript.visibleName}'s {RelatedBodyPart.name} ");
-
-					CancelSurgery();
-					return;
-				}
+					Text = $"Use a {NextTraitToUse} to procced with the next step of the surgery.",
+					Color = Color.yellow
+				});
 			}
-
-			public void SuccessfulProcedure()
+			if (BodyPartIsopen)
 			{
-				if (RNG.Next(0, 100) < ThisSurgeryStep.FailChance)
+				interactions.Add(new TextColor
 				{
-					UnsuccessfulProcedure();
-					return;
-				}
-
-				CurrentStep++;
-
-				int NumberSteps = 0;
-				NumberSteps = SurgeryProcedureBase.SurgerySteps.Count;
-				if (CurrentStep >= NumberSteps)
-				{
-					isOn.ProcedureInProgress = false;
-
-					SurgeryProcedureBase.FinnishSurgeryProcedure(RelatedBodyPart, Stored, this);
-
-					RelatedBodyPart?.SuccessfulProcedure(Stored, this);
-					isOn.ProcedureInProgress = false;
-					//reset!
-				}
+					Text = $"Use a {CommonTraits.Instance.Cautery.Name} to close up.",
+					Color = Color.green
+				});
 			}
-
-			public void UnsuccessfulProcedure()
-			{
-				SurgeryProcedureBase.UnsuccessfulStep(RelatedBodyPart, Stored, this);
-
-				RelatedBodyPart?.UnsuccessfulStep(Stored, this);
-			}
-
-			public void CancelSurgery()
-			{
-				RelatedBodyPart = PreviousBodyPart;
-				isOn.currentlyOn = RelatedBodyPart?.gameObject;
-				CurrentStep = 0;
-				SurgeryProcedureBase = null;
-				isOn.ProcedureInProgress = false;
-			}
-
-			public void Clean()
-			{
-				PreviousBodyPart = RelatedBodyPart;
-				RelatedBodyPart = null;
-				CurrentStep = 0;
-				SurgeryProcedureBase = null;
-			}
-
-			public void SetupProcedure(Dissectible Dissectible, BodyPart bodyPart,
-				SurgeryProcedureBase inSurgeryProcedureBase)
-			{
-				Clean();
-				if (isOn != Dissectible)
-				{
-					PreviousBodyPart = null;
-				}
-
-				isOn = Dissectible;
-				isOn.ProcedureInProgress = true;
-				RelatedBodyPart = bodyPart;
-				SurgeryProcedureBase = inSurgeryProcedureBase;
-			}
-
-			/// <summary>
-			/// Replaces $ tags with their wanted names.
-			/// </summary>
-			/// <param name="toReplace">must have performer, Using and/or OnPart tags to replace.</param>
-			/// <returns></returns>
-			public string ApplyChatModifiers(string toReplace)
-			{
-				if (!string.IsNullOrWhiteSpace(toReplace))
-				{
-					toReplace = toReplace.Replace("{WhoOn}", Stored.TargetObject.ExpensiveName());
-				}
-
-				if (!string.IsNullOrWhiteSpace(toReplace))
-				{
-					toReplace = toReplace.Replace("{performer}", Stored.Performer.ExpensiveName());
-				}
-
-				if (!string.IsNullOrWhiteSpace(toReplace))
-				{
-					toReplace = toReplace.Replace("{Using}", Stored.UsedObject.ExpensiveName());
-				}
-
-				if (!string.IsNullOrWhiteSpace(toReplace))
-				{
-					toReplace = toReplace.Replace("{OnPart}", RelatedBodyPart.OrNull()?.gameObject.OrNull()?.ExpensiveName());
-				}
-
-				return toReplace;
-			}
+			return interactions;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/PresentProcedure.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/PresentProcedure.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using Logs;
+
+namespace HealthV2.Living.Surgery
+{
+	public class PresentProcedure
+	{
+		private readonly Random RNG = new();
+
+		public Dissectible isOn;
+
+		public SurgeryProcedureBase SurgeryProcedureBase;
+		public int CurrentStep;
+		public BodyPart RelatedBodyPart;
+
+		//Used for when surgeries are cancelled
+		public BodyPart PreviousBodyPart;
+		public HandApply Stored;
+		public SurgeryStep ThisSurgeryStep;
+
+		public void TryTool(HandApply interaction)
+		{
+			if (interaction == null)
+			{
+				Loggy.LogError("[PresentProcedure] - Interaction is null!");
+				return;
+			}
+			Stored = interaction;
+			ThisSurgeryStep = null;
+			isOn.NextTraitToUse = "";
+
+			ThisSurgeryStep = SurgeryProcedureBase.SurgerySteps[CurrentStep];
+			isOn.NextTraitToUse = ThisSurgeryStep?.RequiredTrait.Name;
+
+			if (ThisSurgeryStep != null)
+			{
+				if (Validations.HasItemTrait(interaction.HandObject, ThisSurgeryStep.RequiredTrait))
+				{
+					var StartSelf = ApplyChatModifiers(ThisSurgeryStep.StartSelf);
+					var StartOther = ApplyChatModifiers(ThisSurgeryStep.StartOther);
+					var SuccessSelf = ApplyChatModifiers(ThisSurgeryStep.SuccessSelf);
+					var SuccessOther = ApplyChatModifiers(ThisSurgeryStep.SuccessOther);
+					var FailSelf = ApplyChatModifiers(ThisSurgeryStep.FailSelf);
+					var FailOther = ApplyChatModifiers(ThisSurgeryStep.FailOther);
+					ToolUtils.ServerUseToolWithActionMessages(interaction.Performer, interaction.HandObject,
+						ActionTarget.Object(interaction.TargetObject.RegisterTile()), ThisSurgeryStep.Time,
+						StartSelf, StartOther,
+						SuccessSelf, SuccessOther,
+						SuccessfulProcedure,
+						FailSelf, FailOther,
+						UnsuccessfulProcedure);
+					return;
+				}
+				PokeMessage(interaction);
+			}
+			if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Cautery))
+			{
+				Chat.AddActionMsgToChat(interaction,
+					$" You use the {interaction.HandObject.ExpensiveName()} to close up {isOn.LivingHealthMasterBase.playerScript.visibleName}'s {RelatedBodyPart.name} ",
+					$"{interaction.PerformerPlayerScript.visibleName} uses a {interaction.UsedObject.ExpensiveName()} to close up  {isOn.LivingHealthMasterBase.playerScript.visibleName}'s {RelatedBodyPart.name} ");
+				CancelSurgery();
+			}
+		}
+
+		private void PokeMessage(HandApply interaction)
+		{
+			if (interaction.UsedObject == null)
+			{
+				return;
+			}
+			//RelatedBodyPart can be null
+			var pokelimbtext = RelatedBodyPart != null ? $"'s {RelatedBodyPart.name}" : "";
+			Chat.AddActionMsgToChat(interaction,
+				$" You poke {isOn.LivingHealthMasterBase.playerScript.visibleName}{pokelimbtext} with the {interaction.UsedObject.name} ",
+				$"{interaction.PerformerPlayerScript.visibleName} pokes {isOn.LivingHealthMasterBase.playerScript.visibleName}{pokelimbtext} with the {interaction.UsedObject.name} ");
+		}
+
+		public void SuccessfulProcedure()
+		{
+			RelatedBodyPart?.HealthMaster.AddBleedStacks(ThisSurgeryStep.BleedStacksToAdd);
+			if (RNG.Next(0, 100) < ThisSurgeryStep.FailChance)
+			{
+				UnsuccessfulProcedure();
+				return;
+			}
+			CurrentStep++;
+			if (CurrentStep >= SurgeryProcedureBase.SurgerySteps.Count)
+			{
+				isOn.ProcedureInProgress = false;
+
+				SurgeryProcedureBase.FinnishSurgeryProcedure(RelatedBodyPart, Stored, this);
+
+				RelatedBodyPart?.SuccessfulProcedure(Stored, this);
+				isOn.ProcedureInProgress = false;
+				//reset!
+			}
+			else
+			{
+				isOn.NextTraitToUse = ThisSurgeryStep?.RequiredTrait.Name;
+			}
+		}
+
+		public void UnsuccessfulProcedure()
+		{
+			if (ThisSurgeryStep.BleedStacksToAdd > 0)
+			{
+				RelatedBodyPart?.HealthMaster.AddBleedStacks(ThisSurgeryStep.BleedStacksToAdd * 2);
+			}
+			SurgeryProcedureBase.UnsuccessfulStep(RelatedBodyPart, Stored, this);
+			RelatedBodyPart?.UnsuccessfulStep(Stored, this);
+		}
+
+		public void CancelSurgery()
+		{
+			RelatedBodyPart = PreviousBodyPart;
+			isOn.currentlyOn = RelatedBodyPart?.gameObject;
+			CurrentStep = 0;
+			SurgeryProcedureBase = null;
+			isOn.ProcedureInProgress = false;
+		}
+
+		public void Clean()
+		{
+			PreviousBodyPart = RelatedBodyPart;
+			RelatedBodyPart = null;
+			CurrentStep = 0;
+			SurgeryProcedureBase = null;
+		}
+
+		public void SetupProcedure(Dissectible dissectible, BodyPart bodyPart,
+			SurgeryProcedureBase inSurgeryProcedureBase)
+		{
+			Clean();
+			if (isOn != dissectible) PreviousBodyPart = null;
+
+			isOn = dissectible;
+			isOn.ProcedureInProgress = true;
+			RelatedBodyPart = bodyPart;
+			SurgeryProcedureBase = inSurgeryProcedureBase;
+			ThisSurgeryStep = SurgeryProcedureBase?.SurgerySteps[CurrentStep];
+			dissectible.NextTraitToUse = ThisSurgeryStep?.RequiredTrait.Name;
+		}
+
+		/// <summary>
+		///     Replaces $ tags with their wanted names.
+		/// </summary>
+		/// <param name="toReplace">must have performer, Using and/or OnPart tags to replace.</param>
+		/// <returns></returns>
+		public string ApplyChatModifiers(string toReplace)
+		{
+			if (!string.IsNullOrWhiteSpace(toReplace))
+				toReplace = toReplace.Replace("{WhoOn}", Stored.TargetObject.ExpensiveName());
+
+			if (!string.IsNullOrWhiteSpace(toReplace))
+				toReplace = toReplace.Replace("{performer}", Stored.Performer.ExpensiveName());
+
+			if (!string.IsNullOrWhiteSpace(toReplace))
+				toReplace = toReplace.Replace("{Using}", Stored.UsedObject.ExpensiveName());
+
+			if (!string.IsNullOrWhiteSpace(toReplace))
+				toReplace = toReplace.Replace("{OnPart}",
+					RelatedBodyPart.OrNull()?.gameObject.OrNull()?.ExpensiveName());
+
+			return toReplace;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/PresentProcedure.cs.meta
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/PresentProcedure.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 844d24b1b856494ab1017d494fd5da4b
+timeCreated: 1724087353

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Procedures/AffectHealthProcedure.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Procedures/AffectHealthProcedure.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using HealthV2.Living.Surgery;
 using Items;
 using UnityEngine;
 using UnityEngine.Serialization;
@@ -17,16 +18,16 @@ namespace HealthV2
 		public AttackType FailAttackType = AttackType.Melee;
 
 		public override void FinnishSurgeryProcedure(BodyPart OnBodyPart, HandApply interaction,
-			Dissectible.PresentProcedure PresentProcedure)
+			PresentProcedure presentProcedure)
 		{
-			if (PresentProcedure.RelatedBodyPart.ContainedIn != null)
+			if (presentProcedure.RelatedBodyPart.ContainedIn != null)
 			{
-				PresentProcedure.isOn.currentlyOn = PresentProcedure.RelatedBodyPart.ContainedIn.gameObject;
-				PresentProcedure.RelatedBodyPart = PresentProcedure.RelatedBodyPart.ContainedIn;
+				presentProcedure.isOn.currentlyOn = presentProcedure.RelatedBodyPart.ContainedIn.gameObject;
+				presentProcedure.RelatedBodyPart = presentProcedure.RelatedBodyPart.ContainedIn;
 			}
 			else
 			{
-				PresentProcedure.isOn.currentlyOn = null;
+				presentProcedure.isOn.currentlyOn = null;
 			}
 
 			if (interaction.HandSlot.Item != null)
@@ -50,7 +51,7 @@ namespace HealthV2
 		}
 
 		public override void UnsuccessfulStep(BodyPart OnBodyPart, HandApply interaction,
-			Dissectible.PresentProcedure PresentProcedure)
+			PresentProcedure presentProcedure)
 		{
 			OnBodyPart.TakeDamage(interaction.UsedObject,HeelStrength*0.1f,FailAttackType,Affects);
 		}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Procedures/CloseProcedure.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Procedures/CloseProcedure.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using HealthV2.Living.Surgery;
 using UnityEngine;
 
 namespace HealthV2
@@ -8,25 +9,25 @@ namespace HealthV2
 	public class CloseProcedure : SurgeryProcedureBase
 	{
 		public override void FinnishSurgeryProcedure(BodyPart OnBodyPart, HandApply interaction,
-			Dissectible.PresentProcedure PresentProcedure)
+			PresentProcedure presentProcedure)
 		{
-			base.FinnishSurgeryProcedure(OnBodyPart, interaction, PresentProcedure);
-			if (PresentProcedure.RelatedBodyPart.ContainedIn != null)
+			base.FinnishSurgeryProcedure(OnBodyPart, interaction, presentProcedure);
+			if (presentProcedure.RelatedBodyPart.ContainedIn != null)
 			{
-				PresentProcedure.isOn.currentlyOn = PresentProcedure.RelatedBodyPart.ContainedIn.gameObject;
+				presentProcedure.isOn.currentlyOn = presentProcedure.RelatedBodyPart.ContainedIn.gameObject;
 			}
 			else
 			{
-				PresentProcedure.isOn.SetBodyPartIsOpen(false,  false);
-				PresentProcedure.isOn.currentlyOn = null;
-				PresentProcedure.RelatedBodyPart = null;
+				presentProcedure.isOn.SetBodyPartIsOpen(false,  false);
+				presentProcedure.isOn.currentlyOn = null;
+				presentProcedure.RelatedBodyPart = null;
 			}
 		}
 
 		public override void UnsuccessfulStep(BodyPart OnBodyPart, HandApply interaction,
-			Dissectible.PresentProcedure PresentProcedure)
+			PresentProcedure presentProcedure)
 		{
-			base.UnsuccessfulStep(OnBodyPart, interaction,PresentProcedure );
+			base.UnsuccessfulStep(OnBodyPart, interaction,presentProcedure );
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Procedures/ImplantProcedure.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Procedures/ImplantProcedure.cs
@@ -1,6 +1,5 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
+using HealthV2.Living.Surgery;
 using Items;
 using UnityEngine;
 
@@ -14,9 +13,9 @@ namespace HealthV2
 
 
 		public override void FinnishSurgeryProcedure(BodyPart OnBodyPart, HandApply interaction,
-			Dissectible.PresentProcedure PresentProcedure)
+			PresentProcedure presentProcedure)
 		{
-			base.FinnishSurgeryProcedure(OnBodyPart, interaction, PresentProcedure);
+			base.FinnishSurgeryProcedure(OnBodyPart, interaction, presentProcedure);
 
 			var itemApp = interaction?.HandSlot?.Item.OrNull()?.GetComponent<ItemAttributesV2>();
 
@@ -50,18 +49,18 @@ namespace HealthV2
 				}
 				else
 				{
-					var health = PresentProcedure.isOn.GetComponent<LivingHealthMasterBase>();
+					var health = presentProcedure.isOn.GetComponent<LivingHealthMasterBase>();
 
 					if (itemApp.HasTrait(CommonTraits.Instance.CoreBodyPart))
 					{
 						if (health.HasCoreBodyPart()) return;
 						health.BodyPartStorage.ServerTryTransferFrom(ToTakeFrom);
-						PresentProcedure.isOn.currentlyOn = null;
+						presentProcedure.isOn.currentlyOn = null;
 					}
 					else
 					{
 						health.BodyPartStorage.ServerTryTransferFrom(ToTakeFrom);
-						PresentProcedure.isOn.currentlyOn = null;
+						presentProcedure.isOn.currentlyOn = null;
 					}
 				}
 			}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Procedures/OpenProcedure.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Procedures/OpenProcedure.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using HealthV2.Living.Surgery;
 using UnityEngine;
 
 namespace HealthV2
@@ -8,17 +9,17 @@ namespace HealthV2
 	public class OpenProcedure : SurgeryProcedureBase
 	{
 		public override void FinnishSurgeryProcedure(BodyPart OnBodyPart, HandApply interaction,
-			Dissectible.PresentProcedure PresentProcedure)
+			PresentProcedure presentProcedure)
 		{
-			base.FinnishSurgeryProcedure(OnBodyPart, interaction, PresentProcedure);
-			PresentProcedure.isOn.SetBodyPartIsOpen(true,true);
+			base.FinnishSurgeryProcedure(OnBodyPart, interaction, presentProcedure);
+			presentProcedure.isOn.SetBodyPartIsOpen(true,true);
 
 		}
 
 		public override void UnsuccessfulStep(BodyPart OnBodyPart, HandApply interaction,
-			Dissectible.PresentProcedure PresentProcedure)
+			PresentProcedure presentProcedure)
 		{
-			base.UnsuccessfulStep(OnBodyPart, interaction,PresentProcedure );
+			base.UnsuccessfulStep(OnBodyPart, interaction,presentProcedure );
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Procedures/RemovalProcedure.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/Procedures/RemovalProcedure.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using HealthV2.Living.Surgery;
 using UnityEngine;
 
 namespace HealthV2
@@ -8,22 +9,22 @@ namespace HealthV2
 	public class RemovalProcedure : SurgeryProcedureBase
 	{
 		public override void FinnishSurgeryProcedure(BodyPart OnBodyPart, HandApply interaction,
-			Dissectible.PresentProcedure PresentProcedure)
+			PresentProcedure presentProcedure)
 		{
-			base.FinnishSurgeryProcedure(OnBodyPart, interaction, PresentProcedure);
-			if (PresentProcedure.RelatedBodyPart.ContainedIn != null)
+			base.FinnishSurgeryProcedure(OnBodyPart, interaction, presentProcedure);
+			if (presentProcedure.RelatedBodyPart.ContainedIn != null)
 			{
-				PresentProcedure.isOn.SetBodyPartIsOpen(false,true) ;
-				PresentProcedure.isOn.currentlyOn = PresentProcedure.RelatedBodyPart.ContainedIn.gameObject;
+				presentProcedure.isOn.SetBodyPartIsOpen(false,true) ;
+				presentProcedure.isOn.currentlyOn = presentProcedure.RelatedBodyPart.ContainedIn.gameObject;
 			}
 			else
 			{
-				PresentProcedure.isOn.SetBodyPartIsOpen(false,false) ;
-				PresentProcedure.isOn.currentlyOn = null;
+				presentProcedure.isOn.SetBodyPartIsOpen(false,false) ;
+				presentProcedure.isOn.currentlyOn = null;
 			}
 
-			PresentProcedure.isOn.ThisPresentProcedure.PreviousBodyPart = null;
-			PresentProcedure.isOn.ThisPresentProcedure.RelatedBodyPart = null;
+			presentProcedure.isOn.ThisPresentProcedure.PreviousBodyPart = null;
+			presentProcedure.isOn.ThisPresentProcedure.RelatedBodyPart = null;
 
 			OnBodyPart.TryRemoveFromBody();
 		}

--- a/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/SurgeryProcedureBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/Surgery/SurgeryProcedureBase.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using HealthV2.Living.Surgery;
 using UnityEngine;
 
 namespace HealthV2
@@ -12,12 +13,12 @@ namespace HealthV2
 		public List<SurgeryStep> SurgerySteps = new List<SurgeryStep>();
 
 		public virtual void FinnishSurgeryProcedure(BodyPart OnBodyPart, HandApply interaction,
-			Dissectible.PresentProcedure PresentProcedure)
+			PresentProcedure PresentProcedure)
 		{
 		}
 
 		public virtual void UnsuccessfulStep(BodyPart OnBodyPart, HandApply interaction,
-			Dissectible.PresentProcedure PresentProcedure)
+			PresentProcedure PresentProcedure)
 		{
 		}
 	}


### PR DESCRIPTION
CL: [New] Players can be guided through surgery steps in hover tooltips now.
CL: [New] Surgery is no longer clean and safe. Your victim/patient will bleed upon proceeding with surgery steps.
CL: [Improvement] Flashlights have had their light cones buffed in size. 
CL: [Fix] Fixed an issue where flashlights' light cones would not rotate alongside their sprites.
