### PR TITLE
Removes startup scene from admin map list

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/SubScenes/MainStationList.asset
+++ b/UnityProject/Assets/ScriptableObjects/SubScenes/MainStationList.asset
@@ -16,5 +16,4 @@ MonoBehaviour:
   - SquareStation
   - MiniStation
   - FallStation
-  - StartUp
   mapsConfig: maps.json

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/MainStationListSO.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/MainStationListSO.cs
@@ -25,6 +25,8 @@ public class MainStationListSO : ScriptableObject
 			var maps = JsonConvert.DeserializeObject<MapList>(AccessFile.Load(mapsConfig));
 			return maps.GetRandomMap();
 		}
+		Chat.AddGameWideSystemMsgToChat("Uh oh! We're using the legacy way of loading scenes!!" +
+		                                "Make sure that the gamemode has a maps config file set or is not missing!!!");
 
 		// Check that we can actually load the scene.
 		var mapSoList = MainStations.Where(scene => SceneUtility.GetBuildIndexByScenePath(scene) > -1).ToList();


### PR DESCRIPTION
also adds a global warning whenever a gamemode tries to load a map config files, but fails and reverts back to the legacy way of loading maps.

### Changelog

CL: [Fix] Fixed an admin oddity that could let them load the startup scene as the next mainstation scene.
