### PR TITLE
Playtest fixes

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Implants/BreathingTubeImplant.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/BreathingTubeImplant.prefab
@@ -92,7 +92,7 @@ PrefabInstance:
     - target: {fileID: 1641972083238813818, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
       propertyPath: initialName
-      value: Breathing Tube Implant
+      value: breathing tube implant
       objectReference: {fileID: 0}
     - target: {fileID: 1641972083238813818, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
@@ -102,9 +102,8 @@ PrefabInstance:
     - target: {fileID: 1641972083238813818, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
       propertyPath: initialDescription
-      value: This implant will allow the user to use gas tanks for internals, even
-        if he is not wearing a mask. If exposed to EMP, it has a chance to suffocate
-        the user.
+      value: 'When implanted in a targets head, this implant will allow the user
+        to use gas tanks for internals even when they are not wearing a mask. '
       objectReference: {fileID: 0}
     - target: {fileID: 1641972083238813818, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
@@ -234,6 +233,12 @@ PrefabInstance:
     - target: {fileID: 4999823976648774815, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
       propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 0ce00f6382e9b434dafca20c07549220,
+        type: 2}
+    - target: {fileID: 4999823976648774815, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: InitialPresentSpriteSet
       value: 
       objectReference: {fileID: 11400000, guid: 0ce00f6382e9b434dafca20c07549220,
         type: 2}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Explosives/ImplantExplosive.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Explosives/ImplantExplosive.prefab
@@ -84,7 +84,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 8ba48b7c4573e5e4d83ad459ac158f6e,
+      objectReference: {fileID: 21300002, guid: 8ba48b7c4573e5e4d83ad459ac158f6e,
         type: 3}
     - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
@@ -104,7 +104,7 @@ PrefabInstance:
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: initialName
-      value: Implant explosive
+      value: implant explosive
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
@@ -124,7 +124,8 @@ PrefabInstance:
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: initialDescription
-      value: A small explosive charge, small enough to be implanted into a skull.
+      value: A small explosive charge implanted in the victims skull, can be connected
+        to a remote signaller.
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
@@ -196,6 +197,12 @@ PrefabInstance:
     - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 3781008d5eea1004b9b74ccf9cb8bf4d,
+        type: 2}
+    - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: InitialPresentSpriteSet
       value: 
       objectReference: {fileID: 11400000, guid: 3781008d5eea1004b9b74ccf9cb8bf4d,
         type: 2}
@@ -310,6 +317,7 @@ MonoBehaviour:
     SlotContents: []
     DeprecatedContents: []
   SetSlotItemNotRemovableOnStartUp: 0
+  initialignoreRoundstartGrabObjects: 0
   ashPrefab: {fileID: 2957035178188790827, guid: 9ac6968a3f3ed54428662c9aae5a4b32,
     type: 3}
 --- !u!114 &4373764861328305485

--- a/UnityProject/Assets/Prefabs/Items/Implants/Explosives/MacrobombImplant.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Explosives/MacrobombImplant.prefab
@@ -46,7 +46,7 @@ PrefabInstance:
     - target: {fileID: 2925014835611581738, guid: 414ec5b5318df6f4bbd000a4dfb298ca,
         type: 3}
       propertyPath: initialName
-      value: Macrobomb Implant
+      value: macrobomb implant
       objectReference: {fileID: 0}
     - target: {fileID: 2925014835611581738, guid: 414ec5b5318df6f4bbd000a4dfb298ca,
         type: 3}
@@ -56,7 +56,7 @@ PrefabInstance:
     - target: {fileID: 2925014835611581738, guid: 414ec5b5318df6f4bbd000a4dfb298ca,
         type: 3}
       propertyPath: initialDescription
-      value: 'And boom goes the weasel. And everything else nearby.
+      value: 'And boom goes the weasel... and everything else nearby.
 
         Implanted
         in the victims chest.'
@@ -76,7 +76,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: cdc8f1d8e6da1974796be20f42e6d932,
+      objectReference: {fileID: 21300004, guid: cdc8f1d8e6da1974796be20f42e6d932,
         type: 3}
     - target: {fileID: 3344386625987260220, guid: 414ec5b5318df6f4bbd000a4dfb298ca,
         type: 3}
@@ -212,6 +212,12 @@ PrefabInstance:
     - target: {fileID: 8880035226631236047, guid: 414ec5b5318df6f4bbd000a4dfb298ca,
         type: 3}
       propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 42e551f18ce052445bc0de801a3cc830,
+        type: 2}
+    - target: {fileID: 8880035226631236047, guid: 414ec5b5318df6f4bbd000a4dfb298ca,
+        type: 3}
+      propertyPath: InitialPresentSpriteSet
       value: 
       objectReference: {fileID: 11400000, guid: 42e551f18ce052445bc0de801a3cc830,
         type: 2}

--- a/UnityProject/Assets/Prefabs/Items/Implants/Explosives/MicrobombImplant.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/Explosives/MicrobombImplant.prefab
@@ -41,15 +41,14 @@ PrefabInstance:
     - target: {fileID: 2925014835611581738, guid: 414ec5b5318df6f4bbd000a4dfb298ca,
         type: 3}
       propertyPath: initialName
-      value: Microbomb Implant
+      value: microbomb implant
       objectReference: {fileID: 0}
     - target: {fileID: 2925014835611581738, guid: 414ec5b5318df6f4bbd000a4dfb298ca,
         type: 3}
       propertyPath: initialDescription
-      value: 'And boom goes the weasel. And everything else nearby.
-
-        Implanted
-        in the victims head.'
+      value: A larger variant of the standard implant explosive powerful enough to
+        cause damage to the surrounding area and destroy any gear on the victims
+        person. Implanted in the victims head.
       objectReference: {fileID: 0}
     - target: {fileID: 2925014835611581738, guid: 414ec5b5318df6f4bbd000a4dfb298ca,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/ReviverImplant.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/ReviverImplant.prefab
@@ -101,7 +101,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   NetworkThis: 1
   SubCatalogue: []
-  PresentSpriteSet: {fileID: 11400000, guid: 9c47b60dcaf2da347a102487710120e6, type: 2}
+  InitialPresentSpriteSet: {fileID: 11400000, guid: 9c47b60dcaf2da347a102487710120e6,
+    type: 2}
   randomInitialSprite: 0
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
@@ -199,7 +200,7 @@ PrefabInstance:
     - target: {fileID: 1641972083238813818, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
       propertyPath: initialName
-      value: Reviver Implant
+      value: reviver implant
       objectReference: {fileID: 0}
     - target: {fileID: 1641972083238813818, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
@@ -209,9 +210,9 @@ PrefabInstance:
     - target: {fileID: 1641972083238813818, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
       propertyPath: initialDescription
-      value: This implant will heal you whenever you fall into critical health status;
-        it will go on cooldown after each revival. If hit by EMP, has the chance
-        to cause a heart attack.
+      value: When implanted in a target's chest, this implant will heal the user
+        whenever they fall into critical health status. This implant takes considerable
+        time to recharge.
       objectReference: {fileID: 0}
     - target: {fileID: 1641972083238813818, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
@@ -341,6 +342,12 @@ PrefabInstance:
     - target: {fileID: 4999823976648774815, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
       propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 0e9175977d0a4744fbfda8c6656cb802,
+        type: 2}
+    - target: {fileID: 4999823976648774815, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: InitialPresentSpriteSet
       value: 
       objectReference: {fileID: 11400000, guid: 0e9175977d0a4744fbfda8c6656cb802,
         type: 2}

--- a/UnityProject/Assets/Prefabs/Items/Implants/WeldingShieldImplant.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/WeldingShieldImplant.prefab
@@ -92,7 +92,7 @@ PrefabInstance:
     - target: {fileID: 1641972083238813818, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
       propertyPath: initialName
-      value: Welding Shield Implant
+      value: welding shield implant
       objectReference: {fileID: 0}
     - target: {fileID: 1641972083238813818, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
@@ -102,8 +102,8 @@ PrefabInstance:
     - target: {fileID: 1641972083238813818, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
       propertyPath: initialDescription
-      value: "This implant will protect the user from flashes (including the flash
-        part of flashbangs) and prevents welding blindness.\r"
+      value: "This implant will protect the target from flashes when implanted in
+        the target's eye.\r"
       objectReference: {fileID: 0}
     - target: {fileID: 1641972083238813818, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
@@ -233,6 +233,12 @@ PrefabInstance:
     - target: {fileID: 4999823976648774815, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
       propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: df4ef7ada02a4a64d8f62cfc54ac5940,
+        type: 2}
+    - target: {fileID: 4999823976648774815, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: InitialPresentSpriteSet
       value: 
       objectReference: {fileID: 11400000, guid: df4ef7ada02a4a64d8f62cfc54ac5940,
         type: 2}

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/ResearchServer/SpriteEntry.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/ResearchServer/SpriteEntry.prefab
@@ -12,8 +12,8 @@ GameObject:
   - component: {fileID: 4043454298722783681}
   - component: {fileID: 5169272487207651110}
   - component: {fileID: 4186264278110125173}
-  - component: {fileID: 4664166677362770599}
-  m_Layer: 0
+  - component: {fileID: 3327388170725941495}
+  m_Layer: 5
   m_Name: Sprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -67,7 +67,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 086ac8c37802063448b293cbf7672067, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 8afb0f13fbddb19499b01a29f5bebf27, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -91,16 +91,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   NetworkThis: 0
   SubCatalogue: []
-  PresentSpriteSet: {fileID: 11400000, guid: d04afecdfb5d81f4a8560c4f1f80759e, type: 2}
+  InitialPresentSpriteSet: {fileID: 11400000, guid: d04afecdfb5d81f4a8560c4f1f80759e,
+    type: 2}
   randomInitialSprite: 0
   doReverseAnimation: 0
-  pushTextureOnStartUp: 0
+  pushTextureOnStartUp: 1
   initialVariantIndex: 0
   palette: []
-  OnSpriteUpdated:
-    m_PersistentCalls:
-      m_Calls: []
---- !u!114 &4664166677362770599
+--- !u!114 &3327388170725941495
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -123,7 +121,7 @@ GameObject:
   - component: {fileID: 4124674559576906289}
   - component: {fileID: 916990047793769560}
   - component: {fileID: 3960514292349163242}
-  - component: {fileID: 6813837160561949877}
+  - component: {fileID: 900897226750076805}
   m_Layer: 5
   m_Name: SpriteEntry
   m_TagString: Untagged
@@ -179,7 +177,7 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
---- !u!114 &6813837160561949877
+--- !u!114 &900897226750076805
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -188,7 +186,8 @@ MonoBehaviour:
   m_GameObject: {fileID: 4637118177487425818}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4f68104f3ca745b4a6c130b193c5a0f9, type: 3}
+  m_Script: {fileID: 11500000, guid: ab6f2ec0ca9c0d346b999ebc056e30d5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   Poolble: 1
+  spriteHandler: {fileID: 3327388170725941495}

--- a/UnityProject/Assets/Scripts/UI/Objects/Research/ResearchServer/AvailableTechEntry.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Research/ResearchServer/AvailableTechEntry.cs
@@ -38,16 +38,18 @@ namespace UI.Objects.Research
 
 			for(int i = 0; i < unlockCount; i++)
 			{
+				if (spriteList.Entries[i].TryGetComponent<SpriteEntry>(out var handler) == false) continue;
+				
 				string DesignID = technologyToUnlock.DesignIDs[i]; //Gets the designs this research will unlock
 				if (Designs.Globals.InternalIDSearch.ContainsKey(DesignID) == false) continue;
-
+				
 				Design designClass = Designs.Globals.InternalIDSearch[DesignID];
 
 				//Gets the sprite of the gameObject that design is for
-				SpriteDataSO sprite = networkManager.ForeverIDLookupSpawnablePrefabs[designClass.ItemID].GetComponentInChildren<SpriteHandler>().PresentSpritesSet;
+				SpriteDataSO sprite = networkManager.ForeverIDLookupSpawnablePrefabs[designClass.ItemID].GetComponentInChildren<SpriteHandler>().initialPresentSpriteSet;
 
 				//Uses the sprite from above and sets the sprite of the list entry to that sprite
-				spriteList.Entries[i].GetComponentInChildren<NetSpriteHandler>().SetValue(sprite.SetID);
+				handler.Initialise(sprite);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/UI/Objects/Research/ResearchServer/SpriteEntry.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Research/ResearchServer/SpriteEntry.cs
@@ -1,0 +1,17 @@
+using UI.Core.Net.Elements;
+using UI.Core.NetUI;
+using UnityEngine;
+
+namespace UI.Objects.Research
+{
+	public class SpriteEntry : DynamicEntry
+	{
+		[SerializeField] private NetSpriteHandler spriteHandler;
+
+		public void Initialise(SpriteDataSO spriteData)
+		{
+			spriteHandler.MasterSetValue(spriteData.SetID);
+		}
+
+	}
+}

--- a/UnityProject/Assets/Scripts/UI/Objects/Research/ResearchServer/SpriteEntry.cs.meta
+++ b/UnityProject/Assets/Scripts/UI/Objects/Research/ResearchServer/SpriteEntry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ab6f2ec0ca9c0d346b999ebc056e30d5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/StreamingAssets/Config/TechWeb/Designs/MedicalDesigns.json
+++ b/UnityProject/Assets/StreamingAssets/Config/TechWeb/Designs/MedicalDesigns.json
@@ -402,7 +402,7 @@
             "Uranium": 500
         },
         "Machinery_type": [
-            "ExisuitFabricator"
+            "ExosuitFabricator"
         ],
         "Compatible_machinery": [
             "Medical",


### PR DESCRIPTION
### Changelog:
CL: [Improvement] Implants (Including Explosive Implants) now have descriptions that say where they are supposed to be implanted, to improve ease of use.

CL: [Balance] New loot in the form of abandoned crates have been added to lavaland.

CL: [Fix] Fixed Techweb UI sprites not displaying
CL: [Fix] Fixed Techweb UI failing due to errors
CL: [Fix] Fixed reviver implant being produceable at an 'Exisuit Fabricator' instead of an 'Exosuit Fabricator'