### PR TITLE
Implement breakable shields

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Shields/RiotShield.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Shields/RiotShield.prefab
@@ -191,6 +191,24 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 0668f4c7f366b7947a3f8642487b1ba6,
         type: 2}
+    - target: {fileID: 5576016130320151481, guid: d8e28939643d5a34095fed9b0898c45b,
+        type: 3}
+      propertyPath: InitialitemSprites.SpriteLeftHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 340532e8ab171c4489ebc590b660e8ac,
+        type: 2}
+    - target: {fileID: 5576016130320151481, guid: d8e28939643d5a34095fed9b0898c45b,
+        type: 3}
+      propertyPath: InitialitemSprites.SpriteRightHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 268345415e6a6554082b3c7b352162d2,
+        type: 2}
+    - target: {fileID: 5576016130320151481, guid: d8e28939643d5a34095fed9b0898c45b,
+        type: 3}
+      propertyPath: InitialitemSprites.SpriteInventoryIcon
+      value: 
+      objectReference: {fileID: 11400000, guid: 0668f4c7f366b7947a3f8642487b1ba6,
+        type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -199,6 +217,10 @@ PrefabInstance:
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 7802048611900235560}
+    - targetCorrespondingSourceObject: {fileID: 5443839937711004891, guid: d8e28939643d5a34095fed9b0898c45b,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 3346008558528864777}
   m_SourcePrefab: {fileID: 100100000, guid: d8e28939643d5a34095fed9b0898c45b, type: 3}
 --- !u!1 &4015502146010655738 stripped
 GameObject:
@@ -229,3 +251,17 @@ MonoBehaviour:
   hidesSlots: 0
   hideClothingFlags: 0
   disallowConsume: 0
+--- !u!114 &3346008558528864777
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4015502146010655738}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4c5a1c8749bf9485da6e5a1bfe398783, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  allowRepair: 1
+  repairTrait: {fileID: 11400000, guid: eab4a0cf6ec899240b34c27ae82015e2, type: 2}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Shields/RomanShield.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Shields/RomanShield.prefab
@@ -8,6 +8,16 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 3346008558528864777, guid: 5f9896c0cca80e14f8144be44d05e0a0,
+        type: 3}
+      propertyPath: allowRepair
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3346008558528864777, guid: 5f9896c0cca80e14f8144be44d05e0a0,
+        type: 3}
+      propertyPath: repairTrait
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 3554597231095268504, guid: 5f9896c0cca80e14f8144be44d05e0a0,
         type: 3}
       propertyPath: initialName
@@ -38,6 +48,24 @@ PrefabInstance:
     - target: {fileID: 3554597231095268504, guid: 5f9896c0cca80e14f8144be44d05e0a0,
         type: 3}
       propertyPath: itemSprites.SpriteInventoryIcon
+      value: 
+      objectReference: {fileID: 11400000, guid: 9b36b08421e896c498843be81439fcc8,
+        type: 2}
+    - target: {fileID: 3554597231095268504, guid: 5f9896c0cca80e14f8144be44d05e0a0,
+        type: 3}
+      propertyPath: InitialitemSprites.SpriteLeftHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 0077de08a450c704cb7938826f2a9dae,
+        type: 2}
+    - target: {fileID: 3554597231095268504, guid: 5f9896c0cca80e14f8144be44d05e0a0,
+        type: 3}
+      propertyPath: InitialitemSprites.SpriteRightHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 77ecde85fd38d304fad66f46c37a34eb,
+        type: 2}
+    - target: {fileID: 3554597231095268504, guid: 5f9896c0cca80e14f8144be44d05e0a0,
+        type: 3}
+      propertyPath: InitialitemSprites.SpriteInventoryIcon
       value: 
       objectReference: {fileID: 11400000, guid: 9b36b08421e896c498843be81439fcc8,
         type: 2}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Shields/WoodenBuckler.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Shields/WoodenBuckler.prefab
@@ -8,6 +8,16 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 3346008558528864777, guid: 5f9896c0cca80e14f8144be44d05e0a0,
+        type: 3}
+      propertyPath: allowRepair
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3346008558528864777, guid: 5f9896c0cca80e14f8144be44d05e0a0,
+        type: 3}
+      propertyPath: repairTrait
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 3554597231095268504, guid: 5f9896c0cca80e14f8144be44d05e0a0,
         type: 3}
       propertyPath: exportCost
@@ -53,6 +63,24 @@ PrefabInstance:
     - target: {fileID: 3554597231095268504, guid: 5f9896c0cca80e14f8144be44d05e0a0,
         type: 3}
       propertyPath: itemSprites.SpriteInventoryIcon
+      value: 
+      objectReference: {fileID: 11400000, guid: c15a82af01fd84440914df5b1bb87186,
+        type: 2}
+    - target: {fileID: 3554597231095268504, guid: 5f9896c0cca80e14f8144be44d05e0a0,
+        type: 3}
+      propertyPath: InitialitemSprites.SpriteLeftHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 3ac2bc47ddc0e084495eb48d9f6738f7,
+        type: 2}
+    - target: {fileID: 3554597231095268504, guid: 5f9896c0cca80e14f8144be44d05e0a0,
+        type: 3}
+      propertyPath: InitialitemSprites.SpriteRightHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 8ae974ceda08ff44887f4e17fe42d8f3,
+        type: 2}
+    - target: {fileID: 3554597231095268504, guid: 5f9896c0cca80e14f8144be44d05e0a0,
+        type: 3}
+      propertyPath: InitialitemSprites.SpriteInventoryIcon
       value: 
       objectReference: {fileID: 11400000, guid: c15a82af01fd84440914df5b1bb87186,
         type: 2}

--- a/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
@@ -103,7 +103,10 @@ namespace Items
 		/// </summary>
 		public MultiInterestFloat ServerBlockChance = new( InSetFloatBehaviour: MultiInterestFloat.FloatBehaviour.AddBehaviour);
 
-		public Action OnBlock;
+		/// <summary>
+		/// Server only action for OnBlock effects, gameobject is the attacker and float is the amount of damage that was blocked
+		/// </summary>
+		public Action<GameObject, float, DamageType> OnBlock;
 
 		[Header("Sprites/Sounds/Flags/Misc.")]
 

--- a/UnityProject/Assets/Scripts/Items/Weapons/ActivatableWeaponComponents/Client/PreventHandswapWhileActive.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/ActivatableWeaponComponents/Client/PreventHandswapWhileActive.cs
@@ -1,8 +1,5 @@
 namespace Weapons.ActivatableWeapons
 {
-
-
-
 	public class PreventHandswapWhileActive : ClientActivatableWeaponComponent
 	{
 		private Pickupable pickupable;

--- a/UnityProject/Assets/Scripts/Items/Weapons/ActivatableWeaponComponents/Server/DeactivateOnInventoryMove.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/ActivatableWeaponComponents/Server/DeactivateOnInventoryMove.cs
@@ -5,15 +5,15 @@ namespace Weapons.ActivatableWeapons
 	public class DeactivateOnInventoryMove : ServerActivatableWeaponComponent, IServerInventoryMove
 	{
 		public void OnInventoryMoveServer(InventoryMove info)
-			{
-				if (gameObject != info.MovedObject.gameObject) return;
+		{
+			if (gameObject != info.MovedObject.gameObject) return;
 
-				if (info.InventoryMoveType == InventoryMoveType.Remove || info.InventoryMoveType == InventoryMoveType.Transfer )
-				{
-					av.ServerOnDeactivate?.Invoke(info.FromPlayer.gameObject);
-					av.SyncState(av.IsActive, false);
-				}
+			if (info.InventoryMoveType == InventoryMoveType.Remove || info.InventoryMoveType == InventoryMoveType.Transfer )
+			{
+				av.ServerOnDeactivate?.Invoke(info.FromPlayer.gameObject);
+				av.SyncState(av.IsActive, false);
 			}
+		}
 
 		public override void ServerActivateBehaviour(GameObject performer)
 		{

--- a/UnityProject/Assets/Scripts/Items/Weapons/ActivatableWeaponComponents/Server/FlashOnActivate.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/ActivatableWeaponComponents/Server/FlashOnActivate.cs
@@ -15,12 +15,12 @@ namespace Weapons.ActivatableWeapons
 		{
 			flashComp = GetComponent<FlasherBase>();
 			attribs = GetComponent<ItemAttributesV2>();
-			attribs.OnBlock += flashComp.FlashInRadius;
+			attribs.OnBlock += Flash;
 		}
 
 		private void OnDestroy()
 		{
-			attribs.OnBlock -= flashComp.FlashInRadius;
+			attribs.OnBlock -= Flash;
 		}
 
 		public override void ServerActivateBehaviour(GameObject performer)
@@ -31,6 +31,11 @@ namespace Weapons.ActivatableWeapons
 		public override void ServerDeactivateBehaviour(GameObject performer)
 		{
 			//
+		}
+
+		public void Flash(GameObject attacker, float damage, DamageType damageType)
+		{
+			flashComp.FlashInRadius();
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Weapons/BreakableShield.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/BreakableShield.cs
@@ -1,0 +1,70 @@
+using Items;
+using UnityEngine;
+
+namespace Weapons
+{
+	public class BreakableShield : MonoBehaviour, ICheckedInteractable<InventoryApply>
+	{
+		private Integrity integ;
+		private ItemAttributesV2 attribs;
+		protected StandardProgressActionConfig ProgressConfig
+			= new(StandardProgressActionType.ItemTransfer);
+
+		[SerializeField] private bool allowRepair;
+		[SerializeField] private float repairTime = 2f;
+		[SerializeField] private ItemTrait repairTrait;
+
+		private void Awake()
+		{
+			integ = GetComponent<Integrity>();
+			attribs = GetComponent<ItemAttributesV2>();
+			attribs.OnBlock += DamageOnBlock;
+		}
+
+		private void OnDestroy()
+		{
+			attribs.OnBlock -= DamageOnBlock;
+		}
+
+		public void DamageOnBlock(GameObject attacker, float damage, DamageType damageType)
+		{
+			integ.ApplyDamage(damage, AttackType.Melee, damageType);
+		}
+
+		public bool WillInteract(InventoryApply interaction, NetworkSide side)
+		{
+			if (allowRepair == false) return false;
+			if (DefaultWillInteract.Default(interaction, side) == false) return false;
+			if (interaction.TargetObject == gameObject && Validations.HasItemTrait(interaction.UsedObject, repairTrait))
+			{
+				return true;
+			}
+
+			return false;
+		}
+
+		public void ServerPerformInteraction(InventoryApply interaction)
+		{
+			if (Validations.HasItemTrait(interaction.UsedObject, repairTrait) && integ.integrity < integ.initialIntegrity)
+			{
+				void ProgressFinishAction()
+				{
+					string usedObjectName = interaction.UsedObject.ExpensiveName();
+					if (interaction.UsedObject.TryGetComponent<Stackable>(out var stackable) && stackable.Amount > 1)
+					{
+						stackable.ServerConsume(1);
+					} else
+					{
+						Inventory.ServerDespawn(interaction.UsedObject);
+					}
+
+					Chat.AddExamineMsgFromServer(interaction.Performer, $"You repair {gameObject.ExpensiveName()} with {usedObjectName}.");
+					integ.RestoreIntegrity(integ.initialIntegrity);
+				}
+
+				var bar = StandardProgressAction.Create(ProgressConfig, ProgressFinishAction)
+					.ServerStartProgress(interaction.Performer.RegisterTile(), repairTime, interaction.Performer);
+			}
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Weapons/BreakableShield.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/BreakableShield.cs
@@ -62,7 +62,7 @@ namespace Weapons
 					integ.RestoreIntegrity(integ.initialIntegrity);
 				}
 
-				var bar = StandardProgressAction.Create(ProgressConfig, ProgressFinishAction)
+				StandardProgressAction.Create(ProgressConfig, ProgressFinishAction)
 					.ServerStartProgress(interaction.Performer.RegisterTile(), repairTime, interaction.Performer);
 			}
 		}

--- a/UnityProject/Assets/Scripts/Items/Weapons/BreakableShield.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Weapons/BreakableShield.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4c5a1c8749bf9485da6e5a1bfe398783

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
@@ -184,7 +184,7 @@ public class WeaponNetworkActions : NetworkBehaviour
 			// Punches have 90% chance to hit, otherwise it is a miss.
 			if (DMMath.Prob(chanceToHit))
 			{
-				if (BlockCheck(victim))
+				if (BlockCheck(victim, damage, currentDamageType))
 				{
 					// The attack hit.
 					if (victim.TryGetComponent<LivingHealthMasterBase>(out var victimHealth))
@@ -251,12 +251,12 @@ public class WeaponNetworkActions : NetworkBehaviour
 	}
 
 	[Server]
-	private bool BlockCheck(GameObject victim)
+	private bool BlockCheck(GameObject victim, float damage, DamageType damageType)
 	{
 		float blockChance = 100f;
 		AddressableAudioSource blockSound = null;
 		string blockName = null;
-		Action blockAction = null;
+		Action<GameObject, float, DamageType> blockAction = null;
 
 		if (victim.TryGetComponent<PlayerScript>(out var victimScript))
 		{
@@ -287,7 +287,7 @@ public class WeaponNetworkActions : NetworkBehaviour
 			Chat.AddCombatMsgToChat(gameObject, $"{victimName} blocks your attack with {blockName}!",
 				$"{victimName} blocks {gameObject.ExpensiveName()}'s attack with {blockName}!");
 
-			blockAction.Invoke();
+			blockAction?.Invoke(gameObject, damage, damageType);
 
 			return false;
 		}


### PR DESCRIPTION
Creates the breakable shield component, which will make any item with it applied take damage from an attack when an attack is blocked

Additionally the component has a configuration option to allow repairing it with an item

Riot/Tele/Strobe shields have been set to be repairable using a singular titanium sheet (takes 2s), whilst the Roman shields and the wooden buckler cannot be repaired.

### Changelog:
CL: [New] The riot, strobe, telescopic, roman and wooden shields now take durability damage when blocking attacks.
CL: [New] The riot, strobe and telescopic shields can be repaired using a titanium sheet