### PR TITLE
Door bump and activatable weapon fix

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Weapons/ActivatableWeaponComponents/Server/DeactivateOnInventoryMove.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/ActivatableWeaponComponents/Server/DeactivateOnInventoryMove.cs
@@ -7,7 +7,7 @@ namespace Weapons.ActivatableWeapons
 		public void OnInventoryMoveServer(InventoryMove info)
 		{
 			if (gameObject != info.MovedObject.gameObject) return;
-
+			if (av.IsActive == false) return; 
 			if (info.InventoryMoveType == InventoryMoveType.Remove || info.InventoryMoveType == InventoryMoveType.Transfer )
 			{
 				av.ServerOnDeactivate?.Invoke(info.FromPlayer.gameObject);

--- a/UnityProject/Assets/Scripts/Objects/Doors/Modules/PowerModule.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/Modules/PowerModule.cs
@@ -49,7 +49,7 @@ namespace Doors.Modules
 		{
 			if (HasPower == false)
 			{
-				Chat.AddExamineMsgFromServer(byPlayer, $"{gameObject.ExpensiveName()} is unpowered");
+				Chat.AddExamineMsgFromServer(byPlayer, $"{master.gameObject.ExpensiveName()} is unpowered");
 				States.Add(DoorProcessingStates.PowerPrevented);
 			}
 		}


### PR DESCRIPTION
CL: [Fix] Fix unpowered doors displaying "modules" instead of their name in the bump examine text
CL: [Fix] Fix activatable weapons deactivating on drop when they are already deactivated