### PR TITLE
Cyborg tweak

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Implants/cyborg/CyborgChassis.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/cyborg/CyborgChassis.prefab
@@ -11,7 +11,7 @@ PrefabInstance:
     - target: {fileID: 1163316686972202776, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
       propertyPath: m_Name
-      value: cyborg chassis
+      value: CyborgChassis
       objectReference: {fileID: 0}
     - target: {fileID: 1168521912962732652, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
@@ -347,7 +347,7 @@ PrefabInstance:
     - target: {fileID: 2719098251223779414, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
       propertyPath: Populater.SlotContents.Array.size
-      value: 8
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 2719098251223779414, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
@@ -359,37 +359,37 @@ PrefabInstance:
         type: 3}
       propertyPath: Populater.SlotContents.Array.data[1].Prefab
       value: 
-      objectReference: {fileID: 7029765293304545759, guid: 40e2b6f8f7fbcdb4cbe892093907ef91,
+      objectReference: {fileID: 6918345769292873565, guid: c223b70091789db4fbd3d7b0122c07db,
         type: 3}
     - target: {fileID: 2719098251223779414, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
       propertyPath: Populater.SlotContents.Array.data[2].Prefab
       value: 
-      objectReference: {fileID: 6918345769292873565, guid: c223b70091789db4fbd3d7b0122c07db,
+      objectReference: {fileID: 4146909570655625759, guid: 2f8167654012aac4d83e586030d95284,
         type: 3}
     - target: {fileID: 2719098251223779414, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
       propertyPath: Populater.SlotContents.Array.data[3].Prefab
       value: 
-      objectReference: {fileID: 4146909570655625759, guid: 2f8167654012aac4d83e586030d95284,
+      objectReference: {fileID: 266762788856045110, guid: 25e233ffa6e387c489c390743d4fc6e5,
         type: 3}
     - target: {fileID: 2719098251223779414, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
       propertyPath: Populater.SlotContents.Array.data[4].Prefab
       value: 
-      objectReference: {fileID: 7185978976352611110, guid: 0af3fb6f8543f0b4b914da932bd18ea0,
+      objectReference: {fileID: 2380150684190563494, guid: 6355023c74a9a964a9bb0672d5425201,
         type: 3}
     - target: {fileID: 2719098251223779414, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
       propertyPath: Populater.SlotContents.Array.data[5].Prefab
       value: 
-      objectReference: {fileID: 266762788856045110, guid: 25e233ffa6e387c489c390743d4fc6e5,
+      objectReference: {fileID: 4778886125544350650, guid: 22a0f31b240a38d43889201d251db483,
         type: 3}
     - target: {fileID: 2719098251223779414, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
       propertyPath: Populater.SlotContents.Array.data[6].Prefab
       value: 
-      objectReference: {fileID: 2380150684190563494, guid: 6355023c74a9a964a9bb0672d5425201,
+      objectReference: {fileID: 4778886125544350650, guid: 22a0f31b240a38d43889201d251db483,
         type: 3}
     - target: {fileID: 2719098251223779414, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Implants/cyborg/ToolCarousel.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/cyborg/ToolCarousel.prefab
@@ -18,6 +18,128 @@ PrefabInstance:
       propertyPath: DamageContributesToOverallHealth
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 613638773439429783, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
+        type: 3}
+      propertyPath: BodyTypesSprites.BodyTypes.Array.size
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 613638773439429783, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
+        type: 3}
+      propertyPath: 'BodyTypesSprites.SpriteOrder.Orders.Array.data[0]'
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 613638773439429783, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
+        type: 3}
+      propertyPath: 'BodyTypesSprites.SpriteOrder.Orders.Array.data[1]'
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 613638773439429783, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
+        type: 3}
+      propertyPath: 'BodyTypesSprites.SpriteOrder.Orders.Array.data[2]'
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 613638773439429783, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
+        type: 3}
+      propertyPath: 'BodyTypesSprites.SpriteOrder.Orders.Array.data[3]'
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 613638773439429783, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
+        type: 3}
+      propertyPath: BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 613638773439429783, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
+        type: 3}
+      propertyPath: BodyTypesSprites.BodyTypes.Array.data[1].Sprites.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 613638773439429783, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
+        type: 3}
+      propertyPath: BodyTypesSprites.BodyTypes.Array.data[2].Sprites.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 613638773439429783, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
+        type: 3}
+      propertyPath: BodyTypesSprites.BodyTypes.Array.data[3].Sprites.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 613638773439429783, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
+        type: 3}
+      propertyPath: BodyTypesSprites.BodyTypes.Array.data[4].Sprites.Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 613638773439429783, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
+        type: 3}
+      propertyPath: 'BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[0]'
+      value: 
+      objectReference: {fileID: 11400000, guid: b6c6943f596035c499f587f247df5148,
+        type: 2}
+    - target: {fileID: 613638773439429783, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
+        type: 3}
+      propertyPath: 'BodyTypesSprites.BodyTypes.Array.data[0].Sprites.Array.data[1]'
+      value: 
+      objectReference: {fileID: 11400000, guid: ff39be31c4b095246a14e8316367cb30,
+        type: 2}
+    - target: {fileID: 613638773439429783, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
+        type: 3}
+      propertyPath: 'BodyTypesSprites.BodyTypes.Array.data[1].Sprites.Array.data[0]'
+      value: 
+      objectReference: {fileID: 11400000, guid: cfc5b95817408b848a0cd7a97cc95fad,
+        type: 2}
+    - target: {fileID: 613638773439429783, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
+        type: 3}
+      propertyPath: 'BodyTypesSprites.BodyTypes.Array.data[1].Sprites.Array.data[1]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 3504256b68d671b4e8e27f388c56bec6,
+        type: 2}
+    - target: {fileID: 613638773439429783, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
+        type: 3}
+      propertyPath: 'BodyTypesSprites.BodyTypes.Array.data[2].Sprites.Array.data[0]'
+      value: 
+      objectReference: {fileID: 11400000, guid: be6cab7749b036b47b6153388095e9dc,
+        type: 2}
+    - target: {fileID: 613638773439429783, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
+        type: 3}
+      propertyPath: 'BodyTypesSprites.BodyTypes.Array.data[2].Sprites.Array.data[1]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 0615738ec8bebc842ae2a138637884d8,
+        type: 2}
+    - target: {fileID: 613638773439429783, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
+        type: 3}
+      propertyPath: 'BodyTypesSprites.BodyTypes.Array.data[3].Sprites.Array.data[0]'
+      value: 
+      objectReference: {fileID: 11400000, guid: a42e643b09540164ba37e0a1fa151ed0,
+        type: 2}
+    - target: {fileID: 613638773439429783, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
+        type: 3}
+      propertyPath: 'BodyTypesSprites.BodyTypes.Array.data[3].Sprites.Array.data[1]'
+      value: 
+      objectReference: {fileID: 11400000, guid: a31e85bec51ecc0449908af6a19ada79,
+        type: 2}
+    - target: {fileID: 613638773439429783, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
+        type: 3}
+      propertyPath: 'BodyTypesSprites.BodyTypes.Array.data[4].Sprites.Array.data[0]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 6ae08a8dec2a6e64ebfca9945eba0188,
+        type: 2}
+    - target: {fileID: 613638773439429783, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
+        type: 3}
+      propertyPath: 'BodyTypesSprites.BodyTypes.Array.data[4].Sprites.Array.data[1]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 22461163953d0de4f93ab6abb841f931,
+        type: 2}
+    - target: {fileID: 613638773439429783, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
+        type: 3}
+      propertyPath: 'BodyTypesSprites.BodyTypes.Array.data[4].Sprites.Array.data[2]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 14e93bb467f8ed649bd366a6cef200b7,
+        type: 2}
+    - target: {fileID: 613638773439429783, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
+        type: 3}
+      propertyPath: 'BodyTypesSprites.BodyTypes.Array.data[4].Sprites.Array.data[3]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 39e8bd810cff8b042ba80636a74b3505,
+        type: 2}
     - target: {fileID: 4083826922132060799, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
         type: 3}
       propertyPath: m_RootOrder
@@ -87,7 +209,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 670a0c4738c13bf4893ebeb3ae8e0dd4,
+      objectReference: {fileID: 21300014, guid: 670a0c4738c13bf4893ebeb3ae8e0dd4,
         type: 3}
     - target: {fileID: 4490847932940167273, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
         type: 3}
@@ -113,6 +235,12 @@ PrefabInstance:
     - target: {fileID: 7924426477701790860, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
         type: 3}
       propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 4962fed4e349c774f8a98ef6b860597f,
+        type: 2}
+    - target: {fileID: 7924426477701790860, guid: da2b6aaaa6bb94f4f963d5193aa2e1a8,
+        type: 3}
+      propertyPath: InitialPresentSpriteSet
       value: 
       objectReference: {fileID: 11400000, guid: 4962fed4e349c774f8a98ef6b860597f,
         type: 2}
@@ -193,11 +321,13 @@ MonoBehaviour:
       UseIndex: 0
       IndexSlot: 0
       NamedSlot: 0
+      AlternativeNamedSlots: 
       IfOccupiedFindEmptySlot: 0
       ReplacementStrategy: 0
       namedSlotPopulatorEntrys: []
     DeprecatedContents: []
   SetSlotItemNotRemovableOnStartUp: 1
+  initialignoreRoundstartGrabObjects: 0
   ashPrefab: {fileID: 2957035178188790827, guid: 9ac6968a3f3ed54428662c9aae5a4b32,
     type: 3}
 --- !u!114 &7189410730190013466
@@ -213,4 +343,3 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ToSetTo: 0
-  Pickupable: {fileID: 0}

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Occupations/SpookyPops/ClownLordPopulator.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Occupations/SpookyPops/ClownLordPopulator.asset
@@ -80,7 +80,7 @@ MonoBehaviour:
     NamedSlot: 16
     AlternativeNamedSlots: 
     IfOccupiedFindEmptySlot: 1
-    ReplacementStrategy: 1
+    ReplacementStrategy: 2
     namedSlotPopulatorEntrys: []
   - DoNotGetFirstEmptySlot: 0
     Prefab: {fileID: 8734328976324889014, guid: d3c71176f32c1274b929f3a88695a795,

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Occupations/SpookyPops/FrenchLordPopulator.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Occupations/SpookyPops/FrenchLordPopulator.asset
@@ -14,21 +14,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Entries:
   - DoNotGetFirstEmptySlot: 0
-    Prefab: {fileID: 2720625993976664686, guid: 6c06d764ea0ea9e4f9dff0e83cbb46e6,
+    Prefab: {fileID: 5459461966324092099, guid: 01278780a70416648b9751f1f2513612,
       type: 3}
     UseIndex: 0
     IndexSlot: 0
-    NamedSlot: 12
-    AlternativeNamedSlots: 
-    IfOccupiedFindEmptySlot: 1
-    ReplacementStrategy: 1
-    namedSlotPopulatorEntrys: []
-  - DoNotGetFirstEmptySlot: 0
-    Prefab: {fileID: 4188245363048309518, guid: da93b0f7c392d46ba85123e2516cfa49,
-      type: 3}
-    UseIndex: 0
-    IndexSlot: 0
-    NamedSlot: 10
+    NamedSlot: 0
     AlternativeNamedSlots: 
     IfOccupiedFindEmptySlot: 1
     ReplacementStrategy: 1
@@ -38,16 +28,6 @@ MonoBehaviour:
     UseIndex: 0
     IndexSlot: 0
     NamedSlot: 2
-    AlternativeNamedSlots: 
-    IfOccupiedFindEmptySlot: 1
-    ReplacementStrategy: 1
-    namedSlotPopulatorEntrys: []
-  - DoNotGetFirstEmptySlot: 0
-    Prefab: {fileID: 5459461966324092099, guid: 01278780a70416648b9751f1f2513612,
-      type: 3}
-    UseIndex: 0
-    IndexSlot: 0
-    NamedSlot: 0
     AlternativeNamedSlots: 
     IfOccupiedFindEmptySlot: 1
     ReplacementStrategy: 1
@@ -63,6 +43,16 @@ MonoBehaviour:
     ReplacementStrategy: 1
     namedSlotPopulatorEntrys: []
   - DoNotGetFirstEmptySlot: 0
+    Prefab: {fileID: 6404652678407139925, guid: 2a7be38bec4c1de4d9848443b6691ffb,
+      type: 3}
+    UseIndex: 0
+    IndexSlot: 0
+    NamedSlot: 5
+    AlternativeNamedSlots: 
+    IfOccupiedFindEmptySlot: 1
+    ReplacementStrategy: 1
+    namedSlotPopulatorEntrys: []
+  - DoNotGetFirstEmptySlot: 0
     Prefab: {fileID: 473568899097301326, guid: f43feffec45b57c488d5f1a6a997e44e, type: 3}
     UseIndex: 0
     IndexSlot: 0
@@ -70,26 +60,6 @@ MonoBehaviour:
     AlternativeNamedSlots: 
     IfOccupiedFindEmptySlot: 1
     ReplacementStrategy: 0
-    namedSlotPopulatorEntrys: []
-  - DoNotGetFirstEmptySlot: 0
-    Prefab: {fileID: 3946093906104289823, guid: 1a29d7430eef409409b622cc8278453e,
-      type: 3}
-    UseIndex: 0
-    IndexSlot: 0
-    NamedSlot: 16
-    AlternativeNamedSlots: 
-    IfOccupiedFindEmptySlot: 1
-    ReplacementStrategy: 1
-    namedSlotPopulatorEntrys: []
-  - DoNotGetFirstEmptySlot: 0
-    Prefab: {fileID: 8734328976324889014, guid: d3c71176f32c1274b929f3a88695a795,
-      type: 3}
-    UseIndex: 0
-    IndexSlot: 0
-    NamedSlot: 17
-    AlternativeNamedSlots: 
-    IfOccupiedFindEmptySlot: 1
-    ReplacementStrategy: 1
     namedSlotPopulatorEntrys: []
   - DoNotGetFirstEmptySlot: 0
     Prefab: {fileID: 6806663897376166138, guid: 11b50d955d9c17948b8b1081514764dd,
@@ -112,6 +82,26 @@ MonoBehaviour:
     ReplacementStrategy: 1
     namedSlotPopulatorEntrys: []
   - DoNotGetFirstEmptySlot: 0
+    Prefab: {fileID: 4188245363048309518, guid: da93b0f7c392d46ba85123e2516cfa49,
+      type: 3}
+    UseIndex: 0
+    IndexSlot: 0
+    NamedSlot: 10
+    AlternativeNamedSlots: 
+    IfOccupiedFindEmptySlot: 1
+    ReplacementStrategy: 1
+    namedSlotPopulatorEntrys: []
+  - DoNotGetFirstEmptySlot: 0
+    Prefab: {fileID: 2720625993976664686, guid: 6c06d764ea0ea9e4f9dff0e83cbb46e6,
+      type: 3}
+    UseIndex: 0
+    IndexSlot: 0
+    NamedSlot: 12
+    AlternativeNamedSlots: 
+    IfOccupiedFindEmptySlot: 1
+    ReplacementStrategy: 1
+    namedSlotPopulatorEntrys: []
+  - DoNotGetFirstEmptySlot: 0
     Prefab: {fileID: 1761359558521949867, guid: 7bbee52fec703a844bd2434295ba5427,
       type: 3}
     UseIndex: 0
@@ -122,11 +112,21 @@ MonoBehaviour:
     ReplacementStrategy: 1
     namedSlotPopulatorEntrys: []
   - DoNotGetFirstEmptySlot: 0
-    Prefab: {fileID: 6404652678407139925, guid: 2a7be38bec4c1de4d9848443b6691ffb,
+    Prefab: {fileID: 3946093906104289823, guid: 1a29d7430eef409409b622cc8278453e,
       type: 3}
     UseIndex: 0
     IndexSlot: 0
-    NamedSlot: 5
+    NamedSlot: 16
+    AlternativeNamedSlots: 
+    IfOccupiedFindEmptySlot: 1
+    ReplacementStrategy: 2
+    namedSlotPopulatorEntrys: []
+  - DoNotGetFirstEmptySlot: 0
+    Prefab: {fileID: 8734328976324889014, guid: d3c71176f32c1274b929f3a88695a795,
+      type: 3}
+    UseIndex: 0
+    IndexSlot: 0
+    NamedSlot: 17
     AlternativeNamedSlots: 
     IfOccupiedFindEmptySlot: 1
     ReplacementStrategy: 1

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Occupations/SpookyPops/PumpkinKillerPopulator.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Occupations/SpookyPops/PumpkinKillerPopulator.asset
@@ -81,7 +81,7 @@ MonoBehaviour:
     NamedSlot: 16
     AlternativeNamedSlots: 
     IfOccupiedFindEmptySlot: 1
-    ReplacementStrategy: 1
+    ReplacementStrategy: 2
     namedSlotPopulatorEntrys: []
   - DoNotGetFirstEmptySlot: 0
     Prefab: {fileID: 8734328976324889014, guid: d3c71176f32c1274b929f3a88695a795,

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Occupations/SpookyPops/WitchHunterPopulator.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Occupations/SpookyPops/WitchHunterPopulator.asset
@@ -81,7 +81,7 @@ MonoBehaviour:
     NamedSlot: 16
     AlternativeNamedSlots: 
     IfOccupiedFindEmptySlot: 1
-    ReplacementStrategy: 1
+    ReplacementStrategy: 2
     namedSlotPopulatorEntrys: []
   - DoNotGetFirstEmptySlot: 0
     Prefab: {fileID: 8734328976324889014, guid: d3c71176f32c1274b929f3a88695a795,

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Occupations/SpookyPops/WitchPopulator.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Occupations/SpookyPops/WitchPopulator.asset
@@ -80,7 +80,7 @@ MonoBehaviour:
     NamedSlot: 16
     AlternativeNamedSlots: 
     IfOccupiedFindEmptySlot: 1
-    ReplacementStrategy: 1
+    ReplacementStrategy: 2
     namedSlotPopulatorEntrys: []
   - DoNotGetFirstEmptySlot: 0
     Prefab: {fileID: 8734328976324889014, guid: d3c71176f32c1274b929f3a88695a795,

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Occupations/WizardPopulator.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Occupations/WizardPopulator.asset
@@ -19,6 +19,7 @@ MonoBehaviour:
     UseIndex: 0
     IndexSlot: 0
     NamedSlot: 12
+    AlternativeNamedSlots: 
     IfOccupiedFindEmptySlot: 1
     ReplacementStrategy: 0
     namedSlotPopulatorEntrys: []
@@ -28,6 +29,7 @@ MonoBehaviour:
     UseIndex: 0
     IndexSlot: 0
     NamedSlot: 10
+    AlternativeNamedSlots: 
     IfOccupiedFindEmptySlot: 1
     ReplacementStrategy: 0
     namedSlotPopulatorEntrys: []
@@ -37,6 +39,7 @@ MonoBehaviour:
     UseIndex: 0
     IndexSlot: 0
     NamedSlot: 2
+    AlternativeNamedSlots: 
     IfOccupiedFindEmptySlot: 1
     ReplacementStrategy: 1
     namedSlotPopulatorEntrys: []
@@ -46,6 +49,7 @@ MonoBehaviour:
     UseIndex: 0
     IndexSlot: 0
     NamedSlot: 0
+    AlternativeNamedSlots: 
     IfOccupiedFindEmptySlot: 1
     ReplacementStrategy: 1
     namedSlotPopulatorEntrys: []
@@ -55,6 +59,7 @@ MonoBehaviour:
     UseIndex: 0
     IndexSlot: 0
     NamedSlot: 3
+    AlternativeNamedSlots: 
     IfOccupiedFindEmptySlot: 1
     ReplacementStrategy: 1
     namedSlotPopulatorEntrys: []
@@ -64,6 +69,7 @@ MonoBehaviour:
     UseIndex: 0
     IndexSlot: 0
     NamedSlot: 6
+    AlternativeNamedSlots: 
     IfOccupiedFindEmptySlot: 1
     ReplacementStrategy: 0
     namedSlotPopulatorEntrys: []
@@ -73,8 +79,9 @@ MonoBehaviour:
     UseIndex: 0
     IndexSlot: 0
     NamedSlot: 16
+    AlternativeNamedSlots: 
     IfOccupiedFindEmptySlot: 1
-    ReplacementStrategy: 1
+    ReplacementStrategy: 2
     namedSlotPopulatorEntrys: []
   - DoNotGetFirstEmptySlot: 0
     Prefab: {fileID: 8734328976324889014, guid: d3c71176f32c1274b929f3a88695a795,
@@ -82,6 +89,7 @@ MonoBehaviour:
     UseIndex: 0
     IndexSlot: 0
     NamedSlot: 17
+    AlternativeNamedSlots: 
     IfOccupiedFindEmptySlot: 1
     ReplacementStrategy: 1
     namedSlotPopulatorEntrys: []
@@ -91,6 +99,7 @@ MonoBehaviour:
     UseIndex: 0
     IndexSlot: 0
     NamedSlot: 7
+    AlternativeNamedSlots: 
     IfOccupiedFindEmptySlot: 1
     ReplacementStrategy: 1
     namedSlotPopulatorEntrys: []
@@ -100,6 +109,7 @@ MonoBehaviour:
     UseIndex: 0
     IndexSlot: 0
     NamedSlot: 8
+    AlternativeNamedSlots: 
     IfOccupiedFindEmptySlot: 1
     ReplacementStrategy: 1
     namedSlotPopulatorEntrys: []
@@ -109,6 +119,7 @@ MonoBehaviour:
     UseIndex: 0
     IndexSlot: 0
     NamedSlot: 15
+    AlternativeNamedSlots: 
     IfOccupiedFindEmptySlot: 1
     ReplacementStrategy: 1
     namedSlotPopulatorEntrys: []


### PR DESCRIPTION
From Convo on discord

### Changelog:

CL: [Balance] With the recent balance changes to cyborg limbs, role chosen cyborgs no longer spawn with cyborg arms. Instead, the tool carousel item now functions as a tool arm, providing the arm sprites. Cyborg arms may still be implanted by a robotocist if hand slots are desired
CL: [Fix] Fixed witching weekend event replacing cyborg tool carousel with spellbooks

