### PR TITLE
Better Liquid Evaporation, Space Cleaner Grenades actually work now, and more

### DIFF
--- a/UnityProject/Assets/Prefabs/Decal/Resources/Mess Decals/LargeBloodSplat.prefab
+++ b/UnityProject/Assets/Prefabs/Decal/Resources/Mess Decals/LargeBloodSplat.prefab
@@ -158,7 +158,7 @@ MonoBehaviour:
       m_keys:
       - {fileID: 11400000, guid: efcde740e9b85074485bcd68a7a21816, type: 2}
       m_values:
-      - 10
+      - 50
     reagentKeys: []
   destroyOnEmpty: 0
   ContentsSet: 0

--- a/UnityProject/Assets/Prefabs/Decal/Resources/Mess Decals/LargeBloodSplat.prefab
+++ b/UnityProject/Assets/Prefabs/Decal/Resources/Mess Decals/LargeBloodSplat.prefab
@@ -155,8 +155,10 @@ MonoBehaviour:
   initialReagentMix:
     temperature: 273.15
     reagents:
-      m_keys: []
-      m_values: []
+      m_keys:
+      - {fileID: 11400000, guid: efcde740e9b85074485bcd68a7a21816, type: 2}
+      m_values:
+      - 10
     reagentKeys: []
   destroyOnEmpty: 0
   ContentsSet: 0
@@ -187,7 +189,10 @@ MonoBehaviour:
   syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
+  BuckledToObject: {fileID: 0}
+  BuckleOffset: {x: 0, y: 0, z: 0}
   LocalDifferenceNeeded: {x: 0, y: 0}
+  newtonianMovement: {x: 0, y: 0}
   LocalTargetPosition: {x: 0, y: 0, z: 0}
   CorrectingCourse: 0
   Animating: 0
@@ -197,7 +202,6 @@ MonoBehaviour:
   spinMagnitude: 0
   thrownBy: {fileID: 0}
   thrownProtection: {fileID: 0}
-  aim: 0
   ForcedPushedFrame: 0
   TryPushedFrame: 0
   PushedFrame: 0
@@ -206,12 +210,9 @@ MonoBehaviour:
   MappingIntangible: 0
   SnapToGridOnStart: 0
   IsPlayer: 0
-  DEBUG: 0
+  ObjectBouncyness: 0.75
   tileMoveSpeed: 1
   HasOwnGravity: 0
-  isNotPushable: 1
-  CanBeWindPushed: 1
-  rotationTarget: {fileID: 0}
   stickyMovement: 0
   OnThrowEndResetRotation: 0
   maximumStickSpeed: 1.5
@@ -221,14 +222,18 @@ MonoBehaviour:
   - {fileID: 0}
   - {fileID: 0}
   IsCurrentlyFloating: 0
-  Pushing: []
   Hits: []
   isFlyingSliding: 0
   IsMoving: 0
   MoveIsWalking: 0
   LastUpdateClientFlying: 0
   TimeSpentFlying: 0
-  BuckledToObject: {fileID: 0}
+  DEBUG: 0
+  isNotPushable: 1
+  Pushing: []
+  CanBeWindPushed: 1
+  canResetRotationFromRightClick: 0
+  rotationTarget: {fileID: 0}
 --- !u!114 &7987441083183517562
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -241,6 +246,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 837060fa3ebf3e040916b39a97c42ae2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0.1
   attackType: 0
   damageType: 0
   traumaType: 0
@@ -326,6 +334,7 @@ SpriteRenderer:
   m_RayTraceProcedural: 0
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -382,9 +391,11 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 6a98707ee1e7a40409177d0d92bc89c4, type: 2}
   - {fileID: 11400000, guid: df97274b1e6f2ab4facfeae8c31f0f66, type: 2}
   - {fileID: 11400000, guid: 1250c9dc9ff72b94b8ea25eb266db7b4, type: 2}
-  PresentSpriteSet: {fileID: 11400000, guid: df97274b1e6f2ab4facfeae8c31f0f66, type: 2}
+  InitialPresentSpriteSet: {fileID: 11400000, guid: df97274b1e6f2ab4facfeae8c31f0f66,
+    type: 2}
   randomInitialSprite: 1
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
-  variantIndex: 0
+  initialVariantIndex: 0
+  InitialColour: {r: 1, g: 1, b: 1, a: 1}
   palette: []

--- a/UnityProject/Assets/Prefabs/Decal/Resources/Mess Decals/MediumBloodSplat.prefab
+++ b/UnityProject/Assets/Prefabs/Decal/Resources/Mess Decals/MediumBloodSplat.prefab
@@ -153,8 +153,10 @@ MonoBehaviour:
   initialReagentMix:
     temperature: 273.15
     reagents:
-      m_keys: []
-      m_values: []
+      m_keys:
+      - {fileID: 11400000, guid: efcde740e9b85074485bcd68a7a21816, type: 2}
+      m_values:
+      - 5
     reagentKeys: []
   destroyOnEmpty: 0
   ContentsSet: 0
@@ -185,7 +187,10 @@ MonoBehaviour:
   syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
+  BuckledToObject: {fileID: 0}
+  BuckleOffset: {x: 0, y: 0, z: 0}
   LocalDifferenceNeeded: {x: 0, y: 0}
+  newtonianMovement: {x: 0, y: 0}
   LocalTargetPosition: {x: 0, y: 0, z: 0}
   CorrectingCourse: 0
   Animating: 0
@@ -195,7 +200,6 @@ MonoBehaviour:
   spinMagnitude: 0
   thrownBy: {fileID: 0}
   thrownProtection: {fileID: 0}
-  aim: 0
   ForcedPushedFrame: 0
   TryPushedFrame: 0
   PushedFrame: 0
@@ -204,12 +208,9 @@ MonoBehaviour:
   MappingIntangible: 0
   SnapToGridOnStart: 0
   IsPlayer: 0
-  DEBUG: 0
+  ObjectBouncyness: 0.75
   tileMoveSpeed: 1
   HasOwnGravity: 0
-  isNotPushable: 1
-  CanBeWindPushed: 1
-  rotationTarget: {fileID: 0}
   stickyMovement: 0
   OnThrowEndResetRotation: 0
   maximumStickSpeed: 1.5
@@ -219,14 +220,18 @@ MonoBehaviour:
   - {fileID: 0}
   - {fileID: 0}
   IsCurrentlyFloating: 0
-  Pushing: []
   Hits: []
   isFlyingSliding: 0
   IsMoving: 0
   MoveIsWalking: 0
   LastUpdateClientFlying: 0
   TimeSpentFlying: 0
-  BuckledToObject: {fileID: 0}
+  DEBUG: 0
+  isNotPushable: 1
+  Pushing: []
+  CanBeWindPushed: 1
+  canResetRotationFromRightClick: 0
+  rotationTarget: {fileID: 0}
 --- !u!114 &3942917955944046585
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -239,6 +244,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 837060fa3ebf3e040916b39a97c42ae2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0.1
   attackType: 0
   damageType: 0
   traumaType: 0
@@ -324,6 +332,7 @@ SpriteRenderer:
   m_RayTraceProcedural: 0
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -378,9 +387,11 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 5079b2d50806c01429b500c3505887ed, type: 2}
   - {fileID: 11400000, guid: 34255e0ae68afb04ba21fe082d96825c, type: 2}
   - {fileID: 11400000, guid: a20de0ea1ff19a044baee85b1b47971f, type: 2}
-  PresentSpriteSet: {fileID: 11400000, guid: 2e40f54b22cc0e14d9b4de3a0ed7e1a4, type: 2}
+  InitialPresentSpriteSet: {fileID: 11400000, guid: 2e40f54b22cc0e14d9b4de3a0ed7e1a4,
+    type: 2}
   randomInitialSprite: 1
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
-  variantIndex: 0
+  initialVariantIndex: 0
+  InitialColour: {r: 1, g: 1, b: 1, a: 1}
   palette: []

--- a/UnityProject/Assets/Prefabs/Decal/Resources/Mess Decals/SmallBloodSplat.prefab
+++ b/UnityProject/Assets/Prefabs/Decal/Resources/Mess Decals/SmallBloodSplat.prefab
@@ -153,8 +153,10 @@ MonoBehaviour:
   initialReagentMix:
     temperature: 273.15
     reagents:
-      m_keys: []
-      m_values: []
+      m_keys:
+      - {fileID: 11400000, guid: efcde740e9b85074485bcd68a7a21816, type: 2}
+      m_values:
+      - 1
     reagentKeys: []
   destroyOnEmpty: 0
   ContentsSet: 0
@@ -185,7 +187,10 @@ MonoBehaviour:
   syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
+  BuckledToObject: {fileID: 0}
+  BuckleOffset: {x: 0, y: 0, z: 0}
   LocalDifferenceNeeded: {x: 0, y: 0}
+  newtonianMovement: {x: 0, y: 0}
   LocalTargetPosition: {x: 0, y: 0, z: 0}
   CorrectingCourse: 0
   Animating: 0
@@ -195,7 +200,6 @@ MonoBehaviour:
   spinMagnitude: 0
   thrownBy: {fileID: 0}
   thrownProtection: {fileID: 0}
-  aim: 0
   ForcedPushedFrame: 0
   TryPushedFrame: 0
   PushedFrame: 0
@@ -204,12 +208,9 @@ MonoBehaviour:
   MappingIntangible: 0
   SnapToGridOnStart: 0
   IsPlayer: 0
-  DEBUG: 0
+  ObjectBouncyness: 0.75
   tileMoveSpeed: 1
   HasOwnGravity: 0
-  isNotPushable: 1
-  CanBeWindPushed: 1
-  rotationTarget: {fileID: 0}
   stickyMovement: 0
   OnThrowEndResetRotation: 0
   maximumStickSpeed: 1.5
@@ -219,14 +220,18 @@ MonoBehaviour:
   - {fileID: 0}
   - {fileID: 0}
   IsCurrentlyFloating: 0
-  Pushing: []
   Hits: []
   isFlyingSliding: 0
   IsMoving: 0
   MoveIsWalking: 0
   LastUpdateClientFlying: 0
   TimeSpentFlying: 0
-  BuckledToObject: {fileID: 0}
+  DEBUG: 0
+  isNotPushable: 1
+  Pushing: []
+  CanBeWindPushed: 1
+  canResetRotationFromRightClick: 0
+  rotationTarget: {fileID: 0}
 --- !u!114 &2459722541499398688
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -239,6 +244,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 837060fa3ebf3e040916b39a97c42ae2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0.1
   attackType: 0
   damageType: 0
   traumaType: 0
@@ -324,6 +332,7 @@ SpriteRenderer:
   m_RayTraceProcedural: 0
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -378,9 +387,11 @@ MonoBehaviour:
   - {fileID: 11400000, guid: d43bd2f84808ffc4d91dfb47a73c136c, type: 2}
   - {fileID: 11400000, guid: c5e819dd05c3da84aa8c0c37e521ba8a, type: 2}
   - {fileID: 11400000, guid: 63cb7299b29f0944abb3b7128feb33ac, type: 2}
-  PresentSpriteSet: {fileID: 11400000, guid: 31c52b8980d76f64399e469ae370a094, type: 2}
+  InitialPresentSpriteSet: {fileID: 11400000, guid: 31c52b8980d76f64399e469ae370a094,
+    type: 2}
   randomInitialSprite: 1
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
-  variantIndex: 0
+  initialVariantIndex: 0
+  InitialColour: {r: 1, g: 1, b: 1, a: 1}
   palette: []

--- a/UnityProject/Assets/ScriptableObjects/Atmospherics/Gases/CommonGasses.asset
+++ b/UnityProject/Assets/ScriptableObjects/Atmospherics/Gases/CommonGasses.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7b8a703e0150456da3aa3966cb7e17fe, type: 3}
+  m_Name: CommonGasses
+  m_EditorClassIdentifier: 
+  WaterVapor: {fileID: 11400000, guid: 1c91b8121c8c5304c8e734faa640387b, type: 2}
+  Oxygen: {fileID: 11400000, guid: d7d4e6085864f9f4e83593f63d102d08, type: 2}
+  CarbonDioxide: {fileID: 11400000, guid: b466ee2bb3ca27941b3c2393555d4fab, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Atmospherics/Gases/CommonGasses.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Atmospherics/Gases/CommonGasses.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 85d64bc7f067e2a41aafc9f0bbcecc42
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Items/Tool/Mop.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/Mop.cs
@@ -55,7 +55,7 @@ public class Mop : MonoBehaviour, ICheckedInteractable<PositionalHandApply>, IEx
 		{
 			matrixInfo.MetaDataLayer.Clean(worldPos, localPos, slippery);
 			reagentContainer.TakeReagents(reagentsPerUse);
-			matrixInfo.MetaDataLayer.RemoveLiquidOnTile(localPos);
+			matrixInfo.MetaDataLayer.RemoveLiquidOnTile(localPos, matrixInfo.Matrix.GetMetaDataNode(localPos));
 		}
 		//server is performing server-side logic for the interaction
 		//do the mopping

--- a/UnityProject/Assets/Scripts/Items/Tool/Mop.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/Mop.cs
@@ -51,6 +51,12 @@ public class Mop : MonoBehaviour, ICheckedInteractable<PositionalHandApply>, IEx
 			Chat.AddExamineMsg(interaction.Performer, "Your mop is dry!");
 			return;
 		}
+		void CleanUpMess(bool slippery, MatrixInfo matrixInfo, Vector3Int localPos, Vector3Int worldPos)
+		{
+			matrixInfo.MetaDataLayer.Clean(worldPos, localPos, slippery);
+			reagentContainer.TakeReagents(reagentsPerUse);
+			matrixInfo.MetaDataLayer.RemoveLiquidOnTile(localPos);
+		}
 		//server is performing server-side logic for the interaction
 		//do the mopping
 		void CompleteProgress()
@@ -62,20 +68,17 @@ public class Mop : MonoBehaviour, ICheckedInteractable<PositionalHandApply>, IEx
 			{
 				if (reagentContainer.MajorMixReagent == Water)
 				{
-					matrixInfo.MetaDataLayer.Clean(worldPos, localPos, true);
-					reagentContainer.TakeReagents(reagentsPerUse);
+					CleanUpMess(false, matrixInfo, localPos, worldPos);
 				}
-				else if (reagentContainer.MajorMixReagent ==  SpaceCleaner)
+				else if (reagentContainer.MajorMixReagent == SpaceCleaner)
 				{
-					matrixInfo.MetaDataLayer.Clean(worldPos, localPos, false);
-					reagentContainer.TakeReagents(reagentsPerUse);
+					CleanUpMess(false, matrixInfo, localPos, worldPos);
 				}
 				else
 				{
 					MatrixManager.ReagentReact(reagentContainer.TakeReagents(reagentsPerUse), worldPos);
 				}
 			}
-
 			Chat.AddExamineMsg(interaction.Performer, "You finish mopping.");
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/Construction/FloorDecals/FloorDecal.cs
+++ b/UnityProject/Assets/Scripts/Objects/Construction/FloorDecals/FloorDecal.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using Chemistry.Components;
 using UnityEngine;
 using Mirror;
 
@@ -42,6 +43,9 @@ namespace Objects.Construction
 
 		public bool DontTouchSpriteRenderer = false;
 
+		private ReagentContainer reagentContainer;
+		public ReagentContainer ReagentContainer => reagentContainer;
+
 
 		private void Awake()
 		{
@@ -50,6 +54,7 @@ namespace Objects.Construction
 
 		private void EnsureInit()
 		{
+			reagentContainer ??= GetComponent<ReagentContainer>();
 			if (spriteRenderer != null) return;
 			spriteRenderer = GetComponentInChildren<SpriteRenderer>();
 		}

--- a/UnityProject/Assets/Scripts/Systems/Chemistry/ReagentMix.cs
+++ b/UnityProject/Assets/Scripts/Systems/Chemistry/ReagentMix.cs
@@ -100,7 +100,7 @@ namespace Chemistry
 		//should only be accessed when locked so should be okay
 		private Dictionary<Reagent, float> TEMPReagents = new Dictionary<Reagent, float>();
 
-		public DateTime CreationTime { get; private set; } = DateTime.UtcNow;
+		public DateTime LastModificationTime { get; private set; } = DateTime.UtcNow;
 
 		public ReagentMix( SerializableDictionary<Reagent, float> reagents, float temperature = TemperatureUtils.ZERO_CELSIUS_IN_KELVIN)
 		{
@@ -308,6 +308,7 @@ namespace Chemistry
 
 		public void Add(Reagent reagent, float amount)
 		{
+			LastModificationTime = DateTime.UtcNow;
 			if (Mathf.Approximately(amount, 0f))
 			{
 				return;
@@ -360,7 +361,7 @@ namespace Chemistry
 		public float Remove(Reagent reagent, float amount)
 		{
 			if (amount == 0) return 0;
-
+			LastModificationTime = DateTime.UtcNow;
 			if (amount < 0f)
 			{
 				Debug.LogError($"Trying to remove Negative {amount} amount of {reagent}");
@@ -411,10 +412,12 @@ namespace Chemistry
 					Subtract(reagent.Key, reagent.Value);
 				}
 			}
+			LastModificationTime = DateTime.UtcNow;
 		}
 
 		public float Subtract(Reagent reagent, float subAmount)
 		{
+			LastModificationTime = DateTime.UtcNow;
 			if (subAmount < 0)
 			{
 				Loggy.Error().Format("Trying to subtract negative {0} amount of {1}. Use positive amount instead.", Category.Chemistry,
@@ -462,6 +465,7 @@ namespace Chemistry
 		/// </summary>
 		public void Multiply(float multiplier)
 		{
+			LastModificationTime = DateTime.UtcNow;
 			if (multiplier < 0f)
 			{
 				Loggy.Error($"Trying to multiply reagentmix by {multiplier}", Category.Chemistry);
@@ -504,6 +508,7 @@ namespace Chemistry
 		/// </summary>
 		public void Divide(float Divider)
 		{
+			LastModificationTime = DateTime.UtcNow;
 			if (Divider < 0f)
 			{
 				Loggy.Error($"Trying to Divide reagentmix by {Divider}", Category.Chemistry);
@@ -541,6 +546,7 @@ namespace Chemistry
 
 		public ReagentMix Split(float amount)
 		{
+			LastModificationTime = DateTime.UtcNow;
 			ReagentMix split = new ReagentMix();
 			TransferTo(split, amount);
 			return split;
@@ -608,6 +614,7 @@ namespace Chemistry
 
 		public ReagentMix Take(float amount)
 		{
+			LastModificationTime = DateTime.UtcNow;
 			if (amount == 0 || amount < 0)
 			{
 				return new ReagentMix();
@@ -631,6 +638,7 @@ namespace Chemistry
 				return;
 			}
 
+			LastModificationTime = DateTime.UtcNow;
 			if (float.IsNegativeInfinity(amount) || float.IsNaN(amount)  || float.IsPositiveInfinity(amount))
 			{
 				Loggy.Error($"Trying to RemoveVolume {amount}", Category.Chemistry);

--- a/UnityProject/Assets/Scripts/Systems/Chemistry/ReagentMix.cs
+++ b/UnityProject/Assets/Scripts/Systems/Chemistry/ReagentMix.cs
@@ -100,6 +100,8 @@ namespace Chemistry
 		//should only be accessed when locked so should be okay
 		private Dictionary<Reagent, float> TEMPReagents = new Dictionary<Reagent, float>();
 
+		public DateTime CreationTime { get; private set; } = DateTime.UtcNow;
+
 		public ReagentMix( SerializableDictionary<Reagent, float> reagents, float temperature = TemperatureUtils.ZERO_CELSIUS_IN_KELVIN)
 		{
 			Temperature = temperature;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -43,13 +43,14 @@ public class MetaDataLayer : MonoBehaviour
 
 	private Dictionary<Vector3Int, ReagentMix> tileReagentMixes = new Dictionary<Vector3Int, ReagentMix>();
 	private const float REAGENT_LIMIT_PER_CELL = 10f;
+	private const float EVAPORATE_TICK_DURATION = 25f;
 
 	public void OnEnable()
 	{
 		if (CustomNetworkManager.IsServer)
 		{
 			UpdateManager.Add(CallbackType.UPDATE, SynchroniseNodeChanges);
-			UpdateManager.Add(EvaporationTick, 35f);
+			UpdateManager.Add(EvaporationTick, EVAPORATE_TICK_DURATION);
 		}
 	}
 
@@ -88,11 +89,24 @@ public class MetaDataLayer : MonoBehaviour
 	public void EvaporationTick()
 	{
 		if (tileReagentMixes.Count <= 0) return;
-		lock (tileReagentMixes)
+		StartCoroutine(EvaporateCheck());
+	}
+
+	private IEnumerator EvaporateCheck()
+	{
+		var safeList = tileReagentMixes.Shuffle().ToList();
+		for (int i = 0; i < tileReagentMixes.Count - 1; i++)
 		{
-			var toRemove = tileReagentMixes.PickRandom().Key;
-			matrix.MetaTileMap.RemoveOverlaysOfType(toRemove, LayerType.UnderObjectsEffects, OverlayType.Liquid);
-			tileReagentMixes.Remove(toRemove);
+			yield return WaitFor.EndOfFrame;
+			if (safeList.Count <= 0) break;
+			if (tileReagentMixes == null || tileReagentMixes.Count == 0) break;
+			var toRemove = safeList[i];
+			if (tileReagentMixes.ContainsKey(toRemove.Key) == false) continue;
+			TimeSpan timeDifference = DateTime.UtcNow - toRemove.Value.CreationTime;
+			if (timeDifference.TotalSeconds <= 35) continue;
+			matrix.MetaTileMap.RemoveOverlaysOfType(toRemove.Key, LayerType.UnderObjectsEffects, OverlayType.Liquid);
+			tileReagentMixes.Remove(toRemove.Key);
+			yield return WaitFor.EndOfFrame;
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -102,14 +102,19 @@ public class MetaDataLayer : MonoBehaviour
 			if (tileReagentMixes == null || tileReagentMixes.Count == 0) break;
 			var toRemove = safeList[i];
 			if (tileReagentMixes.ContainsKey(toRemove.Key) == false) continue;
+			var node = matrix.GetMetaDataNode(toRemove.Key);
+			if (TemperatureUtils.FromKelvin(node.GasMixLocal.Temperature, TemeratureUnits.C) >= 30f)
+			{
+				node.GasMixLocal.AddGas(CommonGasses.Instance.WaterVapor, toRemove.Value.Total * 2, toRemove.Value.InternalEnergy / 2);
+				RemoveLiquidOnTile(toRemove.Key);
+				continue;
+			}
 			TimeSpan timeDifference = DateTime.UtcNow - toRemove.Value.CreationTime;
-			if (timeDifference.TotalSeconds <= 35) continue;
-			matrix.MetaTileMap.RemoveOverlaysOfType(toRemove.Key, LayerType.UnderObjectsEffects, OverlayType.Liquid);
-			tileReagentMixes.Remove(toRemove.Key);
+			if (timeDifference.TotalSeconds + toRemove.Value.reagents.Count <= 35) continue;
+			RemoveLiquidOnTile(toRemove.Key);
 			yield return WaitFor.EndOfFrame;
 		}
 	}
-
 
 	[Server]
 	public void UpdateNewPlayer(NetworkConnection requestedBy)
@@ -383,6 +388,12 @@ public class MetaDataLayer : MonoBehaviour
 		liquidColor.a = Mathf.Clamp(liquidColor.a, 0, 0.65f); //makes sure liquids don't completely hide everything behind it.
 		matrix.MetaTileMap.AddOverlay(localPosInt, TileType.UnderObjectsEffects, "BaseLiquid", color: liquidColor);
 		SoundManager.PlayNetworkedAtPos(CommonSounds.Instance.Bubbles, localPosInt);
+	}
+
+	public void RemoveLiquidOnTile(Vector3Int localPosInt)
+	{
+		matrix.MetaTileMap.RemoveOverlaysOfType(localPosInt, LayerType.UnderObjectsEffects, OverlayType.Liquid);
+		tileReagentMixes.Remove(localPosInt);
 	}
 
 	public void Paintsplat(Vector3Int worldPosInt, Vector3Int localPosInt, ReagentMix reagents)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -447,8 +447,9 @@ public class MetaDataLayer : MonoBehaviour
 
 	public void CleanAndMoveToExcess(Vector3Int worldPosInt, Vector3Int localPosInt, bool makeSlippery)
 	{
+		var floorDecals = GetFloorDecals(worldPosInt).ToList();
+		if (floorDecals.Count == 0) return;
 		Get(localPosInt, updateTileOnClient: true).IsSlippery = false;
-		var floorDecals = GetFloorDecals(worldPosInt);
 		foreach (var floorDecal in floorDecals)
 		{
 			if (floorDecal.ReagentContainer?.IsEmpty == false)
@@ -591,7 +592,7 @@ public class MetaDataLayer : MonoBehaviour
 #endif
 					// Add this neighbor to the queue for further distribution if needed
 					cellsToProcess.Enqueue(neighbor);
-					Clean(neighbor.ToWorldInt(matrix), neighbor, true);
+					CleanAndMoveToExcess(neighbor.ToWorldInt(matrix), neighbor, false);
 					if (excess.Total > 5)
 					{
 						matrix.ReactionManager.ExtinguishHotspot(neighbor);

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -566,37 +566,37 @@ public class MetaDataLayer : MonoBehaviour
 	{
 		const int MAX_ITERATIONS = 450;
 		var iterations = 0;
-		var cellsToProcess = new Queue<Vector3Int>();
-		cellsToProcess.Enqueue(origin);
+		var cellsToProcess = new Queue<MetaDataNode>();
+		cellsToProcess.Enqueue(matrix.GetMetaDataNode(origin));
 		//(Max): This behavior for some reason breaks when the server is running at low FPS or heavily stuttring. (less than 20)
 		//I have no clue what's the cause, or how to mitgate this.
 		//You can emulate this issue by enabling gizmos in the editor and watching the FPS drop, then testing this.
 		while (cellsToProcess.Count > 0 && iterations < MAX_ITERATIONS)
 		{
 			var currentCell = cellsToProcess.Dequeue();
-			var neighbors = currentCell.GetNeighbors();
-			foreach (var neighbor in neighbors)
+			foreach (var neighbor in currentCell.Neighbors)
 			{
 				if (excess.Total <= 0) return;
 
 				// Skip if the neighbor is not passable
-				if (matrix.GetMetaDataNode(neighbor).IsOccupied) continue;
-				var neighborReagents = HasReagentsAtTile(neighbor);
+				if (neighbor.IsOccupied) continue;
+				var neighborReagents = HasReagentsAtTile(neighbor.LocalPosition);
 
 				// If the neighboring cell is empty, add the excess and break up the amount
 				if (neighborReagents.Item1 == false)
 				{
-					tileReagentMixes.Add(neighbor, excess.Split(excess.Total / 2));
-					CreateLiquidOverlay(neighbor, excess);
+					tileReagentMixes.Add(neighbor.LocalPosition, excess.Split(excess.Total / 2));
+					CreateLiquidOverlay(neighbor.LocalPosition, excess);
 #if UNITY_EDITOR
-					GameGizmomanager.AddNewLineStaticClient(null, currentCell.ToWorldInt(matrix), null, neighbor.ToWorldInt(matrix), Color.red);
+					GameGizmomanager.AddNewLineStaticClient(null,
+						currentCell.LocalPosition.ToWorldInt(matrix), null, neighbor.LocalPosition.ToWorldInt(matrix), Color.red);
 #endif
 					// Add this neighbor to the queue for further distribution if needed
 					cellsToProcess.Enqueue(neighbor);
-					CleanAndMoveToExcess(neighbor.ToWorldInt(matrix), neighbor, false);
+					CleanAndMoveToExcess(neighbor.LocalPosition.ToWorldInt(matrix), neighbor.LocalPosition, false);
 					if (excess.Total > 5)
 					{
-						matrix.ReactionManager.ExtinguishHotspot(neighbor);
+						matrix.ReactionManager.ExtinguishHotspot(neighbor.LocalPosition);
 					}
 					continue;
 				}
@@ -607,7 +607,7 @@ public class MetaDataLayer : MonoBehaviour
 					var availableSpace = REAGENT_LIMIT_PER_CELL - neighborReagents.Item2.Total;
 					var transferMix = excess.Split(Math.Min(excess.Total, availableSpace));
 					neighborReagents.Item2.Add(transferMix);
-					CleanAndMoveToExcess(neighbor.ToWorldInt(matrix), neighbor, false);
+					CleanAndMoveToExcess(neighbor.LocalPosition.ToWorldInt(matrix), neighbor.LocalPosition, false);
 				}
 				cellsToProcess.Enqueue(neighbor);
 			}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -43,7 +43,7 @@ public class MetaDataLayer : MonoBehaviour
 
 	private Dictionary<Vector3Int, ReagentMix> tileReagentMixes = new Dictionary<Vector3Int, ReagentMix>();
 	private const float REAGENT_LIMIT_PER_CELL = 10f;
-	private const float EVAPORATE_TICK_DURATION = 25f;
+	private const float EVAPORATE_TICK_DURATION = 35f;
 
 	public void OnEnable()
 	{
@@ -103,7 +103,7 @@ public class MetaDataLayer : MonoBehaviour
 			var toRemove = safeList[i];
 			if (tileReagentMixes.ContainsKey(toRemove.Key) == false) continue;
 			var node = matrix.GetMetaDataNode(toRemove.Key);
-			if (TemperatureUtils.FromKelvin(node.GasMixLocal.Temperature, TemeratureUnits.C) >= 30f)
+			if (TemperatureUtils.FromKelvin(node.GasMixLocal.Temperature, TemeratureUnits.C) >= 60f)
 			{
 				node.GasMixLocal.AddGas(CommonGasses.Instance.WaterVapor, toRemove.Value.Total * 2, toRemove.Value.InternalEnergy / 2);
 				RemoveLiquidOnTile(toRemove.Key);

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -6,6 +6,7 @@ using Systems.Atmospherics;
 using Chemistry;
 using Chemistry.Components;
 using Core.Factories;
+using Doors;
 using HealthV2;
 using InGameGizmos;
 using Items;
@@ -563,7 +564,7 @@ public class MetaDataLayer : MonoBehaviour
 
 	private void DistributeExcessToNearbyCells(ReagentMix excess, Vector3Int origin)
 	{
-		const int MAX_ITERATIONS = 250;
+		const int MAX_ITERATIONS = 450;
 		var iterations = 0;
 		var cellsToProcess = new Queue<Vector3Int>();
 		cellsToProcess.Enqueue(origin);
@@ -579,7 +580,9 @@ public class MetaDataLayer : MonoBehaviour
 				if (excess.Total <= 0) return;
 
 				// Skip if the neighbor is not passable
-				if (matrix.IsWallAt(neighbor, true) || matrix.IsWindowAt(neighbor, true)) continue;
+				if (matrix.IsWallAt(neighbor, true)
+				    || matrix.IsWindowAt(neighbor, true)
+				    || matrix.GetNoGC(neighbor, true, new List<DoorMasterController>()).Any()) continue;
 				var neighborReagents = HasReagentsAtTile(neighbor);
 
 				// If the neighboring cell is empty, add the excess and break up the amount

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -42,9 +42,11 @@ public class MetaDataLayer : MonoBehaviour
 
 	public List<EtherealThing> EtherealThings = new List<EtherealThing>();
 
-	private Dictionary<Vector3Int, ReagentMix> tileReagentMixes = new Dictionary<Vector3Int, ReagentMix>();
+	private List<MetaDataNode> trackedTilesWithReagentsOnThem = new List<MetaDataNode>();
+	public bool DebugGizmos = false;
+
 	private const float REAGENT_LIMIT_PER_CELL = 10f;
-	private const float EVAPORATE_TICK_DURATION = 35f;
+	private const float EVAPORATE_TICK_DURATION = 64f;
 
 	public void OnEnable()
 	{
@@ -66,7 +68,6 @@ public class MetaDataLayer : MonoBehaviour
 		ChangedNodes.Clear();
 		nodesToUpdate.Clear();
 		EtherealThings.Clear();
-		tileReagentMixes.Clear();
 	}
 
 	private void Awake()
@@ -89,30 +90,28 @@ public class MetaDataLayer : MonoBehaviour
 
 	public void EvaporationTick()
 	{
-		if (tileReagentMixes.Count <= 0) return;
 		StartCoroutine(EvaporateCheck());
 	}
 
 	private IEnumerator EvaporateCheck()
 	{
-		var safeList = tileReagentMixes.Shuffle().ToList();
-		for (int i = 0; i < tileReagentMixes.Count - 1; i++)
+		var safeList = trackedTilesWithReagentsOnThem.Shuffle().ToList();
+		for (int i = 0; i < safeList.Count - 1; i++)
 		{
 			yield return WaitFor.EndOfFrame;
 			if (safeList.Count <= 0) break;
-			if (tileReagentMixes == null || tileReagentMixes.Count == 0) break;
+			if (trackedTilesWithReagentsOnThem == null || trackedTilesWithReagentsOnThem.Count == 0) break;
 			var toRemove = safeList[i];
-			if (tileReagentMixes.ContainsKey(toRemove.Key) == false) continue;
-			var node = matrix.GetMetaDataNode(toRemove.Key);
-			if (TemperatureUtils.FromKelvin(node.GasMixLocal.Temperature, TemeratureUnits.C) >= 60f)
+			if (trackedTilesWithReagentsOnThem.Contains(toRemove) == false) continue;
+			if (TemperatureUtils.FromKelvin(toRemove.GasMixLocal.Temperature, TemeratureUnits.C) >= 32f)
 			{
-				node.GasMixLocal.AddGas(CommonGasses.Instance.WaterVapor, toRemove.Value.Total * 2, toRemove.Value.InternalEnergy / 2);
-				RemoveLiquidOnTile(toRemove.Key);
+				toRemove.GasMixLocal.AddGas(CommonGasses.Instance.WaterVapor, toRemove.ReagentsOnTile.Total * 2, toRemove.ReagentsOnTile.InternalEnergy / 2);
+				RemoveLiquidOnTile(toRemove.LocalPosition, toRemove);
 				continue;
 			}
-			TimeSpan timeDifference = DateTime.UtcNow - toRemove.Value.CreationTime;
-			if (timeDifference.TotalSeconds + toRemove.Value.reagents.Count <= 35) continue;
-			RemoveLiquidOnTile(toRemove.Key);
+			TimeSpan timeDifference = DateTime.UtcNow - toRemove.ReagentsOnTile.CreationTime;
+			if (timeDifference.TotalSeconds + toRemove.ReagentsOnTile.reagents.Count <= 35) continue;
+			RemoveLiquidOnTile(toRemove.LocalPosition, toRemove);
 			yield return WaitFor.EndOfFrame;
 		}
 	}
@@ -305,14 +304,20 @@ public class MetaDataLayer : MonoBehaviour
 
 		if (reagents.Total > 0)
 		{
-			HandleSplats(ref reagents, ref paintBlood, ref didSplat, ref existingSplat, Position, worldPosInt, localPosInt, spawnPrefabEffect);
+			try
+			{
+				HandleSplats(ref reagents, ref paintBlood, ref didSplat, ref existingSplat, Position, worldPosInt, localPosInt, spawnPrefabEffect);
+			}
+			catch (Exception e)
+			{
+				Loggy.Error(e.ToString());
+			}
 		}
 	}
 
 	private void HandleSplats(ref ReagentMix reagents, ref bool paintBlood, ref bool didSplat, ref bool existingSplat,
 		Vector3 position, Vector3Int worldPosInt, Vector3Int localPosInt, bool spawnPrefabEffect = true)
 	{
-		float liquidTotal = 0;
 		lock (reagents.reagents)
 		{
 			foreach (var reagent in reagents.reagents.m_dict)
@@ -391,10 +396,15 @@ public class MetaDataLayer : MonoBehaviour
 		SoundManager.PlayNetworkedAtPos(CommonSounds.Instance.Bubbles, localPosInt);
 	}
 
-	public void RemoveLiquidOnTile(Vector3Int localPosInt)
+	public void RemoveLiquidOverlayOnTile(Vector3Int localPosInt)
 	{
 		matrix.MetaTileMap.RemoveOverlaysOfType(localPosInt, LayerType.UnderObjectsEffects, OverlayType.Liquid);
-		tileReagentMixes.Remove(localPosInt);
+	}
+
+	public void RemoveLiquidOnTile(Vector3Int localPosInt, MetaDataNode node)
+	{
+		RemoveLiquidOverlayOnTile(localPosInt);
+		node.ReagentsOnTile.Clear();
 	}
 
 	public void Paintsplat(Vector3Int worldPosInt, Vector3Int localPosInt, ReagentMix reagents)
@@ -448,17 +458,18 @@ public class MetaDataLayer : MonoBehaviour
 
 	public void CleanAndMoveToExcess(Vector3Int worldPosInt, Vector3Int localPosInt, bool makeSlippery)
 	{
-		var floorDecals = GetFloorDecals(worldPosInt).ToList();
+		List<FloorDecal> floorDecals = GetFloorDecals(worldPosInt).ToList();
 		if (floorDecals.Count == 0) return;
 		Get(localPosInt, updateTileOnClient: true).IsSlippery = false;
+		MetaDataNode node = matrix.GetMetaDataNode(localPosInt);
 		foreach (var floorDecal in floorDecals)
 		{
 			if (floorDecal.ReagentContainer?.IsEmpty == false)
 			{
-				tileReagentMixes[localPosInt].Add(floorDecal.ReagentContainer.CurrentReagentMix.Clone());
+				node.ReagentsOnTile.Add(floorDecal.ReagentContainer.CurrentReagentMix.Clone());
 				//update overlay to show color change.
 				matrix.MetaTileMap.RemoveOverlaysOfType(localPosInt, LayerType.UnderObjectsEffects, OverlayType.Liquid);
-				CreateLiquidOverlay(localPosInt, tileReagentMixes[localPosInt]);
+				CreateLiquidOverlay(localPosInt, node.ReagentsOnTile);
 			}
 			floorDecal.TryClean();
 		}
@@ -534,32 +545,34 @@ public class MetaDataLayer : MonoBehaviour
 
 	public void StoreReagentsAtTile(ReagentMix reagents, Vector3Int localPosInt)
 	{
-		var cellReagents = HasReagentsAtTile(localPosInt);
+		var cell = matrix.GetMetaDataNode(localPosInt);
 		ReagentMix excess = null;
-		if (cellReagents.Item1)
+		ReagentMix reagentsToUse = reagents.Clone();
+		if (cell.ReagentsOnTile.Total <= 0.1f)
 		{
-			excess = cellReagents.Item2.Split(reagents.Total / 2);
-			cellReagents.Item2.Add(reagents);
+			reagentsToUse.TransferTo(cell.ReagentsOnTile, reagentsToUse.Total);
+			cell.ReagentsOnTile.Add(reagentsToUse);
+			trackedTilesWithReagentsOnThem.Add(cell);
+			if (cell.ReagentsOnTile.Total >= REAGENT_LIMIT_PER_CELL)
+			{
+				excess = cell.ReagentsOnTile.Split(reagents.Total / 2);
+			}
+			CreateLiquidOverlay(localPosInt, cell.ReagentsOnTile);
+			if (DebugGizmos)
+			{
+				GameGizmomanager.AddNewSquareStaticClient(null, localPosInt.ToWorldInt(matrix), Color.green);
+			}
 		}
 		else
 		{
-			tileReagentMixes.Add(localPosInt, reagents);
-			if (reagents.Total <= REAGENT_LIMIT_PER_CELL)
+			if (cell.ReagentsOnTile.Total >= REAGENT_LIMIT_PER_CELL)
 			{
-				excess = cellReagents.Item2.Split(REAGENT_LIMIT_PER_CELL);
+				excess = reagentsToUse.Split(reagentsToUse.Total / 2);
 			}
-			CreateLiquidOverlay(localPosInt, reagents);
+			cell.ReagentsOnTile.Add(reagentsToUse);
 		}
-		if (excess != null) DistributeExcessToNearbyCells(excess, localPosInt);
-	}
 
-	public Tuple<bool, ReagentMix> HasReagentsAtTile(Vector3Int localPosInt)
-	{
-		if (tileReagentMixes.TryGetValue(localPosInt, out var mix))
-		{
-			return Tuple.Create(true, mix);
-		}
-		return Tuple.Create(false, new ReagentMix());
+		if (excess != null) DistributeExcessToNearbyCells(excess, localPosInt);
 	}
 
 	private void DistributeExcessToNearbyCells(ReagentMix excess, Vector3Int origin)
@@ -580,17 +593,17 @@ public class MetaDataLayer : MonoBehaviour
 
 				// Skip if the neighbor is not passable
 				if (neighbor.IsOccupied) continue;
-				var neighborReagents = HasReagentsAtTile(neighbor.LocalPosition);
-
 				// If the neighboring cell is empty, add the excess and break up the amount
-				if (neighborReagents.Item1 == false)
+				if (neighbor.ReagentsOnTile.Total <= 0)
 				{
-					tileReagentMixes.Add(neighbor.LocalPosition, excess.Split(excess.Total / 2));
-					CreateLiquidOverlay(neighbor.LocalPosition, excess);
-#if UNITY_EDITOR
-					GameGizmomanager.AddNewLineStaticClient(null,
-						currentCell.LocalPosition.ToWorldInt(matrix), null, neighbor.LocalPosition.ToWorldInt(matrix), Color.red);
-#endif
+					neighbor.ReagentsOnTile.Add(excess.Split(excess.Total / 2));
+					CreateLiquidOverlay(neighbor.LocalPosition, neighbor.ReagentsOnTile);
+					trackedTilesWithReagentsOnThem.Add(neighbor);
+					if (DebugGizmos)
+					{
+						GameGizmomanager.AddNewLineStaticClient(null,
+							currentCell.LocalPosition.ToWorldInt(matrix), null, neighbor.LocalPosition.ToWorldInt(matrix), Color.red);
+					}
 					// Add this neighbor to the queue for further distribution if needed
 					cellsToProcess.Enqueue(neighbor);
 					CleanAndMoveToExcess(neighbor.LocalPosition.ToWorldInt(matrix), neighbor.LocalPosition, false);
@@ -600,13 +613,11 @@ public class MetaDataLayer : MonoBehaviour
 					}
 					continue;
 				}
-
-				// If the neighboring cell has reagents already, transfer the appropriate amount
-				if (neighborReagents.Item2.Total < REAGENT_LIMIT_PER_CELL)
+				else
 				{
-					var availableSpace = REAGENT_LIMIT_PER_CELL - neighborReagents.Item2.Total;
+					var availableSpace = REAGENT_LIMIT_PER_CELL - neighbor.ReagentsOnTile.Total;
 					var transferMix = excess.Split(Math.Min(excess.Total, availableSpace));
-					neighborReagents.Item2.Add(transferMix);
+					neighbor.ReagentsOnTile.Add(transferMix);
 					CleanAndMoveToExcess(neighbor.LocalPosition.ToWorldInt(matrix), neighbor.LocalPosition, false);
 				}
 				cellsToProcess.Enqueue(neighbor);

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -547,7 +547,7 @@ public class MetaDataLayer : MonoBehaviour
 				if (excess.Total <= 0) return;
 
 				// Skip if the neighbor is not passable
-				if (matrix.IsWallAt(neighbor, true)) continue;
+				if (matrix.IsWallAt(neighbor, true) || matrix.IsWindowAt(neighbor, true)) continue;
 				var neighborReagents = HasReagentsAtTile(neighbor);
 
 				// If the neighboring cell is empty, add the excess and break up the amount
@@ -560,6 +560,11 @@ public class MetaDataLayer : MonoBehaviour
 #endif
 					// Add this neighbor to the queue for further distribution if needed
 					cellsToProcess.Enqueue(neighbor);
+					Clean(neighbor.ToWorldInt(matrix), neighbor, true);
+					if (excess.Total > 5)
+					{
+						matrix.ReactionManager.ExtinguishHotspot(neighbor);
+					}
 					continue;
 				}
 
@@ -569,6 +574,7 @@ public class MetaDataLayer : MonoBehaviour
 					var availableSpace = REAGENT_LIMIT_PER_CELL - neighborReagents.Item2.Total;
 					var transferMix = excess.Split(Math.Min(excess.Total, availableSpace));
 					neighborReagents.Item2.Add(transferMix);
+					Clean(neighbor.ToWorldInt(matrix), neighbor, false);
 				}
 				cellsToProcess.Enqueue(neighbor);
 			}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -580,9 +580,7 @@ public class MetaDataLayer : MonoBehaviour
 				if (excess.Total <= 0) return;
 
 				// Skip if the neighbor is not passable
-				if (matrix.IsWallAt(neighbor, true)
-				    || matrix.IsWindowAt(neighbor, true)
-				    || matrix.GetNoGC(neighbor, true, new List<DoorMasterController>()).Any()) continue;
+				if (matrix.GetMetaDataNode(neighbor).IsOccupied) continue;
 				var neighborReagents = HasReagentsAtTile(neighbor);
 
 				// If the neighboring cell is empty, add the excess and break up the amount

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -109,7 +109,7 @@ public class MetaDataLayer : MonoBehaviour
 				RemoveLiquidOnTile(toRemove.LocalPosition, toRemove);
 				continue;
 			}
-			TimeSpan timeDifference = DateTime.UtcNow - toRemove.ReagentsOnTile.CreationTime;
+			TimeSpan timeDifference = DateTime.UtcNow - toRemove.ReagentsOnTile.LastModificationTime;
 			if (timeDifference.TotalSeconds + toRemove.ReagentsOnTile.reagents.Count <= 35) continue;
 			RemoveLiquidOnTile(toRemove.LocalPosition, toRemove);
 			yield return WaitFor.EndOfFrame;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -425,7 +425,7 @@ public class MetaDataLayer : MonoBehaviour
 	public void Clean(Vector3Int worldPosInt, Vector3Int localPosInt, bool makeSlippery)
 	{
 		Get(localPosInt, updateTileOnClient: true).IsSlippery = false;
-		var floorDecals = MatrixManager.GetAt<FloorDecal>(worldPosInt, isServer: true);
+		var floorDecals = GetFloorDecals(worldPosInt);
 
 		foreach (var floorDecal in floorDecals)
 		{
@@ -443,6 +443,37 @@ public class MetaDataLayer : MonoBehaviour
 			// Sets a tile to slippery
 			MakeSlipperyAt(localPosInt);
 		}
+	}
+
+	public void CleanAndMoveToExcess(Vector3Int worldPosInt, Vector3Int localPosInt, bool makeSlippery)
+	{
+		Get(localPosInt, updateTileOnClient: true).IsSlippery = false;
+		var floorDecals = GetFloorDecals(worldPosInt);
+		foreach (var floorDecal in floorDecals)
+		{
+			if (floorDecal.ReagentContainer?.IsEmpty == false)
+			{
+				tileReagentMixes[localPosInt].Add(floorDecal.ReagentContainer.CurrentReagentMix.Clone());
+				//update overlay to show color change.
+				matrix.MetaTileMap.RemoveOverlaysOfType(localPosInt, LayerType.UnderObjectsEffects, OverlayType.Liquid);
+				CreateLiquidOverlay(localPosInt, tileReagentMixes[localPosInt]);
+			}
+			floorDecal.TryClean();
+		}
+		//check for any moppable overlays
+		matrix.TileChangeManager.MetaTileMap.RemoveFloorWallOverlaysOfType(localPosInt, OverlayType.Cleanable);
+		if (MatrixManager.IsSpaceAt(worldPosInt, true, matrix.MatrixInfo) == false && makeSlippery)
+		{
+			// Create a WaterSplat Decal (visible slippery tile)
+			EffectsFactory.WaterSplat(worldPosInt);
+			// Sets a tile to slippery
+			MakeSlipperyAt(localPosInt);
+		}
+	}
+
+	private IEnumerable<FloorDecal> GetFloorDecals(Vector3Int worldPosInt)
+	{
+		return MatrixManager.GetAt<FloorDecal>(worldPosInt, isServer: true);
 	}
 
 	public void BloodDry(Vector3Int position)
@@ -574,7 +605,7 @@ public class MetaDataLayer : MonoBehaviour
 					var availableSpace = REAGENT_LIMIT_PER_CELL - neighborReagents.Item2.Total;
 					var transferMix = excess.Split(Math.Min(excess.Total, availableSpace));
 					neighborReagents.Item2.Add(transferMix);
-					Clean(neighbor.ToWorldInt(matrix), neighbor, false);
+					CleanAndMoveToExcess(neighbor.ToWorldInt(matrix), neighbor, false);
 				}
 				cellsToProcess.Enqueue(neighbor);
 			}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/CommonGasses.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/CommonGasses.cs
@@ -1,0 +1,14 @@
+﻿using ScriptableObjects;
+using ScriptableObjects.Atmospherics;
+using UnityEngine;
+
+namespace Systems.Atmospherics
+{
+	[CreateAssetMenu(fileName = "CommonGasses", menuName = "Atmospherics/CommonGasses")]
+	public class CommonGasses : SingletonScriptableObject<CommonGasses>
+	{
+		public GasSO WaterVapor;
+		public GasSO Oxygen;
+		public GasSO CarbonDioxide;
+	}
+}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/CommonGasses.cs.meta
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/CommonGasses.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7b8a703e0150456da3aa3966cb7e17fe
+timeCreated: 1733087760

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
@@ -293,7 +293,7 @@ namespace Systems.Atmospherics
 
 		public void ExtinguishHotspot(Vector3Int localPosition)
 		{
-			if (hotspots.ContainsKey(localPosition) && hotspots[localPosition].Hotspot != null)
+			if (HasHotspot(localPosition))
 			{
 				RemoveHotspot(hotspots[localPosition].Hotspot.node);
 			}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
@@ -299,6 +299,11 @@ namespace Systems.Atmospherics
 			}
 		}
 
+		public bool HasHotspot(Vector3Int localPosition)
+		{
+			return hotspots.ContainsKey(localPosition) && hotspots[localPosition].Hotspot != null;
+		}
+
 		/// <summary>
 		/// Creates a hotspot if the tile is hot enough
 		/// </summary>

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataNode.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataNode.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Chemistry;
 using Detective;
 using Logs;
 using UnityEngine;
@@ -178,6 +179,8 @@ public class MetaDataNode : IGasMixContainer
 	//How long since the last wind spot particle was spawned
 	//This is here as dictionaries are a pain and for performance but costs more memory
 	public float windEffectTime = 0;
+
+	public ReagentMix ReagentsOnTile = new ReagentMix();
 
 	public void AddGasOverlay(GasSO gas)
 	{


### PR DESCRIPTION
CL: [Improvement] ReagentMixes have their creation date recorded now.
CL: [Improvement] Several optimizations have been done to how reagents are stored and spread on tiles. Expect some bugs and odd behaviors as we iron out the kinks in the future while keeping server performance as good as possible.
CL: [Improvement] Liquids evaporate faster now every (60 seconds + numbers of reagents inside a ReagentMix) in two frame intervals.
CL: [Improvement] Liquids that evaporate in high temperature areas generate water vapor gasses.
CL: [Improvement] Spilled Liquids that are more than 5 units can now be used to extinguish fires.
CL: [Improvement] Liquids will no longer spread through glass windows and airlocks. They can, however, still pass through grills.
CL: [Improvement] Liquids on the ground can now be removed using mops.
CL: [Improvement] Liquids that mix with other reagents on the floor will mix with their color.
CL: [Fix] Some pre-generated blood splats did not contain any blood reagents, this has been corrected.
CL: [Fix] Space Cleaner grenades were supposed to clean multiple tiles at once, this PR brings this intended behavior.