### PR TITLE
Hovertooltips UI improvements and fixes

### DIFF
--- a/UnityProject/Assets/Prefabs/UI/Tooltips/HoverTooltip.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tooltips/HoverTooltip.prefab
@@ -933,8 +933,8 @@ MonoBehaviour:
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
-  m_fontSizeMin: 16
-  m_fontSizeMax: 26
+  m_fontSizeMin: 12
+  m_fontSizeMax: 21
   m_fontStyle: 0
   m_HorizontalAlignment: 1
   m_VerticalAlignment: 256

--- a/UnityProject/Assets/Prefabs/UI/Tooltips/HoverTooltip.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tooltips/HoverTooltip.prefab
@@ -278,15 +278,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -497,15 +499,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -941,15 +945,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0

--- a/UnityProject/Assets/Scripts/UI/Systems/Tooltips/HoverTooltips/HoverTooltipUI.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Tooltips/HoverTooltips/HoverTooltipUI.cs
@@ -161,7 +161,16 @@ namespace UI.Systems.Tooltips.HoverTooltips
 				}
 				UpdateIconSprite(data);
 				// Only show interactions if there is a description or title in the tooltip.
-				if (IsDescOrTitleEmpty() == false) UpdateInteractionsView(data.InteractionsStrings());
+				if (IsDescOrTitleEmpty() == false)
+				{
+					UpdateInteractionsView(data.InteractionsStrings());
+				}
+			}
+			var examines = target.GetComponents<IExaminable>().Length;
+			if (examines >= 3)
+			{
+				List<TextColor> e = new List<TextColor> {new TextColor() { Text = "Shift+Click to examine closely", Color = Color.green }, };
+				UpdateInteractionsView(e);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/UI/Systems/Tooltips/HoverTooltips/HoverTooltipUI.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Tooltips/HoverTooltips/HoverTooltipUI.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Learning;
+using Player;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -105,6 +106,11 @@ namespace UI.Systems.Tooltips.HoverTooltips
 			{
 				iconTarget.sprite = imageObj.CurrentSprite;
 			}
+			var playerSprites = target.GetComponent<PlayerSprites>();
+			if (playerSprites != null)
+			{
+				iconTarget.sprite = playerSprites.ThisCharacter.GetRaceSo()?.Base.PreviewSprite?.Variance?.First().Frames?.First().sprite;
+			}
 		}
 
 		/// <summary>
@@ -144,25 +150,19 @@ namespace UI.Systems.Tooltips.HoverTooltips
 						? descText.text += $"{data.HoverTip()}"
 						: descText.text += $"\n \n{data.HoverTip()}";
 				}
-
 				UpdateIconSprite(data);
 				// Only show interactions if there is a description or title in the tooltip.
 				if (IsDescOrTitleEmpty() == false) UpdateInteractionsView(data.InteractionsStrings());
 			}
 
-			var Examines = target.GetComponents<IExaminable>().OrderByDescending(x => x.ExaminablePriority);
-			foreach (var examinable in Examines)
+			var examines = target.GetComponents<IExaminable>().OrderByDescending(x => x.ExaminablePriority).ToList();
+			if (examines.Any()) descText.text += "\n";
+			foreach (var examinable in examines)
 			{
 				var examinableMsg = examinable.Examine(); //TODO net msg?
-				// if description is empty, don't create extra lines.
-				// if description has text, separate new data away from the previous ones.
-				if (string.IsNullOrWhiteSpace(descText.text))
+				if (string.IsNullOrWhiteSpace(descText.text) == false)
 				{
-					descText.text += $"{examinableMsg}";
-				}
-				else
-				{
-					descText.text += $"\n \n{examinableMsg}";
+					descText.text += $"\n{examinableMsg}";
 				}
 			}
 		}

--- a/UnityProject/Assets/Scripts/UI/Systems/Tooltips/HoverTooltips/HoverTooltipUI.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Tooltips/HoverTooltips/HoverTooltipUI.cs
@@ -20,7 +20,7 @@ namespace UI.Systems.Tooltips.HoverTooltips
 		[SerializeField] private Image iconTarget;
 		[SerializeField] private Sprite errorIconSprite;
 
-		public float HoverDelay { get; set; } = 0.25f;
+		public float HoverDelay { get; set; } = 0.08f;
 
 
 		private GameObject targetObject;
@@ -74,15 +74,14 @@ namespace UI.Systems.Tooltips.HoverTooltips
 
 		private void CheckForInput()
 		{
-			var lastState = detailsModeEnabled;
 			detailsModeEnabled = Input.GetKeyDown(KeyCode.LeftShift);
-			if (lastState != detailsModeEnabled && detailsModeEnabled && targetObject != null)
+			if (detailsModeEnabled && targetObject != null)
 			{
-				SetupTooltip(targetObject, true);
+				SetupTooltip(targetObject);
 			}
 		}
 
-		public void SetupTooltip(GameObject hoverObject, bool noWait = false)
+		public void SetupTooltip(GameObject hoverObject)
 		{
 			targetObject = hoverObject;
 			// Clean up everything for the upcoming data.
@@ -91,8 +90,11 @@ namespace UI.Systems.Tooltips.HoverTooltips
 			if (ProtipManager.Instance.PlayerExperienceLevel >= ProtipManager.ExperienceLevel.SomewhatExperienced
 			    && detailsModeEnabled == false) return;
 			// Don't do anything if there's no object to start with.
-			if (hoverObject == null) return;
-			StartCoroutine(QueueTip(hoverObject, noWait));
+			if (hoverObject == null)
+			{
+				return;
+			}
+			QueueTip(hoverObject);
 		}
 
 		/// <summary>
@@ -127,9 +129,16 @@ namespace UI.Systems.Tooltips.HoverTooltips
 		/// </summary>
 		private void UpdateMainInfo(GameObject target)
 		{
-			if (target.TryGetComponent<Attributes>(out var attribute) == false) return;
-			nameText.text = attribute.ArticleName;
-			descText.text = attribute.ArticleDescription;
+			if (target.TryGetComponent<Attributes>(out var attribute))
+			{
+				nameText.text = attribute.ArticleName;
+				descText.text = attribute.ArticleDescription;
+			}
+			if (target.TryGetComponent<PlayerScript>(out var playerScript))
+			{
+				nameText.text = playerScript.visibleName;
+				detailsModeEnabled = true;
+			}
 		}
 
 		/// <summary>
@@ -153,17 +162,6 @@ namespace UI.Systems.Tooltips.HoverTooltips
 				UpdateIconSprite(data);
 				// Only show interactions if there is a description or title in the tooltip.
 				if (IsDescOrTitleEmpty() == false) UpdateInteractionsView(data.InteractionsStrings());
-			}
-
-			var examines = target.GetComponents<IExaminable>().OrderByDescending(x => x.ExaminablePriority).ToList();
-			if (examines.Any()) descText.text += "\n";
-			foreach (var examinable in examines)
-			{
-				var examinableMsg = examinable.Examine(); //TODO net msg?
-				if (string.IsNullOrWhiteSpace(descText.text) == false)
-				{
-					descText.text += $"\n{examinableMsg}";
-				}
 			}
 		}
 
@@ -248,11 +246,10 @@ namespace UI.Systems.Tooltips.HoverTooltips
 			}
 		}
 
-		private IEnumerator QueueTip(GameObject queuedObject, bool noWait = false)
+		private void QueueTip(GameObject queuedObject)
 		{
-			if (noWait == false) yield return WaitFor.Seconds(HoverDelay);
-			if (targetObject == null || queuedObject != targetObject) yield break;
-			if (noWait == false && showingcurrently == queuedObject) yield break;
+			if (targetObject == null || queuedObject != targetObject) return;
+			if (showingcurrently == queuedObject) return;
 			Setup(queuedObject);
 		}
 	}


### PR DESCRIPTION
CL: [Improvement] The detailed mode only shows the important bits that the player needs now, while reminding that they can obtain more info by shift-clicking objects.
CL: [Improvement] The UI for hover toolips now is much snappier and responsive.
CL: [Improvement] Hovering over players now will no longer require a detailed view to see their names/pronouns.
CL: [Improvement] Hover tooltips will now use a player's species preview icon instead of an ERROR sign when hovering over them.
CL: [Improvement] Interaction strings are no longer comically huge.
CL: [Fix] Fixed some wonky padding/new lines that made hover tooltips look unpleasant for a couple of months now. (blame Bod)