### PR TITLE
Fixes an instance where chat would block character naming

### DIFF
--- a/UnityProject/Assets/Scripts/UI/Systems/Character/CharacterSettings.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Character/CharacterSettings.cs
@@ -63,6 +63,7 @@ namespace UI.Character
 			ShowCharacterPreviewOnCharacterSelector();
 			characterEditor.SetActive(false);
 			characterSelector.SetActive(true);
+			UIManager.Instance.isInputFocus = false;
 		}
 
 		public void EditCharacter(int key)
@@ -71,6 +72,7 @@ namespace UI.Character
 			// Use a copy in case changes are discarded
 			EditedCharacter = (CharacterSheet) CharacterManager.Get(key).Clone();
 			ShowCharacterEditor(EditedCharacter);
+			UIManager.Instance.isInputFocus = true;
 		}
 
 		public void ShowCharacterEditor(CharacterSheet character)
@@ -79,6 +81,7 @@ namespace UI.Character
 			characterSelector.SetActive(false);
 			characterEditor.SetActive(true);
 			characterEditorScript.LoadCharacter(character);
+			UIManager.Instance.isInputFocus = true;
 		}
 
 		public void SaveCharacter(CharacterSheet character)

--- a/UnityProject/Assets/Scripts/UI/Systems/Character/CharacterSettings.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Character/CharacterSettings.cs
@@ -52,6 +52,11 @@ namespace UI.Character
 			ShowCharacterSelector();
 		}
 
+		private void OnDisable()
+		{
+			UIManager.Instance.isInputFocus = false;
+		}
+
 		public void SetWindowTitle(string title)
 		{
 			windowName.text = title;


### PR DESCRIPTION
CL: [Fix] Fixes a long-standing issue where attempting to edit a character's name in the character UI would cause the chat UI to popup while typing.
