### PR TITLE
Fix Linux Clients not connecting to servers

### DIFF
--- a/CodeScanList.json
+++ b/CodeScanList.json
@@ -3112,6 +3112,16 @@
                 ]
             }
         },
+        "kcp2k": {
+            "KcpTransport": {
+                "All": true
+            }
+        },
+        "Mirror.SimpleWeb": {
+            "SimpleWebTransport": {
+                "All": true
+            }
+        },
         "Mirror.RemoteCalls": {
             "RemoteCallDelegate": {
                 "Methods": ["void .ctor(object, nint)"]
@@ -3129,17 +3139,6 @@
             },
             "Invoker": {
                 "All": true
-            }
-        },
-        "Mirror.Transports": {
-            "Mirror.MultiplexTransport": {
-                
-            },
-            "kcp2k.KcpTransport":{
-                
-            },
-            "Mirror.SimpleWeb.SimpleWeb":{
-                
             }
         },
         "Logs": {

--- a/CodeScanList.json
+++ b/CodeScanList.json
@@ -3101,6 +3101,16 @@
             },
             "NetworkManagerMode": {
                 "All": true
+            },
+            "kcp2k": {
+            "KcpTransport": {
+                "All": true
+            }
+            },
+            "Mirror.SimpleWeb": {
+                "SimpleWebTransport": {
+                    "All": true
+                }
             }
         },
         "IgnoranceTransport": {
@@ -3110,16 +3120,6 @@
                     "bool serverBindsAll",
                     "string serverBindAddress"
                 ]
-            }
-        },
-        "kcp2k": {
-            "KcpTransport": {
-                "All": true
-            }
-        },
-        "Mirror.SimpleWeb": {
-            "SimpleWebTransport": {
-                "All": true
             }
         },
         "Mirror.RemoteCalls": {

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/NetworkManager.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/NetworkManager.prefab
@@ -9,6 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2924057578287968402}
+  - component: {fileID: 6343008161402218284}
   - component: {fileID: 2959621213063014110}
   - component: {fileID: 5032898753073590648}
   - component: {fileID: 752180679074368365}
@@ -16,6 +17,7 @@ GameObject:
   - component: {fileID: 1670478699794476422}
   - component: {fileID: 6315295771918704203}
   - component: {fileID: 8081295461890813951}
+  - component: {fileID: 3421720100425240946}
   m_Layer: 0
   m_Name: NetworkManager
   m_TagString: NetworkManager
@@ -38,6 +40,24 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6343008161402218284
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2920527550438430692}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eab1f3e014e64187977bc7e459a7559a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  networkManager: {fileID: 2959621213063014110}
+  multiplexTransport: {fileID: 6315295771918704203}
+  ignoranceTransport: {fileID: 752180679074368365}
+  webSocketTransport: {fileID: 8081295461890813951}
+  kcpTransport: {fileID: 3421720100425240946}
+  defaultTransport: 1
 --- !u!114 &2959621213063014110
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -12239,7 +12259,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   transports:
-  - {fileID: 752180679074368365}
+  - {fileID: 3421720100425240946}
   - {fileID: 8081295461890813951}
 --- !u!114 &8081295461890813951
 MonoBehaviour:
@@ -12268,3 +12288,32 @@ MonoBehaviour:
   sslCertJson: ./cert.json
   sslProtocols: 3072
   _logLevels: 1
+--- !u!114 &3421720100425240946
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2920527550438430692}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b0fecffa3f624585964b0d0eb21b18e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Port: 7777
+  DualMode: 1
+  NoDelay: 1
+  Interval: 10
+  Timeout: 10000
+  RecvBufferSize: 7361536
+  SendBufferSize: 7361536
+  FastResend: 2
+  ReceiveWindowSize: 4096
+  SendWindowSize: 4096
+  MaxRetransmit: 40
+  MaximizeSocketBuffers: 1
+  ReliableMaxMessageSize: 298449
+  UnreliableMaxMessageSize: 1199
+  debugLog: 0
+  statisticsGUI: 0
+  statisticsLog: 0

--- a/UnityProject/Assets/Scripts/Core/Networking/TransportSetter.cs
+++ b/UnityProject/Assets/Scripts/Core/Networking/TransportSetter.cs
@@ -1,0 +1,91 @@
+﻿using IgnoranceTransport;
+using kcp2k;
+using Logs;
+using Mirror;
+using Mirror.SimpleWeb;
+using UnityEngine;
+
+namespace Core.Networking
+{
+	[RequireComponent(typeof(CustomNetworkManager))]
+    public class TransportSetter : MonoBehaviour
+    {
+	    public CustomNetworkManager networkManager;
+	    public MultiplexTransport multiplexTransport;
+	    public Ignorance ignoranceTransport;
+	    public SimpleWebTransport webSocketTransport;
+	    public KcpTransport kcpTransport;
+
+	    public TransportType defaultTransport = TransportType.Multiplex;
+
+        public enum TransportType
+        {
+            Multiplex = 1,
+            KCP = 2,
+            Ignorance = 3,
+            WebSockets = 4
+        }
+
+        private void Awake()
+        {
+	        bool transportArgumentFound = false;
+	        string[] args = System.Environment.GetCommandLineArgs();
+	        for (int i = 0; i < args.Length; i++)
+	        {
+		        Debug.Log($"Argument {i}: {args[i]}");
+	        }
+	        for (int i = 0; i < args.Length; i++)
+	        {
+		        if (args[i] == "-transport" && i + 1 < args.Length)
+		        {
+			        if (int.TryParse(args[i + 1], out int transportValue) && transportValue is >= 1 and <= 4)
+			        {
+				        SetTransport((TransportType)transportValue);
+				        transportArgumentFound = true;
+				        break;
+			        }
+		        }
+	        }
+
+	        if (transportArgumentFound == false)
+	        {
+		        SetTransport(defaultTransport);
+	        }
+        }
+
+        private void SetTransport(TransportType transportType)
+        {
+	        //(Max): For the future.
+#if UNITY_WEBGL
+	        networkManager.transport = multiplexTransport;
+			Loggy.Info($"Transport set to {transportType}");
+	        return;
+#endif
+            if (networkManager == null)
+            {
+                Debug.LogError("NetworkManager is null! Transport cannot be set.");
+                return;
+            }
+
+            switch (transportType)
+            {
+                case TransportType.Multiplex:
+	                networkManager.transport = multiplexTransport;
+                    break;
+                case TransportType.KCP:
+	                networkManager.transport = kcpTransport;
+                    break;
+                case TransportType.Ignorance:
+	                networkManager.transport = ignoranceTransport;
+                    break;
+                case TransportType.WebSockets:
+	                networkManager.transport = webSocketTransport;
+                    break;
+                default:
+                    Debug.LogError("Invalid transport type.");
+                    break;
+            }
+            Loggy.Info($"Transport set to {transportType}");
+        }
+    }
+}

--- a/UnityProject/Assets/Scripts/Core/Networking/TransportSetter.cs.meta
+++ b/UnityProject/Assets/Scripts/Core/Networking/TransportSetter.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: eab1f3e014e64187977bc7e459a7559a
+timeCreated: 1738829900


### PR DESCRIPTION
CL: [New] Added a way for clients and servers to choose their preferred networking transport layer using the `-transport` argument. 
CL: [New] Enabled KCP support for Unitystation. Servers/Clients that use KCP are guaranteed better stability for connections.
CL: [Fix] Fixed Linux clients not being able to connect to servers due to the Ignorance transport layer silently failing on Linux. If you're still unable to join servers after this update; change the active transport layer using `-transport [transport ID here]`
