### PR TITLE
Reverts #10702 and adds an improvemnt to the map loader

### DIFF
--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/ObjectManager.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/ObjectManager.prefab
@@ -1155,6 +1155,7 @@ MonoBehaviour:
     layerTiles:
     - {fileID: 11400000, guid: 3975642db6c52ed4fa2086247abc1f28, type: 2}
     - {fileID: 11400000, guid: c87a62cb7a026433f9d4e361d2740cbc, type: 2}
+    - {fileID: 11400000, guid: c944b9b517852ba488df61f2f6699c70, type: 2}
   - path: Tiles/Objects
     tileType: 6
     layerTiles:
@@ -1231,6 +1232,7 @@ MonoBehaviour:
     - {fileID: 11400000, guid: 28455114dec364442b57e2ae77a4b06e, type: 2}
     - {fileID: 11400000, guid: 8ef47dcbc2f72784797fb63f33a0ac36, type: 2}
     - {fileID: 11400000, guid: f53b9120beb3c1c4c84947233f26ad36, type: 2}
+    - {fileID: 11400000, guid: 5d1f43b4a6ddfb84e9266da723287efe, type: 2}
   - path: Tiles/WindowDamage
     tileType: 8
     layerTiles:
@@ -1432,6 +1434,7 @@ MonoBehaviour:
     - {fileID: 11400000, guid: 427c5e98379cf7d41adf7071402c678c, type: 2}
     - {fileID: 11400000, guid: 426a7efc8138adf46ba05a587574bf85, type: 2}
     - {fileID: 11400000, guid: 4bcf1037b693c9f4f92d2c93c56f9ed5, type: 2}
+  ErrorLayerTile: {fileID: 11400000, guid: c944b9b517852ba488df61f2f6699c70, type: 2}
 --- !u!114 &6456522449831359657
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/ScriptableObjects/Tiles/TileLists/BaseTileList.asset
+++ b/UnityProject/Assets/ScriptableObjects/Tiles/TileLists/BaseTileList.asset
@@ -82,6 +82,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: eacaf3578fd4c384fbf16b922eb15cb0, type: 2}
   - {fileID: 11400000, guid: 871acad77b59acc4fab817e5f713157c, type: 2}
   - {fileID: 11400000, guid: 2597ff9a740874c47b5abaf76e84f92f, type: 2}
+  - {fileID: 11400000, guid: 5d1f43b4a6ddfb84e9266da723287efe, type: 2}
   <CombinedTileList>k__BackingField:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
   - {fileID: 11400000, guid: e8a2685c8a14b7043bf58bde4374c6b1, type: 2}
@@ -145,3 +146,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: bf0867a7bba48c749a370f6534cd3cc3, type: 2}
   - {fileID: 11400000, guid: 871acad77b59acc4fab817e5f713157c, type: 2}
   - {fileID: 11400000, guid: 2597ff9a740874c47b5abaf76e84f92f, type: 2}
+  - {fileID: 11400000, guid: 5d1f43b4a6ddfb84e9266da723287efe, type: 2}

--- a/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawn.cs
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawn.cs
@@ -487,6 +487,10 @@ public static class PlayerSpawn
 		}
 
 		newMind.GetComponent<GhostSprites>().SetGhostSprite(isAdmin);
+		if (account.ViewerScript != null)
+		{
+			_ = Despawn.ServerSingle(account.ViewerScript.gameObject);
+		}
 	}
 
 	private static void TransferAccountOccupyingMind(PlayerInfo account, Mind from, Mind to)
@@ -518,10 +522,30 @@ public static class PlayerSpawn
 
 		if (to)
 		{
+			if (account.ViewerScript != null)
+			{
+				_ = Despawn.ServerSingle(account.ViewerScript.gameObject);
+				account.ViewerScript = null;
+			}
+
+
 			var netIdentity = to.GetComponent<NetworkIdentity>();
 			if (netIdentity.connectionToClient != null && to.connectionToClient != account.Connection)
 			{
 				CustomNetworkManager.Instance.OnServerDisconnect(netIdentity.connectionToClient);
+			}
+
+			if (account.Connection != null && to.connectionToClient != account.Connection)
+			{
+				NetworkServer.ReplacePlayerForConnection(account.Connection, to.gameObject);
+
+				if (account.ViewerScript != null)
+				{
+					_ = Despawn.ServerSingle(account.ViewerScript.gameObject);
+					account.GameObject = null;
+				}
+
+				//TriggerEventMessage.SendTo(To, Event.); //TODO Call this manually
 			}
 
 			//can observe their new inventory
@@ -570,6 +594,7 @@ public static class PlayerSpawn
 				from.RemoveClientAuthority();
 			}
 		}
+
 		if (to)
 		{
 			if (account.Connection != null)

--- a/UnityProject/Assets/Scripts/Core/Lighting/LightSource.cs
+++ b/UnityProject/Assets/Scripts/Core/Lighting/LightSource.cs
@@ -110,7 +110,6 @@ namespace Objects.Lighting
 
 		private void Start()
 		{
-			SetColor(CurrentOnColor, CurrentOnColor);
 			LightSpriteUsed.Color = CurrentOnColor;
 			CheckAudioState();
 		}

--- a/UnityProject/Assets/Scripts/Core/Physics/UniversalObjectPhysics.cs
+++ b/UnityProject/Assets/Scripts/Core/Physics/UniversalObjectPhysics.cs
@@ -105,9 +105,6 @@ namespace Core.Physics
 		[SyncVar(hook = nameof(SyncLocalTarget))]
 		private Vector3WithData synchLocalTargetPosition;
 
-		[SyncVar]
-		private float ZRotation;
-
 		protected bool doStepInteractions = true;
 
 		[NonSerialized] public bool DoImpactVomit = true;
@@ -283,16 +280,11 @@ namespace Core.Physics
 					Matrix = -1,
 					Speed = tileMoveSpeed
 				};
-				ZRotation = transform.localRotation.eulerAngles.z;
 			}
 			else
 			{
 				InternalTriggerOnLocalTileReached(synchLocalTargetPosition.Vector3.RoundToInt());
 				SetTransform(synchLocalTargetPosition.Vector3, false);
-
-				var Euler = transform.localRotation.eulerAngles;
-				Euler.z = ZRotation;
-				transform.localRotation = Quaternion.Euler(Euler);
 			}
 
 			CheckNSnapToGrid(isServer);
@@ -367,6 +359,7 @@ namespace Core.Physics
 			if (isServer) return;
 			if (LocalTargetPosition == newLocalTarget.Vector3) return;
 			if (isOwned && PulledBy.HasComponent == false) return;
+
 
 			var spawned = CustomNetworkManager.Spawned;
 
@@ -930,6 +923,7 @@ namespace Core.Physics
 				};
 			}
 
+
 			NewtonianMovement = Vector2.zero;
 			airTime = 0;
 			slideTime = 0;
@@ -1083,11 +1077,6 @@ namespace Core.Physics
 				IsMoving = false;
 				Animating = false;
 				UpdateManager.Remove(CallbackType.EARLY_UPDATE, AnimationUpdateMe);
-			}
-
-			if (ZRotation != transform.rotation.eulerAngles.z)
-			{
-				ZRotation = transform.rotation.eulerAngles.z;
 			}
 
 			Animating = true;
@@ -1377,12 +1366,6 @@ namespace Core.Physics
 				UpdateManager.Remove(CallbackType.EARLY_UPDATE, FlyingUpdateMe);
 				return;
 			}
-
-			if (ZRotation != transform.rotation.eulerAngles.z)
-			{
-				ZRotation = transform.rotation.eulerAngles.z;
-			}
-
 
 			if (IsMoving) return;
 			isFlyingSliding = true;

--- a/UnityProject/Assets/Scripts/Core/SecureStuff/SecureMapsSaver.cs
+++ b/UnityProject/Assets/Scripts/Core/SecureStuff/SecureMapsSaver.cs
@@ -1036,7 +1036,6 @@ namespace SecureStuff
 			var Recursivetype = TypeMono;
 
 			FieldInfo FieldInfo = null;
-			PropertyInfo PropertyInfo = null;
 
 			// Loop through type and its base types
 			while (Recursivetype != null && FieldInfo == null)
@@ -1054,24 +1053,6 @@ namespace SecureStuff
 						break;
 					}
 				}
-
-				if (FieldInfo != null && HasAttribute(FieldInfo, typeof(SyncVarAttribute)))
-				{
-					var SyncName = "Network" + AppropriateName;
-
-					var Properties = Recursivetype.GetProperties(
-						BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic);
-
-					foreach (var Property in Properties)
-					{
-						if (Property.Name.Equals(SyncName, StringComparison.OrdinalIgnoreCase))
-						{
-							PropertyInfo = Property;
-							break;
-						}
-					}
-				}
-
 
 				// Move to the base type
 				Recursivetype = Recursivetype.BaseType;
@@ -1135,10 +1116,8 @@ namespace SecureStuff
 							IPopulateIDRelation.ObjectsFromForeverID(PrefabComponent.ForeverId,
 								Field.FieldType);
 
-						PropertyInfo?.SetValue(Object, ((GameObject) Prefab)?.GetComponent(PrefabComponent.ComponentName));
-						Field.SetValue(Object, ((GameObject) Prefab)?.GetComponent(PrefabComponent.ComponentName));
-
-
+						Field.SetValue(Object,
+							((GameObject) Prefab)?.GetComponent(PrefabComponent.ComponentName));
 					}
 					else
 					{
@@ -1148,9 +1127,7 @@ namespace SecureStuff
 							IPopulateIDRelation.FlagSaveKey(RootID, root, ModField);
 						}
 
-						PropertyInfo?.SetValue(Object, data);
 						Field.SetValue(Object, data);
-
 						return;
 					}
 				}
@@ -1160,9 +1137,7 @@ namespace SecureStuff
 					if (ModField.IsPrefabID == true)
 					{
 						var Prefab = IPopulateIDRelation.ObjectsFromForeverID(ModField.Data, Field.FieldType);
-						PropertyInfo?.SetValue(Object, ((GameObject) Prefab));
 						Field.SetValue(Object, ((GameObject) Prefab));
-
 					}
 					else
 					{
@@ -1171,9 +1146,8 @@ namespace SecureStuff
 						{
 							IPopulateIDRelation.FlagSaveKey(RootID, root, ModField);
 						}
-						PropertyInfo?.SetValue(Object, data);
-						Field.SetValue(Object, data);
 
+						Field.SetValue(Object, data);
 						return;
 					}
 				}
@@ -1181,9 +1155,7 @@ namespace SecureStuff
 				if (Field.FieldType.IsSubclassOf(typeof(ScriptableObject)))
 				{
 					var SO = IPopulateIDRelation.ObjectsFromForeverID(ModField.Data, Field.FieldType);
-					PropertyInfo?.SetValue(Object, SO);
 					Field.SetValue(Object, SO);
-
 					return;
 				}
 
@@ -1202,10 +1174,7 @@ namespace SecureStuff
 						//NOTE Dangerous
 						try
 						{
-							var valss = Activator.CreateInstance(Field.FieldType);
-							PropertyInfo?.SetValue(Object, valss);
-							Field.SetValue(Object,valss );
-
+							Field.SetValue(Object, Activator.CreateInstance(Field.FieldType));
 						}
 						catch (Exception e)
 						{
@@ -1230,7 +1199,6 @@ namespace SecureStuff
 
 			if (Field.FieldType.IsGenericType) return; //Unity editor can't handle this currently so same Functionality
 			var Value = Librarian.Page.DeSerialiseValue(ModField.Data, Field.FieldType);
-			PropertyInfo?.SetValue(Object, Value);
 			Field.SetValue(Object, Value);
 		}
 
@@ -1840,7 +1808,7 @@ namespace SecureStuff
 						{
 							Loggy.Error(e.ToString());
 						}
-
+						
 					}
 
 					if (MonoComponent.transform != (PrefabDefault as Component)?.transform)

--- a/UnityProject/Assets/Scripts/Items/Others/Candle.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/Candle.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using Logs;
 using UnityEngine;
 using Mirror;
 using Systems.Clothing;
@@ -15,12 +14,10 @@ namespace Items.Others
 
 		[SerializeField]
 		private SpriteHandler spriteHandler = default;
-		[SyncVar] public int InitialLifeSpan = 120;
+
 		[SyncVar] public int LifeSpan = 120; //10 minutes
 		[SyncVar] public int DecayStage = 0;
 		[SyncVar] private bool IsOn = false;
-
-		private bool Updating = false;
 
 		protected int SpriteIndex => IsOn ? 1 : 0;
 
@@ -29,21 +26,10 @@ namespace Items.Others
 			lightControl = GetComponent<ItemLightControl>();
 		}
 
-		public void Start()
-		{
-			LifeSpan = InitialLifeSpan;
-		}
-
 		public void OnDespawnServer(DespawnInfo info)
 		{
 			ToggleLight(false);
-			if (Updating)
-			{
-				UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, Degrade);
-				Updating = false;
-			}
-
-
+			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, Degrade);
 		}
 
 		#region Interaction
@@ -120,56 +106,21 @@ namespace Items.Others
 			}
 			if(IsOn)
 			{
-				if (Updating ==false)
-				{
-					UpdateManager.Add(Degrade, 5f);
-					Updating = true;
-
-				}
-
+				UpdateManager.Add(Degrade, 5f);
 			}
 			else
 			{
-				if (Updating)
-				{
-					UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, Degrade);
-					Updating = false;
-				}
-
+				UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, Degrade);
 			}
 		}
 
 		void Degrade()
 		{
+			if (LifeSpan == -1) return;
+
 			LifeSpan--;
-
-			if (LifeSpan < 0)
-			{
-				LifeSpan = 0;
-			}
-
-			var  Percentage = (float) LifeSpan / (float) InitialLifeSpan;
-
-
-			//0 == full
-			//1 = A bit dead
-			//2 = Nearly dead
-			//3 = dead
-			switch (Percentage)
-			{
-				case > 0.666f:
-					DecayStage = 0;
-					break;
-				case > 0.3333f:
-					DecayStage = 1;
-					break;
-				case > 0:
-					DecayStage = 2;
-					break;
-				default:
-					DecayStage = 3;
-					break;
-			}
+			DecayStage = 4 - Mathf.CeilToInt((LifeSpan / 30f));
+			DecayStage = Mathf.Max(3, DecayStage);
 			if (DecayStage == 3) ToggleLight(false);
 			UpdateSprite();
 		}

--- a/UnityProject/Assets/Scripts/Managers/GameManager.Escape.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.Escape.cs
@@ -83,7 +83,6 @@ public partial class GameManager
 				EndRound(PrimaryEscapeShuttle.loadedOnRoundID);
 			}
 
-			beenToStation = false;
 		}
 
 		if (status == EscapeShuttleStatus.DockedStation && !primaryEscapeShuttle.hostileEnvironment)

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -539,18 +539,31 @@ public class CustomNetworkManager : NetworkManager, IInitialise
 	{
 		Loggy.Error($"Disconnecting {conn.address}");
 		//register them as removed from our own player list
-
 		PlayerList.Instance.RemoveByConnection(conn);
+
+		//NOTE: We don't call the base.OnServerDisconnect method because it destroys the player object -
+		//we want to keep the object around so player can rejoin and reenter their body.
+
+		//note that we can't remove authority from player owned objects, the workaround is to transfer authority to
+		//a different temporary object, remove authority from the original, and then run the normal disconnect logic
+
+
+		//transfer to a temporary object
+		GameObject disconnectedViewer = Instantiate(CustomNetworkManager.Instance.disconnectedViewerPrefab);
+		NetworkServer.ReplacePlayerForConnection(conn, disconnectedViewer,
+			BitConverter.ToUInt32(System.Guid.NewGuid().ToByteArray(), 0), false);
 
 		foreach (var ownedObject in conn.owned.ToArray())
 		{
-			if (ownedObject.connectionToClient?.identity == ownedObject) continue;
+			if (disconnectedViewer == ownedObject.gameObject) continue;
 			ownedObject.RemoveClientAuthority();
 		}
 
 		//now we can call mirror's normal disconnect logic, which will destroy all the player's owned objects
+		//which will preserve their actual body because they no longer own it
 		base.OnServerDisconnect(conn);
 		SubSceneManager.Instance.RemoveSceneObserver(conn);
+		_ = Despawn.ServerSingle(disconnectedViewer);
 	}
 
 	private void OnLevelFinishedLoading(Scene oldScene, Scene newScene)

--- a/UnityProject/Assets/Scripts/MapSaver/MapLoader.cs
+++ b/UnityProject/Assets/Scripts/MapSaver/MapLoader.cs
@@ -310,6 +310,7 @@ namespace MapSaver
 				}
 			}
 
+
 			Object.GetComponent<UniversalObjectPhysics>()?.ResetEverything();
 			if (Matrix != null)
 			{
@@ -363,6 +364,7 @@ namespace MapSaver
 			{
 				ID = prefabData.ID.ToString();
 			}
+
 
 			MapSaver.CodeClass.ThisCodeClass.Objects[ID] = Object;
 			ProcessClassData(prefabData, Object, prefabData.Object);

--- a/UnityProject/Assets/Scripts/MapSaver/MapLoader.cs
+++ b/UnityProject/Assets/Scripts/MapSaver/MapLoader.cs
@@ -202,8 +202,24 @@ namespace MapSaver
 						Matrix4x4 = MapSaver.StringToMatrix4X4(Tile.Tf);
 					}
 
-					Matrix.MetaTileMap.SetTile(NewPos, Tel, Matrix4x4, Colour, Application.isPlaying,
-						useExactForMultilayer: true);
+					try
+					{
+						Matrix.MetaTileMap.SetTile(NewPos, Tel, Matrix4x4, Colour, Application.isPlaying,
+							useExactForMultilayer: true);
+					}
+					catch (Exception e)
+					{
+						Loggy.Error(e.ToString());
+						try
+						{
+							Matrix.MetaTileMap.SetTile(NewPos, TileManager.ErrorTile, Matrix4x4, Colour, Application.isPlaying,
+								useExactForMultilayer: true);
+						}
+						catch (Exception exception)
+						{
+							Loggy.Trace($"Something is incredibly fucked. Unable to place tile AND error placeholder.\n {exception}");
+						}
+					}
 				}
 			}
 		}
@@ -488,16 +504,26 @@ namespace MapSaver
 
 		public static IEnumerator ServerLoadMap(Vector3 Offset00, Vector3 Offset, MapSaver.MapData MapData, SceneType sceneType = SceneType.HiddenScene)
 		{
-			foreach (var ToMapMatrix in MapData.ContainedMatrices)
+			if (MapData == null)
 			{
-				yield return ServerLoadSection(null, Offset00, Offset, ToMapMatrix, null,
-					MatrixName: ToMapMatrix.MatrixName, LoadingMultiple: true, sceneType: sceneType);
+				Loggy.Error("Failed to load map data due to it being null.");
+				yield break;
+			}
+			if (MapData.ContainedMatrices == null || MapData.ContainedMatrices.Count == 0)
+			{
+				Loggy.Error($"Attempted to load map ({MapData.MapName}/{MapData.Ver}) with no matrices.");
+				yield break;
+			}
+			foreach (var toMapMatrix in MapData.ContainedMatrices)
+			{
+				yield return ServerLoadSection(null, Offset00, Offset, toMapMatrix, null,
+					MatrixName: toMapMatrix.MatrixName, LoadingMultiple: true, sceneType: sceneType);
 			}
 
 			MapSaver.CodeClass.ThisCodeClass.ReportStatus();
 			MapSaver.CodeClass.ThisCodeClass.Reset();
 #if UNITY_EDITOR
-			if (Application.isPlaying == false)
+			if (Application.isPlaying == false && CustomNetworkManager.Instance != null)
 			{
 				CustomNetworkManager.Instance.SpawnedByMappingTool = true;
 			}

--- a/UnityProject/Assets/Scripts/MapSaver/MapSaver.cs
+++ b/UnityProject/Assets/Scripts/MapSaver/MapSaver.cs
@@ -1779,11 +1779,6 @@ namespace MapSaver
 
 			GameObject OriginPrefab = null;
 
-			if (CustomNetworkManager.Instance.ForeverIDLookupSpawnablePrefabs.ContainsKey(Tracker.ForeverID) == false)
-			{
-				Loggy.Error($"missing ID for {Tracker.name} for ID {Tracker.ForeverID}");
-			}
-
 			OriginPrefab = CustomNetworkManager.Instance.ForeverIDLookupSpawnablePrefabs[Tracker.ForeverID];
 			if (Compact == false)
 			{

--- a/UnityProject/Assets/Scripts/Player/ItemLightControl.cs
+++ b/UnityProject/Assets/Scripts/Player/ItemLightControl.cs
@@ -126,6 +126,11 @@ public class ItemLightControl : BodyPartFunctionality, IItemInOutMovedPlayer
 	public void Toggle(bool on)
 	{
 		if (IsOn == on) return;
+		if (LightEmission == null)
+		{
+			Loggy.Error($"{this} field LightEmission is null, please check scripts.", Category.Lighting);
+			return;
+		}
 
 		IsOn = on; // Will trigger SyncState.
 		UpdateLights();
@@ -175,12 +180,12 @@ public class ItemLightControl : BodyPartFunctionality, IItemInOutMovedPlayer
 	{
 		if (IsOn)
 		{
-			LightEmission?.AddLight(playerLightData);
+			LightEmission.AddLight(playerLightData);
 			objectLightEmission.SetActive(true);
 		}
 		else
 		{
-			LightEmission?.RemoveLight(playerLightData);
+			LightEmission.RemoveLight(playerLightData);
 			objectLightEmission.SetActive(false);
 		}
 	}

--- a/UnityProject/Assets/Scripts/Player/PlayerManager.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerManager.cs
@@ -105,7 +105,6 @@ public class PlayerManager : SingletonManager<PlayerManager>
 		var move = GetMovementAction();
 		if (ShuttleConsole != null)
 		{
-			if (UIManager.IsInputFocus) return;
 			if (move.moveActions.Length > 0)
 			{
 				ShuttleConsole.CmdMove(Orientation.From(GetMovementAction().ToPlayerMoveDirection().ToVector()));

--- a/UnityProject/Assets/Scripts/Shuttles/AutopilotShipMachine.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/AutopilotShipMachine.cs
@@ -46,8 +46,6 @@ public class AutopilotShipMachine : MonoBehaviour
 		mm.NetworkedMatrixMove.SpinneyThreshold = 9999;
 		mm.NetworkedMatrixMove.rotationSpeed = 90;
 		mm.NetworkedMatrixMove.ShuttleNonSpinneyModeRounding = 90;
-
-
 	}
 
 	public void InItAsIfDockedTo(GuidanceBuoy Buoy)
@@ -215,9 +213,8 @@ public class AutopilotShipMachine : MonoBehaviour
 		if (mm.NetworkedMatrixMove.IsMoving == false)
 		{
 			if (CurrentTarget == null) return;
-			var Difference = (mm.NetworkedMatrixMove.CentreOfAIMovementWorld.RoundToInt() - CurrentTarget.transform.position).magnitude;
-
-			if (Difference < 0.5f)
+			var difference = (mm.NetworkedMatrixMove.CentreOfAIMovementWorld.RoundToInt() - CurrentTarget.transform.position).magnitude;
+			if (difference < 0.5f)
 			{
 				Reached(CurrentTarget);
 			}

--- a/UnityProject/Assets/Scripts/Shuttles/AutopilotShipMachine.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/AutopilotShipMachine.cs
@@ -48,19 +48,6 @@ public class AutopilotShipMachine : MonoBehaviour
 		mm.NetworkedMatrixMove.ShuttleNonSpinneyModeRounding = 90;
 	}
 
-	public void InItAsIfDockedTo(GuidanceBuoy Buoy)
-	{
-		if (CustomNetworkManager.IsServer == false) return;
-		StartOfChain = Buoy;
-		CurrentTarget = Buoy;
-
-		while (CurrentTarget.In.NextInLine != null)
-		{
-			CurrentTarget = CurrentTarget.In.NextInLine;
-		}
-		MoveToInternal(CurrentTarget);
-	}
-
 
 	public void MoveToTargetBuoy(GuidanceBuoy Buoy)
 	{
@@ -147,7 +134,7 @@ public class AutopilotShipMachine : MonoBehaviour
 	{
 		if (MoveDirectionIn)
 		{
-			if (CurrentTarget.In.NextInLine == null)
+			if (CurrentTarget.In.IsEnd)
 			{
 				if (PreviouslyReached == pos) return;
 				PreviouslyReached = pos;
@@ -155,6 +142,7 @@ public class AutopilotShipMachine : MonoBehaviour
 				{
 					ShuttlesMainConnector.TryConnectAdjacent();
 				}
+
 
 				ReachedEndOfInBuoyChain(CurrentTarget, StartOfChain);
 			}
@@ -167,7 +155,7 @@ public class AutopilotShipMachine : MonoBehaviour
 		}
 		else
 		{
-			if (CurrentTarget.Out.NextInLine == null)
+			if (CurrentTarget.Out.IsEnd)
 			{
 
 				if (PreviouslyReached == pos) return;

--- a/UnityProject/Assets/Scripts/Shuttles/EscapeShuttle.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/EscapeShuttle.cs
@@ -164,15 +164,12 @@ public class EscapeShuttle : AutopilotShipMachine
 
 	public int loadedOnRoundID = 0;
 
-	public float timeSpentTravellingToCC;
-
 	private void Start()
 	{
 		base.Start();
 		centComm = GameManager.Instance.GetComponent<CentComm>();
 		initialTimerSecondsCache = initialTimerSeconds;
 		loadedOnRoundID = GameManager.RoundID;
-		InItAsIfDockedTo(StationStartBuoy);
 	}
 
 
@@ -187,6 +184,9 @@ public class EscapeShuttle : AutopilotShipMachine
 			var integrity = thruster.GetComponent<Integrity>();
 			integrity.OnWillDestroyServer.AddListener(OnWillDestroyThruster);
 		}
+
+
+
 	}
 
 
@@ -260,15 +260,6 @@ public class EscapeShuttle : AutopilotShipMachine
 	public override void UpdateMe()
 	{
 		base.UpdateMe();
-		if (Status == EscapeShuttleStatus.OnRouteToCentCom)
-		{
-			timeSpentTravellingToCC += Time.deltaTime;
-		}
-		else if (startedMovingToStation && Status == EscapeShuttleStatus.OnRouteStation)
-		{
-			timeSpentTravellingToCC -= Time.deltaTime;
-		}
-
 		if (Initialised == false)
 		{
 			if (TargetDestinationBuoy != null)
@@ -342,25 +333,22 @@ public class EscapeShuttle : AutopilotShipMachine
 
 		var Alert = centComm.CurrentAlertLevel;
 
-
-		var Achievable = Mathf.RoundToInt(timeSpentTravellingToCC * 2);
-
-
 		//Changes EscapeShuttle time depending on Alert Level
+
 		if (Alert == CentComm.AlertLevel.Green)
 		{
 			//Double the Time
-			InitialTimerSeconds = Achievable * 2;
+			InitialTimerSeconds = initialTimerSecondsCache * 2;
 		}
 		else if (Alert == CentComm.AlertLevel.Blue)
         {
 			//Default values set in inspector
-			InitialTimerSeconds = Achievable;
+			InitialTimerSeconds = initialTimerSecondsCache;
         }
 		else if (Alert == CentComm.AlertLevel.Red || Alert == CentComm.AlertLevel.Delta)
 		{
 			//Half the Time
-			InitialTimerSeconds = Achievable / 2;
+			InitialTimerSeconds = initialTimerSecondsCache / 2;
 		}
 
 		TooLateToRecallSeconds = InitialTimerSeconds / 2;
@@ -458,7 +446,7 @@ public class EscapeShuttle : AutopilotShipMachine
 				}
 				AddToTime(-1);
 				//Time = Distance/Speed
-				if (startedMovingToStation == false && CurrentTimerSeconds <= timeSpentTravellingToCC)
+				if (startedMovingToStation == false && CurrentTimerSeconds <= Vector2.Distance(matrixMove.NetworkedMatrixMove.TargetTransform.position, StationStartBuoy.transform.position) / matrixMove.NetworkedMatrixMove.AITravelSpeed + 10f)
 				{
 					startedMovingToStation = true;
 					MoveToTargetBuoy( StationStartBuoy );

--- a/UnityProject/Assets/Scripts/Shuttles/GuidanceBuoyMoveStep.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/GuidanceBuoyMoveStep.cs
@@ -13,5 +13,6 @@ public class GuidanceBuoyMoveStep
 	//On Reach
 	public ShuttleConnector ConnectTo;
 	public GuidanceBuoy NextInLine;
+	public bool IsEnd = false;
 }
 

--- a/UnityProject/Assets/Scripts/Shuttles/MatrixSync.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/MatrixSync.cs
@@ -23,22 +23,11 @@ namespace Shuttles
 
 		#endregion
 
-		[SyncVar(hook = nameof(SyncIsSpaceMatrix))] public bool IsSpaceMatrix;
+		[SyncVar] public bool IsSpaceMatrix;
 
 		[SyncVar] public bool IsMainStationMatrix;
 
 		public static int matrixIDcounter;
-
-		private void SyncIsSpaceMatrix(bool oldState, bool newState)
-		{
-			IsSpaceMatrix = newState;
-			if (IsSpaceMatrix)
-			{
-				MatrixManager.Instance.spaceMatrix = this.networkedMatrix.matrix;
-			}
-		}
-
-
 
 		private void Awake()
 		{

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Changeling/ChangelingAbility/Implementation/AbsorbAbility.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Changeling/ChangelingAbility/Implementation/AbsorbAbility.cs
@@ -25,7 +25,7 @@ namespace Changeling
 			{
 				return false;
 			}
-			if (target.playerHealth.IsDead)
+			if (target.IsDeadOrGhost)
 			{
 				Chat.AddExamineMsg(changeling.ChangelingMind.gameObject, "<color=red>You cannot absorb a dead body!</color>");
 				return false;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
@@ -70,7 +70,7 @@ public class Matrix : MonoBehaviour
 	private TileChangeManager tileChangeManager;
 	public TileChangeManager TileChangeManager => tileChangeManager;
 
-	public bool AIShuttleShouldAvoid = false;
+	public bool AIShuttleShouldAvoid = true;
 
 	public Color Color => colors.Wrap(Id).WithAlpha(0.7f);
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
@@ -70,7 +70,7 @@ public class Matrix : MonoBehaviour
 	private TileChangeManager tileChangeManager;
 	public TileChangeManager TileChangeManager => tileChangeManager;
 
-	public bool AIShuttleShouldAvoid = true;
+	public bool AIShuttleShouldAvoid = false;
 
 	public Color Color => colors.Wrap(Id).WithAlpha(0.7f);
 
@@ -116,6 +116,7 @@ public class Matrix : MonoBehaviour
 
 	public void Awake()
 	{
+		AIShuttleShouldAvoid = true;
 		metaTileMap = GetComponent<MetaTileMap>();
 		if (metaTileMap == null)
 		{

--- a/UnityProject/Assets/Scripts/Tilemaps/TileManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/TileManager.cs
@@ -59,6 +59,9 @@ public class TileManager : SingletonManager<TileManager>, IInitialise
 
 	[SerializeField] private List<TilePathEntry> layerTileCollections = new List<TilePathEntry>();
 
+	public LayerTile ErrorLayerTile;
+	public static LayerTile ErrorTile => Instance.ErrorLayerTile;
+
 	public InitialisationSystems Subsystem => InitialisationSystems.TileManager;
 
 	void IInitialise.Initialise()
@@ -167,14 +170,17 @@ public class TileManager : SingletonManager<TileManager>, IInitialise
 		}
 	}
 
-	public static LayerTile GetTile( string key)
+	public static LayerTile GetTile(string key, bool returnErrorTileOnFail = true)
 	{
 		if (Instance.AllTiles.TryGetValue(key, out var tl))
 		{
 			return tl;
 		}
-
-		Loggy.Error( $"Could not find layerTile in dictionary with key: {key}");
+		Loggy.Error($"Could not find layerTile in dictionary with key: {key}");
+		if (returnErrorTileOnFail)
+		{
+			return Instance.ErrorLayerTile;
+		}
 
 		return null;
 	}

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/BoxStationV1.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/BoxStationV1.json
@@ -213863,7 +213863,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -213879,6 +213879,10 @@
                     {
                       "Name": "Out@NextInLine",
                       "Data": "69ffc1053dc39a24fb870b2248780be4_-526┼42┼0┼@0@GuidanceBuoy@0"
+                    },
+                    {
+                      "Name": "In@IsEnd",
+                      "Data": "True"
                     }
                   ]
                 }
@@ -213895,6 +213899,10 @@
                 {
                   "ClassID": "GuidanceBuoy@0",
                   "Data": [
+                    {
+                      "Name": "Out@IsEnd",
+                      "Data": "True"
+                    },
                     {
                       "Name": "In@NextInLine",
                       "Data": "69ffc1053dc39a24fb870b2248780be4_-554┼42┼0┼@0@GuidanceBuoy@0"
@@ -213921,6 +213929,10 @@
                     {
                       "Name": "Out@DesiredFaceDirection",
                       "Data": "Up_By0"
+                    },
+                    {
+                      "Name": "Out@IsEnd",
+                      "Data": "True"
                     },
                     {
                       "Name": "In@NextInLine",
@@ -224091,6 +224103,10 @@
                     {
                       "Name": "In@DesiredFaceDirection",
                       "Data": "Up_By0"
+                    },
+                    {
+                      "Name": "In@IsEnd",
+                      "Data": "True"
                     }
                   ]
                 }
@@ -288082,9 +288098,15 @@
             "LocalPRS": "-208.996┼-11┼0┼"
           },
           {
-            "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_-208.99┼-12┼0┼",
+            "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_-208.994┼-12┼0┼",
             "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
             "Name": "ControlRod (1)",
+            "LocalPRS": "-208.994┼-12┼0┼"
+          },
+          {
+            "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_-208.99┼-12┼0┼",
+            "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
+            "Name": "ControlRod (8)",
             "LocalPRS": "-208.99┼-12┼0┼"
           },
           {
@@ -288092,12 +288114,6 @@
             "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
             "Name": "ControlRod (14)",
             "LocalPRS": "-208.99┼-11┼0┼"
-          },
-          {
-            "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_-208.989┼-12┼0┼",
-            "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
-            "Name": "ControlRod (8)",
-            "LocalPRS": "-208.989┼-12┼0┼"
           },
           {
             "GitID": "3252edce30bbb4749a17af748afbaecc_-208┼-8┼0┼",
@@ -365512,6 +365528,10 @@
                     {
                       "Name": "In@DesiredFaceDirection",
                       "Data": "Left_By90"
+                    },
+                    {
+                      "Name": "In@IsEnd",
+                      "Data": "True"
                     }
                   ]
                 }
@@ -365701,6 +365721,10 @@
                       "Data": "Left_By90"
                     },
                     {
+                      "Name": "Out@IsEnd",
+                      "Data": "True"
+                    },
+                    {
                       "Name": "In@NextInLine",
                       "Data": "69ffc1053dc39a24fb870b2248780be4_-124┼64┼0┼@0@GuidanceBuoy@0"
                     }
@@ -365736,14 +365760,14 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "-276.6,31.8,-1",
-          "Size": "554.8,183.5,4"
+          "Pos": "-275.6,32.8,0",
+          "Size": "554.8,183.5,0"
         }
       ]
     },
     {
       "Ver": "1.1.1",
-      "Location": "-126┼14┼0┼0ø0ø90ø",
+      "Location": "0┼63┼0┼",
       "MatrixName": "EscapeShuttle",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",
@@ -368347,7 +368371,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -370776,7 +370800,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "29.5,-7,0",
+          "Pos": "30.5,57,0",
           "Size": "59,14,0"
         }
       ]
@@ -370947,7 +370971,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -371122,7 +371146,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "0.5,-2,0",
+          "Pos": "-299.5,80.1,0",
           "Size": "3,4,0"
         }
       ]
@@ -371963,7 +371987,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -372560,7 +372584,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "-1,-0.5,0",
+          "Pos": "-350,38.5,0",
           "Size": "6,11,0"
         }
       ]
@@ -373015,7 +373039,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -373517,8 +373541,8 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "0,-0.5,0.5",
-          "Size": "4,7,1"
+          "Pos": "-130,73.5,0",
+          "Size": "4,7,0"
         }
       ]
     },
@@ -373972,7 +373996,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -374487,8 +374511,8 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "0,-0.5,0.5",
-          "Size": "4,7,1"
+          "Pos": "-305,85.6,0",
+          "Size": "4,7,0"
         }
       ]
     },
@@ -374942,7 +374966,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -375456,8 +375480,8 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "0,-0.5,0.5",
-          "Size": "4,7,1"
+          "Pos": "-295.5,96,0",
+          "Size": "7,4,0"
         }
       ]
     },
@@ -375911,7 +375935,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -376419,8 +376443,8 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "0,-0.5,0.5",
-          "Size": "4,7,1"
+          "Pos": "-253,31.5,0",
+          "Size": "4,7,0"
         }
       ]
     },
@@ -377576,7 +377600,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -379086,7 +379110,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "3,0,0",
+          "Pos": "-292,72,0",
           "Size": "16,6,0"
         }
       ]

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/FallStation.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/FallStation.json
@@ -88806,7 +88806,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -88834,6 +88834,10 @@
                   "ClassID": "GuidanceBuoy@0",
                   "Data": [
                     {
+                      "Name": "Out@IsEnd",
+                      "Data": "True"
+                    },
+                    {
                       "Name": "In@NextInLine",
                       "Data": "69ffc1053dc39a24fb870b2248780be4_27┼281┼0┼@0@GuidanceBuoy@0"
                     }
@@ -88855,6 +88859,10 @@
                     {
                       "Name": "Out@NextInLine",
                       "Data": "69ffc1053dc39a24fb870b2248780be4_27┼251┼0┼@0@GuidanceBuoy@0"
+                    },
+                    {
+                      "Name": "In@IsEnd",
+                      "Data": "True"
                     }
                   ]
                 }
@@ -88967,6 +88975,10 @@
                     {
                       "Name": "In@DesiredFaceDirection",
                       "Data": "Up_By0"
+                    },
+                    {
+                      "Name": "In@IsEnd",
+                      "Data": "True"
                     }
                   ]
                 }
@@ -89022,6 +89034,10 @@
                 {
                   "ClassID": "GuidanceBuoy@0",
                   "Data": [
+                    {
+                      "Name": "Out@IsEnd",
+                      "Data": "True"
+                    },
                     {
                       "Name": "In@NextInLine",
                       "Data": "69ffc1053dc39a24fb870b2248780be4_28┼131┼0┼@0@GuidanceBuoy@0"
@@ -144889,6 +144905,15 @@
             "Object": {
               "ClassDatas": [
                 {
+                  "ClassID": "NetworkIdentity@0",
+                  "Data": [
+                    {
+                      "Name": "_assetId",
+                      "Data": "565880673"
+                    }
+                  ]
+                },
+                {
                   "ClassID": "EventRouter@0",
                   "Data": [
                     {
@@ -154220,6 +154245,10 @@
                     {
                       "Name": "In@DesiredFaceDirection",
                       "Data": "Up_By0"
+                    },
+                    {
+                      "Name": "In@IsEnd",
+                      "Data": "True"
                     }
                   ]
                 }
@@ -154276,6 +154305,10 @@
                   "ClassID": "GuidanceBuoy@0",
                   "Data": [
                     {
+                      "Name": "Out@IsEnd",
+                      "Data": "True"
+                    },
+                    {
                       "Name": "In@NextInLine",
                       "Data": "69ffc1053dc39a24fb870b2248780be4_122┼145┼0┼@0@GuidanceBuoy@0"
                     }
@@ -154290,8 +154323,8 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "61,140.5,-14",
-          "Size": "122,281,30"
+          "Pos": "62,141.5,0",
+          "Size": "122,281,0"
         }
       ]
     },
@@ -155001,7 +155034,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -155437,7 +155470,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "0,0,0",
+          "Pos": "28,240,0",
           "Size": "4,12,0"
         }
       ]
@@ -155779,7 +155812,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -156072,7 +156105,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "-2,1,0",
+          "Pos": "40,45,0",
           "Size": "6,4,0"
         }
       ]
@@ -156519,7 +156552,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -156906,8 +156939,8 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "1,-1.5,0.5",
-          "Size": "4,7,1"
+          "Pos": "32,51.5,0",
+          "Size": "4,7,0"
         }
       ]
     },
@@ -157358,7 +157391,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -157736,8 +157769,8 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "-0.5,-1,0.5",
-          "Size": "7,4,1"
+          "Pos": "83.5,18,0",
+          "Size": "7,4,0"
         }
       ]
     },
@@ -160907,7 +160940,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [],
         "IDToNetIDClient": {}
@@ -160915,7 +160948,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "2,4.5,0",
+          "Pos": "10003,305.5,0",
           "Size": "28,9,0"
         }
       ]
@@ -170200,7 +170233,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -172798,14 +172831,14 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "43.5,19.5,0",
+          "Pos": "-8955.5,2020.5,0",
           "Size": "87,47,0"
         }
       ]
     },
     {
       "Ver": "1.1.1",
-      "Location": "125┼72┼0┼",
+      "Location": "126┼130┼0┼",
       "MatrixName": "EMS",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",
@@ -174428,7 +174461,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -176026,7 +176059,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "0,7,0",
+          "Pos": "127,138,0",
           "Size": "6,20,0"
         }
       ]

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/MiniStation.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/MiniStation.json
@@ -96660,7 +96660,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -96713,6 +96713,10 @@
                     {
                       "Name": "In@DesiredFaceDirection",
                       "Data": "Up_By0"
+                    },
+                    {
+                      "Name": "In@IsEnd",
+                      "Data": "True"
                     }
                   ]
                 }
@@ -96768,6 +96772,10 @@
                 {
                   "ClassID": "GuidanceBuoy@0",
                   "Data": [
+                    {
+                      "Name": "Out@IsEnd",
+                      "Data": "True"
+                    },
                     {
                       "Name": "In@NextInLine",
                       "Data": "69ffc1053dc39a24fb870b2248780be4_21┼131┼0┼@0@GuidanceBuoy@0"
@@ -124254,7 +124262,20 @@
             "GitID": "cajcKzj41Rgh!X$LAkMi_65┼110┼0┼",
             "PrefabID": "cajcKzj41Rgh!X$LAkMi",
             "Name": "SmallBloodSplat (1)",
-            "LocalPRS": "65┼110┼0┼"
+            "LocalPRS": "65┼110┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "FloorDecal@0",
+                  "Data": [
+                    {
+                      "Name": "CanDryUp",
+                      "Data": "False"
+                    }
+                  ]
+                }
+              ]
+            }
           },
           {
             "GitID": "42bdfe2e83a9b184385867c7ccc527c2_65┼112┼0┼",
@@ -125471,7 +125492,20 @@
             "GitID": "cajcKzj41Rgh!X$LAkMi_66.25┼111.75┼0┼",
             "PrefabID": "cajcKzj41Rgh!X$LAkMi",
             "Name": "SmallBloodSplat (2)",
-            "LocalPRS": "66.25┼111.75┼0┼"
+            "LocalPRS": "66.25┼111.75┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "FloorDecal@0",
+                  "Data": [
+                    {
+                      "Name": "CanDryUp",
+                      "Data": "False"
+                    }
+                  ]
+                }
+              ]
+            }
           },
           {
             "GitID": "a9dfc8bf04d4e4b47aeaeb5193efa5d6_66.27┼52.06┼0┼",
@@ -137897,40 +137931,40 @@
             "LocalPRS": "78.005┼24┼0┼"
           },
           {
-            "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_78.01┼24┼0┼",
+            "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_78.009┼24┼0┼",
             "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
             "Name": "ControlRod (10)",
+            "LocalPRS": "78.009┼24┼0┼"
+          },
+          {
+            "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_78.01┼24┼0┼",
+            "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
+            "Name": "ControlRod (9)",
             "LocalPRS": "78.01┼24┼0┼"
           },
           {
             "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_78.011┼24┼0┼",
             "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
-            "Name": "ControlRod (9)",
+            "Name": "ControlRod (8)",
             "LocalPRS": "78.011┼24┼0┼"
           },
           {
             "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_78.012┼24┼0┼",
             "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
-            "Name": "ControlRod (8)",
+            "Name": "ControlRod (7)",
             "LocalPRS": "78.012┼24┼0┼"
           },
           {
             "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_78.013┼24┼0┼",
             "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
-            "Name": "ControlRod (7)",
+            "Name": "ControlRod (11)",
             "LocalPRS": "78.013┼24┼0┼"
           },
           {
             "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_78.014┼24┼0┼",
             "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
-            "Name": "ControlRod (11)",
-            "LocalPRS": "78.014┼24┼0┼"
-          },
-          {
-            "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_78.015┼24┼0┼",
-            "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
             "Name": "ControlRod (12)",
-            "LocalPRS": "78.015┼24┼0┼"
+            "LocalPRS": "78.014┼24┼0┼"
           },
           {
             "GitID": "e33403c0371fc174aa03640734665a15_78.65┼94.42┼0┼",
@@ -165817,6 +165851,10 @@
                     {
                       "Name": "In@DesiredFaceDirection",
                       "Data": "Up_By0"
+                    },
+                    {
+                      "Name": "In@IsEnd",
+                      "Data": "True"
                     }
                   ]
                 }
@@ -166249,6 +166287,10 @@
                       "Data": "Up_By0"
                     },
                     {
+                      "Name": "Out@IsEnd",
+                      "Data": "True"
+                    },
+                    {
                       "Name": "In@NextInLine",
                       "Data": "69ffc1053dc39a24fb870b2248780be4_140┼64┼0┼@0@GuidanceBuoy@0"
                     }
@@ -166267,6 +166309,10 @@
                 {
                   "ClassID": "GuidanceBuoy@0",
                   "Data": [
+                    {
+                      "Name": "Out@IsEnd",
+                      "Data": "True"
+                    },
                     {
                       "Name": "In@NextInLine",
                       "Data": "69ffc1053dc39a24fb870b2248780be4_730┼64┼0┼@0@GuidanceBuoy@0"
@@ -166289,6 +166335,10 @@
                     {
                       "Name": "Out@NextInLine",
                       "Data": "69ffc1053dc39a24fb870b2248780be4_698┼64┼0┼@0@GuidanceBuoy@0"
+                    },
+                    {
+                      "Name": "In@IsEnd",
+                      "Data": "True"
                     }
                   ]
                 }
@@ -166301,8 +166351,8 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "365,71,-23.5",
-          "Size": "730,152,49"
+          "Pos": "366,72,0",
+          "Size": "730,152,0"
         }
       ]
     },
@@ -167354,7 +167404,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -167748,7 +167798,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "3.5,0,0",
+          "Pos": "277.5,66,0",
           "Size": "11,8,0"
         }
       ]
@@ -168362,7 +168412,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -168738,7 +168788,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "0.5,1,0",
+          "Pos": "30.5,47,0",
           "Size": "11,4,0"
         }
       ]
@@ -169620,7 +169670,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -170255,8 +170305,8 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "2.5,0,0.5",
-          "Size": "9,6,1"
+          "Pos": "115.6,74,0",
+          "Size": "9,6,0"
         }
       ]
     },
@@ -170769,7 +170819,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -171209,14 +171259,14 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "0,-0.5,0.5",
-          "Size": "4,7,1"
+          "Pos": "58,16.5,0",
+          "Size": "4,7,0"
         }
       ]
     },
     {
       "Ver": "1.1.1",
-      "Location": "18┼52┼0┼",
+      "Location": "18┼164┼0┼",
       "MatrixName": "EMS",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",
@@ -172892,7 +172942,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -174169,7 +174219,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "-1,8.5,0",
+          "Pos": "18,173.5,0",
           "Size": "8,17,0"
         }
       ]

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/OutpostStation.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/OutpostStation.json
@@ -190223,7 +190223,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -190255,6 +190255,10 @@
                     {
                       "Name": "In@DesiredFaceDirection",
                       "Data": "Up_By0"
+                    },
+                    {
+                      "Name": "In@IsEnd",
+                      "Data": "True"
                     }
                   ]
                 }
@@ -190303,6 +190307,10 @@
                   "ClassID": "GuidanceBuoy@0",
                   "Data": [
                     {
+                      "Name": "Out@IsEnd",
+                      "Data": "True"
+                    },
+                    {
                       "Name": "In@NextInLine",
                       "Data": "69ffc1053dc39a24fb870b2248780be4_-15┼145┼0┼@0@GuidanceBuoy@0"
                     }
@@ -190321,6 +190329,10 @@
                 {
                   "ClassID": "GuidanceBuoy@0",
                   "Data": [
+                    {
+                      "Name": "Out@IsEnd",
+                      "Data": "True"
+                    },
                     {
                       "Name": "In@NextInLine",
                       "Data": "69ffc1053dc39a24fb870b2248780be4_-15┼541┼0┼@0@GuidanceBuoy@0"
@@ -190343,6 +190355,10 @@
                     {
                       "Name": "Out@NextInLine",
                       "Data": "69ffc1053dc39a24fb870b2248780be4_-15┼479┼0┼@0@GuidanceBuoy@0"
+                    },
+                    {
+                      "Name": "In@IsEnd",
+                      "Data": "True"
                     }
                   ]
                 }
@@ -279296,6 +279312,10 @@
                     {
                       "Name": "In@DesiredFaceDirection",
                       "Data": "Up_By0"
+                    },
+                    {
+                      "Name": "In@IsEnd",
+                      "Data": "True"
                     }
                   ]
                 }
@@ -317387,6 +317407,12 @@
             "LocalPRS": "105.005┼34┼0┼"
           },
           {
+            "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_105.008┼33┼0┼",
+            "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
+            "Name": "ControlRod (7)",
+            "LocalPRS": "105.008┼33┼0┼"
+          },
+          {
             "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_105.009┼33┼0┼",
             "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
             "Name": "ControlRod (8)",
@@ -317395,44 +317421,38 @@
           {
             "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_105.01┼33┼0┼",
             "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
-            "Name": "ControlRod (7)",
+            "Name": "ControlRod (6)",
             "LocalPRS": "105.01┼33┼0┼"
           },
           {
             "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_105.011┼33┼0┼",
             "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
-            "Name": "ControlRod (6)",
+            "Name": "ControlRod (5)",
             "LocalPRS": "105.011┼33┼0┼"
           },
           {
             "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_105.012┼33┼0┼",
             "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
-            "Name": "ControlRod (5)",
+            "Name": "ControlRod (9)",
             "LocalPRS": "105.012┼33┼0┼"
           },
           {
             "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_105.013┼33┼0┼",
             "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
-            "Name": "ControlRod (9)",
+            "Name": "ControlRod (10)",
             "LocalPRS": "105.013┼33┼0┼"
           },
           {
             "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_105.014┼33┼0┼",
             "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
-            "Name": "ControlRod (10)",
+            "Name": "ControlRod (11)",
             "LocalPRS": "105.014┼33┼0┼"
           },
           {
             "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_105.015┼33┼0┼",
             "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
-            "Name": "ControlRod (11)",
-            "LocalPRS": "105.015┼33┼0┼"
-          },
-          {
-            "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_105.016┼33┼0┼",
-            "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
             "Name": "ControlRod (12)",
-            "LocalPRS": "105.016┼33┼0┼"
+            "LocalPRS": "105.015┼33┼0┼"
           },
           {
             "GitID": "e58e1fd483fe772468ad2aab4259397d_105.92┼78┼0┼",
@@ -326364,6 +326384,10 @@
                       "Data": "Up_By0"
                     },
                     {
+                      "Name": "Out@IsEnd",
+                      "Data": "True"
+                    },
+                    {
                       "Name": "In@NextInLine",
                       "Data": "69ffc1053dc39a24fb870b2248780be4_75┼-5┼0┼@0@GuidanceBuoy@0"
                     }
@@ -326378,14 +326402,14 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "71,256,-0.5",
-          "Size": "172,570,3"
+          "Pos": "72,257,0",
+          "Size": "172,570,0"
         }
       ]
     },
     {
       "Ver": "1.1.1",
-      "Location": "15┼-1┼0┼",
+      "Location": "266┼-9┼0┼",
       "MatrixName": "EscapeShuttle",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",
@@ -330675,7 +330699,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -336240,7 +336264,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "37.5,-7,0",
+          "Pos": "304.5,-15,0",
           "Size": "75,14,0"
         }
       ]
@@ -336384,7 +336408,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -336640,7 +336664,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "1,-2,0",
+          "Pos": "105,130,0",
           "Size": "2,4,0"
         }
       ]
@@ -337606,7 +337630,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -338194,7 +338218,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "-1,1,0",
+          "Pos": "-17,226,0",
           "Size": "6,14,0"
         }
       ]
@@ -338635,7 +338659,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -339472,8 +339496,8 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "0,-0.5,0.5",
-          "Size": "4,7,1"
+          "Pos": "26,102.6,0",
+          "Size": "4,7,0"
         }
       ]
     },
@@ -339913,7 +339937,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -340541,8 +340565,8 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "0,-0.5,0.5",
-          "Size": "4,7,1"
+          "Pos": "-5,76.5,0",
+          "Size": "4,7,0"
         }
       ]
     },
@@ -340982,7 +341006,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -341610,8 +341634,8 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "0,-0.5,0.5",
-          "Size": "4,7,1"
+          "Pos": "36.1,120.5,0",
+          "Size": "4,7,0"
         }
       ]
     },
@@ -342051,7 +342075,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -342873,8 +342897,8 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "0,-0.5,0.5",
-          "Size": "4,7,1"
+          "Pos": "10,102.5,0",
+          "Size": "4,7,0"
         }
       ]
     },
@@ -344015,7 +344039,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -345488,7 +345512,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "3,0,0",
+          "Pos": "102,112,0",
           "Size": "16,6,0"
         }
       ]
@@ -345632,7 +345656,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -345888,7 +345912,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "1,-2,0",
+          "Pos": "109,130,0",
           "Size": "2,4,0"
         }
       ]
@@ -347805,7 +347829,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -350702,8 +350726,8 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "7.5,0,0.5",
-          "Size": "23,6,1"
+          "Pos": "16.5,85,0",
+          "Size": "23,6,0"
         }
       ]
     },
@@ -352457,7 +352481,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -352721,8 +352745,8 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "-1,0,-0.5",
-          "Size": "20,14,3"
+          "Pos": "-489,660,0",
+          "Size": "20,14,0"
         }
       ]
     }

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/PogStation.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/PogStation.json
@@ -191521,7 +191521,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -207078,6 +207078,14 @@
                     {
                       "Name": "Out@NextInLine",
                       "Data": "69ffc1053dc39a24fb870b2248780be4_11┼-12┼0┼@0@GuidanceBuoy@0"
+                    },
+                    {
+                      "Name": "Out@IsEnd",
+                      "Data": "True"
+                    },
+                    {
+                      "Name": "In@IsEnd",
+                      "Data": "True"
                     }
                   ]
                 }
@@ -207416,6 +207424,10 @@
                   "ClassID": "GuidanceBuoy@0",
                   "Data": [
                     {
+                      "Name": "Out@IsEnd",
+                      "Data": "True"
+                    },
+                    {
                       "Name": "In@NextInLine",
                       "Data": "69ffc1053dc39a24fb870b2248780be4_10┼-35┼0┼@0@GuidanceBuoy@0"
                     }
@@ -207441,6 +207453,10 @@
                     {
                       "Name": "Out@DesiredFaceDirection",
                       "Data": "Up_By0"
+                    },
+                    {
+                      "Name": "Out@IsEnd",
+                      "Data": "True"
                     },
                     {
                       "Name": "In@NextInLine",
@@ -265368,6 +265384,12 @@
             "LocalPRS": "56.004┼257┼0┼"
           },
           {
+            "GitID": "25108e21a69d52c46a538e66eb85db0a_56.006┼257┼0┼",
+            "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
+            "Name": "SolidPlasmaSheet (22)",
+            "LocalPRS": "56.006┼257┼0┼"
+          },
+          {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_56.007┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
             "Name": "SolidPlasmaSheet (23)",
@@ -265388,44 +265410,38 @@
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_56.01┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (22)",
+            "Name": "SolidPlasmaSheet (21)",
             "LocalPRS": "56.01┼257┼0┼"
           },
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_56.011┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (21)",
+            "Name": "SolidPlasmaSheet (26)",
             "LocalPRS": "56.011┼257┼0┼"
           },
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_56.012┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (26)",
+            "Name": "SolidPlasmaSheet (27)",
             "LocalPRS": "56.012┼257┼0┼"
           },
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_56.013┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (27)",
+            "Name": "SolidPlasmaSheet (28)",
             "LocalPRS": "56.013┼257┼0┼"
           },
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_56.014┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (28)",
+            "Name": "SolidPlasmaSheet (29)",
             "LocalPRS": "56.014┼257┼0┼"
           },
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_56.015┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (29)",
-            "LocalPRS": "56.015┼257┼0┼"
-          },
-          {
-            "GitID": "25108e21a69d52c46a538e66eb85db0a_56.016┼257┼0┼",
-            "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
             "Name": "SolidPlasmaSheet (30)",
-            "LocalPRS": "56.016┼257┼0┼"
+            "LocalPRS": "56.015┼257┼0┼"
           },
           {
             "GitID": "8f1ce2b118c25334fa660be931e62dbf_56.14┼218.28┼0┼",
@@ -266876,6 +266892,12 @@
             "LocalPRS": "57.004┼257┼0┼"
           },
           {
+            "GitID": "25108e21a69d52c46a538e66eb85db0a_57.006┼257┼0┼",
+            "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
+            "Name": "SolidPlasmaSheet (7)",
+            "LocalPRS": "57.006┼257┼0┼"
+          },
+          {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_57.007┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
             "Name": "SolidPlasmaSheet (8)",
@@ -266896,44 +266918,38 @@
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_57.01┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (7)",
+            "Name": "SolidPlasmaSheet (6)",
             "LocalPRS": "57.01┼257┼0┼"
           },
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_57.011┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (6)",
+            "Name": "SolidPlasmaSheet (11)",
             "LocalPRS": "57.011┼257┼0┼"
           },
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_57.012┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (11)",
+            "Name": "SolidPlasmaSheet (12)",
             "LocalPRS": "57.012┼257┼0┼"
           },
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_57.013┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (12)",
+            "Name": "SolidPlasmaSheet (13)",
             "LocalPRS": "57.013┼257┼0┼"
           },
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_57.014┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (13)",
+            "Name": "SolidPlasmaSheet (14)",
             "LocalPRS": "57.014┼257┼0┼"
           },
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_57.015┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (14)",
-            "LocalPRS": "57.015┼257┼0┼"
-          },
-          {
-            "GitID": "25108e21a69d52c46a538e66eb85db0a_57.016┼257┼0┼",
-            "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
             "Name": "SolidPlasmaSheet (15)",
-            "LocalPRS": "57.016┼257┼0┼"
+            "LocalPRS": "57.015┼257┼0┼"
           },
           {
             "GitID": "6015d5ca578d27b43b1c649384760954_57.05┼210.09┼0┼",
@@ -271446,6 +271462,18 @@
             "LocalPRS": "60.004┼268┼0┼"
           },
           {
+            "GitID": "2c62bf4b8bd1b13409822a00ad8cb214_60.006┼268┼0┼",
+            "PrefabID": "2c62bf4b8bd1b13409822a00ad8cb214",
+            "Name": "FuelRod (2)",
+            "LocalPRS": "60.006┼268┼0┼"
+          },
+          {
+            "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_60.006┼268┼0┼",
+            "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
+            "Name": "ControlRod (8)",
+            "LocalPRS": "60.006┼268┼0┼"
+          },
+          {
             "GitID": "2c62bf4b8bd1b13409822a00ad8cb214_60.007┼268┼0┼",
             "PrefabID": "2c62bf4b8bd1b13409822a00ad8cb214",
             "Name": "FuelRod (1)",
@@ -271472,26 +271500,14 @@
           {
             "GitID": "2c62bf4b8bd1b13409822a00ad8cb214_60.01┼268┼0┼",
             "PrefabID": "2c62bf4b8bd1b13409822a00ad8cb214",
-            "Name": "FuelRod (2)",
+            "Name": "FuelRod (3)",
             "LocalPRS": "60.01┼268┼0┼"
           },
           {
             "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_60.01┼268┼0┼",
             "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
-            "Name": "ControlRod (8)",
-            "LocalPRS": "60.01┼268┼0┼"
-          },
-          {
-            "GitID": "2c62bf4b8bd1b13409822a00ad8cb214_60.011┼268┼0┼",
-            "PrefabID": "2c62bf4b8bd1b13409822a00ad8cb214",
-            "Name": "FuelRod (3)",
-            "LocalPRS": "60.011┼268┼0┼"
-          },
-          {
-            "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_60.011┼268┼0┼",
-            "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
             "Name": "ControlRod (7)",
-            "LocalPRS": "60.011┼268┼0┼"
+            "LocalPRS": "60.01┼268┼0┼"
           },
           {
             "GitID": "3edf81f4a32c4c348bad5bfe43e263fd_60.13┼204.08┼0┼",
@@ -297587,16 +297603,16 @@
             "LocalPRS": "79.005┼165┼0┼"
           },
           {
-            "GitID": "d3c71176f32c1274b929f3a88695a795_79.01┼165┼0┼",
+            "GitID": "d3c71176f32c1274b929f3a88695a795_79.007┼165┼0┼",
             "PrefabID": "d3c71176f32c1274b929f3a88695a795",
             "Name": "Paper (16)",
-            "LocalPRS": "79.01┼165┼0┼"
+            "LocalPRS": "79.007┼165┼0┼"
           },
           {
-            "GitID": "d3c71176f32c1274b929f3a88695a795_79.011┼165┼0┼",
+            "GitID": "d3c71176f32c1274b929f3a88695a795_79.01┼165┼0┼",
             "PrefabID": "d3c71176f32c1274b929f3a88695a795",
             "Name": "Paper (15)",
-            "LocalPRS": "79.011┼165┼0┼"
+            "LocalPRS": "79.01┼165┼0┼"
           },
           {
             "GitID": "5059deed2ffb32a439249dcb385321f4_79.2┼223.25┼0┼",
@@ -305028,16 +305044,16 @@
             "LocalPRS": "87.005┼246┼0┼"
           },
           {
-            "GitID": "908afbc5b9f871148b5ccd0b81bd147f_87.01┼246┼0┼",
+            "GitID": "908afbc5b9f871148b5ccd0b81bd147f_87.007┼246┼0┼",
             "PrefabID": "908afbc5b9f871148b5ccd0b81bd147f",
             "Name": "FireExtinguisher (8)",
-            "LocalPRS": "87.01┼246┼0┼"
+            "LocalPRS": "87.007┼246┼0┼"
           },
           {
-            "GitID": "908afbc5b9f871148b5ccd0b81bd147f_87.011┼246┼0┼",
+            "GitID": "908afbc5b9f871148b5ccd0b81bd147f_87.01┼246┼0┼",
             "PrefabID": "908afbc5b9f871148b5ccd0b81bd147f",
             "Name": "FireExtinguisher (7)",
-            "LocalPRS": "87.011┼246┼0┼"
+            "LocalPRS": "87.01┼246┼0┼"
           },
           {
             "GitID": "753e37602e1e0194cbe435fda83795c4_87.79┼229.28┼0┼",
@@ -314515,6 +314531,10 @@
                     {
                       "Name": "In@DesiredFaceDirection",
                       "Data": "Right_By270"
+                    },
+                    {
+                      "Name": "In@IsEnd",
+                      "Data": "True"
                     }
                   ]
                 }
@@ -314570,6 +314590,10 @@
                 {
                   "ClassID": "GuidanceBuoy@0",
                   "Data": [
+                    {
+                      "Name": "Out@IsEnd",
+                      "Data": "True"
+                    },
                     {
                       "Name": "In@NextInLine",
                       "Data": "69ffc1053dc39a24fb870b2248780be4_105┼277┼0┼@0@GuidanceBuoy@0"
@@ -316676,8 +316700,8 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "35.5,130.5,-8",
-          "Size": "179,331,18"
+          "Pos": "86.5,359.5,0",
+          "Size": "179,331,0"
         }
       ]
     },
@@ -317508,7 +317532,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -318454,7 +318478,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "-1,0,0",
+          "Pos": "9,74,0",
           "Size": "6,12,0"
         }
       ]
@@ -319279,7 +319303,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -320107,14 +320131,14 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "0.5,-1,0.5",
-          "Size": "9,6,1"
+          "Pos": "80.5,384,0",
+          "Size": "9,6,0"
         }
       ]
     },
     {
       "Ver": "1.1.1",
-      "Location": "153┼424┼0┼0ø0ø90ø",
+      "Location": "111┼317.25┼0┼",
       "MatrixName": "EscapeShuttle",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",
@@ -323103,7 +323127,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -327885,7 +327909,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "30,-7,0",
+          "Pos": "142,311.2,0",
           "Size": "60,14,0"
         }
       ]
@@ -328467,7 +328491,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -329139,8 +329163,8 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "6,-52,0.5",
-          "Size": "22,106,1"
+          "Pos": "44.9,440,0",
+          "Size": "22,106,0"
         }
       ]
     },
@@ -330135,7 +330159,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -331368,7 +331392,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "-0.5,-0.5,0",
+          "Pos": "140.5,422.4,0",
           "Size": "11,7,0"
         }
       ]

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/SquareStation.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/SquareStation.json
@@ -141661,7 +141661,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -147286,6 +147286,10 @@
                   "ClassID": "GuidanceBuoy@0",
                   "Data": [
                     {
+                      "Name": "Out@IsEnd",
+                      "Data": "True"
+                    },
+                    {
                       "Name": "In@NextInLine",
                       "Data": "69ffc1053dc39a24fb870b2248780be4_40┼321┼0┼@0@GuidanceBuoy@0"
                     }
@@ -147307,6 +147311,10 @@
                     {
                       "Name": "Out@NextInLine",
                       "Data": "69ffc1053dc39a24fb870b2248780be4_40┼309┼0┼@0@GuidanceBuoy@0"
+                    },
+                    {
+                      "Name": "In@IsEnd",
+                      "Data": "True"
                     }
                   ]
                 }
@@ -148528,6 +148536,10 @@
                     {
                       "Name": "In@DesiredFaceDirection",
                       "Data": "Up_By0"
+                    },
+                    {
+                      "Name": "In@IsEnd",
+                      "Data": "True"
                     }
                   ]
                 }
@@ -148583,6 +148595,10 @@
                 {
                   "ClassID": "GuidanceBuoy@0",
                   "Data": [
+                    {
+                      "Name": "Out@IsEnd",
+                      "Data": "True"
+                    },
                     {
                       "Name": "In@NextInLine",
                       "Data": "69ffc1053dc39a24fb870b2248780be4_44┼178┼0┼@0@GuidanceBuoy@0"
@@ -220164,6 +220180,10 @@
                     {
                       "Name": "In@DesiredFaceDirection",
                       "Data": "Left_By90"
+                    },
+                    {
+                      "Name": "In@IsEnd",
+                      "Data": "True"
                     }
                   ]
                 }
@@ -221373,6 +221393,10 @@
                       "Data": "Left_By90"
                     },
                     {
+                      "Name": "Out@IsEnd",
+                      "Data": "True"
+                    },
+                    {
                       "Name": "In@NextInLine",
                       "Data": "69ffc1053dc39a24fb870b2248780be4_155┼120┼0┼@0@GuidanceBuoy@0"
                     }
@@ -221387,14 +221411,14 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "95.5,160.5,-1",
-          "Size": "243,321,4"
+          "Pos": "96.5,161.5,0",
+          "Size": "243,321,0"
         }
       ]
     },
     {
       "Ver": "1.1.1",
-      "Location": "148┼58┼0┼0ø0ø90ø",
+      "Location": "206┼104┼0┼",
       "MatrixName": "EscapeShuttle",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",
@@ -224019,7 +224043,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -226973,7 +226997,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "29.5,-7,0",
+          "Pos": "236.5,98,0",
           "Size": "59,14,0"
         }
       ]
@@ -227412,7 +227436,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -227887,8 +227911,8 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "0,0,0.5",
-          "Size": "4,6,1"
+          "Pos": "148,149,0",
+          "Size": "4,6,0"
         }
       ]
     },
@@ -228329,7 +228353,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -228810,8 +228834,8 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "0,0,0.5",
-          "Size": "4,6,1"
+          "Pos": "73.2,148.1,0",
+          "Size": "4,6,0"
         }
       ]
     },
@@ -229651,7 +229675,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -230128,7 +230152,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "-1,-0.5,0",
+          "Pos": "40,291.5,0",
           "Size": "6,11,0"
         }
       ]
@@ -230978,7 +231002,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -231713,8 +231737,8 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "0,-1,0.5",
-          "Size": "10,6,1"
+          "Pos": "54,160,0",
+          "Size": "10,6,0"
         }
       ]
     },
@@ -232914,7 +232938,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -233907,7 +233931,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "5.5,-6.5,0",
+          "Pos": "37.5,105.5,0",
           "Size": "11,17,0"
         }
       ]

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/UnRealStation.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/UnRealStation.json
@@ -113383,7 +113383,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -139273,6 +139273,10 @@
                     {
                       "Name": "In@DesiredFaceDirection",
                       "Data": "Right_By270"
+                    },
+                    {
+                      "Name": "In@IsEnd",
+                      "Data": "True"
                     }
                   ]
                 }
@@ -148347,6 +148351,10 @@
                     {
                       "Name": "Out@NextInLine",
                       "Data": "69ffc1053dc39a24fb870b2248780be4_53┼-139┼0┼@0@GuidanceBuoy@0"
+                    },
+                    {
+                      "Name": "In@IsEnd",
+                      "Data": "True"
                     }
                   ]
                 }
@@ -148363,6 +148371,10 @@
                 {
                   "ClassID": "GuidanceBuoy@0",
                   "Data": [
+                    {
+                      "Name": "Out@IsEnd",
+                      "Data": "True"
+                    },
                     {
                       "Name": "In@NextInLine",
                       "Data": "69ffc1053dc39a24fb870b2248780be4_53┼-164┼0┼@0@GuidanceBuoy@0"
@@ -148389,6 +148401,10 @@
                     {
                       "Name": "Out@DesiredFaceDirection",
                       "Data": "Up_By0"
+                    },
+                    {
+                      "Name": "Out@IsEnd",
+                      "Data": "True"
                     },
                     {
                       "Name": "In@NextInLine",
@@ -148428,6 +148444,10 @@
                     {
                       "Name": "In@DesiredFaceDirection",
                       "Data": "Up_By0"
+                    },
+                    {
+                      "Name": "In@IsEnd",
+                      "Data": "True"
                     }
                   ]
                 }
@@ -161012,6 +161032,10 @@
                       "Data": "True"
                     },
                     {
+                      "Name": "Out@IsEnd",
+                      "Data": "True"
+                    },
+                    {
                       "Name": "In@NextInLine",
                       "Data": "69ffc1053dc39a24fb870b2248780be4_80┼100┼0┼@0@GuidanceBuoy@0"
                     }
@@ -161026,14 +161050,14 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "64,-21,-0.5",
-          "Size": "204,286,3"
+          "Pos": "65,-20,0",
+          "Size": "204,286,0"
         }
       ]
     },
     {
       "Ver": "1.1.1",
-      "Location": "41┼104┼0┼0ø0ø270ø",
+      "Location": "141┼105┼0┼0ø0ø270ø",
       "MatrixName": "EscapeShuttle",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",
@@ -162745,7 +162769,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -164720,8 +164744,8 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "-1,0.5,0",
-          "Size": "6,21,0"
+          "Pos": "142.5,105,0",
+          "Size": "21,6,0"
         }
       ]
     },
@@ -164873,7 +164897,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -165056,7 +165080,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "-1,-1.5,0",
+          "Pos": "12,95.5,0",
           "Size": "2,3,0"
         }
       ]
@@ -165209,7 +165233,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -165372,7 +165396,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "-1,-1.5,0",
+          "Pos": "83,27.5,0",
           "Size": "2,3,0"
         }
       ]
@@ -165797,7 +165821,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -166190,7 +166214,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "-1,-2,0",
+          "Pos": "54,-126,0",
           "Size": "6,6,0"
         }
       ]
@@ -166917,7 +166941,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -167462,7 +167486,7 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "0.5,0,0",
+          "Pos": "69.5,122,0",
           "Size": "9,6,0"
         }
       ]
@@ -168925,7 +168949,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -169973,8 +169997,8 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "1,1.6,0.5",
-          "Size": "19.9,13.2,1"
+          "Pos": "35,4.6,0",
+          "Size": "19.9,13.2,0"
         }
       ]
     },
@@ -171915,7 +171939,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.4.1",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -173246,8 +173270,8 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "-39.1,-28.9,0.5",
-          "Size": "92.2,71.9,1"
+          "Pos": "73.1,33.9,0",
+          "Size": "92.2,71.9,0"
         }
       ]
     }

--- a/UnityProject/Assets/Tilemaps/Palettes/Space.meta
+++ b/UnityProject/Assets/Tilemaps/Palettes/Space.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6cc2908642a83b248820e07e5006fe4e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Tilemaps/Palettes/Space/FakeSpace.prefab
+++ b/UnityProject/Assets/Tilemaps/Palettes/Space/FakeSpace.prefab
@@ -1,0 +1,230 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3623337651672099384
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6365488764757277029}
+  - component: {fileID: 3626607322175588157}
+  m_Layer: 0
+  m_Name: FakeSpace
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6365488764757277029
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3623337651672099384}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7369561610205487207}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!156049354 &3626607322175588157
+Grid:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3623337651672099384}
+  m_Enabled: 1
+  m_CellSize: {x: 1, y: 1, z: 0}
+  m_CellGap: {x: 0, y: 0, z: 0}
+  m_CellLayout: 0
+  m_CellSwizzle: 0
+--- !u!1 &8408698252687355552
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7369561610205487207}
+  - component: {fileID: 6916371873997378402}
+  - component: {fileID: 7284576546086576985}
+  m_Layer: 0
+  m_Name: Layer1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7369561610205487207
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8408698252687355552}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6365488764757277029}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1839735485 &6916371873997378402
+Tilemap:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8408698252687355552}
+  m_Enabled: 1
+  m_Tiles:
+  - first: {x: -1, y: 0, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  m_AnimatedTiles:
+  - first: {x: -1, y: 0, z: 0}
+    second:
+      serializedVersion: 2
+      m_AnimatedSprites:
+      - {fileID: 21300000, guid: 705b944805423a44f873e208f2c4aca4, type: 3}
+      - {fileID: 21300002, guid: 705b944805423a44f873e208f2c4aca4, type: 3}
+      - {fileID: 21300004, guid: 705b944805423a44f873e208f2c4aca4, type: 3}
+      - {fileID: 21300006, guid: 705b944805423a44f873e208f2c4aca4, type: 3}
+      m_AnimationSpeed: 2
+      m_AnimationTimeOffset: 0
+      m_Flags: 0
+  m_TileAssetArray:
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 5d1f43b4a6ddfb84e9266da723287efe, type: 2}
+  m_TileSpriteArray:
+  - m_RefCount: 1
+    m_Data: {fileID: 21300000, guid: 705b944805423a44f873e208f2c4aca4, type: 3}
+  m_TileMatrixArray:
+  - m_RefCount: 1
+    m_Data:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+  m_TileColorArray:
+  - m_RefCount: 1
+    m_Data: {r: 1, g: 1, b: 1, a: 1}
+  m_TileObjectToInstantiateArray: []
+  m_AnimationFrameRate: 1
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Origin: {x: -1, y: 0, z: 0}
+  m_Size: {x: 1, y: 1, z: 1}
+  m_TileAnchor: {x: 0.5, y: 0.5, z: 0}
+  m_TileOrientation: 0
+  m_TileOrientationMatrix:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+--- !u!483693784 &7284576546086576985
+TilemapRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8408698252687355552}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 0
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_ChunkSize: {x: 32, y: 32, z: 32}
+  m_ChunkCullingBounds: {x: 0, y: 0, z: 0}
+  m_MaxChunkCount: 16
+  m_MaxFrameAge: 16
+  m_SortOrder: 0
+  m_Mode: 0
+  m_DetectChunkCullingBounds: 0
+  m_MaskInteraction: 0
+--- !u!114 &6035874176171246284
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 12395, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: Palette Settings
+  m_EditorClassIdentifier: 
+  cellSizing: 0
+  m_TransparencySortMode: 0
+  m_TransparencySortAxis: {x: 0, y: 0, z: 1}

--- a/UnityProject/Assets/Tilemaps/Palettes/Space/FakeSpace.prefab.meta
+++ b/UnityProject/Assets/Tilemaps/Palettes/Space/FakeSpace.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 63c069cbd0981394195106a2260e60c5
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Placeholder-Error.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Placeholder-Error.asset
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1796e5cfb0bb4f9b81661d07e7794f1d, type: 3}
+  m_Name: Placeholder-Error
+  m_EditorClassIdentifier: 
+  <ForeverID>k__BackingField: 
+  displayName: 
+  description: 
+  LayerType: -1
+  TileType: 5
+  RequiredTiles: []
+  Mass: 1
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 0
+  passable: 1
+  mineable: 0
+  miningTime: 5
+  miningHardness: 1
+  constructable: 0
+  RadiationPassability: 1
+  ThermalConductivity: 0.05
+  HeatCapacity: 10000
+  doesReflectBullet: 1
+  indestructible: 0
+  ExplosionImpassable: 1
+  BlocksTileInteractionsUnder: 1
+  passableException:
+    m_keys: 
+    m_values: 
+  maxHealth: 0
+  damageDeflection: 0
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+    Anomaly: 0
+    DismembermentProtectionChance: 0
+    StunImmunity: 0
+    TemperatureProtectionInK: {x: 268.15, y: 313.15}
+    PressureProtectionInKpa: {x: 30, y: 300}
+  tileInteractions: []
+  <OnTileStartMining>k__BackingField: []
+  <OnTileFinishMining>k__BackingField: []
+  tileStepInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectGUID: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
+  SoundOnDestroy: []
+  Sprites:
+  - {fileID: -2512927661099922447, guid: a08e177daac794cf680f161215685ce4, type: 3}
+  - {fileID: 4659265657221884602, guid: a08e177daac794cf680f161215685ce4, type: 3}
+  - {fileID: -3138123007396962320, guid: a08e177daac794cf680f161215685ce4, type: 3}
+  - {fileID: -7145856751783321575, guid: a08e177daac794cf680f161215685ce4, type: 3}
+  AnimationSpeed: 5
+  AnimationStartTime: 0
+  randomizeStartTime: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Placeholder-Error.asset.meta
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Placeholder-Error.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c944b9b517852ba488df61f2f6699c70
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Space.meta
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Space.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 026a8d3d984e6ba40b66505f6dff3323
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Space/Slipstream-Space.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Space/Slipstream-Space.asset
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1796e5cfb0bb4f9b81661d07e7794f1d, type: 3}
+  m_Name: Slipstream-Space
+  m_EditorClassIdentifier: 
+  <ForeverID>k__BackingField: 
+  displayName: 
+  description: 
+  LayerType: 4
+  TileType: 7
+  RequiredTiles: []
+  Mass: 1
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 0
+  passable: 1
+  mineable: 0
+  miningTime: 5
+  miningHardness: 1
+  constructable: 0
+  RadiationPassability: 1
+  ThermalConductivity: 0.05
+  HeatCapacity: 10000
+  doesReflectBullet: 0
+  indestructible: 1
+  ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
+  passableException:
+    m_keys: 
+    m_values: 
+  maxHealth: 0
+  damageDeflection: 0
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+    Anomaly: 0
+    DismembermentProtectionChance: 0
+    StunImmunity: 0
+    TemperatureProtectionInK: {x: 268.15, y: 313.15}
+    PressureProtectionInKpa: {x: 30, y: 300}
+  tileInteractions: []
+  <OnTileStartMining>k__BackingField: []
+  <OnTileFinishMining>k__BackingField: []
+  tileStepInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectGUID: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
+  SoundOnDestroy: []
+  Sprites:
+  - {fileID: 21300000, guid: 705b944805423a44f873e208f2c4aca4, type: 3}
+  - {fileID: 21300002, guid: 705b944805423a44f873e208f2c4aca4, type: 3}
+  - {fileID: 21300004, guid: 705b944805423a44f873e208f2c4aca4, type: 3}
+  - {fileID: 21300006, guid: 705b944805423a44f873e208f2c4aca4, type: 3}
+  AnimationSpeed: 2
+  AnimationStartTime: 0
+  randomizeStartTime: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Space/Slipstream-Space.asset.meta
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Space/Slipstream-Space.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5d1f43b4a6ddfb84e9266da723287efe
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
CL: [Fix] Reverted a problematic patch that turned all shuttles into kamikazes.
CL: [Improvement] The map loader will no longer break down over a single missing tile, and any missing data will be replaced with an "ERROR" tile.