### PR TITLE
more robust animated fire

### DIFF
--- a/UnityProject/Assets/Resources/Effects/Light2D/AnimatedFire/firelight.asset
+++ b/UnityProject/Assets/Resources/Effects/Light2D/AnimatedFire/firelight.asset
@@ -16,28 +16,52 @@ MonoBehaviour:
   Variance:
   - Frames:
     - sprite: {fileID: 21300000, guid: 77dec0be2e676214aac82240280e21e2, type: 3}
-      secondDelay: 0.125
+      secondDelay: 0.09375
     - sprite: {fileID: 21300000, guid: 466381dc9b1546648a8832bbb9420c20, type: 3}
-      secondDelay: 0.125
-    - sprite: {fileID: 21300000, guid: b8cd93930715f9640b8a8e38a0ee39e7, type: 3}
-      secondDelay: 0.125
-    - sprite: {fileID: 21300000, guid: 2be444078395d6e49a5e96cb401fd695, type: 3}
-      secondDelay: 0.125
-    - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
-      secondDelay: 0.125
-    - sprite: {fileID: 21300000, guid: bb4c5a10ebf40144bb44e432b1c4082d, type: 3}
-      secondDelay: 0.125
-    - sprite: {fileID: 21300000, guid: 466381dc9b1546648a8832bbb9420c20, type: 3}
-      secondDelay: 0.125
-    - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
-      secondDelay: 0.125
+      secondDelay: 0.09375
     - sprite: {fileID: 21300000, guid: 77dec0be2e676214aac82240280e21e2, type: 3}
-      secondDelay: 0.125
-    - sprite: {fileID: 21300000, guid: bb4c5a10ebf40144bb44e432b1c4082d, type: 3}
-      secondDelay: 0.125
-    - sprite: {fileID: 21300000, guid: 2be444078395d6e49a5e96cb401fd695, type: 3}
-      secondDelay: 0.125
-    - sprite: {fileID: 21300000, guid: b8cd93930715f9640b8a8e38a0ee39e7, type: 3}
-      secondDelay: 0.125
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 77dec0be2e676214aac82240280e21e2, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 77dec0be2e676214aac82240280e21e2, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 466381dc9b1546648a8832bbb9420c20, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 77dec0be2e676214aac82240280e21e2, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 77dec0be2e676214aac82240280e21e2, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 77dec0be2e676214aac82240280e21e2, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 466381dc9b1546648a8832bbb9420c20, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 77dec0be2e676214aac82240280e21e2, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 466381dc9b1546648a8832bbb9420c20, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 77dec0be2e676214aac82240280e21e2, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 77dec0be2e676214aac82240280e21e2, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 77dec0be2e676214aac82240280e21e2, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 466381dc9b1546648a8832bbb9420c20, type: 3}
+      secondDelay: 0.09375
   IsPalette: 0
   DisplayName: 

--- a/UnityProject/Assets/Resources/Effects/Light2D/AnimatedFire/firelight2.asset
+++ b/UnityProject/Assets/Resources/Effects/Light2D/AnimatedFire/firelight2.asset
@@ -15,29 +15,53 @@ MonoBehaviour:
   foreverID: 1c5634ade123e2543afaa807c01a0ffb
   Variance:
   - Frames:
-    - sprite: {fileID: 21300000, guid: b8cd93930715f9640b8a8e38a0ee39e7, type: 3}
-      secondDelay: 0.125
-    - sprite: {fileID: 21300000, guid: 2be444078395d6e49a5e96cb401fd695, type: 3}
-      secondDelay: 0.125
-    - sprite: {fileID: 21300000, guid: bb4c5a10ebf40144bb44e432b1c4082d, type: 3}
-      secondDelay: 0.125
-    - sprite: {fileID: 21300000, guid: 77dec0be2e676214aac82240280e21e2, type: 3}
-      secondDelay: 0.125
-    - sprite: {fileID: 21300000, guid: 466381dc9b1546648a8832bbb9420c20, type: 3}
-      secondDelay: 0.125
     - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
-      secondDelay: 0.125
-    - sprite: {fileID: 21300000, guid: bb4c5a10ebf40144bb44e432b1c4082d, type: 3}
-      secondDelay: 0.125
+      secondDelay: 0.09375
     - sprite: {fileID: 21300000, guid: 466381dc9b1546648a8832bbb9420c20, type: 3}
-      secondDelay: 0.125
+      secondDelay: 0.09375
     - sprite: {fileID: 21300000, guid: 77dec0be2e676214aac82240280e21e2, type: 3}
-      secondDelay: 0.125
-    - sprite: {fileID: 21300000, guid: 2be444078395d6e49a5e96cb401fd695, type: 3}
-      secondDelay: 0.125
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 466381dc9b1546648a8832bbb9420c20, type: 3}
+      secondDelay: 0.09375
     - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
-      secondDelay: 0.125
-    - sprite: {fileID: 21300000, guid: b8cd93930715f9640b8a8e38a0ee39e7, type: 3}
-      secondDelay: 0.125
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: bb4c5a10ebf40144bb44e432b1c4082d, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 466381dc9b1546648a8832bbb9420c20, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: bb4c5a10ebf40144bb44e432b1c4082d, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 466381dc9b1546648a8832bbb9420c20, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 77dec0be2e676214aac82240280e21e2, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 466381dc9b1546648a8832bbb9420c20, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 2be444078395d6e49a5e96cb401fd695, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 466381dc9b1546648a8832bbb9420c20, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 77dec0be2e676214aac82240280e21e2, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 466381dc9b1546648a8832bbb9420c20, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 77dec0be2e676214aac82240280e21e2, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 77dec0be2e676214aac82240280e21e2, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: bb4c5a10ebf40144bb44e432b1c4082d, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 77dec0be2e676214aac82240280e21e2, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 466381dc9b1546648a8832bbb9420c20, type: 3}
+      secondDelay: 0.09375
   IsPalette: 0
   DisplayName: 

--- a/UnityProject/Assets/Resources/Effects/Light2D/AnimatedFire/firelight3.asset
+++ b/UnityProject/Assets/Resources/Effects/Light2D/AnimatedFire/firelight3.asset
@@ -13,6 +13,55 @@ MonoBehaviour:
   m_Name: firelight3
   m_EditorClassIdentifier: 
   foreverID: 4308782497813cd4bbd8d5acec692d14
-  Variance: []
+  Variance:
+  - Frames:
+    - sprite: {fileID: 21300000, guid: bb4c5a10ebf40144bb44e432b1c4082d, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 2be444078395d6e49a5e96cb401fd695, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: bb4c5a10ebf40144bb44e432b1c4082d, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 2be444078395d6e49a5e96cb401fd695, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 466381dc9b1546648a8832bbb9420c20, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: bb4c5a10ebf40144bb44e432b1c4082d, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: b8cd93930715f9640b8a8e38a0ee39e7, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 466381dc9b1546648a8832bbb9420c20, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 466381dc9b1546648a8832bbb9420c20, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 466381dc9b1546648a8832bbb9420c20, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 77dec0be2e676214aac82240280e21e2, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 2be444078395d6e49a5e96cb401fd695, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 466381dc9b1546648a8832bbb9420c20, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 466381dc9b1546648a8832bbb9420c20, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: bb4c5a10ebf40144bb44e432b1c4082d, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 77dec0be2e676214aac82240280e21e2, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 466381dc9b1546648a8832bbb9420c20, type: 3}
+      secondDelay: 0.09375
   IsPalette: 0
   DisplayName: 

--- a/UnityProject/Assets/Resources/Effects/Light2D/AnimatedFire/firelight4.asset
+++ b/UnityProject/Assets/Resources/Effects/Light2D/AnimatedFire/firelight4.asset
@@ -13,6 +13,55 @@ MonoBehaviour:
   m_Name: firelight4
   m_EditorClassIdentifier: 
   foreverID: fc22d71c1c3167245ad53699c82a0a3f
-  Variance: []
+  Variance:
+  - Frames:
+    - sprite: {fileID: 21300000, guid: b8cd93930715f9640b8a8e38a0ee39e7, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: bb4c5a10ebf40144bb44e432b1c4082d, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: b8cd93930715f9640b8a8e38a0ee39e7, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: b8cd93930715f9640b8a8e38a0ee39e7, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: bb4c5a10ebf40144bb44e432b1c4082d, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 77dec0be2e676214aac82240280e21e2, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: b8cd93930715f9640b8a8e38a0ee39e7, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 466381dc9b1546648a8832bbb9420c20, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 2be444078395d6e49a5e96cb401fd695, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: b8cd93930715f9640b8a8e38a0ee39e7, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 2be444078395d6e49a5e96cb401fd695, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 77dec0be2e676214aac82240280e21e2, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: b8cd93930715f9640b8a8e38a0ee39e7, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: bb4c5a10ebf40144bb44e432b1c4082d, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: b8cd93930715f9640b8a8e38a0ee39e7, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 466381dc9b1546648a8832bbb9420c20, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: b8cd93930715f9640b8a8e38a0ee39e7, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 2be444078395d6e49a5e96cb401fd695, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 03ced3fa0e8cb854a8f70bb3064f8097, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: bb4c5a10ebf40144bb44e432b1c4082d, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: b8cd93930715f9640b8a8e38a0ee39e7, type: 3}
+      secondDelay: 0.09375
+    - sprite: {fileID: 21300000, guid: 2be444078395d6e49a5e96cb401fd695, type: 3}
+      secondDelay: 0.09375
   IsPalette: 0
   DisplayName: 


### PR DESCRIPTION
### Purpose
initial upgrade of the animated fire sprites for mapping and potential use with hotspots.
intended use: scale 16, light sprite color/alpha info TBD with testing
firelight1 - small, weak fires
firelight2 - normal fires
firelight3 - hot fires
firelight4 - raging infernos

### Notes:
faster framerates and more intense flickering for hotter fires
further refinements planned, including uncolored variants for other kinds of fire & if needed so as not to conflict with color assignment in the hotspot code

### Changelog:
n/a