### PR TITLE
potted plants & a text fix

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Other/PottedPlants/PottedPlant.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/PottedPlants/PottedPlant.prefab
@@ -143,6 +143,12 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 780b29e5202931c47951b3b389d231a1,
         type: 2}
+    - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: InitialPresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 780b29e5202931c47951b3b389d231a1,
+        type: 2}
     - target: {fileID: 6393191727481188567, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: parentID
@@ -229,7 +235,7 @@ MonoBehaviour:
     SlotContents: []
     DeprecatedContents: []
   SetSlotItemNotRemovableOnStartUp: 0
-  ignoreRoundstartGrabObjects: 0
+  initialignoreRoundstartGrabObjects: 0
   ashPrefab: {fileID: 0}
 --- !u!114 &7760753812183991672
 MonoBehaviour:

--- a/UnityProject/Assets/Prefabs/Items/Other/PottedPlants/PottedPlant20.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/PottedPlants/PottedPlant20.prefab
@@ -1,5 +1,111 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4997324947772619753
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1364698529054501816}
+  - component: {fileID: 8971725166273590411}
+  - component: {fileID: 3988591232970504352}
+  - component: {fileID: 8666910022471884816}
+  m_Layer: 21
+  m_Name: Light2D
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1364698529054501816
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4997324947772619753}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 3, y: 3, z: 3}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1164968030392107538}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8971725166273590411
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4997324947772619753}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 61930e16e81db5c43a4ecc22422a0953, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  InitialColour: {r: 1, g: 0.99607843, b: 0.88235295, a: 0.8627451}
+  Sprite: {fileID: 21300000, guid: 7d4ab37af9168d243a3eead2ef5b5758, type: 3}
+  SortingOrder: 0
+  Material: {fileID: 2100000, guid: b7e7f24fa2e49cb48818dace424b5868, type: 2}
+  LightOrigin: {x: 0, y: 0, z: 1}
+  Shape: 0
+  GivenID: 0
+--- !u!23 &3988591232970504352
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4997324947772619753}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &8666910022471884816
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4997324947772619753}
+  m_Mesh: {fileID: 0}
 --- !u!1001 &1347485146735535233
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -90,6 +196,12 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 58e19f5e1f96aca4e831c3dc97d67781,
         type: 2}
+    - target: {fileID: 6326550108531515488, guid: 0271f252689106348ad30060b7abea96,
+        type: 3}
+      propertyPath: InitialPresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 58e19f5e1f96aca4e831c3dc97d67781,
+        type: 2}
     - target: {fileID: 6498919792659126154, guid: 0271f252689106348ad30060b7abea96,
         type: 3}
       propertyPath: parentID
@@ -102,6 +214,16 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 187452277244307091, guid: 0271f252689106348ad30060b7abea96,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1364698529054501816}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0271f252689106348ad30060b7abea96, type: 3}
+--- !u!4 &1164968030392107538 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 187452277244307091, guid: 0271f252689106348ad30060b7abea96,
+    type: 3}
+  m_PrefabInstance: {fileID: 1347485146735535233}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Other/PottedPlants/PottedPlant26.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/PottedPlants/PottedPlant26.prefab
@@ -1,0 +1,92 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &8758650241418566651
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 34763699688138939, guid: 0271f252689106348ad30060b7abea96,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 2f49a8c8c525e0b4bb08388316f84737,
+        type: 3}
+    - target: {fileID: 183087353082436583, guid: 0271f252689106348ad30060b7abea96,
+        type: 3}
+      propertyPath: m_Name
+      value: PottedPlant26
+      objectReference: {fileID: 0}
+    - target: {fileID: 187452277244307091, guid: 0271f252689106348ad30060b7abea96,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 187452277244307091, guid: 0271f252689106348ad30060b7abea96,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 187452277244307091, guid: 0271f252689106348ad30060b7abea96,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 187452277244307091, guid: 0271f252689106348ad30060b7abea96,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 187452277244307091, guid: 0271f252689106348ad30060b7abea96,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 187452277244307091, guid: 0271f252689106348ad30060b7abea96,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 187452277244307091, guid: 0271f252689106348ad30060b7abea96,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 187452277244307091, guid: 0271f252689106348ad30060b7abea96,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 187452277244307091, guid: 0271f252689106348ad30060b7abea96,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 187452277244307091, guid: 0271f252689106348ad30060b7abea96,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224688921972729427, guid: 0271f252689106348ad30060b7abea96,
+        type: 3}
+      propertyPath: _assetId
+      value: 651715370
+      objectReference: {fileID: 0}
+    - target: {fileID: 6326550108531515488, guid: 0271f252689106348ad30060b7abea96,
+        type: 3}
+      propertyPath: InitialPresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: ec71b74dd533c4e4bb3eba5358a09cd2,
+        type: 2}
+    - target: {fileID: 6498919792659126154, guid: 0271f252689106348ad30060b7abea96,
+        type: 3}
+      propertyPath: foreverID
+      value: 47820ec4f427100c183c0a7dd1a55c0c
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0271f252689106348ad30060b7abea96, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Other/PottedPlants/PottedPlant26.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Items/Other/PottedPlants/PottedPlant26.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 47820ec4f427100c183c0a7dd1a55c0c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Items/Other/PottedPlants/PottedPlant9.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/PottedPlants/PottedPlant9.prefab
@@ -46,7 +46,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 61930e16e81db5c43a4ecc22422a0953, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Color: {r: 0.17254902, g: 0.69803923, b: 0.9098039, a: 1}
+  InitialColour: {r: 0.17254902, g: 0.69803923, b: 0.9098039, a: 0.8627451}
   Sprite: {fileID: 21300000, guid: 7d4ab37af9168d243a3eead2ef5b5758, type: 3}
   SortingOrder: 0
   Material: {fileID: 2100000, guid: b7e7f24fa2e49cb48818dace424b5868, type: 2}
@@ -72,6 +72,7 @@ MeshRenderer:
   m_RayTraceProcedural: 0
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -207,6 +208,12 @@ PrefabInstance:
     - target: {fileID: 6326550108531515488, guid: 0271f252689106348ad30060b7abea96,
         type: 3}
       propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: aace53907327f6f498d31ca3cb14ed4d,
+        type: 2}
+    - target: {fileID: 6326550108531515488, guid: 0271f252689106348ad30060b7abea96,
+        type: 3}
+      propertyPath: InitialPresentSpriteSet
       value: 
       objectReference: {fileID: 11400000, guid: aace53907327f6f498d31ca3cb14ed4d,
         type: 2}

--- a/UnityProject/Assets/Prefabs/Items/Spawners/RandomPottedPlantSpawner.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Spawners/RandomPottedPlantSpawner.prefab
@@ -1,0 +1,96 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &2120896665545771814
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[0].probability
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[0].randomItemPool
+      value: 
+      objectReference: {fileID: 11400000, guid: 30938da04b06e35a19cd4ed03da07b73,
+        type: 2}
+    - target: {fileID: 2806690048445349940, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: _assetId
+      value: 1126924138
+      objectReference: {fileID: 0}
+    - target: {fileID: 2839352587806555520, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_Name
+      value: RandomPottedPlantSpawner
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9213751064059195885, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: foreverID
+      value: 86570587e3d5cba1e9ffdeead16603e4
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: abff3ae0227731244b0814b2055fa6f0, type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Spawners/RandomPottedPlantSpawner.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Items/Spawners/RandomPottedPlantSpawner.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 86570587e3d5cba1e9ffdeead16603e4
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Objects/Machines/VendingMachines/WardDrobes/DetDrobe.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Machines/VendingMachines/WardDrobes/DetDrobe.prefab
@@ -563,7 +563,7 @@ PrefabInstance:
     - target: {fileID: 2300265576470810490, guid: bc2878fc1e4346c41bf6bc3b53b91f6a,
         type: 3}
       propertyPath: InitialVendorContent.Array.data[10].ItemName
-      value: Noir Suitskirt
+      value: Noir Suit Coat
       objectReference: {fileID: 0}
     - target: {fileID: 2300265576470810490, guid: bc2878fc1e4346c41bf6bc3b53b91f6a,
         type: 3}
@@ -727,6 +727,21 @@ PrefabInstance:
       propertyPath: Color.r
       value: 0.8313726
       objectReference: {fileID: 0}
+    - target: {fileID: 6229150752284204976, guid: bc2878fc1e4346c41bf6bc3b53b91f6a,
+        type: 3}
+      propertyPath: InitialColour.b
+      value: 0.7411765
+      objectReference: {fileID: 0}
+    - target: {fileID: 6229150752284204976, guid: bc2878fc1e4346c41bf6bc3b53b91f6a,
+        type: 3}
+      propertyPath: InitialColour.g
+      value: 0.8000001
+      objectReference: {fileID: 0}
+    - target: {fileID: 6229150752284204976, guid: bc2878fc1e4346c41bf6bc3b53b91f6a,
+        type: 3}
+      propertyPath: InitialColour.r
+      value: 0.8313726
+      objectReference: {fileID: 0}
     - target: {fileID: 6267070499382879197, guid: bc2878fc1e4346c41bf6bc3b53b91f6a,
         type: 3}
       propertyPath: _assetId
@@ -746,6 +761,12 @@ PrefabInstance:
     - target: {fileID: 7022302039327439973, guid: bc2878fc1e4346c41bf6bc3b53b91f6a,
         type: 3}
       propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 39b1a138676dafb49ab10c5932419be2,
+        type: 2}
+    - target: {fileID: 7022302039327439973, guid: bc2878fc1e4346c41bf6bc3b53b91f6a,
+        type: 3}
+      propertyPath: InitialPresentSpriteSet
       value: 
       objectReference: {fileID: 11400000, guid: 39b1a138676dafb49ab10c5932419be2,
         type: 2}

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/NetworkManager.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/NetworkManager.prefab
@@ -50,17 +50,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   dontDestroyOnLoad: 1
   runInBackground: 1
-  headlessStartMode: 0
-  editorAutoStart: 0
+  autoStartServerBuild: 1
+  autoConnectClientBuild: 0
   sendRate: 100
   offlineScene: Assets/Scenes/ActiveScenes/Lobby.unity
   onlineScene: Assets/Scenes/ActiveScenes/OnlineScene.unity
-  offlineSceneLoadDelay: 0
   transport: {fileID: 752180679074368365}
   networkAddress: localhost
   maxConnections: 100
-  disconnectInactiveConnections: 0
-  disconnectInactiveTimeout: 60
   authenticator: {fileID: 1670478699794476422}
   playerPrefab: {fileID: 2821122072132512938, guid: 70fd2614e91344280b501ff52714aaa4,
     type: 3}
@@ -3320,6 +3317,9 @@ MonoBehaviour:
   - {fileID: 730139938013958830, guid: 96b4dc9d66cb61d48b6256b2938e3223, type: 3}
   - {fileID: 5321017984928167108, guid: 1b0c3377af5f2bd44b42d585db731857, type: 3}
   - {fileID: 7340410660843788043, guid: 604650204fcc2de47b0dc15897c3d7e6, type: 3}
+  - {fileID: 100328150011014054, guid: 876a8a766c24ac644bdd651d75eb7579, type: 3}
+  - {fileID: 100328150011014054, guid: 0ce26c964edbf4648838e431a9b00af4, type: 3}
+  - {fileID: 100328150011014054, guid: 6d35633b5b18cea4f96e0fe207e2b75d, type: 3}
   - {fileID: 7572413834478188295, guid: f9b48c194efec7840b9dea9662005173, type: 3}
   - {fileID: 7792469808048322689, guid: 496bd7f7917a94e44878b6f2a57900a0, type: 3}
   - {fileID: 776659237916025105, guid: 651304d8cd4458e4097191da621c0f30, type: 3}
@@ -3339,9 +3339,6 @@ MonoBehaviour:
   - {fileID: 522969193494093943, guid: 9eaebd66cb3e3d145a9bb373c42925e7, type: 3}
   - {fileID: 100328150011014054, guid: b998cf4e42b95ec4fbbb893c889010e8, type: 3}
   - {fileID: 100328150011014054, guid: 0be5d7918d0a16a4394474841c0dc985, type: 3}
-  - {fileID: 100328150011014054, guid: 876a8a766c24ac644bdd651d75eb7579, type: 3}
-  - {fileID: 100328150011014054, guid: 0ce26c964edbf4648838e431a9b00af4, type: 3}
-  - {fileID: 100328150011014054, guid: 6d35633b5b18cea4f96e0fe207e2b75d, type: 3}
   - {fileID: 183087353082436583, guid: 0271f252689106348ad30060b7abea96, type: 3}
   - {fileID: 927106199623348646, guid: 5774ff0e04d62b64cb27e95b37c7bdcf, type: 3}
   - {fileID: 1229118127587491959, guid: 784e156c2fa7a7441b4dc401774df667, type: 3}
@@ -3367,6 +3364,7 @@ MonoBehaviour:
   - {fileID: 4127435538221997789, guid: f43e9c183d039b94bb00ddc02178457a, type: 3}
   - {fileID: 7298438421084278332, guid: 5f14c38c95655fb4bb6ca21bc66c7db1, type: 3}
   - {fileID: 327135214468665366, guid: dea27be34c1d22841a1a7f11bd965ca0, type: 3}
+  - {fileID: 8864927979826626588, guid: 47820ec4f427100c183c0a7dd1a55c0c, type: 3}
   - {fileID: 6495039292157115771, guid: bd0b61b5f22871e40bdf20387ae9d642, type: 3}
   - {fileID: 4654023963797447867, guid: b2106f2bb290cd04481e9a31d2820d83, type: 3}
   - {fileID: 3717015295150579386, guid: 075cfdcf2f568054899e908988835830, type: 3}
@@ -3725,6 +3723,7 @@ MonoBehaviour:
   - {fileID: 1641352176154375968, guid: 8f349984e8916a04589f2dedb76073db, type: 3}
   - {fileID: 1985225060070187228, guid: c9ff0ae76b2598543904bc2649caf83d, type: 3}
   - {fileID: 4245553451975094303, guid: ff24082abd00ae449afc0b8a09657724, type: 3}
+  - {fileID: 4182041290015323814, guid: 86570587e3d5cba1e9ffdeead16603e4, type: 3}
   - {fileID: 1841225579218662542, guid: 397461e981e81df4c8983f127dbabae6, type: 3}
   - {fileID: 5959050984793011564, guid: 07bfe3ca581f72f42ac5ae48b23d91d8, type: 3}
   - {fileID: 3100582945146078791, guid: 8f5ccb83cc0733748a9137c50f7049c7, type: 3}
@@ -5843,10 +5842,8 @@ MonoBehaviour:
   - {fileID: 7469762742606550612, guid: 744b0cb256b76454bb452aa847daf921, type: 3}
   - {fileID: 7469762742606550612, guid: 041da926944070b4a9056013727394ae, type: 3}
   - {fileID: 7469762742606550612, guid: 400c9a3ef18ca344ba6745843a4e5f15, type: 3}
-  exceptionsDisconnect: 1
   snapshotSettings:
     bufferTimeMultiplier: 2
-    bufferLimit: 32
     catchupNegativeThreshold: -1
     catchupPositiveThreshold: 1
     catchupSpeed: 0.009999999776482582
@@ -5855,13 +5852,10 @@ MonoBehaviour:
     dynamicAdjustment: 1
     dynamicAdjustmentTolerance: 1
     deliveryTimeEmaDuration: 2
-  evaluationMethod: 0
-  evaluationInterval: 3
   timeInterpolationGui: 0
   NetworkedManagersPrefabs:
   - {fileID: 6401940811625325638, guid: d3e6b8892ab5b5d42a41cdd379324029, type: 3}
   ActiveNetworkedManagersPrefabs: []
-  _isServer: 0
   humanPlayerPrefab: {fileID: 1133514949248654, guid: c4494414d24d2f2468e74daa79468631,
     type: 3}
   ghostPrefab: {fileID: 4390267312333422610, guid: 15adb8ff4b5062d41a3738e0a52ea01c,
@@ -5947,8 +5941,6 @@ MonoBehaviour:
   - {fileID: 1939797917786674, guid: f5503bdd2384c444e863c8394a808b7f, type: 3}
   - {fileID: 7013270530123256728, guid: e9f60ed79c0ab4b479d37f3f8ebb5164, type: 3}
   - {fileID: 8136126520353531243, guid: 5f42e5d8580a79a4e90162e59161a74b, type: 3}
-  - {fileID: 3109035668459811093, guid: 0044109ca09aecc4a85e0829f5feaf81, type: 3}
-  - {fileID: 5723503134307942014, guid: 703862b62c5d7e949809214c9263ecf3, type: 3}
   - {fileID: 6581091922847212398, guid: 3fb7829bb2f79f1438ef88c4d69cd34f, type: 3}
   - {fileID: 2333946950029219510, guid: 1c8abd1afb208014a9cc83f7120ab311, type: 3}
   - {fileID: 4535904140882285198, guid: 7039abd0db1d8fe4a84238a638019f39, type: 3}
@@ -9179,6 +9171,9 @@ MonoBehaviour:
   - {fileID: 730139938013958830, guid: 96b4dc9d66cb61d48b6256b2938e3223, type: 3}
   - {fileID: 5321017984928167108, guid: 1b0c3377af5f2bd44b42d585db731857, type: 3}
   - {fileID: 7340410660843788043, guid: 604650204fcc2de47b0dc15897c3d7e6, type: 3}
+  - {fileID: 100328150011014054, guid: 876a8a766c24ac644bdd651d75eb7579, type: 3}
+  - {fileID: 100328150011014054, guid: 0ce26c964edbf4648838e431a9b00af4, type: 3}
+  - {fileID: 100328150011014054, guid: 6d35633b5b18cea4f96e0fe207e2b75d, type: 3}
   - {fileID: 7572413834478188295, guid: f9b48c194efec7840b9dea9662005173, type: 3}
   - {fileID: 7792469808048322689, guid: 496bd7f7917a94e44878b6f2a57900a0, type: 3}
   - {fileID: 776659237916025105, guid: 651304d8cd4458e4097191da621c0f30, type: 3}
@@ -9198,9 +9193,6 @@ MonoBehaviour:
   - {fileID: 522969193494093943, guid: 9eaebd66cb3e3d145a9bb373c42925e7, type: 3}
   - {fileID: 100328150011014054, guid: b998cf4e42b95ec4fbbb893c889010e8, type: 3}
   - {fileID: 100328150011014054, guid: 0be5d7918d0a16a4394474841c0dc985, type: 3}
-  - {fileID: 100328150011014054, guid: 876a8a766c24ac644bdd651d75eb7579, type: 3}
-  - {fileID: 100328150011014054, guid: 0ce26c964edbf4648838e431a9b00af4, type: 3}
-  - {fileID: 100328150011014054, guid: 6d35633b5b18cea4f96e0fe207e2b75d, type: 3}
   - {fileID: 183087353082436583, guid: 0271f252689106348ad30060b7abea96, type: 3}
   - {fileID: 927106199623348646, guid: 5774ff0e04d62b64cb27e95b37c7bdcf, type: 3}
   - {fileID: 1229118127587491959, guid: 784e156c2fa7a7441b4dc401774df667, type: 3}
@@ -9226,6 +9218,7 @@ MonoBehaviour:
   - {fileID: 4127435538221997789, guid: f43e9c183d039b94bb00ddc02178457a, type: 3}
   - {fileID: 7298438421084278332, guid: 5f14c38c95655fb4bb6ca21bc66c7db1, type: 3}
   - {fileID: 327135214468665366, guid: dea27be34c1d22841a1a7f11bd965ca0, type: 3}
+  - {fileID: 8864927979826626588, guid: 47820ec4f427100c183c0a7dd1a55c0c, type: 3}
   - {fileID: 6495039292157115771, guid: bd0b61b5f22871e40bdf20387ae9d642, type: 3}
   - {fileID: 4654023963797447867, guid: b2106f2bb290cd04481e9a31d2820d83, type: 3}
   - {fileID: 3717015295150579386, guid: 075cfdcf2f568054899e908988835830, type: 3}
@@ -9584,6 +9577,7 @@ MonoBehaviour:
   - {fileID: 1641352176154375968, guid: 8f349984e8916a04589f2dedb76073db, type: 3}
   - {fileID: 1985225060070187228, guid: c9ff0ae76b2598543904bc2649caf83d, type: 3}
   - {fileID: 4245553451975094303, guid: ff24082abd00ae449afc0b8a09657724, type: 3}
+  - {fileID: 4182041290015323814, guid: 86570587e3d5cba1e9ffdeead16603e4, type: 3}
   - {fileID: 1841225579218662542, guid: 397461e981e81df4c8983f127dbabae6, type: 3}
   - {fileID: 5959050984793011564, guid: 07bfe3ca581f72f42ac5ae48b23d91d8, type: 3}
   - {fileID: 3100582945146078791, guid: 8f5ccb83cc0733748a9137c50f7049c7, type: 3}

--- a/UnityProject/Assets/ScriptableObjects/RandomItemPools/RandomPottedPlant.asset
+++ b/UnityProject/Assets/ScriptableObjects/RandomItemPools/RandomPottedPlant.asset
@@ -1,0 +1,117 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
+  m_Name: RandomPottedPlant
+  m_EditorClassIdentifier: 
+  foreverID: 
+  pool:
+  - prefab: {fileID: 183087353082436583, guid: 0271f252689106348ad30060b7abea96, type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 927106199623348646, guid: 5774ff0e04d62b64cb27e95b37c7bdcf, type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 1229118127587491959, guid: 784e156c2fa7a7441b4dc401774df667,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 8105396684267358443, guid: 0459b1d785b20444091314cfbe43dc09,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 2247982239226404679, guid: a0afa45378f91b443831390829ec8de4,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 6532409802427281048, guid: a7c2979c41e655d46b3075c66534e985,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 5740398705741342215, guid: 464bda740133c7b4e9993be9e5bff46a,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 8967935501628578988, guid: 806f9cfe52446ec4e83046ea1833e421,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 1610462930538100664, guid: d29b970035b2d7e4e93ef13dd092ddb8,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 8530578589570408608, guid: c025acaacd9a1eb46a1812159309f801,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 6235964335812830118, guid: 15be5142b38020941a63d0616b231319,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 413160797338000752, guid: efc2639f7db147945bedde314a35b59e, type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 6497901317884382080, guid: b09b51eeb0f922648b6238b10866b08a,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 3149599044612121158, guid: c05da286b12f7d548ba49b18b7dd9d37,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 3123475762850637153, guid: 32874c4e171cf814392dae869380fdc0,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 1836160738898918934, guid: cccae4558eadd484ba316f2476bad32e,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 5801842941948159383, guid: ab5993d71f3b82345a54e2b22200ff46,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 6027566199015482743, guid: 87338a13e74f5114e88e645ccf0d9b60,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 9002078534967010456, guid: 26813775f0d95cd46817ff49fd798379,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 1169051753645162342, guid: 0b2447dff8de6a542888ce08e0783ccd,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 4610571268132094221, guid: 1bedc677f3be43d4b9b35fd81227e9bb,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 4991123930087057998, guid: 91c9d12631cdc854ca6453debdc43aec,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 4127435538221997789, guid: f43e9c183d039b94bb00ddc02178457a,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 7298438421084278332, guid: 5f14c38c95655fb4bb6ca21bc66c7db1,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 327135214468665366, guid: dea27be34c1d22841a1a7f11bd965ca0, type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 8864927979826626588, guid: 47820ec4f427100c183c0a7dd1a55c0c,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  RequiredTrait: {fileID: 0}

--- a/UnityProject/Assets/ScriptableObjects/RandomItemPools/RandomPottedPlant.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/RandomItemPools/RandomPottedPlant.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 30938da04b06e35a19cd4ed03da07b73
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
- added a potted plant that didn't have a prefab made for its sprite
- added a light to one potted plant type that is clearly glowing & slightly toned down the light on the existing bioluminescent one (255 => 220)
- created a random item spawner (/pool) for potted plants to eventually replace PottedPlantRandom, which just picks a random plant sprite while losing any of the individual potted plants' distinctive properties (like the bioluminescent one's glow)--will replace prefabs in maps in future
- detective's vendrobe had a mislabeled item

### Notes:
n/a

### Changelog:
n/a (too small to mention i assume)
