### PR TITLE
Staging Balancing

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Botany/Produce/Cereal/CornEar.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Botany/Produce/Cereal/CornEar.prefab
@@ -259,8 +259,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   juicedReagents:
     m_keys:
-    - {fileID: 11400000, guid: bcfadcef446d8271fa8576b781a24a13, type: 2}
-    m_values: 05000000
+    - {fileID: 11400000, guid: 3dc3f81736a407fda8141be714d3e47f, type: 2}
+    m_values: 06000000
 --- !u!114 &4768935822710236466
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -277,7 +277,7 @@ MonoBehaviour:
   fermentedReagents:
     m_keys:
     - {fileID: 11400000, guid: 8d1468f2ac5202e65af28854a30b9c55, type: 2}
-    m_values: 00000000
+    m_values: 05000000
 --- !u!114 &2782517646729712355
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -292,5 +292,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   groundReagents:
     m_keys:
-    - {fileID: 11400000, guid: 3dc3f81736a407fda8141be714d3e47f, type: 2}
-    m_values: 06000000
+    - {fileID: 11400000, guid: bcfadcef446d8271fa8576b781a24a13, type: 2}
+    m_values: 05000000

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Others/Glycerol.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Others/Glycerol.asset
@@ -32,7 +32,7 @@ MonoBehaviour:
   results:
     m_keys:
     - {fileID: 11400000, guid: 3a54c19300dc2022cb0d10a8e5883ea7, type: 2}
-    m_values: 03000000
+    m_values: 01000000
   effectDict:
     m_keys: []
     m_values: 

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Others/Glycerol.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Others/Glycerol.asset
@@ -25,16 +25,15 @@ MonoBehaviour:
   inhibitors:
     m_keys: []
     m_values: 
-  hasMinTemp: 0
-  serializableTempMin: 0
-  hasMaxTemp: 0
-  serializableTempMax: 0
+  hasMinTemp: 1
+  serializableTempMin: 100
+  hasMaxTemp: 1
+  serializableTempMax: 350
   results:
     m_keys:
     - {fileID: 11400000, guid: 3a54c19300dc2022cb0d10a8e5883ea7, type: 2}
-    m_values: 01000000
+    m_values: 03000000
   effectDict:
     m_keys: []
     m_values: 
-  effects: []
   overrideDisplayName: 

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Pyrotechnics/ReagentExplosionmethsplosion.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Pyrotechnics/ReagentExplosionmethsplosion.asset
@@ -34,5 +34,5 @@ MonoBehaviour:
   effectDict:
     m_keys:
     - {fileID: 11400000, guid: 9e563eef533023d47b4596fa10583f3a, type: 2}
-    m_values: 01000000
+    m_values: 02000000
   overrideDisplayName: Explosion Meth

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Pyrotechnics/ReagentExplosionmethsplosionmethboom2.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Pyrotechnics/ReagentExplosionmethsplosionmethboom2.asset
@@ -38,5 +38,5 @@ MonoBehaviour:
   effectDict:
     m_keys:
     - {fileID: 11400000, guid: 9e563eef533023d47b4596fa10583f3a, type: 2}
-    m_values: 01000000
+    m_values: 06000000
   overrideDisplayName: Explosion Meth

--- a/UnityProject/Assets/Scripts/Systems/Chemistry/ChemistryUtils.cs
+++ b/UnityProject/Assets/Scripts/Systems/Chemistry/ChemistryUtils.cs
@@ -52,7 +52,7 @@ namespace Chemistry
 
 		public static float CalculateYieldFromReaction(float reactionAmount, float reactionPotency)
 		{
-			return 32 * Mathf.Pow(reactionAmount, 0.65f) * reactionPotency;
+			return 32 * Mathf.Pow(reactionAmount, 0.7f) * reactionPotency;
 		}
 
 	}

--- a/UnityProject/Assets/Scripts/Systems/Chemistry/ChemistryUtils.cs
+++ b/UnityProject/Assets/Scripts/Systems/Chemistry/ChemistryUtils.cs
@@ -52,7 +52,7 @@ namespace Chemistry
 
 		public static float CalculateYieldFromReaction(float reactionAmount, float reactionPotency)
 		{
-			return 32 * Mathf.Pow(reactionAmount, 0.6f) * reactionPotency;
+			return 32 * Mathf.Pow(reactionAmount, 0.65f) * reactionPotency;
 		}
 
 	}

--- a/UnityProject/Assets/Scripts/Systems/ChemistryEffects/ChemExplosion.cs
+++ b/UnityProject/Assets/Scripts/Systems/ChemistryEffects/ChemExplosion.cs
@@ -20,7 +20,7 @@ namespace Chemistry.Effects
 		[Tooltip("Explosion type")]
 		[field: SerializeField] public ExplosionTypes.ExplosionType explosionType { get; private set; } = ExplosionTypes.ExplosionType.Regular;
 
-		private const int CHEM_EXPLOSIONS_RADIUS_MULTIPLIER = 5;
+		private const int CHEM_EXPLOSIONS_RADIUS_MULTIPLIER = 4;
 		//Chem explosions are often lower potency than standard explosives like syndi bombs.
 		//But as a result they often have tiny radii, looking at most 1-2 tiles.
 		//We give chemical ordnance a radius boost so they cover an area and not just 1-2 tiles.

--- a/UnityProject/Assets/Scripts/Systems/ChemistryEffects/ChemExplosion.cs
+++ b/UnityProject/Assets/Scripts/Systems/ChemistryEffects/ChemExplosion.cs
@@ -20,7 +20,7 @@ namespace Chemistry.Effects
 		[Tooltip("Explosion type")]
 		[field: SerializeField] public ExplosionTypes.ExplosionType explosionType { get; private set; } = ExplosionTypes.ExplosionType.Regular;
 
-		private const int CHEM_EXPLOSIONS_RADIUS_MULTIPLIER = 4;
+		private const int CHEM_EXPLOSIONS_RADIUS_MULTIPLIER = 5;
 		//Chem explosions are often lower potency than standard explosives like syndi bombs.
 		//But as a result they often have tiny radii, looking at most 1-2 tiles.
 		//We give chemical ordnance a radius boost so they cover an area and not just 1-2 tiles.

--- a/UnityProject/Assets/Scripts/Systems/ChemistryEffects/ChemExplosion.cs
+++ b/UnityProject/Assets/Scripts/Systems/ChemistryEffects/ChemExplosion.cs
@@ -20,6 +20,11 @@ namespace Chemistry.Effects
 		[Tooltip("Explosion type")]
 		[field: SerializeField] public ExplosionTypes.ExplosionType explosionType { get; private set; } = ExplosionTypes.ExplosionType.Regular;
 
+		private const int CHEM_EXPLOSIONS_RADIUS_MULTIPLIER = 4;
+		//Chem explosions are often lower potency than standard explosives like syndi bombs.
+		//But as a result they often have tiny radii, looking at most 1-2 tiles.
+		//We give chemical ordnance a radius boost so they cover an area and not just 1-2 tiles.
+
 		public float Delay = 0;
 
 		public override void Apply(MonoBehaviour sender, float amount)
@@ -45,19 +50,11 @@ namespace Chemistry.Effects
 			BodyPart bodyPart = sender.GetComponent<BodyPart>();
 			ExplosionNode node = ExplosionTypes.NodeTypes[explosionType];
 
-			bool insideBody = false;
-			if (bodyPart != null && bodyPart.HealthMaster != null)
-			{
-				insideBody = true;
-			}
+			bool insideBody = bodyPart && bodyPart.HealthMaster;
 
 			float strength = ChemistryUtils.CalculateYieldFromReaction(amount, potency);
 
-
-			if (insideBody && strength > 0)
-			{
-				node.DoInternalDamage(strength, bodyPart);
-			}
+			if (insideBody && strength > 0) node.DoInternalDamage(strength, bodyPart);
 
 			// Explosion here
 			var picked = sender.GetComponent<Pickupable>();
@@ -81,17 +78,17 @@ namespace Chemistry.Effects
 					//If not, we need to check if the item is a bodypart inside of a player
 					if (insideBody)
 					{
-						Explosion.StartExplosion(bodyPart.HealthMaster.RegisterTile.WorldPosition, strength, node, radiusMultiplier: 3);
+						Explosion.StartExplosion(bodyPart.HealthMaster.RegisterTile.WorldPosition, strength, node, radiusMultiplier: CHEM_EXPLOSIONS_RADIUS_MULTIPLIER);
 					}
 					else
 					{
 						//Otherwise, if it's not inside of a player, we consider it just an item
-						Explosion.StartExplosion(objectBehaviour.registerTile.WorldPosition, strength, node, stunNearbyPlayers: strength > 400, radiusMultiplier: 3);
+						Explosion.StartExplosion(objectBehaviour.registerTile.WorldPosition, strength, node, stunNearbyPlayers: strength > 400, radiusMultiplier: CHEM_EXPLOSIONS_RADIUS_MULTIPLIER);
 					}
 				}
 				else
 				{
-					Explosion.StartExplosion(registerObject.WorldPosition, strength, node, stunNearbyPlayers: strength > 400, radiusMultiplier: 3);
+					Explosion.StartExplosion(registerObject.WorldPosition, strength, node, stunNearbyPlayers: strength > 400, radiusMultiplier: CHEM_EXPLOSIONS_RADIUS_MULTIPLIER);
 				}
 			}
 

--- a/UnityProject/Assets/Scripts/Systems/Research/LaserPuzzle/LaserLine.prefab
+++ b/UnityProject/Assets/Scripts/Systems/Research/LaserPuzzle/LaserLine.prefab
@@ -29,7 +29,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.2, y: 1.2, z: 1}
+  m_LocalScale: {x: 1.05, y: 1.25, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4664813114326260710}
@@ -96,7 +96,7 @@ MonoBehaviour:
   SortingOrder: 0
   Material: {fileID: 2100000, guid: b7e7f24fa2e49cb48818dace424b5868, type: 2}
   LightOrigin: {x: 0, y: 0, z: 1}
-  Shape: 1
+  Shape: 0
   GivenID: 0
 --- !u!33 &8798806693015559868
 MeshFilter:

--- a/UnityProject/Assets/Scripts/UI/Core/Net/Elements/Dynamic/NetUIDynamicList.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/Net/Elements/Dynamic/NetUIDynamicList.cs
@@ -96,7 +96,7 @@ namespace UI.Core.NetUI
 		{
 			foreach (var entry in Entries)
 			{
-				DestroyImmediate(entry.gameObject);
+				Destroy(entry.gameObject);
 			}
 			Entries.Clear();
 			entryCount = 0;


### PR DESCRIPTION
Fixes an NRE related to clearing netdynamiclists

### Changelog:
CL: [Balance] Corn Oil is now made from juicing, Corn starch from grinding instead of the other way around
CL: [Balance] Glycerol recipe now has a temperature range of 100K-350K.
CL: [Balance] Explosive power of meth increased from 1 to 2.

CL: [Balance] Chemical explosion formula adjusted slightly to provide slightly better potencies at higher component amounts.
Base yield at 200u has gone from 770 => 1300, and from 980 => 1700 at 300u. (Base yield is prior to any multipliers from reaction type, ClF3 being 1, nitroglycerin being 10)
CL: [Balance] Chemical explosion radius multiplier increased from 3 to 5. Chemical explosions should now be roughly 66% larger for the same yield in ideal uninterrupted conditions. (This does not affect its capacity to destroy objects, see previous change for potency balancing)

CL: [Fix] Fixed Corn producing 0u of whiskey in fermentation barrel, will now produce 5u
CL: [Fix] Fixed Laser line light stretching too far along the beams path and not far enough perpendicular
