### PR TITLE
Improve explosion performance

### DIFF
--- a/UnityProject/Assets/Prefabs/Effects/Lights/FireLight2D.prefab
+++ b/UnityProject/Assets/Prefabs/Effects/Lights/FireLight2D.prefab
@@ -19,6 +19,7 @@ GameObject:
   - component: {fileID: 2910449130835195783}
   - component: {fileID: 5369051684285136003}
   - component: {fileID: 4811951289892001390}
+  - component: {fileID: 1180428793869839989}
   m_Layer: 21
   m_Name: FireLight2D
   m_TagString: Untagged
@@ -53,7 +54,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 61930e16e81db5c43a4ecc22422a0953, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Color: {r: 0.7735849, g: 0.20882004, b: 0, a: 0.8}
+  InitialColour: {r: 0.7735849, g: 0.20882004, b: 0, a: 0.8}
   Sprite: {fileID: 21300000, guid: 3cd49c29477fa8648bd693e5a51d3c51, type: 3}
   SortingOrder: 0
   Material: {fileID: 2100000, guid: b7e7f24fa2e49cb48818dace424b5868, type: 2}
@@ -79,6 +80,7 @@ MeshRenderer:
   m_RayTraceProcedural: 0
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -163,18 +165,20 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1762630675659964}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: a6510c9b95b6fa3498b97083dcdd5e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   NetworkThis: 0
   SubCatalogue: []
-  PresentSpriteSet: {fileID: 11400000, guid: 54f00872c0db5d043ab67b7f96af72b5, type: 2}
+  InitialPresentSpriteSet: {fileID: 11400000, guid: 54f00872c0db5d043ab67b7f96af72b5,
+    type: 2}
   randomInitialSprite: 0
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
   initialVariantIndex: 0
+  InitialColour: {r: 1, g: 1, b: 1, a: 1}
   palette: []
 --- !u!114 &2910449130835195783
 MonoBehaviour:
@@ -191,7 +195,10 @@ MonoBehaviour:
   syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
+  BuckledToObject: {fileID: 0}
+  BuckleOffset: {x: 0, y: 0, z: 0}
   LocalDifferenceNeeded: {x: 0, y: 0}
+  newtonianMovement: {x: 0, y: 0}
   LocalTargetPosition: {x: 0, y: 0, z: 0}
   CorrectingCourse: 0
   Animating: 0
@@ -201,7 +208,6 @@ MonoBehaviour:
   spinMagnitude: 0
   thrownBy: {fileID: 0}
   thrownProtection: {fileID: 0}
-  aim: 0
   ForcedPushedFrame: 0
   TryPushedFrame: 0
   PushedFrame: 0
@@ -210,12 +216,9 @@ MonoBehaviour:
   MappingIntangible: 0
   SnapToGridOnStart: 1
   IsPlayer: 0
-  DEBUG: 0
+  ObjectBouncyness: 0.75
   tileMoveSpeed: 1
   HasOwnGravity: 0
-  isNotPushable: 1
-  CanBeWindPushed: 0
-  rotationTarget: {fileID: 0}
   stickyMovement: 0
   OnThrowEndResetRotation: 0
   maximumStickSpeed: 1.5
@@ -225,14 +228,19 @@ MonoBehaviour:
   - {fileID: 0}
   - {fileID: 0}
   IsCurrentlyFloating: 0
-  Pushing: []
   Hits: []
   isFlyingSliding: 0
   IsMoving: 0
   MoveIsWalking: 0
   LastUpdateClientFlying: 0
   TimeSpentFlying: 0
-  BuckledToObject: {fileID: 0}
+  <Scale>k__BackingField: {fileID: 0}
+  DEBUG: 0
+  isNotPushable: 1
+  Pushing: []
+  CanBeWindPushed: 0
+  canResetRotationFromRightClick: 0
+  rotationTarget: {fileID: 0}
 --- !u!114 &5369051684285136003
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -269,3 +277,19 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   scaleTransform: {x: 1, y: 1, z: 1}
+--- !u!114 &1180428793869839989
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1762630675659964}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 13b3f20d3b30cb24fb70b1f35524c360, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  commonComponentsToRegister:
+  - {fileID: 4811951289892001390}
+  - {fileID: 2910449130835195783}
+  - {fileID: 5369051684285136003}

--- a/UnityProject/Assets/Prefabs/Items/Item.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Item.prefab
@@ -417,6 +417,7 @@ MonoBehaviour:
   MoveIsWalking: 0
   LastUpdateClientFlying: 0
   TimeSpentFlying: 0
+  <Scale>k__BackingField: {fileID: 0}
   DEBUG: 0
   isNotPushable: 0
   Pushing: []
@@ -435,6 +436,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 13b3f20d3b30cb24fb70b1f35524c360, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  commonComponentsToRegister:
+  - {fileID: 8552236617046534393}
+  - {fileID: 499351249353511896}
+  - {fileID: 114734890905785284}
+  - {fileID: 114776788309089574}
+  - {fileID: 5414819541850508356}
 --- !u!114 &4885464012290422036
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Objects/Object.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Object.prefab
@@ -364,6 +364,7 @@ MonoBehaviour:
   MoveIsWalking: 0
   LastUpdateClientFlying: 0
   TimeSpentFlying: 0
+  <Scale>k__BackingField: {fileID: 0}
   DEBUG: 0
   isNotPushable: 1
   Pushing: []
@@ -382,6 +383,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 13b3f20d3b30cb24fb70b1f35524c360, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  commonComponentsToRegister:
+  - {fileID: 4083520829584162099}
+  - {fileID: 4732959556644653524}
+  - {fileID: 4800765294880679425}
+  - {fileID: 6838691275677014393}
 --- !u!114 &6271532286324056904
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
+++ b/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
@@ -1515,6 +1515,7 @@ MonoBehaviour:
   MoveIsWalking: 0
   LastUpdateClientFlying: 0
   TimeSpentFlying: 0
+  <Scale>k__BackingField: {fileID: 0}
   DEBUG: 0
   isNotPushable: 0
   Pushing: []
@@ -1710,6 +1711,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 13b3f20d3b30cb24fb70b1f35524c360, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  commonComponentsToRegister:
+  - {fileID: 5323151696653614753}
+  - {fileID: 6182295504772674896}
+  - {fileID: 6097234027102085964}
+  - {fileID: 3483459317486548442}
+  - {fileID: 2122636020811656725}
+  - {fileID: 1812110424391118221}
+  - {fileID: 8176686349149668929}
+  - {fileID: 7505980873864335948}
+  - {fileID: 1141615694652522293}
+  - {fileID: 3844190322150875557}
+  - {fileID: 3901833431230868314}
+  - {fileID: 7265610720913237329}
+  - {fileID: 1354417930896543338}
+  - {fileID: 114285504268110804}
+  - {fileID: 114617133355526680}
 --- !u!114 &6363338118611276038
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Core/ITrackableType.cs
+++ b/UnityProject/Assets/Scripts/Core/ITrackableType.cs
@@ -9,6 +9,25 @@ namespace Core
 	public static class ComponentsTracker<T>
 	{
 		public static HashSet<T> Instances { get; } = new HashSet<T>();
+		private static Dictionary<GameObject, T> instanceLookup = new Dictionary<GameObject, T>();
+
+		public static void RegisterInstance(T instance)
+		{
+			if (instance is Component component)
+			{
+				Instances.Add(instance);
+				instanceLookup[component.gameObject] = instance;
+			}
+		}
+
+		public static void UnregisterInstance(T instance)
+		{
+			if (instance is Component component)
+			{
+				Instances.Remove(instance);
+				instanceLookup.Remove(component.gameObject);
+			}
+		}
 
 		public static List<T> GetAllNearbyTypesToTarget(GameObject target, float maximumDistance, bool bypassInventories = true)
 		{
@@ -83,6 +102,11 @@ namespace Core
 				components.Add(stationObject);
 			}
 			return components;
+		}
+
+		public static T GetComponentFromGameObject(GameObject obj)
+		{
+			return instanceLookup.GetValueOrDefault(obj);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Core/Lighting/LightSource.cs
+++ b/UnityProject/Assets/Scripts/Core/Lighting/LightSource.cs
@@ -105,7 +105,7 @@ namespace Objects.Lighting
 			traitRequired = currentState.TraitRequired;
 			RefreshBoxCollider();
 			loopKey = Guid.NewGuid().ToString();
-			ComponentsTracker<LightSource>.Instances.Add(this);
+			ComponentsTracker<LightSource>.RegisterInstance(this);
 		}
 
 		private void Start()
@@ -152,7 +152,7 @@ namespace Objects.Lighting
 
 		private void OnDestroy()
 		{
-			ComponentsTracker<LightSource>.Instances.Remove(this);
+			ComponentsTracker<LightSource>.UnregisterInstance(this);
 		}
 
 		#endregion

--- a/UnityProject/Assets/Scripts/Core/Physics/UniversalObjectPhysics.cs
+++ b/UnityProject/Assets/Scripts/Core/Physics/UniversalObjectPhysics.cs
@@ -271,9 +271,8 @@ namespace Core.Physics
 			registerTile = GetComponent<RegisterTile>();
 			rotatable = GetComponent<Rotatable>();
 			pickupable.DirectSetComponent(GetComponent<Pickupable>());
-			Scale = GetComponent<ScaleSync>();
+			Scale ??= GetComponent<ScaleSync>();
 			SetRotationTarget();
-			ComponentsTracker<UniversalObjectPhysics>.RegisterInstance(this);
 		}
 
 		public void Start()
@@ -318,7 +317,6 @@ namespace Core.Physics
 			if (CorrectingCourse) UpdateManager.Remove(CallbackType.EARLY_UPDATE, FloatingCourseCorrection);
 			if (BuckledToObject != null) Unbuckle();
 			if (ObjectIsBuckling != null) ObjectIsBuckling.Unbuckle();
-			ComponentsTracker<UniversalObjectPhysics>.UnregisterInstance(this);
 		}
 
 		public virtual void OnEnable()

--- a/UnityProject/Assets/Scripts/Core/Physics/UniversalObjectPhysics.cs
+++ b/UnityProject/Assets/Scripts/Core/Physics/UniversalObjectPhysics.cs
@@ -8,6 +8,7 @@ using Messages.Server.SoundMessages;
 using Mirror;
 using Objects;
 using Objects.Construction;
+using Scripts.Core.Transform;
 using SecureStuff;
 using Tiles;
 using UnityEngine;
@@ -230,6 +231,8 @@ namespace Core.Physics
 		[PlayModeOnly] public float TimeSpentFlying = 0;
 		[PlayModeOnly] private float SecondsFlying;
 
+		[field: SerializeField] public ScaleSync Scale { get; protected set; }
+
 		public bool IsFlyingSliding
 		{
 			get
@@ -268,8 +271,9 @@ namespace Core.Physics
 			registerTile = GetComponent<RegisterTile>();
 			rotatable = GetComponent<Rotatable>();
 			pickupable.DirectSetComponent(GetComponent<Pickupable>());
-
+			Scale = GetComponent<ScaleSync>();
 			SetRotationTarget();
+			ComponentsTracker<UniversalObjectPhysics>.RegisterInstance(this);
 		}
 
 		public void Start()
@@ -314,6 +318,7 @@ namespace Core.Physics
 			if (CorrectingCourse) UpdateManager.Remove(CallbackType.EARLY_UPDATE, FloatingCourseCorrection);
 			if (BuckledToObject != null) Unbuckle();
 			if (ObjectIsBuckling != null) ObjectIsBuckling.Unbuckle();
+			ComponentsTracker<UniversalObjectPhysics>.UnregisterInstance(this);
 		}
 
 		public virtual void OnEnable()

--- a/UnityProject/Assets/Scripts/Core/Utils/CommonComponents.cs
+++ b/UnityProject/Assets/Scripts/Core/Utils/CommonComponents.cs
@@ -24,6 +24,25 @@ public class CommonComponents : MonoBehaviour
 
 	public Dictionary<Type, Component> dictionary = new Dictionary<Type, Component>();
 
+	[SerializeField] private List<Component> commonComponentsToRegister = new List<Component>();
+
+
+	private void Awake()
+	{
+		ComponentsTracker<CommonComponents>.RegisterInstance(this);
+		foreach (var c in commonComponentsToRegister)
+		{
+			if (c == null) continue;
+			var type = c.GetType();
+			dictionary.Add(type, c);
+		}
+	}
+
+	private void OnDestroy()
+	{
+		ComponentsTracker<CommonComponents>.UnregisterInstance(this);
+	}
+
 	public bool TrySafeGetComponent<T>(out T component) where T : Component
 	{
 		if (dictionary.ContainsKey(typeof(T)) == false)

--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -118,6 +118,7 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 	private RegisterTile registerTile;
 	public RegisterTile RegisterTile => registerTile;
 	private UniversalObjectPhysics universalObjectPhysics;
+	public UniversalObjectPhysics Physics => universalObjectPhysics;
 
 	private Meleeable meleeable;
 	public Meleeable Meleeable => meleeable;

--- a/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
@@ -6,6 +6,8 @@ using Mirror;
 using AddressableReferences;
 using Core;
 using Core.Utils;
+using Cysharp.Threading.Tasks;
+using Cysharp.Threading.Tasks.Linq;
 using Systems.Clothing;
 using UI.Systems.Tooltips.HoverTooltips;
 using UnityEngine.Serialization;
@@ -280,13 +282,27 @@ namespace Items
 
 		/// <summary>
 		/// Does it have any of the given traits?
+		/// Causes allocations. Use HasAnyTraitZeroAlloc instead.
 		/// </summary>
-		/// <param name="expectedTraits"></param>
-		/// <returns></returns>
+		[Obsolete]
 		public bool HasAnyTrait(IEnumerable<ItemTrait> expectedTraits)
 		{
 			return traits.Any(expectedTraits.Contains);
 		}
+
+
+		/// <summary>
+		/// Does it have any of the given traits?
+		/// </summary>
+		/// <param name="expectedTraits">The list of traits to check.</param>
+		/// <returns>True if one of the traits in expectedTraits is included in traits.</returns>
+		public bool HasAnyTraitZeroAlloc(List<ItemTrait> expectedTraits)
+		{
+			if (expectedTraits.Count == 0 || traits.Count == 0) return false;
+			return traits.Overlaps(expectedTraits);
+		}
+
+
 
 		/// <summary>
 		/// Does it have all of the given traits?

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
@@ -870,6 +870,31 @@ public partial class MatrixManager : SingletonManager<MatrixManager>
 	}
 
 	/// <summary>
+	/// checks all tiles adjacent to the indicated world position for objects with the indicated component.
+	/// Probably pretty expensive.
+	/// </summary>
+	/// <param name="worldPos">Position on the map using world (global) cordinates.</param>
+	/// <param name="isServer"></param>
+	/// <param name="withCenter">Get items on the center of the tile you want to check as well if true.</param>
+	/// <typeparam name="T"></typeparam>
+	/// <returns></returns>
+	public static List<T> GetAdjacent<T>(Vector3Int worldPos, bool isServer, bool withCenter) where T : MonoBehaviour
+	{
+		List<T> result = new List<T>();
+		if (withCenter) result.AddRange(GetAt<T>(worldPos, isServer));
+		result.AddRange(GetAt<T>(worldPos + Vector3Int.right, isServer));
+		result.AddRange(GetAt<T>(worldPos + Vector3Int.right + Vector3Int.up, isServer));
+		result.AddRange(GetAt<T>(worldPos + Vector3Int.up, isServer));
+		result.AddRange(GetAt<T>(worldPos + Vector3Int.up + Vector3Int.left, isServer));
+		result.AddRange(GetAt<T>(worldPos + Vector3Int.left, isServer));
+		result.AddRange(GetAt<T>(worldPos + Vector3Int.left + Vector3Int.down, isServer));
+		result.AddRange(GetAt<T>(worldPos + Vector3Int.down, isServer));
+		result.AddRange(GetAt<T>(worldPos + Vector3Int.down + Vector3Int.right, isServer));
+
+		return result;
+	}
+
+	/// <summary>
 	/// checks all reachable tiles adjacent to the indicated world position for objects with the indicated component.
 	/// Probably pretty expensive.
 	/// </summary>

--- a/UnityProject/Assets/Scripts/Systems/Explosions/Explosion.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/Explosion.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Core;
 using Core.Admin.Logs;
+using Cysharp.Threading.Tasks;
 using HealthV2;
 using Logs;
 using Systems.Score;
@@ -32,72 +33,73 @@ namespace Systems.Explosions
 			nodeType ??= new ExplosionNode();
 			nodeType.IgnoreAttributes = damageIgnoreAttributes;
 
-			int Radius = 0;
+			int radius = 0;
 			if (fixedRadius <= 0)
 			{
-				Radius = (int)(Math.Round(strength / (Math.PI * 75)) + 5) * radiusMultiplier;
+				radius = (int)(Math.Round(strength / (Math.PI * 75)) + 5) * radiusMultiplier;
 			}
 			else
 			{
-				Radius = fixedRadius;
+				radius = fixedRadius;
 			}
-			if (Radius > 150)
+			if (radius > 150)
 			{
-				Radius = 150;
+				radius = 150;
 			}
 
-			byte ShakingStrength = 0;
+			byte shakingStrength = 0;
 			if (fixedShakingStrength <= 0 || fixedShakingStrength > 255)
 			{
-				ShakingStrength = 25;
+				shakingStrength = 25;
 				if (strength > EXPLOSION_STRENGTH_LOW)
 				{
-					ShakingStrength = 75;
+					shakingStrength = 75;
 				}
 				else if (strength > EXPLOSION_STRENGTH_MEDIUM)
 				{
-					ShakingStrength = 125;
+					shakingStrength = 125;
 				}
 				else if (strength > EXPLOSION_STRENGTH_HIGH)
 				{
-					ShakingStrength = 255;
+					shakingStrength = 255;
 				}
 			}
 			else
 			{
-				ShakingStrength = (byte)fixedShakingStrength;
+				shakingStrength = (byte)fixedShakingStrength;
 			}
 
 			float volumeMultiplier = Mathf.Clamp(strength / EXPLOSION_STRENGTH_LOW, 0.25f, 1);
-			ExplosionUtils.PlaySoundAndShake(WorldPOS, ShakingStrength, Radius / 20, nodeType.CustomSound, volumeMultiplier);
+			ExplosionUtils.PlaySoundAndShake(WorldPOS, shakingStrength, radius / 20, nodeType.CustomSound, volumeMultiplier);
 
 			//Generates the conference
 			var explosionData = new ExplosionData();
-			circleBres(explosionData, WorldPOS.x, WorldPOS.y, Radius);
-			float InitialStrength = strength / explosionData.CircleCircumference.Count;
+			circleBres(explosionData, WorldPOS.x, WorldPOS.y, radius);
+			float initialStrength = strength / explosionData.CircleCircumference.Count;
 
-			foreach (var ToPoint in explosionData.CircleCircumference)
+			foreach (var toPoint in explosionData.CircleCircumference)
 			{
-				var Line = ExplosionPropagationLine.Getline();
-				Line.SetUp(WorldPOS.x, WorldPOS.y, ToPoint.x, ToPoint.y, InitialStrength, nodeType);
-				Line.Step();
+				var line = ExplosionPropagationLine.Getline();
+				line.SetUp(WorldPOS.x, WorldPOS.y, toPoint.x, toPoint.y, initialStrength, nodeType);
+				line.Step();
 			}
 
 			// we assume that the explosion isn't something small like an EMP gernade or
 			if (stunNearbyPlayers || strength > EXPLOSION_STRENGTH_HIGH)
 			{
-				StunAndFlashPlayers(WorldPOS.To2Int(), strength);
+				_ = StunAndFlashPlayers(WorldPOS.To2Int(), strength);
 			}
 
 			ScoreMachine.AddToScoreInt(1, RoundEndScoreBuilder.COMMON_SCORE_EXPLOSION);
 		}
 
-		public static void StunAndFlashPlayers(Vector2Int startingPos, float strength)
+		public static async UniTask StunAndFlashPlayers(Vector2Int startingPos, float strength)
 		{
 			var distance = GetDistanceFromStrength(strength);;
 			var s = ComponentsTracker<LivingHealthMasterBase>.GetAllNearbyTypesToLocation(startingPos.To3(), distance);
 			foreach (var obj in s)
 			{
+				await UniTask.Delay(25);
 				// for performance reasons, if we have a big enough explosion: skip physics line checks as they're expensive.
 				// large explosions are slow enough as is because it has to damage/check hundreds of objects which all trigger
 				// different behaviors and events. We shouldn't strain the server with extra physics check ontop of that.

--- a/UnityProject/Assets/Scripts/Systems/Explosions/ExplosionManager.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/ExplosionManager.cs
@@ -74,16 +74,16 @@ namespace Systems.Explosions
 		{
 			SubCheckLines.UnionWith(CheckLines);
 			CheckLines.Clear();
-			foreach (var CheckLine in SubCheckLines)
+			foreach (var checkLine in SubCheckLines)
 			{
-				CheckLine.Step();
+				checkLine.Step();
 			}
 			SubCheckLines.Clear();
 
 			foreach (ExplosionNode explosionNode in CheckLocations.ToArray())
 			{
 				CheckLocations.Remove(explosionNode); //lets not create infinite explosions in the case of a runtime
-				explosionNode.Process();
+				_ = explosionNode.Process();
 			}
 
 			for (int i = DelayedEffectsToRemove.Count - 1; i >= 0; i--)

--- a/UnityProject/Assets/Scripts/Systems/Explosions/NodeTypes/ExplosionEmpNode.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/NodeTypes/ExplosionEmpNode.cs
@@ -8,6 +8,7 @@ using Items.Others;
 using Objects.Machines;
 using Doors;
 using AddressableReferences;
+using Cysharp.Threading.Tasks;
 using TileManagement;
 
 namespace Systems.Explosions
@@ -27,9 +28,32 @@ namespace Systems.Explosions
 			get { return CommonSounds.Instance.Empulse; }
 		}
 
-		public override float DoDamage(Matrix matrix, float DamageDealt, Vector3Int v3int)
+		public override async UniTask Process()
 		{
-			EmpThings(v3int, (int)DamageDealt);
+			float damageDealt = AngleAndIntensity.magnitude;
+			if (damageDealt <= 0)
+			{
+				return;
+			}
+
+			if (matrix.MetaTileMap == null)
+			{
+				return;
+			}
+
+			if (damageDealt > 0)
+			{
+				//(Max): This is a terrible name. Whoever named it this way should be ashamed.
+				//I have no clue what's the context of this vector. Is it local position? Is it world position? Is it a direction? Who knows!
+				//Keep gatekeeping the codebase, it's not like there are other people working on this project..
+				var v3int = new Vector3Int(Location.x, Location.y, 0);
+				await ReguralProcessingToTilesOnly(damageDealt, v3int);
+			}
+		}
+
+		public override float DoDamageToTiles(Matrix matrix, float damageDealt, Vector3Int v3int, MetaTileMap tileMap)
+		{
+			EmpThings(v3int, (int)damageDealt);
 			return 10.0f; //magic number
 		}
 

--- a/UnityProject/Assets/Scripts/Systems/Explosions/NodeTypes/ExplosionNode.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/NodeTypes/ExplosionNode.cs
@@ -236,7 +236,7 @@ namespace Systems.Explosions
 			if (tileChangeManager.MetaTileMap.HasOverlay(position, TileType.Effects, effectName)) return UniTask.CompletedTask;
 			tileChangeManager.MetaTileMap.AddOverlay(position, TileType.Effects, effectName);
 			var Position = position.ToWorld(tileChangeManager.MetaTileMap.matrix);
-			//TODO: Pool this because it's ruining performance heavily when multiple explosions occur.
+			//TODO: Pool this because it's ruining performance when multiple explosions occur.
 			var fireLightSpawn = Spawn.ServerPrefab(tileChangeManager.MetaTileMap.matrix.ReactionManager.FireLightPrefab, Position);
 			var physics =
 				ComponentsTracker<UniversalObjectPhysics>.GetComponentFromGameObject(fireLightSpawn.GameObject);

--- a/UnityProject/Assets/Scripts/Systems/Explosions/NodeTypes/ExplosionNode.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/NodeTypes/ExplosionNode.cs
@@ -136,7 +136,7 @@ namespace Systems.Explosions
 			foreach (var player in matrix.Get<LivingHealthMasterBase>(v3int, ObjectType.Player, true))
 			{
 				//Player damage is relatively fine performance wise, and doesn't generate any GC.
-				//However, it is still a bit too complex; and it's complexity shows when several mobs are recieving damage at once.
+				//However, it is still a bit too complex; and its complexity shows when several mobs are recieving damage at once.
 				//Processing one at a time each frame should give the game plenty of breathing room.
 				await UniTask.WaitForEndOfFrame();
 				try

--- a/UnityProject/Assets/Scripts/Systems/Explosions/NodeTypes/ExplosionNode.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/NodeTypes/ExplosionNode.cs
@@ -65,10 +65,9 @@ namespace Systems.Explosions
 				return;
 			}
 
-
 			if (damageDealt > 0)
 			{
-				//(Max): This is a terrible name. Whoever named it this way should be ashamed.
+				//(Max): v3int is a terrible name. Whoever named it this way should be ashamed.
 				//I have no clue what's the context of this vector. Is it local position? Is it world position? Is it a direction? Who knows!
 				//Keep gatekeeping the codebase, it's not like there are other people working on this project..
 				var v3int = new Vector3Int(Location.x, Location.y, 0);
@@ -82,7 +81,7 @@ namespace Systems.Explosions
 			var tileManager = matrix.TileChangeManager;
 			if (EffectName != null && EffectOverlayType != null && tileManager != null)
 			{
-				await TimedEffect(v3int, damageDealt * 10, EffectName, EffectOverlayType, tileManager);
+				if (damageDealt >= 2) await TimedEffect(v3int, damageDealt * 10, EffectName, EffectOverlayType, tileManager);
 			}
 			var metaTileMap = matrix.MetaTileMap;
 			var energyExpended = DoDamageToTiles(matrix, damageDealt, v3int, metaTileMap);
@@ -107,33 +106,28 @@ namespace Systems.Explosions
 
 		public virtual async UniTask DoDamageToObjects(Matrix matrix, float damageDealt, Vector3Int v3int)
 		{
-			foreach (var integrity in matrix.Get<Integrity>(v3int, true))
+			var stuffOnTile = matrix.Get<CommonComponents>(v3int, true);
+			var playersOnTile = matrix.Get<LivingHealthMasterBase>(v3int, ObjectType.Player, true);
+			var spliceCounter = 0;
+			foreach (var something in stuffOnTile)
 			{
+				if (spliceCounter > 30)
+				{
+					spliceCounter = 0;
+					await UniTask.WaitForEndOfFrame();
+				}
+				spliceCounter++;
 				// Incase of multiple explosions occuring at once (i.e: multiple Gibtonites)
 				// trycatch this to avoid trying to destroy stuff that is already destroyed by other damage sources.
-				try
+				if (something == null || something.gameObject == null) continue;
+				if (something.TrySafeGetComponent<Integrity>(out var integrity))
 				{
-					integrity.Physics.NewtonianNewtonPush(AngleAndIntensity.Rotate90(), AngleAndIntensity.magnitude * 0.1f , 1, 3,
-						BodyPartType.Chest, integrity.gameObject, 15);
-
-					if (IgnoreAttributes != null)
-					{
-						await UniTask.WaitForEndOfFrame();
-						if (integrity.TryGetComponent<ItemAttributesV2>(out var traits) &&
-						    traits.HasAnyTraitZeroAlloc(IgnoreAttributes)) continue;
-					}
-
-					// And do damage to objects
-					integrity.ApplyDamage(damageDealt, AttackType.Bomb, DamageType.Brute);
-				}
-				catch (Exception e)
-				{
-					Loggy.Error($"An error occured while trying to damage an object. Maybe it's no longer avaliable?\n {e}");
+					DamageObjects(something, integrity, damageDealt);
 				}
 			}
 
 			// Damage mobs
-			foreach (var player in matrix.Get<LivingHealthMasterBase>(v3int, ObjectType.Player, true))
+			foreach (var player in playersOnTile)
 			{
 				//Player damage is relatively fine performance wise, and doesn't generate any GC.
 				//However, it is still a bit too complex; and its complexity shows when several mobs are recieving damage at once.
@@ -150,6 +144,27 @@ namespace Systems.Explosions
 					Loggy.Error(
 						$"An issue occured while trying to damage players during an explosion. Maybe they got gibbed?\n {e}");
 				}
+			}
+		}
+
+		private void DamageObjects(CommonComponents components, Integrity integrity, float damageDealt)
+		{
+			try
+			{
+				integrity.Physics.NewtonianNewtonPush(AngleAndIntensity.Rotate90(), AngleAndIntensity.magnitude * 0.1f , 1, 3,
+					BodyPartType.Chest, integrity.gameObject, 15);
+
+				if (IgnoreAttributes != null)
+				{
+					if (components.TrySafeGetComponent<ItemAttributesV2>(out var traits) &&
+					    traits.HasAnyTraitZeroAlloc(IgnoreAttributes)) return;
+				}
+				// And do damage to objects
+				integrity.ApplyDamage(damageDealt, AttackType.Bomb, DamageType.Brute);
+			}
+			catch (Exception e)
+			{
+				Loggy.Error($"An error occured while trying to damage an object in an explosion.\n {e}");
 			}
 		}
 
@@ -230,24 +245,32 @@ namespace Systems.Explosions
 			}
 		}
 
-		public UniTask TimedEffect(Vector3Int position, float time, string effectName, OverlayType effectOverlayType, TileChangeManager tileChangeManager)
+		public async UniTask TimedEffect(Vector3Int position, float time, string effectName, OverlayType effectOverlayType, TileChangeManager tileChangeManager)
 		{
 			//Dont add effect if it is already there
-			if (tileChangeManager.MetaTileMap.HasOverlay(position, TileType.Effects, effectName)) return UniTask.CompletedTask;
+			if (tileChangeManager.MetaTileMap.HasOverlay(position, TileType.Effects, effectName)) return;
 			tileChangeManager.MetaTileMap.AddOverlay(position, TileType.Effects, effectName);
 			var Position = position.ToWorld(tileChangeManager.MetaTileMap.matrix);
 			//TODO: Pool this because it's ruining performance when multiple explosions occur.
 			var fireLightSpawn = Spawn.ServerPrefab(tileChangeManager.MetaTileMap.matrix.ReactionManager.FireLightPrefab, Position);
-			var physics =
-				ComponentsTracker<UniversalObjectPhysics>.GetComponentFromGameObject(fireLightSpawn.GameObject);
-			if (physics != null)
+			await UniTask.Delay(75);
+			var components =
+				ComponentsTracker<CommonComponents>.GetComponentFromGameObject(fireLightSpawn.GameObject);
+			if (components != null)
 			{
-				physics.AppearAtWorldPositionServer(Position);
-				physics.Scale.SetScale(Vector3.one * 30);
+				if (components.TrySafeGetComponent<UniversalObjectPhysics>(out var physics))
+				{
+					physics.AppearAtWorldPositionServer(Position);
+					physics.Scale.SetScale(Vector3.one * 30);
+				}
+			}
+			else
+			{
+				Loggy.Error("Attempted to acces CommonComponents on a FireLight object, but couldn't find one!");
 			}
 			ExplosionManager.CleanupEffectLater(time * 0.001f, tileChangeManager.MetaTileMap,
 				position, effectOverlayType, fireLightSpawn.GameObject);
-			return UniTask.CompletedTask;
+			return;
 		}
 
 		public virtual ExplosionNode GenInstance()

--- a/UnityProject/Assets/Scripts/Systems/Explosions/NodeTypes/ExplosionNode.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/NodeTypes/ExplosionNode.cs
@@ -11,6 +11,7 @@ using TileManagement;
 using AddressableReferences;
 using Core;
 using Core.Lighting_System.Light2D;
+using Cysharp.Threading.Tasks;
 using Logs;
 using Player;
 using Scripts.Core.Transform;
@@ -51,14 +52,10 @@ namespace Systems.Explosions
 			matrix = Inmatrix;
 		}
 
-		public virtual void Process()
+		public virtual async UniTask Process()
 		{
-			float DamageDealt = AngleAndIntensity.magnitude;
-			float EnergyExpended = 0;
-			var v3int = new Vector3Int(Location.x, Location.y, 0);
-			var tileManager = matrix.TileChangeManager;
-
-			if (DamageDealt <= 0)
+			float damageDealt = AngleAndIntensity.magnitude;
+			if (damageDealt <= 0)
 			{
 				return;
 			}
@@ -68,57 +65,92 @@ namespace Systems.Explosions
 				return;
 			}
 
-			if(DamageDealt > 0)
-			{
-				if (EffectName != null && EffectOverlayType != null && tileManager != null)
-				{
-					TimedEffect(v3int, DamageDealt * 10, EffectName, EffectOverlayType, tileManager);
-				}
-				EnergyExpended = DoDamage(matrix, DamageDealt, v3int);
 
-				foreach (var line in PresentLines)
-				{
-					line.ExplosionStrength -= EnergyExpended * (line.ExplosionStrength / DamageDealt);
-				}
-				AngleAndIntensity = Vector2.zero;
+			if (damageDealt > 0)
+			{
+				//(Max): This is a terrible name. Whoever named it this way should be ashamed.
+				//I have no clue what's the context of this vector. Is it local position? Is it world position? Is it a direction? Who knows!
+				//Keep gatekeeping the codebase, it's not like there are other people working on this project..
+				var v3int = new Vector3Int(Location.x, Location.y, 0);
+				await ReguralProcessingToTilesOnly(damageDealt, v3int);
+				_ = DoDamageToObjects(matrix, damageDealt, v3int);
 			}
 		}
 
-		//method that, surprise, does damage to stuff on node's tile. override for custom behaviour. must return EnergyExpended value
-		public virtual float DoDamage(Matrix matrix, float damageDealt, Vector3Int v3int)
+		protected async UniTask ReguralProcessingToTilesOnly(float damageDealt, Vector3Int v3int)
 		{
+			var tileManager = matrix.TileChangeManager;
+			if (EffectName != null && EffectOverlayType != null && tileManager != null)
+			{
+				await TimedEffect(v3int, damageDealt * 10, EffectName, EffectOverlayType, tileManager);
+			}
 			var metaTileMap = matrix.MetaTileMap;
+			var energyExpended = DoDamageToTiles(matrix, damageDealt, v3int, metaTileMap);
+			foreach (var line in PresentLines)
+			{
+				line.ExplosionStrength -= energyExpended * (line.ExplosionStrength / damageDealt);
+			}
+			AngleAndIntensity = Vector2.zero;
+		}
+
+		//method that, surprise, does damage to stuff on node's tile. override for custom behaviour. must return EnergyExpended value
+		public virtual float DoDamageToTiles(Matrix matrix, float damageDealt, Vector3Int v3int, MetaTileMap metaTileMap)
+		{
 			float energyExpended = metaTileMap.ApplyDamage(v3int, damageDealt,
 			MatrixManager.LocalToWorldInt(v3int, matrix.MatrixInfo), AttackType.Bomb);
 
 			DamageLayers(damageDealt, v3int);
-
-			foreach (var integrity in matrix.Get<Integrity>(v3int, true))
-			{
-				//Throw items and Objects
-				integrity.GetComponent<UniversalObjectPhysics>()?.NewtonianNewtonPush(AngleAndIntensity.Rotate90(), AngleAndIntensity.magnitude * 0.1f , 1, 3,
-					BodyPartType.Chest, integrity.gameObject, 15);
-
-				if (integrity.TryGetComponent<ItemAttributesV2>(out var traits))
-				{
-					if (IgnoreAttributes != null && traits.HasAnyTrait(IgnoreAttributes)) continue;
-				}
-
-				//And do damage to objects
-				integrity.ApplyDamage(damageDealt, AttackType.Bomb, DamageType.Brute);
-			}
-
-			foreach (var player in matrix.Get<LivingHealthMasterBase>(v3int, ObjectType.Player, true))
-			{
-				player.GetComponent<UniversalObjectPhysics>()?.NewtonianPush(AngleAndIntensity.Rotate90(), 7, 1, 3,
-                					BodyPartType.Chest, player.gameObject, 15);
-				// do damage
-				player.ApplyDamageAll(null, damageDealt, AttackType.Bomb, DamageType.Brute, default, TraumaticDamageTypes.NONE, 75);
-			}
-
 			ChangeNodeTemp(matrix, damageDealt, v3int);
 
 			return energyExpended;
+		}
+
+		public virtual async UniTask DoDamageToObjects(Matrix matrix, float damageDealt, Vector3Int v3int)
+		{
+			foreach (var integrity in matrix.Get<Integrity>(v3int, true))
+			{
+				// Incase of multiple explosions occuring at once (i.e: multiple Gibtonites)
+				// trycatch this to avoid trying to destroy stuff that is already destroyed by other damage sources.
+				try
+				{
+					integrity.Physics.NewtonianNewtonPush(AngleAndIntensity.Rotate90(), AngleAndIntensity.magnitude * 0.1f , 1, 3,
+						BodyPartType.Chest, integrity.gameObject, 15);
+
+					if (IgnoreAttributes != null)
+					{
+						await UniTask.WaitForEndOfFrame();
+						if (integrity.TryGetComponent<ItemAttributesV2>(out var traits) &&
+						    traits.HasAnyTraitZeroAlloc(IgnoreAttributes)) continue;
+					}
+
+					// And do damage to objects
+					integrity.ApplyDamage(damageDealt, AttackType.Bomb, DamageType.Brute);
+				}
+				catch (Exception e)
+				{
+					Loggy.Error($"An error occured while trying to damage an object. Maybe it's no longer avaliable?\n {e}");
+				}
+			}
+
+			// Damage mobs
+			foreach (var player in matrix.Get<LivingHealthMasterBase>(v3int, ObjectType.Player, true))
+			{
+				//Player damage is relatively fine performance wise, and doesn't generate any GC.
+				//However, it is still a bit too complex; and it's complexity shows when several mobs are recieving damage at once.
+				//Processing one at a time each frame should give the game plenty of breathing room.
+				await UniTask.WaitForEndOfFrame();
+				try
+				{
+					player.playerScript.playerMove.NewtonianPush(AngleAndIntensity.Rotate90(), 7, 1, 3,
+						BodyPartType.Chest, player.gameObject, 15);
+					player.ApplyDamageAll(null, damageDealt, AttackType.Bomb, DamageType.Brute, default, TraumaticDamageTypes.NONE, 75);
+				}
+				catch (Exception e)
+				{
+					Loggy.Error(
+						$"An issue occured while trying to damage players during an explosion. Maybe they got gibbed?\n {e}");
+				}
+			}
 		}
 
 		private void ChangeNodeTemp(Matrix matrix, float damageDealt, Vector3Int v3int)
@@ -198,18 +230,24 @@ namespace Systems.Explosions
 			}
 		}
 
-		public void TimedEffect(Vector3Int position, float time, string effectName, OverlayType effectOverlayType, TileChangeManager tileChangeManager)
+		public UniTask TimedEffect(Vector3Int position, float time, string effectName, OverlayType effectOverlayType, TileChangeManager tileChangeManager)
 		{
 			//Dont add effect if it is already there
-			if (tileChangeManager.MetaTileMap.HasOverlay(position, TileType.Effects, effectName)) return;
+			if (tileChangeManager.MetaTileMap.HasOverlay(position, TileType.Effects, effectName)) return UniTask.CompletedTask;
 			tileChangeManager.MetaTileMap.AddOverlay(position, TileType.Effects, effectName);
 			var Position = position.ToWorld(tileChangeManager.MetaTileMap.matrix);
-			var fireLightSpawn = Spawn.ServerPrefab(tileChangeManager.MetaTileMap.matrix.ReactionManager.FireLightPrefab,Position );
-
-			fireLightSpawn.GameObject.GetComponent<UniversalObjectPhysics>().AppearAtWorldPositionServer(Position);
-			fireLightSpawn.GameObject.GetComponent< ScaleSync>().SetScale(Vector3.one * 30);
+			//TODO: Pool this because it's ruining performance heavily when multiple explosions occur.
+			var fireLightSpawn = Spawn.ServerPrefab(tileChangeManager.MetaTileMap.matrix.ReactionManager.FireLightPrefab, Position);
+			var physics =
+				ComponentsTracker<UniversalObjectPhysics>.GetComponentFromGameObject(fireLightSpawn.GameObject);
+			if (physics != null)
+			{
+				physics.AppearAtWorldPositionServer(Position);
+				physics.Scale.SetScale(Vector3.one * 30);
+			}
 			ExplosionManager.CleanupEffectLater(time * 0.001f, tileChangeManager.MetaTileMap,
 				position, effectOverlayType, fireLightSpawn.GameObject);
+			return UniTask.CompletedTask;
 		}
 
 		public virtual ExplosionNode GenInstance()

--- a/UnityProject/Assets/Scripts/Systems/Explosions/NodeTypes/HarmlessExplosionNode.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/NodeTypes/HarmlessExplosionNode.cs
@@ -1,9 +1,11 @@
 using System.Collections;
 using System.Collections.Generic;
+using Cysharp.Threading.Tasks;
 using HealthV2;
 using Items;
 using Light2D;
 using Systems.Explosions;
+using TileManagement;
 using UnityEngine;
 using UniversalObjectPhysics = Core.Physics.UniversalObjectPhysics;
 
@@ -12,12 +14,13 @@ namespace Systems.Explosions
 	public class HarmlessExplosionNode : ExplosionNode
 	{
 
-		public override void Process()
+		public override UniTask Process()
 		{
 			//Harmless explosives can't affect the environment at all, so no checks and/or additional methods are required
+			return UniTask.CompletedTask;
 		}
 
-		public override float DoDamage(Matrix matrix, float damageDealt, Vector3Int v3int)
+		public override float DoDamageToTiles(Matrix matrix, float damageDealt, Vector3Int v3int, MetaTileMap tileMap)
 		{
 			return 0;
 		}

--- a/UnityProject/Assets/Scripts/Systems/Explosions/NodeTypes/PlayerFriendlyExplosionNode.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/NodeTypes/PlayerFriendlyExplosionNode.cs
@@ -1,24 +1,42 @@
 using System.Collections;
 using System.Collections.Generic;
 using Core;
+using Cysharp.Threading.Tasks;
 using HealthV2;
 using Items;
 using Light2D;
 using Systems.Explosions;
+using TileManagement;
 using UnityEngine;
 using UniversalObjectPhysics = Core.Physics.UniversalObjectPhysics;
 
 public class PlayerFriendlyExplosionNode : ExplosionNode
 {
-
-	public override float DoDamage(Matrix matrix, float damageDealt, Vector3Int v3int)
+	public override async UniTask Process()
 	{
-		var metaTileMap = matrix.MetaTileMap;
-		float energyExpended = metaTileMap.ApplyDamage(v3int, damageDealt,
-			MatrixManager.LocalToWorldInt(v3int, matrix.MatrixInfo), AttackType.Bomb);
+		float damageDealt = AngleAndIntensity.magnitude;
+		if (damageDealt <= 0)
+		{
+			return;
+		}
 
-		DamageLayers(damageDealt, v3int);
+		if (matrix.MetaTileMap == null)
+		{
+			return;
+		}
 
+		if (damageDealt > 0)
+		{
+			//(Max): This is a terrible name. Whoever named it this way should be ashamed.
+			//I have no clue what's the context of this vector. Is it local position? Is it world position? Is it a direction? Who knows!
+			//Keep gatekeeping the codebase, it's not like there are other people working on this project..
+			var v3int = new Vector3Int(Location.x, Location.y, 0);
+			await ReguralProcessingToTilesOnly(damageDealt, v3int);
+		}
+	}
+
+	public override float DoDamageToTiles(Matrix matrix, float damageDealt, Vector3Int v3int, MetaTileMap tileMap)
+	{
 		foreach (var integrity in matrix.Get<Integrity>(v3int, true))
 		{
 			//Throw items
@@ -35,7 +53,7 @@ public class PlayerFriendlyExplosionNode : ExplosionNode
 			integrity.ApplyDamage(damageDealt, AttackType.Bomb, DamageType.Brute);
 		}
 
-		return energyExpended;
+		return base.DoDamageToTiles(matrix, damageDealt, v3int, tileMap);;
 	}
 
 	public override void DoInternalDamage(float strength, BodyPart bodyPart)


### PR DESCRIPTION
CL: [Improvement] Improved memory and CPU usage for explosions, as they attempt less allocations now, while also splitting checks over multiple frames.
