### PR TITLE
replace random potted plant prefab with new spawner version in maps

### DIFF
--- a/UnityProject/Assets/StreamingAssets/Maps/AwaySites/AncientTemple.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/AwaySites/AncientTemple.json
@@ -85251,7 +85251,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.0",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -85401,8 +85401,8 @@
             "LocalPRS": "-29┼-19┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-29┼-17┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-29┼-17┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (2)",
             "LocalPRS": "-29┼-17┼0┼"
           },
@@ -85603,8 +85603,8 @@
             "LocalPRS": "-25┼-21┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-25┼-13┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-25┼-13┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (3)",
             "LocalPRS": "-25┼-13┼0┼"
           },
@@ -85677,8 +85677,8 @@
             "LocalPRS": "-22┼-19┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-22┼-16┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-22┼-16┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (1)",
             "LocalPRS": "-22┼-16┼0┼"
           },
@@ -86136,8 +86136,8 @@
             "LocalPRS": "-3┼10┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-3┼14┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-3┼14┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (4)",
             "LocalPRS": "-3┼14┼0┼"
           },
@@ -86149,8 +86149,8 @@
             "LocalPRS": "-3┼16┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-3┼20┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-3┼20┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (7)",
             "LocalPRS": "-3┼20┼0┼"
           },
@@ -86203,7 +86203,7 @@
             "GitID": "7147422770216fc47b220e213ce8395c_-2.049┼28.93┼0┼",
             "PrefabID": "7147422770216fc47b220e213ce8395c",
             "Name": "GoldBar (7)",
-            "LocalPRS": "-2.05┼28.93┼0┼",
+            "LocalPRS": "-2.049┼28.93┼0┼",
             "Object": {
               "ClassDatas": [
                 {
@@ -86346,8 +86346,8 @@
             "LocalPRS": "0┼10┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_0┼14┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_0┼14┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (5)",
             "LocalPRS": "0┼14┼0┼"
           },
@@ -86359,8 +86359,8 @@
             "LocalPRS": "0┼16┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_0┼20┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_0┼20┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (6)",
             "LocalPRS": "0┼20┼0┼"
           },
@@ -87093,13 +87093,6 @@
             "LocalPRS": "11┼-32┼0┼"
           },
           {
-            "GitID": "20a3d1857d5f66c4aa945129302471a7_11.001┼-32┼0┼",
-            "PrefabID": "20a3d1857d5f66c4aa945129302471a7",
-            "NameMatches": true,
-            "Name": "BananaSeeds",
-            "LocalPRS": "11┼-32┼0┼"
-          },
-          {
             "GitID": "6632299223265324f8ad6b9a74159e0c_11┼-30┼0┼",
             "PrefabID": "6632299223265324f8ad6b9a74159e0c",
             "Name": "FoodCart",
@@ -87117,6 +87110,13 @@
             "PrefabID": "1488f67a55cb9b84098e095e65e5a2b3",
             "Name": "Shovel (1)",
             "LocalPRS": "11┼-7.5┼0┼"
+          },
+          {
+            "GitID": "20a3d1857d5f66c4aa945129302471a7_11.001┼-32┼0┼",
+            "PrefabID": "20a3d1857d5f66c4aa945129302471a7",
+            "NameMatches": true,
+            "Name": "BananaSeeds",
+            "LocalPRS": "11.001┼-32┼0┼"
           },
           {
             "GitID": "d56b65cebb41c78479fed5218fb0344c_12┼-39┼0┼",
@@ -88078,10 +88078,10 @@
             "LocalPRS": "27┼-17┼0┼"
           },
           {
-            "GitID": "7147422770216fc47b220e213ce8395c_27.5781┼-6.9445┼0┼",
+            "GitID": "7147422770216fc47b220e213ce8395c_27.58┼-6.94┼0┼",
             "PrefabID": "7147422770216fc47b220e213ce8395c",
             "Name": "GoldBar (3)",
-            "LocalPRS": "27.5781┼-6.9445┼0┼",
+            "LocalPRS": "27.58┼-6.94┼0┼",
             "Object": {
               "ClassDatas": [
                 {
@@ -88097,16 +88097,16 @@
             }
           },
           {
-            "GitID": "7147422770216fc47b220e213ce8395c_27.58┼-6.94┼0┼",
-            "PrefabID": "7147422770216fc47b220e213ce8395c",
-            "Name": "GoldBar (2)",
-            "LocalPRS": "27.58┼-6.94┼0┼"
-          },
-          {
             "GitID": "7147422770216fc47b220e213ce8395c_27.581┼-6.94┼0┼",
             "PrefabID": "7147422770216fc47b220e213ce8395c",
+            "Name": "GoldBar (2)",
+            "LocalPRS": "27.581┼-6.94┼0┼"
+          },
+          {
+            "GitID": "7147422770216fc47b220e213ce8395c_27.582┼-6.94┼0┼",
+            "PrefabID": "7147422770216fc47b220e213ce8395c",
             "Name": "GoldBar (1)",
-            "LocalPRS": "27.58┼-6.94┼0┼"
+            "LocalPRS": "27.582┼-6.94┼0┼"
           },
           {
             "GitID": "7147422770216fc47b220e213ce8395c_28.86┼-2.96┼0┼",
@@ -88206,8 +88206,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_30┼-41┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_30┼-41┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (1)",
             "LocalPRS": "30┼-41┼0┼"
           },
@@ -88678,8 +88678,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_34┼-34┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_34┼-34┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (1)",
             "LocalPRS": "34┼-34┼0┼"
           },
@@ -89103,8 +89103,8 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "4901.5,9790,0",
-          "Size": "93,90,0"
+          "Pos": "0.5,-11,0.5",
+          "Size": "93,90,1"
         }
       ]
     }

--- a/UnityProject/Assets/StreamingAssets/Maps/AwaySites/MysticValley.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/AwaySites/MysticValley.json
@@ -1,6 +1,6 @@
 {
   "Ver": "1.0.0",
-  "MapName": "Teh Mystic Valley",
+  "MapName": "Mystic Valley",
   "ContainedMatrices": [
     {
       "Ver": "1.1.1",
@@ -625874,7 +625874,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -626315,10 +626315,6 @@
                   "ClassID": "Turret@0",
                   "Data": [
                     {
-                      "Name": "spawnGun",
-                      "Data": "NULL"
-                    },
-                    {
                       "Name": "range",
                       "Data": "17"
                     },
@@ -626364,10 +626360,6 @@
                 {
                   "ClassID": "Turret@0",
                   "Data": [
-                    {
-                      "Name": "spawnGun",
-                      "Data": "NULL"
-                    },
                     {
                       "Name": "range",
                       "Data": "27"
@@ -626642,6 +626634,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -626985,6 +626978,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -629449,10 +629443,10 @@
             }
           },
           {
-            "GitID": "1gVVwsp$tC6EF8VO_69n_-143.997┼24┼0┼",
+            "GitID": "1gVVwsp$tC6EF8VO_69n_-143.9971┼24┼0┼",
             "PrefabID": "1gVVwsp$tC6EF8VO_69n",
             "Name": "MobSpawner lizard",
-            "LocalPRS": "-143.997┼24┼0┼",
+            "LocalPRS": "-143.9971┼24┼0┼",
             "SortPath": "MapObjects/MobSpawners",
             "Object": {
               "ClassDatas": [
@@ -629470,10 +629464,10 @@
             }
           },
           {
-            "GitID": "1gVVwsp$tC6EF8VO_69n_-143.996┼24┼0┼",
+            "GitID": "1gVVwsp$tC6EF8VO_69n_-143.9961┼24┼0┼",
             "PrefabID": "1gVVwsp$tC6EF8VO_69n",
             "Name": "MobSpawner god endgamevisit",
-            "LocalPRS": "-143.996┼24┼0┼",
+            "LocalPRS": "-143.9961┼24┼0┼",
             "SortPath": "MapObjects/MobSpawners",
             "Object": {
               "ClassDatas": [
@@ -629491,10 +629485,10 @@
             }
           },
           {
-            "GitID": "1gVVwsp$tC6EF8VO_69n_-143.995┼24┼0┼",
+            "GitID": "1gVVwsp$tC6EF8VO_69n_-143.9951┼24┼0┼",
             "PrefabID": "1gVVwsp$tC6EF8VO_69n",
             "Name": "MobSpawner gondola (2)",
-            "LocalPRS": "-143.995┼24┼0┼",
+            "LocalPRS": "-143.9951┼24┼0┼",
             "SortPath": "MapObjects/MobSpawners",
             "Object": {
               "ClassDatas": [
@@ -629512,31 +629506,10 @@
             }
           },
           {
-            "GitID": "1gVVwsp$tC6EF8VO_69n_-143.994┼24┼0┼",
-            "PrefabID": "1gVVwsp$tC6EF8VO_69n",
-            "Name": "MobSpawner CatCak",
-            "LocalPRS": "-143.994┼24┼0┼",
-            "SortPath": "MapObjects/MobSpawners",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "LegacyMobSpawnScript@0",
-                  "Data": [
-                    {
-                      "Name": "MobToSpawn",
-                      "Data": "3f2f2704988bd9346901595057b7513d",
-                      "IsPrefabID": true
-                    }
-                  ]
-                }
-              ]
-            }
-          },
-          {
-            "GitID": "1gVVwsp$tC6EF8VO_69n_-143.993┼24┼0┼",
+            "GitID": "1gVVwsp$tC6EF8VO_69n_-143.9932┼24┼0┼",
             "PrefabID": "1gVVwsp$tC6EF8VO_69n",
             "Name": "MobSpawner fox",
-            "LocalPRS": "-143.993┼24┼0┼",
+            "LocalPRS": "-143.9932┼24┼0┼",
             "SortPath": "MapObjects/MobSpawners",
             "Object": {
               "ClassDatas": [
@@ -629554,10 +629527,10 @@
             }
           },
           {
-            "GitID": "1gVVwsp$tC6EF8VO_69n_-143.992┼24┼0┼",
+            "GitID": "1gVVwsp$tC6EF8VO_69n_-143.9922┼24┼0┼",
             "PrefabID": "1gVVwsp$tC6EF8VO_69n",
             "Name": "MobSpawner sneknice",
-            "LocalPRS": "-143.992┼24┼0┼",
+            "LocalPRS": "-143.9922┼24┼0┼",
             "SortPath": "MapObjects/MobSpawners",
             "Object": {
               "ClassDatas": [
@@ -629567,6 +629540,27 @@
                     {
                       "Name": "MobToSpawn",
                       "Data": "a842771eff0d78e42bb2686d82094c96",
+                      "IsPrefabID": true
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "1gVVwsp$tC6EF8VO_69n_-143.99┼24┼0┼",
+            "PrefabID": "1gVVwsp$tC6EF8VO_69n",
+            "Name": "MobSpawner CatCak",
+            "LocalPRS": "-143.99┼24┼0┼",
+            "SortPath": "MapObjects/MobSpawners",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "LegacyMobSpawnScript@0",
+                  "Data": [
+                    {
+                      "Name": "MobToSpawn",
+                      "Data": "3f2f2704988bd9346901595057b7513d",
                       "IsPrefabID": true
                     }
                   ]
@@ -630041,6 +630035,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -630317,6 +630312,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -631611,6 +631607,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø270ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -633140,6 +633137,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -633667,6 +633665,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -633765,10 +633764,6 @@
                       "Data": "2000"
                     },
                     {
-                      "Name": "SpawnOnDeconstruct",
-                      "Data": "NULL"
-                    },
-                    {
                       "Name": "pipeData@NetCompatible",
                       "Data": "True"
                     }
@@ -633841,6 +633836,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -634000,6 +633996,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -634528,6 +634525,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -637029,10 +637027,6 @@
                       "Data": "2000"
                     },
                     {
-                      "Name": "SpawnOnDeconstruct",
-                      "Data": "NULL"
-                    },
-                    {
                       "Name": "pipeData@NetCompatible",
                       "Data": "True"
                     }
@@ -637105,6 +637099,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -639372,6 +639367,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -639578,6 +639574,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -640110,6 +640107,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -641582,6 +641580,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -641763,6 +641762,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -641915,6 +641915,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -642082,6 +642083,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -643569,6 +643571,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -643648,8 +643651,8 @@
             "SortPath": "MapObjects/Other"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-109.96┼-39.95┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-109.96┼-39.95┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (1)",
             "LocalPRS": "-109.96┼-39.95┼0┼",
             "SortPath": "MapObjects/Furniture"
@@ -644095,6 +644098,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -644270,6 +644274,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -644665,6 +644670,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -644815,8 +644821,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-108┼75┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-108┼75┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (11)",
             "LocalPRS": "-108┼75┼0┼",
             "SortPath": "MapObjects/Furniture"
@@ -645114,6 +645120,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -645322,10 +645329,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼0ø0ø270ø1.64↔1.64↔2.81↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -645354,10 +645366,6 @@
                       ]
                     },
                     {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
-                    },
-                    {
                       "ClassID": "MeshFilter@0",
                       "Data": []
                     }
@@ -645367,8 +645375,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-106.01┼87.13┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-106.01┼87.13┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (10)",
             "LocalPRS": "-106.01┼87.13┼0┼",
             "SortPath": "MapObjects/Furniture"
@@ -645858,8 +645866,8 @@
             "SortPath": "MapObjects/Furniture"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-105┼75┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-105┼75┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (13)",
             "LocalPRS": "-105┼75┼0┼",
             "SortPath": "MapObjects/Furniture"
@@ -645912,10 +645920,6 @@
                     {
                       "Name": "nominalMolesTransferCap",
                       "Data": "2000"
-                    },
-                    {
-                      "Name": "SpawnOnDeconstruct",
-                      "Data": "NULL"
                     },
                     {
                       "Name": "pipeData@NetCompatible",
@@ -645990,6 +645994,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -646188,10 +646193,6 @@
                       "Data": "2000"
                     },
                     {
-                      "Name": "SpawnOnDeconstruct",
-                      "Data": "NULL"
-                    },
-                    {
                       "Name": "pipeData@NetCompatible",
                       "Data": "True"
                     }
@@ -646264,6 +646265,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -646636,6 +646638,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -646804,6 +646807,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -646964,6 +646968,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -648393,6 +648398,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -649157,6 +649163,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -649275,6 +649282,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -649393,6 +649401,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -649511,6 +649520,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -649629,6 +649639,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -649747,6 +649758,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -649865,6 +649877,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -650143,6 +650156,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -650261,6 +650275,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -650379,6 +650394,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -650777,6 +650793,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -650895,6 +650912,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -651013,6 +651031,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -651207,6 +651226,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -651312,10 +651332,6 @@
                       "Data": "2000"
                     },
                     {
-                      "Name": "SpawnOnDeconstruct",
-                      "Data": "NULL"
-                    },
-                    {
                       "Name": "pipeData@NetCompatible",
                       "Data": "True"
                     }
@@ -651388,6 +651404,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -651555,6 +651572,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -651715,6 +651733,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -651956,6 +651975,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -652074,6 +652094,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -652416,6 +652437,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -652534,6 +652556,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -652747,6 +652770,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -652960,6 +652984,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -653157,6 +653182,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -653387,6 +653413,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -653664,6 +653691,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -653782,6 +653810,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -654012,6 +654041,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -654130,6 +654160,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -654297,6 +654328,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -654590,6 +654622,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -654880,6 +654913,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -655203,6 +655237,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -655519,6 +655554,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -655719,6 +655755,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -655919,6 +655956,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -656119,6 +656157,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -656319,6 +656358,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -656639,6 +656679,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -656986,6 +657027,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -657794,6 +657836,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -658045,6 +658088,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -658180,10 +658224,6 @@
                       "Data": "2000"
                     },
                     {
-                      "Name": "SpawnOnDeconstruct",
-                      "Data": "NULL"
-                    },
-                    {
                       "Name": "pipeData@NetCompatible",
                       "Data": "True"
                     }
@@ -658256,6 +658296,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -658395,13 +658436,6 @@
                     }
                   ]
                 }
-              ],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "Active": false,
-                  "ClassDatas": []
-                }
               ]
             }
           },
@@ -658479,10 +658513,6 @@
                       "Data": "2000"
                     },
                     {
-                      "Name": "SpawnOnDeconstruct",
-                      "Data": "NULL"
-                    },
-                    {
                       "Name": "pipeData@NetCompatible",
                       "Data": "True"
                     }
@@ -658555,6 +658585,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -658903,6 +658934,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -659153,6 +659185,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -659353,6 +659386,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -659553,6 +659587,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -659753,6 +659788,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -659953,6 +659989,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -660262,6 +660299,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -660552,6 +660590,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -660939,6 +660978,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -661057,6 +661097,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -661287,6 +661328,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -661405,6 +661447,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -661593,6 +661636,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -661837,6 +661881,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -662067,6 +662112,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -662702,6 +662748,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -662820,6 +662867,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -663162,6 +663210,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -663280,6 +663329,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -663735,6 +663785,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -663853,6 +663904,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -663971,6 +664023,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -664369,6 +664422,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -664487,6 +664541,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -664605,6 +664660,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -664942,10 +664998,6 @@
                       "Data": "2000"
                     },
                     {
-                      "Name": "SpawnOnDeconstruct",
-                      "Data": "NULL"
-                    },
-                    {
                       "Name": "pipeData@NetCompatible",
                       "Data": "True"
                     }
@@ -665018,6 +665070,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -665185,6 +665238,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -665303,6 +665357,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -665421,6 +665476,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -665539,6 +665595,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -665657,6 +665714,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -665775,6 +665833,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -665893,6 +665952,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -666675,6 +666735,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -667074,7 +667135,7 @@
                     },
                     {
                       "Name": "MobSpawners#194",
-                      "Data": "1gVVwsp$tC6EF8VO_69n_-143.992┼24┼0┼@0@LegacyMobSpawnScript@0"
+                      "Data": "1gVVwsp$tC6EF8VO_69n_-143.9922┼24┼0┼@0@LegacyMobSpawnScript@0"
                     },
                     {
                       "Name": "MobSpawners#193",
@@ -667102,7 +667163,7 @@
                     },
                     {
                       "Name": "MobSpawners#187",
-                      "Data": "1gVVwsp$tC6EF8VO_69n_-34.996┼-86┼0┼@0@LegacyMobSpawnScript@0"
+                      "Data": "1gVVwsp$tC6EF8VO_69n_-34.9961┼-86┼0┼@0@LegacyMobSpawnScript@0"
                     },
                     {
                       "Name": "MobSpawners#186",
@@ -667134,7 +667195,7 @@
                     },
                     {
                       "Name": "MobSpawners#179",
-                      "Data": "1gVVwsp$tC6EF8VO_69n_-143.997┼24┼0┼@0@LegacyMobSpawnScript@0"
+                      "Data": "1gVVwsp$tC6EF8VO_69n_-143.9971┼24┼0┼@0@LegacyMobSpawnScript@0"
                     },
                     {
                       "Name": "MobSpawners#178",
@@ -667330,11 +667391,11 @@
                     },
                     {
                       "Name": "MobSpawners#130",
-                      "Data": "1gVVwsp$tC6EF8VO_69n_-143.995┼24┼0┼@0@LegacyMobSpawnScript@0"
+                      "Data": "1gVVwsp$tC6EF8VO_69n_-143.9951┼24┼0┼@0@LegacyMobSpawnScript@0"
                     },
                     {
                       "Name": "MobSpawners#129",
-                      "Data": "1gVVwsp$tC6EF8VO_69n_-143.996┼24┼0┼@0@LegacyMobSpawnScript@0"
+                      "Data": "1gVVwsp$tC6EF8VO_69n_-143.9961┼24┼0┼@0@LegacyMobSpawnScript@0"
                     },
                     {
                       "Name": "MobSpawners#128",
@@ -667362,7 +667423,7 @@
                     },
                     {
                       "Name": "MobSpawners#122",
-                      "Data": "1gVVwsp$tC6EF8VO_69n_-143.993┼24┼0┼@0@LegacyMobSpawnScript@0"
+                      "Data": "1gVVwsp$tC6EF8VO_69n_-143.9932┼24┼0┼@0@LegacyMobSpawnScript@0"
                     },
                     {
                       "Name": "MobSpawners#121",
@@ -667654,7 +667715,7 @@
                     },
                     {
                       "Name": "MobSpawners#49",
-                      "Data": "1gVVwsp$tC6EF8VO_69n_-34.997┼-86┼0┼@0@LegacyMobSpawnScript@0"
+                      "Data": "1gVVwsp$tC6EF8VO_69n_-34.9971┼-86┼0┼@0@LegacyMobSpawnScript@0"
                     },
                     {
                       "Name": "MobSpawners#48",
@@ -667694,7 +667755,7 @@
                     },
                     {
                       "Name": "MobSpawners#39",
-                      "Data": "1gVVwsp$tC6EF8VO_69n_-26.997┼-86┼0┼@0@LegacyMobSpawnScript@0"
+                      "Data": "1gVVwsp$tC6EF8VO_69n_-26.9971┼-86┼0┼@0@LegacyMobSpawnScript@0"
                     },
                     {
                       "Name": "MobSpawners#38",
@@ -667738,7 +667799,7 @@
                     },
                     {
                       "Name": "MobSpawners#28",
-                      "Data": "1gVVwsp$tC6EF8VO_69n_-143.994┼24┼0┼@0@LegacyMobSpawnScript@0"
+                      "Data": "1gVVwsp$tC6EF8VO_69n_-143.99┼24┼0┼@0@LegacyMobSpawnScript@0"
                     },
                     {
                       "Name": "MobSpawners#27",
@@ -669299,6 +669360,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -670579,10 +670641,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼2↔2↔2↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -670609,10 +670676,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -671263,10 +671326,6 @@
                       "Data": "2000"
                     },
                     {
-                      "Name": "SpawnOnDeconstruct",
-                      "Data": "NULL"
-                    },
-                    {
                       "Name": "pipeData@NetCompatible",
                       "Data": "True"
                     }
@@ -671339,6 +671398,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -671605,6 +671665,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -671945,6 +672006,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -672172,10 +672234,6 @@
                       "Data": "2000"
                     },
                     {
-                      "Name": "SpawnOnDeconstruct",
-                      "Data": "NULL"
-                    },
-                    {
                       "Name": "pipeData@NetCompatible",
                       "Data": "True"
                     }
@@ -672248,6 +672306,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -672438,10 +672497,6 @@
                       "Data": "2000"
                     },
                     {
-                      "Name": "SpawnOnDeconstruct",
-                      "Data": "NULL"
-                    },
-                    {
                       "Name": "pipeData@NetCompatible",
                       "Data": "True"
                     }
@@ -672514,6 +672569,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -673179,6 +673235,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -673665,6 +673722,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -673734,8 +673792,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-72.98┼-28.98┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-72.98┼-28.98┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (9)",
             "LocalPRS": "-72.98┼-28.98┼0┼",
             "SortPath": "MapObjects/Furniture"
@@ -675933,6 +675991,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -676500,6 +676559,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -676549,8 +676609,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-67┼50.03┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-67┼50.03┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (8)",
             "LocalPRS": "-67┼50.03┼0┼",
             "SortPath": "MapObjects/Furniture"
@@ -678073,6 +678133,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -678196,8 +678257,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-62.99┼48.04┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-62.99┼48.04┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (7)",
             "LocalPRS": "-62.99┼48.04┼0┼",
             "SortPath": "MapObjects/Furniture"
@@ -678530,10 +678591,6 @@
                       "Data": "2000"
                     },
                     {
-                      "Name": "SpawnOnDeconstruct",
-                      "Data": "NULL"
-                    },
-                    {
                       "Name": "pipeData@NetCompatible",
                       "Data": "True"
                     }
@@ -678606,6 +678663,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -678786,6 +678844,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -680874,6 +680933,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -681036,6 +681096,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -682135,6 +682196,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -683547,6 +683609,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -683706,6 +683769,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -683873,6 +683937,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -684575,6 +684640,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -684693,8 +684759,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-53┼78┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-53┼78┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (6)",
             "LocalPRS": "-53┼78┼0┼",
             "SortPath": "MapObjects/Furniture"
@@ -685128,10 +685194,6 @@
                       "Data": "2000"
                     },
                     {
-                      "Name": "SpawnOnDeconstruct",
-                      "Data": "NULL"
-                    },
-                    {
                       "Name": "pipeData@NetCompatible",
                       "Data": "True"
                     }
@@ -685204,6 +685266,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -685768,8 +685831,8 @@
             "SortPath": "MapObjects/Flora&Rocks"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-51┼74.01┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-51┼74.01┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (5)",
             "LocalPRS": "-51┼74.01┼0┼",
             "SortPath": "MapObjects/Furniture"
@@ -687428,1761 +687491,6 @@
                       "Data": "Observers"
                     }
                   ]
-                },
-                {
-                  "ClassID": "WearableArmor@0",
-                  "Data": [
-                    {
-                      "Name": "slot",
-                      "Data": "leftHand"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armoringBodyPartType",
-                      "Data": "RightFoot"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armoringBodyPartType",
-                      "Data": "RightLeg"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armoringBodyPartType",
-                      "Data": "LeftLeg"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armoringBodyPartType",
-                      "Data": "RightArm"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armoringBodyPartType",
-                      "Data": "LeftArm"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armoringBodyPartType",
-                      "Data": "Chest"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armoringBodyPartType",
-                      "Data": "Mouth"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armoringBodyPartType",
-                      "Data": "Eyes"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armoringBodyPartType",
-                      "Data": "Head"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    }
-                  ]
-                },
-                {
-                  "ClassID": "WearableArmor@1",
-                  "Data": [
-                    {
-                      "Name": "slot",
-                      "Data": "belt"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armoringBodyPartType",
-                      "Data": "RightFoot"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armoringBodyPartType",
-                      "Data": "RightLeg"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armoringBodyPartType",
-                      "Data": "LeftLeg"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armoringBodyPartType",
-                      "Data": "RightArm"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armoringBodyPartType",
-                      "Data": "LeftArm"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armoringBodyPartType",
-                      "Data": "Chest"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armoringBodyPartType",
-                      "Data": "Mouth"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armoringBodyPartType",
-                      "Data": "Eyes"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armoringBodyPartType",
-                      "Data": "Head"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    }
-                  ]
-                },
-                {
-                  "ClassID": "WearableArmor@2",
-                  "Data": [
-                    {
-                      "Name": "slot",
-                      "Data": "rightHand"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armoringBodyPartType",
-                      "Data": "RightFoot"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#8@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armoringBodyPartType",
-                      "Data": "RightLeg"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#7@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armoringBodyPartType",
-                      "Data": "LeftLeg"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#6@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armoringBodyPartType",
-                      "Data": "RightArm"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#5@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armoringBodyPartType",
-                      "Data": "LeftArm"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#4@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armoringBodyPartType",
-                      "Data": "Chest"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#3@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armoringBodyPartType",
-                      "Data": "Mouth"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#2@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armoringBodyPartType",
-                      "Data": "Eyes"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#1@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armoringBodyPartType",
-                      "Data": "Head"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Bullet",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Laser",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Energy",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Bomb",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Rad",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Fire",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Acid",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Magic",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Bio",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@Anomaly",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@DismembermentProtectionChance",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@StunImmunity",
-                      "Data": "False"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@TemperatureProtectionInK",
-                      "Data": "0,313.15"
-                    },
-                    {
-                      "Name": "armoredBodyParts#0@armor@PressureProtectionInKpa",
-                      "Data": "0,50000"
-                    }
-                  ]
                 }
               ],
               "Children": [
@@ -689195,23 +687503,6 @@
                         {
                           "Name": "InitialPresentSpriteSet",
                           "Data": "26abc55eeab731c4092b89161e558078"
-                        }
-                      ]
-                    },
-                    {
-                      "ClassID": "Pickupable@0",
-                      "Data": [
-                        {
-                          "Name": "pickupAnimSpeed",
-                          "Data": "0.2"
-                        },
-                        {
-                          "Name": "syncDirection",
-                          "Data": "ServerToClient"
-                        },
-                        {
-                          "Name": "syncMode",
-                          "Data": "Observers"
                         }
                       ]
                     },
@@ -689229,6 +687520,23 @@
                         {
                           "Name": "visible",
                           "Data": "Default"
+                        }
+                      ]
+                    },
+                    {
+                      "ClassID": "Pickupable@0",
+                      "Data": [
+                        {
+                          "Name": "pickupAnimSpeed",
+                          "Data": "0.2"
+                        },
+                        {
+                          "Name": "syncDirection",
+                          "Data": "ServerToClient"
+                        },
+                        {
+                          "Name": "syncMode",
+                          "Data": "Observers"
                         }
                       ]
                     }
@@ -689257,10 +687565,15 @@
                 {
                   "Name": "Light2D (1)",
                   "LocalPRS": "0┼0┼0┼0ø0ø270ø12↔12↔12↔",
+                  "ObjectLayer": 0,
                   "ID": "0,5",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -689287,10 +687600,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -689566,6 +687875,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -690604,10 +688914,6 @@
                   "ClassID": "Turret@0",
                   "Data": [
                     {
-                      "Name": "spawnGun",
-                      "Data": "NULL"
-                    },
-                    {
                       "Name": "range",
                       "Data": "15"
                     },
@@ -690712,10 +689018,6 @@
                 {
                   "ClassID": "Turret@0",
                   "Data": [
-                    {
-                      "Name": "spawnGun",
-                      "Data": "NULL"
-                    },
                     {
                       "Name": "range",
                       "Data": "16"
@@ -691021,8 +689323,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-44┼76.28┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-44┼76.28┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (3)",
             "LocalPRS": "-44┼76.28┼0┼",
             "SortPath": "MapObjects/Furniture"
@@ -691082,8 +689384,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-44┼80┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-44┼80┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (1)",
             "LocalPRS": "-44┼80┼0┼",
             "SortPath": "MapObjects/Furniture"
@@ -691568,6 +689870,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -692973,6 +691276,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -693132,6 +691436,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -693305,6 +691610,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -693762,6 +692068,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -693900,8 +692207,8 @@
             "SortPath": "MapObjects/Flora&Rocks"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-38┼76.28┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-38┼76.28┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (4)",
             "LocalPRS": "-38┼76.28┼0┼",
             "SortPath": "MapObjects/Furniture"
@@ -695321,10 +693628,6 @@
                       "Data": "200"
                     },
                     {
-                      "Name": "SpawnOnDeconstruct",
-                      "Data": "NULL"
-                    },
-                    {
                       "Name": "pipeData@NetCompatible",
                       "Data": "True"
                     }
@@ -695397,6 +693700,7 @@
                 {
                   "Name": "Variable Sprite Indicator",
                   "LocalPRS": "0┼0┼0┼0ø0ø180ø",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -695847,10 +694151,10 @@
             }
           },
           {
-            "GitID": "1gVVwsp$tC6EF8VO_69n_-34.997┼-86┼0┼",
+            "GitID": "1gVVwsp$tC6EF8VO_69n_-34.9971┼-86┼0┼",
             "PrefabID": "1gVVwsp$tC6EF8VO_69n",
             "Name": "MobSpawner clown (16)c",
-            "LocalPRS": "-34.997┼-86┼0┼",
+            "LocalPRS": "-34.9971┼-86┼0┼",
             "SortPath": "MapObjects/MobSpawners",
             "Object": {
               "ClassDatas": [
@@ -695868,10 +694172,10 @@
             }
           },
           {
-            "GitID": "1gVVwsp$tC6EF8VO_69n_-34.996┼-86┼0┼",
+            "GitID": "1gVVwsp$tC6EF8VO_69n_-34.9961┼-86┼0┼",
             "PrefabID": "1gVVwsp$tC6EF8VO_69n",
             "Name": "MobSpawner naked clown (16)",
-            "LocalPRS": "-34.996┼-86┼0┼",
+            "LocalPRS": "-34.9961┼-86┼0┼",
             "SortPath": "MapObjects/MobSpawners",
             "Object": {
               "ClassDatas": [
@@ -698651,10 +696955,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼0ø0ø270ø1.64↔1.64↔2.81↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -698681,10 +696990,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -700401,10 +698706,10 @@
             }
           },
           {
-            "GitID": "1gVVwsp$tC6EF8VO_69n_-26.997┼-86┼0┼",
+            "GitID": "1gVVwsp$tC6EF8VO_69n_-26.9971┼-86┼0┼",
             "PrefabID": "1gVVwsp$tC6EF8VO_69n",
             "Name": "MobSpawner clown (6)",
-            "LocalPRS": "-26.997┼-86┼0┼",
+            "LocalPRS": "-26.9971┼-86┼0┼",
             "SortPath": "MapObjects/MobSpawners",
             "Object": {
               "ClassDatas": [
@@ -700726,6 +699031,7 @@
                 {
                   "Name": "wallframe_newscaster (1)",
                   "LocalPRS": "0.0313┼0.25┼0┼",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -700758,6 +699064,7 @@
                 {
                   "Name": "wallframe_newscaster (6)",
                   "LocalPRS": "0.0312┼-0.0313┼0┼",
+                  "ObjectLayer": 0,
                   "ID": "0,2",
                   "ClassDatas": [
                     {
@@ -700790,6 +699097,7 @@
                 {
                   "Name": "wallframe_newscaster (3)",
                   "LocalPRS": "0.1881┼0.0936┼0┼",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -700805,6 +699113,7 @@
                 {
                   "Name": "wallframe_newscaster (7)",
                   "LocalPRS": "0.2104┼-0.024┼0┼0.41↔0.12↔0.41↔",
+                  "ObjectLayer": 0,
                   "ID": "0,4",
                   "ClassDatas": [
                     {
@@ -700820,6 +699129,7 @@
                 {
                   "Name": "wallframe_newscaster (8)",
                   "LocalPRS": "0.205┼0.0468┼0┼0.41↔0.15↔0.41↔",
+                  "ObjectLayer": 0,
                   "ID": "0,5",
                   "ClassDatas": [
                     {
@@ -701216,6 +699526,7 @@
                 {
                   "Name": "wallframe_newscaster (1)",
                   "LocalPRS": "0.0313┼0.25┼0┼",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -701248,6 +699559,7 @@
                 {
                   "Name": "wallframe_newscaster (6)",
                   "LocalPRS": "0.0312┼-0.0313┼0┼",
+                  "ObjectLayer": 0,
                   "ID": "0,2",
                   "ClassDatas": [
                     {
@@ -701280,6 +699592,7 @@
                 {
                   "Name": "wallframe_newscaster (3)",
                   "LocalPRS": "0.1881┼0.0936┼0┼",
+                  "ObjectLayer": 0,
                   "ID": "0,3",
                   "ClassDatas": [
                     {
@@ -701295,6 +699608,7 @@
                 {
                   "Name": "wallframe_newscaster (7)",
                   "LocalPRS": "0.2104┼-0.024┼0┼0.41↔0.12↔0.41↔",
+                  "ObjectLayer": 0,
                   "ID": "0,4",
                   "ClassDatas": [
                     {
@@ -701310,6 +699624,7 @@
                 {
                   "Name": "wallframe_newscaster (8)",
                   "LocalPRS": "0.205┼0.0468┼0┼0.41↔0.15↔0.41↔",
+                  "ObjectLayer": 0,
                   "ID": "0,5",
                   "ClassDatas": [
                     {
@@ -701767,8 +700082,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-22.04┼35.05┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-22.04┼35.05┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (1)",
             "LocalPRS": "-22.04┼35.05┼0┼",
             "SortPath": "MapObjects/Furniture"
@@ -702369,10 +700684,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -702399,10 +700719,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -702868,10 +701184,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -702898,10 +701219,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -702985,10 +701302,6 @@
                 {
                   "ClassID": "Turret@0",
                   "Data": [
-                    {
-                      "Name": "spawnGun",
-                      "Data": "NULL"
-                    },
                     {
                       "Name": "range",
                       "Data": "15"
@@ -703445,10 +701758,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -703475,10 +701793,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -703647,10 +701961,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -703677,10 +701996,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -703953,10 +702268,6 @@
                 {
                   "ClassID": "Turret@0",
                   "Data": [
-                    {
-                      "Name": "spawnGun",
-                      "Data": "NULL"
-                    },
                     {
                       "Name": "range",
                       "Data": "19"
@@ -704393,10 +702704,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -704423,10 +702739,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -704595,10 +702907,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -704625,10 +702942,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -704978,10 +703291,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -705008,10 +703326,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -705180,10 +703494,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -705210,10 +703529,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -705608,10 +703923,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -705638,10 +703958,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -705810,10 +704126,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -705840,10 +704161,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -706012,10 +704329,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -706042,10 +704364,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -706323,6 +704641,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -706911,10 +705230,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -706941,10 +705265,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -709123,10 +707443,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -709153,10 +707478,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -709644,10 +707965,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -709674,10 +708000,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -710440,10 +708762,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -710470,10 +708797,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -710909,10 +709232,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -710939,10 +709267,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -711895,10 +710219,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -711925,10 +710254,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -712394,10 +710719,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -712424,10 +710754,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -713017,10 +711343,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -713047,10 +711378,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -713196,6 +711523,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -713307,10 +711635,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼16↔16↔16↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -713337,10 +711670,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -714125,6 +712454,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -714392,10 +712722,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -714422,10 +712757,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -714705,10 +713036,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -714735,10 +713071,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -714907,10 +713239,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -714937,10 +713274,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -715613,10 +713946,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -715643,10 +713981,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -716190,10 +714524,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -716220,10 +714559,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -716392,10 +714727,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -716422,10 +714762,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -716594,10 +714930,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -716624,10 +714965,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -717003,10 +715340,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -717033,10 +715375,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -717205,10 +715543,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -717235,10 +715578,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -717407,10 +715746,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -717437,10 +715781,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -718597,10 +716937,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -718627,10 +716972,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -719945,10 +718286,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -719975,10 +718321,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -720658,6 +719000,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -720776,6 +719119,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -720967,15 +719311,11 @@
                   ]
                 },
                 {
-                  "ClassID": "ClearanceRestricted@1",
+                  "ClassID": "ClearanceRestricted@0",
                   "Data": [
                     {
                       "Name": "requiredClearance#0",
                       "Data": "AwayGeneric1"
-                    },
-                    {
-                      "Name": "type",
-                      "Data": "Any"
                     }
                   ]
                 }
@@ -721419,10 +719759,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -721449,10 +719794,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -722100,10 +720441,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -722130,10 +720476,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -722491,10 +720833,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -722521,10 +720868,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -722693,10 +721036,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -722723,10 +721071,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -722895,10 +721239,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -722925,10 +721274,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -723097,10 +721442,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -723127,10 +721477,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -723276,6 +721622,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -723540,10 +721887,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -723570,10 +721922,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -723742,10 +722090,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -723772,10 +722125,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -723944,10 +722293,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -723974,10 +722328,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -724146,10 +722496,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -724176,10 +722531,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -724348,10 +722699,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -724378,10 +722734,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -724692,10 +723044,15 @@
                 {
                   "Name": "Light2D",
                   "LocalPRS": "0┼0┼0┼4↔4↔4↔",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
                       "ClassID": "Transform@0",
+                      "Data": []
+                    },
+                    {
+                      "ClassID": "MeshRenderer@0",
                       "Data": []
                     },
                     {
@@ -724722,10 +723079,6 @@
                           "Data": "0"
                         }
                       ]
-                    },
-                    {
-                      "ClassID": "MeshRenderer@0",
-                      "Data": []
                     },
                     {
                       "ClassID": "MeshFilter@0",
@@ -737522,6 +735875,7 @@
                 },
                 {
                   "Name": "Variable Sprite Indicator",
+                  "ObjectLayer": 0,
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -738290,11 +736644,6 @@
                       ]
                     }
                   ]
-                },
-                {
-                  "ID": "0,8",
-                  "Active": false,
-                  "ClassDatas": []
                 }
               ]
             }
@@ -739077,11 +737426,6 @@
                       ]
                     }
                   ]
-                },
-                {
-                  "ID": "0,8",
-                  "Active": false,
-                  "ClassDatas": []
                 }
               ]
             }
@@ -739667,11 +738011,6 @@
                       ]
                     }
                   ]
-                },
-                {
-                  "ID": "0,8",
-                  "Active": false,
-                  "ClassDatas": []
                 }
               ]
             }
@@ -740296,11 +738635,6 @@
                       ]
                     }
                   ]
-                },
-                {
-                  "ID": "0,8",
-                  "Active": false,
-                  "ClassDatas": []
                 }
               ]
             }
@@ -740341,11 +738675,6 @@
                       ]
                     }
                   ]
-                },
-                {
-                  "ID": "0,8",
-                  "Active": false,
-                  "ClassDatas": []
                 }
               ]
             }
@@ -740406,11 +738735,6 @@
                       ]
                     }
                   ]
-                },
-                {
-                  "ID": "0,8",
-                  "Active": false,
-                  "ClassDatas": []
                 }
               ]
             }
@@ -741287,10 +739611,6 @@
                       "Data": "0"
                     },
                     {
-                      "Name": "cellPrefab",
-                      "Data": "NULL"
-                    },
-                    {
                       "Name": "allowScrewdriver",
                       "Data": "True"
                     }
@@ -741488,11 +739808,6 @@
                       ]
                     }
                   ]
-                },
-                {
-                  "ID": "0,8",
-                  "Active": false,
-                  "ClassDatas": []
                 }
               ]
             }
@@ -741990,11 +740305,6 @@
                       ]
                     }
                   ]
-                },
-                {
-                  "ID": "0,8",
-                  "Active": false,
-                  "ClassDatas": []
                 }
               ]
             }
@@ -742082,11 +740392,6 @@
                       ]
                     }
                   ]
-                },
-                {
-                  "ID": "0,8",
-                  "Active": false,
-                  "ClassDatas": []
                 }
               ]
             }
@@ -742480,11 +740785,6 @@
                       ]
                     }
                   ]
-                },
-                {
-                  "ID": "0,8",
-                  "Active": false,
-                  "ClassDatas": []
                 }
               ]
             }
@@ -742506,13 +740806,6 @@
                       "Data": "cd57203a8d3f54f478446e9b0ced6cf9_34┼-51┼0┼@0@APC@0"
                     }
                   ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,8",
-                  "Active": false,
-                  "ClassDatas": []
                 }
               ]
             }
@@ -743056,11 +741349,6 @@
                       ]
                     }
                   ]
-                },
-                {
-                  "ID": "0,8",
-                  "Active": false,
-                  "ClassDatas": []
                 }
               ]
             }
@@ -743130,11 +741418,6 @@
                       ]
                     }
                   ]
-                },
-                {
-                  "ID": "0,8",
-                  "Active": false,
-                  "ClassDatas": []
                 }
               ]
             }
@@ -743175,11 +741458,6 @@
                       ]
                     }
                   ]
-                },
-                {
-                  "ID": "0,8",
-                  "Active": false,
-                  "ClassDatas": []
                 }
               ]
             }
@@ -760415,15 +758693,15 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_95┼-65┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_95┼-65┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (12)",
             "LocalPRS": "95┼-65┼0┼",
             "SortPath": "MapObjects/Furniture"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_95┼-62┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_95┼-62┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (1)",
             "LocalPRS": "95┼-62┼0┼",
             "SortPath": "MapObjects/Furniture"
@@ -760939,8 +759217,8 @@
             "SortPath": "MapObjects/Other"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_97┼-55┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_97┼-55┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (2)",
             "LocalPRS": "97┼-55┼0┼",
             "SortPath": "MapObjects/Furniture"

--- a/UnityProject/Assets/StreamingAssets/Maps/AwaySites/Palace.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/AwaySites/Palace.json
@@ -32261,7 +32261,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -33333,29 +33333,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-11┼13┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-11┼13┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "-11┼13┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "1f304806278cdf942bd94c857f6f5286"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "-11┼13┼0┼"
           },
           {
             "GitID": "177ff6e5fbec9d84bbda485c726757e8_-10┼7┼0┼",
@@ -35010,54 +34991,16 @@
             "LocalPRS": "-4┼22.14┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-4┼25┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-4┼25┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "-4┼25┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "de09cd0271850d942bb3705a8d815390"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "-4┼25┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-4┼31┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-4┼31┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "-4┼31┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "9459b9918b0083842a221474925da005"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "-4┼31┼0┼"
           },
           {
             "GitID": "fbd124bf6338aaf4c80061def5cac102_-3┼-9┼0┼",
@@ -37837,29 +37780,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_8┼9┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_8┼9┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "8┼9┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "a686f645ff5ffe64e9130ddc623705df"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "8┼9┼0┼"
           },
           {
             "GitID": "053a1ecc988b4ae49b5e748c60d98ad9_8┼15┼0┼",
@@ -37904,29 +37828,10 @@
             "LocalPRS": "8┼22┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_8┼24┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_8┼24┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "8┼24┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "a8f565955a2addb4ab79549b97a0d5d7"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "8┼24┼0┼"
           },
           {
             "GitID": "2304f6197e788654ebfe0cf0947a8b1a_8.5┼-18┼0┼",
@@ -38315,29 +38220,10 @@
             "LocalPRS": "11┼12┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_11┼13┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_11┼13┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "11┼13┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "1f304806278cdf942bd94c857f6f5286"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "11┼13┼0┼"
           },
           {
             "GitID": "93dbd338c6220214c926ec72a2c9c6b2_11┼24┼0┼",
@@ -38567,29 +38453,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_13┼3┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_13┼3┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "13┼3┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "1f304806278cdf942bd94c857f6f5286"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "13┼3┼0┼"
           },
           {
             "GitID": "6dad1248a16ebbd48a81433d413e37ec_13┼12┼0┼",

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/BoxStationV1.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/BoxStationV1.json
@@ -213863,7 +213863,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -214734,30 +214734,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-295┼54┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-295┼54┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "-295┼54┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "fad97914a675f2c48ba0ca4c0afe6450"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "-295┼54┼0┼"
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_-295┼55┼0┼",
@@ -214900,30 +214880,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-295┼79┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-295┼79┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "-295┼79┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "735947d90f766f449b4132229640fd8d"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "-295┼79┼0┼"
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_-295┼79┼0┼",
@@ -215365,30 +215325,10 @@
             "LocalPRS": "-292┼52┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-292┼66┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-292┼66┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "-292┼66┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "a686f645ff5ffe64e9130ddc623705df"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "-292┼66┼0┼"
           },
           {
             "GitID": "91d832be818283a4188516804e8d5ef0_-292┼76┼0┼",
@@ -215778,30 +215718,10 @@
             "LocalPRS": "-289┼66┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-289┼76┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-289┼76┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "-289┼76┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "2a90bceb663133a4493375ad0daf719c"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "-289┼76┼0┼"
           },
           {
             "GitID": "177ff6e5fbec9d84bbda485c726757e8_-289┼85┼0┼",
@@ -219904,30 +219824,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-278┼66┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-278┼66┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "-278┼66┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "fad97914a675f2c48ba0ca4c0afe6450"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "-278┼66┼0┼"
           },
           {
             "GitID": "3edf81f4a32c4c348bad5bfe43e263fd_-278┼72┼0┼",
@@ -221772,30 +221672,10 @@
             "LocalPRS": "-273┼55┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-273┼58┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-273┼58┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "-273┼58┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "b48a3709120744b4fb993541ac80ccf4"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "-273┼58┼0┼"
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_-273┼59┼0┼",
@@ -225196,30 +225076,10 @@
             "LocalPRS": "-266┼63┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-266┼64┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-266┼64┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "-266┼64┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "7f666d019f23e24419c4bfd8d03a165e"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "-266┼64┼0┼"
           },
           {
             "GitID": "e6e7f915b6b6fc14c981a592369d47f8_-266┼69┼0┼",
@@ -242363,30 +242223,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-238┼47┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-238┼47┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "-238┼47┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "b48a3709120744b4fb993541ac80ccf4"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "-238┼47┼0┼"
           },
           {
             "GitID": "e6e7f915b6b6fc14c981a592369d47f8_-238┼48┼0┼",
@@ -252848,30 +252688,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-230┼52┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-230┼52┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "-230┼52┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "a686f645ff5ffe64e9130ddc623705df"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "-230┼52┼0┼"
           },
           {
             "GitID": "f4e2ccb49d51f6b4c9d391d9ee285911_-230┼54┼0┼",
@@ -256880,30 +256700,10 @@
             "LocalPRS": "-227┼44┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-227┼47┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-227┼47┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "-227┼47┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "a02cb7685269db14ba4ee98f89ffdf4f"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "-227┼47┼0┼"
           },
           {
             "GitID": "f2432d244a6b7774ea00ff013beb7dcb_-227┼48┼0┼",
@@ -282421,29 +282221,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-212┼88┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-212┼88┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (1)",
-            "LocalPRS": "-212┼88┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "8fa53d06c952b3646a5c799fd39806c3"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "-212┼88┼0┼"
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_-212┼90┼0┼",
@@ -291954,30 +291735,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-206┼57┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-206┼57┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "-206┼57┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "aace53907327f6f498d31ca3cb14ed4d"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "-206┼57┼0┼"
           },
           {
             "GitID": "cd57203a8d3f54f478446e9b0ced6cf9_-206┼58┼0┼",
@@ -312255,30 +312016,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-188┼52┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-188┼52┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "-188┼52┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "735947d90f766f449b4132229640fd8d"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "-188┼52┼0┼"
           },
           {
             "GitID": "cdd75698355b0a14fb404e6041b9f9b3_-188┼53┼0┼",
@@ -339713,30 +339454,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-163┼58┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-163┼58┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "-163┼58┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "58e19f5e1f96aca4e831c3dc97d67781"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "-163┼58┼0┼"
           },
           {
             "GitID": "48c055fcd2fc08c45a9f53310133aa8b_-163┼68┼0┼",
@@ -361316,30 +361037,10 @@
             "LocalPRS": "-139┼53┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-139┼60┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-139┼60┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "-139┼60┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "de09cd0271850d942bb3705a8d815390"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "-139┼60┼0┼"
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_-139┼60┼0┼",
@@ -361947,30 +361648,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-138┼67┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-138┼67┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "-138┼67┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "2a90bceb663133a4493375ad0daf719c"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "-138┼67┼0┼"
           },
           {
             "GitID": "0e933e4f965c9bf4082015f5e176ac73_-137.999┼22┼0┼",
@@ -362271,30 +361952,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-137┼55┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-137┼55┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "-137┼55┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "af4cef8aa7a68b74f8e5aeffa5dd8dbc"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "-137┼55┼0┼"
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_-137┼55┼0┼",
@@ -364064,30 +363725,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_-133┼60┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_-133┼60┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "-133┼60┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "780b29e5202931c47951b3b389d231a1"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "-133┼60┼0┼"
           },
           {
             "GitID": "c1aebfea91112ef4a83ba10f37d3f437_-132┼8┼0┼",
@@ -368347,7 +367988,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -368660,30 +368301,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_39┼-10┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_39┼-10┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "39┼-10┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "b48a3709120744b4fb993541ac80ccf4"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "39┼-10┼0┼"
           },
           {
             "GitID": "cbae9a210d638ba4b9402e836c970fa2_39┼-5┼0┼",
@@ -370325,30 +369946,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_53┼-13┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_53┼-13┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "53┼-13┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "110d065ad23466d428883eadbb80ceb0"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "53┼-13┼0┼"
           },
           {
             "GitID": "67c1a2e93881ef1479a466ad4ee872eb_53┼-7┼0┼",
@@ -370947,7 +370548,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -371963,7 +371564,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -373015,7 +372616,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -373972,7 +373573,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -374942,7 +374543,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -375911,7 +375512,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -377576,7 +377177,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/FallStation.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/FallStation.json
@@ -88806,7 +88806,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -90408,8 +90408,8 @@
             "LocalPRS": "33┼77┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_33┼83┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_33┼83┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (3)",
             "LocalPRS": "33┼83┼0┼"
           },
@@ -90497,8 +90497,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_33┼91┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_33┼91┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (2)",
             "LocalPRS": "33┼91┼0┼"
           },
@@ -90622,9 +90622,8 @@
             "LocalPRS": "33.09┼99.99┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_33.97┼75┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_33.97┼75┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
             "LocalPRS": "33.97┼75┼0┼"
           },
@@ -93103,8 +93102,8 @@
             "LocalPRS": "38┼53┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_38┼55┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_38┼55┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (2)",
             "LocalPRS": "38┼55┼0┼"
           },
@@ -94956,8 +94955,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_42┼61┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_42┼61┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (6)",
             "LocalPRS": "42┼61┼0┼"
           },
@@ -98385,8 +98384,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_46┼83┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_46┼83┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (1)",
             "LocalPRS": "46┼83┼0┼"
           },
@@ -100660,8 +100659,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_50┼55┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_50┼55┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (15)",
             "LocalPRS": "50┼55┼0┼"
           },
@@ -102083,27 +102082,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_52.03┼75.03┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_52.03┼75.03┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (1)",
-            "LocalPRS": "52.03┼75.03┼0┼",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "ItemAttributesV2@0",
-                  "Data": [
-                    {
-                      "Name": "inventoryMoveSound@AssetAddress",
-                      "Data": "null"
-                    },
-                    {
-                      "Name": "inventoryRemoveSound@AssetAddress",
-                      "Data": "null"
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "52.03┼75.03┼0┼"
           },
           {
             "GitID": "185de036320d458499ea157f9966a162_52.98┼66.98┼0┼",
@@ -102384,8 +102366,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_54┼40┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_54┼40┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (13)",
             "LocalPRS": "54┼40┼0┼"
           },
@@ -102397,8 +102379,8 @@
             "LocalPRS": "54┼41┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_54┼43┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_54┼43┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (12)",
             "LocalPRS": "54┼43┼0┼"
           },
@@ -104029,8 +104011,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_57┼67┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_57┼67┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (3)",
             "LocalPRS": "57┼67┼0┼"
           },
@@ -105901,30 +105883,10 @@
             "LocalPRS": "59┼53┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_59┼59┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_59┼59┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "59┼59┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "af4cef8aa7a68b74f8e5aeffa5dd8dbc"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "59┼59┼0┼"
           },
           {
             "GitID": "c21551dd992a57349973e4b5af103ca6_59┼61┼0┼",
@@ -106040,30 +106002,10 @@
             "LocalPRS": "59┼69┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_59┼71┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_59┼71┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "59┼71┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "c42540cf1f836b9408645b8e65574c64"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "59┼71┼0┼"
           },
           {
             "GitID": "f2441585d37f1914395df59a57c5e925_59┼76┼0┼",
@@ -109295,8 +109237,8 @@
             "LocalPRS": "63┼79┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_63┼81┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_63┼81┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (1)",
             "LocalPRS": "63┼81┼0┼"
           },
@@ -118296,8 +118238,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_72┼59.07┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_72┼59.07┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (8)",
             "LocalPRS": "72┼59.07┼0┼"
           },
@@ -119938,8 +119880,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_75┼22┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_75┼22┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (14)",
             "LocalPRS": "75┼22┼0┼"
           },
@@ -122983,30 +122925,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_78┼42┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_78┼42┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "78┼42┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "cca234472b9754542a39bfecb0e0ceea"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "78┼42┼0┼"
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_78┼42┼0┼",
@@ -124985,30 +124907,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_81┼48┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_81┼48┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "81┼48┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "8fa53d06c952b3646a5c799fd39806c3"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "81┼48┼0┼"
           },
           {
             "GitID": "3edf81f4a32c4c348bad5bfe43e263fd_81┼51.95┼0┼",
@@ -127271,8 +127173,8 @@
             "LocalPRS": "83┼57┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_83┼59┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_83┼59┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (9)",
             "LocalPRS": "83┼59┼0┼"
           },
@@ -130819,8 +130721,8 @@
             "LocalPRS": "86┼73┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_86┼75┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_86┼75┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (10)",
             "LocalPRS": "86┼75┼0┼"
           },
@@ -133686,8 +133588,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_89┼101┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_89┼101┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (11)",
             "LocalPRS": "89┼101┼0┼"
           },
@@ -136441,8 +136343,8 @@
             "LocalPRS": "92┼69┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_92┼70┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_92┼70┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (7)",
             "LocalPRS": "92┼70┼0┼"
           },
@@ -136930,8 +136832,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_92.98┼80.12┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_92.98┼80.12┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (1)",
             "LocalPRS": "92.98┼80.12┼0┼"
           },
@@ -139352,8 +139254,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_95.01┼80.12┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_95.01┼80.12┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (16)",
             "LocalPRS": "95.01┼80.12┼0┼"
           },
@@ -141388,30 +141290,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_97┼83.96┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_97┼83.96┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "97┼83.96┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "cca234472b9754542a39bfecb0e0ceea"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "97┼83.96┼0┼"
           },
           {
             "GitID": "dfe099bbe8a17b149ae79fc5f2771410_97┼86┼0┼",
@@ -141481,30 +141363,10 @@
             "LocalPRS": "97┼87┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_97┼89┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_97┼89┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "97┼89┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "7327ccd49186c1c42bbd651d4d6287c2"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "97┼89┼0┼"
           },
           {
             "GitID": "5a7af30c589b41a449d0ba74c9e1771c_97┼91┼0┼",
@@ -141526,30 +141388,10 @@
             "LocalPRS": "97┼92┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_97┼94┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_97┼94┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "97┼94┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "cca234472b9754542a39bfecb0e0ceea"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "97┼94┼0┼"
           },
           {
             "GitID": "08990b75a4ff90847a517eacd5a4a6d8_97┼97┼0┼",
@@ -142191,30 +142033,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_98┼103.01┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_98┼103.01┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "98┼103.01┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "c42540cf1f836b9408645b8e65574c64"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "98┼103.01┼0┼"
           },
           {
             "GitID": "68ef2c0235224f347b94384d5dcdae47_98.93┼67.88┼0┼",
@@ -145284,30 +145106,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_102┼84┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_102┼84┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "102┼84┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "780b29e5202931c47951b3b389d231a1"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "102┼84┼0┼"
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_102┼86┼0┼",
@@ -146732,8 +146534,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_104┼63┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_104┼63┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (5)",
             "LocalPRS": "104┼63┼0┼"
           },
@@ -147702,30 +147504,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_105┼96.95┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_105┼96.95┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "105┼96.95┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "9459b9918b0083842a221474925da005"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "105┼96.95┼0┼"
           },
           {
             "GitID": "b2d9e215b3fd72d41a5df489b5b86386_105.01┼52┼0┼",
@@ -149509,8 +149291,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_108┼21┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_108┼21┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (1)",
             "LocalPRS": "108┼21┼0┼"
           },
@@ -150313,8 +150095,8 @@
             "LocalPRS": "109.04┼57.96┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_109.98┼82.06┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_109.98┼82.06┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (4)",
             "LocalPRS": "109.98┼82.06┼0┼"
           },
@@ -153395,30 +153177,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_117┼71┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_117┼71┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "117┼71┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "7f666d019f23e24419c4bfd8d03a165e"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "117┼71┼0┼"
           },
           {
             "GitID": "c21551dd992a57349973e4b5af103ca6_117┼72┼0┼",
@@ -155001,7 +154763,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -155779,7 +155541,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -156519,7 +156281,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -157358,7 +157120,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -160907,7 +160669,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [],
         "IDToNetIDClient": {}
@@ -170200,7 +169962,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -170913,14 +170675,14 @@
             "LocalPRS": "55┼4┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_56┼24┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_56┼24┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (6)",
             "LocalPRS": "56┼24┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_56┼35┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_56┼35┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (4)",
             "LocalPRS": "56┼35┼0┼"
           },
@@ -170973,8 +170735,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_56┼41┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_56┼41┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (5)",
             "LocalPRS": "56┼41┼0┼"
           },
@@ -171976,8 +171738,8 @@
             "LocalPRS": "70┼31┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_70┼37┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_70┼37┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (3)",
             "LocalPRS": "70┼37┼0┼"
           },
@@ -172372,8 +172134,8 @@
             "LocalPRS": "75┼28┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_75┼37┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_75┼37┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (2)",
             "LocalPRS": "75┼37┼0┼"
           },
@@ -172565,8 +172327,8 @@
             "LocalPRS": "81┼36┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_82┼24┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_82┼24┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (1)",
             "LocalPRS": "82┼24┼0┼"
           },
@@ -174428,7 +174190,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/OutpostStation.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/OutpostStation.json
@@ -190223,7 +190223,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -197482,8 +197482,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_5┼40┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_5┼40┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (13)",
             "LocalPRS": "5┼40┼0┼"
           },
@@ -198951,8 +198951,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_7┼46┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_7┼46┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (14)",
             "LocalPRS": "7┼46┼0┼"
           },
@@ -202917,8 +202917,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_13┼41┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_13┼41┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (7)",
             "LocalPRS": "13┼41┼0┼"
           },
@@ -203777,8 +203777,8 @@
             "LocalPRS": "14┼54.11┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_14┼56┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_14┼56┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (6)",
             "LocalPRS": "14┼56┼0┼"
           },
@@ -207433,8 +207433,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_17┼64┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_17┼64┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (16)",
             "LocalPRS": "17┼64┼0┼"
           },
@@ -210633,8 +210633,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_20┼60┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_20┼60┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (17)",
             "LocalPRS": "20┼60┼0┼"
           },
@@ -213190,8 +213190,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_24┼62┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_24┼62┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (10)",
             "LocalPRS": "24┼62┼0┼"
           },
@@ -223644,8 +223644,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_34┼44┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_34┼44┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (1)",
             "LocalPRS": "34┼44┼0┼"
           },
@@ -225456,8 +225456,8 @@
             "LocalPRS": "35┼107┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_35┼110┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_35┼110┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (12)",
             "LocalPRS": "35┼110┼0┼"
           },
@@ -226287,8 +226287,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_36┼100┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_36┼100┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (21)",
             "LocalPRS": "36┼100┼0┼"
           },
@@ -226702,8 +226702,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_37┼35┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_37┼35┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (18)",
             "LocalPRS": "37┼35┼0┼"
           },
@@ -237578,8 +237578,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_45┼109┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_45┼109┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (11)",
             "LocalPRS": "45┼109┼0┼"
           },
@@ -246632,6 +246632,12 @@
             }
           },
           {
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_52┼52┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
+            "Name": "PotPlant (9)",
+            "LocalPRS": "52┼52┼0┼"
+          },
+          {
             "GitID": "aef082ffdd3b51f45bd9a56c6afda863_52┼52┼0┼",
             "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
             "Name": "emergency_lights",
@@ -246646,12 +246652,6 @@
                 }
               ]
             }
-          },
-          {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_52┼52┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "Name": "PotPlant (9)",
-            "LocalPRS": "52┼52┼0┼"
           },
           {
             "GitID": "cdd75698355b0a14fb404e6041b9f9b3_52┼55┼0┼",
@@ -247214,6 +247214,12 @@
             }
           },
           {
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_52┼88┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
+            "Name": "PotPlant (1)",
+            "LocalPRS": "52┼88┼0┼"
+          },
+          {
             "GitID": "aef082ffdd3b51f45bd9a56c6afda863_52┼88┼0┼",
             "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
             "Name": "emergency_lights (8)",
@@ -247238,12 +247244,6 @@
                 }
               ]
             }
-          },
-          {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_52┼88┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "Name": "PotPlant (1)",
-            "LocalPRS": "52┼88┼0┼"
           },
           {
             "GitID": "c21551dd992a57349973e4b5af103ca6_52┼89┼0┼",
@@ -249163,8 +249163,8 @@
             "LocalPRS": "53┼103┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_53┼106┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_53┼106┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (8)",
             "LocalPRS": "53┼106┼0┼"
           },
@@ -250539,8 +250539,8 @@
             "LocalPRS": "54.78┼82.34┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_55┼0┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_55┼0┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (5)",
             "LocalPRS": "55┼0┼0┼"
           },
@@ -261276,8 +261276,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_61┼58┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_61┼58┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant",
             "LocalPRS": "61┼58┼0┼"
           },
@@ -261582,8 +261582,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_61┼110┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_61┼110┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (22)",
             "LocalPRS": "61┼110┼0┼"
           },
@@ -261675,8 +261675,8 @@
             "LocalPRS": "61┼116┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_61┼117┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_61┼117┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (23)",
             "LocalPRS": "61┼117┼0┼"
           },
@@ -265286,8 +265286,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_64┼80┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_64┼80┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (19)",
             "LocalPRS": "64┼80┼0┼"
           },
@@ -265523,8 +265523,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_64┼94┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_64┼94┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (1)",
             "LocalPRS": "64┼94┼0┼"
           },
@@ -273274,8 +273274,8 @@
             "LocalPRS": "69┼110┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_69┼114┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_69┼114┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (24)",
             "LocalPRS": "69┼114┼0┼"
           },
@@ -275653,8 +275653,8 @@
             "LocalPRS": "71.09┼41.06┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_72┼0┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_72┼0┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (4)",
             "LocalPRS": "72┼0┼0┼"
           },
@@ -277658,8 +277658,8 @@
             "LocalPRS": "73┼48┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_73┼49┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_73┼49┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (15)",
             "LocalPRS": "73┼49┼0┼"
           },
@@ -277763,8 +277763,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_73┼58┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_73┼58┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (2)",
             "LocalPRS": "73┼58┼0┼"
           },
@@ -278755,8 +278755,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_74┼67┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_74┼67┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (20)",
             "LocalPRS": "74┼67┼0┼"
           },
@@ -284358,8 +284358,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_78┼6┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_78┼6┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (1)",
             "LocalPRS": "78┼6┼0┼"
           },
@@ -287194,8 +287194,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_80┼50┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_80┼50┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (1)",
             "LocalPRS": "80┼50┼0┼"
           },
@@ -291125,8 +291125,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_83.95┼92.14┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_83.95┼92.14┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (3)",
             "LocalPRS": "83.95┼92.14┼0┼"
           },
@@ -317387,52 +317387,52 @@
             "LocalPRS": "105.005┼34┼0┼"
           },
           {
-            "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_105.009┼33┼0┼",
-            "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
-            "Name": "ControlRod (8)",
-            "LocalPRS": "105.009┼33┼0┼"
-          },
-          {
             "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_105.01┼33┼0┼",
             "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
-            "Name": "ControlRod (7)",
+            "Name": "ControlRod (8)",
             "LocalPRS": "105.01┼33┼0┼"
           },
           {
             "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_105.011┼33┼0┼",
             "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
-            "Name": "ControlRod (6)",
+            "Name": "ControlRod (7)",
             "LocalPRS": "105.011┼33┼0┼"
           },
           {
             "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_105.012┼33┼0┼",
             "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
-            "Name": "ControlRod (5)",
+            "Name": "ControlRod (6)",
             "LocalPRS": "105.012┼33┼0┼"
           },
           {
             "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_105.013┼33┼0┼",
             "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
-            "Name": "ControlRod (9)",
+            "Name": "ControlRod (5)",
             "LocalPRS": "105.013┼33┼0┼"
           },
           {
             "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_105.014┼33┼0┼",
             "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
-            "Name": "ControlRod (10)",
+            "Name": "ControlRod (9)",
             "LocalPRS": "105.014┼33┼0┼"
           },
           {
             "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_105.015┼33┼0┼",
             "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
-            "Name": "ControlRod (11)",
+            "Name": "ControlRod (10)",
             "LocalPRS": "105.015┼33┼0┼"
           },
           {
             "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_105.016┼33┼0┼",
             "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
-            "Name": "ControlRod (12)",
+            "Name": "ControlRod (11)",
             "LocalPRS": "105.016┼33┼0┼"
+          },
+          {
+            "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_105.02┼33┼0┼",
+            "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
+            "Name": "ControlRod (12)",
+            "LocalPRS": "105.02┼33┼0┼"
           },
           {
             "GitID": "e58e1fd483fe772468ad2aab4259397d_105.92┼78┼0┼",
@@ -330675,7 +330675,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -331625,8 +331625,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_46.99┼-5.06┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_46.99┼-5.06┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (2)",
             "LocalPRS": "46.99┼-5.06┼0┼"
           },
@@ -335176,8 +335176,8 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_61.99┼-12.06┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_61.99┼-12.06┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (1)",
             "LocalPRS": "61.99┼-12.06┼0┼"
           },
@@ -335946,14 +335946,14 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_70.99┼-11.06┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_70.99┼-11.06┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (4)",
             "LocalPRS": "70.99┼-11.06┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_70.99┼-7.06┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_70.99┼-7.06┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PotPlant (3)",
             "LocalPRS": "70.99┼-7.06┼0┼"
           },
@@ -336384,7 +336384,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -337606,7 +337606,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -338635,7 +338635,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -339913,7 +339913,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -340982,7 +340982,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -342051,7 +342051,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -344015,7 +344015,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -345632,7 +345632,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -347805,7 +347805,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -352457,7 +352457,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/PogStation.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/PogStation.json
@@ -191521,7 +191521,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -221421,30 +221421,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_24┼186┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_24┼186┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "24┼186┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "9459b9918b0083842a221474925da005"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "24┼186┼0┼"
           },
           {
             "GitID": "a075086024d70074e8747c26b57dfa7f_24┼191┼0┼",
@@ -223314,30 +223294,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_25┼244┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_25┼244┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "25┼244┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "5f3d9026e8621e64f9e29bd4018ea911"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "25┼244┼0┼"
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_25┼244┼0┼",
@@ -225602,30 +225562,10 @@
             "LocalPRS": "27┼203┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_27┼204┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_27┼204┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "27┼204┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "1f304806278cdf942bd94c857f6f5286"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "27┼204┼0┼"
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_27┼211┼0┼",
@@ -225844,30 +225784,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_27┼229┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_27┼229┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "27┼229┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "fad97914a675f2c48ba0ca4c0afe6450"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "27┼229┼0┼"
           },
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_27┼231┼0┼",
@@ -231311,30 +231231,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_31┼249┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_31┼249┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "31┼249┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "aace53907327f6f498d31ca3cb14ed4d"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "31┼249┼0┼"
           },
           {
             "GitID": "cb2f847ef3b8b754181a970a4032c552_31┼249┼0┼",
@@ -231414,30 +231314,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_31┼253┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_31┼253┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "31┼253┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "9be5b6a895571524f849570158129637"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "31┼253┼0┼"
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_31┼253┼0┼",
@@ -232488,29 +232368,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_32┼207┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_32┼207┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (21)",
-            "LocalPRS": "32┼207┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "b48a3709120744b4fb993541ac80ccf4"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "32┼207┼0┼"
           },
           {
             "GitID": "cb2f847ef3b8b754181a970a4032c552_32┼208┼0┼",
@@ -245157,56 +245018,16 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_42┼249┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_42┼249┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "42┼249┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "7327ccd49186c1c42bbd651d4d6287c2"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "42┼249┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_42┼253┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_42┼253┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "42┼253┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "c42540cf1f836b9408645b8e65574c64"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "42┼253┼0┼"
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_42┼253┼0┼",
@@ -250622,29 +250443,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_46┼218┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_46┼218┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (8)",
-            "LocalPRS": "46┼218┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "9be5b6a895571524f849570158129637"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "46┼218┼0┼"
           },
           {
             "GitID": "48c055fcd2fc08c45a9f53310133aa8b_46┼220┼0┼",
@@ -251047,29 +250849,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_46┼247┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_46┼247┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (9)",
-            "LocalPRS": "46┼247┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "5f3d9026e8621e64f9e29bd4018ea911"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "46┼247┼0┼"
           },
           {
             "GitID": "cb2f847ef3b8b754181a970a4032c552_46┼247┼0┼",
@@ -252331,54 +252114,16 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_47┼225┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_47┼225┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (1)",
-            "LocalPRS": "47┼225┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "af4cef8aa7a68b74f8e5aeffa5dd8dbc"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "47┼225┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_47┼231┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_47┼231┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (2)",
-            "LocalPRS": "47┼231┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "824fb6fa4d185624f9f89e8ed8e2831c"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "47┼231┼0┼"
           },
           {
             "GitID": "9203bf917337c3e4db0a64a10ef0e50b_47┼233┼0┼",
@@ -262150,44 +261895,10 @@
             "LocalPRS": "53┼274┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_53.03┼180.04┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_53.03┼180.04┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "53.03┼180.04┼0┼",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "ItemAttributesV2@0",
-                  "Data": [
-                    {
-                      "Name": "inventoryMoveSound@AssetAddress",
-                      "Data": "null"
-                    },
-                    {
-                      "Name": "inventoryRemoveSound@AssetAddress",
-                      "Data": "null"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "a02cb7685269db14ba4ee98f89ffdf4f"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "53.03┼180.04┼0┼"
           },
           {
             "GitID": "0bf643131a7f0e3469673a5d636ae7c2_53.05┼228.2┼0┼",
@@ -263966,29 +263677,10 @@
             "LocalPRS": "55┼213.1┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_55┼216┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_55┼216┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (4)",
-            "LocalPRS": "55┼216┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "780b29e5202931c47951b3b389d231a1"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "55┼216┼0┼"
           },
           {
             "GitID": "ce971a77eb7c2894e8583efec1c56965_55┼218┼0┼",
@@ -265368,12 +265060,6 @@
             "LocalPRS": "56.004┼257┼0┼"
           },
           {
-            "GitID": "25108e21a69d52c46a538e66eb85db0a_56.007┼257┼0┼",
-            "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (23)",
-            "LocalPRS": "56.007┼257┼0┼"
-          },
-          {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_56.008┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
             "Name": "SolidPlasmaSheet (24)",
@@ -265388,44 +265074,50 @@
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_56.01┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (22)",
+            "Name": "SolidPlasmaSheet (23)",
             "LocalPRS": "56.01┼257┼0┼"
           },
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_56.011┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (21)",
+            "Name": "SolidPlasmaSheet (22)",
             "LocalPRS": "56.011┼257┼0┼"
           },
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_56.012┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (26)",
+            "Name": "SolidPlasmaSheet (21)",
             "LocalPRS": "56.012┼257┼0┼"
           },
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_56.013┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (27)",
+            "Name": "SolidPlasmaSheet (26)",
             "LocalPRS": "56.013┼257┼0┼"
           },
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_56.014┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (28)",
+            "Name": "SolidPlasmaSheet (27)",
             "LocalPRS": "56.014┼257┼0┼"
           },
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_56.015┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (29)",
+            "Name": "SolidPlasmaSheet (28)",
             "LocalPRS": "56.015┼257┼0┼"
           },
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_56.016┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (30)",
+            "Name": "SolidPlasmaSheet (29)",
             "LocalPRS": "56.016┼257┼0┼"
+          },
+          {
+            "GitID": "25108e21a69d52c46a538e66eb85db0a_56.02┼257┼0┼",
+            "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
+            "Name": "SolidPlasmaSheet (30)",
+            "LocalPRS": "56.02┼257┼0┼"
           },
           {
             "GitID": "8f1ce2b118c25334fa660be931e62dbf_56.14┼218.28┼0┼",
@@ -265947,30 +265639,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_57┼207┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_57┼207┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "57┼207┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "5f3d9026e8621e64f9e29bd4018ea911"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "57┼207┼0┼"
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_57┼208┼0┼",
@@ -266876,12 +266548,6 @@
             "LocalPRS": "57.004┼257┼0┼"
           },
           {
-            "GitID": "25108e21a69d52c46a538e66eb85db0a_57.007┼257┼0┼",
-            "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (8)",
-            "LocalPRS": "57.007┼257┼0┼"
-          },
-          {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_57.008┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
             "Name": "SolidPlasmaSheet (9)",
@@ -266896,44 +266562,50 @@
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_57.01┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (7)",
+            "Name": "SolidPlasmaSheet (8)",
             "LocalPRS": "57.01┼257┼0┼"
           },
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_57.011┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (6)",
+            "Name": "SolidPlasmaSheet (7)",
             "LocalPRS": "57.011┼257┼0┼"
           },
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_57.012┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (11)",
+            "Name": "SolidPlasmaSheet (6)",
             "LocalPRS": "57.012┼257┼0┼"
           },
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_57.013┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (12)",
+            "Name": "SolidPlasmaSheet (11)",
             "LocalPRS": "57.013┼257┼0┼"
           },
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_57.014┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (13)",
+            "Name": "SolidPlasmaSheet (12)",
             "LocalPRS": "57.014┼257┼0┼"
           },
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_57.015┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (14)",
+            "Name": "SolidPlasmaSheet (13)",
             "LocalPRS": "57.015┼257┼0┼"
           },
           {
             "GitID": "25108e21a69d52c46a538e66eb85db0a_57.016┼257┼0┼",
             "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
-            "Name": "SolidPlasmaSheet (15)",
+            "Name": "SolidPlasmaSheet (14)",
             "LocalPRS": "57.016┼257┼0┼"
+          },
+          {
+            "GitID": "25108e21a69d52c46a538e66eb85db0a_57.02┼257┼0┼",
+            "PrefabID": "25108e21a69d52c46a538e66eb85db0a",
+            "Name": "SolidPlasmaSheet (15)",
+            "LocalPRS": "57.02┼257┼0┼"
           },
           {
             "GitID": "6015d5ca578d27b43b1c649384760954_57.05┼210.09┼0┼",
@@ -269067,30 +268739,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_59┼207┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_59┼207┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "59┼207┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "aace53907327f6f498d31ca3cb14ed4d"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "59┼207┼0┼"
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_59┼207┼0┼",
@@ -271446,18 +271098,6 @@
             "LocalPRS": "60.004┼268┼0┼"
           },
           {
-            "GitID": "2c62bf4b8bd1b13409822a00ad8cb214_60.007┼268┼0┼",
-            "PrefabID": "2c62bf4b8bd1b13409822a00ad8cb214",
-            "Name": "FuelRod (1)",
-            "LocalPRS": "60.007┼268┼0┼"
-          },
-          {
-            "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_60.007┼268┼0┼",
-            "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
-            "Name": "ControlRod (9)",
-            "LocalPRS": "60.007┼268┼0┼"
-          },
-          {
             "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_60.008┼268┼0┼",
             "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
             "Name": "ControlRod (10)",
@@ -271472,26 +271112,38 @@
           {
             "GitID": "2c62bf4b8bd1b13409822a00ad8cb214_60.01┼268┼0┼",
             "PrefabID": "2c62bf4b8bd1b13409822a00ad8cb214",
-            "Name": "FuelRod (2)",
+            "Name": "FuelRod (1)",
             "LocalPRS": "60.01┼268┼0┼"
           },
           {
             "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_60.01┼268┼0┼",
             "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
-            "Name": "ControlRod (8)",
+            "Name": "ControlRod (9)",
             "LocalPRS": "60.01┼268┼0┼"
           },
           {
             "GitID": "2c62bf4b8bd1b13409822a00ad8cb214_60.011┼268┼0┼",
             "PrefabID": "2c62bf4b8bd1b13409822a00ad8cb214",
-            "Name": "FuelRod (3)",
+            "Name": "FuelRod (2)",
             "LocalPRS": "60.011┼268┼0┼"
           },
           {
             "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_60.011┼268┼0┼",
             "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
-            "Name": "ControlRod (7)",
+            "Name": "ControlRod (8)",
             "LocalPRS": "60.011┼268┼0┼"
+          },
+          {
+            "GitID": "2c62bf4b8bd1b13409822a00ad8cb214_60.012┼268┼0┼",
+            "PrefabID": "2c62bf4b8bd1b13409822a00ad8cb214",
+            "Name": "FuelRod (3)",
+            "LocalPRS": "60.012┼268┼0┼"
+          },
+          {
+            "GitID": "f035a877ddd6fa8458a3ad86fd4069ee_60.012┼268┼0┼",
+            "PrefabID": "f035a877ddd6fa8458a3ad86fd4069ee",
+            "Name": "ControlRod (7)",
+            "LocalPRS": "60.012┼268┼0┼"
           },
           {
             "GitID": "3edf81f4a32c4c348bad5bfe43e263fd_60.13┼204.08┼0┼",
@@ -272897,29 +272549,10 @@
             "LocalPRS": "61┼246┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_61┼250┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_61┼250┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (10)",
-            "LocalPRS": "61┼250┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "c42540cf1f836b9408645b8e65574c64"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "61┼250┼0┼"
           },
           {
             "GitID": "56207cafd3f8d8549b442fe7b1ad7777_61┼253┼0┼",
@@ -274023,29 +273656,10 @@
             "LocalPRS": "62┼207┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_62┼216┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_62┼216┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (3)",
-            "LocalPRS": "62┼216┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "58e19f5e1f96aca4e831c3dc97d67781"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "62┼216┼0┼"
           },
           {
             "GitID": "ce971a77eb7c2894e8583efec1c56965_62┼218┼0┼",
@@ -275324,29 +274938,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_63┼192┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_63┼192┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (7)",
-            "LocalPRS": "63┼192┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "8fa53d06c952b3646a5c799fd39806c3"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "63┼192┼0┼"
           },
           {
             "GitID": "c21551dd992a57349973e4b5af103ca6_63┼194┼0┼",
@@ -278745,30 +278340,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_65┼232┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_65┼232┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "65┼232┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "2a90bceb663133a4493375ad0daf719c"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "65┼232┼0┼"
           },
           {
             "GitID": "d683da3ad01cc02479a3ac6df782c111_65┼234.24┼0┼",
@@ -281431,30 +281006,10 @@
             "LocalPRS": "67┼168┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_67┼171┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_67┼171┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "67┼171┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "58e19f5e1f96aca4e831c3dc97d67781"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "67┼171┼0┼"
           },
           {
             "GitID": "c21551dd992a57349973e4b5af103ca6_67┼174┼0┼",
@@ -281534,29 +281089,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_67┼177┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_67┼177┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (20)",
-            "LocalPRS": "67┼177┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "b48a3709120744b4fb993541ac80ccf4"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "67┼177┼0┼"
           },
           {
             "GitID": "c80393b4412660b41937e05425ceb921_67┼179┼0┼",
@@ -281709,29 +281245,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_67┼183┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_67┼183┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (19)",
-            "LocalPRS": "67┼183┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "780b29e5202931c47951b3b389d231a1"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "67┼183┼0┼"
           },
           {
             "GitID": "1a00e842e154f7d43811c5d45328988c_67┼185┼0┼",
@@ -290733,82 +290250,16 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_74┼211┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_74┼211┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (13)",
-            "LocalPRS": "74┼211┼0┼",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "ItemAttributesV2@0",
-                  "Data": [
-                    {
-                      "Name": "inventoryMoveSound@AssetAddress",
-                      "Data": "null"
-                    },
-                    {
-                      "Name": "inventoryRemoveSound@AssetAddress",
-                      "Data": "null"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "a02cb7685269db14ba4ee98f89ffdf4f"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "74┼211┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_74┼219┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_74┼219┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (14)",
-            "LocalPRS": "74┼219┼0┼",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "ItemAttributesV2@0",
-                  "Data": [
-                    {
-                      "Name": "inventoryMoveSound@AssetAddress",
-                      "Data": "null"
-                    },
-                    {
-                      "Name": "inventoryRemoveSound@AssetAddress",
-                      "Data": "null"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "9459b9918b0083842a221474925da005"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "74┼219┼0┼"
           },
           {
             "GitID": "91d832be818283a4188516804e8d5ef0_74┼220┼0┼",
@@ -293177,29 +292628,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_76┼192┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_76┼192┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (22)",
-            "LocalPRS": "76┼192┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "58e19f5e1f96aca4e831c3dc97d67781"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "76┼192┼0┼"
           },
           {
             "GitID": "41432e034ee6b30418de8668905d7fd1_76┼195┼0┼",
@@ -293375,29 +292807,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_76┼221┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_76┼221┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (12)",
-            "LocalPRS": "76┼221┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "7327ccd49186c1c42bbd651d4d6287c2"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "76┼221┼0┼"
           },
           {
             "GitID": "f2432d244a6b7774ea00ff013beb7dcb_76┼222┼0┼",
@@ -299269,30 +298682,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_81┼237┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_81┼237┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "81┼237┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "9459b9918b0083842a221474925da005"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "81┼237┼0┼"
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_81┼237┼0┼",
@@ -299565,54 +298958,16 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_82┼189┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_82┼189┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (17)",
-            "LocalPRS": "82┼189┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "641427c814c42e048bb8c536e8597a57"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "82┼189┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_82┼198┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_82┼198┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (18)",
-            "LocalPRS": "82┼198┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "58e19f5e1f96aca4e831c3dc97d67781"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "82┼198┼0┼"
           },
           {
             "GitID": "c21551dd992a57349973e4b5af103ca6_82┼205┼0┼",
@@ -301772,29 +301127,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_84┼207┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_84┼207┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (15)",
-            "LocalPRS": "84┼207┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "ec71b74dd533c4e4bb3eba5358a09cd2"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "84┼207┼0┼"
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_84┼207┼0┼",
@@ -305325,29 +304661,10 @@
             "LocalPRS": "88┼235┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_88┼237┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_88┼237┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (11)",
-            "LocalPRS": "88┼237┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "8fa53d06c952b3646a5c799fd39806c3"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "88┼237┼0┼"
           },
           {
             "GitID": "c21551dd992a57349973e4b5af103ca6_88┼255┼0┼",
@@ -308395,29 +307712,10 @@
             "LocalPRS": "94┼217┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_94┼219┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_94┼219┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (16)",
-            "LocalPRS": "94┼219┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "75d610e14a60e7d43b2720cede2925ef"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "94┼219┼0┼"
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_94┼223┼0┼",
@@ -317508,7 +316806,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -319279,7 +318577,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -323103,7 +322401,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -326896,30 +326194,10 @@
             "LocalPRS": "50┼-4┼0┼0ø0ø270ø"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_51┼-13┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_51┼-13┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "51┼-13┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "fad97914a675f2c48ba0ca4c0afe6450"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "51┼-13┼0┼"
           },
           {
             "GitID": "91d832be818283a4188516804e8d5ef0_51┼-9┼0┼",
@@ -328467,7 +327745,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -330135,7 +329413,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/SquareStation.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/SquareStation.json
@@ -141661,7 +141661,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -151402,30 +151402,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_49┼44┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_49┼44┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "49┼44┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "735947d90f766f449b4132229640fd8d"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "49┼44┼0┼"
           },
           {
             "GitID": "c21551dd992a57349973e4b5af103ca6_49┼45┼0┼",
@@ -153146,30 +153126,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_50┼103┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_50┼103┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "50┼103┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "58e19f5e1f96aca4e831c3dc97d67781"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "50┼103┼0┼"
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_50┼104┼0┼",
@@ -153221,30 +153181,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_50┼105┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_50┼105┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "50┼105┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "735947d90f766f449b4132229640fd8d"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "50┼105┼0┼"
           },
           {
             "GitID": "f2441585d37f1914395df59a57c5e925_50┼109┼0┼",
@@ -162651,30 +162591,10 @@
             "LocalPRS": "59┼110┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_59┼112┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_59┼112┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "59┼112┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "a686f645ff5ffe64e9130ddc623705df"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "59┼112┼0┼"
           },
           {
             "GitID": "bdae81f88094e1b4e909f4b7911be203_59┼141┼0┼",
@@ -163960,30 +163880,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_61┼137┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_61┼137┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "61┼137┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "735947d90f766f449b4132229640fd8d"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "61┼137┼0┼"
           },
           {
             "GitID": "c21551dd992a57349973e4b5af103ca6_61┼140┼0┼",
@@ -164237,30 +164137,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_62┼39┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_62┼39┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "62┼39┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "a686f645ff5ffe64e9130ddc623705df"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "62┼39┼0┼"
           },
           {
             "GitID": "c21551dd992a57349973e4b5af103ca6_62┼39┼0┼",
@@ -166701,30 +166581,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_64┼107┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_64┼107┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "64┼107┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "75d610e14a60e7d43b2720cede2925ef"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "64┼107┼0┼"
           },
           {
             "GitID": "959aef1c36706b7428a7e700a978e648_64┼111┼0┼",
@@ -167153,44 +167013,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_65┼94┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_65┼94┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "65┼94┼0┼",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "ItemAttributesV2@0",
-                  "Data": [
-                    {
-                      "Name": "inventoryMoveSound@AssetAddress",
-                      "Data": "null"
-                    },
-                    {
-                      "Name": "inventoryRemoveSound@AssetAddress",
-                      "Data": "null"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "ec71b74dd533c4e4bb3eba5358a09cd2"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "65┼94┼0┼"
           },
           {
             "GitID": "c04905100b9b3d746ad50b5a62efe998_65┼97┼0┼",
@@ -168213,30 +168039,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_66┼132┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_66┼132┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "66┼132┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "780b29e5202931c47951b3b389d231a1"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "66┼132┼0┼"
           },
           {
             "GitID": "1a00e842e154f7d43811c5d45328988c_66┼133┼0┼",
@@ -172476,30 +172282,10 @@
             "LocalPRS": "74┼122┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_74┼124┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_74┼124┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "74┼124┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "2a90bceb663133a4493375ad0daf719c"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "74┼124┼0┼"
           },
           {
             "GitID": "9203bf917337c3e4db0a64a10ef0e50b_74┼127┼0┼",
@@ -174480,30 +174266,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_83┼108┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_83┼108┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "83┼108┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "9459b9918b0083842a221474925da005"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "83┼108┼0┼"
           },
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_83┼108┼0┼",
@@ -175026,30 +174792,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_84┼132┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_84┼132┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "84┼132┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "de09cd0271850d942bb3705a8d815390"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "84┼132┼0┼"
           },
           {
             "GitID": "1a00e842e154f7d43811c5d45328988c_84┼133┼0┼",
@@ -178115,30 +177861,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_88┼76┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_88┼76┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "88┼76┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "9be5b6a895571524f849570158129637"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "88┼76┼0┼"
           },
           {
             "GitID": "c21551dd992a57349973e4b5af103ca6_88┼95┼0┼",
@@ -180676,30 +180402,10 @@
             "LocalPRS": "90.84┼101.2┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_90.97┼111.99┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_90.97┼111.99┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "90.97┼111.99┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "a02cb7685269db14ba4ee98f89ffdf4f"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "90.97┼111.99┼0┼"
           },
           {
             "GitID": "9f6a082ba93c5684b808b09619c08044_91┼65┼0┼",
@@ -180759,30 +180465,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_91┼70┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_91┼70┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "91┼70┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "735947d90f766f449b4132229640fd8d"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "91┼70┼0┼"
           },
           {
             "GitID": "ddcfc3ab784dec1419565255774956c5_91┼96┼0┼",
@@ -181327,30 +181013,10 @@
             "LocalPRS": "91.87┼149.02┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_91.99┼101.99┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_91.99┼101.99┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "91.99┼101.99┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "5f3d9026e8621e64f9e29bd4018ea911"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "91.99┼101.99┼0┼"
           },
           {
             "GitID": "9f6a082ba93c5684b808b09619c08044_92┼48┼0┼",
@@ -183873,30 +183539,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_94┼145┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_94┼145┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "94┼145┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "7f666d019f23e24419c4bfd8d03a165e"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "94┼145┼0┼"
           },
           {
             "GitID": "29107a3e6fd05d34c864ad077d34bafc_94┼149┼0┼",
@@ -188165,30 +187811,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_98┼147┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_98┼147┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "98┼147┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "af4cef8aa7a68b74f8e5aeffa5dd8dbc"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "98┼147┼0┼"
           },
           {
             "GitID": "29107a3e6fd05d34c864ad077d34bafc_98┼151┼0┼",
@@ -189908,30 +189534,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_100┼132┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_100┼132┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "100┼132┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "780b29e5202931c47951b3b389d231a1"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "100┼132┼0┼"
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_100┼137┼0┼",
@@ -190198,30 +189804,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_100┼152┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_100┼152┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "100┼152┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "75d610e14a60e7d43b2720cede2925ef"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "100┼152┼0┼"
           },
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_100┼152┼0┼",
@@ -191101,30 +190687,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_101┼145┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_101┼145┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "101┼145┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "c42540cf1f836b9408645b8e65574c64"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "101┼145┼0┼"
           },
           {
             "GitID": "c21551dd992a57349973e4b5af103ca6_101┼145┼0┼",
@@ -191649,56 +191215,16 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_102┼93.97┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_102┼93.97┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "102┼93.97┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "2a90bceb663133a4493375ad0daf719c"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "102┼93.97┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_102┼99┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_102┼99┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "102┼99┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "824fb6fa4d185624f9f89e8ed8e2831c"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "102┼99┼0┼"
           },
           {
             "GitID": "51c0e5d18b9c1fa44badeb798e344d05_102┼100┼0┼",
@@ -192962,30 +192488,10 @@
             "LocalPRS": "104┼53┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_104┼55┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_104┼55┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "104┼55┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "8fa53d06c952b3646a5c799fd39806c3"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "104┼55┼0┼"
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_104┼55┼0┼",
@@ -193084,30 +192590,10 @@
             "LocalPRS": "104┼73┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_104┼76┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_104┼76┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "104┼76┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "ec71b74dd533c4e4bb3eba5358a09cd2"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "104┼76┼0┼"
           },
           {
             "GitID": "91d832be818283a4188516804e8d5ef0_104┼95┼0┼",
@@ -193414,30 +192900,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_104┼132┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_104┼132┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "104┼132┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "a8f565955a2addb4ab79549b97a0d5d7"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "104┼132┼0┼"
           },
           {
             "GitID": "ce7cba87749bfec438e125938f489ca6_104┼134┼0┼",
@@ -194308,30 +193774,10 @@
             "LocalPRS": "108┼124┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_108┼146┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_108┼146┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "108┼146┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "735947d90f766f449b4132229640fd8d"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "108┼146┼0┼"
           },
           {
             "GitID": "5a7af30c589b41a449d0ba74c9e1771c_108┼149┼0┼",
@@ -194634,30 +194080,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_109┼120┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_109┼120┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "109┼120┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "a686f645ff5ffe64e9130ddc623705df"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "109┼120┼0┼"
           },
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_109┼120┼0┼",
@@ -196847,30 +196273,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_116┼39┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_116┼39┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "116┼39┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "824fb6fa4d185624f9f89e8ed8e2831c"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "116┼39┼0┼"
           },
           {
             "GitID": "bb684284e149a524d9f53b039e51b806_116┼42┼0┼",
@@ -197714,30 +197120,10 @@
             "LocalPRS": "118┼124┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_118┼146┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_118┼146┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "118┼146┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "75d610e14a60e7d43b2720cede2925ef"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "118┼146┼0┼"
           },
           {
             "GitID": "5a7af30c589b41a449d0ba74c9e1771c_118┼149┼0┼",
@@ -198915,30 +198301,10 @@
             "LocalPRS": "122┼115┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_122┼132┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_122┼132┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "122┼132┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "5f3d9026e8621e64f9e29bd4018ea911"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "122┼132┼0┼"
           },
           {
             "GitID": "8f82edb9563c8d049a32cc719373b968_122┼134┼0┼",
@@ -198947,30 +198313,10 @@
             "LocalPRS": "122┼134┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_122┼136┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_122┼136┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "122┼136┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "9459b9918b0083842a221474925da005"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "122┼136┼0┼"
           },
           {
             "GitID": "2c62bf4b8bd1b13409822a00ad8cb214_122.91┼59.06┼0┼",
@@ -200214,30 +199560,10 @@
             "LocalPRS": "124┼132┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_124┼145┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_124┼145┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "124┼145┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "c42540cf1f836b9408645b8e65574c64"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "124┼145┼0┼"
           },
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_124┼145┼0┼",
@@ -200303,30 +199629,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_124┼150┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_124┼150┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "124┼150┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "cca234472b9754542a39bfecb0e0ceea"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "124┼150┼0┼"
           },
           {
             "GitID": "3edf81f4a32c4c348bad5bfe43e263fd_124.83┼109.14┼0┼",
@@ -206046,30 +205352,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_131.01┼146┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_131.01┼146┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "131.01┼146┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "110d065ad23466d428883eadbb80ceb0"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "131.01┼146┼0┼"
           },
           {
             "GitID": "025f9c4810685f645804eb0b80b1b0ed_131.07┼56.86┼0┼",
@@ -207788,30 +207074,10 @@
             "LocalPRS": "132.92┼56.05┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_132.98┼150.02┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_132.98┼150.02┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "132.98┼150.02┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "c42540cf1f836b9408645b8e65574c64"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "132.98┼150.02┼0┼"
           },
           {
             "GitID": "3edf81f4a32c4c348bad5bfe43e263fd_132.99┼140.12┼0┼",
@@ -211389,30 +210655,10 @@
             "LocalPRS": "135┼138┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_135┼140┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_135┼140┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "135┼140┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "735947d90f766f449b4132229640fd8d"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "135┼140┼0┼"
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_135┼142┼0┼",
@@ -217636,30 +216882,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_142┼97┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_142┼97┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "142┼97┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "cca234472b9754542a39bfecb0e0ceea"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "142┼97┼0┼"
           },
           {
             "GitID": "1a00e842e154f7d43811c5d45328988c_142┼99┼0┼",
@@ -224019,7 +223245,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -224867,30 +224093,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_43┼-13┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_43┼-13┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "43┼-13┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "824fb6fa4d185624f9f89e8ed8e2831c"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "43┼-13┼0┼"
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_43┼-9┼0┼",
@@ -226424,30 +225630,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_53┼-13┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
-            "NameMatches": true,
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_53┼-13┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
-            "LocalPRS": "53┼-13┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "2a90bceb663133a4493375ad0daf719c"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "53┼-13┼0┼"
           },
           {
             "GitID": "67c1a2e93881ef1479a466ad4ee872eb_53┼-7┼0┼",
@@ -227412,7 +226598,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -228329,7 +227515,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -229651,7 +228837,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -230978,7 +230164,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -232914,7 +232100,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/UnRealStation.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/UnRealStation.json
@@ -113383,7 +113383,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -118326,29 +118326,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_7.91┼69.18┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_7.91┼69.18┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (8)",
-            "LocalPRS": "7.91┼69.18┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "a02cb7685269db14ba4ee98f89ffdf4f"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "7.91┼69.18┼0┼"
           },
           {
             "GitID": "e58e1fd483fe772468ad2aab4259397d_7.98┼48.02┼0┼",
@@ -124019,29 +124000,10 @@
             "LocalPRS": "19.07┼83.22┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_19.1┼42.13┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_19.1┼42.13┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (9)",
-            "LocalPRS": "19.1┼42.13┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "fad97914a675f2c48ba0ca4c0afe6450"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "19.1┼42.13┼0┼"
           },
           {
             "GitID": "e33403c0371fc174aa03640734665a15_19.4┼88.32┼0┼",
@@ -124424,29 +124386,10 @@
             "LocalPRS": "20.96┼88.17┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_20.97┼42.03┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_20.97┼42.03┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (10)",
-            "LocalPRS": "20.97┼42.03┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "7f666d019f23e24419c4bfd8d03a165e"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "20.97┼42.03┼0┼"
           },
           {
             "GitID": "2fc845c9458dc2a4cac1698d1d500af9_21┼12┼0┼",
@@ -127155,29 +127098,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_24.98┼65.04┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_24.98┼65.04┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (7)",
-            "LocalPRS": "24.98┼65.04┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "aace53907327f6f498d31ca3cb14ed4d"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "24.98┼65.04┼0┼"
           },
           {
             "GitID": "3edf81f4a32c4c348bad5bfe43e263fd_24.98┼89.02┼0┼",
@@ -129721,29 +129645,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_27.97┼29.06┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_27.97┼29.06┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (11)",
-            "LocalPRS": "27.97┼29.06┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "780b29e5202931c47951b3b389d231a1"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "27.97┼29.06┼0┼"
           },
           {
             "GitID": "bdee015617db52248b97de650920e2c0_27.97┼34.02┼0┼",
@@ -131341,29 +131246,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_29.45┼65.17┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_29.45┼65.17┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (6)",
-            "LocalPRS": "29.45┼65.17┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "a02cb7685269db14ba4ee98f89ffdf4f"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "29.45┼65.17┼0┼"
           },
           {
             "GitID": "e58e1fd483fe772468ad2aab4259397d_29.92┼34.15┼0┼",
@@ -135761,29 +135647,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_35.95┼31.1┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_35.95┼31.1┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (12)",
-            "LocalPRS": "35.95┼31.1┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "aace53907327f6f498d31ca3cb14ed4d"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "35.95┼31.1┼0┼"
           },
           {
             "GitID": "856296105f077014ca9e533266df237a_36┼11┼0┼",
@@ -136387,29 +136254,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_36.02┼114┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_36.02┼114┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (1)",
-            "LocalPRS": "36.02┼114┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "a8f565955a2addb4ab79549b97a0d5d7"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "36.02┼114┼0┼"
           },
           {
             "GitID": "e58e1fd483fe772468ad2aab4259397d_36.96┼61.02┼0┼",
@@ -139492,29 +139340,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_40.96┼83.73┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_40.96┼83.73┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (3)",
-            "LocalPRS": "40.96┼83.73┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "824fb6fa4d185624f9f89e8ed8e2831c"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "40.96┼83.73┼0┼"
           },
           {
             "GitID": "856296105f077014ca9e533266df237a_41┼11┼0┼",
@@ -142045,29 +141874,10 @@
             }
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_44┼113.95┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_44┼113.95┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (2)",
-            "LocalPRS": "44┼113.95┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "110d065ad23466d428883eadbb80ceb0"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "44┼113.95┼0┼"
           },
           {
             "GitID": "032e150131f53a64fbf6048aca6a879a_44.96┼63.04┼0┼",
@@ -144969,29 +144779,10 @@
             "LocalPRS": "48.01┼35.87┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_48.01┼38.03┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_48.01┼38.03┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (13)",
-            "LocalPRS": "48.01┼38.03┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "9be5b6a895571524f849570158129637"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "48.01┼38.03┼0┼"
           },
           {
             "GitID": "1a1b6f4ded6f86441bbb000972ea2089_48.01┼47.86┼0┼",
@@ -145062,29 +144853,10 @@
             "LocalPRS": "48.9┼84.12┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_48.96┼44.06┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_48.96┼44.06┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (14)",
-            "LocalPRS": "48.96┼44.06┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "de09cd0271850d942bb3705a8d815390"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "48.96┼44.06┼0┼"
           },
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_49┼15┼0┼",
@@ -146776,54 +146548,16 @@
             "LocalPRS": "50┼116┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_50.02┼77.01┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_50.02┼77.01┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (5)",
-            "LocalPRS": "50.02┼77.01┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "af4cef8aa7a68b74f8e5aeffa5dd8dbc"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "50.02┼77.01┼0┼"
           },
           {
-            "GitID": "bd0b61b5f22871e40bdf20387ae9d642_50.02┼78.95┼0┼",
-            "PrefabID": "bd0b61b5f22871e40bdf20387ae9d642",
+            "GitID": "86570587e3d5cba1e9ffdeead16603e4_50.02┼78.95┼0┼",
+            "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom (4)",
-            "LocalPRS": "50.02┼78.95┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "aace53907327f6f498d31ca3cb14ed4d"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "50.02┼78.95┼0┼"
           },
           {
             "GitID": "0d3043f6d48ca14478534a739fb01782_50.03┼51.86┼0┼",
@@ -162745,7 +162479,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -164873,7 +164607,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -165209,7 +164943,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -165797,7 +165531,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -166917,7 +166651,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -168925,7 +168659,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -171915,7 +171649,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {


### PR DESCRIPTION
### Purpose
replace old (variable-sprite) random potted plant prefab with new (spawner) version in maps

### Notes:
will delete old prefab in a separate PR

### Changelog:
CL: [Improvement] Randomized potted plants now come in many more varieties and ones that are supposed to glow or have other distinct properties will now do so.