### PR TITLE
file metadata

### DIFF
--- a/UnityProject/Assets/Textures/items/bureaucracy/paperaged0.asset
+++ b/UnityProject/Assets/Textures/items/bureaucracy/paperaged0.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: paperaged0
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: d4d4648c18fe56eafa2a5d6f881064bb
   Variance:
   - Frames:
     - sprite: {fileID: 4693417965594183325, guid: 441600e37c7f4ccf4be1129d87c7ddf8,

--- a/UnityProject/Assets/Textures/items/bureaucracy/paperaged1.asset
+++ b/UnityProject/Assets/Textures/items/bureaucracy/paperaged1.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: paperaged1
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: 8b6abc443702cfbafb268f354f24def8
   Variance:
   - Frames:
     - sprite: {fileID: -7055985836973681252, guid: 441600e37c7f4ccf4be1129d87c7ddf8,

--- a/UnityProject/Assets/Textures/items/bureaucracy/paperaged_bloody.asset
+++ b/UnityProject/Assets/Textures/items/bureaucracy/paperaged_bloody.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: paperaged_bloody
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: 64232cfdeb22ac196b0c6be9643b6f68
   Variance:
   - Frames:
     - sprite: {fileID: -828322475, guid: 441600e37c7f4ccf4be1129d87c7ddf8, type: 3}

--- a/UnityProject/Assets/Textures/items/bureaucracy/paperaged_torn.asset
+++ b/UnityProject/Assets/Textures/items/bureaucracy/paperaged_torn.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: paperaged_torn
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: cbd8727ad5b3fc851aa0cd38f6469405
   Variance:
   - Frames:
     - sprite: {fileID: -7712671023250068437, guid: 441600e37c7f4ccf4be1129d87c7ddf8,

--- a/UnityProject/Assets/Textures/items/bureaucracy/papercrumpled.asset
+++ b/UnityProject/Assets/Textures/items/bureaucracy/papercrumpled.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: papercrumpled
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: b51c14d5d729926f28d7463c427a2afe
   Variance:
   - Frames:
     - sprite: {fileID: -6095409518775050255, guid: 6862ae2b3d58b4960b2ee48bd37741cd,

--- a/UnityProject/Assets/Textures/items/bureaucracy/papercrumpled0.asset
+++ b/UnityProject/Assets/Textures/items/bureaucracy/papercrumpled0.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: papercrumpled0
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: caf38aac560c00a20b493118bb753ba6
   Variance:
   - Frames:
     - sprite: {fileID: -6095409518775050255, guid: 6862ae2b3d58b4960b2ee48bd37741cd,

--- a/UnityProject/Assets/Textures/items/bureaucracy/papercrumpled1.asset
+++ b/UnityProject/Assets/Textures/items/bureaucracy/papercrumpled1.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: papercrumpled1
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: 71b1d8f3522aa7ca886bd1803f7c267e
   Variance:
   - Frames:
     - sprite: {fileID: 6939897008621192275, guid: 6862ae2b3d58b4960b2ee48bd37741cd,

--- a/UnityProject/Assets/Textures/items/bureaucracy/papercult0.asset
+++ b/UnityProject/Assets/Textures/items/bureaucracy/papercult0.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: papercult0
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: 12741bfcce11b87afa70254a936477c2
   Variance:
   - Frames:
     - sprite: {fileID: -7281757579086998148, guid: f24a92f340bd97a0991efe5c6cbcd3ab,

--- a/UnityProject/Assets/Textures/items/bureaucracy/papercult1.asset
+++ b/UnityProject/Assets/Textures/items/bureaucracy/papercult1.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: papercult1
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: b684fac9e196d6926aba58885f7d3945
   Variance:
   - Frames:
     - sprite: {fileID: 7080538410098202182, guid: f24a92f340bd97a0991efe5c6cbcd3ab,

--- a/UnityProject/Assets/Textures/items/bureaucracy/scroll0.asset
+++ b/UnityProject/Assets/Textures/items/bureaucracy/scroll0.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: scroll0
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: 99388c50b3a352a679903bfec6c6781c
   Variance:
   - Frames:
     - sprite: {fileID: -519052415876542791, guid: 2780748c58b422c01b28976b30c0e42e,

--- a/UnityProject/Assets/Textures/items/bureaucracy/scroll1.asset
+++ b/UnityProject/Assets/Textures/items/bureaucracy/scroll1.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: scroll1
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: 24f6d6ff41e23586ba79f6fa7cde19ba
   Variance:
   - Frames:
     - sprite: {fileID: 4792454202395124893, guid: 2780748c58b422c01b28976b30c0e42e,

--- a/UnityProject/Assets/Textures/objects/chairs/woodenthrone.asset
+++ b/UnityProject/Assets/Textures/objects/chairs/woodenthrone.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: woodenthrone
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: 2809872d840db864ab4d09097fb237ec
   Variance:
   - Frames:
     - sprite: {fileID: 5754102103422029663, guid: 7269724c2b6c314df965aece760fdb7e,

--- a/UnityProject/Assets/Textures/objects/dead bodies/deadbody.asset
+++ b/UnityProject/Assets/Textures/objects/dead bodies/deadbody.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: deadbody
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: de792b23180b47d388f926716283d07e
   Variance:
   - Frames:
     - sprite: {fileID: 100915257935432836, guid: 2ed413727f1b5a4db98703e9d2e643b5,

--- a/UnityProject/Assets/Textures/objects/dead bodies/deadbody1.asset
+++ b/UnityProject/Assets/Textures/objects/dead bodies/deadbody1.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: deadbody1
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: 1f52a556c7262b4b88a236e04002077d
   Variance:
   - Frames:
     - sprite: {fileID: -8513517338123875131, guid: 2ed413727f1b5a4db98703e9d2e643b5,

--- a/UnityProject/Assets/Textures/objects/doors/false walls/shuttle/shuttle_fwall_closing.png.meta
+++ b/UnityProject/Assets/Textures/objects/doors/false walls/shuttle/shuttle_fwall_closing.png.meta
@@ -18,7 +18,7 @@ TextureImporter:
       213: 21300008
     second: fwall_closing_4
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -82,7 +82,7 @@ TextureImporter:
   swizzle: 50462976
   cookieLightType: 1
   platformSettings:
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -92,9 +92,10 @@ TextureImporter:
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
+    ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 1
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: Standalone
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -104,9 +105,10 @@ TextureImporter:
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
+    ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 1
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: Server
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -116,6 +118,7 @@ TextureImporter:
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
+    ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 1
   spriteSheet:
@@ -132,6 +135,7 @@ TextureImporter:
       alignment: 0
       pivot: {x: 0, y: 0}
       border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
       outline: []
       physicsShape: []
       tessellationDetail: 0
@@ -153,6 +157,7 @@ TextureImporter:
       alignment: 0
       pivot: {x: 0, y: 0}
       border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
       outline: []
       physicsShape: []
       tessellationDetail: 0
@@ -174,6 +179,7 @@ TextureImporter:
       alignment: 0
       pivot: {x: 0, y: 0}
       border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
       outline: []
       physicsShape: []
       tessellationDetail: 0
@@ -195,6 +201,7 @@ TextureImporter:
       alignment: 0
       pivot: {x: 0, y: 0}
       border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
       outline: []
       physicsShape: []
       tessellationDetail: 0
@@ -216,6 +223,7 @@ TextureImporter:
       alignment: 0
       pivot: {x: 0, y: 0}
       border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
       outline: []
       physicsShape: []
       tessellationDetail: 0
@@ -227,6 +235,7 @@ TextureImporter:
       edges: []
       weights: []
     outline: []
+    customData: 
     physicsShape: []
     bones: []
     spriteID: 280b93732caf29f42b334a277f625760
@@ -236,6 +245,8 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    spriteCustomMetadata:
+      entries: []
     nameFileIdTable:
       fwall_closing_0: 21300000
       fwall_closing_1: 21300002

--- a/UnityProject/Assets/Textures/objects/doors/false walls/shuttle/shuttle_fwall_open.png.meta
+++ b/UnityProject/Assets/Textures/objects/doors/false walls/shuttle/shuttle_fwall_open.png.meta
@@ -3,7 +3,7 @@ guid: f933b8b826488ab489db04ae848067fb
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -67,7 +67,7 @@ TextureImporter:
   swizzle: 50462976
   cookieLightType: 1
   platformSettings:
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -77,9 +77,10 @@ TextureImporter:
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
+    ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 1
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: Standalone
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -89,9 +90,10 @@ TextureImporter:
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
+    ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 1
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: Server
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -101,12 +103,14 @@ TextureImporter:
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
+    ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 1
   spriteSheet:
     serializedVersion: 2
     sprites: []
     outline: []
+    customData: 
     physicsShape: []
     bones: []
     spriteID: c6ca1fe9de45a2945a18997595334da7
@@ -116,6 +120,8 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    spriteCustomMetadata:
+      entries: []
     nameFileIdTable: {}
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0

--- a/UnityProject/Assets/Textures/objects/doors/false walls/shuttle/shuttle_fwall_opening.png.meta
+++ b/UnityProject/Assets/Textures/objects/doors/false walls/shuttle/shuttle_fwall_opening.png.meta
@@ -18,7 +18,7 @@ TextureImporter:
       213: 21300008
     second: fwall_opening_4
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -82,7 +82,7 @@ TextureImporter:
   swizzle: 50462976
   cookieLightType: 1
   platformSettings:
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -92,9 +92,10 @@ TextureImporter:
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
+    ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 1
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: Standalone
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -104,9 +105,10 @@ TextureImporter:
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
+    ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 1
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: Server
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -116,6 +118,7 @@ TextureImporter:
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
+    ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 1
   spriteSheet:
@@ -132,6 +135,7 @@ TextureImporter:
       alignment: 0
       pivot: {x: 0, y: 0}
       border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
       outline: []
       physicsShape: []
       tessellationDetail: 0
@@ -153,6 +157,7 @@ TextureImporter:
       alignment: 0
       pivot: {x: 0, y: 0}
       border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
       outline: []
       physicsShape: []
       tessellationDetail: 0
@@ -174,6 +179,7 @@ TextureImporter:
       alignment: 0
       pivot: {x: 0, y: 0}
       border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
       outline: []
       physicsShape: []
       tessellationDetail: 0
@@ -195,6 +201,7 @@ TextureImporter:
       alignment: 0
       pivot: {x: 0, y: 0}
       border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
       outline: []
       physicsShape: []
       tessellationDetail: 0
@@ -216,6 +223,7 @@ TextureImporter:
       alignment: 0
       pivot: {x: 0, y: 0}
       border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
       outline: []
       physicsShape: []
       tessellationDetail: 0
@@ -227,6 +235,7 @@ TextureImporter:
       edges: []
       weights: []
     outline: []
+    customData: 
     physicsShape: []
     bones: []
     spriteID: 280b93732caf29f42b334a277f625760
@@ -236,6 +245,8 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    spriteCustomMetadata:
+      entries: []
     nameFileIdTable:
       fwall_opening_0: 21300000
       fwall_opening_1: 21300002

--- a/UnityProject/Assets/Textures/objects/flora/rocks/grey_stalagmite1.asset
+++ b/UnityProject/Assets/Textures/objects/flora/rocks/grey_stalagmite1.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: grey_stalagmite1
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: 13945cee4ca56de0eaa9cff2bd8cdb11
   Variance:
   - Frames:
     - sprite: {fileID: 21300000, guid: fcb67fc2d6ce1b8069cd3ec2d05755e3, type: 3}

--- a/UnityProject/Assets/Textures/objects/flora/rocks/grey_stalagmite2.asset
+++ b/UnityProject/Assets/Textures/objects/flora/rocks/grey_stalagmite2.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: grey_stalagmite2
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: 71382e6576e1400e5820656692d9491e
   Variance:
   - Frames:
     - sprite: {fileID: 21300000, guid: b18cb69afdb8e3e22a5eb0c137603698, type: 3}

--- a/UnityProject/Assets/Textures/objects/flora/rocks/grey_stalagmite3.asset
+++ b/UnityProject/Assets/Textures/objects/flora/rocks/grey_stalagmite3.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: grey_stalagmite3
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: bd383852756c690ccb9f56e44a1d214f
   Variance:
   - Frames:
     - sprite: {fileID: 21300000, guid: 45c2fbe7f203504a8b5f267e9b723a67, type: 3}

--- a/UnityProject/Assets/Textures/objects/flora/rocks/grey_stalagmite4.asset
+++ b/UnityProject/Assets/Textures/objects/flora/rocks/grey_stalagmite4.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: grey_stalagmite4
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: 1cebd242db467316ebecf2bd713538c5
   Variance:
   - Frames:
     - sprite: {fileID: 21300000, guid: 5b879f1fdeaa0fc7ebf5fcc813f3e33e, type: 3}

--- a/UnityProject/Assets/Textures/objects/flora/rocks/grey_stalagmite5.asset
+++ b/UnityProject/Assets/Textures/objects/flora/rocks/grey_stalagmite5.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: grey_stalagmite5
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: 1b3983b30e1e4e18ab020175a7e80c29
   Variance:
   - Frames:
     - sprite: {fileID: 21300000, guid: 33fc839db31b66026aa20a6d4304574c, type: 3}

--- a/UnityProject/Assets/Textures/objects/flora/rocks/grey_stalagmite6.asset
+++ b/UnityProject/Assets/Textures/objects/flora/rocks/grey_stalagmite6.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: grey_stalagmite6
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: f870c84df008c42ac9d6717444d09aff
   Variance:
   - Frames:
     - sprite: {fileID: 21300000, guid: ede4b2bd9e3d1decf8325f915a4bfe77, type: 3}

--- a/UnityProject/Assets/Textures/objects/flora/rocks/rocks_basalt4.asset
+++ b/UnityProject/Assets/Textures/objects/flora/rocks/rocks_basalt4.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: rocks_basalt4
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: b1ea3ff1343dd9894a490cf673d7d161
   Variance:
   - Frames:
     - sprite: {fileID: -1916236507332333500, guid: 8e545dfbc3677fedb82548a2d8c1b577,

--- a/UnityProject/Assets/Textures/objects/flora/rocks/rocks_lavarocks4.asset
+++ b/UnityProject/Assets/Textures/objects/flora/rocks/rocks_lavarocks4.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: rocks_lavarocks4
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: 3d4710083f05af98ea4ad17bbeb51280
   Variance:
   - Frames:
     - sprite: {fileID: -2705597995764985619, guid: 8e545dfbc3677fedb82548a2d8c1b577,

--- a/UnityProject/Assets/Textures/objects/flora/rocks/rocks_mediumrock.asset
+++ b/UnityProject/Assets/Textures/objects/flora/rocks/rocks_mediumrock.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: rocks_mediumrock
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: 43ff2445e1f4597839549f41f9bc2e82
   Variance:
   - Frames:
     - sprite: {fileID: 8032301891362702160, guid: 8e545dfbc3677fedb82548a2d8c1b577,

--- a/UnityProject/Assets/Textures/objects/furniture/podium.asset
+++ b/UnityProject/Assets/Textures/objects/furniture/podium.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: podium
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: 19638056835c7175b96a8fe62e464a8e
   Variance:
   - Frames:
     - sprite: {fileID: -1657150626, guid: 4856036fd48136fb794b2ec8e252b1af, type: 3}

--- a/UnityProject/Assets/Textures/objects/statue/statuewinged.asset
+++ b/UnityProject/Assets/Textures/objects/statue/statuewinged.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: statuewinged
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: 495fd05e2dc58024eb76586715fc8be1
   Variance: []
   IsPalette: 0
   DisplayName: 

--- a/UnityProject/Assets/Textures/objects/statue/statuewingedarmsout.asset
+++ b/UnityProject/Assets/Textures/objects/statue/statuewingedarmsout.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: statuewingedarmsout
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: 90805498f2f234464af35480c7e12d75
   Variance: []
   IsPalette: 0
   DisplayName: 

--- a/UnityProject/Assets/Textures/objects/statue/statuewingedeyescovered.asset
+++ b/UnityProject/Assets/Textures/objects/statue/statuewingedeyescovered.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: statuewingedeyescovered
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: 21c3341df17521f3090b48f18fdc9737
   Variance: []
   IsPalette: 0
   DisplayName: 

--- a/UnityProject/Assets/Textures/wall/inorganic/invincible/adminwall.asset
+++ b/UnityProject/Assets/Textures/wall/inorganic/invincible/adminwall.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
   m_Name: adminwall
   m_EditorClassIdentifier: 
-  foreverID: 
+  foreverID: 7605642969814b0ca9a51a15fb93b21d
   Variance:
   - Frames:
     - sprite: {fileID: 314866325829982272, guid: afa1843e3e9b7b7c4a102aee939a1955,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/snowplating.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/snowplating.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: snowplating
   m_EditorClassIdentifier: 
-  <ForeverID>k__BackingField: 
+  <ForeverID>k__BackingField: beb50d69a6ac86bc181935757e59ad21
   displayName: plating
   description: 
   LayerType: 4


### PR DESCRIPTION
### Purpose
unity keeps wanting to update these files with metadata. i don't understand why they weren't and it's scary and i want it to go away. i don't know what this PR does but it's almost all just putting something in a foreverID field.

### Notes:
n/a

### Changelog:
n/a