### PR TITLE
[URGENT] Security fix for players receiving perms randomly

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
@@ -139,7 +139,6 @@ public partial class PlayerList
 		{
 			Instance.CheckAdminState(Info);
 		}
-
 	}
 
 	[Server]
@@ -225,6 +224,7 @@ public partial class PlayerList
 	}
 
 
+	[Server]
 	public void TryAddRank(string userID, string inRank, bool addToFile = true)
 	{
 		var data = GetRank(userID, out var Rank);
@@ -241,6 +241,7 @@ public partial class PlayerList
 		}
 	}
 
+	[Server]
 	public void TryRemoveRank(string userID, string inRank, bool addToFile = true)
 	{
 		var data = GetRank(userID, out var Rank);
@@ -709,7 +710,8 @@ public partial class PlayerList
 		AdminEnableMessage.SendMessage(Player, Permissions);
 	}
 
-	void AddPlayerTAGS(PlayerInfo player)
+	[Server]
+	private void AddPlayerTAGS(PlayerInfo player)
 	{
 		//wtf?
 		if (player == null)
@@ -718,17 +720,28 @@ public partial class PlayerList
 			return;
 		}
 
-		if ((player.GameObject == PlayerManager.LocalViewerScript?.gameObject) || Application.isEditor || GameData.Instance.DevBuild)
+
+		if (Application.isEditor || GameData.Instance.DevBuild || player.ConnectionIP == "localhost")
 		{
-			TryAddRank( player.AccountId,"host", false);
+			//full admin privs for local offline testing for host player
+			LocalAdminSetup(player);
+			return;
 		}
+		if (PermissionsManager.Instance.HasAnyRank(player.AccountId)) EnableAdmin(player);
+	}
 
-		var permissions = PermissionsManager.Instance.GetPermissions(player.AccountId, out var Rank );
+	private void LocalAdminSetup(PlayerInfo player)
+	{
+		TryAddRank(player.AccountId,"host", false);
+		Loggy.Info($"Found local host ({player.AccountId}/{player.ConnectionIP}). Assigning 'host' perms to them.");
+		EnableAdmin(player);
+	}
 
-		//full admin privs for local offline testing for host player
+	private void EnableAdmin(PlayerInfo player)
+	{
+		var permissions = PermissionsManager.Instance.GetPermissions(player.AccountId, out var Rank);
 		if (permissions.Count > 0)
 		{
-			//This is an admin, send admin notify to the users client
 			Loggy.Info($"{player.Username} logged in with tags. IP: {player.ConnectionIP} and Rank {Rank} ", Category.Admin);
 			foreach (var tag in permissions)
 			{

--- a/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
@@ -721,7 +721,7 @@ public partial class PlayerList
 		}
 
 
-		if (Application.isEditor || GameData.Instance.DevBuild || player.ConnectionIP == "localhost")
+		if (Application.isEditor || GameData.Instance.DevBuild || player.Connection.address == "localhost")
 		{
 			//full admin privs for local offline testing for host player
 			LocalAdminSetup(player);
@@ -733,7 +733,7 @@ public partial class PlayerList
 	private void LocalAdminSetup(PlayerInfo player)
 	{
 		TryAddRank(player.AccountId,"host", false);
-		Loggy.Info($"Found local host ({player.AccountId}/{player.ConnectionIP}). Assigning 'host' perms to them.");
+		Loggy.Info($"Found local host ({player.AccountId}/{player.Connection.address}). Assigning 'host' perms to them.");
 		EnableAdmin(player);
 	}
 

--- a/UnityProject/Assets/Scripts/Systems/Permissions/PermissionsManager.cs
+++ b/UnityProject/Assets/Scripts/Systems/Permissions/PermissionsManager.cs
@@ -16,8 +16,6 @@ namespace Systems.Permissions
 
 		public PermissionsConfig Config { get; private set; }
 
-
-
 		/// <summary>
 		/// Tries to read the permissions config file and load it in memory. If for whatever reason it fails,
 		/// there will be no permissions config and thus, no one will have any permissions.
@@ -26,7 +24,6 @@ namespace Systems.Permissions
 		/// </summary>
 		public void LoadPermissionsConfig()
 		{
-
 			if (AccessFile.Exists(configPath) == false)
 			{
 				Loggy.Error("Permissions config file not found!", Category.Admin);
@@ -165,6 +162,27 @@ namespace Systems.Permissions
 			{
 				AccessFile.Save(configPath, Toml.FromModel(Config));
 			}
+		}
+
+		public bool HasRank(string identifier, string rankType)
+		{
+			var player = Config.Players.Find(p => p.Identifier == identifier);
+			if (player == null)
+			{
+				// Player not found, so they don't have any rank
+				return false;
+			}
+			return player.Rank == rankType;
+		}
+
+		public bool HasAnyRank(string identifier)
+		{
+			var player = Config.Players.Find(p => p.Identifier == identifier);
+			if (player == null)
+			{
+				return false;
+			}
+			return true;
 		}
 	}
 }


### PR DESCRIPTION
CL: [Fix] Locked admin tag functions as server only to avoid clients from attempting to use them.
CL: [Fix] Added a general player check to see if they are registered anywhere in the permissions manager before attempting to assign any roles to them.
CL: [Fix] Local player checks will now explicitly check for localhost status when attempting to assign a host role when playing offline.
