### PR TITLE
Bring back errorsign on failing to load tile for future fork maps

### DIFF
--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/ObjectManager.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/ObjectManager.prefab
@@ -1435,6 +1435,8 @@ MonoBehaviour:
     - {fileID: 11400000, guid: 427c5e98379cf7d41adf7071402c678c, type: 2}
     - {fileID: 11400000, guid: 426a7efc8138adf46ba05a587574bf85, type: 2}
     - {fileID: 11400000, guid: 4bcf1037b693c9f4f92d2c93c56f9ed5, type: 2}
+  <ErrorTile>k__BackingField: {fileID: 11400000, guid: 2ece1cb55d2b41f4786f7369ddcf4bbf,
+    type: 2}
 --- !u!114 &6456522449831359657
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/ObjectManager.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/ObjectManager.prefab
@@ -1277,6 +1277,7 @@ MonoBehaviour:
     - {fileID: 11400000, guid: 46803c0a5c8548b4982b90c208023696, type: 2}
     - {fileID: 11400000, guid: 83f0b866c5a9427458a8024c827312da, type: 2}
     - {fileID: 11400000, guid: ea3a5556a9f2f4d419847e4a2891b339, type: 2}
+    - {fileID: 11400000, guid: 2ece1cb55d2b41f4786f7369ddcf4bbf, type: 2}
   - path: Tiles/UnderFloors
     tileType: 10
     layerTiles: []

--- a/UnityProject/Assets/ScriptableObjects/Tiles/TileLists/BaseTileList.asset
+++ b/UnityProject/Assets/ScriptableObjects/Tiles/TileLists/BaseTileList.asset
@@ -82,6 +82,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: eacaf3578fd4c384fbf16b922eb15cb0, type: 2}
   - {fileID: 11400000, guid: 871acad77b59acc4fab817e5f713157c, type: 2}
   - {fileID: 11400000, guid: 2597ff9a740874c47b5abaf76e84f92f, type: 2}
+  - {fileID: 11400000, guid: 2ece1cb55d2b41f4786f7369ddcf4bbf, type: 2}
   <CombinedTileList>k__BackingField:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
   - {fileID: 11400000, guid: e8a2685c8a14b7043bf58bde4374c6b1, type: 2}
@@ -145,3 +146,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: bf0867a7bba48c749a370f6534cd3cc3, type: 2}
   - {fileID: 11400000, guid: 871acad77b59acc4fab817e5f713157c, type: 2}
   - {fileID: 11400000, guid: 2597ff9a740874c47b5abaf76e84f92f, type: 2}
+  - {fileID: 11400000, guid: 2ece1cb55d2b41f4786f7369ddcf4bbf, type: 2}

--- a/UnityProject/Assets/Scripts/MapSaver/MapLoader.cs
+++ b/UnityProject/Assets/Scripts/MapSaver/MapLoader.cs
@@ -113,7 +113,22 @@ namespace MapSaver
 					Matrix4x4 = CommonMatrix4x4[0];
 				}
 
-				Matrix.MetaTileMap.SetTile(Position, Tel, Matrix4x4, Colour, Application.isPlaying, true);
+				try
+				{
+					Matrix.MetaTileMap.SetTile(Position, Tel, Matrix4x4, Colour, Application.isPlaying, true);
+				}
+				catch (Exception e)
+				{
+					try
+					{
+						Matrix.MetaTileMap.SetTile(Position, TileManager.Instance.ErrorTile, Matrix4x4, Colour, Application.isPlaying, true);
+					}
+					catch (Exception exception)
+					{
+						Loggy.Error(exception.ToString());
+					}
+					Loggy.Error(e.ToString());
+				}
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/TileManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/TileManager.cs
@@ -59,6 +59,8 @@ public class TileManager : SingletonManager<TileManager>, IInitialise
 
 	[SerializeField] private List<TilePathEntry> layerTileCollections = new List<TilePathEntry>();
 
+	[field:SerializeField] public AnimatedTile ErrorTile { get; private set; }
+
 	public InitialisationSystems Subsystem => InitialisationSystems.TileManager;
 
 	void IInitialise.Initialise()

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Grilles/Error.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Grilles/Error.asset
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1796e5cfb0bb4f9b81661d07e7794f1d, type: 3}
+  m_Name: Error
+  m_EditorClassIdentifier: 
+  <ForeverID>k__BackingField: ERRORTILE
+  displayName: Error
+  description: Simulation breaking.. something is missing here..
+  LayerType: 6
+  TileType: 9
+  RequiredTiles: []
+  Mass: 0.1
+  floorTileSounds: {fileID: 0}
+  CanSoundOverride: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 0
+  passable: 1
+  mineable: 0
+  miningTime: 5
+  miningHardness: 1
+  constructable: 0
+  RadiationPassability: 1
+  ThermalConductivity: 0.05
+  HeatCapacity: 10000
+  doesReflectBullet: 0
+  indestructible: 1
+  ExplosionImpassable: 0
+  BlocksTileInteractionsUnder: 1
+  passableException:
+    m_keys: 
+    m_values: 
+  maxHealth: 1000000
+  damageDeflection: 40000
+  armor:
+    Melee: 100
+    Bullet: 100
+    Laser: 100
+    Energy: 100
+    Bomb: 100
+    Rad: 100
+    Fire: 100
+    Acid: 100
+    Magic: 100
+    Bio: 100
+    Anomaly: 0
+    DismembermentProtectionChance: 0
+    StunImmunity: 0
+    TemperatureProtectionInK: {x: 268.15, y: 313.15}
+    PressureProtectionInKpa: {x: 30, y: 300}
+  tileInteractions: []
+  <OnTileStartMining>k__BackingField: []
+  <OnTileFinishMining>k__BackingField: []
+  tileStepInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
+  lootOnDespawn: {fileID: 0}
+  toTileWhenDestroyed: {fileID: 0}
+  spawnOnDestroy: {fileID: 0}
+  damageOverlayList: {fileID: 0}
+  soundOnHit:
+    AssetAddress: Assets/Prefabs/UI/Bwoink.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectGUID: 
+      m_SubObjectType: 
+      m_EditorAssetChanged: 0
+  SoundOnDestroy: []
+  Sprites:
+  - {fileID: -2512927661099922447, guid: a08e177daac794cf680f161215685ce4, type: 3}
+  - {fileID: 4659265657221884602, guid: a08e177daac794cf680f161215685ce4, type: 3}
+  - {fileID: -3138123007396962320, guid: a08e177daac794cf680f161215685ce4, type: 3}
+  - {fileID: -7145856751783321575, guid: a08e177daac794cf680f161215685ce4, type: 3}
+  AnimationSpeed: 1
+  AnimationStartTime: 0
+  randomizeStartTime: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Grilles/Error.asset.meta
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Grilles/Error.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2ece1cb55d2b41f4786f7369ddcf4bbf
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This was reverted by Bod a while back, and I needed to bring this back in.