### PR TITLE
Fix Emissive lights only working over walls

### DIFF
--- a/UnityProject/Assets/Shaders/Sprite Fov Masked Emission.shader
+++ b/UnityProject/Assets/Shaders/Sprite Fov Masked Emission.shader
@@ -73,7 +73,7 @@ Shader "Stencil/Unlit background masked emission" {
 		float additionalEmission = i.color.g;
 		fixed4 final = (textureSample * intencity);
 
-		float maskChennel =  maskSample.r;
+		float maskChennel = maskSample.g + maskSample.r;
 
 		//0.70 to Because 1 = blown out
 		//additionalEmission+1 , Because it goes between 0 and 1, and it should be default on its 0


### PR DESCRIPTION

![2025-03-15-19:39:53](https://github.com/user-attachments/assets/25abd685-e479-4591-abb4-abd68bb15d32)

Literally just makes emissive lights work when not over walls cus funtime mentioned this broke at some point in the discord and that they wanted to use it to make doors emit light when the doorlights show 
thats it. thats the change
