### PR TITLE
Fix surface body part colors not getting applied correctly

### DIFF
--- a/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
@@ -327,16 +327,16 @@ namespace Player
 
 		public void SetSurfaceColour()
 		{
-			Color CurrentSurfaceColour = Color.white;
+			Color currentSurfaceColour = Color.white;
 			if (RaceBodyparts.Base.SkinColours.Count > 0)
 			{
-				ColorUtility.TryParseHtmlString(ThisCharacter.SkinTone, out CurrentSurfaceColour);
+				ColorUtility.TryParseHtmlString(ThisCharacter.SkinTone, out currentSurfaceColour);
 
 				var hasColour = false;
 
-				foreach (var color in RaceBodyparts.Base.SkinColours)
+				foreach (Color color in RaceBodyparts.Base.SkinColours)
 				{
-					if (color.ColorApprox(CurrentSurfaceColour))
+					if (color.ColorApprox(currentSurfaceColour))
 					{
 						hasColour = true;
 						break;
@@ -345,19 +345,21 @@ namespace Player
 
 				if (hasColour == false)
 				{
-					CurrentSurfaceColour = RaceBodyparts.Base.SkinColours[0];
+					Loggy.Error($"None-matching skin tone colors found on {gameObject.name}. Using closest skin tone.\n " +
+					            $"parsed SurfaceColor: {currentSurfaceColour}\n ThisCharacter skintone: {ThisCharacter.SkinTone}]");
+					currentSurfaceColour = currentSurfaceColour.ClosestColor(RaceBodyparts.Base.SkinColours.ToArray());
 				}
 			}
 			else
 			{
-				ColorUtility.TryParseHtmlString(ThisCharacter.SkinTone, out CurrentSurfaceColour);
+				ColorUtility.TryParseHtmlString(ThisCharacter.SkinTone, out currentSurfaceColour);
 			}
 
-			CurrentSurfaceColour.a = 1;
+			currentSurfaceColour.a = 1;
 
 			foreach (var sp in SurfaceSprite)
 			{
-				sp.baseSpriteHandler.SetColor(CurrentSurfaceColour);
+				sp.baseSpriteHandler.SetColor(currentSurfaceColour);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
+++ b/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
@@ -701,22 +701,35 @@ public static class SweetExtensions
 	}
 
 	/// <summary>
-	/// See if two colours are approximately the same
+	/// See if two colors are approximately the same within a small tolerance.
 	/// </summary>
-	public static bool ColorApprox(this Color a, Color b, bool checkAlpha = true)
+	public static bool ColorApprox(this Color a, Color b, bool checkAlpha = true, float tolerance = 0.0001f)
 	{
+		bool CloseEnough(float x, float y) => Mathf.Abs(x - y) <= tolerance;
+
 		if (checkAlpha)
 		{
-			return Mathf.Approximately(a.b, b.b) &&
-			       Mathf.Approximately(a.r, b.r) &&
-			       Mathf.Approximately(a.g, b.g) &&
-			       Mathf.Approximately(a.a, b.a);
+			return CloseEnough(a.r, b.r) &&
+			       CloseEnough(a.g, b.g) &&
+			       CloseEnough(a.b, b.b) &&
+			       CloseEnough(a.a, b.a);
 		}
 
-		return Mathf.Approximately(a.b, b.b) &&
-		       Mathf.Approximately(a.r, b.r) &&
-		       Mathf.Approximately(a.g, b.g);
+		return CloseEnough(a.r, b.r) &&
+		       CloseEnough(a.g, b.g) &&
+		       CloseEnough(a.b, b.b);
 	}
+
+	public static Color ClosestColor(this Color targetColor, Color[] colorPalette)
+	{
+		return colorPalette.OrderBy(c => ColorDifference(targetColor, c)).FirstOrDefault();
+	}
+
+	public static float ColorDifference(Color a, Color b)
+	{
+		return Mathf.Pow(a.r - b.r, 2) + Mathf.Pow(a.g - b.g, 2) + Mathf.Pow(a.b - b.b, 2);
+	}
+
 	public static string Truncate(this string value, int maxLength)
 	{
 		if (string.IsNullOrEmpty(value)) return value;


### PR DESCRIPTION
fix #10747

CL: [Fix] Made color matching for surface body parts more robust in case the way we use colors get changed in the future. This fixes a current issue with tieflings not having their chosen colors applied.
