### PR TITLE
Fix Coordinates Space Mixing for SoundSpawns + Audio Resume for local ambient sounds

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Sound/SoundSpawn.cs
+++ b/UnityProject/Assets/Scripts/Core/Sound/SoundSpawn.cs
@@ -29,6 +29,8 @@ namespace Core.Sound
 		/// </remarks>
 		public string Token;
 
+		private float pauseLocation = 0;
+
 		private void Awake()
 		{
 			AudioSource = GetComponent<AudioSource>();
@@ -102,15 +104,23 @@ namespace Core.Sound
 		{
 			if (PlayerManager.LocalPlayerScript == null || RegisterTile == null) return false; // player hasn't spawned yet or world hasn't fully loaded.
 			if (PlayerManager.LocalPlayerScript.playerMove == null) return false; // player hasn't fully initialized yet.
-			if (Vector3.Distance(RegisterTile.WorldPosition,
+			if (Vector3.Distance(transform.position,
 				    PlayerManager.LocalPlayerScript.playerMove.OfficialPosition) > AudioSource.maxDistance)
 			{
-				if (AudioSource.isPlaying) AudioSource.Stop();
+				if (AudioSource.isPlaying)
+				{
+					pauseLocation = AudioSource.time;
+					AudioSource.Stop();
+				}
 				return true;
 			}
 			else
 			{
-				if (AudioSource.isPlaying == false) AudioSource.Play();
+				if (AudioSource.isPlaying == false)
+				{
+					AudioSource.Play();
+					AudioSource.time = pauseLocation;
+				}
 			}
 			return false;
 		}


### PR DESCRIPTION
CL: [Improvement] Culled local ambient sounds will now remember the last second they were left on when resuming play.
CL: [Fix] Fixed SoundSpawns mixing local and world coordinates, which caused some issues on maps that are offset from 0,0.