### PR TITLE
Various Fixes

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/_AirlockBase.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/_AirlockBase.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 1409280515635118615}
   - component: {fileID: 1684877350854915770}
   - component: {fileID: 8542447127197164955}
+  - component: {fileID: 7210397487269927506}
   m_Layer: 18
   m_Name: overlayLights
   m_TagString: Untagged
@@ -117,6 +118,21 @@ MonoBehaviour:
   initialVariantIndex: 0
   InitialColour: {r: 1, g: 1, b: 1, a: 1}
   palette: []
+--- !u!114 &7210397487269927506
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 46041202269146236}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 967620e59e52cc14c89c22c4176bac09, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mIntensity: 0.5
+  mAdditionalEmission: 0
+  mScale: 1
 --- !u!1 &404576362407937357
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Objects/Nuke/New Nuke.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Nuke/New Nuke.prefab
@@ -92,6 +92,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5212070883374448474, guid: b06b702714bab49b9ad949eab1ca4534,
         type: 3}
+      propertyPath: InitialPresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 8052c1708b6d99043a2da0a67d842306,
+        type: 2}
+    - target: {fileID: 5212070883374448474, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
       propertyPath: SubCatalogue.Array.size
       value: 2
       objectReference: {fileID: 0}
@@ -116,6 +122,11 @@ PrefabInstance:
         type: 3}
       propertyPath: initialDescription
       value: You probably shouldn't stick around to see if this is armed.
+      objectReference: {fileID: 0}
+    - target: {fileID: 8208024911721290269, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: Resistances.Indestructable
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 9212640593017544930, guid: b06b702714bab49b9ad949eab1ca4534,
         type: 3}
@@ -207,7 +218,7 @@ MonoBehaviour:
     SlotContents: []
     DeprecatedContents: []
   SetSlotItemNotRemovableOnStartUp: 0
-  ignoreRoundstartGrabObjects: 0
+  initialignoreRoundstartGrabObjects: 0
   ashPrefab: {fileID: 0}
 --- !u!114 &692548729324142341
 MonoBehaviour:
@@ -242,13 +253,15 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   TimerTickSound:
-    SetLoadSetting: 0
     AssetAddress: Assets/Prefabs/UI/Tick.prefab
     AssetReference:
       m_AssetGUID: 
       m_SubObjectName: 
+      m_SubObjectGUID: 
       m_SubObjectType: 
       m_EditorAssetChanged: 0
   isAncharable: 1
   explosionRadius: 500
   minTimer: 270
+  UseSyndiNukeCode: 0
+  loadedOnRoundID: 0

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/MiniStation.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/MiniStation.json
@@ -96660,7 +96660,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -133630,6 +133630,10 @@
                   "ClassID": "ReagentContainer@0",
                   "Data": [
                     {
+                      "Name": "possibleTransferAmounts#0",
+                      "Data": "#removed#"
+                    },
+                    {
                       "Name": "maxCapacity",
                       "Data": "100"
                     },
@@ -133639,10 +133643,6 @@
                     },
                     {
                       "Name": "initialReagentMix@reagents#Water",
-                      "Data": "#removed#"
-                    },
-                    {
-                      "Name": "possibleTransferAmounts#0",
                       "Data": "#removed#"
                     }
                   ]
@@ -153501,6 +153501,15 @@
             "Object": {
               "ClassDatas": [
                 {
+                  "ClassID": "UniversalObjectPhysics@0",
+                  "Data": [
+                    {
+                      "Name": "CanBeWindPushed",
+                      "Data": "False"
+                    }
+                  ]
+                },
+                {
                   "ClassID": "GasContainer@0",
                   "Data": [
                     {
@@ -156917,6 +156926,15 @@
             "LocalPRS": "97┼14┼0┼",
             "Object": {
               "ClassDatas": [
+                {
+                  "ClassID": "UniversalObjectPhysics@0",
+                  "Data": [
+                    {
+                      "Name": "CanBeWindPushed",
+                      "Data": "False"
+                    }
+                  ]
+                },
                 {
                   "ClassID": "GasContainer@0",
                   "Data": [
@@ -161434,6 +161452,15 @@
             "Object": {
               "ClassDatas": [
                 {
+                  "ClassID": "UniversalObjectPhysics@0",
+                  "Data": [
+                    {
+                      "Name": "CanBeWindPushed",
+                      "Data": "False"
+                    }
+                  ]
+                },
+                {
                   "ClassID": "GasContainer@0",
                   "Data": [
                     {
@@ -165850,6 +165877,15 @@
             "Object": {
               "ClassDatas": [
                 {
+                  "ClassID": "UniversalObjectPhysics@0",
+                  "Data": [
+                    {
+                      "Name": "CanBeWindPushed",
+                      "Data": "False"
+                    }
+                  ]
+                },
+                {
                   "ClassID": "GasContainer@0",
                   "Data": [
                     {
@@ -165908,6 +165944,15 @@
             "LocalPRS": "112┼29┼0┼",
             "Object": {
               "ClassDatas": [
+                {
+                  "ClassID": "UniversalObjectPhysics@0",
+                  "Data": [
+                    {
+                      "Name": "CanBeWindPushed",
+                      "Data": "False"
+                    }
+                  ]
+                },
                 {
                   "ClassID": "GasContainer@0",
                   "Data": [
@@ -167354,7 +167399,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -168362,7 +168407,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -169620,7 +169665,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -170769,7 +170814,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {
@@ -172892,7 +172937,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {


### PR DESCRIPTION
modifies the nuke so it cant be destroyed, sets the cant be wind pushed bool on the cans in mini's atmos chambers so they dont noclip the fuck into space and also makes doorlights glow (but only a little)

![2025-03-30-14:16:21](https://github.com/user-attachments/assets/7df8333e-1070-4d6e-bf3a-b86e08603c03)
![2025-03-30-14:15:46](https://github.com/user-attachments/assets/95144b2c-a246-425c-bae0-f419c91f1c0d)


### Changelog:
CL: [Fix] Fix gas cans sometimes clipping out of ministations atmos chambers.
CL: [Fix] The station nuke and nukeops nuke can no longer be defused by destroying them.
CL: [Improvement] The lights on doors are now emissive

