### PR TITLE
Interaction messages for switches and buttons

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Wallmounts/LightSwitch.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Wallmounts/LightSwitch.prefab
@@ -18,6 +18,11 @@ PrefabInstance:
       propertyPath: deviceType
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: -6356777978426299504, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: initialwattusage
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
       propertyPath: m_Size.x
@@ -156,7 +161,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6109775972905365350, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
+      propertyPath: spriteRenderer
+      value: 
+      objectReference: {fileID: 5201104623901103339}
+    - target: {fileID: 6109775972905365350, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
       propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: fa797ac5f2c4f724b8be835f30a4e3e6,
+        type: 2}
+    - target: {fileID: 6109775972905365350, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: InitialPresentSpriteSet
       value: 
       objectReference: {fileID: 11400000, guid: fa797ac5f2c4f724b8be835f30a4e3e6,
         type: 2}
@@ -257,6 +273,14 @@ MonoBehaviour:
   SynchroniseCurrentDirection: 3
   IgnoreServerUpdatesIfLocalPlayer: 0
   MatrixRotateUpdate: 1
+  SetOrder: 0
+  Orders: 00000000000000000000000000000000
+  SetLayer: 0
+  Layers:
+  - Rename me 1
+  - Rename me 2
+  - Rename me 3
+  - Rename me 4
   IsAtmosphericDevice: 0
   doNotResetOtherSpriteOptions: 0
 --- !u!114 &5448639519452539588
@@ -278,8 +302,11 @@ MonoBehaviour:
   - {fileID: 0}
   - {fileID: 0}
   listOfLights: []
+  OnButtonPressed:
+    m_PersistentCalls:
+      m_Calls: []
   isOn: 1
-  coolDownTime: 2
+  coolDownTime: 2.5
   sprites:
   - {fileID: 21300000, guid: e5190e92b1300c449b22db8ea3f4f37d, type: 3}
   - {fileID: 21300000, guid: 78c7a580cdf74bc4a8f85b744365253a, type: 3}

--- a/UnityProject/Assets/Scripts/Objects/Wallmounts/Switches/DoorSwitch.cs
+++ b/UnityProject/Assets/Scripts/Objects/Wallmounts/Switches/DoorSwitch.cs
@@ -11,6 +11,7 @@ using CustomInspectors;
 using Items;
 using Shared.Systems.ObjectConnection;
 using Systems.Electricity;
+using Util.Independent.FluentRichText;
 
 namespace Objects.Wallmounts
 {
@@ -65,19 +66,18 @@ namespace Objects.Wallmounts
 
 		public void ServerPerformInteraction(HandApply interaction)
 		{
-			if(TestCoolDown() == false) return;
+			if (TestCoolDown() == false) return;
 
+			var storage = interaction.Performer.OrNull()?.GetComponent<DynamicItemStorage>();
 
-			var Storage = interaction.Performer.OrNull()?.GetComponent<DynamicItemStorage>();
-
-			if (Storage != null)
+			if (storage != null)
 			{
-				var emag = Emag.GetEmagInDynamicItemStorage(Storage);
+				var emag = Emag.GetEmagInDynamicItemStorage(storage);
 				if (emag != null)
 				{
 					if (emag.UseCharge(interaction))
 					{
-						RunDoorController();
+						RunDoorController(interaction);
 						RpcPlayButtonAnim(false);
 						return;
 					}
@@ -87,16 +87,18 @@ namespace Objects.Wallmounts
 			if (clearanceRestricted.HasClearance(interaction.Performer) == false)
 			{
 				RpcPlayButtonAnim(false);
+				Chat.AddActionMsgToChat(interaction.Performer,
+					$"The {gameObject.ExpensiveName()} makes a loud buzz as it denies {interaction.PerformerPlayerScript.visibleName}'s clearance.");
 				return;
 			}
-
-			RunDoorController();
+			RunDoorController(interaction);
 		}
 
-		public void RunDoorController()
+		public void RunDoorController(HandApply interaction = null)
 		{
 			if (NewdoorControllers.Count == 0)
 			{
+				if (interaction != null) Chat.AddExamineMsg(interaction.Performer, "There doesn't seem to be anything connected to this button.");
 				return;
 			}
 
@@ -104,11 +106,19 @@ namespace Objects.Wallmounts
 			{
 				if (APCPoweredDevice.IsOn(thisAPCPoweredDevice.State) == false)
 				{
+					if (interaction != null) Chat.AddExamineMsg(interaction.Performer, "There doesn't seem to be power connected to this button.".Color(Color.red));
 					return;
 				}
 			}
 
 			RpcPlayButtonAnim(true);
+
+			if (interaction != null)
+			{
+				Chat.AddActionMsgToChat(interaction.Performer,
+					$"{interaction.PerformerPlayerScript.visibleName} interacts with the {gameObject.ExpensiveName()}, " +
+					$"and a small chirp can be heard as it approves {interaction.PerformerPlayerScript.characterSettings.TheirPronoun(interaction.PerformerPlayerScript)} clearance.");
+			}
 
 			foreach (var door in NewdoorControllers)
 			{

--- a/UnityProject/Assets/Scripts/Objects/Wallmounts/Switches/GeneralSwitch.cs
+++ b/UnityProject/Assets/Scripts/Objects/Wallmounts/Switches/GeneralSwitch.cs
@@ -7,6 +7,7 @@ using CustomInspectors;
 using Systems.Clearance;
 using Shared.Systems.ObjectConnection;
 using Systems.Electricity;
+using Util.Independent.FluentRichText;
 
 namespace Objects.Wallmounts
 {
@@ -26,6 +27,7 @@ namespace Objects.Wallmounts
 		private APCPoweredDevice APCPoweredDevice;
 		[field: SerializeField] public bool CanRelink { get; set; } = true;
 		[field: SerializeField] public bool IgnoreMaxDistanceMapper { get; set; } = false;
+
 		private void Start()
 		{
 			//This is needed because you can no longer apply shutterSwitch prefabs (it will move all of the child sprite positions)
@@ -52,17 +54,16 @@ namespace Objects.Wallmounts
 
 		public void ServerPerformInteraction(HandApply interaction)
 		{
-
 			if (clearanceRestricted.HasClearance(interaction.Performer) == false)
 			{
 				RpcPlayButtonAnim(false);
+				Chat.AddExamineMsg(interaction.Performer, "You don't have clearance to use this switch.".Color(Color.red));
 				return;
 			}
-
-			RunDoorController();
+			RunDoorController(interaction);
 		}
 
-		public void RunDoorController()
+		public void RunDoorController(HandApply interaction = null)
 		{
 			if (APCPoweredDevice != null)
 			{
@@ -71,12 +72,17 @@ namespace Objects.Wallmounts
 
 			RpcPlayButtonAnim(true);
 
-			for (int i = 0; i < generalSwitchControllers.Count; i++)
+			foreach (var controller in generalSwitchControllers)
 			{
-				if (generalSwitchControllers[i] == null) continue;
-
+				if (controller == null) continue;
 				//Trigger Event
-				generalSwitchControllers[i].SwitchPressedDoAction.Invoke();
+				controller.SwitchPressedDoAction?.Invoke();
+			}
+
+			if (interaction != null)
+			{
+				Chat.AddActionMsgToChat(interaction.Performer, "Small chirps can be heard as " +
+				                                               $"{interaction.PerformerPlayerScript.visibleName} presses the {gameObject.ExpensiveName()}.");
 			}
 		}
 
@@ -104,28 +110,12 @@ namespace Objects.Wallmounts
 			{
 				if (status)
 				{
-					if (spriteRenderer.sprite == greenSprite)
-					{
-						spriteRenderer.sprite = offSprite;
-					}
-					else
-					{
-						spriteRenderer.sprite = greenSprite;
-					}
-
+					spriteRenderer.sprite = spriteRenderer.sprite == greenSprite ? offSprite : greenSprite;
 					yield return WaitFor.Seconds(0.2f);
 				}
 				else
 				{
-					if (spriteRenderer.sprite == redSprite)
-					{
-						spriteRenderer.sprite = offSprite;
-					}
-					else
-					{
-						spriteRenderer.sprite = redSprite;
-					}
-
+					spriteRenderer.sprite = spriteRenderer.sprite == redSprite ? offSprite : redSprite;
 					yield return WaitFor.Seconds(0.1f);
 				}
 			}

--- a/UnityProject/Assets/Scripts/Objects/Wallmounts/Switches/LightSwitchV2.cs
+++ b/UnityProject/Assets/Scripts/Objects/Wallmounts/Switches/LightSwitchV2.cs
@@ -1,19 +1,25 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using Mirror;
 using UnityEngine;
 using Systems.Electricity;
 using Systems.Interaction;
 using CustomInspectors;
+using Cysharp.Threading.Tasks;
+using NUnit.Framework;
 using Shared.Systems.ObjectConnection;
+using Systems.Ai;
+using UI.Systems.Tooltips.HoverTooltips;
 using UnityEngine.Events;
 using Random = UnityEngine.Random;
 
 
 namespace Objects.Lighting
 {
-	public class LightSwitchV2 : ImnterfaceMultitoolGUI, ISubscriptionController, ICheckedInteractable<HandApply>, IAPCPowerable, IMultitoolMasterable, ICheckedInteractable<AiActivate>
+	public class LightSwitchV2 : ImnterfaceMultitoolGUI, ISubscriptionController,
+		ICheckedInteractable<HandApply>, IAPCPowerable, IMultitoolMasterable, ICheckedInteractable<AiActivate>, IHoverTooltip
 	{
 		public List<LightSource> listOfLights;
 		public UnityEvent OnButtonPressed = new UnityEvent();
@@ -22,7 +28,7 @@ namespace Objects.Lighting
 		public bool isOn = true;
 
 		[SerializeField]
-		private float coolDownTime = 1.0f;
+		private float coolDownTime = 2f;
 
 		private bool isInCoolDown;
 
@@ -86,27 +92,32 @@ namespace Objects.Lighting
 		{
 			if (DefaultWillInteract.Default(interaction, side) == false) return false;
 			if (interaction.HandObject != null && interaction.Intent == Intent.Harm) return false;
-
-			if (side == NetworkSide.Server)
-			{
-				if (isInCoolDown) return false;
-				StartCoroutine(SwitchCoolDown());
-			}
-
 			return true;
 		}
 
 		public void ServerPerformInteraction(HandApply interaction)
 		{
+			if (isInCoolDown)
+			{
+				Chat.AddExamineMsg(interaction.Performer, "You can't use the switch yet.");
+				return;
+			}
 			TryInteraction();
 			if (powerState == PowerState.Off || powerState == PowerState.LowVoltage)
 			{
-				Chat.AddExamineMsg(gameObject, "You flip the switch... But nothing happens.");
+				Chat.AddExamineMsg(interaction.Performer, "You flip the switch... But nothing happens.");
 				return;
 			}
 			OnButtonPressed?.Invoke();
-			string state = isOn ? "on" : "off";
-			Chat.AddExamineMsg(gameObject, $"You flip the switch back {state}.");
+			if (interaction.IsAltClick)
+			{
+				Chat.AddExamineMsg(interaction.Performer, $"You quietly flip the switch back {IsOnOffString()}.");
+			}
+			else
+			{
+				Chat.AddActionMsgToChat(interaction.Performer, $"{interaction.PerformerPlayerScript.visibleName} flips the switch back {IsOnOffString()}.");
+			}
+			_ = SwitchCoolDown();
 		}
 
 		#endregion
@@ -130,7 +141,7 @@ namespace Objects.Lighting
 			//Trigger client cooldown only, or else it will break for local host
 			if (CustomNetworkManager.IsServer == false)
 			{
-				StartCoroutine(SwitchCoolDown());
+				_ = SwitchCoolDown();
 			}
 
 			return true;
@@ -139,7 +150,7 @@ namespace Objects.Lighting
 		public void ServerPerformInteraction(AiActivate interaction)
 		{
 			//Start server cooldown
-			StartCoroutine(SwitchCoolDown());
+			_ = SwitchCoolDown();
 			TryInteraction();
 		}
 
@@ -169,10 +180,10 @@ namespace Objects.Lighting
 
 		#endregion
 
-		private IEnumerator SwitchCoolDown()
+		private async UniTask SwitchCoolDown()
 		{
 			isInCoolDown = true;
-			yield return WaitFor.Seconds(coolDownTime);
+			await UniTask.WaitForSeconds(coolDownTime); // unitask has zero allocations compared to IEnumrators.
 			isInCoolDown = false;
 		}
 
@@ -219,5 +230,74 @@ namespace Objects.Lighting
 		}
 
 		#endregion
+
+		#region Hover ToolTips
+
+		public string HoverTip()
+		{
+			return $"The switch seems to be {IsOnOffString()}.";
+		}
+
+		public string CustomTitle()
+		{
+			return null;
+		}
+
+		public Sprite CustomIcon()
+		{
+			return null;
+		}
+
+		public List<Sprite> IconIndicators()
+		{
+			return null;
+		}
+
+		public List<TextColor> InteractionsStrings()
+		{
+			var interactions = new List<TextColor>
+			{
+				new TextColor
+				{
+					Text = $"Click to Flip the switch {IsOnOffString()}.",
+					Color = IntentColors.Help
+				},
+				new TextColor
+				{
+					Text = $"Alt+Click to quietly Flip the switch {IsOnOffString()}.",
+					Color = IntentColors.Help
+				},
+			};
+
+			if (LocalPlayerHasMultiTool())
+			{
+				interactions.Add(new TextColor
+				{
+					Text = "Use the Multitool to rewire the switch.",
+					Color = IntentColors.Help
+				});
+			}
+
+			return interactions;
+		}
+
+		private bool LocalPlayerHasMultiTool()
+		{
+			if (PlayerManager.LocalPlayerScript == null) return false;
+			if (PlayerManager.LocalPlayerScript.DynamicItemStorage == null) return false;
+			foreach (var slot in PlayerManager.LocalPlayerScript.DynamicItemStorage.GetHandSlots())
+			{
+				if (slot.IsEmpty) continue;
+				if (slot.ItemAttributes.GetTraits().Contains(CommonTraits.Instance.Multitool)) return true;
+			}
+
+			return false;
+		}
+		#endregion
+
+		private string IsOnOffString()
+		{
+			return isOn ? "on" : "off";
+		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Objects/Wallmounts/Switches/LightSwitchV2.cs
+++ b/UnityProject/Assets/Scripts/Objects/Wallmounts/Switches/LightSwitchV2.cs
@@ -183,7 +183,7 @@ namespace Objects.Lighting
 		private async UniTask SwitchCoolDown()
 		{
 			isInCoolDown = true;
-			await UniTask.WaitForSeconds(coolDownTime); // unitask has zero allocations compared to IEnumrators.
+			await UniTask.WaitForSeconds(coolDownTime); // unitask has zero allocations compared to IEnumerators.
 			isInCoolDown = false;
 		}
 


### PR DESCRIPTION
SS13 is originally a MUD (Multi-User-Dungeon), and has always shown its interactivity via written messages, rather than visuals.
This PR embraces our original roots by expanding some of the interactions we have with light switches to include visible messages that indicate what players are doing to buttons.

Though due to how a lot of players are used to button interactions being silent, I've added a way to mimic that old behavior to allow crew members to continue pulling pranks on one another more easily.

![image](https://github.com/user-attachments/assets/0e91b21c-18dc-4ef1-b242-93ff64454eb9)


CL: [New] Added interaction messages for buttons that showcase and explain their successful/failed interactions to players.
CL: [New] Added a way for pranksters to silently turn off lights without alerting other crew members.
CL: [New] Added contextual hover tooltips for light switches.
