### PR TITLE
Misc Firearm fixes

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Weapons/CrankRecharge.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/CrankRecharge.cs
@@ -18,6 +18,8 @@ namespace Weapons
 
 		private GameObject serverHolder;
 
+		private bool isCharging = false;
+
 		private void Awake()
 		{
 			gunComp = GetComponent<Gun>();
@@ -31,11 +33,14 @@ namespace Weapons
 
 		public void ServerPerformInteraction(HandActivate interaction)
 		{
+			if (isCharging) return;
+
 			Chat.AddActionMsgToChat(serverHolder,
 				$"You start {rechargeVerb} the {gameObject.ExpensiveName()}.",
 				$"{serverHolder.ExpensiveName()} starts {rechargeVerb} the {gameObject.ExpensiveName()}.");
 
 			StartCoroutine(Recharging());
+			isCharging = true;
 		}
 
 		public void OnInventoryMoveServer(InventoryMove info)
@@ -43,6 +48,7 @@ namespace Weapons
 			if (gameObject != info.MovedObject.gameObject) return;
 
 			StopAllCoroutines();
+			isCharging = false;
 			serverHolder = info.ToPlayer != null ? info.ToPlayer.gameObject : null;
 		}
 
@@ -87,6 +93,8 @@ namespace Weapons
 			Chat.AddActionMsgToChat(serverHolder,
 				$"You finish {rechargeVerb} the {gameObject.ExpensiveName()}.",
 				$"{serverHolder.ExpensiveName()} finishes {rechargeVerb} the {gameObject.ExpensiveName()}.");
+
+			isCharging = false;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Weapons/PlasmaRefill.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/PlasmaRefill.cs
@@ -14,13 +14,12 @@ namespace Weapons
 		private int toRefill;
 		private int refilledAmmo;
 		private int toConsume;
-		private MagazineBehaviour magazineBehaviour;
-		private ElectricalMagazine electricalMagazine;
-		private Battery battery;
+	
+		private Gun gunComp;
 
 		private void Start()
 		{
-			magazineBehaviour = GetComponent<Gun>().CurrentMagazine;
+			gunComp = GetComponent<Gun>();
 		}
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)
@@ -55,13 +54,15 @@ namespace Weapons
 			{
 				return;
 			}
-			var needAmmo = magazineBehaviour.magazineSize - magazineBehaviour.ServerAmmoRemains;
+
+			var currentMag = gunComp.CurrentMagazine;
+
+			if (currentMag == null) return;
+
+			var needAmmo = currentMag.magazineSize - currentMag.ServerAmmoRemains;
 			if (needAmmo <= 0) return;
 
 			var stackable = interaction.HandObject.GetComponent<Stackable>();
-			var intbattery = interaction.HandObject.GetComponent<InternalBattery>();
-			battery = intbattery.GetBattery();
-			electricalMagazine = battery.GetComponent<ElectricalMagazine>();
 			Refill(stackable, needAmmo, refilledAmmo);
 		}
 
@@ -95,17 +96,30 @@ namespace Weapons
 
 		private void AddCharge(int ChargingWatts)
 		{
-			battery.Watts += ChargingWatts;
+			var mag = gunComp.magSlot.Item;
+			if (mag == null) return;
 
-			if (battery.Watts > battery.MaxWatts)
+			var battery = mag.GetComponent<Battery>();
+			if (battery != null)
 			{
-				battery.Watts = battery.MaxWatts;
+				battery.Watts += ChargingWatts;
+
+				if (battery.Watts > battery.MaxWatts)
+				{
+					battery.Watts = battery.MaxWatts;
+				}
 			}
 
+			var electricalMagazine = mag.GetComponent<ElectricalMagazine>();
 			if (electricalMagazine != null)
 			{
-				//For electrical guns
 				electricalMagazine.AddCharge();
+			}
+
+			var GunElectrical = gameObject.GetComponent<GunElectrical>();
+			if (GunElectrical != null)
+			{
+				GunElectrical.UpdateChargeSprite();
 			}
 		}
 
@@ -143,13 +157,15 @@ namespace Weapons
 			{
 				return;
 			}
-			var needAmmo = magazineBehaviour.magazineSize - magazineBehaviour.ServerAmmoRemains;
+
+			var currentMag = gunComp.CurrentMagazine;
+
+			if (currentMag == null) return;
+
+			var needAmmo = currentMag.magazineSize - currentMag.ServerAmmoRemains;
 			if (needAmmo <= 0) return;
 
 			var stackable = interaction.UsedObject.GetComponent<Stackable>();
-			var intbattery = interaction.TargetObject.GetComponent<InternalBattery>();
-			battery = intbattery.GetBattery();
-			electricalMagazine = battery.GetComponent<ElectricalMagazine>();
 			Refill(stackable, needAmmo, refilledAmmo);
 		}
 	}


### PR DESCRIPTION
Adds a check to crank weapons so its not possible to spam them over and over whilst its already recharging
Also modifies plasma refill to be a little bit more modern and work with energy weapon charge sprites

### Changelog:
CL: [Improvement] Crank weapon recharging can no longer be spammed
