### PR TITLE
light emission fixes

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Other/PottedPlants/PottedPlant20.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/PottedPlants/PottedPlant20.prefab
@@ -29,7 +29,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 3, y: 3, z: 3}
+  m_LocalScale: {x: 4, y: 4, z: 3}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1164968030392107538}
@@ -46,7 +46,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 61930e16e81db5c43a4ecc22422a0953, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  InitialColour: {r: 1, g: 0.99607843, b: 0.88235295, a: 0.8627451}
+  InitialColour: {r: 1, g: 0.99607843, b: 0.88235295, a: 0.7254902}
   Sprite: {fileID: 21300000, guid: 7d4ab37af9168d243a3eead2ef5b5758, type: 3}
   SortingOrder: 0
   Material: {fileID: 2100000, guid: b7e7f24fa2e49cb48818dace424b5868, type: 2}
@@ -202,6 +202,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6326550108531515488, guid: 0271f252689106348ad30060b7abea96,
         type: 3}
+      propertyPath: spriteRenderer
+      value: 
+      objectReference: {fileID: 1353538381542591546}
+    - target: {fileID: 6326550108531515488, guid: 0271f252689106348ad30060b7abea96,
+        type: 3}
       propertyPath: PresentSpriteSet
       value: 
       objectReference: {fileID: 11400000, guid: 58e19f5e1f96aca4e831c3dc97d67781,
@@ -229,11 +234,54 @@ PrefabInstance:
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 1364698529054501816}
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 183087353082436583, guid: 0271f252689106348ad30060b7abea96,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 5864912850942061666}
   m_SourcePrefab: {fileID: 100100000, guid: 0271f252689106348ad30060b7abea96, type: 3}
 --- !u!4 &1164968030392107538 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 187452277244307091, guid: 0271f252689106348ad30060b7abea96,
+    type: 3}
+  m_PrefabInstance: {fileID: 1347485146735535233}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1169051753645162342 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 183087353082436583, guid: 0271f252689106348ad30060b7abea96,
+    type: 3}
+  m_PrefabInstance: {fileID: 1347485146735535233}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &5864912850942061666
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1169051753645162342}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3d3d65b4ce352374ba2f4a8645c9476c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0.1
+  RelatedPart: {fileID: 0}
+  LightEmission: {fileID: 0}
+  objectLightEmission: {fileID: 4997324947772619753}
+  IsOn: 1
+  colour: {r: 1, g: 0.99607843, b: 0.88235295, a: 0.7254902}
+  objectLightSprite: {fileID: 0}
+  commonComponents: {fileID: 0}
+  SpriteShape: 0
+  Size: 4
+  weakenOnGround: 0
+  revertToOldConsistencyBehavior: 0
+  weakenStrength: 1.45
+--- !u!212 &1353538381542591546 stripped
+SpriteRenderer:
+  m_CorrespondingSourceObject: {fileID: 34763699688138939, guid: 0271f252689106348ad30060b7abea96,
     type: 3}
   m_PrefabInstance: {fileID: 1347485146735535233}
   m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Other/PottedPlants/PottedPlant9.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/PottedPlants/PottedPlant9.prefab
@@ -29,7 +29,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 3, y: 3, z: 3}
+  m_LocalScale: {x: 4, y: 4, z: 3}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1606098006712257228}
@@ -46,7 +46,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 61930e16e81db5c43a4ecc22422a0953, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  InitialColour: {r: 0.17254902, g: 0.69803923, b: 0.9098039, a: 0.8627451}
+  InitialColour: {r: 0.17254902, g: 0.69803923, b: 0.9098039, a: 0.7254902}
   Sprite: {fileID: 21300000, guid: 7d4ab37af9168d243a3eead2ef5b5758, type: 3}
   SortingOrder: 0
   Material: {fileID: 2100000, guid: b7e7f24fa2e49cb48818dace424b5868, type: 2}
@@ -207,6 +207,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6326550108531515488, guid: 0271f252689106348ad30060b7abea96,
         type: 3}
+      propertyPath: spriteRenderer
+      value: 
+      objectReference: {fileID: 1488569541138924772}
+    - target: {fileID: 6326550108531515488, guid: 0271f252689106348ad30060b7abea96,
+        type: 3}
       propertyPath: PresentSpriteSet
       value: 
       objectReference: {fileID: 11400000, guid: aace53907327f6f498d31ca3cb14ed4d,
@@ -234,11 +239,54 @@ PrefabInstance:
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 6033720368224876263}
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 183087353082436583, guid: 0271f252689106348ad30060b7abea96,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 6082362842374168899}
   m_SourcePrefab: {fileID: 100100000, guid: 0271f252689106348ad30060b7abea96, type: 3}
+--- !u!212 &1488569541138924772 stripped
+SpriteRenderer:
+  m_CorrespondingSourceObject: {fileID: 34763699688138939, guid: 0271f252689106348ad30060b7abea96,
+    type: 3}
+  m_PrefabInstance: {fileID: 1500815208261626975}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1606098006712257228 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 187452277244307091, guid: 0271f252689106348ad30060b7abea96,
     type: 3}
   m_PrefabInstance: {fileID: 1500815208261626975}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1610462930538100664 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 183087353082436583, guid: 0271f252689106348ad30060b7abea96,
+    type: 3}
+  m_PrefabInstance: {fileID: 1500815208261626975}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &6082362842374168899
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1610462930538100664}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3d3d65b4ce352374ba2f4a8645c9476c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0.1
+  RelatedPart: {fileID: 0}
+  LightEmission: {fileID: 0}
+  objectLightEmission: {fileID: 8722500347396248980}
+  IsOn: 1
+  colour: {r: 0.17254902, g: 0.69803923, b: 0.9098039, a: 0.7254902}
+  objectLightSprite: {fileID: 0}
+  commonComponents: {fileID: 0}
+  SpriteShape: 0
+  Size: 4
+  weakenOnGround: 0
+  revertToOldConsistencyBehavior: 0
+  weakenStrength: 1.45

--- a/UnityProject/Assets/Prefabs/Objects/ClosetsAndCrates/Closets/SecureLockers/SecureLockerBase.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/ClosetsAndCrates/Closets/SecureLockers/SecureLockerBase.prefab
@@ -318,7 +318,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 967620e59e52cc14c89c22c4176bac09, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  mIntensity: 0.5
+  mIntensity: 0.4
   mAdditionalEmission: 0
   mScale: 1
 --- !u!212 &4630238151158220691 stripped

--- a/UnityProject/Assets/Prefabs/Objects/ClosetsAndCrates/Crates/SecureCrates/SecureCrateBase.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/ClosetsAndCrates/Crates/SecureCrates/SecureCrateBase.prefab
@@ -349,6 +349,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 967620e59e52cc14c89c22c4176bac09, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  mIntensity: 0.5
+  mIntensity: 0.4
   mAdditionalEmission: 0
   mScale: 1

--- a/UnityProject/Assets/Prefabs/Objects/Consoles/_ComputerBase.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Consoles/_ComputerBase.prefab
@@ -140,7 +140,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0.00000031610082, y: 0.00000021073387, z: -0.70710665, w: 0.707107}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.0420799, y: 1.2660398, z: 12}
+  m_LocalScale: {x: 4, y: 4, z: 12}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7762584330458228387}
@@ -157,8 +157,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 61930e16e81db5c43a4ecc22422a0953, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  InitialColour: {r: 0.007, g: 0.459, b: 0.007, a: 0.65882355}
-  Sprite: {fileID: 21300000, guid: 9e9f6c63bf3334c8791e01efff5c16fb, type: 3}
+  InitialColour: {r: 0.007, g: 0.459, b: 0.007, a: 0.11764706}
+  Sprite: {fileID: 21300000, guid: 829e670f0b809f24a8615ee6be808dd6, type: 3}
   SortingOrder: 0
   Material: {fileID: 2100000, guid: b7e7f24fa2e49cb48818dace424b5868, type: 2}
   LightOrigin: {x: 0, y: 0, z: 1}
@@ -295,7 +295,7 @@ SpriteRenderer:
   m_SortingLayerID: 142874271
   m_SortingLayer: 12
   m_SortingOrder: 11
-  m_Sprite: {fileID: 21300000, guid: d83cafad350511e4f9bf827042c0b441, type: 3}
+  m_Sprite: {fileID: 21300008, guid: d83cafad350511e4f9bf827042c0b441, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -341,7 +341,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 967620e59e52cc14c89c22c4176bac09, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  mIntensity: 0.5
+  mIntensity: 0.35
   mAdditionalEmission: 0
   mScale: 1
 --- !u!1001 &9022170925615687109

--- a/UnityProject/Assets/Prefabs/Objects/Furniture/Podiums/PodiumBanner1.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Furniture/Podiums/PodiumBanner1.prefab
@@ -69,6 +69,31 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 234983893, guid: 4856036fd48136fb794b2ec8e252b1af,
         type: 3}
+    - target: {fileID: 2485368455509880589, guid: fff4be697c28f15eba72fd24618f8476,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2485368455509880589, guid: fff4be697c28f15eba72fd24618f8476,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2485368455509880589, guid: fff4be697c28f15eba72fd24618f8476,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2485368455509880589, guid: fff4be697c28f15eba72fd24618f8476,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2485368455509880589, guid: fff4be697c28f15eba72fd24618f8476,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3344293317101787895, guid: fff4be697c28f15eba72fd24618f8476,
         type: 3}
       propertyPath: foreverID
@@ -76,8 +101,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6577588581666901604, guid: fff4be697c28f15eba72fd24618f8476,
         type: 3}
+      propertyPath: spriteRenderer
+      value: 
+      objectReference: {fileID: 2966636686878432610}
+    - target: {fileID: 6577588581666901604, guid: fff4be697c28f15eba72fd24618f8476,
+        type: 3}
       propertyPath: initialVariantIndex
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7837786049156534748, guid: fff4be697c28f15eba72fd24618f8476,
         type: 3}
@@ -89,3 +119,9 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fff4be697c28f15eba72fd24618f8476, type: 3}
+--- !u!212 &2966636686878432610 stripped
+SpriteRenderer:
+  m_CorrespondingSourceObject: {fileID: 1907421502579425449, guid: fff4be697c28f15eba72fd24618f8476,
+    type: 3}
+  m_PrefabInstance: {fileID: 3698327865553034699}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Objects/Furniture/Podiums/PodiumBanner2.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Furniture/Podiums/PodiumBanner2.prefab
@@ -69,6 +69,31 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1041371622, guid: 4856036fd48136fb794b2ec8e252b1af,
         type: 3}
+    - target: {fileID: 2485368455509880589, guid: fff4be697c28f15eba72fd24618f8476,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2485368455509880589, guid: fff4be697c28f15eba72fd24618f8476,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2485368455509880589, guid: fff4be697c28f15eba72fd24618f8476,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2485368455509880589, guid: fff4be697c28f15eba72fd24618f8476,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2485368455509880589, guid: fff4be697c28f15eba72fd24618f8476,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3344293317101787895, guid: fff4be697c28f15eba72fd24618f8476,
         type: 3}
       propertyPath: foreverID
@@ -76,8 +101,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6577588581666901604, guid: fff4be697c28f15eba72fd24618f8476,
         type: 3}
+      propertyPath: spriteRenderer
+      value: 
+      objectReference: {fileID: 4584186502464678497}
+    - target: {fileID: 6577588581666901604, guid: fff4be697c28f15eba72fd24618f8476,
+        type: 3}
       propertyPath: initialVariantIndex
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 7837786049156534748, guid: fff4be697c28f15eba72fd24618f8476,
         type: 3}
@@ -89,3 +119,9 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fff4be697c28f15eba72fd24618f8476, type: 3}
+--- !u!212 &4584186502464678497 stripped
+SpriteRenderer:
+  m_CorrespondingSourceObject: {fileID: 1907421502579425449, guid: fff4be697c28f15eba72fd24618f8476,
+    type: 3}
+  m_PrefabInstance: {fileID: 2731090769908361928}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Objects/Furniture/Podiums/PodiumWhite.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Furniture/Podiums/PodiumWhite.prefab
@@ -69,6 +69,31 @@ PrefabInstance:
       value: 
       objectReference: {fileID: -1647903413, guid: 4856036fd48136fb794b2ec8e252b1af,
         type: 3}
+    - target: {fileID: 2485368455509880589, guid: fff4be697c28f15eba72fd24618f8476,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2485368455509880589, guid: fff4be697c28f15eba72fd24618f8476,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2485368455509880589, guid: fff4be697c28f15eba72fd24618f8476,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2485368455509880589, guid: fff4be697c28f15eba72fd24618f8476,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2485368455509880589, guid: fff4be697c28f15eba72fd24618f8476,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3344293317101787895, guid: fff4be697c28f15eba72fd24618f8476,
         type: 3}
       propertyPath: foreverID
@@ -76,8 +101,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6577588581666901604, guid: fff4be697c28f15eba72fd24618f8476,
         type: 3}
+      propertyPath: spriteRenderer
+      value: 
+      objectReference: {fileID: 6495747529587547163}
+    - target: {fileID: 6577588581666901604, guid: fff4be697c28f15eba72fd24618f8476,
+        type: 3}
       propertyPath: initialVariantIndex
-      value: 4
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 6577588581666901604, guid: fff4be697c28f15eba72fd24618f8476,
         type: 3}
@@ -130,3 +160,9 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fff4be697c28f15eba72fd24618f8476, type: 3}
+--- !u!212 &6495747529587547163 stripped
+SpriteRenderer:
+  m_CorrespondingSourceObject: {fileID: 1907421502579425449, guid: fff4be697c28f15eba72fd24618f8476,
+    type: 3}
+  m_PrefabInstance: {fileID: 4637865624253471922}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Objects/Furniture/Podiums/PodiumWhiteBanner1.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Furniture/Podiums/PodiumWhiteBanner1.prefab
@@ -11,7 +11,7 @@ PrefabInstance:
     - target: {fileID: 1951549307202327254, guid: d9b124d8873fbcf45a481f8bbe51f901,
         type: 3}
       propertyPath: initialVariantIndex
-      value: 5
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 3213435796600343918, guid: d9b124d8873fbcf45a481f8bbe51f901,
         type: 3}
@@ -79,6 +79,21 @@ PrefabInstance:
       value: 
       objectReference: {fileID: -1385373013, guid: 4856036fd48136fb794b2ec8e252b1af,
         type: 3}
+    - target: {fileID: 7070879320150848447, guid: d9b124d8873fbcf45a481f8bbe51f901,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7070879320150848447, guid: d9b124d8873fbcf45a481f8bbe51f901,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7070879320150848447, guid: d9b124d8873fbcf45a481f8bbe51f901,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7941063559839942213, guid: d9b124d8873fbcf45a481f8bbe51f901,
         type: 3}
       propertyPath: foreverID

--- a/UnityProject/Assets/Prefabs/Objects/Furniture/Podiums/PodiumWhiteBanner2.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Furniture/Podiums/PodiumWhiteBanner2.prefab
@@ -11,7 +11,7 @@ PrefabInstance:
     - target: {fileID: 1951549307202327254, guid: d9b124d8873fbcf45a481f8bbe51f901,
         type: 3}
       propertyPath: initialVariantIndex
-      value: 6
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 3213435796600343918, guid: d9b124d8873fbcf45a481f8bbe51f901,
         type: 3}
@@ -83,6 +83,21 @@ PrefabInstance:
         type: 3}
       propertyPath: m_WasSpriteAssigned
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7070879320150848447, guid: d9b124d8873fbcf45a481f8bbe51f901,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7070879320150848447, guid: d9b124d8873fbcf45a481f8bbe51f901,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7070879320150848447, guid: d9b124d8873fbcf45a481f8bbe51f901,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7941063559839942213, guid: d9b124d8873fbcf45a481f8bbe51f901,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Objects/WallProtrusions/LightTubeFixture.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/WallProtrusions/LightTubeFixture.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 5173863171863889205}
   - component: {fileID: 1689274832931870787}
   - component: {fileID: 1952478272362544665}
-  - component: {fileID: 5654744772247092005}
   m_Layer: 19
   m_Name: LightOn
   m_TagString: Untagged
@@ -118,21 +117,6 @@ MonoBehaviour:
   initialVariantIndex: 0
   InitialColour: {r: 1, g: 1, b: 1, a: 1}
   palette: []
---- !u!114 &5654744772247092005
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2161202133596991296}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 967620e59e52cc14c89c22c4176bac09, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  mIntensity: 0.5
-  mAdditionalEmission: 0
-  mScale: 1
 --- !u!1 &8582599332015320669
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Objects/Wallmounts/FireAlarm.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Wallmounts/FireAlarm.prefab
@@ -53,6 +53,7 @@ SpriteRenderer:
   m_RayTraceProcedural: 0
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -106,11 +107,14 @@ MonoBehaviour:
   - {fileID: 11400000, guid: f0d9ef9cb1bd60041ba7bece6502cad1, type: 2}
   - {fileID: 11400000, guid: 438e55d815092a542bfd51688ac1ca5b, type: 2}
   - {fileID: 11400000, guid: da165232a664e42478b67852c0c20ceb, type: 2}
-  PresentSpriteSet: {fileID: 11400000, guid: 43216e6a6e9d3ec4681d25def5310123, type: 2}
+  InitialPresentSpriteSet: {fileID: 11400000, guid: 43216e6a6e9d3ec4681d25def5310123,
+    type: 2}
   randomInitialSprite: 0
+  spriteRenderer: {fileID: 575592768451504345}
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
   initialVariantIndex: 0
+  InitialColour: {r: 1, g: 1, b: 1, a: 1}
   palette: []
 --- !u!114 &3777985596206283457
 MonoBehaviour:
@@ -126,7 +130,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   mIntensity: 0.4
   mAdditionalEmission: 0
-  mScale: 0.9
+  mScale: 1
 --- !u!1 &8844773903192739836
 GameObject:
   m_ObjectHideFlags: 0
@@ -180,6 +184,7 @@ SpriteRenderer:
   m_RayTraceProcedural: 0
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -232,11 +237,14 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 5209ae0633fb8a24d9d4f9d45d46053d, type: 2}
   - {fileID: 11400000, guid: 8656127b1191f6d4397dab145b7fcaf7, type: 2}
   - {fileID: 11400000, guid: d0e82ed9ea095c64c81c7790c1e07758, type: 2}
-  PresentSpriteSet: {fileID: 11400000, guid: 5209ae0633fb8a24d9d4f9d45d46053d, type: 2}
+  InitialPresentSpriteSet: {fileID: 11400000, guid: 5209ae0633fb8a24d9d4f9d45d46053d,
+    type: 2}
   randomInitialSprite: 0
+  spriteRenderer: {fileID: 6173794422173241655}
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
   initialVariantIndex: 0
+  InitialColour: {r: 1, g: 1, b: 1, a: 1}
   palette: []
 --- !u!114 &3296440861055232477
 MonoBehaviour:
@@ -252,7 +260,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   mIntensity: 0.4
   mAdditionalEmission: 0
-  mScale: 0.9
+  mScale: 1
 --- !u!1001 &3074947235549192634
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -269,6 +277,11 @@ PrefabInstance:
     - target: {fileID: -6356777978426299504, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
       propertyPath: deviceType
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: -6356777978426299504, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: initialwattusage
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
@@ -399,7 +412,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6109775972905365350, guid: b69bfc56f39849d4ba9139d2d51bedb6,
         type: 3}
+      propertyPath: spriteRenderer
+      value: 
+      objectReference: {fileID: 4564095785055846417}
+    - target: {fileID: 6109775972905365350, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
       propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 1355c8740991a9047a3546b6f422dd19,
+        type: 2}
+    - target: {fileID: 6109775972905365350, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+        type: 3}
+      propertyPath: InitialPresentSpriteSet
       value: 
       objectReference: {fileID: 11400000, guid: 1355c8740991a9047a3546b6f422dd19,
         type: 2}
@@ -610,6 +634,14 @@ MonoBehaviour:
   SynchroniseCurrentDirection: 3
   IgnoreServerUpdatesIfLocalPlayer: 0
   MatrixRotateUpdate: 1
+  SetOrder: 0
+  Orders: 00000000000000000000000000000000
+  SetLayer: 0
+  Layers:
+  - Rename me 1
+  - Rename me 2
+  - Rename me 3
+  - Rename me 4
   IsAtmosphericDevice: 0
   doNotResetOtherSpriteOptions: 0
 --- !u!114 &7882156339634519424
@@ -640,18 +672,48 @@ MonoBehaviour:
   bottomLightSpriteHandler: {fileID: 6366995917858756332}
   coverOpen: 0
   hasCables: 1
-  registerTile: {fileID: 0}
-  integrity: {fileID: 0}
+  registerTile: {fileID: 4966197239815423054}
+  integrity: {fileID: 5177482785941875611}
   FireAlarmSFX:
-    SetLoadSetting: 0
     AssetAddress: Assets/Prefabs/Machines/FireAlarm.prefab
     AssetReference:
       m_AssetGUID: 
       m_SubObjectName: 
+      m_SubObjectGUID: 
       m_SubObjectType: 
       m_EditorAssetChanged: 0
   <CanRelink>k__BackingField: 1
   <IgnoreMaxDistanceMapper>k__BackingField: 0
+--- !u!212 &4564095785055846417 stripped
+SpriteRenderer:
+  m_CorrespondingSourceObject: {fileID: 1583724279418462635, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+    type: 3}
+  m_PrefabInstance: {fileID: 3074947235549192634}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4966197239815423054 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7946340047006197236, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+    type: 3}
+  m_PrefabInstance: {fileID: 3074947235549192634}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4338884022056035334}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9a459a0316cc4d5b87d046f28dc136c8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &5177482785941875611 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7887620515462466081, guid: b69bfc56f39849d4ba9139d2d51bedb6,
+    type: 3}
+  m_PrefabInstance: {fileID: 3074947235549192634}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4338884022056035334}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f24590037b6b486082fc874d1bfd9d95, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &5529437522813867580 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7354635586586802054, guid: b69bfc56f39849d4ba9139d2d51bedb6,
@@ -670,9 +732,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 967620e59e52cc14c89c22c4176bac09, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  mIntensity: 0.5
+  mIntensity: 0.15
   mAdditionalEmission: 0
-  mScale: 0.76
+  mScale: 1
 --- !u!114 &9108003409961094876 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6109775972905365350, guid: b69bfc56f39849d4ba9139d2d51bedb6,

--- a/UnityProject/Assets/Prefabs/Objects/Wallmounts/LightSwitch.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Wallmounts/LightSwitch.prefab
@@ -261,7 +261,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 967620e59e52cc14c89c22c4176bac09, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  mIntensity: 0.5
+  mIntensity: 0.3
   mAdditionalEmission: 0
   mScale: 1
 --- !u!212 &5201104623901103339 stripped


### PR DESCRIPTION

### Purpose
remove light emission behavior from lighttubefixture's so-called LightOn sprite
bioluminescent potted plants: alpha 220 => 185, scale 3 => 4, added item light control so they'll still be lit while held
lightswitch m intensity 0.5 => 0.3
securecratebase & securelockerbase locklight m intensity 0.5 => 0.4
fire alarm main sprite m intensity 0.5 => 0.15 scale 0.76 => 1, light sprites scale 0.9 => 1
computerbase screensprite m intensity 0.5 => 0.35, light2d screenglow changed to a small area light and dimmed significantly
fixed stupid podium sprite variant indices

### Notes:
further tweaks probably needed to hit ideal levels--i'm shooting in the dark currently.

### Changelog:
n/a