### PR TITLE
Checks if any parts of the player is null before attempting to gasp

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Chat/EmoteActionManager.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/EmoteActionManager.cs
@@ -51,6 +51,7 @@ namespace Core.Chat
 
 		public static void DoEmote(string emote, GameObject player)
 		{
+			if (player == null) return;
 			foreach (var e in Instance.emoteList.Emotes)
 			{
 				if(emote.Equals(e.EmoteName, StringComparison.CurrentCultureIgnoreCase))

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/Lungs.cs
@@ -323,6 +323,7 @@ namespace Items.Implants.Organs
 				suffocating = true;
 				if (DMMath.Prob(20))
 				{
+					if (LivingHealthMaster == null || LivingHealthMaster.gameObject == null) return false; //how does this even happen midway? this isn't async
 					EmoteActionManager.DoEmote("gasp-air", LivingHealthMaster.gameObject);
 				}
 			}
@@ -348,11 +349,12 @@ namespace Items.Implants.Organs
 		/// </summary>
 		public void BreatheIn(GasMix breathGasMix, float efficiency)
 		{
+			if (LivingHealthMaster == null || LivingHealthMaster.gameObject == null) return;
 			ReagentMix availableBlood =
-				LivingHealthMaster.reagentPoolSystem.BloodPool.Take(
+				LivingHealthMaster.reagentPoolSystem?.BloodPool.Take(
 					(LivingHealthMaster.reagentPoolSystem.BloodPool.Total * efficiency) / 2f);
 			BreatheIn(breathGasMix, availableBlood, efficiency);
-			LivingHealthMaster.reagentPoolSystem.BloodPool.Add(availableBlood);
+			LivingHealthMaster.reagentPoolSystem?.BloodPool.Add(availableBlood);
 		}
 
 		/// <summary>
@@ -361,8 +363,10 @@ namespace Items.Implants.Organs
 		/// <param name="gasMix">the gases the character is breathing in</param>
 		public virtual void ToxinBreathinCheck(GasMix gasMix)
 		{
-			if (RelatedPart.HealthMaster.RespiratorySystem.CanBreatheAnywhere ||
-				RelatedPart.HealthMaster.playerScript == null) return;
+			if (RelatedPart == null || RelatedPart.HealthMaster == null
+			                        || RelatedPart.HealthMaster.RespiratorySystem == null
+			                        || RelatedPart.HealthMaster.playerScript == null) return;
+			if (RelatedPart.HealthMaster.RespiratorySystem.CanBreatheAnywhere) return;
 
 			var hasToxins = false;
 

--- a/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteBehaviors/InhaleOnEmote.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteBehaviors/InhaleOnEmote.cs
@@ -16,7 +16,7 @@ namespace ScriptableObjects.RP.EmoteBehaviors
 			if (actor == null || actor.TryGetComponent<LivingHealthMasterBase>(out var health) == false) return;
 			var gas = GasMix.GetEnvironmentalGasMixForObject(actor.GetUniversalObjectPhysics());
 			var lungs = GetLungs(health);
-			if (lungs == null || gas == null) return;
+			if (lungs.Count == 0 || gas == null) return;
 			foreach (var lung in lungs)
 			{
 				lung.BreatheIn(gas, Efficiency);

--- a/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/RP/EmoteSO.cs
@@ -8,6 +8,7 @@ using Messages.Server.SoundMessages;
 using NaughtyAttributes;
 using UnityEngine;
 using UnityEngine.Serialization;
+using Util.Independent.FluentRichText;
 using Random = UnityEngine.Random;
 
 namespace ScriptableObjects.RP
@@ -119,7 +120,7 @@ namespace ScriptableObjects.RP
 			switch (type)
 			{
 				case FailType.Normal:
-					Chat.AddActionMsgToChat(player, $"{failText}", "");
+					Chat.AddExamineMsg(player, $"[Emote: {emoteName}] - {failText}".Italic());
 					break;
 				case FailType.Critical:
 					Chat.AddActionMsgToChat(player, $"{player.ExpensiveName()} {critViewText}.", $"{player.ExpensiveName()} {critViewText}.");


### PR DESCRIPTION
CL: [Fix] Fix a weird bug where some aspects of gasp and respiratory checks would pass in null values to the emote manager.
CL: [Fix] Fixed an issue where some emotes should have not publicly displayed their failure text.
