### PR TITLE
Fallstation APC work and foreverid fixes

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Other/Toys/Plushes/OddSlugPlushie.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/Toys/Plushes/OddSlugPlushie.prefab
@@ -96,6 +96,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6236086576208570426, guid: 75421751b31ee7f49b1adb8b70cd2375,
         type: 3}
+      propertyPath: spriteRenderer
+      value: 
+      objectReference: {fileID: 7269613952178807973}
+    - target: {fileID: 6236086576208570426, guid: 75421751b31ee7f49b1adb8b70cd2375,
+        type: 3}
       propertyPath: PresentSpriteSet
       value: 
       objectReference: {fileID: 11400000, guid: c819d8a72ab14b1489b3790e18c4dc54,
@@ -110,6 +115,12 @@ PrefabInstance:
       propertyPath: randomInitialSprite
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 6236086576208570426, guid: 75421751b31ee7f49b1adb8b70cd2375,
+        type: 3}
+      propertyPath: InitialPresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: c819d8a72ab14b1489b3790e18c4dc54,
+        type: 2}
     - target: {fileID: 6590914017311023056, guid: 75421751b31ee7f49b1adb8b70cd2375,
         type: 3}
       propertyPath: parentID
@@ -118,10 +129,16 @@ PrefabInstance:
     - target: {fileID: 6590914017311023056, guid: 75421751b31ee7f49b1adb8b70cd2375,
         type: 3}
       propertyPath: foreverID
-      value: EkKax?M$hbn0fMg@aU5X
+      value: 409gLRNpRQA6ZJ-B4F7U
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 75421751b31ee7f49b1adb8b70cd2375, type: 3}
+--- !u!212 &7269613952178807973 stripped
+SpriteRenderer:
+  m_CorrespondingSourceObject: {fileID: 89206780398788833, guid: 75421751b31ee7f49b1adb8b70cd2375,
+    type: 3}
+  m_PrefabInstance: {fileID: 7340364123394180164}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Items/Tools/HandPick.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/HandPick.prefab
@@ -10,7 +10,18 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1237339817834502954, guid: 7976a84ef9209f14697cdd941b913e2a,
         type: 3}
+      propertyPath: spriteRenderer
+      value: 
+      objectReference: {fileID: 2197727713988966463}
+    - target: {fileID: 1237339817834502954, guid: 7976a84ef9209f14697cdd941b913e2a,
+        type: 3}
       propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: c385ee2e573c8d94bbe2887e69a9510f,
+        type: 2}
+    - target: {fileID: 1237339817834502954, guid: 7976a84ef9209f14697cdd941b913e2a,
+        type: 3}
+      propertyPath: InitialPresentSpriteSet
       value: 
       objectReference: {fileID: 11400000, guid: c385ee2e573c8d94bbe2887e69a9510f,
         type: 2}
@@ -22,7 +33,7 @@ PrefabInstance:
     - target: {fileID: 2078214216639179968, guid: 7976a84ef9209f14697cdd941b913e2a,
         type: 3}
       propertyPath: foreverID
-      value: 8gzr!x7_Yea@71L--kC5
+      value: yZZOh_oxUsRnJuf$HNg8
       objectReference: {fileID: 0}
     - target: {fileID: 2762265701145370199, guid: 7976a84ef9209f14697cdd941b913e2a,
         type: 3}
@@ -85,6 +96,18 @@ PrefabInstance:
     - target: {fileID: 4791952605902770127, guid: 7976a84ef9209f14697cdd941b913e2a,
         type: 3}
       propertyPath: itemSprites.SpriteRightHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 4111f042fe2174641bfba131ce87df1a,
+        type: 2}
+    - target: {fileID: 4791952605902770127, guid: 7976a84ef9209f14697cdd941b913e2a,
+        type: 3}
+      propertyPath: InitialitemSprites.SpriteLeftHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 0b395bda1e929674e9fec2099782a493,
+        type: 2}
+    - target: {fileID: 4791952605902770127, guid: 7976a84ef9209f14697cdd941b913e2a,
+        type: 3}
+      propertyPath: InitialitemSprites.SpriteRightHand
       value: 
       objectReference: {fileID: 11400000, guid: 4111f042fe2174641bfba131ce87df1a,
         type: 2}
@@ -174,3 +197,9 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7976a84ef9209f14697cdd941b913e2a, type: 3}
+--- !u!212 &2197727713988966463 stripped
+SpriteRenderer:
+  m_CorrespondingSourceObject: {fileID: 5087942406049846257, guid: 7976a84ef9209f14697cdd941b913e2a,
+    type: 3}
+  m_PrefabInstance: {fileID: 6405215018495290318}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Objects/Security/SecBarrier.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Security/SecBarrier.prefab
@@ -16,7 +16,7 @@ PrefabInstance:
     - target: {fileID: 951381747229521920, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
       propertyPath: foreverID
-      value: 8D0W-BGDVb8469ufZ@aF
+      value: J5UF3VXxKdTV9iopbA17
       objectReference: {fileID: 0}
     - target: {fileID: 4116897424394887774, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
@@ -32,7 +32,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 1713f5ab87046054cbfd4f3c0ca6b65b,
+      objectReference: {fileID: 21300008, guid: 1713f5ab87046054cbfd4f3c0ca6b65b,
         type: 3}
     - target: {fileID: 4116897424394887774, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
@@ -131,7 +131,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8652228875761003667, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
+      propertyPath: spriteRenderer
+      value: 
+      objectReference: {fileID: 8659369892982235948}
+    - target: {fileID: 8652228875761003667, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
       propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 4d8397bcf17f31c4998aca1d17eab147,
+        type: 2}
+    - target: {fileID: 8652228875761003667, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: InitialPresentSpriteSet
       value: 
       objectReference: {fileID: 11400000, guid: 4d8397bcf17f31c4998aca1d17eab147,
         type: 2}
@@ -152,6 +163,12 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 3264902312100370501}
   m_SourcePrefab: {fileID: 100100000, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
+--- !u!212 &8659369892982235948 stripped
+SpriteRenderer:
+  m_CorrespondingSourceObject: {fileID: 4116897424394887774, guid: ebb08cf966efc084aa918bd8d9429604,
+    type: 3}
+  m_PrefabInstance: {fileID: 4687802377970647410}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &8884616769721009979 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4197940402254186057, guid: ebb08cf966efc084aa918bd8d9429604,

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/BoxStationV1.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/BoxStationV1.json
@@ -242807,15 +242807,15 @@
             "LocalPRS": "-238┼88┼0┼"
           },
           {
-            "GitID": "8D0W-BGDVb8469ufZ@aF_-238┼92┼0┼",
-            "PrefabID": "8D0W-BGDVb8469ufZ@aF",
+            "GitID": "J5UF3VXxKdTV9iopbA17_-238┼92┼0┼",
+            "PrefabID": "J5UF3VXxKdTV9iopbA17",
             "NameMatches": true,
             "Name": "SecBarrier",
             "LocalPRS": "-238┼92┼0┼"
           },
           {
-            "GitID": "8D0W-BGDVb8469ufZ@aF_-238┼93┼0┼",
-            "PrefabID": "8D0W-BGDVb8469ufZ@aF",
+            "GitID": "J5UF3VXxKdTV9iopbA17_-238┼93┼0┼",
+            "PrefabID": "J5UF3VXxKdTV9iopbA17",
             "NameMatches": true,
             "Name": "SecBarrier",
             "LocalPRS": "-238┼93┼0┼"
@@ -267689,8 +267689,8 @@
             "LocalPRS": "-221┼99┼0┼"
           },
           {
-            "GitID": "8D0W-BGDVb8469ufZ@aF_-221┼102┼0┼",
-            "PrefabID": "8D0W-BGDVb8469ufZ@aF",
+            "GitID": "J5UF3VXxKdTV9iopbA17_-221┼102┼0┼",
+            "PrefabID": "J5UF3VXxKdTV9iopbA17",
             "NameMatches": true,
             "Name": "SecBarrier",
             "LocalPRS": "-221┼102┼0┼"
@@ -272084,15 +272084,15 @@
             }
           },
           {
-            "GitID": "8D0W-BGDVb8469ufZ@aF_-218┼99┼0┼",
-            "PrefabID": "8D0W-BGDVb8469ufZ@aF",
+            "GitID": "J5UF3VXxKdTV9iopbA17_-218┼99┼0┼",
+            "PrefabID": "J5UF3VXxKdTV9iopbA17",
             "NameMatches": true,
             "Name": "SecBarrier",
             "LocalPRS": "-218┼99┼0┼"
           },
           {
-            "GitID": "8D0W-BGDVb8469ufZ@aF_-218┼102┼0┼",
-            "PrefabID": "8D0W-BGDVb8469ufZ@aF",
+            "GitID": "J5UF3VXxKdTV9iopbA17_-218┼102┼0┼",
+            "PrefabID": "J5UF3VXxKdTV9iopbA17",
             "NameMatches": true,
             "Name": "SecBarrier",
             "LocalPRS": "-218┼102┼0┼"

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/FallStation.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/FallStation.json
@@ -92960,15 +92960,6 @@
                       "Data": "cd57203a8d3f54f478446e9b0ced6cf9_33┼102┼0┼@0@APC@0"
                     }
                   ]
-                },
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Up_By0"
-                    }
-                  ]
                 }
               ],
               "Children": [
@@ -93287,8 +93278,8 @@
             "LocalPRS": "33.03┼111.83┼0┼"
           },
           {
-            "GitID": "8gzr!x7_Yea@71L--kC5_33.04┼95.2┼0┼",
-            "PrefabID": "8gzr!x7_Yea@71L--kC5",
+            "GitID": "yZZOh_oxUsRnJuf$HNg8_33.04┼95.2┼0┼",
+            "PrefabID": "yZZOh_oxUsRnJuf$HNg8",
             "Name": "HandPick (1)",
             "LocalPRS": "33.04┼95.2┼0┼"
           },
@@ -94457,6 +94448,69 @@
             }
           },
           {
+            "GitID": "c21551dd992a57349973e4b5af103ca6_36┼70┼0┼",
+            "PrefabID": "c21551dd992a57349973e4b5af103ca6",
+            "NameMatches": true,
+            "Name": "SecurityCamera",
+            "LocalPRS": "36┼70┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "UniversalObjectPhysics@0",
+                  "Data": [
+                    {
+                      "Name": "SnapToGridOnStart",
+                      "Data": "False"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_37┼70┼0┼@0@APC@0"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "SecurityCamera@0",
+                  "Data": [
+                    {
+                      "Name": "cameraName",
+                      "Data": "Teleporter"
+                    },
+                    {
+                      "Name": "motionSensingCamera",
+                      "Data": "True"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Left_By90"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,1",
+                  "Active": false,
+                  "ClassDatas": []
+                },
+                {
+                  "ID": "0,2",
+                  "Active": false,
+                  "ClassDatas": []
+                }
+              ]
+            }
+          },
+          {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_36┼70┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
             "NameMatches": true,
@@ -94856,68 +94910,6 @@
             "NameMatches": true,
             "Name": "EODClosetScience",
             "LocalPRS": "36┼113┼0┼"
-          },
-          {
-            "GitID": "c21551dd992a57349973e4b5af103ca6_36.03┼69.67┼0┼",
-            "PrefabID": "c21551dd992a57349973e4b5af103ca6",
-            "Name": "SecurityCamera (1)",
-            "LocalPRS": "36.03┼69.67┼0┼",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "UniversalObjectPhysics@0",
-                  "Data": [
-                    {
-                      "Name": "SnapToGridOnStart",
-                      "Data": "False"
-                    }
-                  ]
-                },
-                {
-                  "ClassID": "APCPoweredDevice@0",
-                  "Data": [
-                    {
-                      "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_37┼70┼0┼@0@APC@0"
-                    }
-                  ]
-                },
-                {
-                  "ClassID": "SecurityCamera@0",
-                  "Data": [
-                    {
-                      "Name": "cameraName",
-                      "Data": "Teleporter"
-                    },
-                    {
-                      "Name": "motionSensingCamera",
-                      "Data": "True"
-                    }
-                  ]
-                },
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Left_By90"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "Active": false,
-                  "ClassDatas": []
-                },
-                {
-                  "ID": "0,2",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
           },
           {
             "GitID": "567c92f423be65e49becad1f3fc2dfb9_36.16┼98.83┼0┼",
@@ -95343,7 +95335,7 @@
                     },
                     {
                       "Name": "connectedDevices#11",
-                      "Data": "c21551dd992a57349973e4b5af103ca6_36.03┼69.67┼0┼@0@APCPoweredDevice@0"
+                      "Data": "c21551dd992a57349973e4b5af103ca6_36┼70┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#10",
@@ -97628,6 +97620,26 @@
             }
           },
           {
+            "GitID": "5425ee650c49e0849b4bed132cfb588f_40┼117┼0┼",
+            "PrefabID": "5425ee650c49e0849b4bed132cfb588f",
+            "NameMatches": true,
+            "Name": "TinyFan",
+            "LocalPRS": "40┼117┼0┼0↔0↔1↔",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
             "GitID": "79cea07a5f8e66f49a554df1a003ecba_40┼117┼0┼",
             "PrefabID": "79cea07a5f8e66f49a554df1a003ecba",
             "NameMatches": true,
@@ -98777,13 +98789,30 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
           {
             "GitID": "ddcfc3ab784dec1419565255774956c5_42┼90┼0┼",
             "PrefabID": "ddcfc3ab784dec1419565255774956c5",
-            "Name": "WinDoorLeft (1)",
+            "NameMatches": true,
+            "Name": "WinDoorLeft",
             "LocalPRS": "42┼90┼0┼",
             "Object": {
               "ClassDatas": [
@@ -98808,6 +98837,20 @@
               ],
               "Children": [
                 {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -98816,6 +98859,90 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Robotics"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,3",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,4",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,5",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,6",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,7",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
                         }
                       ]
                     }
@@ -100843,7 +100970,8 @@
           {
             "GitID": "cbe919cf00f84254f83d474582798520_44┼107┼0┼",
             "PrefabID": "cbe919cf00f84254f83d474582798520",
-            "Name": "SecureWinDoorRight (1)",
+            "NameMatches": true,
+            "Name": "SecureWinDoorRight",
             "LocalPRS": "44┼107┼0┼",
             "Object": {
               "ClassDatas": [
@@ -100868,7 +100996,8 @@
           {
             "GitID": "cbe919cf00f84254f83d474582798520_44.001┼107┼0┼",
             "PrefabID": "cbe919cf00f84254f83d474582798520",
-            "Name": "SecureWinDoorRight (4)",
+            "NameMatches": true,
+            "Name": "SecureWinDoorRight",
             "LocalPRS": "44.001┼107┼0┼",
             "Object": {
               "ClassDatas": [
@@ -100887,6 +101016,106 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Up_By0"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,3",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,4",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,5",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,6",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,7",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -102674,6 +102903,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -103798,7 +104043,8 @@
           {
             "GitID": "cbe919cf00f84254f83d474582798520_47┼107┼0┼",
             "PrefabID": "cbe919cf00f84254f83d474582798520",
-            "Name": "SecureWinDoorRight (2)",
+            "NameMatches": true,
+            "Name": "SecureWinDoorRight",
             "LocalPRS": "47┼107┼0┼",
             "Object": {
               "ClassDatas": [
@@ -103817,7 +104063,8 @@
           {
             "GitID": "cbe919cf00f84254f83d474582798520_47.001┼107┼0┼",
             "PrefabID": "cbe919cf00f84254f83d474582798520",
-            "Name": "SecureWinDoorRight (5)",
+            "NameMatches": true,
+            "Name": "SecureWinDoorRight",
             "LocalPRS": "47.001┼107┼0┼",
             "Object": {
               "ClassDatas": [
@@ -103836,6 +104083,106 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Up_By0"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,3",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,4",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,5",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,6",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,7",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -103895,7 +104242,8 @@
           {
             "GitID": "6fa1bf6a566af2f479f551f9bb604178_48┼36┼0┼",
             "PrefabID": "6fa1bf6a566af2f479f551f9bb604178",
-            "Name": "SecureWinDoorLeft (2)",
+            "NameMatches": true,
+            "Name": "SecureWinDoorLeft",
             "LocalPRS": "48┼36┼0┼",
             "Object": {
               "ClassDatas": [
@@ -103914,6 +104262,106 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,3",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,4",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,5",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,6",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,7",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -104110,6 +104558,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Up_By0"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -104486,7 +104950,8 @@
           {
             "GitID": "ddcfc3ab784dec1419565255774956c5_49┼69┼0┼",
             "PrefabID": "ddcfc3ab784dec1419565255774956c5",
-            "Name": "WinDoorLeft (4)",
+            "NameMatches": true,
+            "Name": "WinDoorLeft",
             "LocalPRS": "49┼69┼0┼",
             "Object": {
               "ClassDatas": [
@@ -104511,6 +104976,20 @@
               ],
               "Children": [
                 {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -104519,6 +104998,90 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Cargo"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,3",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,4",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,5",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,6",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,7",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
                         }
                       ]
                     }
@@ -105053,7 +105616,8 @@
           {
             "GitID": "cbe919cf00f84254f83d474582798520_50┼107┼0┼",
             "PrefabID": "cbe919cf00f84254f83d474582798520",
-            "Name": "SecureWinDoorRight (3)",
+            "NameMatches": true,
+            "Name": "SecureWinDoorRight",
             "LocalPRS": "50┼107┼0┼",
             "Object": {
               "ClassDatas": [
@@ -105072,7 +105636,8 @@
           {
             "GitID": "cbe919cf00f84254f83d474582798520_50.001┼107┼0┼",
             "PrefabID": "cbe919cf00f84254f83d474582798520",
-            "Name": "SecureWinDoorRight (6)",
+            "NameMatches": true,
+            "Name": "SecureWinDoorRight",
             "LocalPRS": "50.001┼107┼0┼",
             "Object": {
               "ClassDatas": [
@@ -105091,6 +105656,106 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Up_By0"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,3",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,4",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,5",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,6",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,7",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -107088,6 +107753,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -107440,7 +108121,8 @@
           {
             "GitID": "c21551dd992a57349973e4b5af103ca6_55┼128┼0┼",
             "PrefabID": "c21551dd992a57349973e4b5af103ca6",
-            "Name": "SecurityCamera (1)",
+            "NameMatches": true,
+            "Name": "SecurityCamera",
             "LocalPRS": "55┼128┼0┼",
             "Object": {
               "ClassDatas": [
@@ -107605,6 +108287,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -107794,7 +108492,8 @@
           {
             "GitID": "6fa1bf6a566af2f479f551f9bb604178_56┼57┼0┼",
             "PrefabID": "6fa1bf6a566af2f479f551f9bb604178",
-            "Name": "SecureWinDoorLeft (3)",
+            "NameMatches": true,
+            "Name": "SecureWinDoorLeft",
             "LocalPRS": "56┼57┼0┼",
             "Object": {
               "ClassDatas": [
@@ -107819,6 +108518,20 @@
               ],
               "Children": [
                 {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -107827,6 +108540,90 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Cargo"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,3",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,4",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,5",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,6",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,7",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
                         }
                       ]
                     }
@@ -108992,6 +109789,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Left_By90"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -110630,6 +111443,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -110844,6 +111673,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -111376,6 +112221,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -111392,6 +112253,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Left_By90"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -111414,6 +112291,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -111430,6 +112323,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Left_By90"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -111452,13 +112361,30 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
           {
             "GitID": "ddcfc3ab784dec1419565255774956c5_61┼28┼0┼",
             "PrefabID": "ddcfc3ab784dec1419565255774956c5",
-            "Name": "WinDoorLeft (1)",
+            "NameMatches": true,
+            "Name": "WinDoorLeft",
             "LocalPRS": "61┼28┼0┼",
             "Object": {
               "ClassDatas": [
@@ -111933,6 +112859,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -111949,6 +112891,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Left_By90"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -111971,6 +112929,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -111990,13 +112964,30 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
           {
             "GitID": "ddcfc3ab784dec1419565255774956c5_62┼24┼0┼",
             "PrefabID": "ddcfc3ab784dec1419565255774956c5",
-            "Name": "WinDoorLeft (1)",
+            "NameMatches": true,
+            "Name": "WinDoorLeft",
             "LocalPRS": "62┼24┼0┼",
             "Object": {
               "ClassDatas": [
@@ -112021,6 +113012,20 @@
               ],
               "Children": [
                 {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -112029,6 +113034,90 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "ChapelOffice"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,3",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,4",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,5",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,6",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,7",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
                         }
                       ]
                     }
@@ -112161,6 +113250,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Left_By90"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -113186,13 +114291,30 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
           {
             "GitID": "cf93667e32e15bc43b0347cd102fef98_63┼28┼0┼",
             "PrefabID": "cf93667e32e15bc43b0347cd102fef98",
-            "Name": "WinDoorRight (1)",
+            "NameMatches": true,
+            "Name": "WinDoorRight",
             "LocalPRS": "63┼28┼0┼",
             "Object": {
               "ClassDatas": [
@@ -113427,7 +114549,8 @@
           {
             "GitID": "cf93667e32e15bc43b0347cd102fef98_63┼58┼0┼",
             "PrefabID": "cf93667e32e15bc43b0347cd102fef98",
-            "Name": "WinDoorRight (2)",
+            "NameMatches": true,
+            "Name": "WinDoorRight",
             "LocalPRS": "63┼58┼0┼",
             "Object": {
               "ClassDatas": [
@@ -114190,6 +115313,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -114821,7 +115960,8 @@
           {
             "GitID": "cf93667e32e15bc43b0347cd102fef98_64┼58┼0┼",
             "PrefabID": "cf93667e32e15bc43b0347cd102fef98",
-            "Name": "WinDoorRight (5)",
+            "NameMatches": true,
+            "Name": "WinDoorRight",
             "LocalPRS": "64┼58┼0┼",
             "Object": {
               "ClassDatas": [
@@ -115244,7 +116384,8 @@
           {
             "GitID": "c21551dd992a57349973e4b5af103ca6_64┼125┼0┼",
             "PrefabID": "c21551dd992a57349973e4b5af103ca6",
-            "Name": "SecurityCamera (1)",
+            "NameMatches": true,
+            "Name": "SecurityCamera",
             "LocalPRS": "64┼125┼0┼",
             "Object": {
               "ClassDatas": [
@@ -115348,7 +116489,8 @@
           {
             "GitID": "c21551dd992a57349973e4b5af103ca6_64┼132┼0┼",
             "PrefabID": "c21551dd992a57349973e4b5af103ca6",
-            "Name": "SecurityCamera (2)",
+            "NameMatches": true,
+            "Name": "SecurityCamera",
             "LocalPRS": "64┼132┼0┼",
             "Object": {
               "ClassDatas": [
@@ -116375,7 +117517,8 @@
           {
             "GitID": "c21551dd992a57349973e4b5af103ca6_65┼129┼0┼",
             "PrefabID": "c21551dd992a57349973e4b5af103ca6",
-            "Name": "SecurityCamera (1)",
+            "NameMatches": true,
+            "Name": "SecurityCamera",
             "LocalPRS": "65┼129┼0┼",
             "Object": {
               "ClassDatas": [
@@ -117724,6 +118867,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Up_By0"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -120727,7 +121886,8 @@
           {
             "GitID": "c21551dd992a57349973e4b5af103ca6_70┼128┼0┼",
             "PrefabID": "c21551dd992a57349973e4b5af103ca6",
-            "Name": "SecurityCamera (1)",
+            "NameMatches": true,
+            "Name": "SecurityCamera",
             "LocalPRS": "70┼128┼0┼",
             "Object": {
               "ClassDatas": [
@@ -120874,6 +122034,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -122165,7 +123341,8 @@
           {
             "GitID": "c21551dd992a57349973e4b5af103ca6_71┼118┼0┼",
             "PrefabID": "c21551dd992a57349973e4b5af103ca6",
-            "Name": "SecurityCamera (1)",
+            "NameMatches": true,
+            "Name": "SecurityCamera",
             "LocalPRS": "71┼118┼0┼",
             "Object": {
               "ClassDatas": [
@@ -122541,7 +123718,8 @@
           {
             "GitID": "6fa1bf6a566af2f479f551f9bb604178_72┼64┼0┼",
             "PrefabID": "6fa1bf6a566af2f479f551f9bb604178",
-            "Name": "SecureWinDoorLeft (1)",
+            "NameMatches": true,
+            "Name": "SecureWinDoorLeft",
             "LocalPRS": "72┼64┼0┼",
             "Object": {
               "ClassDatas": [
@@ -122700,6 +123878,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Left_By90"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -122972,6 +124166,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -122989,6 +124199,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -123216,7 +124442,8 @@
           {
             "GitID": "c21551dd992a57349973e4b5af103ca6_73┼128┼0┼",
             "PrefabID": "c21551dd992a57349973e4b5af103ca6",
-            "Name": "SecurityCamera (2)",
+            "NameMatches": true,
+            "Name": "SecurityCamera",
             "LocalPRS": "73┼128┼0┼",
             "Object": {
               "ClassDatas": [
@@ -123884,7 +125111,8 @@
           {
             "GitID": "cf93667e32e15bc43b0347cd102fef98_74┼47┼0┼",
             "PrefabID": "cf93667e32e15bc43b0347cd102fef98",
-            "Name": "WinDoorRight (7)",
+            "NameMatches": true,
+            "Name": "WinDoorRight",
             "LocalPRS": "74┼47┼0┼",
             "Object": {
               "ClassDatas": [
@@ -123909,6 +125137,20 @@
               ],
               "Children": [
                 {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -123917,6 +125159,90 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Library"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,3",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,4",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,5",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,6",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,7",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
                         }
                       ]
                     }
@@ -124995,6 +126321,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -125232,6 +126574,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -125249,6 +126607,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -125272,6 +126646,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -125292,6 +126682,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -125309,6 +126715,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -128387,8 +129809,8 @@
             }
           },
           {
-            "GitID": "8D0W-BGDVb8469ufZ@aF_79┼95┼0┼",
-            "PrefabID": "8D0W-BGDVb8469ufZ@aF",
+            "GitID": "J5UF3VXxKdTV9iopbA17_79┼95┼0┼",
+            "PrefabID": "J5UF3VXxKdTV9iopbA17",
             "NameMatches": true,
             "Name": "SecBarrier",
             "LocalPRS": "79┼95┼0┼"
@@ -128607,6 +130029,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -128868,8 +130306,8 @@
             "LocalPRS": "80┼93┼0┼"
           },
           {
-            "GitID": "8D0W-BGDVb8469ufZ@aF_80┼95┼0┼",
-            "PrefabID": "8D0W-BGDVb8469ufZ@aF",
+            "GitID": "J5UF3VXxKdTV9iopbA17_80┼95┼0┼",
+            "PrefabID": "J5UF3VXxKdTV9iopbA17",
             "NameMatches": true,
             "Name": "SecBarrier",
             "LocalPRS": "80┼95┼0┼"
@@ -128929,6 +130367,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -130312,7 +131766,8 @@
           {
             "GitID": "6fa1bf6a566af2f479f551f9bb604178_81┼100┼0┼",
             "PrefabID": "6fa1bf6a566af2f479f551f9bb604178",
-            "Name": "SecureWinDoorLeft (5)",
+            "NameMatches": true,
+            "Name": "SecureWinDoorLeft",
             "LocalPRS": "81┼100┼0┼",
             "Object": {
               "ClassDatas": [
@@ -130334,13 +131789,114 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,3",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,4",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,5",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,6",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,7",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
           {
             "GitID": "cbe919cf00f84254f83d474582798520_81┼100┼0┼",
             "PrefabID": "cbe919cf00f84254f83d474582798520",
-            "Name": "SecureWinDoorRight (2)",
+            "NameMatches": true,
+            "Name": "SecureWinDoorRight",
             "LocalPRS": "81┼100┼0┼",
             "Object": {
               "ClassDatas": [
@@ -130359,6 +131915,106 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Left_By90"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,3",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,4",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,5",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,6",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,7",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -132767,7 +134423,8 @@
           {
             "GitID": "c21551dd992a57349973e4b5af103ca6_84┼109┼0┼",
             "PrefabID": "c21551dd992a57349973e4b5af103ca6",
-            "Name": "SecurityCamera (1)",
+            "NameMatches": true,
+            "Name": "SecurityCamera",
             "LocalPRS": "84┼109┼0┼",
             "Object": {
               "ClassDatas": [
@@ -134583,7 +136240,8 @@
           {
             "GitID": "6fa1bf6a566af2f479f551f9bb604178_85┼104┼0┼",
             "PrefabID": "6fa1bf6a566af2f479f551f9bb604178",
-            "Name": "SecureWinDoorLeft (6)",
+            "NameMatches": true,
+            "Name": "SecureWinDoorLeft",
             "LocalPRS": "85┼104┼0┼",
             "Object": {
               "ClassDatas": [
@@ -134605,13 +136263,114 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,3",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,4",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,5",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,6",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,7",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
           {
             "GitID": "cbe919cf00f84254f83d474582798520_85┼104┼0┼",
             "PrefabID": "cbe919cf00f84254f83d474582798520",
-            "Name": "SecureWinDoorRight (3)",
+            "NameMatches": true,
+            "Name": "SecureWinDoorRight",
             "LocalPRS": "85┼104┼0┼",
             "Object": {
               "ClassDatas": [
@@ -134630,6 +136389,106 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,3",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,4",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,5",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,6",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,7",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -136321,8 +138180,8 @@
             }
           },
           {
-            "GitID": "8D0W-BGDVb8469ufZ@aF_87┼85┼0┼",
-            "PrefabID": "8D0W-BGDVb8469ufZ@aF",
+            "GitID": "J5UF3VXxKdTV9iopbA17_87┼85┼0┼",
+            "PrefabID": "J5UF3VXxKdTV9iopbA17",
             "NameMatches": true,
             "Name": "SecBarrier",
             "LocalPRS": "87┼85┼0┼"
@@ -136727,8 +138586,8 @@
             }
           },
           {
-            "GitID": "8D0W-BGDVb8469ufZ@aF_88┼85┼0┼",
-            "PrefabID": "8D0W-BGDVb8469ufZ@aF",
+            "GitID": "J5UF3VXxKdTV9iopbA17_88┼85┼0┼",
+            "PrefabID": "J5UF3VXxKdTV9iopbA17",
             "NameMatches": true,
             "Name": "SecBarrier",
             "LocalPRS": "88┼85┼0┼"
@@ -138024,13 +139883,14 @@
           {
             "GitID": "86570587e3d5cba1e9ffdeead16603e4_89┼101┼0┼",
             "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
-            "Name": "PottedPlantRandom (11)",
+            "Name": "PottedPlantRandom",
             "LocalPRS": "89┼101┼0┼"
           },
           {
             "GitID": "bb2d0192db81c7d469ced45d96e3629e_89┼103┼0┼",
             "PrefabID": "bb2d0192db81c7d469ced45d96e3629e",
-            "Name": "SecTech (1)",
+            "NameMatches": true,
+            "Name": "SecTech",
             "LocalPRS": "89┼103┼0┼",
             "Object": {
               "ClassDatas": [
@@ -138163,8 +140023,8 @@
             }
           },
           {
-            "GitID": "EkKax?M$hbn0fMg@aU5X_89.96┼65.14┼0┼",
-            "PrefabID": "EkKax?M$hbn0fMg@aU5X",
+            "GitID": "409gLRNpRQA6ZJ-B4F7U_89.96┼65.14┼0┼",
+            "PrefabID": "409gLRNpRQA6ZJ-B4F7U",
             "Name": "OddSlugPlushie (1)",
             "LocalPRS": "89.96┼65.14┼0┼"
           },
@@ -141104,6 +142964,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -141279,6 +143155,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -141576,6 +143468,50 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Up_By0"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,1",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -141878,8 +143814,8 @@
             "LocalPRS": "93.14┼91.47┼0┼"
           },
           {
-            "GitID": "EkKax?M$hbn0fMg@aU5X_93.78┼72.21┼0┼",
-            "PrefabID": "EkKax?M$hbn0fMg@aU5X",
+            "GitID": "409gLRNpRQA6ZJ-B4F7U_93.78┼72.21┼0┼",
+            "PrefabID": "409gLRNpRQA6ZJ-B4F7U",
             "Name": "OddSlugPlushie (1)",
             "LocalPRS": "93.78┼72.21┼0┼",
             "Object": {
@@ -142556,6 +144492,50 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,1",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -142636,7 +144616,8 @@
           {
             "GitID": "6fa1bf6a566af2f479f551f9bb604178_94┼83┼0┼",
             "PrefabID": "6fa1bf6a566af2f479f551f9bb604178",
-            "Name": "SecureWinDoorLeft (4)",
+            "NameMatches": true,
+            "Name": "SecureWinDoorLeft",
             "LocalPRS": "94┼83┼0┼",
             "Object": {
               "ClassDatas": [
@@ -142661,6 +144642,20 @@
               ],
               "Children": [
                 {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
                   "ID": "0,1",
                   "ClassDatas": [
                     {
@@ -142673,6 +144668,90 @@
                       ]
                     }
                   ]
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,3",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,4",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,5",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,6",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,7",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             }
@@ -142680,7 +144759,8 @@
           {
             "GitID": "cbe919cf00f84254f83d474582798520_94┼83┼0┼",
             "PrefabID": "cbe919cf00f84254f83d474582798520",
-            "Name": "SecureWinDoorRight (1)",
+            "NameMatches": true,
+            "Name": "SecureWinDoorRight",
             "LocalPRS": "94┼83┼0┼",
             "Object": {
               "ClassDatas": [
@@ -142846,7 +144926,8 @@
           {
             "GitID": "1a00e842e154f7d43811c5d45328988c_94┼91┼0┼",
             "PrefabID": "1a00e842e154f7d43811c5d45328988c",
-            "Name": "Chair (14)",
+            "NameMatches": true,
+            "Name": "Chair",
             "LocalPRS": "94┼91┼0┼",
             "Object": {
               "ClassDatas": [
@@ -142856,6 +144937,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Left_By90"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -143047,8 +145144,8 @@
             "LocalPRS": "94.17┼75.01┼0┼"
           },
           {
-            "GitID": "EkKax?M$hbn0fMg@aU5X_94.44┼72.19┼0┼",
-            "PrefabID": "EkKax?M$hbn0fMg@aU5X",
+            "GitID": "409gLRNpRQA6ZJ-B4F7U_94.44┼72.19┼0┼",
+            "PrefabID": "409gLRNpRQA6ZJ-B4F7U",
             "Name": "OddSlugPlushie (1)",
             "LocalPRS": "94.44┼72.19┼0┼",
             "Object": {
@@ -143102,7 +145199,8 @@
           {
             "GitID": "9944313d68658b341966d43e2c218eaa_95┼28┼0┼",
             "PrefabID": "9944313d68658b341966d43e2c218eaa",
-            "Name": "CanisterNitrogen (4)",
+            "NameMatches": true,
+            "Name": "CanisterNitrogen",
             "LocalPRS": "95┼28┼0┼",
             "Object": {
               "ClassDatas": [
@@ -143325,7 +145423,8 @@
           {
             "GitID": "0058e1fe0dba62b4db396c6a0bbfd99d_95┼57┼0┼",
             "PrefabID": "0058e1fe0dba62b4db396c6a0bbfd99d",
-            "Name": "Morgue (5)",
+            "NameMatches": true,
+            "Name": "Morgue",
             "LocalPRS": "95┼57┼0┼",
             "Object": {
               "ClassDatas": [
@@ -143362,32 +145461,13 @@
                   "ClassID": "Rotatable@0",
                   "Data": [
                     {
-                      "Name": "MethodRotation",
-                      "Data": "Sprites"
-                    },
-                    {
                       "Name": "CurrentDirection",
-                      "Data": "Right_By270"
+                      "Data": "Left_By90"
                     }
                   ]
                 }
               ],
               "Children": [
-                {
-                  "LocalPRS": "0┼0┼0┼0ø0ø270ø",
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "fdf36b612a3a56e419736ba884a6c48e"
-                        }
-                      ]
-                    }
-                  ]
-                },
                 {
                   "ID": "0,1",
                   "Active": false,
@@ -143626,6 +145706,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Up_By0"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -145388,7 +147484,7 @@
                   "Data": [
                     {
                       "Name": "CurrentDirection",
-                      "Data": "Up_By0"
+                      "Data": "Right_By270"
                     }
                   ]
                 }
@@ -145531,7 +147627,8 @@
           {
             "GitID": "ddcfc3ab784dec1419565255774956c5_97┼72┼0┼",
             "PrefabID": "ddcfc3ab784dec1419565255774956c5",
-            "Name": "WinDoorLeft (5)",
+            "NameMatches": true,
+            "Name": "WinDoorLeft",
             "LocalPRS": "97┼72┼0┼",
             "Object": {
               "ClassDatas": [
@@ -146315,6 +148412,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -146603,6 +148716,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Up_By0"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -147624,6 +149753,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -147796,12 +149941,8 @@
                   "ClassID": "Rotatable@0",
                   "Data": [
                     {
-                      "Name": "MethodRotation",
-                      "Data": "Sprites"
-                    },
-                    {
                       "Name": "CurrentDirection",
-                      "Data": "Right_By270"
+                      "Data": "Left_By90"
                     }
                   ]
                 }
@@ -147935,6 +150076,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Up_By0"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -149591,7 +151748,8 @@
           {
             "GitID": "cf93667e32e15bc43b0347cd102fef98_102┼72┼0┼",
             "PrefabID": "cf93667e32e15bc43b0347cd102fef98",
-            "Name": "WinDoorRight (3)",
+            "NameMatches": true,
+            "Name": "WinDoorRight",
             "LocalPRS": "102┼72┼0┼",
             "Object": {
               "ClassDatas": [
@@ -150645,6 +152803,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -150661,6 +152835,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -151184,6 +153374,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -151245,7 +153451,8 @@
           {
             "GitID": "6fa1bf6a566af2f479f551f9bb604178_104┼93┼0┼",
             "PrefabID": "6fa1bf6a566af2f479f551f9bb604178",
-            "Name": "SecureWinDoorLeft (7)",
+            "NameMatches": true,
+            "Name": "SecureWinDoorLeft",
             "LocalPRS": "104┼93┼0┼",
             "Object": {
               "ClassDatas": [
@@ -151839,6 +154046,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -151991,6 +154214,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -152870,6 +155109,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -152914,7 +155169,8 @@
           {
             "GitID": "cf93667e32e15bc43b0347cd102fef98_106┼76┼0┼",
             "PrefabID": "cf93667e32e15bc43b0347cd102fef98",
-            "Name": "WinDoorRight (6)",
+            "NameMatches": true,
+            "Name": "WinDoorRight",
             "LocalPRS": "106┼76┼0┼",
             "Object": {
               "ClassDatas": [
@@ -152949,7 +155205,8 @@
           {
             "GitID": "ddcfc3ab784dec1419565255774956c5_106┼76┼0┼",
             "PrefabID": "ddcfc3ab784dec1419565255774956c5",
-            "Name": "WinDoorLeft (6)",
+            "NameMatches": true,
+            "Name": "WinDoorLeft",
             "LocalPRS": "106┼76┼0┼",
             "Object": {
               "ClassDatas": [
@@ -152968,6 +155225,106 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Up_By0"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,3",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,4",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,5",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,6",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,7",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -152990,6 +155347,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -153006,6 +155379,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Left_By90"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -154179,6 +156568,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -155567,6 +157972,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -155587,6 +158008,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -155603,6 +158040,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -155626,6 +158079,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -155642,6 +158111,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -155665,6 +158150,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -155685,6 +158186,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -155701,6 +158218,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Left_By90"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -156114,6 +158647,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -156130,6 +158679,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -156152,6 +158717,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -156168,6 +158749,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -156190,6 +158787,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -156206,6 +158819,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -156228,6 +158857,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -156244,6 +158889,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -156736,7 +159397,7 @@
                   "Data": [
                     {
                       "Name": "relatedLightSwitch",
-                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_115┼61┼0┼@0@LightSwitchV2@0"
+                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_109┼63┼0┼@0@LightSwitchV2@0"
                     }
                   ]
                 }
@@ -156777,6 +159438,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Up_By0"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -156884,6 +159561,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -156900,6 +159593,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Left_By90"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -156922,6 +159631,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -156938,6 +159663,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Left_By90"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -156960,6 +159701,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -156976,6 +159733,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Left_By90"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -156998,6 +159771,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -157014,6 +159803,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Left_By90"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -157285,6 +160090,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -157406,6 +160227,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -157422,6 +160259,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -157444,6 +160297,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -157460,6 +160329,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -157482,6 +160367,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -157498,6 +160399,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -157520,6 +160437,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -157536,6 +160469,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -157706,6 +160655,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Up_By0"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -161020,9 +163985,37 @@
               ],
               "Children": [
                 {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
                   "ID": "0,1",
                   "Active": false,
                   "ClassDatas": []
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             }
@@ -161902,9 +164895,37 @@
               ],
               "Children": [
                 {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
                   "ID": "0,1",
                   "Active": false,
                   "ClassDatas": []
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             }
@@ -176148,6 +179169,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -176284,6 +179321,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -176312,6 +179365,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Up_By0"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -176462,6 +179531,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Up_By0"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -178966,9 +182051,37 @@
               ],
               "Children": [
                 {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
                   "ID": "0,1",
                   "Active": false,
                   "ClassDatas": []
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             }
@@ -178986,6 +182099,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -179158,9 +182287,37 @@
               ],
               "Children": [
                 {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
                   "ID": "0,1",
                   "Active": false,
                   "ClassDatas": []
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             }
@@ -179185,9 +182342,37 @@
               ],
               "Children": [
                 {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
                   "ID": "0,1",
                   "Active": false,
                   "ClassDatas": []
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             }
@@ -179239,9 +182424,37 @@
               ],
               "Children": [
                 {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
                   "ID": "0,1",
                   "Active": false,
                   "ClassDatas": []
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             }
@@ -179259,6 +182472,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "2"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -179554,9 +182783,37 @@
               ],
               "Children": [
                 {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
                   "ID": "0,1",
                   "Active": false,
                   "ClassDatas": []
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             }
@@ -179713,6 +182970,22 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           },
@@ -179858,9 +183131,37 @@
               ],
               "Children": [
                 {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
                   "ID": "0,1",
                   "Active": false,
                   "ClassDatas": []
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             }
@@ -179912,9 +183213,37 @@
               ],
               "Children": [
                 {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
                   "ID": "0,1",
                   "Active": false,
                   "ClassDatas": []
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             }
@@ -179932,6 +183261,22 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Left_By90"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -180115,9 +183460,37 @@
               ],
               "Children": [
                 {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
                   "ID": "0,1",
                   "Active": false,
                   "ClassDatas": []
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             }
@@ -180142,9 +183515,37 @@
               ],
               "Children": [
                 {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
                   "ID": "0,1",
                   "Active": false,
                   "ClassDatas": []
+                },
+                {
+                  "ID": "0,2",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             }

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/FallStation.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/FallStation.json
@@ -66762,6 +66762,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "EO-Low_Voltage_Cable",
+                "Z": 1
               }
             ]
           },
@@ -66964,6 +66968,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "EO-Low_Voltage_Cable",
+                "Z": 1
               }
             ]
           },
@@ -67718,6 +67726,10 @@
                 "Tel": "Plating"
               },
               {
+                "Tel": "WE-Low_Voltage_Cable",
+                "Z": 1
+              },
+              {
                 "Tel": "FluidStraightPipe",
                 "Z": 1,
                 "Col": "#FF0031FF"
@@ -67940,6 +67952,9 @@
               {
                 "Tel": "NS-Medium_Voltage_Cable",
                 "Z": 1
+              },
+              {
+                "Tel": "WE-Low_Voltage_Cable"
               }
             ]
           },
@@ -68622,6 +68637,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "WE-Low_Voltage_Cable",
+                "Z": 1
               }
             ]
           },
@@ -68828,6 +68847,9 @@
               {
                 "Tel": "WE-Low_Voltage_Cable",
                 "Z": 1
+              },
+              {
+                "Tel": "NW-Low_Voltage_Cable"
               }
             ]
           },
@@ -68839,6 +68861,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "NS-Low_Voltage_Cable",
+                "Z": 1
               }
             ]
           },
@@ -68850,6 +68876,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "SW-Low_Voltage_Cable",
+                "Z": 1
               }
             ]
           },
@@ -69582,6 +69612,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "WE-Low_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "FluidStraightPipe",
@@ -70654,6 +70688,13 @@
                 "Tel": "Plating"
               },
               {
+                "Tel": "WE-Low_Voltage_Cable",
+                "Z": 1
+              },
+              {
+                "Tel": "NE-Low_Voltage_Cable"
+              },
+              {
                 "Tel": "FluidBentPipe",
                 "Z": 1,
                 "Col": "#0057FFFF",
@@ -70672,6 +70713,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "NS-Low_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "FluidStraightPipe",
@@ -70693,6 +70738,10 @@
                 "Tel": "Plating"
               },
               {
+                "Tel": "NS-Low_Voltage_Cable",
+                "Z": 1
+              },
+              {
                 "Tel": "FluidStraightPipe",
                 "Z": 1,
                 "Col": "#0057FFFF"
@@ -70710,6 +70759,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "NS-Low_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "FluidStraightPipe",
@@ -70731,6 +70784,10 @@
                 "Tel": "Plating"
               },
               {
+                "Tel": "NS-Low_Voltage_Cable",
+                "Z": 1
+              },
+              {
                 "Tel": "FluidStraightPipe",
                 "Z": 1,
                 "Col": "#0057FFFF"
@@ -70748,6 +70805,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "SE-Low_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "FluidStraightPipe",
@@ -71711,6 +71772,10 @@
                 "Tel": "Plating"
               },
               {
+                "Tel": "WE-Low_Voltage_Cable",
+                "Z": 1
+              },
+              {
                 "Tel": "3WayManifold",
                 "Z": 1,
                 "Col": "#0057FFFF"
@@ -71772,6 +71837,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "WE-Low_Voltage_Cable",
+                "Z": 1
               }
             ]
           },
@@ -72769,6 +72838,10 @@
                 "Tel": "Plating"
               },
               {
+                "Tel": "WE-Low_Voltage_Cable",
+                "Z": 1
+              },
+              {
                 "Tel": "FluidStraightPipe",
                 "Z": 1,
                 "Col": "#0057FFFF",
@@ -72835,6 +72908,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "WO-Low_Voltage_Cable",
+                "Z": 1
               }
             ]
           },
@@ -72879,6 +72956,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "NO-Low_Voltage_Cable",
+                "Z": 1
               }
             ]
           },
@@ -72890,6 +72971,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "SE-Low_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "FluidStraightPipe",
@@ -73794,6 +73879,10 @@
                 "Tel": "Plating"
               },
               {
+                "Tel": "WE-Low_Voltage_Cable",
+                "Z": 1
+              },
+              {
                 "Tel": "FluidStraightPipe",
                 "Z": 1,
                 "Col": "#0057FFFF",
@@ -73915,6 +74004,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "WE-Low_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "FluidStraightPipe",
@@ -74890,6 +74983,10 @@
                 "Tel": "Plating"
               },
               {
+                "Tel": "WE-Low_Voltage_Cable",
+                "Z": 1
+              },
+              {
                 "Tel": "NS-Medium_Voltage_Cable"
               },
               {
@@ -75060,7 +75157,7 @@
               },
               {
                 "Tel": "DisposalPipeStraight-NS",
-                "Z": -1
+                "Z": 1
               }
             ]
           },
@@ -75074,7 +75171,8 @@
                 "Tel": "Plating"
               },
               {
-                "Tel": "NS-Medium_Voltage_Cable"
+                "Tel": "NS-Medium_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "FluidStraightPipe",
@@ -75083,7 +75181,7 @@
               },
               {
                 "Tel": "DisposalPipeStraight-NS",
-                "Z": -1
+                "Z": 1
               }
             ]
           },
@@ -75106,7 +75204,7 @@
               },
               {
                 "Tel": "DisposalPipeStraight-NS",
-                "Z": -1
+                "Z": 1
               }
             ]
           },
@@ -75118,6 +75216,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "WE-Low_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "NS-Medium_Voltage_Cable"
@@ -76142,6 +76244,13 @@
                 "Tel": "Plating"
               },
               {
+                "Tel": "NW-Low_Voltage_Cable",
+                "Z": 1
+              },
+              {
+                "Tel": "NE-Low_Voltage_Cable"
+              },
+              {
                 "Tel": "FluidStraightPipe",
                 "Z": 1,
                 "Col": "#0057FFFF",
@@ -76167,6 +76276,10 @@
                 "Tel": "Plating"
               },
               {
+                "Tel": "NS-Low_Voltage_Cable",
+                "Z": 1
+              },
+              {
                 "Tel": "FluidStraightPipe",
                 "Z": 1,
                 "Col": "#FF0031FF"
@@ -76181,6 +76294,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "NS-Low_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "FluidStraightPipe",
@@ -76199,6 +76316,10 @@
                 "Tel": "Plating"
               },
               {
+                "Tel": "NS-Low_Voltage_Cable",
+                "Z": 1
+              },
+              {
                 "Tel": "FluidStraightPipe",
                 "Z": 1,
                 "Col": "#FF0031FF"
@@ -76213,6 +76334,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "NS-Low_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "FluidStraightPipe",
@@ -76231,6 +76356,10 @@
                 "Tel": "Plating"
               },
               {
+                "Tel": "NS-Low_Voltage_Cable",
+                "Z": 1
+              },
+              {
                 "Tel": "FluidStraightPipe",
                 "Z": 1,
                 "Col": "#FF0031FF"
@@ -76245,6 +76374,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "NS-Low_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "FluidStraightPipe",
@@ -76263,6 +76396,10 @@
                 "Tel": "Plating"
               },
               {
+                "Tel": "NS-Low_Voltage_Cable",
+                "Z": 1
+              },
+              {
                 "Tel": "FluidStraightPipe",
                 "Z": 1,
                 "Col": "#FF0031FF"
@@ -76279,7 +76416,8 @@
                 "Tel": "Plating"
               },
               {
-                "Tel": "NO-Low_Voltage_Cable"
+                "Tel": "NS-Low_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "FluidStraightPipe",
@@ -76298,7 +76436,8 @@
                 "Tel": "Plating"
               },
               {
-                "Tel": "NS-Low_Voltage_Cable"
+                "Tel": "NS-Low_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "FluidStraightPipe",
@@ -76315,6 +76454,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "NW-Low_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "NS-Low_Voltage_Cable"
@@ -76415,6 +76558,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "WE-Low_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "SW-Low_Voltage_Cable"
@@ -77417,6 +77564,10 @@
                 "Tel": "Plating"
               },
               {
+                "Tel": "WE-Low_Voltage_Cable",
+                "Z": 1
+              },
+              {
                 "Tel": "FluidStraightPipe",
                 "Z": 1,
                 "Col": "#0057FFFF",
@@ -77609,6 +77760,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "WE-Low_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "FluidStraightPipe",
@@ -78423,6 +78578,13 @@
                 "Tel": "Plating"
               },
               {
+                "Tel": "NW-Low_Voltage_Cable",
+                "Z": 1
+              },
+              {
+                "Tel": "WE-Low_Voltage_Cable"
+              },
+              {
                 "Tel": "FluidStraightPipe",
                 "Z": 1,
                 "Col": "#0057FFFF",
@@ -78443,6 +78605,10 @@
                 "Tel": "Plating"
               },
               {
+                "Tel": "NS-Low_Voltage_Cable",
+                "Z": 1
+              },
+              {
                 "Tel": "DisposalPipeStraight-NS",
                 "Z": 1
               }
@@ -78456,6 +78622,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "SO-Low_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "DisposalPipeStraight-NS",
@@ -78518,6 +78688,10 @@
               },
               {
                 "Tel": "table_wood"
+              },
+              {
+                "Tel": "EO-Low_Voltage_Cable",
+                "Z": 1
               }
             ]
           },
@@ -78540,6 +78714,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "EO-Low_Voltage_Cable",
+                "Z": 1
               }
             ]
           },
@@ -78621,6 +78799,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "WE-Low_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "FluidBentPipe",
@@ -79463,6 +79645,10 @@
                 "Tel": "Plating"
               },
               {
+                "Tel": "WE-Low_Voltage_Cable",
+                "Z": 1
+              },
+              {
                 "Tel": "FluidStraightPipe",
                 "Z": 1,
                 "Col": "#0057FFFF",
@@ -79565,6 +79751,10 @@
                 "Tel": "Plating"
               },
               {
+                "Tel": "WE-Low_Voltage_Cable",
+                "Z": 1
+              },
+              {
                 "Tel": "FluidStraightPipe",
                 "Z": 1,
                 "Col": "#FF0031FF"
@@ -79595,6 +79785,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "WE-Low_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "FluidStraightPipe",
@@ -79694,6 +79888,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "WE-Low_Voltage_Cable",
+                "Z": 1
               }
             ]
           },
@@ -80601,6 +80799,10 @@
                 "Tel": "table_wood"
               },
               {
+                "Tel": "NW-Low_Voltage_Cable",
+                "Z": 1
+              },
+              {
                 "Tel": "FluidBentPipe",
                 "Z": 1,
                 "Col": "#0057FFFF",
@@ -80621,6 +80823,10 @@
                 "Tel": "table_wood"
               },
               {
+                "Tel": "NS-Low_Voltage_Cable",
+                "Z": 1
+              },
+              {
                 "Tel": "FluidStraightPipe",
                 "Z": 1,
                 "Col": "#0057FFFF"
@@ -80635,6 +80841,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "NS-Low_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "3WayManifold",
@@ -80652,6 +80862,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "NS-Low_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "FluidStraightPipe",
@@ -80675,6 +80889,10 @@
                 "Tel": "Plating"
               },
               {
+                "Tel": "NS-Low_Voltage_Cable",
+                "Z": 1
+              },
+              {
                 "Tel": "FluidStraightPipe",
                 "Z": 1,
                 "Col": "#0057FFFF"
@@ -80689,6 +80907,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "NS-Low_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "FluidStraightPipe",
@@ -80707,6 +80929,13 @@
                 "Tel": "Plating"
               },
               {
+                "Tel": "SW-Low_Voltage_Cable",
+                "Z": 1
+              },
+              {
+                "Tel": "NS-Low_Voltage_Cable"
+              },
+              {
                 "Tel": "FluidStraightPipe",
                 "Z": 1,
                 "Col": "#0057FFFF"
@@ -80723,6 +80952,10 @@
                 "Tel": "Plating"
               },
               {
+                "Tel": "NS-Low_Voltage_Cable",
+                "Z": 1
+              },
+              {
                 "Tel": "FluidStraightPipe",
                 "Z": 1,
                 "Col": "#0057FFFF"
@@ -80737,6 +80970,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "SW-Low_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "FluidStraightPipe",
@@ -80828,6 +81065,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "WE-Low_Voltage_Cable",
+                "Z": 1
               }
             ]
           },
@@ -81935,6 +82176,10 @@
                 "Tel": "Plating"
               },
               {
+                "Tel": "NO-Low_Voltage_Cable",
+                "Z": 1
+              },
+              {
                 "Tel": "DisposalPipeStraight-EW",
                 "Z": 1
               }
@@ -81948,6 +82193,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "SW-Low_Voltage_Cable",
+                "Z": 1
               }
             ]
           },
@@ -135051,128 +135300,124 @@
                   "ClassID": "APC@0",
                   "Data": [
                     {
-                      "Name": "connectedDevices#39",
+                      "Name": "connectedDevices#38",
                       "Data": "ea7280b49083dfa469fb176f6a7e4772_77┼66┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#38",
+                      "Name": "connectedDevices#37",
                       "Data": "cb2f847ef3b8b754181a970a4032c552_90┼69┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#37",
+                      "Name": "connectedDevices#36",
                       "Data": "fd07f1ca390dd8f48b0cf257cb070d2a_90┼66┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#36",
+                      "Name": "connectedDevices#35",
                       "Data": "faf5221e3b4b94a4f926ef17e295d14a_90┼67┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#35",
+                      "Name": "connectedDevices#34",
                       "Data": "bdee015617db52248b97de650920e2c0_84┼73┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#34",
+                      "Name": "connectedDevices#33",
                       "Data": "56207cafd3f8d8549b442fe7b1ad7777_83┼73┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#33",
+                      "Name": "connectedDevices#32",
                       "Data": "56207cafd3f8d8549b442fe7b1ad7777_87┼65┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#32",
+                      "Name": "connectedDevices#31",
                       "Data": "a50474d976314462a79602e20a762520_87┼64┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#31",
+                      "Name": "connectedDevices#30",
                       "Data": "a50474d976314462a79602e20a762520_86┼68┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#30",
+                      "Name": "connectedDevices#29",
                       "Data": "42b6820b415420f458301d5ce3f81940_87┼66┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#29",
+                      "Name": "connectedDevices#28",
                       "Data": "ea7280b49083dfa469fb176f6a7e4772_80┼66┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#28",
+                      "Name": "connectedDevices#27",
                       "Data": "f2432d244a6b7774ea00ff013beb7dcb_85┼76┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#27",
+                      "Name": "connectedDevices#26",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_88┼65┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#26",
+                      "Name": "connectedDevices#25",
                       "Data": "38246cd9491b4c248abb2e296cc6c76f_89┼64┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#25",
+                      "Name": "connectedDevices#24",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_85┼71┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#24",
+                      "Name": "connectedDevices#23",
                       "Data": "c21551dd992a57349973e4b5af103ca6_82┼71┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#23",
+                      "Name": "connectedDevices#22",
                       "Data": "c21551dd992a57349973e4b5af103ca6_90┼71┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#22",
+                      "Name": "connectedDevices#21",
                       "Data": "a075086024d70074e8747c26b57dfa7f_85┼77┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#21",
+                      "Name": "connectedDevices#20",
                       "Data": "e6e7f915b6b6fc14c981a592369d47f8_90┼80┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#20",
+                      "Name": "connectedDevices#19",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_86┼75┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#19",
+                      "Name": "connectedDevices#18",
                       "Data": "38246cd9491b4c248abb2e296cc6c76f_88┼62┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#18",
+                      "Name": "connectedDevices#17",
                       "Data": "ea7280b49083dfa469fb176f6a7e4772_83┼66┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#17",
+                      "Name": "connectedDevices#16",
                       "Data": "c21551dd992a57349973e4b5af103ca6_84┼75┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#16",
+                      "Name": "connectedDevices#15",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_90┼79┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#15",
+                      "Name": "connectedDevices#14",
                       "Data": "e6e7f915b6b6fc14c981a592369d47f8_85┼74┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#14",
+                      "Name": "connectedDevices#13",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_84┼74┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#13",
+                      "Name": "connectedDevices#12",
                       "Data": "38246cd9491b4c248abb2e296cc6c76f_88┼80┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#12",
+                      "Name": "connectedDevices#11",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_85┼66┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#11",
+                      "Name": "connectedDevices#10",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_90┼70┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#10",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_82┼66┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
                       "Name": "connectedDevices#9",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_91┼82┼0┼@0@APCPoweredDevice@0"
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_82┼66┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#8",
@@ -141223,7 +141468,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -141240,6 +141485,130 @@
                           "Data": "Hop"
                         }
                       ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼",
+            "PrefabID": "cd57203a8d3f54f478446e9b0ced6cf9",
+            "Name": "APC - HOP",
+            "LocalPRS": "90┼85┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Right_By270"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "APC@0",
+                  "Data": [
+                    {
+                      "Name": "connectedDevices#24",
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_91┼82┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#23",
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_97┼82┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#22",
+                      "Data": "6fa1bf6a566af2f479f551f9bb604178_94┼83┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#21",
+                      "Data": "cbe919cf00f84254f83d474582798520_94┼83┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#20",
+                      "Data": "a50474d976314462a79602e20a762520_96┼88┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#19",
+                      "Data": "0d553281bdfc0fd438b3f6c7db58688c_96┼86┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#18",
+                      "Data": "cb2f847ef3b8b754181a970a4032c552_92┼86┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#17",
+                      "Data": "f8db3418b6542874396d1eaa52946e19_93┼87┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#16",
+                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_98┼84┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#15",
+                      "Data": "06f461555a8bd5947b6bfa4ecbc95627_98┼85┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#14",
+                      "Data": "38246cd9491b4c248abb2e296cc6c76f_90┼84┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#13",
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_91┼86┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#12",
+                      "Data": "19dd1cfccb59c8245a70c4923037c950_95┼84┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#11",
+                      "Data": "f2441585d37f1914395df59a57c5e925_97┼80┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#10",
+                      "Data": "f2441585d37f1914395df59a57c5e925_91┼80┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#9",
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_97┼86┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#8",
+                      "Data": "c21551dd992a57349973e4b5af103ca6_96┼87┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#7",
+                      "Data": "b7053ef275ce5b74e827e60b034d1647_93┼88┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#6",
+                      "Data": "ea7280b49083dfa469fb176f6a7e4772_97┼83┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#5",
+                      "Data": "f2441585d37f1914395df59a57c5e925_96┼83┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#4",
+                      "Data": "f2441585d37f1914395df59a57c5e925_95┼83┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#3",
+                      "Data": "f2441585d37f1914395df59a57c5e925_94┼83┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#2",
+                      "Data": "f2441585d37f1914395df59a57c5e925_93┼83┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#1",
+                      "Data": "f2441585d37f1914395df59a57c5e925_92┼83┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#0",
+                      "Data": "ea7280b49083dfa469fb176f6a7e4772_91┼83┼0┼@0@APCPoweredDevice@0"
                     }
                   ]
                 }
@@ -141988,7 +142357,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -142017,7 +142386,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_85┼73┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -142091,7 +142460,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -142130,6 +142499,13 @@
             }
           },
           {
+            "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_91┼85┼0┼",
+            "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
+            "NameMatches": true,
+            "Name": "New Low Machine  Connector Variant",
+            "LocalPRS": "91┼85┼0┼"
+          },
+          {
             "GitID": "zJyaf3Uy!rYaamX$9?Zq_91┼85┼0┼",
             "PrefabID": "zJyaf3Uy!rYaamX$9?Zq",
             "NameMatches": true,
@@ -142158,7 +142534,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -142209,7 +142585,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_98┼90┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -142268,7 +142644,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_91┼103┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -142306,6 +142682,60 @@
             "NameMatches": true,
             "Name": "New Station Self Destruct",
             "LocalPRS": "91┼101┼0┼"
+          },
+          {
+            "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_91┼102┼0┼",
+            "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
+            "NameMatches": true,
+            "Name": "New Low Machine  Connector Variant",
+            "LocalPRS": "91┼102┼0┼"
+          },
+          {
+            "GitID": "cd57203a8d3f54f478446e9b0ced6cf9_91┼103┼0┼",
+            "PrefabID": "cd57203a8d3f54f478446e9b0ced6cf9",
+            "Name": "APC - Nuke Room",
+            "LocalPRS": "91┼103┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "APC@0",
+                  "Data": [
+                    {
+                      "Name": "connectedDevices#7",
+                      "Data": "06f461555a8bd5947b6bfa4ecbc95627_95┼100┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#6",
+                      "Data": "06f461555a8bd5947b6bfa4ecbc95627_95┼101┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#5",
+                      "Data": "60ca8a399a7aa194dae1560980333f3b_93┼102┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#4",
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_91┼100┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#3",
+                      "Data": "c21551dd992a57349973e4b5af103ca6_92┼99┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#2",
+                      "Data": "cb2f847ef3b8b754181a970a4032c552_93┼101┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#1",
+                      "Data": "0d553281bdfc0fd438b3f6c7db58688c_93┼100┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#0",
+                      "Data": "a50474d976314462a79602e20a762520_94┼103┼0┼@0@APCPoweredDevice@0"
+                    }
+                  ]
+                }
+              ]
+            }
           },
           {
             "GitID": "68ef2c0235224f347b94384d5dcdae47_91.83┼64┼0┼",
@@ -142903,7 +143333,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -142922,7 +143352,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -143030,7 +143460,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_98┼90┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -143056,7 +143486,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_98┼94┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -143093,7 +143523,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_98┼94┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -143113,7 +143543,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_91┼103┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -143555,7 +143985,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -143581,7 +144011,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -143619,7 +144049,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -143645,7 +144075,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_98┼94┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -143685,7 +144115,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_98┼94┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -143711,7 +144141,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_91┼103┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -143748,7 +144178,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_91┼103┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -143786,7 +144216,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_91┼103┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -144626,7 +145056,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -144769,7 +145199,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_96┼70┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -144788,7 +145218,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_96┼70┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -144824,7 +145254,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_98┼90┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -144861,7 +145291,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_98┼90┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -144898,7 +145328,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_98┼90┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -144981,7 +145411,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_98┼90┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -145035,7 +145465,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_98┼94┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -145078,7 +145508,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_98┼94┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -145124,7 +145554,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_91┼103┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -145563,7 +145993,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -145582,7 +146012,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -145611,7 +146041,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_98┼90┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -145647,7 +146077,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_98┼90┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -145678,7 +146108,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_98┼90┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -145788,7 +146218,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_91┼103┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -145824,7 +146254,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_91┼103┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -146374,260 +146804,236 @@
                   "ClassID": "APC@0",
                   "Data": [
                     {
-                      "Name": "connectedDevices#77",
+                      "Name": "connectedDevices#71",
                       "Data": "9f6a082ba93c5684b808b09619c08044_103┼59┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#76",
+                      "Name": "connectedDevices#70",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_93┼57┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#75",
+                      "Name": "connectedDevices#69",
                       "Data": "4ca7e9a3bb55005418ddd62621ac8667_97┼58┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#74",
+                      "Name": "connectedDevices#68",
                       "Data": "baeafe1b5e8214344a5acf3315766acc_97┼60┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#73",
+                      "Name": "connectedDevices#67",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_105┼61┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#72",
+                      "Name": "connectedDevices#66",
                       "Data": "b7053ef275ce5b74e827e60b034d1647_103┼62┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#71",
+                      "Name": "connectedDevices#65",
                       "Data": "0d553281bdfc0fd438b3f6c7db58688c_98┼63┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#70",
+                      "Name": "connectedDevices#64",
                       "Data": "cb2f847ef3b8b754181a970a4032c552_94┼65┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#69",
+                      "Name": "connectedDevices#63",
                       "Data": "a50474d976314462a79602e20a762520_99┼67┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#68",
+                      "Name": "connectedDevices#62",
                       "Data": "7ca27018ad6a1a04ab813ab2fbcc0236_100┼66┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#67",
+                      "Name": "connectedDevices#61",
                       "Data": "7ca27018ad6a1a04ab813ab2fbcc0236_99┼66┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#66",
+                      "Name": "connectedDevices#60",
                       "Data": "9f6a082ba93c5684b808b09619c08044_97┼67┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#65",
+                      "Name": "connectedDevices#59",
                       "Data": "9f6a082ba93c5684b808b09619c08044_98┼67┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#64",
+                      "Name": "connectedDevices#58",
                       "Data": "69dfd2945b85d4f42904f8b7a00ade80_99┼71┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#63",
+                      "Name": "connectedDevices#57",
                       "Data": "97fde3b4a977e294395f1b8c3929200a_102┼60┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#62",
+                      "Name": "connectedDevices#56",
                       "Data": "a50474d976314462a79602e20a762520_93┼63┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#61",
+                      "Name": "connectedDevices#55",
                       "Data": "a50474d976314462a79602e20a762520_93┼76┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#60",
+                      "Name": "connectedDevices#54",
                       "Data": "a50474d976314462a79602e20a762520_96┼63┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#59",
+                      "Name": "connectedDevices#53",
                       "Data": "cb2f847ef3b8b754181a970a4032c552_101┼60┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#58",
+                      "Name": "connectedDevices#52",
                       "Data": "0d553281bdfc0fd438b3f6c7db58688c_98┼60┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#57",
+                      "Name": "connectedDevices#51",
                       "Data": "a50474d976314462a79602e20a762520_91┼66┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#56",
+                      "Name": "connectedDevices#50",
                       "Data": "a075086024d70074e8747c26b57dfa7f_96┼61┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#55",
+                      "Name": "connectedDevices#49",
                       "Data": "f2432d244a6b7774ea00ff013beb7dcb_96┼73┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#54",
+                      "Name": "connectedDevices#48",
                       "Data": "f2432d244a6b7774ea00ff013beb7dcb_91┼73┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#53",
+                      "Name": "connectedDevices#47",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_92┼70┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#52",
+                      "Name": "connectedDevices#46",
                       "Data": "cd57a2813ebc4ff4caf28b5fb793b3eb_89┼60┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#51",
+                      "Name": "connectedDevices#45",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_103┼63┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#50",
+                      "Name": "connectedDevices#44",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_97┼63┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#49",
+                      "Name": "connectedDevices#43",
                       "Data": "a075086024d70074e8747c26b57dfa7f_98┼76┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#48",
+                      "Name": "connectedDevices#42",
                       "Data": "f2432d244a6b7774ea00ff013beb7dcb_94┼63┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#47",
+                      "Name": "connectedDevices#41",
                       "Data": "a075086024d70074e8747c26b57dfa7f_97┼76┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#46",
+                      "Name": "connectedDevices#40",
                       "Data": "e6e7f915b6b6fc14c981a592369d47f8_103┼67┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#45",
-                      "Data": "c21551dd992a57349973e4b5af103ca6_100┼81┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#44",
+                      "Name": "connectedDevices#39",
                       "Data": "f2432d244a6b7774ea00ff013beb7dcb_101┼57┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#43",
+                      "Name": "connectedDevices#38",
                       "Data": "c21551dd992a57349973e4b5af103ca6_96┼77┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#42",
+                      "Name": "connectedDevices#37",
                       "Data": "9f6a082ba93c5684b808b09619c08044_100┼62┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#41",
+                      "Name": "connectedDevices#36",
                       "Data": "9f6a082ba93c5684b808b09619c08044_99┼62┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#40",
+                      "Name": "connectedDevices#35",
                       "Data": "38246cd9491b4c248abb2e296cc6c76f_91┼61┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#39",
+                      "Name": "connectedDevices#34",
                       "Data": "c21551dd992a57349973e4b5af103ca6_92┼66┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#38",
+                      "Name": "connectedDevices#33",
                       "Data": "c21551dd992a57349973e4b5af103ca6_92┼72┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#37",
+                      "Name": "connectedDevices#32",
                       "Data": "c21551dd992a57349973e4b5af103ca6_103┼66┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#36",
+                      "Name": "connectedDevices#31",
                       "Data": "c21551dd992a57349973e4b5af103ca6_95┼58┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#35",
+                      "Name": "connectedDevices#30",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_98┼79┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#34",
+                      "Name": "connectedDevices#29",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_102┼58┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#33",
+                      "Name": "connectedDevices#28",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_97┼71┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#32",
+                      "Name": "connectedDevices#27",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_94┼62┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#31",
-                      "Data": "a075086024d70074e8747c26b57dfa7f_100┼80┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#30",
-                      "Data": "a075086024d70074e8747c26b57dfa7f_99┼80┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#29",
+                      "Name": "connectedDevices#26",
                       "Data": "f2432d244a6b7774ea00ff013beb7dcb_96┼60┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#28",
+                      "Name": "connectedDevices#25",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_92┼74┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#27",
+                      "Name": "connectedDevices#24",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_97┼59┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#26",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_97┼82┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#25",
+                      "Name": "connectedDevices#23",
                       "Data": "a075086024d70074e8747c26b57dfa7f_100┼62┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#24",
+                      "Name": "connectedDevices#22",
                       "Data": "a075086024d70074e8747c26b57dfa7f_99┼62┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#23",
+                      "Name": "connectedDevices#21",
                       "Data": "a075086024d70074e8747c26b57dfa7f_101┼76┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#22",
+                      "Name": "connectedDevices#20",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_94┼64┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#21",
+                      "Name": "connectedDevices#19",
                       "Data": "9f6a082ba93c5684b808b09619c08044_96┼74┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#20",
+                      "Name": "connectedDevices#18",
                       "Data": "7ca27018ad6a1a04ab813ab2fbcc0236_92┼65┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#19",
+                      "Name": "connectedDevices#17",
                       "Data": "cf93667e32e15bc43b0347cd102fef98_102┼72┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#18",
+                      "Name": "connectedDevices#16",
                       "Data": "ddcfc3ab784dec1419565255774956c5_97┼72┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#17",
-                      "Data": "cbe919cf00f84254f83d474582798520_94┼83┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#16",
+                      "Name": "connectedDevices#15",
                       "Data": "03b219e90d0fc84459987c15b444d17c_95┼67┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#15",
-                      "Data": "bbc06330a48bad4429a153c0fd6e878a_100┼58┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
                       "Name": "connectedDevices#14",
-                      "Data": "f2441585d37f1914395df59a57c5e925_94┼83┼0┼@0@APCPoweredDevice@0"
+                      "Data": "bbc06330a48bad4429a153c0fd6e878a_100┼58┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#13",
@@ -146849,7 +147255,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -146868,7 +147274,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -146906,7 +147312,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -146937,7 +147343,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -146956,7 +147362,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_98┼94┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -146993,7 +147399,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_98┼94┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -147013,7 +147419,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼98┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -147730,7 +148136,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -147759,7 +148165,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_96┼70┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -147834,7 +148240,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -147926,7 +148332,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -147972,6 +148378,13 @@
             "LocalPRS": "97┼89┼0┼"
           },
           {
+            "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_97┼90┼0┼",
+            "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
+            "NameMatches": true,
+            "Name": "New Low Machine  Connector Variant",
+            "LocalPRS": "97┼90┼0┼"
+          },
+          {
             "GitID": "5a7af30c589b41a449d0ba74c9e1771c_97┼91┼0┼",
             "PrefabID": "5a7af30c589b41a449d0ba74c9e1771c",
             "NameMatches": true,
@@ -147997,6 +148410,13 @@
             "LocalPRS": "97┼94┼0┼"
           },
           {
+            "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_97┼94┼0┼",
+            "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
+            "NameMatches": true,
+            "Name": "New Low Machine  Connector Variant",
+            "LocalPRS": "97┼94┼0┼"
+          },
+          {
             "GitID": "08990b75a4ff90847a517eacd5a4a6d8_97┼97┼0┼",
             "PrefabID": "08990b75a4ff90847a517eacd5a4a6d8",
             "Name": "SuitStorageUnitHeadOfSecurity (1)",
@@ -148008,7 +148428,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_98┼94┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -148027,7 +148447,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼98┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -148478,7 +148898,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -148516,7 +148936,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼85┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -148540,6 +148960,134 @@
             }
           },
           {
+            "GitID": "cd57203a8d3f54f478446e9b0ced6cf9_98┼90┼0┼",
+            "PrefabID": "cd57203a8d3f54f478446e9b0ced6cf9",
+            "Name": "APC - HOP Office",
+            "LocalPRS": "98┼90┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Left_By90"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "APC@0",
+                  "Data": [
+                    {
+                      "Name": "connectedDevices#8",
+                      "Data": "86dfd01ee418a3f448b82af5f5b28850_91┼92┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#7",
+                      "Data": "9965705e0b30db94ab453acb77547175_92┼92┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#6",
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_94┼92┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#5",
+                      "Data": "a50474d976314462a79602e20a762520_95┼93┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#4",
+                      "Data": "0d553281bdfc0fd438b3f6c7db58688c_94┼91┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#3",
+                      "Data": "cb2f847ef3b8b754181a970a4032c552_94┼90┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#2",
+                      "Data": "06f461555a8bd5947b6bfa4ecbc95627_95┼88┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#1",
+                      "Data": "c21551dd992a57349973e4b5af103ca6_95┼92┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#0",
+                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_94┼88┼0┼@0@APCPoweredDevice@0"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "cd57203a8d3f54f478446e9b0ced6cf9_98┼94┼0┼",
+            "PrefabID": "cd57203a8d3f54f478446e9b0ced6cf9",
+            "Name": "APC - HOS Office",
+            "LocalPRS": "98┼94┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Left_By90"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "APC@0",
+                  "Data": [
+                    {
+                      "Name": "connectedDevices#10",
+                      "Data": "06f461555a8bd5947b6bfa4ecbc95627_98┼95┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#9",
+                      "Data": "a50474d976314462a79602e20a762520_92┼98┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#8",
+                      "Data": "0d553281bdfc0fd438b3f6c7db58688c_96┼96┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#7",
+                      "Data": "cb2f847ef3b8b754181a970a4032c552_92┼96┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#6",
+                      "Data": "b5e5d6463b96de0458a195cebc18a3e2_93┼97┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#5",
+                      "Data": "f8db3418b6542874396d1eaa52946e19_94┼97┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#4",
+                      "Data": "bc0cd2a586c78b846a43622b6ea5c953_96┼97┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#3",
+                      "Data": "08990b75a4ff90847a517eacd5a4a6d8_97┼97┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#2",
+                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_98┼96┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#1",
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_94┼94┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#0",
+                      "Data": "c21551dd992a57349973e4b5af103ca6_93┼94┼0┼@0@APCPoweredDevice@0"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
             "GitID": "06f461555a8bd5947b6bfa4ecbc95627_98┼95┼0┼",
             "PrefabID": "06f461555a8bd5947b6bfa4ecbc95627",
             "NameMatches": true,
@@ -148552,7 +149100,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_98┼94┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -148597,7 +149145,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_98┼94┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -148635,7 +149183,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼98┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -149018,7 +149566,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_96┼70┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -149216,7 +149764,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼98┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -149235,7 +149783,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼98┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -149904,7 +150452,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_96┼70┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -149933,7 +150481,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_96┼70┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -150036,13 +150584,6 @@
             }
           },
           {
-            "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_100┼93┼0┼",
-            "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
-            "Name": "New Low Machine  Connector Variant",
-            "LocalPRS": "100┼93┼0┼"
-          },
-          {
             "GitID": "2bb2787c427eb384ba89c9fd13ec823b_100┼98┼0┼",
             "PrefabID": "2bb2787c427eb384ba89c9fd13ec823b",
             "NameMatches": true,
@@ -150055,7 +150596,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼98┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -151006,7 +151547,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼87┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -151035,7 +151576,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼87┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -151062,6 +151603,122 @@
                     {
                       "Name": "listOfLights#0",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_102┼86┼0┼@0@LightSource@0"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "cd57203a8d3f54f478446e9b0ced6cf9_101┼87┼0┼",
+            "PrefabID": "cd57203a8d3f54f478446e9b0ced6cf9",
+            "Name": "APC - Meeting Room",
+            "LocalPRS": "101┼87┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Right_By270"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "APC@0",
+                  "Data": [
+                    {
+                      "Name": "connectedDevices#7",
+                      "Data": "a50474d976314462a79602e20a762520_105┼89┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#6",
+                      "Data": "c21551dd992a57349973e4b5af103ca6_103┼88┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#5",
+                      "Data": "2bb2787c427eb384ba89c9fd13ec823b_101┼85┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#4",
+                      "Data": "cb2f847ef3b8b754181a970a4032c552_105┼88┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#3",
+                      "Data": "0d553281bdfc0fd438b3f6c7db58688c_105┼87┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#2",
+                      "Data": "bc0cd2a586c78b846a43622b6ea5c953_104┼85┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#1",
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_102┼86┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#0",
+                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_101┼86┼0┼@0@APCPoweredDevice@0"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "cd57203a8d3f54f478446e9b0ced6cf9_101┼91┼0┼",
+            "PrefabID": "cd57203a8d3f54f478446e9b0ced6cf9",
+            "Name": "APC - Captain Office",
+            "LocalPRS": "101┼91┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Right_By270"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "APC@0",
+                  "Data": [
+                    {
+                      "Name": "connectedDevices#8",
+                      "Data": "8a5248bf3330c4449bed77940fbeb820_106┼97┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#7",
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_104┼97┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#6",
+                      "Data": "cb2f847ef3b8b754181a970a4032c552_103┼96┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#5",
+                      "Data": "0d553281bdfc0fd438b3f6c7db58688c_105┼95┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#4",
+                      "Data": "6fa1bf6a566af2f479f551f9bb604178_104┼93┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#3",
+                      "Data": "9ee00dec6bcc89c41908f9f20efa9068_105┼92┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#2",
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_106┼91┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#1",
+                      "Data": "a50474d976314462a79602e20a762520_107┼94┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#0",
+                      "Data": "06f461555a8bd5947b6bfa4ecbc95627_104┼89┼0┼@0@APCPoweredDevice@0"
                     }
                   ]
                 }
@@ -151114,340 +151771,44 @@
                   "ClassID": "APC@0",
                   "Data": [
                     {
-                      "Name": "connectedDevices#83",
-                      "Data": "60ca8a399a7aa194dae1560980333f3b_93┼102┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#82",
-                      "Data": "cb2f847ef3b8b754181a970a4032c552_93┼101┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#81",
-                      "Data": "0d553281bdfc0fd438b3f6c7db58688c_93┼100┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#80",
-                      "Data": "c21551dd992a57349973e4b5af103ca6_92┼99┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#79",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_91┼100┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#78",
-                      "Data": "a50474d976314462a79602e20a762520_92┼98┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#77",
-                      "Data": "b5e5d6463b96de0458a195cebc18a3e2_93┼97┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#76",
-                      "Data": "cb2f847ef3b8b754181a970a4032c552_92┼96┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#75",
-                      "Data": "c21551dd992a57349973e4b5af103ca6_93┼94┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#74",
-                      "Data": "9965705e0b30db94ab453acb77547175_92┼92┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#73",
-                      "Data": "86dfd01ee418a3f448b82af5f5b28850_91┼92┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#72",
-                      "Data": "cb2f847ef3b8b754181a970a4032c552_92┼86┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#71",
-                      "Data": "cb2f847ef3b8b754181a970a4032c552_94┼90┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#70",
-                      "Data": "a50474d976314462a79602e20a762520_105┼89┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#69",
-                      "Data": "cb2f847ef3b8b754181a970a4032c552_105┼88┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#68",
-                      "Data": "19dd1cfccb59c8245a70c4923037c950_95┼84┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#67",
-                      "Data": "ea7280b49083dfa469fb176f6a7e4772_91┼83┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#66",
-                      "Data": "ea7280b49083dfa469fb176f6a7e4772_97┼83┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#65",
-                      "Data": "38246cd9491b4c248abb2e296cc6c76f_90┼84┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#64",
-                      "Data": "f2441585d37f1914395df59a57c5e925_97┼80┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#63",
-                      "Data": "f2441585d37f1914395df59a57c5e925_91┼80┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#62",
-                      "Data": "6fa1bf6a566af2f479f551f9bb604178_94┼83┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#61",
-                      "Data": "f2441585d37f1914395df59a57c5e925_93┼83┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#60",
-                      "Data": "f2441585d37f1914395df59a57c5e925_92┼83┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#59",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_91┼86┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#58",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_97┼86┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#57",
-                      "Data": "a50474d976314462a79602e20a762520_96┼88┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#56",
-                      "Data": "a50474d976314462a79602e20a762520_95┼93┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#55",
-                      "Data": "a50474d976314462a79602e20a762520_94┼103┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#54",
-                      "Data": "a50474d976314462a79602e20a762520_103┼98┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#53",
-                      "Data": "a50474d976314462a79602e20a762520_107┼94┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#52",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_106┼91┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#51",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_104┼99┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#50",
-                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_98┼84┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#49",
-                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_101┼84┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#48",
-                      "Data": "b7053ef275ce5b74e827e60b034d1647_93┼88┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#47",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_94┼92┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#46",
-                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_94┼88┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#45",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_100┼90┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#44",
-                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_101┼86┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#43",
-                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_98┼96┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#42",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_104┼97┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#41",
-                      "Data": "b7053ef275ce5b74e827e60b034d1647_98┼98┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#40",
-                      "Data": "c21551dd992a57349973e4b5af103ca6_102┼99┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#39",
-                      "Data": "c21551dd992a57349973e4b5af103ca6_95┼92┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#38",
-                      "Data": "c21551dd992a57349973e4b5af103ca6_96┼87┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#37",
-                      "Data": "c21551dd992a57349973e4b5af103ca6_99┼92┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#36",
-                      "Data": "c21551dd992a57349973e4b5af103ca6_103┼88┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#35",
-                      "Data": "06f461555a8bd5947b6bfa4ecbc95627_95┼100┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#34",
-                      "Data": "06f461555a8bd5947b6bfa4ecbc95627_95┼101┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#33",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_96┼102┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#32",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_102┼86┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#31",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_94┼94┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#30",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_99┼84┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#29",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_99┼97┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#28",
-                      "Data": "f2441585d37f1914395df59a57c5e925_95┼83┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#27",
-                      "Data": "f2441585d37f1914395df59a57c5e925_96┼83┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#26",
-                      "Data": "6fa1bf6a566af2f479f551f9bb604178_104┼93┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#25",
-                      "Data": "0d553281bdfc0fd438b3f6c7db58688c_105┼87┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#24",
-                      "Data": "2bb2787c427eb384ba89c9fd13ec823b_101┼85┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#23",
-                      "Data": "0d553281bdfc0fd438b3f6c7db58688c_105┼95┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#22",
-                      "Data": "0d553281bdfc0fd438b3f6c7db58688c_96┼86┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#21",
-                      "Data": "0d553281bdfc0fd438b3f6c7db58688c_94┼91┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#20",
-                      "Data": "0d553281bdfc0fd438b3f6c7db58688c_97┼101┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#19",
-                      "Data": "0d553281bdfc0fd438b3f6c7db58688c_96┼96┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#18",
-                      "Data": "cb2f847ef3b8b754181a970a4032c552_103┼96┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#17",
-                      "Data": "cb2f847ef3b8b754181a970a4032c552_102┼101┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#16",
-                      "Data": "08990b75a4ff90847a517eacd5a4a6d8_97┼97┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#15",
-                      "Data": "9ee00dec6bcc89c41908f9f20efa9068_101┼103┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#14",
-                      "Data": "8a5248bf3330c4449bed77940fbeb820_106┼97┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#13",
-                      "Data": "2bb2787c427eb384ba89c9fd13ec823b_100┼98┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#12",
-                      "Data": "2bb2787c427eb384ba89c9fd13ec823b_99┼98┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#11",
-                      "Data": "2bb2787c427eb384ba89c9fd13ec823b_100┼83┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#10",
-                      "Data": "2bb2787c427eb384ba89c9fd13ec823b_99┼83┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
                       "Name": "connectedDevices#9",
-                      "Data": "9ee00dec6bcc89c41908f9f20efa9068_105┼92┼0┼@0@APCPoweredDevice@0"
+                      "Data": "c21551dd992a57349973e4b5af103ca6_100┼81┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#8",
-                      "Data": "bc0cd2a586c78b846a43622b6ea5c953_104┼85┼0┼@0@APCPoweredDevice@0"
+                      "Data": "a075086024d70074e8747c26b57dfa7f_100┼80┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#7",
-                      "Data": "bc0cd2a586c78b846a43622b6ea5c953_99┼103┼0┼@0@APCPoweredDevice@0"
+                      "Data": "a075086024d70074e8747c26b57dfa7f_99┼80┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#6",
-                      "Data": "bc0cd2a586c78b846a43622b6ea5c953_96┼97┼0┼@0@APCPoweredDevice@0"
+                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_101┼84┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#5",
-                      "Data": "06f461555a8bd5947b6bfa4ecbc95627_95┼88┼0┼@0@APCPoweredDevice@0"
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_100┼90┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#4",
-                      "Data": "06f461555a8bd5947b6bfa4ecbc95627_98┼95┼0┼@0@APCPoweredDevice@0"
+                      "Data": "c21551dd992a57349973e4b5af103ca6_99┼92┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#3",
-                      "Data": "f8db3418b6542874396d1eaa52946e19_93┼87┼0┼@0@APCPoweredDevice@0"
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_99┼84┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#2",
-                      "Data": "f8db3418b6542874396d1eaa52946e19_94┼97┼0┼@0@APCPoweredDevice@0"
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_99┼97┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#1",
-                      "Data": "06f461555a8bd5947b6bfa4ecbc95627_98┼85┼0┼@0@APCPoweredDevice@0"
+                      "Data": "2bb2787c427eb384ba89c9fd13ec823b_100┼83┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#0",
-                      "Data": "06f461555a8bd5947b6bfa4ecbc95627_104┼89┼0┼@0@APCPoweredDevice@0"
+                      "Data": "2bb2787c427eb384ba89c9fd13ec823b_99┼83┼0┼@0@APCPoweredDevice@0"
                     }
                   ]
                 }
@@ -151466,7 +151827,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼98┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -151847,7 +152208,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼87┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -151880,6 +152241,13 @@
             }
           },
           {
+            "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_102┼87┼0┼",
+            "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
+            "NameMatches": true,
+            "Name": "New Low Machine  Connector Variant",
+            "LocalPRS": "102┼87┼0┼"
+          },
+          {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_102┼88┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
             "NameMatches": true,
@@ -151892,6 +152260,13 @@
             "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "102┼90┼0┼"
+          },
+          {
+            "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_102┼91┼0┼",
+            "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
+            "NameMatches": true,
+            "Name": "New Low Machine  Connector Variant",
+            "LocalPRS": "102┼91┼0┼"
           },
           {
             "GitID": "3bffe96abee6e3940805d4c2724b8f5b_102┼92┼0┼",
@@ -151947,6 +152322,13 @@
             "LocalPRS": "102┼93┼0┼"
           },
           {
+            "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_102┼93┼0┼",
+            "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
+            "NameMatches": true,
+            "Name": "New Low Machine  Connector Variant",
+            "LocalPRS": "102┼93┼0┼"
+          },
+          {
             "GitID": "6889368ca37503245b8aee273cc97b03_102┼96.98┼0┼",
             "PrefabID": "6889368ca37503245b8aee273cc97b03",
             "NameMatches": true,
@@ -151972,7 +152354,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼98┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -152012,7 +152394,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼98┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -152870,7 +153252,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼87┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -152913,7 +153295,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼91┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -152950,7 +153332,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼98┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -153405,7 +153787,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼87┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -153425,7 +153807,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼91┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -153461,7 +153843,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼91┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -153503,7 +153885,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼91┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -153557,7 +153939,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼98┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -154077,7 +154459,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼87┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -154114,7 +154496,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼87┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -154151,7 +154533,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼87┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -154248,7 +154630,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼91┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -154273,7 +154655,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼91┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -154303,6 +154685,81 @@
             "PrefabID": "86570587e3d5cba1e9ffdeead16603e4",
             "Name": "PottedPlantRandom",
             "LocalPRS": "105┼96.95┼0┼"
+          },
+          {
+            "GitID": "cd57203a8d3f54f478446e9b0ced6cf9_105┼98┼0┼",
+            "PrefabID": "cd57203a8d3f54f478446e9b0ced6cf9",
+            "Name": "APC - Bridge",
+            "LocalPRS": "105┼98┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Up_By0"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "APC@0",
+                  "Data": [
+                    {
+                      "Name": "connectedDevices#10",
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_96┼102┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#9",
+                      "Data": "a50474d976314462a79602e20a762520_103┼98┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#8",
+                      "Data": "0d553281bdfc0fd438b3f6c7db58688c_97┼101┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#7",
+                      "Data": "cb2f847ef3b8b754181a970a4032c552_102┼101┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#6",
+                      "Data": "2bb2787c427eb384ba89c9fd13ec823b_100┼98┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#5",
+                      "Data": "2bb2787c427eb384ba89c9fd13ec823b_99┼98┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#4",
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_104┼99┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#3",
+                      "Data": "9ee00dec6bcc89c41908f9f20efa9068_101┼103┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#2",
+                      "Data": "c21551dd992a57349973e4b5af103ca6_102┼99┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#1",
+                      "Data": "bc0cd2a586c78b846a43622b6ea5c953_99┼103┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#0",
+                      "Data": "b7053ef275ce5b74e827e60b034d1647_98┼98┼0┼@0@APCPoweredDevice@0"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_105┼99┼0┼",
+            "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
+            "NameMatches": true,
+            "Name": "New Low Machine  Connector Variant",
+            "LocalPRS": "105┼99┼0┼"
           },
           {
             "GitID": "b2d9e215b3fd72d41a5df489b5b86386_105.01┼52┼0┼",
@@ -155431,7 +155888,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼91┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -155481,7 +155938,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼91┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -156097,7 +156554,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼93┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_101┼91┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -163985,37 +164442,9 @@
               ],
               "Children": [
                 {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "1"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
                   "ID": "0,1",
                   "Active": false,
                   "ClassDatas": []
-                },
-                {
-                  "ID": "0,2",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "1"
-                        }
-                      ]
-                    }
-                  ]
                 }
               ]
             }
@@ -164895,37 +165324,9 @@
               ],
               "Children": [
                 {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "2"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
                   "ID": "0,1",
                   "Active": false,
                   "ClassDatas": []
-                },
-                {
-                  "ID": "0,2",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "2"
-                        }
-                      ]
-                    }
-                  ]
                 }
               ]
             }
@@ -179169,22 +179570,6 @@
                     }
                   ]
                 }
-              ],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "1"
-                        }
-                      ]
-                    }
-                  ]
-                }
               ]
             }
           },
@@ -179321,22 +179706,6 @@
                     }
                   ]
                 }
-              ],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "1"
-                        }
-                      ]
-                    }
-                  ]
-                }
               ]
             }
           },
@@ -179365,22 +179734,6 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Up_By0"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "1"
-                        }
-                      ]
                     }
                   ]
                 }
@@ -179531,22 +179884,6 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Up_By0"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "1"
-                        }
-                      ]
                     }
                   ]
                 }
@@ -182051,37 +182388,9 @@
               ],
               "Children": [
                 {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "1"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
                   "ID": "0,1",
                   "Active": false,
                   "ClassDatas": []
-                },
-                {
-                  "ID": "0,2",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "1"
-                        }
-                      ]
-                    }
-                  ]
                 }
               ]
             }
@@ -182099,22 +182408,6 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "2"
-                        }
-                      ]
                     }
                   ]
                 }
@@ -182287,37 +182580,9 @@
               ],
               "Children": [
                 {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "2"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
                   "ID": "0,1",
                   "Active": false,
                   "ClassDatas": []
-                },
-                {
-                  "ID": "0,2",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "2"
-                        }
-                      ]
-                    }
-                  ]
                 }
               ]
             }
@@ -182342,37 +182607,9 @@
               ],
               "Children": [
                 {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "2"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
                   "ID": "0,1",
                   "Active": false,
                   "ClassDatas": []
-                },
-                {
-                  "ID": "0,2",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "2"
-                        }
-                      ]
-                    }
-                  ]
                 }
               ]
             }
@@ -182424,37 +182661,9 @@
               ],
               "Children": [
                 {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "1"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
                   "ID": "0,1",
                   "Active": false,
                   "ClassDatas": []
-                },
-                {
-                  "ID": "0,2",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "1"
-                        }
-                      ]
-                    }
-                  ]
                 }
               ]
             }
@@ -182472,22 +182681,6 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Right_By270"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "2"
-                        }
-                      ]
                     }
                   ]
                 }
@@ -182783,37 +182976,9 @@
               ],
               "Children": [
                 {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "1"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
                   "ID": "0,1",
                   "Active": false,
                   "ClassDatas": []
-                },
-                {
-                  "ID": "0,2",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "1"
-                        }
-                      ]
-                    }
-                  ]
                 }
               ]
             }
@@ -182970,22 +183135,6 @@
                     }
                   ]
                 }
-              ],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "3"
-                        }
-                      ]
-                    }
-                  ]
-                }
               ]
             }
           },
@@ -183131,37 +183280,9 @@
               ],
               "Children": [
                 {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "1"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
                   "ID": "0,1",
                   "Active": false,
                   "ClassDatas": []
-                },
-                {
-                  "ID": "0,2",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "1"
-                        }
-                      ]
-                    }
-                  ]
                 }
               ]
             }
@@ -183213,37 +183334,9 @@
               ],
               "Children": [
                 {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "1"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
                   "ID": "0,1",
                   "Active": false,
                   "ClassDatas": []
-                },
-                {
-                  "ID": "0,2",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "1"
-                        }
-                      ]
-                    }
-                  ]
                 }
               ]
             }
@@ -183261,22 +183354,6 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Left_By90"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "3"
-                        }
-                      ]
                     }
                   ]
                 }
@@ -183460,37 +183537,9 @@
               ],
               "Children": [
                 {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "3"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
                   "ID": "0,1",
                   "Active": false,
                   "ClassDatas": []
-                },
-                {
-                  "ID": "0,2",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "3"
-                        }
-                      ]
-                    }
-                  ]
                 }
               ]
             }
@@ -183515,37 +183564,9 @@
               ],
               "Children": [
                 {
-                  "ID": "0,0",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "3"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
                   "ID": "0,1",
                   "Active": false,
                   "ClassDatas": []
-                },
-                {
-                  "ID": "0,2",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "initialVariantIndex",
-                          "Data": "3"
-                        }
-                      ]
-                    }
-                  ]
                 }
               ]
             }

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/MiniStation.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/MiniStation.json
@@ -113852,8 +113852,8 @@
             }
           },
           {
-            "GitID": "8D0W-BGDVb8469ufZ@aF_53┼95┼0┼",
-            "PrefabID": "8D0W-BGDVb8469ufZ@aF",
+            "GitID": "J5UF3VXxKdTV9iopbA17_53┼95┼0┼",
+            "PrefabID": "J5UF3VXxKdTV9iopbA17",
             "NameMatches": true,
             "Name": "SecBarrier",
             "LocalPRS": "53┼95┼0┼"
@@ -114290,8 +114290,8 @@
             }
           },
           {
-            "GitID": "8D0W-BGDVb8469ufZ@aF_54┼95┼0┼",
-            "PrefabID": "8D0W-BGDVb8469ufZ@aF",
+            "GitID": "J5UF3VXxKdTV9iopbA17_54┼95┼0┼",
+            "PrefabID": "J5UF3VXxKdTV9iopbA17",
             "NameMatches": true,
             "Name": "SecBarrier",
             "LocalPRS": "54┼95┼0┼"
@@ -115173,8 +115173,8 @@
             }
           },
           {
-            "GitID": "8D0W-BGDVb8469ufZ@aF_55┼95┼0┼",
-            "PrefabID": "8D0W-BGDVb8469ufZ@aF",
+            "GitID": "J5UF3VXxKdTV9iopbA17_55┼95┼0┼",
+            "PrefabID": "J5UF3VXxKdTV9iopbA17",
             "NameMatches": true,
             "Name": "SecBarrier",
             "LocalPRS": "55┼95┼0┼"
@@ -149204,8 +149204,8 @@
             "LocalPRS": "88.18┼85.2┼0┼"
           },
           {
-            "GitID": "8gzr!x7_Yea@71L--kC5_88.25┼85.95┼0┼",
-            "PrefabID": "8gzr!x7_Yea@71L--kC5",
+            "GitID": "yZZOh_oxUsRnJuf$HNg8_88.25┼85.95┼0┼",
+            "PrefabID": "yZZOh_oxUsRnJuf$HNg8",
             "Name": "HandPick (1)",
             "LocalPRS": "88.25┼85.95┼0┼"
           },

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/OutpostStation.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/OutpostStation.json
@@ -262071,8 +262071,8 @@
             }
           },
           {
-            "GitID": "8D0W-BGDVb8469ufZ@aF_62┼27┼0┼",
-            "PrefabID": "8D0W-BGDVb8469ufZ@aF",
+            "GitID": "J5UF3VXxKdTV9iopbA17_62┼27┼0┼",
+            "PrefabID": "J5UF3VXxKdTV9iopbA17",
             "NameMatches": true,
             "Name": "SecBarrier",
             "LocalPRS": "62┼27┼0┼"
@@ -263135,8 +263135,8 @@
             "LocalPRS": "63┼26.08┼0┼"
           },
           {
-            "GitID": "8D0W-BGDVb8469ufZ@aF_63┼27┼0┼",
-            "PrefabID": "8D0W-BGDVb8469ufZ@aF",
+            "GitID": "J5UF3VXxKdTV9iopbA17_63┼27┼0┼",
+            "PrefabID": "J5UF3VXxKdTV9iopbA17",
             "NameMatches": true,
             "Name": "SecBarrier",
             "LocalPRS": "63┼27┼0┼"
@@ -273964,8 +273964,8 @@
             }
           },
           {
-            "GitID": "8D0W-BGDVb8469ufZ@aF_70┼48┼0┼",
-            "PrefabID": "8D0W-BGDVb8469ufZ@aF",
+            "GitID": "J5UF3VXxKdTV9iopbA17_70┼48┼0┼",
+            "PrefabID": "J5UF3VXxKdTV9iopbA17",
             "NameMatches": true,
             "Name": "SecBarrier",
             "LocalPRS": "70┼48┼0┼"

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/PogStation.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/PogStation.json
@@ -197001,8 +197001,8 @@
             "LocalPRS": "-13.82┼231.69┼0┼"
           },
           {
-            "GitID": "8gzr!x7_Yea@71L--kC5_-13.77┼223.05┼0┼",
-            "PrefabID": "8gzr!x7_Yea@71L--kC5",
+            "GitID": "yZZOh_oxUsRnJuf$HNg8_-13.77┼223.05┼0┼",
+            "PrefabID": "yZZOh_oxUsRnJuf$HNg8",
             "Name": "HandPick (1)",
             "LocalPRS": "-13.77┼223.05┼0┼"
           },

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/SquareStation.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/SquareStation.json
@@ -160099,8 +160099,8 @@
             "LocalPRS": "56.09┼57.49┼0┼"
           },
           {
-            "GitID": "8gzr!x7_Yea@71L--kC5_56.41┼57.09┼0┼",
-            "PrefabID": "8gzr!x7_Yea@71L--kC5",
+            "GitID": "yZZOh_oxUsRnJuf$HNg8_56.41┼57.09┼0┼",
+            "PrefabID": "yZZOh_oxUsRnJuf$HNg8",
             "Name": "HandPick (1)",
             "LocalPRS": "56.41┼57.09┼0┼"
           },
@@ -180937,8 +180937,8 @@
             "LocalPRS": "91┼152┼0┼"
           },
           {
-            "GitID": "8D0W-BGDVb8469ufZ@aF_91┼154┼0┼",
-            "PrefabID": "8D0W-BGDVb8469ufZ@aF",
+            "GitID": "J5UF3VXxKdTV9iopbA17_91┼154┼0┼",
+            "PrefabID": "J5UF3VXxKdTV9iopbA17",
             "NameMatches": true,
             "Name": "SecBarrier",
             "LocalPRS": "91┼154┼0┼"
@@ -180989,8 +180989,8 @@
             }
           },
           {
-            "GitID": "8D0W-BGDVb8469ufZ@aF_91┼155┼0┼",
-            "PrefabID": "8D0W-BGDVb8469ufZ@aF",
+            "GitID": "J5UF3VXxKdTV9iopbA17_91┼155┼0┼",
+            "PrefabID": "J5UF3VXxKdTV9iopbA17",
             "NameMatches": true,
             "Name": "SecBarrier",
             "LocalPRS": "91┼155┼0┼"
@@ -181691,8 +181691,8 @@
             }
           },
           {
-            "GitID": "8D0W-BGDVb8469ufZ@aF_92┼155┼0┼",
-            "PrefabID": "8D0W-BGDVb8469ufZ@aF",
+            "GitID": "J5UF3VXxKdTV9iopbA17_92┼155┼0┼",
+            "PrefabID": "J5UF3VXxKdTV9iopbA17",
             "NameMatches": true,
             "Name": "SecBarrier",
             "LocalPRS": "92┼155┼0┼"


### PR DESCRIPTION
Fixes some bad foreverids for the sec barrier, odd slug and handpick
Adds a tiny fan to fallstation ord
Fixes the rotation of some sec cams, windoors and directional windows in fallstation
Adds APCS in fallstation bridge, nuke room, hop office, hop, hos office, cap office and the meeting room
![2025-04-21-05:16:05](https://github.com/user-attachments/assets/cc99f7f8-cbe9-4dd9-8dc4-b8491bb52eab)

### Changelog:
CL: [Improvement] APCS have been added to fallstation bridge, nuke room, hop office, hop, hos office, cap office and the meeting room.
CL: [Improvement] A tinyfan has been added to fallstation ord
