### PR TITLE
Witching Weekend Adjustments

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Occupations/SpookyPops/ClownLordPopulator.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Occupations/SpookyPops/ClownLordPopulator.asset
@@ -44,7 +44,8 @@ MonoBehaviour:
     ReplacementStrategy: 1
     namedSlotPopulatorEntrys: []
   - DoNotGetFirstEmptySlot: 0
-    Prefab: {fileID: 376751530547593975, guid: 7eb26c268df1f04438bf349f2ad5c638, type: 3}
+    Prefab: {fileID: 4396341318306884477, guid: 1d54376f0c6f4474b8839a8847d19a9f,
+      type: 3}
     UseIndex: 0
     IndexSlot: 0
     NamedSlot: 0

--- a/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Occupations/SpookyPops/WitchPopulator.asset
+++ b/UnityProject/Assets/ScriptableObjects/Inventory/Populators/Occupations/SpookyPops/WitchPopulator.asset
@@ -73,7 +73,7 @@ MonoBehaviour:
     ReplacementStrategy: 0
     namedSlotPopulatorEntrys: []
   - DoNotGetFirstEmptySlot: 0
-    Prefab: {fileID: 3946093906104289823, guid: 1a29d7430eef409409b622cc8278453e,
+    Prefab: {fileID: 6346491876050255640, guid: d8834cdce3ea33048bfac1dae6872d8e,
       type: 3}
     UseIndex: 0
     IndexSlot: 0
@@ -81,16 +81,6 @@ MonoBehaviour:
     AlternativeNamedSlots: 
     IfOccupiedFindEmptySlot: 1
     ReplacementStrategy: 2
-    namedSlotPopulatorEntrys: []
-  - DoNotGetFirstEmptySlot: 0
-    Prefab: {fileID: 8734328976324889014, guid: d3c71176f32c1274b929f3a88695a795,
-      type: 3}
-    UseIndex: 0
-    IndexSlot: 0
-    NamedSlot: 17
-    AlternativeNamedSlots: 
-    IfOccupiedFindEmptySlot: 1
-    ReplacementStrategy: 1
     namedSlotPopulatorEntrys: []
   - DoNotGetFirstEmptySlot: 0
     Prefab: {fileID: 6806663897376166138, guid: 11b50d955d9c17948b8b1081514764dd,

--- a/UnityProject/Assets/ScriptableObjects/TimedEvents/WitchingWeekendTimedEvent.asset
+++ b/UnityProject/Assets/ScriptableObjects/TimedEvents/WitchingWeekendTimedEvent.asset
@@ -12,22 +12,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3c6335f50312476aa36048ce01d5d58b, type: 3}
   m_Name: WitchingWeekendTimedEvent
   m_EditorClassIdentifier: 
-  Months: 0a0000000100000003000000050000000700000009000000
+  Months: 0a000000
   MonthDayRanges:
-    m_keys: 0a0000000900000001000000030000000500000007000000
+    m_keys: 0a000000
     m_values:
-    - DayOfMonthStart: 18
-      DayOfMonthEnd: 27
-    - DayOfMonthStart: 5
-      DayOfMonthEnd: 7
-    - DayOfMonthStart: 3
-      DayOfMonthEnd: 5
-    - DayOfMonthStart: 1
-      DayOfMonthEnd: 3
-    - DayOfMonthStart: 2
-      DayOfMonthEnd: 4
-    - DayOfMonthStart: 4
-      DayOfMonthEnd: 6
+    - DayOfMonthStart: 17
+      DayOfMonthEnd: 19
   EventName: Witching Weekend
   EventDesc: 'Evil creatures and spooky witches, Rejoice! It''s the Witching Weekend!
 

--- a/UnityProject/Assets/Scripts/ScriptableObjects/TimedGameEvents/SeasonalEvents/WitchingWeekend.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/TimedGameEvents/SeasonalEvents/WitchingWeekend.cs
@@ -1,5 +1,8 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using Cysharp.Threading.Tasks;
+using Managers;
+using Strings;
 using Systems.Storage;
 using UnityEngine;
 using Random = UnityEngine.Random;
@@ -11,15 +14,22 @@ namespace ScriptableObjects.TimedGameEvents.SeasonalEvents
 	{
 		[SerializeField] private List<PlayerSlotStoragePopulator> outfits = new List<PlayerSlotStoragePopulator>();
 
+		private string randomTitle = "Spooky";
+
+		private const string SPOOKY = "Spooky";
+		private const string EVIL = "Evil";
+
 		public override IEnumerator EventStart()
 		{
 			PlayerSpawn.OnBodySpawnedEvent += DressUpPlayer;
+			EventManager.AddHandler(Event.PostRoundStarted, AnnounceEventOnRoundStart);
 			return base.EventStart();
 		}
 
 		public override void Clean()
 		{
 			PlayerSpawn.OnBodySpawnedEvent -= DressUpPlayer;
+			EventManager.RemoveHandler(Event.PostRoundStarted, AnnounceEventOnRoundStart);
 			base.Clean();
 		}
 
@@ -27,10 +37,29 @@ namespace ScriptableObjects.TimedGameEvents.SeasonalEvents
 		{
 			if (player == null) return;
 			if (player.TryGetComponent<PlayerScript>(out var playerScript) == false) return;
+			if (playerScript.characterSettings == null) return;
+			if (playerScript.characterSettings.Name.Contains(SPOOKY) || playerScript.characterSettings.Name.Contains(EVIL)) return;
+			if (playerScript.Mind.occupation.JobType is
+			    JobType.AI or JobType.CYBORG or // we don't want robots to be spooky.
+			    JobType.CAPTAIN or JobType.HOP or JobType.HOS or // probably not
+			    JobType.WARDEN or JobType.SECURITY_OFFICER or // be serious
+			    JobType.ASHWALKER or JobType.NULL or JobType.FUGITIVE or JobType.ANCIENT_ENGINEER) return; // ghost roles are almost likely never part of the crew.
 			if (player.TryGetComponent<DynamicItemStorage>(out var storage) == false) return;
-			var randomTitle = Random.Range(0f, 1f) >= 0.5 ? "Spooky" : "Evil";
+			randomTitle = Random.Range(0f, 1f) >= 0.5 ? SPOOKY : EVIL;
 			playerScript.characterSettings.Name = randomTitle + " " + playerScript.characterSettings.Name;
 			storage.SetUpFromPopulator(outfits.PickRandom());
+		}
+
+		private void AnnounceEventOnRoundStart()
+		{
+			_ = Announcement();
+		}
+
+		private async UniTask Announcement()
+		{
+			await UniTask.WaitForSeconds(10f);
+			CentComm.MakeAnnouncement(ChatTemplates.CentcomAnnounce, "Welcome to the witching weekend, a crew exchange event between Nanotrasen and the Wizards Federation." +
+			                                                         "\nWe put our differences aside today to celeberate the legends of old that brought science into the world of darkness that engulfed humanity for hundreds - if not thousands - of years on our origin planet, Earth.", CentComm.UpdateSound.Announce);
 		}
 	}
 }


### PR DESCRIPTION
CL: [Improvement] The Witching Weekend is now an exclusive October event that starts on the 17th and ends on the 19th. It is no longer a bi-monthly event.
CL: [Improvement] The "Clown Lord" costume no longer spawns with human skin as outerwear.
CL: [Improvement] Added a centcom announcement regarding the witching weekend event to help people realize why they all look like they're attending a with hunt trial.
CL: [Fix] Players will no longer spawn with a book of spells during the witching weekend.
CL: [Fix] Blacklisted several occupations from being effected by the witching weekend event, this includes ghost roles, some antagonists, and most of the security and heads personnel.
CL: [Fix] Names will hopefully no longer get unreasonably long during the witching event due to Scriptable Objects being dumb.
