### PR TITLE
Slightly improves the preround screen for smaller resolutions

### DIFF
--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/Windows/PreRoundScreen.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/Windows/PreRoundScreen.prefab
@@ -1533,10 +1533,10 @@ RectTransform:
   - {fileID: 6556161646035900180}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 1090, y: 516}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1505121974795170588
 CanvasRenderer:


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ee71a226-197c-4c43-94df-a95b66b2d6e6)
![image](https://github.com/user-attachments/assets/d2d11138-2717-4081-9dcf-8771dc0da971)
![image](https://github.com/user-attachments/assets/37ab3673-8abb-4b10-a435-f7e36c4ead94)
![image](https://github.com/user-attachments/assets/a6fc5701-206d-465c-8c74-73a125babcf5)

Still not perfect, but better than nothing.

CL: [Improvement] The new lobby screen is now better centered in lower resolutions.