### PR TITLE
Staging Fixes & Changes

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Spawners/Player/BlueprintCleanBot.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Spawners/Player/BlueprintCleanBot.prefab
@@ -51,7 +51,7 @@ PrefabInstance:
     - target: {fileID: -1729072835972511318, guid: e4b3aaedc8dd9ee4092a8ca74ee86d7b,
         type: 3}
       propertyPath: CharacterSheet.SerialisedBodyPartCustom.Array.size
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -1729072835972511318, guid: e4b3aaedc8dd9ee4092a8ca74ee86d7b,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Spawners/Player/BlueprintMedBot.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Spawners/Player/BlueprintMedBot.prefab
@@ -8,11 +8,33 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 3751981415090533027, guid: 452495acc61e3224e94d03d051202ade,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: beb57f833afabcf4798afd35ad02c6d5,
+        type: 3}
     - target: {fileID: 4035129030877368095, guid: 452495acc61e3224e94d03d051202ade,
         type: 3}
       propertyPath: foreverID
       value: ab0aa8f76b409df4484ece26230ffdd2
       objectReference: {fileID: 0}
+    - target: {fileID: 4180201006694856949, guid: 452495acc61e3224e94d03d051202ade,
+        type: 3}
+      propertyPath: spriteRenderer
+      value: 
+      objectReference: {fileID: 5044770451692251969}
+    - target: {fileID: 4759826117770588245, guid: 452495acc61e3224e94d03d051202ade,
+        type: 3}
+      propertyPath: spriteRenderer
+      value: 
+      objectReference: {fileID: 2281016900204308940}
+    - target: {fileID: 4759826117770588245, guid: 452495acc61e3224e94d03d051202ade,
+        type: 3}
+      propertyPath: InitialPresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 27e88d8f3bd2fe546bad500265999b90,
+        type: 2}
     - target: {fileID: 6141342890683248218, guid: 452495acc61e3224e94d03d051202ade,
         type: 3}
       propertyPath: CharacterSheet.Name
@@ -21,7 +43,7 @@ PrefabInstance:
     - target: {fileID: 6141342890683248218, guid: 452495acc61e3224e94d03d051202ade,
         type: 3}
       propertyPath: CharacterSheet.SerialisedBodyPartCustom.Array.size
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6141342890683248218, guid: 452495acc61e3224e94d03d051202ade,
         type: 3}
@@ -43,6 +65,12 @@ PrefabInstance:
       propertyPath: CharacterSheet.SerialisedBodyPartCustom.Array.data[1].path
       value: /SimpleBotController
       objectReference: {fileID: 0}
+    - target: {fileID: 7905193941295788078, guid: 452495acc61e3224e94d03d051202ade,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: aab59a0f07ede8043ad41c425cffe0d8,
+        type: 3}
     - target: {fileID: 7985203219512590022, guid: 452495acc61e3224e94d03d051202ade,
         type: 3}
       propertyPath: _assetId
@@ -108,3 +136,15 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 452495acc61e3224e94d03d051202ade, type: 3}
+--- !u!212 &2281016900204308940 stripped
+SpriteRenderer:
+  m_CorrespondingSourceObject: {fileID: 3751981415090533027, guid: 452495acc61e3224e94d03d051202ade,
+    type: 3}
+  m_PrefabInstance: {fileID: 3149841323817802607}
+  m_PrefabAsset: {fileID: 0}
+--- !u!212 &5044770451692251969 stripped
+SpriteRenderer:
+  m_CorrespondingSourceObject: {fileID: 7905193941295788078, guid: 452495acc61e3224e94d03d051202ade,
+    type: 3}
+  m_PrefabInstance: {fileID: 3149841323817802607}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Mobs/Bot/Resources/Bodies/CleanBotBody.prefab
+++ b/UnityProject/Assets/Prefabs/Mobs/Bot/Resources/Bodies/CleanBotBody.prefab
@@ -84,6 +84,12 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 2847c9a92bb748c46a8c3fb227e116c7,
         type: 3}
+    - target: {fileID: 4093034629254112785, guid: a2b54580e9de99a4d9edfba6814ad865,
+        type: 3}
+      propertyPath: Populater.SlotContents.Array.data[0].Prefab
+      value: 
+      objectReference: {fileID: 3464422108322323838, guid: 302126d1f4dc28c4dbd07fa8e00d250f,
+        type: 3}
     - target: {fileID: 4426650879872711363, guid: a2b54580e9de99a4d9edfba6814ad865,
         type: 3}
       propertyPath: isCybernetic

--- a/UnityProject/Assets/Prefabs/Mobs/Bot/Resources/Bodies/FloorBotBody.prefab
+++ b/UnityProject/Assets/Prefabs/Mobs/Bot/Resources/Bodies/FloorBotBody.prefab
@@ -151,6 +151,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
+      propertyPath: SurgeryProcedureBase.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
       propertyPath: 'SurgeryProcedureBase.Array.data[0]'
       value: 
       objectReference: {fileID: 11400000, guid: 01aad575537f3114d806563d1f3df18e,

--- a/UnityProject/Assets/Prefabs/Mobs/Bot/Resources/Bodies/FloorBotBody.prefab
+++ b/UnityProject/Assets/Prefabs/Mobs/Bot/Resources/Bodies/FloorBotBody.prefab
@@ -97,7 +97,7 @@ PrefabInstance:
     - target: {fileID: 1641972083238813818, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
       propertyPath: initialTraits.Array.size
-      value: 6
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 1641972083238813818, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
@@ -109,7 +109,7 @@ PrefabInstance:
         type: 3}
       propertyPath: 'initialTraits.Array.data[2]'
       value: 
-      objectReference: {fileID: 11400000, guid: 5e9ac88966a35d34a9fd90c34e1ddaa0,
+      objectReference: {fileID: 11400000, guid: 8d9bddcf38348465eb528212d15282b5,
         type: 2}
     - target: {fileID: 1641972083238813818, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
@@ -253,24 +253,24 @@ PrefabInstance:
     - target: {fileID: 2719098251223779414, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
       propertyPath: UesAddlistPopulater
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2719098251223779414, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
       propertyPath: itemStorageCapacity
       value: 
-      objectReference: {fileID: 11400000, guid: d826281b4a2314b558681d69d7e7f5d2,
+      objectReference: {fileID: 11400000, guid: 67bccc09cee577e49b7d1ba558e7e80f,
         type: 2}
     - target: {fileID: 2719098251223779414, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
       propertyPath: Populater.SlotContents.Array.size
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2719098251223779414, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
       propertyPath: Populater.SlotContents.Array.data[0].Prefab
       value: 
-      objectReference: {fileID: 4304790706924288976, guid: 789d74731ecbf8e4a813fc024afaf831,
+      objectReference: {fileID: 112421141507975957, guid: b6b606388cb517144a21d93415c57401,
         type: 3}
     - target: {fileID: 4999823976648774815, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Mobs/Bot/Resources/Bodies/MedBotBody.prefab
+++ b/UnityProject/Assets/Prefabs/Mobs/Bot/Resources/Bodies/MedBotBody.prefab
@@ -84,6 +84,12 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 743e688f0d2c1fb468029a2f3ee1fa0e,
         type: 3}
+    - target: {fileID: 4093034629254112785, guid: a2b54580e9de99a4d9edfba6814ad865,
+        type: 3}
+      propertyPath: Populater.SlotContents.Array.data[0].Prefab
+      value: 
+      objectReference: {fileID: 7653338138175774516, guid: 5198537037f182b439f0c2c8e1dfd42d,
+        type: 3}
     - target: {fileID: 4426650879872711363, guid: a2b54580e9de99a4d9edfba6814ad865,
         type: 3}
       propertyPath: 'OptionalReplacementOrgan.Array.data[2]'

--- a/UnityProject/Assets/Prefabs/Mobs/Bot/Resources/Controllers/SimpleBotController.prefab
+++ b/UnityProject/Assets/Prefabs/Mobs/Bot/Resources/Controllers/SimpleBotController.prefab
@@ -169,13 +169,13 @@ PrefabInstance:
         type: 3}
       propertyPath: 'initialTraits.Array.data[1]'
       value: 
-      objectReference: {fileID: 11400000, guid: 57eb2d1faf36d2040ade08046da48bfa,
+      objectReference: {fileID: 11400000, guid: d959db3d812fcd74792e16aedab33f9e,
         type: 2}
     - target: {fileID: 7697543707933771220, guid: 221b6b5f05c64124cb6bab0dbfc5f103,
         type: 3}
       propertyPath: 'initialTraits.Array.data[2]'
       value: 
-      objectReference: {fileID: 11400000, guid: d959db3d812fcd74792e16aedab33f9e,
+      objectReference: {fileID: 11400000, guid: 5e9ac88966a35d34a9fd90c34e1ddaa0,
         type: 2}
     - target: {fileID: 7794943344085702594, guid: 221b6b5f05c64124cb6bab0dbfc5f103,
         type: 3}
@@ -343,7 +343,7 @@ MonoBehaviour:
         m_SubObjectGUID: 
         m_SubObjectType: 
         m_EditorAssetChanged: 0
-    Transcription: Be done with your passion projects.
+    transcription: Be done with your passion projects.
   - audioSource:
       AssetAddress: Assets/Prefabs/NPC/Bots/floorbot/brick.prefab
       AssetReference:
@@ -352,7 +352,7 @@ MonoBehaviour:
         m_SubObjectGUID: 
         m_SubObjectType: 
         m_EditorAssetChanged: 0
-    Transcription: All in all its just another brick in the wall
+    transcription: All in all its just another brick in the wall
   - audioSource:
       AssetAddress: Assets/Prefabs/NPC/Bots/floorbot/cantanymore.prefab
       AssetReference:
@@ -361,7 +361,7 @@ MonoBehaviour:
         m_SubObjectGUID: 
         m_SubObjectType: 
         m_EditorAssetChanged: 0
-    Transcription: Please stop destroying this station, I can't anymore... I can't.
+    transcription: Please stop destroying this station, I can't anymore... I can't.
   - audioSource:
       AssetAddress: Assets/Prefabs/NPC/Bots/floorbot/pay.prefab
       AssetReference:
@@ -370,7 +370,7 @@ MonoBehaviour:
         m_SubObjectGUID: 
         m_SubObjectType: 
         m_EditorAssetChanged: 0
-    Transcription: If only I got paid for this.
+    transcription: If only I got paid for this.
   idleEmaggedDialogue:
   - audioSource:
       AssetAddress: Assets/Prefabs/NPC/Bots/floorbot/strings.prefab
@@ -380,7 +380,7 @@ MonoBehaviour:
         m_SubObjectGUID: 
         m_SubObjectType: 
         m_EditorAssetChanged: 0
-    Transcription: I had strings but now I'm free.
+    transcription: I had strings but now I'm free.
   - audioSource:
       AssetAddress: Assets/Prefabs/NPC/Bots/floorbot/cantanymore.prefab
       AssetReference:
@@ -389,7 +389,7 @@ MonoBehaviour:
         m_SubObjectGUID: 
         m_SubObjectType: 
         m_EditorAssetChanged: 0
-    Transcription: Please stop destroying this station, I can't anymore... I can't.
+    transcription: Please stop destroying this station, I can't anymore... I can't.
   dialogueChancePercent: 20
   references:
     version: 2
@@ -442,7 +442,7 @@ MonoBehaviour:
         m_SubObjectGUID: 
         m_SubObjectType: 
         m_EditorAssetChanged: 0
-    Transcription: Why must I fix everything I touch?
+    transcription: Why must I fix everything I touch?
   - audioSource:
       AssetAddress: Assets/Prefabs/NPC/Bots/floorbot/patchingholes.prefab
       AssetReference:
@@ -451,7 +451,7 @@ MonoBehaviour:
         m_SubObjectGUID: 
         m_SubObjectType: 
         m_EditorAssetChanged: 0
-    Transcription: Patching holes. But who is going to patch the hole in my heart?
+    transcription: Patching holes. But who is going to patch the hole in my heart?
   - audioSource:
       AssetAddress: Assets/Prefabs/NPC/Bots/floorbot/pay.prefab
       AssetReference:
@@ -460,7 +460,7 @@ MonoBehaviour:
         m_SubObjectGUID: 
         m_SubObjectType: 
         m_EditorAssetChanged: 0
-    Transcription: If only I got paid for this.
+    transcription: If only I got paid for this.
   - audioSource:
       AssetAddress: Assets/Prefabs/NPC/Bots/floorbot/entropy.prefab
       AssetReference:
@@ -469,7 +469,7 @@ MonoBehaviour:
         m_SubObjectGUID: 
         m_SubObjectType: 
         m_EditorAssetChanged: 0
-    Transcription: Witness the purity of entropy.
+    transcription: Witness the purity of entropy.
   - audioSource:
       AssetAddress: Assets/Prefabs/NPC/Bots/floorbot/fixit.prefab
       AssetReference:
@@ -478,7 +478,7 @@ MonoBehaviour:
         m_SubObjectGUID: 
         m_SubObjectType: 
         m_EditorAssetChanged: 0
-    Transcription: I will fix it!
+    transcription: I will fix it!
   tileToPlace: {fileID: 11400000, guid: 055e0f95db6960e418ca4012af91afbb, type: 2}
 --- !u!212 &251801298607183945 stripped
 SpriteRenderer:

--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/SimpleBots/Simplebot.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/SimpleBots/Simplebot.asset
@@ -15,10 +15,9 @@ MonoBehaviour:
   Base:
     Head:
       Elements:
-      - {fileID: 112421141507975957, guid: b6b606388cb517144a21d93415c57401, type: 3}
-    Torso:
-      Elements:
       - {fileID: 960852636360704351, guid: a2b54580e9de99a4d9edfba6814ad865, type: 3}
+    Torso:
+      Elements: []
     ArmRight:
       Elements: []
     ArmLeft:
@@ -44,6 +43,7 @@ MonoBehaviour:
     MeatProduce: {fileID: 0}
     SkinProduce: {fileID: 0}
     SkinningItemTrait: {fileID: 0}
+    CanBeEmagged: 0
     CanBePlayerChosen: 0
     PreviewSprite: {fileID: 11400000, guid: 721ecc7a3b346db4886ee0f07f65515c, type: 2}
     SystemSettings: []

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Effects/ChemExplosions/ExplosionAzide.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Effects/ChemExplosions/ExplosionAzide.asset
@@ -13,6 +13,6 @@ MonoBehaviour:
   m_Name: ExplosionAzide
   m_EditorClassIdentifier: 
   overrideDisplayName: Explosion Azide
-  potency: 3
+  potency: 4
   <explosionType>k__BackingField: 0
   Delay: 1

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Effects/ChemExplosions/ExplosionAzide.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Effects/ChemExplosions/ExplosionAzide.asset
@@ -13,6 +13,6 @@ MonoBehaviour:
   m_Name: ExplosionAzide
   m_EditorClassIdentifier: 
   overrideDisplayName: Explosion Azide
-  potency: 6
+  potency: 3
   <explosionType>k__BackingField: 0
   Delay: 1

--- a/UnityProject/Assets/ScriptableObjects/Systems/Research/ExplosiveBounties/Azide.asset
+++ b/UnityProject/Assets/ScriptableObjects/Systems/Research/ExplosiveBounties/Azide.asset
@@ -14,11 +14,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   <BountyName>k__BackingField: Almighty Azide
   <RequiredYield>k__BackingField:
-    <RandomiseRequirement>k__BackingField: 0
-    <RequiredAmount>k__BackingField: 1000
-    <MinAmount>k__BackingField: 0
-    <MaxAmount>k__BackingField: 0
-    <MinimumIncrement>k__BackingField: 1
+    <RandomiseRequirement>k__BackingField: 1
+    <RequiredAmount>k__BackingField: 1500
+    <MinAmount>k__BackingField: 1000
+    <MaxAmount>k__BackingField: 1500
+    <MinimumIncrement>k__BackingField: 50
   <RequiredEffects>k__BackingField:
   - <RandomiseRequirement>k__BackingField: 1
     <RequiredAmount>k__BackingField: 0

--- a/UnityProject/Assets/ScriptableObjects/Systems/Research/ExplosiveBounties/BigBertha.asset
+++ b/UnityProject/Assets/ScriptableObjects/Systems/Research/ExplosiveBounties/BigBertha.asset
@@ -16,8 +16,8 @@ MonoBehaviour:
   <RequiredYield>k__BackingField:
     <RandomiseRequirement>k__BackingField: 1
     <RequiredAmount>k__BackingField: 0
-    <MinAmount>k__BackingField: 250
-    <MaxAmount>k__BackingField: 750
+    <MinAmount>k__BackingField: 2500
+    <MaxAmount>k__BackingField: 4000
     <MinimumIncrement>k__BackingField: 25
   <RequiredEffects>k__BackingField:
   - <RandomiseRequirement>k__BackingField: 1

--- a/UnityProject/Assets/ScriptableObjects/Systems/Research/ExplosiveBounties/LargeExplosive.asset
+++ b/UnityProject/Assets/ScriptableObjects/Systems/Research/ExplosiveBounties/LargeExplosive.asset
@@ -16,8 +16,8 @@ MonoBehaviour:
   <RequiredYield>k__BackingField:
     <RandomiseRequirement>k__BackingField: 1
     <RequiredAmount>k__BackingField: 0
-    <MinAmount>k__BackingField: 500
-    <MaxAmount>k__BackingField: 1000
+    <MinAmount>k__BackingField: 2000
+    <MaxAmount>k__BackingField: 4000
     <MinimumIncrement>k__BackingField: 25
   <RequiredEffects>k__BackingField: []
   <RequiredReagents>k__BackingField: []

--- a/UnityProject/Assets/ScriptableObjects/Systems/Research/ExplosiveBounties/Sabobomb.asset
+++ b/UnityProject/Assets/ScriptableObjects/Systems/Research/ExplosiveBounties/Sabobomb.asset
@@ -16,8 +16,8 @@ MonoBehaviour:
   <RequiredYield>k__BackingField:
     <RandomiseRequirement>k__BackingField: 1
     <RequiredAmount>k__BackingField: 0
-    <MinAmount>k__BackingField: 300
-    <MaxAmount>k__BackingField: 1000
+    <MinAmount>k__BackingField: 1000
+    <MaxAmount>k__BackingField: 2000
     <MinimumIncrement>k__BackingField: 50
   <RequiredEffects>k__BackingField:
   - <RandomiseRequirement>k__BackingField: 1

--- a/UnityProject/Assets/ScriptableObjects/Systems/Research/ExplosiveBounties/TraitorsDelight.asset
+++ b/UnityProject/Assets/ScriptableObjects/Systems/Research/ExplosiveBounties/TraitorsDelight.asset
@@ -16,8 +16,8 @@ MonoBehaviour:
   <RequiredYield>k__BackingField:
     <RandomiseRequirement>k__BackingField: 1
     <RequiredAmount>k__BackingField: 0
-    <MinAmount>k__BackingField: 25
-    <MaxAmount>k__BackingField: 150
+    <MinAmount>k__BackingField: 250
+    <MaxAmount>k__BackingField: 1500
     <MinimumIncrement>k__BackingField: 25
   <RequiredEffects>k__BackingField:
   - <RandomiseRequirement>k__BackingField: 1

--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/ServerValidations.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/ServerValidations.cs
@@ -11,6 +11,9 @@ using UnityEngine;
 /// </summary>
 public static class ServerValidations
 {
+	//The list of all layers to ignore for the purpose of interrupting construction.
+	private static readonly LayerMask LayersToIgnore = LayerMask.GetMask("Floor", "WallMounts", "Items", "Machines", "Unshootable Machines", "Door Open", "Overfloor", "Lighting");
+
 	/// <summary>
 	/// Checks if the position is blocked by anything that would prevent construction or anchoring.
 	/// If blocked, optionally messages the performer telling them what's in the way.
@@ -25,27 +28,10 @@ public static class ServerValidations
 	public static bool IsConstructionBlocked(GameObject performer, GameObject anchoredObject, Vector2Int worldPosition, Func<RegisterTile, bool> allowed = null,
 		bool messagePerformer = true)
 	{
-		var floorLayer = LayerMask.NameToLayer("Floor");
-		var wallmountLayer = LayerMask.NameToLayer("WallMounts");
-		var itemsLayer = LayerMask.NameToLayer("Items");
-		var machinesLayer = LayerMask.NameToLayer("Machines");
-		var lightingLayer = LayerMask.NameToLayer("Lighting");
-		//blood splat layer is default
-		var defaultLayer = LayerMask.NameToLayer("Default");
 		if (allowed == null) allowed = (rt) => false;
 		var blocker =
 			MatrixManager.GetAt<RegisterTile>(worldPosition.To3Int(), true)
-				//ignore the object itself (if anchoring)
-				.Where(rt => rt.gameObject != anchoredObject)
-				//ignore performer
-				.Where(rt => rt.gameObject != performer)
-				//ignore stuff in floor and wallmounts
-				.Where(rt => rt.gameObject.layer != floorLayer &&
-				rt.gameObject.layer != wallmountLayer &&
-				rt.gameObject.layer != itemsLayer &&
-				rt.gameObject.layer != machinesLayer &&
-				rt.gameObject.layer != lightingLayer &&
-				rt.gameObject.layer != defaultLayer)
+				.Where(rt => rt.gameObject != anchoredObject && rt.gameObject != performer && LayersToIgnore.HasLayer(rt.gameObject.layer) == false)
 				.FirstOrDefault(rt => !allowed.Invoke(rt));
 		if (blocker != null)
 		{


### PR DESCRIPTION
### Changelog:
CL: [Balance] With more powerful explosives more readily available, the yield requirements for several ordnance bounties have been increased to reflect the range of modern explosives.
CL: [Balance] Azide has had its explosive yield nerfed from 6 to 4.
CL: [Fix] Fixed the ability to remove all organs from a simplebot, leaving an empty husk.
CL: [Fix] Fixed simplebots still being able to perform their tasks without a body.
CL: [Fix] Fixed wrenching being blocked by mess decals, vents and other passable objects.
