### PR TITLE
Objects on fire dont cool the enviroment

### DIFF
--- a/UnityProject/Assets/Scripts/Health/Objects/Flammable.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Flammable.cs
@@ -115,7 +115,7 @@ namespace Health.Objects
 				SyncOnFire(fireStacks, 0);
 				return;
 			}
-			node?.GasMixLocal.AddGas(Gas.Smoke, BURNING_DAMAGE_PER_STACK * 75, Kelvin.FromC(100f));
+			node?.GasMixLocal.AddGasWithTemperature(Gas.Smoke, BURNING_DAMAGE_PER_STACK * 75, Kelvin.FromC(100f));
 
 			if (integrity.Resistances.Flammable || skipFlammableCheck)
 			{

--- a/UnityProject/Assets/Scripts/Systems/Inventory/ItemSlot.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/ItemSlot.cs
@@ -95,11 +95,11 @@ public class ItemSlot
 	public NamedSlot? NamedSlot => slotIdentifier.NamedSlot;
 
 	/// <summary>
-	/// True iff the slot has no item.
+	/// True if the slot has no item.
 	/// </summary>
 	public bool IsEmpty => Item == null;
 	/// <summary>
-	/// True iff the slot has an item
+	/// True if the slot has an item
 	/// </summary>
 	public bool IsOccupied => !IsEmpty;
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
@@ -110,7 +110,7 @@ namespace Systems.Atmospherics
 			}
 		}
 
-		public float InternalEnergy //This is forgetting the amount of energy inside of the Gas
+		public float InternalEnergy //This is for getting the amount of energy inside of the Gas
 		{
 			get => (WholeHeatCapacity * Temperature);
 


### PR DESCRIPTION
TLDR: 
flammable objects would cool the tile when adding smoke 
as it used addgas with the added energy being far lower then the added heatcapacity from the extra moles
so replace addgas with addgaswithtemperature

also some bonus small spelling fixes

<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->


### Changelog:
CL: [Improvement] Flammable objects should no longer cool the air around them when they are on fire
<!-- Add here individual lines with all your remarkable changes using the prefix ``CL:`` -->
<!-- Mind that the changes meant to be logged in the in changelog are those that are remarkable for the end user, so things like new features and fixes of known bugs are perfect for this section -->

<!-- CL: [New] For new features, things that didn't exist before the PR. -->

<!-- CL: [Improvement] For any change on any existing feature. -->

<!-- CL: [Balance] For any change on an existing feature done in the sake of improving game balance. It's the only exception to the rule above. -->

<!-- CL: [Fix] For any change that fixes a bug. -->
