### PR TITLE
Fixes rubberbanding on lighting and improves performance slightly

### DIFF
--- a/UnityProject/Assets/Prefabs/SceneConstruction/Camera.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/Camera.prefab
@@ -459,19 +459,19 @@ MonoBehaviour:
       serializedVersion: 2
       m_Bits: 16
     fovBlurIterations: 1
-    fovBlurInterpolation: 8
-    fovOcclusionSpread: 0
+    fovBlurInterpolation: 6
+    fovOcclusionSpread: 0.1
     fovHorizonSmooth: 23
     lightBlurIterations: 1
     lightBlurInterpolation: 0.56
     occlusionBlurIterations: 3
-    occlusionBlurInterpolation: 3.75
+    occlusionBlurInterpolation: 2.5
     occlusionMaskMultiplier: 1
-    occlusionMaskLimit: 0.7
+    occlusionMaskLimit: 3.16
     occlusionMaskSizeAdd: {x: 6, y: 9}
     rotationBlurInterpolation: 0.2
     rotationBlurIterations: 1
-    occlusionDetail: 32
+    occlusionDetail: 24
     lightResample: 1
     doubleFrameRenderingMode: 0
     disableAsyncGPUReadback: 0


### PR DESCRIPTION
Much like V1 Mobs, do NOT change anything regarding this game's lighting again while the current lighting system is still in place. I don't care if you have some colorful thoughts on how we could make the lighting more "pretty", do NOT touch this stupid system at all unless you're trying to fix a major game breaking bug.

Have an issue with our lighting system? Download an ebook on shaders and 2D lighting, grease your arms and elbows, and tear this system apart and make a new one that's more sensible and optimized than this garbage. If I could lock files from being modified in this repository, I would have done this ages ago, so you people would stop breaking obsolete shit that I don't want to even acknowledge it still exists in this project.

### Changelog:

CL: [Fix] Fixed several issues that affected performance with our lighting system.
CL: [Fix] Fixed the rubber banding effect that was plaguing occlusion culling.