### PR TITLE
fix ruin

### DIFF
--- a/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidMediumCircle.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidMediumCircle.json
@@ -1,10 +1,10 @@
 {
   "Ver": "1.0.0",
-  "MapName": "AsteroidCircle",
+  "MapName": "AsteroidMediumCircle",
   "ContainedMatrices": [
     {
       "Ver": "1.1.1",
-      "Location": "-485┼392┼0┼",
+      "Location": "-550┼392┼0┼",
       "MatrixName": "AsteroidMediumCircle",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",
@@ -5019,7 +5019,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {

--- a/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidMediumHardCracked.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidMediumHardCracked.json
@@ -1,10 +1,10 @@
 {
   "Ver": "1.0.0",
-  "MapName": "AsteroidHardCracked",
+  "MapName": "AsteroidMediumHardCracked",
   "ContainedMatrices": [
     {
       "Ver": "1.1.1",
-      "Location": "-485┼392┼0┼",
+      "Location": "-555┼445┼0┼",
       "MatrixName": "AsteroidMediumHardCracked",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",
@@ -7613,7 +7613,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {

--- a/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidMediumOldRuin.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidMediumOldRuin.json
@@ -4,7 +4,7 @@
   "ContainedMatrices": [
     {
       "Ver": "1.1.1",
-      "Location": "-324┼18┼0┼",
+      "Location": "-691┼463┼0┼",
       "MatrixName": "AsteroidMediumOldRuin",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",

--- a/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidMediumSkirt.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidMediumSkirt.json
@@ -4,7 +4,7 @@
   "ContainedMatrices": [
     {
       "Ver": "1.1.1",
-      "Location": "-485┼392┼0┼",
+      "Location": "-563┼543┼0┼",
       "MatrixName": "AsteroidMediumSkirt",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",

--- a/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidMediumXenoInfestation.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidMediumXenoInfestation.json
@@ -4,7 +4,7 @@
   "ContainedMatrices": [
     {
       "Ver": "1.1.1",
-      "Location": "-316┼-123┼0┼",
+      "Location": "-690┼393┼0┼",
       "MatrixName": "AsteroidMediumXenoInfestation",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",

--- a/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidMediumXenoVillage.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidMediumXenoVillage.json
@@ -4,7 +4,7 @@
   "ContainedMatrices": [
     {
       "Ver": "1.1.1",
-      "Location": "-418┼-218┼0┼",
+      "Location": "-689┼334┼0┼",
       "MatrixName": "AsteroidMediumXenoVillage",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",

--- a/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidScattered.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidScattered.json
@@ -4,7 +4,7 @@
   "ContainedMatrices": [
     {
       "Ver": "1.1.1",
-      "Location": "-485┼392┼0┼",
+      "Location": "-577┼588┼0┼",
       "MatrixName": "AsteroidScattered",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",

--- a/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidSmallHollow.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidSmallHollow.json
@@ -1,10 +1,10 @@
 {
   "Ver": "1.0.0",
-  "MapName": "AsteroidHollow",
+  "MapName": "AsteroidSmallHollow",
   "ContainedMatrices": [
     {
       "Ver": "1.1.1",
-      "Location": "-485┼392┼0┼",
+      "Location": "-629┼597┼0┼",
       "MatrixName": "AsteroidSmallHollow",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",
@@ -2680,7 +2680,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {

--- a/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidSmallTpose.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidSmallTpose.json
@@ -1,10 +1,10 @@
 {
   "Ver": "1.0.0",
-  "MapName": "AsteroidTpose",
+  "MapName": "AsteroidSmallTpose",
   "ContainedMatrices": [
     {
       "Ver": "1.1.1",
-      "Location": "-485┼392┼0┼",
+      "Location": "-631┼528┼0┼",
       "MatrixName": "AsteroidSmallTpose",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",
@@ -3024,7 +3024,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {

--- a/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidSmallX.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidSmallX.json
@@ -1,10 +1,10 @@
 {
   "Ver": "1.0.0",
-  "MapName": "AsteroidX",
+  "MapName": "AsteroidSmallX",
   "ContainedMatrices": [
     {
       "Ver": "1.1.1",
-      "Location": "-420┼372┼0┼",
+      "Location": "-629┼455┼0┼",
       "MatrixName": "AsteroidSmallX",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",
@@ -3921,7 +3921,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {

--- a/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidTiny.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidTiny.json
@@ -1,10 +1,10 @@
 {
   "Ver": "1.0.0",
-  "MapName": "Asteroid6",
+  "MapName": "AsteroidTiny",
   "ContainedMatrices": [
     {
       "Ver": "1.1.1",
-      "Location": "-485┼392┼0┼",
+      "Location": "-625┼401┼0┼",
       "MatrixName": "AsteroidTiny",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",
@@ -2042,7 +2042,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {

--- a/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidTiny2.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidTiny2.json
@@ -1,10 +1,10 @@
 {
   "Ver": "1.0.0",
-  "MapName": "Asteroid9",
+  "MapName": "AsteroidTiny2",
   "ContainedMatrices": [
     {
       "Ver": "1.1.1",
-      "Location": "-485┼392┼0┼",
+      "Location": "-696┼598┼0┼",
       "MatrixName": "AsteroidTiny2",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",
@@ -2437,7 +2437,7 @@
         ]
       },
       "CompactObjectMapData": {
-        "Ver": "1.4.2",
+        "Ver": "1.5.0",
         "CommonPrefabs": [],
         "PrefabData": [
           {

--- a/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidTinyVeryHard.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/Asteroids/AsteroidTinyVeryHard.json
@@ -4,7 +4,7 @@
   "ContainedMatrices": [
     {
       "Ver": "1.1.1",
-      "Location": "-485┼392┼0┼",
+      "Location": "-693┼540┼0┼",
       "MatrixName": "AsteroidTinyVeryHard",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",

--- a/UnityProject/Assets/StreamingAssets/Maps/Ruin/RuinAutonomousPlatform.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/Ruin/RuinAutonomousPlatform.json
@@ -4,7 +4,7 @@
   "ContainedMatrices": [
     {
       "Ver": "1.1.1",
-      "Location": "-420┼372┼0┼",
+      "Location": "-420┼337┼0┼",
       "MatrixName": "RuinAutonomousPlatform",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",
@@ -3958,12 +3958,6 @@
                 }
               ]
             }
-          },
-          {
-            "GitID": "83b269ab1421fcf4a95ad3cf33935cff_-2┼-8┼0┼",
-            "PrefabID": "83b269ab1421fcf4a95ad3cf33935cff",
-            "Name": "OreGenerator (1)",
-            "LocalPRS": "-2┼-8┼0┼"
           },
           {
             "GitID": "f10c70de452d8b84ba9d9fd4c169f205_7┼4┼0┼",

--- a/UnityProject/Assets/StreamingAssets/Maps/Ruin/RuinBar.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/Ruin/RuinBar.json
@@ -2341,25 +2341,18 @@
             "LocalPRS": "-0.5┼-0.5┼0┼"
           },
           {
-            "GitID": "911f81eefba53574788e7659d9b3dbfe_-0.5┼-0.5┼0┼",
-            "PrefabID": "911f81eefba53574788e7659d9b3dbfe",
-            "NameMatches": true,
-            "Name": "AsteroidSystem",
-            "LocalPRS": "-0.5┼-0.5┼0┼"
-          },
-          {
-            "GitID": "e02a5954be8d94b4bbaaa0d63d813c71_-0.5┼-0.5┼0┼",
+            "GitID": "e02a5954be8d94b4bbaaa0d63d813c71_0.5┼-0.5┼0┼",
             "PrefabID": "e02a5954be8d94b4bbaaa0d63d813c71",
             "NameMatches": true,
             "Name": "AI_ShouldNavigateAround",
-            "LocalPRS": "-0.5┼-0.5┼0┼"
+            "LocalPRS": "0.5┼-0.5┼0┼"
           },
           {
-            "GitID": "83b269ab1421fcf4a95ad3cf33935cff_0┼0┼0┼",
-            "PrefabID": "83b269ab1421fcf4a95ad3cf33935cff",
+            "GitID": "911f81eefba53574788e7659d9b3dbfe_1.5┼-0.5┼0┼",
+            "PrefabID": "911f81eefba53574788e7659d9b3dbfe",
             "NameMatches": true,
-            "Name": "OreGenerator",
-            "LocalPRS": "0┼0┼0┼"
+            "Name": "AsteroidSystem",
+            "LocalPRS": "1.5┼-0.5┼0┼"
           },
           {
             "GitID": "74f1764f9ae8c6146a627626bfa4c6c0_3┼17┼0┼",

--- a/UnityProject/Assets/StreamingAssets/Maps/Ruin/RuinBiodomeDamaged.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/Ruin/RuinBiodomeDamaged.json
@@ -4,7 +4,7 @@
   "ContainedMatrices": [
     {
       "Ver": "1.1.1",
-      "Location": "-398┼373┼0┼",
+      "Location": "-398┼334┼0┼",
       "MatrixName": "RuinBiodomeDamaged",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",
@@ -3794,12 +3794,6 @@
             "PrefabID": "86f1fa4a01e7f0142a6e2ce35cce0930",
             "Name": "MatrixGasSettings (1)",
             "LocalPRS": "27┼1┼0┼"
-          },
-          {
-            "GitID": "83b269ab1421fcf4a95ad3cf33935cff_28┼1┼0┼",
-            "PrefabID": "83b269ab1421fcf4a95ad3cf33935cff",
-            "Name": "OreGenerator (1)",
-            "LocalPRS": "28┼1┼0┼"
           },
           {
             "GitID": "d56b65cebb41c78479fed5218fb0344c_28┼12┼0┼",

--- a/UnityProject/Assets/StreamingAssets/Maps/Ruin/RuinBluespaceJumper.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/Ruin/RuinBluespaceJumper.json
@@ -1,11 +1,11 @@
 {
   "Ver": "1.0.0",
-  "MapName": "RuinWhiteShip1",
+  "MapName": "WhiteshipBluespaceJumper",
   "ContainedMatrices": [
     {
       "Ver": "1.1.1",
       "Location": "-485┼392┼0┼",
-      "MatrixName": "RuinWhiteShip1",
+      "MatrixName": "WhiteshipBluespaceJumper",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",
         "XYs": [
@@ -2199,25 +2199,18 @@
             "LocalPRS": "-0.5┼-0.5┼0┼"
           },
           {
-            "GitID": "911f81eefba53574788e7659d9b3dbfe_-0.5┼-0.5┼0┼",
-            "PrefabID": "911f81eefba53574788e7659d9b3dbfe",
-            "NameMatches": true,
-            "Name": "AsteroidSystem",
-            "LocalPRS": "-0.5┼-0.5┼0┼"
-          },
-          {
-            "GitID": "e02a5954be8d94b4bbaaa0d63d813c71_-0.5┼-0.5┼0┼",
+            "GitID": "e02a5954be8d94b4bbaaa0d63d813c71_0.5┼-0.5┼0┼",
             "PrefabID": "e02a5954be8d94b4bbaaa0d63d813c71",
             "NameMatches": true,
             "Name": "AI_ShouldNavigateAround",
-            "LocalPRS": "-0.5┼-0.5┼0┼"
+            "LocalPRS": "0.5┼-0.5┼0┼"
           },
           {
-            "GitID": "83b269ab1421fcf4a95ad3cf33935cff_0┼0┼0┼",
-            "PrefabID": "83b269ab1421fcf4a95ad3cf33935cff",
+            "GitID": "911f81eefba53574788e7659d9b3dbfe_1.5┼-0.5┼0┼",
+            "PrefabID": "911f81eefba53574788e7659d9b3dbfe",
             "NameMatches": true,
-            "Name": "OreGenerator",
-            "LocalPRS": "0┼0┼0┼"
+            "Name": "AsteroidSystem",
+            "LocalPRS": "1.5┼-0.5┼0┼"
           },
           {
             "GitID": "1002c0247e412884e91c857ce6e51d9c_7.89┼9.82┼0┼",

--- a/UnityProject/Assets/StreamingAssets/Maps/Ruin/RuinMysteriousOutpost.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/Ruin/RuinMysteriousOutpost.json
@@ -4,7 +4,7 @@
   "ContainedMatrices": [
     {
       "Ver": "1.1.1",
-      "Location": "0┼0┼0┼",
+      "Location": "-439┼276┼0┼",
       "MatrixName": "MysteriousOutpost",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",
@@ -8973,24 +8973,38 @@
             }
           },
           {
-            "GitID": "83b269ab1421fcf4a95ad3cf33935cff_3┼0┼0┼",
-            "PrefabID": "83b269ab1421fcf4a95ad3cf33935cff",
-            "Name": "OreGenerator (1)",
-            "LocalPRS": "3┼0┼0┼"
-          },
-          {
-            "GitID": "e654148c91063ed499de6438ee9dd63e_4┼7┼0┼",
-            "PrefabID": "e654148c91063ed499de6438ee9dd63e",
-            "Name": "CommServer (2)",
+            "GitID": "a7af28adb717b4c44b8b2002b27670bd_4┼7┼0┼",
+            "PrefabID": "a7af28adb717b4c44b8b2002b27670bd",
+            "Name": "StructureBase (2)",
             "LocalPRS": "4┼7┼0┼",
             "Object": {
               "ClassDatas": [
                 {
-                  "ClassID": "APCPoweredDevice@0",
+                  "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_9┼2┼0┼@0@APC@0"
+                      "Name": "initialName",
+                      "Data": "telecommunication server"
+                    },
+                    {
+                      "Name": "initialDescription",
+                      "Data": "A machine used to store data and network statistics."
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "InitialPresentSpriteSet",
+                          "Data": "6742ea5946896b148a992d3e8629a973"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -8998,18 +9012,38 @@
             }
           },
           {
-            "GitID": "3cb701e51433c4046bba232ed4f350d1_4┼8┼0┼",
-            "PrefabID": "3cb701e51433c4046bba232ed4f350d1",
-            "Name": "Hub (1)",
+            "GitID": "a7af28adb717b4c44b8b2002b27670bd_4┼8┼0┼",
+            "PrefabID": "a7af28adb717b4c44b8b2002b27670bd",
+            "Name": "StructureBase (4)",
             "LocalPRS": "4┼8┼0┼",
             "Object": {
               "ClassDatas": [
                 {
-                  "ClassID": "APCPoweredDevice@0",
+                  "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_9┼2┼0┼@0@APC@0"
+                      "Name": "initialName",
+                      "Data": "telecommunication hub"
+                    },
+                    {
+                      "Name": "initialDescription",
+                      "Data": "A mighty piece of hardware used to send/receive massive amounts of data."
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "InitialPresentSpriteSet",
+                          "Data": "3644c184b9936e249bbe585339c0e784"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -9061,18 +9095,38 @@
             }
           },
           {
-            "GitID": "e654148c91063ed499de6438ee9dd63e_4┼9┼0┼",
-            "PrefabID": "e654148c91063ed499de6438ee9dd63e",
-            "Name": "CommServer (1)",
+            "GitID": "a7af28adb717b4c44b8b2002b27670bd_4┼9┼0┼",
+            "PrefabID": "a7af28adb717b4c44b8b2002b27670bd",
+            "Name": "StructureBase (11)",
             "LocalPRS": "4┼9┼0┼",
             "Object": {
               "ClassDatas": [
                 {
-                  "ClassID": "APCPoweredDevice@0",
+                  "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_9┼2┼0┼@0@APC@0"
+                      "Name": "initialName",
+                      "Data": "telecommunication server"
+                    },
+                    {
+                      "Name": "initialDescription",
+                      "Data": "A machine used to store data and network statistics."
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "InitialPresentSpriteSet",
+                          "Data": "6742ea5946896b148a992d3e8629a973"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -9408,44 +9462,32 @@
                   "ClassID": "APC@0",
                   "Data": [
                     {
-                      "Name": "connectedDevices#13",
+                      "Name": "connectedDevices#10",
                       "Data": "1172c577b92e17940afd7e1729f184f6_15┼9┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#12",
+                      "Name": "connectedDevices#9",
                       "Data": "c21551dd992a57349973e4b5af103ca6_9┼15┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#11",
+                      "Name": "connectedDevices#8",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_14┼8┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#10",
+                      "Name": "connectedDevices#7",
                       "Data": "cbe919cf00f84254f83d474582798520_9┼7┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#9",
+                      "Name": "connectedDevices#6",
                       "Data": "c21551dd992a57349973e4b5af103ca6_9┼1┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#8",
+                      "Name": "connectedDevices#5",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_4┼8┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#7",
-                      "Data": "c21551dd992a57349973e4b5af103ca6_2┼8┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#6",
-                      "Data": "e654148c91063ed499de6438ee9dd63e_4┼9┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#5",
-                      "Data": "3cb701e51433c4046bba232ed4f350d1_4┼8┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
                       "Name": "connectedDevices#4",
-                      "Data": "e654148c91063ed499de6438ee9dd63e_4┼7┼0┼@0@APCPoweredDevice@0"
+                      "Data": "c21551dd992a57349973e4b5af103ca6_2┼8┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#3",
@@ -10190,152 +10232,140 @@
                   "ClassID": "APC@0",
                   "Data": [
                     {
-                      "Name": "connectedDevices#60",
+                      "Name": "connectedDevices#57",
                       "Data": "be26d178314bedc419e95cd4466da4e5_19┼7┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#59",
+                      "Name": "connectedDevices#56",
                       "Data": "be26d178314bedc419e95cd4466da4e5_20┼6┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#58",
+                      "Name": "connectedDevices#55",
                       "Data": "24eaaeb286e2fbe48a16783af29e3c02_22┼14┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#57",
+                      "Name": "connectedDevices#54",
                       "Data": "24eaaeb286e2fbe48a16783af29e3c02_24┼14┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#56",
+                      "Name": "connectedDevices#53",
                       "Data": "f2432d244a6b7774ea00ff013beb7dcb_29┼8┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#55",
+                      "Name": "connectedDevices#52",
                       "Data": "f2432d244a6b7774ea00ff013beb7dcb_33┼28┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#54",
+                      "Name": "connectedDevices#51",
                       "Data": "f2432d244a6b7774ea00ff013beb7dcb_30┼10┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#53",
+                      "Name": "connectedDevices#50",
                       "Data": "f2432d244a6b7774ea00ff013beb7dcb_31┼13┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#52",
+                      "Name": "connectedDevices#49",
                       "Data": "f2432d244a6b7774ea00ff013beb7dcb_20┼16┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#51",
+                      "Name": "connectedDevices#48",
                       "Data": "f2432d244a6b7774ea00ff013beb7dcb_29┼12┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#50",
+                      "Name": "connectedDevices#47",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_30┼14┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#49",
+                      "Name": "connectedDevices#46",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_37┼14┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#48",
+                      "Name": "connectedDevices#45",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_40┼17┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#47",
+                      "Name": "connectedDevices#44",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_40┼22┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#46",
+                      "Name": "connectedDevices#43",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_24┼17┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#45",
+                      "Name": "connectedDevices#42",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_24┼22┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#44",
+                      "Name": "connectedDevices#41",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_30┼27┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#43",
+                      "Name": "connectedDevices#40",
                       "Data": "fde32c02abddc814f9366ff1fb21f234_34┼27┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#42",
+                      "Name": "connectedDevices#39",
                       "Data": "c937e0abe85aca9499d09951de736ec6_18┼12┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#41",
+                      "Name": "connectedDevices#38",
                       "Data": "c937e0abe85aca9499d09951de736ec6_22┼15┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#40",
+                      "Name": "connectedDevices#37",
                       "Data": "c937e0abe85aca9499d09951de736ec6_28┼10┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#39",
+                      "Name": "connectedDevices#36",
                       "Data": "c937e0abe85aca9499d09951de736ec6_21┼5┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#38",
+                      "Name": "connectedDevices#35",
                       "Data": "c937e0abe85aca9499d09951de736ec6_33┼11┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#37",
+                      "Name": "connectedDevices#34",
                       "Data": "c937e0abe85aca9499d09951de736ec6_32┼9┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#36",
+                      "Name": "connectedDevices#33",
                       "Data": "c937e0abe85aca9499d09951de736ec6_20┼19┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#35",
+                      "Name": "connectedDevices#32",
                       "Data": "c937e0abe85aca9499d09951de736ec6_43┼20┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#34",
+                      "Name": "connectedDevices#31",
                       "Data": "c937e0abe85aca9499d09951de736ec6_37┼28┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#33",
+                      "Name": "connectedDevices#30",
                       "Data": "c937e0abe85aca9499d09951de736ec6_32┼30┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#32",
+                      "Name": "connectedDevices#29",
                       "Data": "a50474d976314462a79602e20a762520_23┼16┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#31",
-                      "Data": "e654148c91063ed499de6438ee9dd63e_22┼9┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#30",
-                      "Data": "b86f34553f52566458169ac066409af7_24┼11┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#29",
+                      "Name": "connectedDevices#28",
                       "Data": "78a19fdb4261d9143b2808ede0c330ed_23┼5┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#28",
+                      "Name": "connectedDevices#27",
                       "Data": "ea7280b49083dfa469fb176f6a7e4772_42┼21┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#27",
+                      "Name": "connectedDevices#26",
                       "Data": "ea7280b49083dfa469fb176f6a7e4772_44┼21┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#26",
+                      "Name": "connectedDevices#25",
                       "Data": "ea7280b49083dfa469fb176f6a7e4772_36┼11.88┼0┼@0@APCPoweredDevice@0"
                     },
                     {
-                      "Name": "connectedDevices#25",
-                      "Data": "fe295f9b660522a41978f6b83f7cb800_29┼9┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
                       "Name": "connectedDevices#24",
-                      "Data": "d80287f2984bd444d96284d43dd860b5_24┼9┼0┼@0@APCPoweredDevice@0"
+                      "Data": "fe295f9b660522a41978f6b83f7cb800_29┼9┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#23",
@@ -10954,18 +10984,38 @@
             }
           },
           {
-            "GitID": "e654148c91063ed499de6438ee9dd63e_22┼9┼0┼",
-            "PrefabID": "e654148c91063ed499de6438ee9dd63e",
-            "Name": "CommServer (1)",
+            "GitID": "a7af28adb717b4c44b8b2002b27670bd_22┼9┼0┼",
+            "PrefabID": "a7af28adb717b4c44b8b2002b27670bd",
+            "Name": "StructureBase (12)",
             "LocalPRS": "22┼9┼0┼",
             "Object": {
               "ClassDatas": [
                 {
-                  "ClassID": "APCPoweredDevice@0",
+                  "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_17┼11┼0┼@0@APC@0"
+                      "Name": "initialName",
+                      "Data": "telecommunication server"
+                    },
+                    {
+                      "Name": "initialDescription",
+                      "Data": "A machine used to store data and network statistics."
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "InitialPresentSpriteSet",
+                          "Data": "6742ea5946896b148a992d3e8629a973"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -11534,18 +11584,38 @@
             }
           },
           {
-            "GitID": "d80287f2984bd444d96284d43dd860b5_24┼9┼0┼",
-            "PrefabID": "d80287f2984bd444d96284d43dd860b5",
-            "Name": "Processor (1)",
+            "GitID": "a7af28adb717b4c44b8b2002b27670bd_24┼9┼0┼",
+            "PrefabID": "a7af28adb717b4c44b8b2002b27670bd",
+            "Name": "StructureBase (6)",
             "LocalPRS": "24┼9┼0┼",
             "Object": {
               "ClassDatas": [
                 {
-                  "ClassID": "APCPoweredDevice@0",
+                  "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_17┼11┼0┼@0@APC@0"
+                      "Name": "initialName",
+                      "Data": "processor unit"
+                    },
+                    {
+                      "Name": "initialDescription",
+                      "Data": "This machine is used to process large quantities of information."
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "InitialPresentSpriteSet",
+                          "Data": "ebf3b03218a3171489782a07f393f178"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -11588,18 +11658,38 @@
             }
           },
           {
-            "GitID": "b86f34553f52566458169ac066409af7_24┼11┼0┼",
-            "PrefabID": "b86f34553f52566458169ac066409af7",
-            "Name": "Relay (1)",
+            "GitID": "a7af28adb717b4c44b8b2002b27670bd_24┼11┼0┼",
+            "PrefabID": "a7af28adb717b4c44b8b2002b27670bd",
+            "Name": "StructureBase (7)",
             "LocalPRS": "24┼11┼0┼",
             "Object": {
               "ClassDatas": [
                 {
-                  "ClassID": "APCPoweredDevice@0",
+                  "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_17┼11┼0┼@0@APC@0"
+                      "Name": "initialName",
+                      "Data": "telecommunication relay"
+                    },
+                    {
+                      "Name": "initialDescription",
+                      "Data": "A mighty piece of hardware used to send massive amounts of data far away."
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "InitialPresentSpriteSet",
+                          "Data": "74c0502e16ec74546a0d77ec4381c95c"
+                        }
+                      ]
                     }
                   ]
                 }

--- a/UnityProject/Assets/StreamingAssets/Maps/Ruin/RuinStationWing.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/Ruin/RuinStationWing.json
@@ -4,7 +4,7 @@
   "ContainedMatrices": [
     {
       "Ver": "1.1.1",
-      "Location": "-393┼380┼0┼",
+      "Location": "-380┼375┼0┼",
       "MatrixName": "RuinStationWing",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",
@@ -7020,12 +7020,6 @@
             "PrefabID": "911f81eefba53574788e7659d9b3dbfe",
             "Name": "AsteroidSystem (1)",
             "LocalPRS": "2┼6┼0┼"
-          },
-          {
-            "GitID": "83b269ab1421fcf4a95ad3cf33935cff_3┼6┼0┼",
-            "PrefabID": "83b269ab1421fcf4a95ad3cf33935cff",
-            "Name": "OreGenerator (1)",
-            "LocalPRS": "3┼6┼0┼"
           },
           {
             "GitID": "d19f068f30aed4d468cdba7a0e5824a0_10┼21┼0┼",

--- a/UnityProject/Assets/StreamingAssets/Maps/Ruin/RuinWhiteshipMantaray.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/Ruin/RuinWhiteshipMantaray.json
@@ -4,7 +4,7 @@
   "ContainedMatrices": [
     {
       "Ver": "1.1.1",
-      "Location": "0┼0┼0┼",
+      "Location": "-369┼277┼0┼",
       "MatrixName": "WhiteshipMantaray",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",
@@ -6190,12 +6190,6 @@
             "PrefabID": "fd466498ead2721489a1f6f5e35691c2",
             "Name": "RetroLaserBlaster (1)",
             "LocalPRS": "10┼18┼0┼"
-          },
-          {
-            "GitID": "83b269ab1421fcf4a95ad3cf33935cff_11┼6┼0┼",
-            "PrefabID": "83b269ab1421fcf4a95ad3cf33935cff",
-            "Name": "OreGenerator (1)",
-            "LocalPRS": "11┼6┼0┼"
           },
           {
             "GitID": "79cea07a5f8e66f49a554df1a003ecba_11┼10┼0┼",

--- a/UnityProject/Assets/StreamingAssets/Maps/Ruin/RuinWhiteshipRapture.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/Ruin/RuinWhiteshipRapture.json
@@ -4,7 +4,7 @@
   "ContainedMatrices": [
     {
       "Ver": "1.1.1",
-      "Location": "0┼0┼0┼",
+      "Location": "-484┼279┼0┼",
       "MatrixName": "WhiteshipRapture",
       "GitFriendlyTileMapData": {
         "Ver": "1.0.0",
@@ -4809,12 +4809,6 @@
             "PrefabID": "86f1fa4a01e7f0142a6e2ce35cce0930",
             "Name": "MatrixGasSettings (1)",
             "LocalPRS": "3┼0┼0┼"
-          },
-          {
-            "GitID": "83b269ab1421fcf4a95ad3cf33935cff_4┼0┼0┼",
-            "PrefabID": "83b269ab1421fcf4a95ad3cf33935cff",
-            "Name": "OreGenerator (1)",
-            "LocalPRS": "4┼0┼0┼"
           },
           {
             "GitID": "7dea0790d26246447a9b881689c7dbdf_5┼17┼0┼",


### PR DESCRIPTION
<!-- PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes. -->

### Purpose
replace telecomms devices in a ruin with fake ones
remove unnecessary oregens from derelicts (on the reasonable assumption that they actually are unnecessary and won't break anything for some dumb reason)
reposition all derelicts/asteroids away from 0,0 and so none overlap with each other
![image](https://github.com/user-attachments/assets/9dee4443-a2f1-4fe7-a52e-390eb0a3921f)

### Notes:
n/a

### Media Preview:
n/a

### Changelog:
CL: [Fix] Fix duplicated radio messages
