### PR TITLE
various minor updates

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Other/Magical/ChillPotion.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/Magical/ChillPotion.prefab
@@ -14,6 +14,12 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 3a7264d9466afcd4cbdbb9057a6c53ce,
         type: 2}
+    - target: {fileID: 1162272864508818684, guid: 1e86836ca86312b47b6c5416bd8426f1,
+        type: 3}
+      propertyPath: InitialPresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 3a7264d9466afcd4cbdbb9057a6c53ce,
+        type: 2}
     - target: {fileID: 2152051915416306454, guid: 1e86836ca86312b47b6c5416bd8426f1,
         type: 3}
       propertyPath: parentID
@@ -32,7 +38,7 @@ PrefabInstance:
     - target: {fileID: 4866909607520428057, guid: 1e86836ca86312b47b6c5416bd8426f1,
         type: 3}
       propertyPath: initialName
-      value: Chill Potion
+      value: chill potion
       objectReference: {fileID: 0}
     - target: {fileID: 4866909607520428057, guid: 1e86836ca86312b47b6c5416bd8426f1,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Other/Magical/PotionSlimStabiliser.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/Magical/PotionSlimStabiliser.prefab
@@ -14,6 +14,12 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 9093253379e8be340b9a09b1faf39664,
         type: 2}
+    - target: {fileID: 1162272864508818684, guid: 1e86836ca86312b47b6c5416bd8426f1,
+        type: 3}
+      propertyPath: InitialPresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 9093253379e8be340b9a09b1faf39664,
+        type: 2}
     - target: {fileID: 2152051915416306454, guid: 1e86836ca86312b47b6c5416bd8426f1,
         type: 3}
       propertyPath: parentID
@@ -27,13 +33,13 @@ PrefabInstance:
     - target: {fileID: 4866909607520428057, guid: 1e86836ca86312b47b6c5416bd8426f1,
         type: 3}
       propertyPath: initialName
-      value: Slime Stabilizer
+      value: slime stabilizer
       objectReference: {fileID: 0}
     - target: {fileID: 4866909607520428057, guid: 1e86836ca86312b47b6c5416bd8426f1,
         type: 3}
       propertyPath: initialDescription
-      value: A potent chemical mix that will reduce the chance of a slime mutating.
-        by 15%
+      value: A potent chemical mix that will reduce the chance of a slime mutating
+        by 15%.
       objectReference: {fileID: 0}
     - target: {fileID: 4968336445900272335, guid: 1e86836ca86312b47b6c5416bd8426f1,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Other/Magical/SlimeMutationPotion.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/Magical/SlimeMutationPotion.prefab
@@ -14,6 +14,12 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 31726d8234adad44991bb46642657854,
         type: 2}
+    - target: {fileID: 1162272864508818684, guid: 1e86836ca86312b47b6c5416bd8426f1,
+        type: 3}
+      propertyPath: InitialPresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 31726d8234adad44991bb46642657854,
+        type: 2}
     - target: {fileID: 2152051915416306454, guid: 1e86836ca86312b47b6c5416bd8426f1,
         type: 3}
       propertyPath: parentID
@@ -32,7 +38,7 @@ PrefabInstance:
     - target: {fileID: 4866909607520428057, guid: 1e86836ca86312b47b6c5416bd8426f1,
         type: 3}
       propertyPath: initialName
-      value: Slime Mutation Potion
+      value: slime mutation potion
       objectReference: {fileID: 0}
     - target: {fileID: 4866909607520428057, guid: 1e86836ca86312b47b6c5416bd8426f1,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Other/Magical/SpeedPotion.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/Magical/SpeedPotion.prefab
@@ -14,6 +14,12 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: d104b82ab97d5ae4a80bf6f1211dfb7e,
         type: 2}
+    - target: {fileID: 1162272864508818684, guid: 1e86836ca86312b47b6c5416bd8426f1,
+        type: 3}
+      propertyPath: InitialPresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: d104b82ab97d5ae4a80bf6f1211dfb7e,
+        type: 2}
     - target: {fileID: 2152051915416306454, guid: 1e86836ca86312b47b6c5416bd8426f1,
         type: 3}
       propertyPath: parentID
@@ -32,7 +38,7 @@ PrefabInstance:
     - target: {fileID: 4866909607520428057, guid: 1e86836ca86312b47b6c5416bd8426f1,
         type: 3}
       propertyPath: initialName
-      value: Speed Potion
+      value: speed potion
       objectReference: {fileID: 0}
     - target: {fileID: 4866909607520428057, guid: 1e86836ca86312b47b6c5416bd8426f1,
         type: 3}

--- a/UnityProject/Assets/Prefabs/Items/Tanks/EmergencyOxygenTankDouble.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tanks/EmergencyOxygenTankDouble.prefab
@@ -44,7 +44,7 @@ PrefabInstance:
     - target: {fileID: 3519444805694504380, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
         type: 3}
       propertyPath: MaximumMoles
-      value: 400
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 3519444805694504380, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
         type: 3}
@@ -68,6 +68,16 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3519444805694504380, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
         type: 3}
+      propertyPath: StoredInitialGasMix.Volume
+      value: 2.00107
+      objectReference: {fileID: 0}
+    - target: {fileID: 3519444805694504380, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
+        type: 3}
+      propertyPath: StoredInitialGasMix.pressure
+      value: 109.62365
+      objectReference: {fileID: 0}
+    - target: {fileID: 3519444805694504380, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
+        type: 3}
       propertyPath: StoredGasMix.GasData.GasesArray.Array.data[0].Moles
       value: 350
       objectReference: {fileID: 0}
@@ -75,6 +85,11 @@ PrefabInstance:
         type: 3}
       propertyPath: StoredGasMix.GasData.GasesArray.Array.data[0].moles
       value: 350
+      objectReference: {fileID: 0}
+    - target: {fileID: 3519444805694504380, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
+        type: 3}
+      propertyPath: StoredInitialGasMix.GasData.GasesArray.Array.data[0].moles
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 8683563700070376267, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
         type: 3}
@@ -166,6 +181,18 @@ PrefabInstance:
     - target: {fileID: 9114212219146629469, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
         type: 3}
       propertyPath: itemSprites.SpriteRightHand
+      value: 
+      objectReference: {fileID: 11400000, guid: d36c552d52628744f9329654bbdf563b,
+        type: 2}
+    - target: {fileID: 9114212219146629469, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
+        type: 3}
+      propertyPath: InitialitemSprites.SpriteLeftHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 7335808bfdf794f40a9e4a2b475c9870,
+        type: 2}
+    - target: {fileID: 9114212219146629469, guid: 9ad3756f014fe4f4c9aa35bf9b523a1a,
+        type: 3}
+      propertyPath: InitialitemSprites.SpriteRightHand
       value: 
       objectReference: {fileID: 11400000, guid: d36c552d52628744f9329654bbdf563b,
         type: 2}

--- a/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/_AirlockBase.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Doors/MachineDoors/Airlocks/_AirlockBase.prefab
@@ -113,11 +113,14 @@ MonoBehaviour:
   InitialPresentSpriteSet: {fileID: 11400000, guid: 7d2de9c440cedfa4a855277fac47f8d0,
     type: 2}
   randomInitialSprite: 0
+  spriteRenderer: {fileID: 1684877350854915770}
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
   initialVariantIndex: 0
   InitialColour: {r: 1, g: 1, b: 1, a: 1}
   palette: []
+  initialSortingOrder: -1
+  initialSortingLayerName: 
 --- !u!114 &7210397487269927506
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -248,11 +251,14 @@ MonoBehaviour:
   InitialPresentSpriteSet: {fileID: 11400000, guid: 7d2de9c440cedfa4a855277fac47f8d0,
     type: 2}
   randomInitialSprite: 0
+  spriteRenderer: {fileID: 2457204209736774934}
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
   initialVariantIndex: 0
   InitialColour: {r: 1, g: 1, b: 1, a: 1}
   palette: []
+  initialSortingOrder: -1
+  initialSortingLayerName: 
 --- !u!114 &7418526098909645323
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -374,11 +380,14 @@ MonoBehaviour:
   InitialPresentSpriteSet: {fileID: 11400000, guid: 83e7069aacdb7864587c92e14b75f560,
     type: 2}
   randomInitialSprite: 0
+  spriteRenderer: {fileID: 5572436852781215207}
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
   initialVariantIndex: 0
   InitialColour: {r: 1, g: 1, b: 1, a: 1}
   palette: []
+  initialSortingOrder: -1
+  initialSortingLayerName: 
 --- !u!1 &512806237205393311
 GameObject:
   m_ObjectHideFlags: 0
@@ -390,6 +399,7 @@ GameObject:
   - component: {fileID: 8660843556563420507}
   - component: {fileID: 3824116807351544659}
   - component: {fileID: 6553321152649453446}
+  - component: {fileID: 951708970458455624}
   m_Layer: 18
   m_Name: overlaySparks
   m_TagString: Untagged
@@ -489,11 +499,29 @@ MonoBehaviour:
   InitialPresentSpriteSet: {fileID: 11400000, guid: 7d2de9c440cedfa4a855277fac47f8d0,
     type: 2}
   randomInitialSprite: 0
+  spriteRenderer: {fileID: 3824116807351544659}
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
   initialVariantIndex: 0
   InitialColour: {r: 1, g: 1, b: 1, a: 1}
   palette: []
+  initialSortingOrder: -1
+  initialSortingLayerName: 
+--- !u!114 &951708970458455624
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 512806237205393311}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 967620e59e52cc14c89c22c4176bac09, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mIntensity: 0.5
+  mAdditionalEmission: 0
+  mScale: 1
 --- !u!1 &773641709186510069
 GameObject:
   m_ObjectHideFlags: 0
@@ -601,11 +629,14 @@ MonoBehaviour:
   InitialPresentSpriteSet: {fileID: 11400000, guid: 7d2de9c440cedfa4a855277fac47f8d0,
     type: 2}
   randomInitialSprite: 0
+  spriteRenderer: {fileID: 7351817648409257026}
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
   initialVariantIndex: 0
   InitialColour: {r: 1, g: 1, b: 1, a: 1}
   palette: []
+  initialSortingOrder: -1
+  initialSortingLayerName: 
 --- !u!1 &2233065044779290990
 GameObject:
   m_ObjectHideFlags: 0
@@ -720,11 +751,14 @@ MonoBehaviour:
   InitialPresentSpriteSet: {fileID: 11400000, guid: 7d2de9c440cedfa4a855277fac47f8d0,
     type: 2}
   randomInitialSprite: 0
+  spriteRenderer: {fileID: 612945537152015592}
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
   initialVariantIndex: 0
   InitialColour: {r: 1, g: 1, b: 1, a: 1}
   palette: []
+  initialSortingOrder: -1
+  initialSortingLayerName: 
 --- !u!114 &5292488675851686727
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1030,11 +1064,14 @@ MonoBehaviour:
   InitialPresentSpriteSet: {fileID: 11400000, guid: 7d2de9c440cedfa4a855277fac47f8d0,
     type: 2}
   randomInitialSprite: 0
+  spriteRenderer: {fileID: 6311369837043129362}
   doReverseAnimation: 0
   pushTextureOnStartUp: 1
   initialVariantIndex: 0
   InitialColour: {r: 1, g: 1, b: 1, a: 1}
   palette: []
+  initialSortingOrder: -1
+  initialSortingLayerName: 
 --- !u!1001 &3511082394880060143
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1058,6 +1095,11 @@ PrefabInstance:
       propertyPath: CurrentsortingGroup
       value: 
       objectReference: {fileID: 6682145752921394767}
+    - target: {fileID: 44702923082529482, guid: 1291a5cb15d008c41bf0a373403f56b2,
+        type: 3}
+      propertyPath: spriteRenderer
+      value: 
+      objectReference: {fileID: 8149197489328545512}
     - target: {fileID: 44702923082529482, guid: 1291a5cb15d008c41bf0a373403f56b2,
         type: 3}
       propertyPath: PresentSpriteSet
@@ -1382,6 +1424,12 @@ MonoBehaviour:
 --- !u!210 &6682145752921394767 stripped
 SortingGroup:
   m_CorrespondingSourceObject: {fileID: 7782817179362649248, guid: 1291a5cb15d008c41bf0a373403f56b2,
+    type: 3}
+  m_PrefabInstance: {fileID: 3511082394880060143}
+  m_PrefabAsset: {fileID: 0}
+--- !u!212 &8149197489328545512 stripped
+SpriteRenderer:
+  m_CorrespondingSourceObject: {fileID: 4732752304642126855, guid: 1291a5cb15d008c41bf0a373403f56b2,
     type: 3}
   m_PrefabInstance: {fileID: 3511082394880060143}
   m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Objects/Electricity/New Department Battery.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Electricity/New Department Battery.prefab
@@ -184,6 +184,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1890456236835584536}
   - component: {fileID: 128980603473721859}
+  - component: {fileID: 501759338476595414}
   m_Layer: 0
   m_Name: Battery charge
   m_TagString: Untagged
@@ -261,6 +262,21 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &501759338476595414
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8895412586294323591}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 967620e59e52cc14c89c22c4176bac09, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mIntensity: 0.6
+  mAdditionalEmission: 0
+  mScale: 1
 --- !u!1001 &7584629247270157436
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -558,7 +574,32 @@ PrefabInstance:
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 7864670987055946486}
+    - targetCorrespondingSourceObject: {fileID: 8657137545173925816, guid: 170e72b76e0da9645995a9bac3f49cb2,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 9194211995050328333}
   m_SourcePrefab: {fileID: 100100000, guid: 170e72b76e0da9645995a9bac3f49cb2, type: 3}
+--- !u!1 &1253778225857463236 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8657137545173925816, guid: 170e72b76e0da9645995a9bac3f49cb2,
+    type: 3}
+  m_PrefabInstance: {fileID: 7584629247270157436}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &9194211995050328333
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1253778225857463236}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 967620e59e52cc14c89c22c4176bac09, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mIntensity: 0.6
+  mAdditionalEmission: 0
+  mScale: 1
 --- !u!114 &2838865338122053255 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5631655566716459771, guid: 170e72b76e0da9645995a9bac3f49cb2,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/ReinforcedWall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/ReinforcedWall.asset
@@ -68,14 +68,14 @@ MonoBehaviour:
   lootOnDespawn: {fileID: 0}
   toTileWhenDestroyed: {fileID: 11400000, guid: e5521a40048af4964ad58c041a5dc7f4,
     type: 2}
-  spawnOnDestroy: {fileID: 0}
+  spawnOnDestroy: {fileID: 11400000, guid: 017dad844ab5047cab969a94134a1fdb, type: 2}
   damageOverlayList: {fileID: 0}
   soundOnHit:
-    SetLoadSetting: 0
     AssetAddress: 
     AssetReference:
       m_AssetGUID: 
       m_SubObjectName: 
+      m_SubObjectGUID: 
       m_SubObjectType: 
       m_EditorAssetChanged: 0
   SoundOnDestroy: []

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RustyReinforcedWall/RustyReinforcedWall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWalls/RustyReinforcedWall/RustyReinforcedWall.asset
@@ -68,14 +68,14 @@ MonoBehaviour:
   lootOnDespawn: {fileID: 0}
   toTileWhenDestroyed: {fileID: 11400000, guid: 73a1eb94ba00f6d4196c037f45efba7c,
     type: 2}
-  spawnOnDestroy: {fileID: 0}
+  spawnOnDestroy: {fileID: 11400000, guid: 017dad844ab5047cab969a94134a1fdb, type: 2}
   damageOverlayList: {fileID: 0}
   soundOnHit:
-    SetLoadSetting: 0
     AssetAddress: 
     AssetReference:
       m_AssetGUID: 
       m_SubObjectName: 
+      m_SubObjectGUID: 
       m_SubObjectType: 
       m_EditorAssetChanged: 0
   SoundOnDestroy: []


### PR DESCRIPTION
### Purpose
fix reinforced walls not leaving a girder behind on destruction like regular walls do (now they leave a reinforced girder. disassembly with tools still works as before)

light emission behavior added for lights on dept battery and overlaySparks on airlocks

emergency o2 tank double - decreased o2 moles from 350 to 90 cause it was bizarrely high (normal emergency tank has 45, ext. capacity emergency tank has 85, fullsize o2 tanks have 190)

some capitalization/punctuation text edits on potion items 

### Notes:
n/a

### Media Preview:
n/a

### Changelog:

CL: [Fix] Reinforced walls now behave like regular walls when destroyed, leaving a (reinforced) girder behind.
