### PR TITLE
Lavaland Client Crash/Preformance Fix 

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/Atmospherics/Gases/Ash.asset
+++ b/UnityProject/Assets/ScriptableObjects/Atmospherics/Gases/Ash.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
   MolarMass: 12
   Name: Ash
   MinMolesToSee: 0.4
-  OverlayTile: {fileID: 11400000, guid: dab137ac4040d8a4a935e1df58d81002, type: 2}
+  OverlayTile: {fileID: 0}
   CustomColour: 0
   Colour: {r: 1, g: 1, b: 1, a: 1}
   FusionPower: 0

--- a/UnityProject/Assets/Scripts/Core/Lighting/LightSource.cs
+++ b/UnityProject/Assets/Scripts/Core/Lighting/LightSource.cs
@@ -118,13 +118,13 @@ namespace Objects.Lighting
 		private void OnEnable()
 		{
 			directional.OnRotationChange.AddListener(OnDirectionChange);
-			integrity.OnApplyDamage.AddListener(OnDamageReceived);
+			integrity.OnApplyDamage += OnDamageReceived;
 		}
 
 		private void OnDisable()
 		{
 			directional.OnRotationChange.RemoveListener(OnDirectionChange);
-			if (integrity != null) integrity.OnApplyDamage.RemoveListener(OnDamageReceived);
+			if (integrity) integrity.OnApplyDamage -= OnDamageReceived;
 
 			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, TrySpark);
 		}

--- a/UnityProject/Assets/Scripts/Health/Objects/Flammable.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Flammable.cs
@@ -56,9 +56,12 @@ namespace Health.Objects
 		private void Awake()
 		{
 			integrity = GetComponent<Integrity>();
-			integrity.OnDestruction.AddListener(ExtingushFireAndDestroy);
-			integrity.OnApplyDamage.AddListener(OnDamageReceived);
 			EnsureInit();
+		}
+
+		private void OnEnable()
+		{
+			EnableIntegrityObserver();
 		}
 
 		private void OnDisable()
@@ -67,6 +70,23 @@ namespace Health.Objects
 			{
 				UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, PeriodicUpdateBurn);
 			}
+			DisableIntegrityObserver();
+		}
+
+		private void EnableIntegrityObserver()
+		{
+			if (CustomNetworkManager.IsServer == false) return;
+			if (!integrity) return;
+			integrity.OnDestruction.AddListener(ExtingushFireAndDestroy);
+			integrity.OnApplyDamage += OnDamageReceived;
+		}
+
+		private void DisableIntegrityObserver()
+		{
+			if (CustomNetworkManager.IsServer == false) return;
+			if (!integrity) return;
+			integrity.OnDestruction.RemoveListener(ExtingushFireAndDestroy);
+			integrity.OnApplyDamage -= OnDamageReceived;
 		}
 
 		private void EnsureInit()

--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -45,8 +45,7 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 	/// Server-side event invoked when ApplyDamage is called
 	/// and Integrity is about to apply damage.
 	/// </summary>
-	[NonSerialized]
-	public DamagedEvent OnApplyDamage = new DamagedEvent();
+	public Action<DamageInfo> OnApplyDamage = null;
 
 	public UnityEvent OnDamaged = new UnityEvent();
 	public UnityEvent OnDestruction = new UnityEvent();
@@ -430,7 +429,6 @@ public class DestructionInfo
 /// Event fired when an object is destroyed
 /// </summary>
 public class DestructionEvent : UnityEvent<DestructionInfo> { }
-public class DamagedEvent : UnityEvent<DamageInfo> { }
 
 /// <summary>
 /// Event fired when ApplyDamage is called

--- a/UnityProject/Assets/Scripts/Items/ItemBreakable.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemBreakable.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using AddressableReferences;
@@ -18,11 +19,15 @@ namespace Items
 		[SerializeField] private AddressableAudioSource soundOnBreak = null;
 
 		// Start is called before the first frame update
-		void Awake()
+		private void Awake()
 		{
 			integrity = GetComponent<Integrity>();
+			integrity.OnApplyDamage += OnDamageReceived;
+		}
 
-			integrity.OnApplyDamage.AddListener(OnDamageReceived);
+		private void OnDestroy()
+		{
+			if (integrity) integrity.OnApplyDamage -= OnDamageReceived;
 		}
 
 		public void AddDamage()

--- a/UnityProject/Assets/Scripts/Items/Kitchen/Cookable.cs
+++ b/UnityProject/Assets/Scripts/Items/Kitchen/Cookable.cs
@@ -55,7 +55,7 @@ namespace Items.Food
 		{
 			if (integrity == null) integrity = GetComponent<Integrity>();
 			Pickupable = this.GetComponent<Pickupable>();
-			integrity.OnApplyDamage.AddListener(OnDamageReceived);
+			integrity.OnApplyDamage += OnDamageReceived;
 			if (CookableBy.HasFlag(CookSource.BurnUp))
 			{
 				integrity.OnBurnUpServer += OnBurnUpServer;

--- a/UnityProject/Assets/Scripts/Items/Others/Gibtonite.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/Gibtonite.cs
@@ -48,7 +48,7 @@ namespace Items.Others
 		private void Start()
 		{
 			if(CustomNetworkManager.IsServer == false) return;
-			integrity.OnApplyDamage.AddListener(OnDamageTaken);
+			integrity.OnApplyDamage += OnDamageTaken;
 			// If this ore starts in storage already, then assume it is safe.
 			SetState(pickupable.ItemSlot != null ? GibState.INACTIVE : GibState.FUSED);
 		}

--- a/UnityProject/Assets/Scripts/Objects/Closets/FireAxeCabinet.cs
+++ b/UnityProject/Assets/Scripts/Objects/Closets/FireAxeCabinet.cs
@@ -7,20 +7,20 @@ namespace Objects.Wallmounts
 	[RequireComponent(typeof(ItemStorage))]
 	public class FireAxeCabinet : NetworkBehaviour, ICheckedInteractable<HandApply>, IServerSpawn
 	{
-		
+
 		private ClearanceRestricted restricted;
 		private Integrity integrity;
 		private ItemStorage itemStorage;
 		private ItemSlot axeSlot;
-		
+
 		[SerializeField] private SpriteHandler axeSpriteHandler;
 		[SerializeField] private SpriteHandler glassSpriteHandler;
 		[SerializeField] private SpriteHandler lockSpriteHandler;
-		
+
 		private bool isLocked = true;
 		private bool isOpened = false;
 		private bool isBroken = false;
-		
+
 		private const int OPEN_SPRITE = 5;
 		private const float LOCK_TOGGLE_TIME = 2f;
 		private const float GLASS_REPAIR_TIME = 2f;
@@ -32,35 +32,35 @@ namespace Objects.Wallmounts
 			itemStorage = GetComponent<ItemStorage>();
 			axeSlot = itemStorage.GetIndexedItemSlot(0);
 		}
-		
+
 		public void OnSpawnServer(SpawnInfo info)
 		{
-			integrity.OnApplyDamage.AddListener(OnServerDamage);
+			integrity.OnApplyDamage += OnServerDamage;
 		}
 
 		private void OnDisable()
 		{
-			integrity.OnApplyDamage.RemoveListener(OnServerDamage);
+			integrity.OnApplyDamage -= OnServerDamage;
 		}
-		
+
 		private void OnServerDamage(DamageInfo info)
 		{
 			if (isBroken == false && integrity.integrity <= 0.2 * integrity.initialIntegrity)
 			{
 				isBroken = true;
 			}
-			
+
 			if (isOpened == false)
 			{
 				UpdateGlassSprite();
 			}
 		}
-		
+
 		private void UpdateGlassSprite()
 		{
-				
+
 				int index = Mathf.CeilToInt(integrity.integrity / integrity.initialIntegrity * 100f / 20);
-				glassSpriteHandler.SetCatalogueIndexSprite(index - 1);					
+				glassSpriteHandler.SetCatalogueIndexSprite(index - 1);
 		}
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)
@@ -85,19 +85,19 @@ namespace Objects.Wallmounts
 				ToggleOpen();
 				return;
 			}
-			
+
 			if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.GlassSheet) && isBroken)
 			{
 				DoRepair(interaction);
 				return;
 			}
-			
+
 			if (restricted.HasClearance(interaction.HandObject) && isOpened == false)
 			{
 				ToggleLock(interaction);
 				return;
 			}
-			
+
 			if (Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.Screwdriver) && isOpened == false)
 			{
 				ForceLock(interaction);
@@ -118,7 +118,7 @@ namespace Objects.Wallmounts
 					else
 					{
 						axeSpriteHandler.PushTexture();
-					}										
+					}
 				}
 			}
 			else if (isLocked == false)
@@ -126,7 +126,7 @@ namespace Objects.Wallmounts
 				ToggleOpen();
 			}
 		}
-		
+
 		private void DoRepair(HandApply interaction)
 		{
 			if (interaction.UsedObject.TryGetComponent<Stackable>(out var stackable) && stackable.Amount > 2)
@@ -141,10 +141,10 @@ namespace Objects.Wallmounts
 						UpdateGlassSprite();
 					}
 				}
-				
+
 				var bar = StandardProgressAction.Create(new StandardProgressActionConfig(StandardProgressActionType.Construction), ProgressFinishAction)
 					.ServerStartProgress(interaction.Performer.RegisterTile(), GLASS_REPAIR_TIME , interaction.Performer);
-	
+
 				if (bar != null)
 				{
 					Chat.AddExamineMsg(interaction.Performer, "You begin replacing the glass.");
@@ -152,17 +152,17 @@ namespace Objects.Wallmounts
 			}
 			else
 			{
-				Chat.AddExamineMsg(interaction.Performer, $"You need more glass for that.");				
+				Chat.AddExamineMsg(interaction.Performer, $"You need more glass for that.");
 			}
 		}
-		
+
 		private void ToggleLock(HandApply interaction)
 		{
 			isLocked = !isLocked;
 			Chat.AddExamineMsg(interaction.Performer, $"You {(isLocked ? "lock" : "unlock")} the fire axe cabinet.");
-			lockSpriteHandler.SetCatalogueIndexSprite(isLocked ? 0 : 1);			
+			lockSpriteHandler.SetCatalogueIndexSprite(isLocked ? 0 : 1);
 		}
-		
+
 		private void ForceLock(HandApply interaction)
 		{
 			void ProgressFinishAction()
@@ -171,7 +171,7 @@ namespace Objects.Wallmounts
 				Chat.AddExamineMsg(interaction.Performer, $"You {(isLocked ? "re-enable" : "disable")} the locking modules.");
 				lockSpriteHandler.SetCatalogueIndexSprite(isLocked ? 0 : 1);
 			}
-			
+
 			var bar = StandardProgressAction.Create(new StandardProgressActionConfig(StandardProgressActionType.ItemTransfer), ProgressFinishAction)
 				.ServerStartProgress(interaction.Performer.RegisterTile(), LOCK_TOGGLE_TIME, interaction.Performer);
 
@@ -180,11 +180,11 @@ namespace Objects.Wallmounts
 				Chat.AddExamineMsg(interaction.Performer, "You begin resetting the locking modules.");
 			}
 		}
-		
+
 		private void ToggleOpen()
 		{
 			isOpened = !isOpened;
-			
+
 			if (isOpened)
 			{
 				glassSpriteHandler.SetCatalogueIndexSprite(OPEN_SPRITE);
@@ -194,5 +194,5 @@ namespace Objects.Wallmounts
 				UpdateGlassSprite();
 			}
 		}
-	}		
+	}
 }

--- a/UnityProject/Assets/Scripts/Objects/GasContainer.cs
+++ b/UnityProject/Assets/Scripts/Objects/GasContainer.cs
@@ -103,7 +103,7 @@ namespace Objects.Atmospherics
 			// Not all containers need integrity e.g. DisposalVirtualContainer
 			if (integrity != null)
 			{
-				integrity.OnApplyDamage.AddListener(OnServerDamage);
+				integrity.OnApplyDamage += OnServerDamage;
 			}
 		}
 
@@ -117,7 +117,7 @@ namespace Objects.Atmospherics
 		{
 			if (integrity != null)
 			{
-				integrity.OnApplyDamage.RemoveListener(OnServerDamage);
+				integrity.OnApplyDamage -= OnServerDamage;
 			}
 
 			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, InventoryUpdateLoop);

--- a/UnityProject/Assets/Scripts/Objects/Machines/Jukebox.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/Jukebox.cs
@@ -128,7 +128,7 @@ namespace Objects
 			registerTile = GetComponent<RegisterTile>();
 			vinylStorage = GetComponent<ItemStorage>();
 			integrity = GetComponent<Integrity>();
-			integrity.OnApplyDamage.AddListener(OnDamageReceived);
+			integrity.OnApplyDamage += OnDamageReceived;
 
 			audioSourceParameters = new AudioSourceParameters(volume: Volume, spatialBlend: 2, spread: Spread,
 				minDistance: MinSoundDistance, maxDistance: MaxSoundDistance, mixerType: MixerType.JukeBox,

--- a/UnityProject/Assets/Scripts/Objects/Machines/ServerMachines/Communications/CommsServer.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/ServerMachines/Communications/CommsServer.cs
@@ -21,7 +21,7 @@ namespace Objects.Machines.ServerMachines.Communications
 			if (integrity == null)
 			{
 				integrity = GetComponent<Integrity>();
-				integrity.OnApplyDamage.AddListener(OnDamageReceived);
+				integrity.OnApplyDamage += OnDamageReceived;
 			}
 			if (apcPoweredDevice == null)
 			{
@@ -38,7 +38,7 @@ namespace Objects.Machines.ServerMachines.Communications
 		private void OnDisable()
 		{
 			GameManager.Instance.CommsServers.Remove(this);
-			integrity.OnApplyDamage.RemoveListener(OnDamageReceived);
+			integrity.OnApplyDamage -= OnDamageReceived;
 		}
 
 		public override void ReceiveSignal(SignalStrength strength, SignalEmitter responsibleEmitter, ISignalMessage message = null)

--- a/UnityProject/Assets/Scripts/Objects/Research/Artifacts/Artifact.cs
+++ b/UnityProject/Assets/Scripts/Objects/Research/Artifacts/Artifact.cs
@@ -118,7 +118,7 @@ namespace Objects.Research
 			radiationProducer = GetComponent<RadiationProducer>();
 			objectPhysics = GetComponent<UniversalObjectPhysics>();
 
-			integrity.OnApplyDamage.AddListener(DoDamageEffect);
+			integrity.OnApplyDamage += DoDamageEffect;
 		}
 
 		public void OnSpawnServer(SpawnInfo info)
@@ -228,7 +228,7 @@ namespace Objects.Research
 
 		public void OnDespawnServer(DespawnInfo info)
 		{
-			integrity.OnApplyDamage.RemoveListener(DoDamageEffect);
+			integrity.OnApplyDamage -= DoDamageEffect;
 
 			// remove it from global artifacts registry
 			if (ServerSpawnedArtifacts.Contains(this))

--- a/UnityProject/Assets/Scripts/Systems/Ai/AiPlayer.cs
+++ b/UnityProject/Assets/Scripts/Systems/Ai/AiPlayer.cs
@@ -205,7 +205,7 @@ namespace Systems.Ai
 		{
 			var coreIntegrity = vesselObject.GetComponent<Integrity>();
 			coreIntegrity.OnWillDestroyServer.AddListener(OnCoreDestroy);
-			coreIntegrity.OnApplyDamage.AddListener(OnCoreDamage);
+			coreIntegrity.OnApplyDamage += OnCoreDamage;
 			hasPower = true;
 
 			//Power set up
@@ -236,7 +236,7 @@ namespace Systems.Ai
 
 			var coreIntegrity = vesselObject.GetComponent<Integrity>();
 			coreIntegrity.OnWillDestroyServer.RemoveListener(OnCoreDestroy);
-			coreIntegrity.OnApplyDamage.RemoveListener(OnCoreDamage);
+			coreIntegrity.OnApplyDamage -= OnCoreDamage;
 
 			var apc = vesselObject.GetComponent<APCPoweredDevice>();
 			if (apc != null)

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobPlayer.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobPlayer.cs
@@ -1699,7 +1699,7 @@ namespace Blob
 
 			structure.integrity.OnWillDestroyServer.AddListener(BlobTileDeath);
 
-			structure.integrity.OnApplyDamage.AddListener(OnDamageReceived);
+			structure.integrity.OnApplyDamage += OnDamageReceived;
 		}
 
 		private void OnDamageReceived(DamageInfo info)

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobStructure.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobStructure.cs
@@ -76,7 +76,6 @@ namespace Blob
 			if(integrity == null) return;
 
 			integrity.OnWillDestroyServer.RemoveAllListeners();
-			integrity.OnApplyDamage.RemoveAllListeners();
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Explosions/NodeTypes/ExplosionNode.cs
+++ b/UnityProject/Assets/Scripts/Systems/Explosions/NodeTypes/ExplosionNode.cs
@@ -38,6 +38,9 @@ namespace Systems.Explosions
 		/// </summary>
 		public Vector3 ExplosionStartWorldPosition = Vector3.zero;
 
+		public const int MINIMUM_DAMAGE_TO_THROW_OBJECTS = 8;
+		public const int OBJECT_PROCESS_SPLICE_LIMIT = 6;
+
 		public ExplosionNode(Vector3 _explosionStartWorldPosition)
 		{
 			ExplosionStartWorldPosition = _explosionStartWorldPosition;
@@ -120,7 +123,7 @@ namespace Systems.Explosions
 			var spliceCounter = 0;
 			foreach (var something in stuffOnTile)
 			{
-				if (spliceCounter > 30)
+				if (spliceCounter > OBJECT_PROCESS_SPLICE_LIMIT)
 				{
 					spliceCounter = 0;
 					await UniTask.WaitForEndOfFrame();
@@ -128,7 +131,7 @@ namespace Systems.Explosions
 				spliceCounter++;
 				// Incase of multiple explosions occuring at once (i.e: multiple Gibtonites)
 				// trycatch this to avoid trying to destroy stuff that is already destroyed by other damage sources.
-				if (something == null || something.gameObject == null) continue;
+				if (!something) continue;
 				if (something.TrySafeGetComponent<Integrity>(out var integrity))
 				{
 					DamageObjects(something, integrity, damageDealt);
@@ -144,8 +147,11 @@ namespace Systems.Explosions
 				await UniTask.WaitForEndOfFrame();
 				try
 				{
-					player.playerScript.playerMove.NewtonianPush(AngleAndIntensity.Rotate90(), 7, 1, 3,
-						BodyPartType.Chest, player.gameObject, 15);
+					if (damageDealt >= MINIMUM_DAMAGE_TO_THROW_OBJECTS)
+					{
+						player.playerScript.playerMove.NewtonianPush(AngleAndIntensity.Rotate90(), 7, 1, 3,
+							BodyPartType.Chest, player.gameObject, 15);
+					}
 					player.ApplyDamageAll(null, damageDealt, AttackType.Bomb, DamageType.Brute, default, TraumaticDamageTypes.NONE, 75);
 				}
 				catch (Exception e)
@@ -160,8 +166,11 @@ namespace Systems.Explosions
 		{
 			try
 			{
-				integrity.Physics.NewtonianNewtonPush(AngleAndIntensity.Rotate90(), AngleAndIntensity.magnitude * 0.1f , 1, 3,
-					BodyPartType.Chest, integrity.gameObject, 15);
+				if (damageDealt >= MINIMUM_DAMAGE_TO_THROW_OBJECTS)
+				{
+					integrity.Physics.NewtonianNewtonPush(AngleAndIntensity.Rotate90(), AngleAndIntensity.magnitude * 0.1f , 1, 3,
+						BodyPartType.Chest, integrity.gameObject, 15);
+				}
 
 				if (IgnoreAttributes != null)
 				{

--- a/UnityProject/Assets/StreamingAssets/Logs/InfiniteLoopTracker.txt
+++ b/UnityProject/Assets/StreamingAssets/Logs/InfiniteLoopTracker.txt
@@ -1,1 +1,0 @@
-2025/05/29 17:27:07 possible infinite loop detected on frame: 43892025/05/29 17:28:08 possible infinite loop detected on frame: 43892025/05/29 17:29:09 possible infinite loop detected on frame: 43892025/05/29 17:30:10 possible infinite loop detected on frame: 4389

--- a/UnityProject/Assets/StreamingAssets/Logs/InfiniteLoopTracker.txt
+++ b/UnityProject/Assets/StreamingAssets/Logs/InfiniteLoopTracker.txt
@@ -1,0 +1,1 @@
+2025/05/29 17:27:07 possible infinite loop detected on frame: 43892025/05/29 17:28:08 possible infinite loop detected on frame: 43892025/05/29 17:29:09 possible infinite loop detected on frame: 43892025/05/29 17:30:10 possible infinite loop detected on frame: 4389


### PR DESCRIPTION
This is a small piece of something larger I'm working on to fix Lavaland's glaring issues that have been plaguing the game's stability for a while now. There will be more PRs related to this in the future after I'm done with my finals and the nasty cold I'm having.

### Changelog:

CL: [Improvement] Items and Players will only be thrown around by explosions if the explosion damage is greater than 8 damage.
CL: [Improvement] Explosion nodes can only process 6 objects in a single frame instead of 30 now.
CL: [Fix] We've disabled Lavaland's atmospheric overlay for the time being until we introduce a more robust and performant system.
CL: [Fix] Fixed an issue where clients wrongly had the ability to observe the server's flammable functions.
CL: [Fix] Fixed an issue where clients would crash due to explosions occurring nearby artifacts.
CL: [Fix] Fixed an issue where clients would suffer an extreme performance hit when explosions occur on lavaland.
CL: [Fix] Fixed an issue with some pooled objects still having the ability to react to different events despite them being disabled.
CL: [Fix] Fixed some actions leaking due to them not removing themselves after disabling themselves.

