### PR TITLE
Fixes chat acting funky when there's no admins present

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
@@ -189,16 +189,16 @@ public partial class PlayerList
 
 	public static bool HasTAGServer(string TAG, string AccountID)
 	{
-		if (Instance.LoggedInWithTag.ContainsKey(TAG))
+		if (Instance.LoggedInWithTag.TryGetValue(TAG, out var loggedIn))
 		{
-			if (Instance.LoggedInWithTag[TAG].Contains(AccountID))
+			if (loggedIn.Contains(AccountID))
 			{
 				return true;
 			}
 		}
 		else
 		{
-			return Instance.LoggedInWithTag["*"].Contains(AccountID);
+			return Instance.LoggedInWithTag.TryGetValue("*", out var allAdmins) && allAdmins.Contains(AccountID);
 		}
 		return false;
 	}

--- a/UnityProject/Assets/Scripts/Objects/Machines/ServerMachines/Communications/CommsServer.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/ServerMachines/Communications/CommsServer.cs
@@ -1,5 +1,7 @@
+using System;
 using Communications;
 using InGameEvents;
+using Logs;
 using Managers;
 using Systems.Electricity;
 using Systems.Explosions;
@@ -51,8 +53,15 @@ namespace Objects.Machines.ServerMachines.Communications
 				finalMessage.message = EventProcessorOverload.ProcessMessage(c.ChatEvent.message);
 			}
 			//Not the best way to do this currently but we can worry about it later during the chat rework
-			ChatRelay.Instance.PropagateChatToClients(finalMessage);
-			if(blackbox != null) blackbox.StoreChatEvents(finalMessage);
+			try
+			{
+				ChatRelay.Instance.PropagateChatToClients(finalMessage);
+				if (blackbox != null) blackbox.StoreChatEvents(finalMessage);
+			}
+			catch (Exception e)
+			{
+				Loggy.Error($"Error while processing radio message: {e.Message}\n{e.StackTrace}");
+			}
 		}
 
 		private void OnDamageReceived(DamageInfo damageInfo)


### PR DESCRIPTION
please use `TryGetValue` since it's safer.

### Changelog

CL: [Fix] Fixed an issue with chat that would not work until an admin was present.