### PR TITLE
Fixes reagents spilling in space and the scrubber surge event affecting other matrices 

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
@@ -764,13 +764,30 @@ public partial class MatrixManager : SingletonManager<MatrixManager>
 			return;
 		}
 
-		if (matrixInfo is null)
+		matrixInfo ??= AtPoint(worldPos, true);
+
+		if (IsSpaceWithNoTilesNearbyAt(worldPos, matrixInfo))
 		{
-			matrixInfo = AtPoint(worldPos, true);
+			Loggy.Warning($"Attempted to do a reagent reaction in the middle of space at {worldPos}", Category.Chemistry);
+			return;
 		}
 
 		Vector3Int localPos = WorldToLocalInt(worldPos, matrixInfo);
 		matrixInfo.MetaDataLayer.ReagentReact(reagents, worldPos, localPos, spawnPrefabEffect, direction, Scatter, from);
+	}
+
+	public static bool IsSpaceWithNoTilesNearbyAt(Vector3Int worldPos, MatrixInfo matrixInfo = null)
+	{
+		if (IsSpaceAt(worldPos, true, matrixInfo) == false) return false;
+		var dontReactInSpace = worldPos;
+		var neighbors = worldPos.GetNeighbors();
+		foreach (var n in neighbors)
+		{
+			if (IsSpaceAt(n, true, matrixInfo)) continue;
+			worldPos = n;
+			break;
+		}
+		return dontReactInSpace != worldPos;
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventScrubberSurge.cs
+++ b/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventScrubberSurge.cs
@@ -42,6 +42,14 @@ namespace InGameEvents
 		[SerializeField, MinMaxSlider(0f, 100f)]
 		private Vector2 spawnDelayRange = new Vector2(3f, 10f);
 
+		[Tooltip("The probability that this scrubber will spill any reagents.")]
+		[SerializeField]
+		private float dispenseChance = 35f;
+
+		[Tooltip("The amount of reagents to spill.")]
+		[SerializeField]
+		private float spillAmount = 55f;
+
 
 		public bool ShouldDispenseRareDispersionAgents()
 		{
@@ -68,8 +76,9 @@ namespace InGameEvents
 		{
 			ReagentContainer container = Instantiate(reagentContainer).GetComponent<ReagentContainer>();
 
-			foreach (var scrubber in FindObjectsOfType<Scrubber>())
+			foreach (var scrubber in MatrixManager.MainStationMatrix.GameObject.GetComponentsInChildren<Scrubber>())
 			{
+				if (DMMath.Prob(dispenseChance) == false) continue;
 				StartCoroutine(SpillAtScrubber(scrubber, container));
 			}
 
@@ -95,7 +104,7 @@ namespace InGameEvents
 					reagentMix.Add(dispersionMix.PickRandom());
 				}
 
-				reagentMix.reagents.m_dict.Add(ChemistryReagentsSO.Instance.AllChemistryReagents.PickRandom(), 75f);
+				reagentMix.reagents.m_dict.Add(ChemistryReagentsSO.Instance.AllChemistryReagents.PickRandom(), spillAmount);
 			}
 
 


### PR DESCRIPTION
Fixes #10945


CL: [Improvement] Nerfed the amount of spillage made by the scrubber surge event.
CL: [Fix] The scrubber surge event now only affects main stations.
CL: [Fix] Reagents won't spill over to space if it can't find a suitable place to dump its extra contents in.