### PR TITLE
Adds chat backgrounds as an accessibility option

### DIFF
--- a/UnityProject/Assets/Prefabs/Chat/ChatEntry.prefab
+++ b/UnityProject/Assets/Prefabs/Chat/ChatEntry.prefab
@@ -33,6 +33,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 5172785732226332731}
   - {fileID: 4575721326021693385}
   - {fileID: 2000913768062860772}
   m_Father: {fileID: 0}
@@ -283,7 +284,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 14.2
+  m_fontSize: 14.15
   m_fontSizeBase: 54
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -305,7 +306,7 @@ MonoBehaviour:
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
-  m_ActiveFontFeatures: 00000000
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 0
@@ -419,6 +420,81 @@ MonoBehaviour:
   m_EffectColor: {r: 0, g: 0, b: 0, a: 0.5}
   m_EffectDistance: {x: -1, y: -1}
   m_UseGraphicAlpha: 1
+--- !u!1 &4620392732038735957
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5172785732226332731}
+  - component: {fileID: 3734334398806632182}
+  - component: {fileID: 4415855544694991946}
+  m_Layer: 5
+  m_Name: EntryBackground
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5172785732226332731
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4620392732038735957}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 224781789997769250}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -3.798996, y: 1.5402002}
+  m_SizeDelta: {x: 13.0137, y: 11.7742}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3734334398806632182
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4620392732038735957}
+  m_CullTransparentMesh: 1
+--- !u!114 &4415855544694991946
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4620392732038735957}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.43137255}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: ebbd50a7baefb824f9e2ddf0545f13fd, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1.75
 --- !u!1 &5196287763013459055
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Chat/ChatEntry.prefab
+++ b/UnityProject/Assets/Prefabs/Chat/ChatEntry.prefab
@@ -170,6 +170,8 @@ MonoBehaviour:
   stackObject: {fileID: 4585939312796838426}
   stackText: {fileID: 8305450687204186126}
   stackImage: {fileID: 6621845892192530244}
+  entryBackground: {fileID: 4415855544694991946}
+  maximumAlpha: 0.8
 --- !u!114 &9023113108366749766
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -478,7 +480,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.43137255}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.8156863}
   m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/NetworkManager.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/NetworkManager.prefab
@@ -5204,7 +5204,6 @@ MonoBehaviour:
   - {fileID: 8587713973174609844, guid: 5211e71d15de2e249b7745f3d7a6afe4, type: 3}
   - {fileID: 8720001268064069434, guid: 78c6245dbf4dc8743ac91347971ee3f1, type: 3}
   - {fileID: 7144248469089430455, guid: 5cb5bf2efb47fce45b5b2e7311b9a6fc, type: 3}
-  - {fileID: 1000012542722638, guid: 506edc0541ee4ecbbf1a545b24ced013, type: 3}
   - {fileID: 3357068366710454748, guid: cc5909c573e2f834e97b3488bb2902d0, type: 3}
   - {fileID: 3250310938253979280, guid: cbae9a210d638ba4b9402e836c970fa2, type: 3}
   - {fileID: 5000210999076068843, guid: ce1469b185c9aa348bb2a055e6dcc0f7, type: 3}
@@ -11252,7 +11251,6 @@ MonoBehaviour:
   - {fileID: 8587713973174609844, guid: 5211e71d15de2e249b7745f3d7a6afe4, type: 3}
   - {fileID: 8720001268064069434, guid: 78c6245dbf4dc8743ac91347971ee3f1, type: 3}
   - {fileID: 7144248469089430455, guid: 5cb5bf2efb47fce45b5b2e7311b9a6fc, type: 3}
-  - {fileID: 1000012542722638, guid: 506edc0541ee4ecbbf1a545b24ced013, type: 3}
   - {fileID: 3357068366710454748, guid: cc5909c573e2f834e97b3488bb2902d0, type: 3}
   - {fileID: 3250310938253979280, guid: cbae9a210d638ba4b9402e836c970fa2, type: 3}
   - {fileID: 5000210999076068843, guid: ce1469b185c9aa348bb2a055e6dcc0f7, type: 3}

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/OptionsScreen.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/OptionsScreen.prefab
@@ -1,5 +1,82 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &449489849675795
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3707963288127977036}
+  - component: {fileID: 668100382221253009}
+  - component: {fileID: 2112899718473248297}
+  m_Layer: 5
+  m_Name: EnableChatBackground
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3707963288127977036
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 449489849675795}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 616976776852842882}
+  - {fileID: 7750989028159495074}
+  m_Father: {fileID: 3311291840069775786}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 715.77563, y: -2131.2874}
+  m_SizeDelta: {x: 1431.5513, y: 142.64862}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &668100382221253009
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 449489849675795}
+  m_CullTransparentMesh: 0
+--- !u!114 &2112899718473248297
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 449489849675795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.047058824}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &31039112921984205
 GameObject:
   m_ObjectHideFlags: 0
@@ -2956,7 +3033,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: -0.000061035156, y: -520.18005}
+  m_AnchoredPosition: {x: -0.000061035156, y: -454.5282}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &3279563441495495434
@@ -6305,8 +6382,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 7807788660649586917}
   m_HandleRect: {fileID: 1139529994206577920}
   m_Direction: 2
-  m_Value: 0.5120295
-  m_Size: 0.26888946
+  m_Value: 0.50638354
+  m_Size: 0.2615579
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -7315,6 +7392,103 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2062275869911403074
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7750989028159495074}
+  - component: {fileID: 609413153512122014}
+  m_Layer: 5
+  m_Name: Toggle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7750989028159495074
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2062275869911403074}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5085570710470308679}
+  m_Father: {fileID: 3707963288127977036}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5186986, y: 0.5}
+  m_AnchorMax: {x: 0.5186986, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -1.5074997}
+  m_SizeDelta: {x: 73.099976, y: 103}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &609413153512122014
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2062275869911403074}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 7187849925085160664}
+  toggleTransition: 1
+  graphic: {fileID: 5220010314155043798}
+  m_Group: {fileID: 0}
+  onValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 737317418037894760}
+        m_TargetAssemblyTypeName: Unitystation.Options.ThemeOptions, Assets
+        m_MethodName: OnChatEntryBackgroundToggle
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  m_IsOn: 0
 --- !u!1 &2093747371234768531
 GameObject:
   m_ObjectHideFlags: 0
@@ -10004,7 +10178,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 715.77563, y: -3337.9783}
+  m_AnchoredPosition: {x: 715.77563, y: -3531.687}
   m_SizeDelta: {x: 1431.5513, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5497985431822626865
@@ -11542,6 +11716,82 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &3144390295497877517
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5085570710470308679}
+  - component: {fileID: 7986121560473021608}
+  - component: {fileID: 7187849925085160664}
+  m_Layer: 5
+  m_Name: InputBox
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5085570710470308679
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3144390295497877517}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.6854, y: 1.6854, z: 1.6854}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3971767515621629340}
+  m_Father: {fileID: 7750989028159495074}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -2, y: -0.00005722046}
+  m_SizeDelta: {x: 29.47998, y: 30.009995}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7986121560473021608
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3144390295497877517}
+  m_CullTransparentMesh: 0
+--- !u!114 &7187849925085160664
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3144390295497877517}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: b3f0d976f6d6802479d6465d11b3aa68, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &3157073114649537602
 GameObject:
   m_ObjectHideFlags: 0
@@ -13711,6 +13961,7 @@ RectTransform:
   - {fileID: 256619098775286783}
   - {fileID: 2970395558945804799}
   - {fileID: 3852820661219802144}
+  - {fileID: 3707963288127977036}
   - {fileID: 6245620090485389360}
   - {fileID: 7709080864006530486}
   - {fileID: 3779528707920681505}
@@ -13724,7 +13975,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
   m_AnchoredPosition: {x: 32, y: -485.29282}
-  m_SizeDelta: {x: 1431.5513, y: 3387.9783}
+  m_SizeDelta: {x: 1431.5513, y: 3581.687}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2208241204637172415
 MonoBehaviour:
@@ -13917,7 +14168,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 715.77563, y: -3035.8582}
+  m_AnchoredPosition: {x: 715.77563, y: -3229.567}
   m_SizeDelta: {x: 1431.5513, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1329619467370058476
@@ -16926,7 +17177,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 715.77563, y: -2131.2874}
+  m_AnchoredPosition: {x: 715.77563, y: -2324.996}
   m_SizeDelta: {x: 1431.5513, y: 142.64862}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &363025347333863235
@@ -21989,7 +22240,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 715.77563, y: -2712.4136}
+  m_AnchoredPosition: {x: 715.77563, y: -2906.1223}
   m_SizeDelta: {x: 1431.5513, y: 142.64862}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1283328494420376818
@@ -23984,6 +24235,81 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
   m_IsOn: 1
+--- !u!1 &5054313151701746440
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3971767515621629340}
+  - component: {fileID: 8786176739626763719}
+  - component: {fileID: 5220010314155043798}
+  m_Layer: 5
+  m_Name: Checkmark
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3971767515621629340
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5054313151701746440}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5085570710470308679}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 30, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8786176739626763719
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5054313151701746440}
+  m_CullTransparentMesh: 0
+--- !u!114 &5220010314155043798
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5054313151701746440}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: a1e2921eff2065542be6ac778f4c8569, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &5092146018231533221
 GameObject:
   m_ObjectHideFlags: 0
@@ -24020,7 +24346,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 715.77563, y: -2324.996}
+  m_AnchoredPosition: {x: 715.77563, y: -2518.7048}
   m_SizeDelta: {x: 1431.5513, y: 142.64862}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1917222179063376777
@@ -24435,6 +24761,85 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Padding: {x: -8, y: -5, z: -8, w: -5}
   m_Softness: {x: 0, y: 0}
+--- !u!1 &5255887514638275687
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 616976776852842882}
+  - component: {fileID: 6848132686484167695}
+  - component: {fileID: 5715434159130827719}
+  m_Layer: 5
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &616976776852842882
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5255887514638275687}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3707963288127977036}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 369.62988, y: -1.5073242}
+  m_SizeDelta: {x: 631.87, y: -44.639}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6848132686484167695
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5255887514638275687}
+  m_CullTransparentMesh: 0
+--- !u!114 &5715434159130827719
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5255887514638275687}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 0
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 0
+    m_MaxSize: 34
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Chat Entries Always Have a Background:'
 --- !u!1 &5297655454560050381
 GameObject:
   m_ObjectHideFlags: 0
@@ -27217,8 +27622,8 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 4138299138101940902}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.3743502}
-  m_AnchorMax: {x: 1, y: 0.6432396}
+  m_AnchorMin: {x: 0, y: 0.37393492}
+  m_AnchorMax: {x: 1, y: 0.6354928}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -29317,8 +29722,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 5509754770975811987}
   m_HandleRect: {fileID: 1129184145592968099}
   m_Direction: 2
-  m_Value: 1
-  m_Size: 0.8756504
+  m_Value: 0.3807599
+  m_Size: 0.8980931
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -30599,6 +31004,7 @@ MonoBehaviour:
   chatBubbleClownColourToggle: {fileID: 7862198488392396367}
   HighlightToggle: {fileID: 1069442087302972574}
   chatHighlightToggle: {fileID: 5326794833485050631}
+  chatEntryBackgroundToggle: {fileID: 609413153512122014}
   mentionSoundToggle: {fileID: 2131679445502184789}
   mentionSoundDropdown: {fileID: 3845528380894983303}
   chatAlphaFadeMinimum: {fileID: 4573192463254389082}
@@ -33209,7 +33615,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 715.77563, y: -3186.9182}
+  m_AnchoredPosition: {x: 715.77563, y: -3380.627}
   m_SizeDelta: {x: 1431.5513, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5251995511064037086
@@ -34128,7 +34534,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 715.77563, y: -2884.798}
+  m_AnchoredPosition: {x: 715.77563, y: -3078.5068}
   m_SizeDelta: {x: 1431.5513, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3515408502858438618
@@ -36618,7 +37024,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 715.77563, y: -2518.7048}
+  m_AnchoredPosition: {x: 715.77563, y: -2712.4136}
   m_SizeDelta: {x: 1431.5513, y: 142.64862}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7740308410925256765

--- a/UnityProject/Assets/Scripts/Core/Chat/ChatEntry.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/ChatEntry.cs
@@ -38,6 +38,13 @@ namespace UI.Chat_UI
 		[SerializeField, BoxGroup("Stack Object")]
 		private Image stackImage = default;
 
+		[SerializeField, BoxGroup("Background")]
+		private Image entryBackground = default;
+
+		[SerializeField, BoxGroup("Background")]
+		private float maximumAlpha = 0.8f;
+
+
 		public RectTransform ViewportTransform { get; set; }
 
 		/// <summary>The current message of the <see cref="ChatEntry"/>.</summary>
@@ -356,6 +363,13 @@ namespace UI.Chat_UI
 			messageTextDark.CrossFadeAlpha(toAlpha, time, false);
 			stackText.CrossFadeAlpha(toAlpha, time, false);
 			stackImage.CrossFadeAlpha(toAlpha, time, false);
+			Debug.Log($"chat background always enabled: {PlayerPrefs.GetInt(PlayerPrefKeys.CHAT_BACKGROUND_ALLWAYS_ENABLED, 0)}");
+			//(Max): The alpha check is for when players disable this setting while one of the backgrounds is still visible.
+			//TODO: Add a check later if the background is custom set for templates to always display them.
+			if (PlayerPrefs.GetInt(PlayerPrefKeys.CHAT_BACKGROUND_ALLWAYS_ENABLED, 0) == 1 || toAlpha <= 0.01f)
+			{
+				entryBackground.CrossFadeAlpha(Mathf.Clamp(toAlpha, 0, maximumAlpha), time, false);
+			}
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/PlayerPrefs/PlayerPrefKeys.cs
+++ b/UnityProject/Assets/Scripts/PlayerPrefs/PlayerPrefKeys.cs
@@ -227,4 +227,6 @@
 	public static readonly string ThrowHoldPreference = "ThrowHoldPreference";
 
 	public static readonly string DefaultVoice = "TTSDefaultVoice";
+
+	public const string CHAT_BACKGROUND_ALLWAYS_ENABLED = "ChatBackgroundAllwaysEnabled";
 }

--- a/UnityProject/Assets/Scripts/Strings/ChatTemplates.cs
+++ b/UnityProject/Assets/Scripts/Strings/ChatTemplates.cs
@@ -15,15 +15,15 @@ namespace Strings
 		public const string Blue = "#0077ff";
 
 		public static readonly string CaptainAnnounce =
-			$"\n\n<color=white><size={ExtremelyLargeText}><b>Captain Announces</b></size></color>\n\n"
+			$"\n<color=white><size={ExtremelyLargeText}><b>Captain Announces</b></size></color>\n\n"
 			+ "<color=#FF151F><b>{0}</b></color>\n\n";
 
 		public static readonly string CentcomAnnounce =
-			$"\n\n<color=white><size={ExtremelyLargeText}><b>Central Command Update</b></size></color>\n\n"
+			$"\n<color=white><size={ExtremelyLargeText}><b>Central Command Update</b></size></color>\n\n"
 			+ "<color=#FF151F><b>{0}</b></color>\n\n";
 
 		public static readonly string PriorityAnnouncement =
-			$"\n\n<color=white><size={ExtremelyLargeText}><b>Priority Announcement</b></size></color>\n\n"
+			$"\n<color=white><size={ExtremelyLargeText}><b>Priority Announcement</b></size></color>\n\n"
 			+ "<color=#FF151F>{0}</color>\n\n";
 
 		public static readonly string ShuttleCallSub =

--- a/UnityProject/Assets/Scripts/UI/Core/OptionsMenu/ThemeOptions/ThemeOptions.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/OptionsMenu/ThemeOptions/ThemeOptions.cs
@@ -8,7 +8,6 @@ using TMPro;
 using UI;
 using UI.Chat_UI;
 using UnityEngine;
-using UnityEngine.Serialization;
 using UnityEngine.UI;
 
 namespace Unitystation.Options
@@ -42,6 +41,9 @@ namespace Unitystation.Options
 
 		[SerializeField]
 		private Toggle chatHighlightToggle = null;
+
+		[SerializeField]
+		private Toggle chatEntryBackgroundToggle = null;
 
 		[SerializeField]
 		private Toggle mentionSoundToggle = null;
@@ -99,6 +101,7 @@ namespace Unitystation.Options
 			HighlightToggle.isOn = Highlight.HighlightEnabled;
 			chatHighlightToggle.isOn = ThemeManager.ChatHighlight;
 			mentionSoundToggle.isOn = ThemeManager.MentionSound;
+			chatEntryBackgroundToggle.isOn = PlayerPrefs.GetInt(PlayerPrefKeys.CHAT_BACKGROUND_ALLWAYS_ENABLED, 0) == 1;
 
 			chatBubbleSizeSlider.value = DisplaySettings.Instance.ChatBubbleSize;
 			chatBubbleInstantToggle.isOn = DisplaySettings.Instance.ChatBubbleInstant == 1;
@@ -302,6 +305,12 @@ namespace Unitystation.Options
 		public void OnChatBubbleNumber()
 		{
 			ChatBubble.SetPreferenceNummberBubbles(Mathf.RoundToInt(NumberOfBubblesSlider.value));
+		}
+
+		public void OnChatEntryBackgroundToggle()
+		{
+			PlayerPrefs.SetInt(PlayerPrefKeys.CHAT_BACKGROUND_ALLWAYS_ENABLED, chatEntryBackgroundToggle.isOn ? 1 : 0);
+			PlayerPrefs.Save();
 		}
 	}
 }


### PR DESCRIPTION
This PR was meant to be a bit bigger, but because I kept having issues with adding custom backgrounds for templates for so long, I decided to split this PR into one for the accessibility bits, and another for the extra features later in the future.

You can enable chat entry backgrounds from the options screen under the theme category.

### Changelog:

CL: [New] Added a new accessibility setting under the themes' category that enables backgrounds for chat entries.