### PR TITLE
Add a Sync for animations

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
@@ -174,6 +174,7 @@ namespace Doors
 				openSortingLayer = SortingLayer.NameToID("Machines");
 			}
 
+			doorAnimator.SyncDoorStatus(doorAnimator.SyncDoorUpdateType, DoorAnimatorV2.DoorUpdateType.Close);
 		}
 
 		public void OnSpawnServer(SpawnInfo info)

--- a/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
@@ -516,7 +516,7 @@ namespace Doors
 			}
 			else
 			{
-				soundController.PlaySound(DoorSoundController.DoorSoundType.Close);
+				soundController.ServerPlaySound(DoorSoundController.DoorSoundType.Close);
 			}
 		}
 
@@ -550,7 +550,7 @@ namespace Doors
 			}
 			else
 			{
-				soundController.PlaySound(DoorSoundController.DoorSoundType.Open);
+				soundController.ServerPlaySound(DoorSoundController.DoorSoundType.Open);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/Doors/DoorSoundController.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/DoorSoundController.cs
@@ -95,19 +95,6 @@ namespace Doors
             }
             return toPlay;
         }
-
-        public void PlaySound(DoorSoundType sound)
-        {
-            StopSound();
-            AddressableAudioSource toPlay = GetSound(sound);
-
-            if (toPlay != null)
-            {
-                soundGuid = Guid.NewGuid().ToString();
-                _ = SoundManager.PlayAtPosition(toPlay, gameObject.AssumedWorldPosServer(), gameObject, soundGuid);
-            }
-
-        }
                 
         public void ServerPlaySound(DoorSoundType sound)
         {


### PR DESCRIPTION
### Purpose
Adds syncing the door animation state at server start, they were in a not-open but not-closed state.  Fixed an audio issue where sounds would sometimes not play for the client.

### Notes:
Before my previous PR The sync issue was actually causing a very small delay of a few frames when first opening doors at the start of the round, I had always attributed to lag from loading in but it was actually the same bug.  Of course, when I made it so doors don't let you walk through them until half way through their animation and bumps have delay now as well, the few frames of lag turned into a full half second or more depending on the door.  Not sure how I missed that.  The sound bug was from when I moved the code over from door animator, I guess because it is a sync function it was able to use the PlaySound function without any issue, but moving off of a sync function caused it to not work right, so I just removed the function.

### Changelog:
CL: [Fix] Doors are now properly synced with clients

