### PR TITLE
Doorfix

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Construction/Girder.cs
+++ b/UnityProject/Assets/Scripts/Objects/Construction/Girder.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections;
+using System.Collections.Generic;
 using Core;
 using UnityEngine;
 using Mirror;
@@ -206,31 +207,42 @@ namespace Objects.Construction
 		[Server]
 		private void ReinforceGirder(HandApply interaction)
 		{
-			interaction.HandObject.GetComponent<Stackable>().ServerConsume(1);
-			Spawn.ServerPrefab(reinforcedGirder, SpawnDestination.At(gameObject));
-			_ = Despawn.ServerSingle(gameObject);
+			StartCoroutine(SyncSpawn(interaction, reinforcedGirder, 1));
 		}
 
 		[Server]
 		private void ConstructFalseWall(HandApply interaction)
 		{
-			GameObject theWall = Spawn.ServerPrefab(FalseWall, SpawnDestination.At(gameObject)).GameObject;
-			DoorMasterController doorController = theWall.GetComponent<DoorMasterController>();
-			tileChangeManager.MetaTileMap.SetTile(registerObject.LocalPositionServer, falseTile);
-			interaction.HandObject.GetComponent<Stackable>().ServerConsume(2);
-			_ = Despawn.ServerSingle(gameObject);
-			doorController.TryClose();
+			StartCoroutine(SyncSpawn(interaction, FalseWall, 2));
 		}
 
 		[Server]
 		private void ConstructReinforcedFalseWall(HandApply interaction)
 		{
-			GameObject theWall = Spawn.ServerPrefab(FalseReinforcedWall, SpawnDestination.At(gameObject)).GameObject;
-			DoorMasterController doorController = theWall.GetComponent<DoorMasterController>();
-			tileChangeManager.MetaTileMap.SetTile(registerObject.LocalPositionServer, falseTile);
-			interaction.HandObject.GetComponent<Stackable>().ServerConsume(2);
-			_ = Despawn.ServerSingle(gameObject);
-			doorController.TryClose();
+			StartCoroutine(SyncSpawn(interaction, FalseReinforcedWall, 2));
 		}
+
+		/// <summary>
+		/// Waits for the girder to despawn before spawning the desired object
+		/// </summary>
+		/// <param name="interaction">The HandApply action that doing the constructing</param>
+		/// <param name="toSpawn">What we are constructing</param>
+		/// <param name="toConsume">How many resources to consume from the active hand slot</param>
+		IEnumerator SyncSpawn(HandApply interaction, GameObject toSpawn, int toConsume)
+		{
+			interaction.HandObject.GetComponent<Stackable>().ServerConsume(toConsume);
+			SpawnDestination destination = SpawnDestination.At(gameObject);
+			yield return _ = Despawn.ServerSingle(gameObject);
+			GameObject spawned = Spawn.ServerPrefab(toSpawn, destination).GameObject;
+			
+			//Some extra logic to get that Open -> Close animation for the FalseWalls spawning
+			//We want this rather than spawning the door closed so the builder can see they did it right
+			if(toSpawn == FalseReinforcedWall || toSpawn == FalseWall)
+			{
+				DoorMasterController doorController = spawned.GetComponent<DoorMasterController>();
+                tileChangeManager.MetaTileMap.SetTile(registerObject.LocalPositionServer, falseTile);
+				doorController.Close();
+            }
+        }
 	}
 }

--- a/UnityProject/Assets/Scripts/Objects/Construction/Girder.cs
+++ b/UnityProject/Assets/Scripts/Objects/Construction/Girder.cs
@@ -207,42 +207,31 @@ namespace Objects.Construction
 		[Server]
 		private void ReinforceGirder(HandApply interaction)
 		{
-			StartCoroutine(SyncSpawn(interaction, reinforcedGirder, 1));
+			interaction.HandObject.GetComponent<Stackable>().ServerConsume(1);
+			Spawn.ServerPrefab(reinforcedGirder, SpawnDestination.At(gameObject));
+			_ = Despawn.ServerSingle(gameObject);
 		}
 
 		[Server]
 		private void ConstructFalseWall(HandApply interaction)
 		{
-			StartCoroutine(SyncSpawn(interaction, FalseWall, 2));
+			GameObject theWall = Spawn.ServerPrefab(FalseWall, SpawnDestination.At(gameObject)).GameObject;
+			DoorMasterController doorController = theWall.GetComponent<DoorMasterController>();
+			tileChangeManager.MetaTileMap.SetTile(registerObject.LocalPositionServer, falseTile);
+			interaction.HandObject.GetComponent<Stackable>().ServerConsume(2);
+			doorController.Close();
+			_ = Despawn.ServerSingle(gameObject);
 		}
 
 		[Server]
 		private void ConstructReinforcedFalseWall(HandApply interaction)
 		{
-			StartCoroutine(SyncSpawn(interaction, FalseReinforcedWall, 2));
+			GameObject theWall = Spawn.ServerPrefab(FalseReinforcedWall, SpawnDestination.At(gameObject)).GameObject;
+			DoorMasterController doorController = theWall.GetComponent<DoorMasterController>();
+			tileChangeManager.MetaTileMap.SetTile(registerObject.LocalPositionServer, falseTile);
+			interaction.HandObject.GetComponent<Stackable>().ServerConsume(2);
+			doorController.Close();
+			_ = Despawn.ServerSingle(gameObject);
 		}
-
-		/// <summary>
-		/// Waits for the girder to despawn before spawning the desired object
-		/// </summary>
-		/// <param name="interaction">The HandApply action that doing the constructing</param>
-		/// <param name="toSpawn">What we are constructing</param>
-		/// <param name="toConsume">How many resources to consume from the active hand slot</param>
-		IEnumerator SyncSpawn(HandApply interaction, GameObject toSpawn, int toConsume)
-		{
-			interaction.HandObject.GetComponent<Stackable>().ServerConsume(toConsume);
-			SpawnDestination destination = SpawnDestination.At(gameObject);
-			yield return _ = Despawn.ServerSingle(gameObject);
-			GameObject spawned = Spawn.ServerPrefab(toSpawn, destination).GameObject;
-			
-			//Some extra logic to get that Open -> Close animation for the FalseWalls spawning
-			//We want this rather than spawning the door closed so the builder can see they did it right
-			if(toSpawn == FalseReinforcedWall || toSpawn == FalseWall)
-			{
-				DoorMasterController doorController = spawned.GetComponent<DoorMasterController>();
-                tileChangeManager.MetaTileMap.SetTile(registerObject.LocalPositionServer, falseTile);
-				doorController.Close();
-            }
-        }
 	}
 }

--- a/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
@@ -174,6 +174,7 @@ namespace Doors
 				openSortingLayer = SortingLayer.NameToID("Machines");
 			}
 
+			doorAnimator.SyncDoorStatus(doorAnimator.SyncDoorUpdateType, DoorAnimatorV2.DoorUpdateType.Close);
 		}
 
 		public void OnSpawnServer(SpawnInfo info)

--- a/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
@@ -209,7 +209,7 @@ namespace Doors
 		{
 			var firelock = matrix.GetFirst<FireLock>(registerTile.LocalPositionServer, true);
 			if (firelock != null && firelock.fireAlarm.activated && firelock.DoorMasterController.IsClosed) return;
-			if (!isAutomatic || !allowInput)
+			if (isAutomatic == false || allowInput == false)
 			{
 				return;
 			}
@@ -222,7 +222,7 @@ namespace Doors
 			}
 
 
-			if (!isPerformingAction && CheckStatusAllow(states))
+			if (isPerformingAction == false && CheckStatusAllow(states))
 			{
 				TryOpen(byPlayer);
 			}
@@ -290,7 +290,7 @@ namespace Doors
 				module.OpenInteraction(interaction, states);
 			}
 			// If there is nothing preventing the door from closing, try closing it
-			if (!isPerformingAction && CheckStatusAllow(states) && allowInteraction)
+			if (isPerformingAction == false && CheckStatusAllow(states) && allowInteraction)
 			{
 				if (clickDisablesAutoClose)
 				{
@@ -302,7 +302,7 @@ namespace Doors
 
 			// If we can't close the door because we are taking an action other than closing a door, don't send a message
 			// Otherwise, send a message explaining why we can't close the door
-			if (!states.Contains(DoorProcessingStates.PreventSilently))
+			if (states.Contains(DoorProcessingStates.PreventSilently) == false)
 			{
 				AddChatTryInteractMessage(interaction, states);
 			}
@@ -322,7 +322,7 @@ namespace Doors
 			}
 
 			// If there is nothing preventing the door from opening, try opening it
-			if (!isPerformingAction && CheckStatusAllow(states) && allowInteraction)
+			if (isPerformingAction == false && CheckStatusAllow(states) && allowInteraction)
 			{
 				if (clickDisablesAutoClose)
 				{
@@ -335,7 +335,7 @@ namespace Doors
 
 			// If we can't open the door because we are taking an action other than opening a door, don't send a message
 			// Otherwise, send a message explaining why we can't open the door
-			if (!states.Contains(DoorProcessingStates.PreventSilently))
+			if (states.Contains(DoorProcessingStates.PreventSilently) == false)
 			{
 				AddChatTryInteractMessage(interaction, states);
 			}
@@ -377,16 +377,23 @@ namespace Doors
 			}
 		}
 
-		public void TryOpen(GameObject originator, bool blockClosing = false)
+		/// <summary>
+		/// Checks if there is a firelock in place, returns false if there is no firelock
+		/// </summary>
+		public bool CheckFirelock()
 		{
-			if (!IsClosed) return; //Can't open if we are open. Figures.
 			if (isFireLock == false)
 			{
 				var fireLock = matrix.GetFirst<FireLock>(registerTile.LocalPositionServer, true);
-				if (fireLock != null && fireLock.fireAlarm.activated && fireLock.DoorMasterController.IsClosed) return;
+				if (fireLock != null && fireLock.fireAlarm.activated && fireLock.DoorMasterController.IsClosed) return true;
 			}
+			return false;
+		}
 
-			if(isPerformingAction) return;
+		public void TryOpen(GameObject originator, bool blockClosing = false)
+		{
+			//Can't open the door if its already open, in motion, or if there is a firelock in place
+			if (IsClosed == false || CheckFirelock() == true || isPerformingAction == true) return;
 
 			Open(blockClosing);
 		}
@@ -398,7 +405,8 @@ namespace Doors
 		/// </summary>
 		public bool TryForceOpen()
 		{
-			if (!IsClosed) return false; //Can't open if we are open. Figures.
+			//Can't open the door if its already open, in motion, or if there is a firelock in place
+			if (IsClosed == false || CheckFirelock() == true || isPerformingAction == true) return false;
 
 			HashSet<DoorProcessingStates> states = new HashSet<DoorProcessingStates>();
 
@@ -424,7 +432,8 @@ namespace Doors
 		/// </summary>
 		public void TryForceClose()
 		{
-			if (IsClosed) return; //Can't close if we are closed. Figures.
+			//Can't close the door if its already closed, in motion, or if there is a firelock in place
+			if (IsClosed == true || CheckFirelock() == true || isPerformingAction == true) return;
 
 			HashSet<DoorProcessingStates> states = new HashSet<DoorProcessingStates>();
 
@@ -437,6 +446,16 @@ namespace Doors
 
 			Close(true);
 		}
+
+		public void PulseTryOpen(GameObject inoriginator = null, bool inforce = false, bool inOverrideLogic = false)
+		{
+			originator = inoriginator;
+			force = inforce;
+			OverrideLogic = inOverrideLogic;
+
+			HackingProcessBase.ImpulsePort(TryClose);
+		}
+
 
 		public void PulseTryClose(GameObject inoriginator = null, bool inforce = false, bool inOverrideLogic = false)
 		{
@@ -454,12 +473,11 @@ namespace Doors
 
 		public void TryClose()
 		{
-			if (IsClosed) return; //Can't close if we are closed. Figures.
-			if(isPerformingAction) return;
+			//Can't close the door if its already closed, in motion, or if there is a firelock in place
+			if (IsClosed == true || CheckFirelock() == true || isPerformingAction == true) return;
 
 			// Sliding door is not passable according to matrix
-			if (!isPerformingAction &&
-				(ignorePassableChecks || matrix.CanCloseDoorAt(registerTile.LocalPositionServer, true)) &&
+			if ((ignorePassableChecks || matrix.CanCloseDoorAt(registerTile.LocalPositionServer, true)) &&
 				(HasPower || force))
 
 			{
@@ -494,7 +512,7 @@ namespace Doors
 
 		public void Close(bool byForce = false)
 		{
-			if (!gameObject) return; // probably destroyed by a shuttle crash
+			if (gameObject == false) return; // probably destroyed by a shuttle crash
 			UpdateGui();
 			
 			doorAnimator.LightsWork = !byForce;
@@ -513,9 +531,9 @@ namespace Doors
 
 		public void Open(bool byForce = false)
 		{
-			if (!gameObject) return;  // probably destroyed by a shuttle crash
+			if (gameObject == false) return;  // probably destroyed by a shuttle crash
 
-			if (!BlockAutoClose)
+			if (BlockAutoClose == false)
 			{
 				ResetWaiting();
 			}
@@ -675,8 +693,8 @@ namespace Doors
 			// the below logic and reopen the door if the client got stuck in the door in the .15 s gap.
 
 			//only do this check when door is closing, and only for doors that block all directions (like airlocks)
-			if (!CustomNetworkManager.IsServer ||
-				!IsClosed ||
+			if (CustomNetworkManager.IsServer == false ||
+				IsClosed == false ||
 				registerTile.OneDirectionRestricted ||
 				ignorePassableChecks)
 			{

--- a/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
@@ -176,14 +176,8 @@ namespace Doors
 
 			if (CustomNetworkManager.IsServer == true)
             {
-                if (IsClosed)
-				{
-					Close();
-				}
-				else
-				{
-					Open();
-				}
+                if (IsClosed) Close();
+				else Open();
             }
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
@@ -516,7 +516,7 @@ namespace Doors
 			}
 			else
 			{
-				soundController.PlaySound(DoorSoundController.DoorSoundType.Close);
+				soundController.ServerPlaySound(DoorSoundController.DoorSoundType.Close);
 			}
 		}
 
@@ -550,7 +550,7 @@ namespace Doors
 			}
 			else
 			{
-				soundController.PlaySound(DoorSoundController.DoorSoundType.Open);
+				soundController.ServerPlaySound(DoorSoundController.DoorSoundType.Open);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
@@ -169,10 +169,6 @@ namespace Doors
 
 			soundController = GetComponent<DoorSoundController>();
 
-			if (CustomNetworkManager.IsServer)
-            {
-                
-            }
 			if (UseMachinesForOpenLayeer)
 			{
 				openSortingLayer = SortingLayer.NameToID("Machines");

--- a/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
@@ -169,19 +169,26 @@ namespace Doors
 
 			soundController = GetComponent<DoorSoundController>();
 
+			if (CustomNetworkManager.IsServer)
+            {
+                
+            }
 			if (UseMachinesForOpenLayeer)
 			{
 				openSortingLayer = SortingLayer.NameToID("Machines");
 			}
 
-			if (IsClosed)
-			{
-				Close();
-			}
-			else
-			{
-				Open();
-			}
+			if (CustomNetworkManager.IsServer == true)
+            {
+                if (IsClosed)
+				{
+					Close();
+				}
+				else
+				{
+					Open();
+				}
+            }
 		}
 
 		public void OnSpawnServer(SpawnInfo info)
@@ -209,7 +216,7 @@ namespace Doors
 		{
 			var firelock = matrix.GetFirst<FireLock>(registerTile.LocalPositionServer, true);
 			if (firelock != null && firelock.fireAlarm.activated && firelock.DoorMasterController.IsClosed) return;
-			if (isAutomatic == false || allowInput == false)
+			if (!isAutomatic || !allowInput)
 			{
 				return;
 			}
@@ -222,7 +229,7 @@ namespace Doors
 			}
 
 
-			if (isPerformingAction == false && CheckStatusAllow(states))
+			if (!isPerformingAction && CheckStatusAllow(states))
 			{
 				TryOpen(byPlayer);
 			}
@@ -290,7 +297,7 @@ namespace Doors
 				module.OpenInteraction(interaction, states);
 			}
 			// If there is nothing preventing the door from closing, try closing it
-			if (isPerformingAction == false && CheckStatusAllow(states) && allowInteraction)
+			if (!isPerformingAction && CheckStatusAllow(states) && allowInteraction)
 			{
 				if (clickDisablesAutoClose)
 				{
@@ -302,7 +309,7 @@ namespace Doors
 
 			// If we can't close the door because we are taking an action other than closing a door, don't send a message
 			// Otherwise, send a message explaining why we can't close the door
-			if (states.Contains(DoorProcessingStates.PreventSilently) == false)
+			if (!states.Contains(DoorProcessingStates.PreventSilently))
 			{
 				AddChatTryInteractMessage(interaction, states);
 			}
@@ -322,7 +329,7 @@ namespace Doors
 			}
 
 			// If there is nothing preventing the door from opening, try opening it
-			if (isPerformingAction == false && CheckStatusAllow(states) && allowInteraction)
+			if (!isPerformingAction && CheckStatusAllow(states) && allowInteraction)
 			{
 				if (clickDisablesAutoClose)
 				{
@@ -335,7 +342,7 @@ namespace Doors
 
 			// If we can't open the door because we are taking an action other than opening a door, don't send a message
 			// Otherwise, send a message explaining why we can't open the door
-			if (states.Contains(DoorProcessingStates.PreventSilently) == false)
+			if (!states.Contains(DoorProcessingStates.PreventSilently))
 			{
 				AddChatTryInteractMessage(interaction, states);
 			}
@@ -377,23 +384,16 @@ namespace Doors
 			}
 		}
 
-		/// <summary>
-		/// Checks if there is a firelock in place, returns false if there is no firelock
-		/// </summary>
-		public bool CheckFirelock()
+		public void TryOpen(GameObject originator, bool blockClosing = false)
 		{
+			if (!IsClosed) return; //Can't open if we are open. Figures.
 			if (isFireLock == false)
 			{
 				var fireLock = matrix.GetFirst<FireLock>(registerTile.LocalPositionServer, true);
-				if (fireLock != null && fireLock.fireAlarm.activated && fireLock.DoorMasterController.IsClosed) return true;
+				if (fireLock != null && fireLock.fireAlarm.activated && fireLock.DoorMasterController.IsClosed) return;
 			}
-			return false;
-		}
 
-		public void TryOpen(GameObject originator, bool blockClosing = false)
-		{
-			//Can't open the door if its already open, in motion, or if there is a firelock in place
-			if (IsClosed == false || CheckFirelock() == true || isPerformingAction == true) return;
+			if(isPerformingAction) return;
 
 			Open(blockClosing);
 		}
@@ -405,8 +405,7 @@ namespace Doors
 		/// </summary>
 		public bool TryForceOpen()
 		{
-			//Can't open the door if its already open, in motion, or if there is a firelock in place
-			if (IsClosed == false || CheckFirelock() == true || isPerformingAction == true) return false;
+			if (!IsClosed) return false; //Can't open if we are open. Figures.
 
 			HashSet<DoorProcessingStates> states = new HashSet<DoorProcessingStates>();
 
@@ -432,8 +431,7 @@ namespace Doors
 		/// </summary>
 		public void TryForceClose()
 		{
-			//Can't close the door if its already closed, in motion, or if there is a firelock in place
-			if (IsClosed == true || CheckFirelock() == true || isPerformingAction == true) return;
+			if (IsClosed) return; //Can't close if we are closed. Figures.
 
 			HashSet<DoorProcessingStates> states = new HashSet<DoorProcessingStates>();
 
@@ -446,16 +444,6 @@ namespace Doors
 
 			Close(true);
 		}
-
-		public void PulseTryOpen(GameObject inoriginator = null, bool inforce = false, bool inOverrideLogic = false)
-		{
-			originator = inoriginator;
-			force = inforce;
-			OverrideLogic = inOverrideLogic;
-
-			HackingProcessBase.ImpulsePort(TryClose);
-		}
-
 
 		public void PulseTryClose(GameObject inoriginator = null, bool inforce = false, bool inOverrideLogic = false)
 		{
@@ -473,11 +461,12 @@ namespace Doors
 
 		public void TryClose()
 		{
-			//Can't close the door if its already closed, in motion, or if there is a firelock in place
-			if (IsClosed == true || CheckFirelock() == true || isPerformingAction == true) return;
+			if (IsClosed) return; //Can't close if we are closed. Figures.
+			if(isPerformingAction) return;
 
 			// Sliding door is not passable according to matrix
-			if ((ignorePassableChecks || matrix.CanCloseDoorAt(registerTile.LocalPositionServer, true)) &&
+			if (!isPerformingAction &&
+				(ignorePassableChecks || matrix.CanCloseDoorAt(registerTile.LocalPositionServer, true)) &&
 				(HasPower || force))
 
 			{
@@ -512,7 +501,7 @@ namespace Doors
 
 		public void Close(bool byForce = false)
 		{
-			if (gameObject == false) return; // probably destroyed by a shuttle crash
+			if (!gameObject) return; // probably destroyed by a shuttle crash
 			UpdateGui();
 			
 			doorAnimator.LightsWork = !byForce;
@@ -531,9 +520,9 @@ namespace Doors
 
 		public void Open(bool byForce = false)
 		{
-			if (gameObject == false) return;  // probably destroyed by a shuttle crash
+			if (!gameObject) return;  // probably destroyed by a shuttle crash
 
-			if (BlockAutoClose == false)
+			if (!BlockAutoClose)
 			{
 				ResetWaiting();
 			}
@@ -693,8 +682,8 @@ namespace Doors
 			// the below logic and reopen the door if the client got stuck in the door in the .15 s gap.
 
 			//only do this check when door is closing, and only for doors that block all directions (like airlocks)
-			if (CustomNetworkManager.IsServer == false ||
-				IsClosed == false ||
+			if (!CustomNetworkManager.IsServer ||
+				!IsClosed ||
 				registerTile.OneDirectionRestricted ||
 				ignorePassableChecks)
 			{

--- a/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
@@ -174,7 +174,14 @@ namespace Doors
 				openSortingLayer = SortingLayer.NameToID("Machines");
 			}
 
-			doorAnimator.SyncDoorStatus(doorAnimator.SyncDoorUpdateType, DoorAnimatorV2.DoorUpdateType.Close);
+			if (IsClosed)
+			{
+				Close();
+			}
+			else
+			{
+				Open();
+			}
 		}
 
 		public void OnSpawnServer(SpawnInfo info)
@@ -183,18 +190,6 @@ namespace Doors
 			HackingProcessBase.RegisterPort(TryBump, this.GetType());
 			HackingProcessBase.RegisterPort(TryClose, this.GetType());
 			HackingProcessBase.RegisterPort(ConfirmAIConnection, this.GetType());
-			if (CustomNetworkManager.IsServer)
-			{
-				if (IsClosed)
-				{
-					Close();
-				}
-				else
-				{
-					Open();
-				}
-
-			}
 		}
 
 
@@ -320,7 +315,6 @@ namespace Doors
 		/// <param name="interaction"></param>
 		public void ClosedInteraction(HandApply interaction)
 		{
-			bool canOpen = true;
 			HashSet<DoorProcessingStates> states = new HashSet<DoorProcessingStates>();
 			foreach (DoorModuleBase module in modulesList)
 			{
@@ -385,6 +379,7 @@ namespace Doors
 
 		public void TryOpen(GameObject originator, bool blockClosing = false)
 		{
+			if (!IsClosed) return; //Can't open if we are open. Figures.
 			if (isFireLock == false)
 			{
 				var fireLock = matrix.GetFirst<FireLock>(registerTile.LocalPositionServer, true);
@@ -459,6 +454,7 @@ namespace Doors
 
 		public void TryClose()
 		{
+			if (IsClosed) return; //Can't close if we are closed. Figures.
 			if(isPerformingAction) return;
 
 			// Sliding door is not passable according to matrix
@@ -498,16 +494,11 @@ namespace Doors
 
 		public void Close(bool byForce = false)
 		{
-			if (IsClosed == true) return;
-
 			if (!gameObject) return; // probably destroyed by a shuttle crash
-			if (isPerformingAction) return;
-
 			UpdateGui();
 			
 			doorAnimator.LightsWork = !byForce;
 			doorAnimator.PanelOpen = ConstructibleDoor != null && ConstructibleDoor.Panelopen;
-
 			doorAnimator.SyncDoorStatus(doorAnimator.SyncDoorUpdateType,DoorAnimatorV2.DoorUpdateType.Close);
 
 			if(byForce)
@@ -522,15 +513,7 @@ namespace Doors
 
 		public void Open(bool byForce = false)
 		{
-			if (IsClosed == false) return;
-
-			if (isFireLock == false)
-			{
-				var fireLock = matrix.GetFirst<FireLock>(registerTile.LocalPositionServer, true);
-				if (fireLock != null && fireLock.fireAlarm.activated && fireLock.DoorMasterController.IsClosed) return;
-			}
-
-			if (!this || !gameObject) return; // probably destroyed by a shuttle crash
+			if (!gameObject) return;  // probably destroyed by a shuttle crash
 
 			if (!BlockAutoClose)
 			{

--- a/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
@@ -508,7 +508,6 @@ namespace Doors
 			else
 			{
 				soundController.ServerPlaySound(DoorSoundController.DoorSoundType.Close);
-				soundController.ServerPlaySound(DoorSoundController.DoorSoundType.Close);
 			}
 		}
 
@@ -534,7 +533,6 @@ namespace Doors
 			}
 			else
 			{
-				soundController.ServerPlaySound(DoorSoundController.DoorSoundType.Open);
 				soundController.ServerPlaySound(DoorSoundController.DoorSoundType.Open);
 			}
 		}

--- a/UnityProject/Assets/Scripts/Objects/Doors/DoorSoundController.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/DoorSoundController.cs
@@ -95,19 +95,6 @@ namespace Doors
             }
             return toPlay;
         }
-
-        public void PlaySound(DoorSoundType sound)
-        {
-            StopSound();
-            AddressableAudioSource toPlay = GetSound(sound);
-
-            if (toPlay != null)
-            {
-                soundGuid = Guid.NewGuid().ToString();
-                _ = SoundManager.PlayAtPosition(toPlay, gameObject.AssumedWorldPosServer(), gameObject, soundGuid);
-            }
-
-        }
                 
         public void ServerPlaySound(DoorSoundType sound)
         {


### PR DESCRIPTION
### Purpose
Fixes a couple of bugs from my recent door changes related to doors that spawn on the server open.  Adjusts how girder works to wait for the girder to despawn before spawning the object that is being built.

### Notes:
The door code is full of a lot of fiddly older code, a lot of redundant checks and some orphaned booleans that aren't actually doing anything. I am working on a refactor to make it a bit more intuitive, should be done in a few days if life doesn't get in the way.  This included some of that because it was related to the issue, I removed the non-essential checks from Open() and Close(), those functions will now close/open the door no matter what, the logic for firelocks and whether the door is already opened and what not is now solely on the TryOpen and TryClosed functions, so use those if you want to check for those kind of things, use close/open if you just want the server to close the darned thing.

Continue to @ me on discord if anything spots anything related to doors.
