### PR TITLE
Update emag interactions to be a bit more clear

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Cards/Emag.cs
+++ b/UnityProject/Assets/Scripts/Items/Cards/Emag.cs
@@ -4,6 +4,8 @@ using AddressableReferences;
 using Core.Admin.Logs;
 using UnityEngine;
 using Mirror;
+using Systems.Explosions;
+using Util.Independent.FluentRichText;
 
 namespace Items
 {
@@ -100,9 +102,24 @@ namespace Items
 
 		public bool UseCharge(GameObject TargetObject, GameObject Performer)
 		{
-			Chat.AddActionMsgToChat(Performer,
-				$"You wave the Emag over the {TargetObject.ExpensiveName()}'s electrical panel.",
-				$"{Performer.ExpensiveName()} waves something over the {TargetObject.ExpensiveName()}'s electrical panel.");
+			var chargeUsed = UseChargeLogic(Performer);
+			if (chargeUsed)
+			{
+				Chat.AddActionMsgToChat(
+					Performer,
+					$"You wave the emag over the {TargetObject.ExpensiveName()}'s electrical panel, and it emits a satisfying electrical pop while the number {charges.ToString().Color(Color.green)} flashes in green.",
+					$"{Performer.ExpensiveName()} waves something over the {TargetObject.ExpensiveName()}'s electrical panel."
+					);
+				SparkUtil.TrySpark(Performer);
+			}
+			else
+			{
+				Chat.AddActionMsgToChat(
+					Performer,
+					$"You wave the emag over the {TargetObject.ExpensiveName()}'s electrical panel, but nothing happens as the emag's components flash the number {charges.ToString().Color(Color.red)} in red.",
+					$"{Performer.ExpensiveName()} waves something over the {TargetObject.ExpensiveName()}'s electrical panel."
+					);
+			}
 			return UseChargeLogic(Performer);
 		}
 
@@ -110,13 +127,7 @@ namespace Items
 		{
 			if (Charges > 0)
 			{
-				//if this is the first charge taken off, add recharge loop
-				if (Charges >= startCharges)
-				{
-					UpdateManager.Add(RegenerateCharge, rechargeTimeInSeconds);
-				}
-
-				SyncCharges(Charges, Charges - 1);
+				charges = Charges - 1;
 				if (Charges > 0)
 				{
 					spriteHandler.SetCatalogueIndexSprite(ScaleChargesToSpriteIndex());
@@ -125,6 +136,12 @@ namespace Items
 				{
 					SoundManager.PlayNetworkedForPlayer(recipient: Performer, OutOfChargesSFXA, sourceObj: gameObject);
 					spriteHandler.Empty();
+				}
+
+				//if this is the first charge taken off, add recharge loop
+				if (Charges < startCharges || Charges == 0)
+				{
+					UpdateManager.Add(RegenerateCharge, rechargeTimeInSeconds);
 				}
 
 				return true;

--- a/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/DoorMasterController.cs
@@ -304,9 +304,9 @@ namespace Doors
 			foreach (DoorModuleBase module in modulesList)
 			{
 				if (IsClosed)
-					module.ClosedInteraction(interaction, states);
+					module.ClosedInteraction(interaction, ref states);
 				else
-					module.OpenInteraction(interaction, states);
+					module.OpenInteraction(interaction, ref states);
 			}
 
 			// Forcing the door only cares about physical blocking states
@@ -388,7 +388,7 @@ namespace Doors
 			HashSet<DoorProcessingStates> states = new HashSet<DoorProcessingStates>();
 			foreach (var module in modulesList)
 			{
-				module.BumpingInteraction(originator, states);
+				module.BumpingInteraction(originator, ref states);
 			}
 			return states;
 		}
@@ -689,7 +689,7 @@ namespace Doors
 			isPerformingAction = false;
 
 			// Check if the door is closing on something, and reopen it if so.
-			// Only do this check if: we are the server, the door isn't allowed to close on things, 
+			// Only do this check if: we are the server, the door isn't allowed to close on things,
 			// the door is closing, and the door blocks all directions (eg airlocks)
 			if (CustomNetworkManager.IsServer && ignorePassableChecks == false && CanCloseDoor() == false && IsClosed &&
 				registerTile.OneDirectionRestricted == false && MatrixManager.IsPassableAtAllMatrices(worldPosition,
@@ -843,7 +843,7 @@ namespace Doors
 				//TODO: AI does not have access, if that changes also change this to go off of connected player;
 				PulseTryOpen(bypassSoftware: true);
 
-				// Tells the AI if the door is miswired. We pulse the door anyway in case of hacking shennanigans, 
+				// Tells the AI if the door is miswired. We pulse the door anyway in case of hacking shennanigans,
 				// but the AI player should get some feedback as to why the door didn't open when they clicked
 				if (HackingProcessBase.HasConnection(Open) == false)
 					Chat.AddExamineMsgFromServer(performer, $"The {DoorName} is wired incorrectly and wont open");
@@ -860,7 +860,7 @@ namespace Doors
 				//TODO: AI does not have access, if that gets fix change this to PulseTryOpen(performer);
 				PulseTryClose(bypassSoftware: true);
 
-				// Tells the AI if the door is miswired. We pulse the door anyway in case of hacking shennanigans, 
+				// Tells the AI if the door is miswired. We pulse the door anyway in case of hacking shennanigans,
 				// but the AI player should get some feedback as to why the door didn't close when they clicked
 				if (HackingProcessBase.HasConnection(Close) == false)
 					Chat.AddExamineMsgFromServer(performer, $"The {DoorName} is wired incorrectly and wont close");

--- a/UnityProject/Assets/Scripts/Objects/Doors/Modules/AccessModule.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/Modules/AccessModule.cs
@@ -30,7 +30,7 @@ namespace Doors.Modules
 		}
 
 
-		public override void OpenInteraction(HandApply interaction, HashSet<DoorProcessingStates> States)
+		public override void OpenInteraction(HandApply interaction, ref HashSet<DoorProcessingStates> States)
 		{
 			// We check access only if the door has power and it isn't emagged, in which case we still deny but don't play a sound
 			// Emagging is in its own module and could play another sound we don't want to overlap. Interaction can be null for several 
@@ -41,7 +41,7 @@ namespace Doors.Modules
 				States.Add(DoorProcessingStates.SoftwarePrevented);
 		}
 
-		public override void ClosedInteraction(HandApply interaction, HashSet<DoorProcessingStates> States)
+		public override void ClosedInteraction(HandApply interaction, ref HashSet<DoorProcessingStates> States)
 		{
 			// We check access only if the door has power and it isn't emagged, in which case we still deny but don't play a sound
 			// Emagging is in its own module and could play another sound we don't want to overlap. Interaction can be null for several 
@@ -52,7 +52,7 @@ namespace Doors.Modules
 				States.Add(DoorProcessingStates.SoftwarePrevented);
 		}
 
-		public override void BumpingInteraction(GameObject byPlayer, HashSet<DoorProcessingStates> States)
+		public override void BumpingInteraction(GameObject byPlayer, ref HashSet<DoorProcessingStates> States)
 		{
 			// We check access only if the door has power and it isn't emagged, in which case we still deny but don't play a sound
 			// Emagging is in its own module and could play another sound we don't want to overlap. Interaction can be null for several 

--- a/UnityProject/Assets/Scripts/Objects/Doors/Modules/BoltsModule.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/Modules/BoltsModule.cs
@@ -74,7 +74,7 @@ namespace Doors.Modules
 			SetBoltsState(!boltsDown);
 		}
 
-		public override void OpenInteraction(HandApply interaction, HashSet<DoorProcessingStates> States)
+		public override void OpenInteraction(HandApply interaction, ref HashSet<DoorProcessingStates> States)
 		{
 			if (interaction != null && interaction.UsedObject != null)
 			{
@@ -98,7 +98,7 @@ namespace Doors.Modules
 			return;
 		}
 
-		public override void ClosedInteraction(HandApply interaction, HashSet<DoorProcessingStates> States)
+		public override void ClosedInteraction(HandApply interaction, ref HashSet<DoorProcessingStates> States)
 		{
 			if (interaction != null && interaction.UsedObject != null)
 			{
@@ -146,7 +146,7 @@ namespace Doors.Modules
 
 		}
 
-		public override void BumpingInteraction(GameObject byPlayer, HashSet<DoorProcessingStates> States)
+		public override void BumpingInteraction(GameObject byPlayer, ref HashSet<DoorProcessingStates> States)
 		{
 			if (PulsePreventBoltsFall())
 			{

--- a/UnityProject/Assets/Scripts/Objects/Doors/Modules/CrowbarModule.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/Modules/CrowbarModule.cs
@@ -23,7 +23,7 @@ namespace Doors.Modules
 			weldModule = GetComponentInChildren<WeldModule>();
 		}
 
-		public override void OpenInteraction(HandApply interaction, HashSet<DoorProcessingStates> States)
+		public override void OpenInteraction(HandApply interaction, ref HashSet<DoorProcessingStates> States)
 		{
 			//Require help intent to pry doors
 			if (interaction is { Intent: Intent.Help })
@@ -51,7 +51,7 @@ namespace Doors.Modules
 			}
 		}
 
-		public override void ClosedInteraction(HandApply interaction, HashSet<DoorProcessingStates> States)
+		public override void ClosedInteraction(HandApply interaction, ref HashSet<DoorProcessingStates> States)
 		{
 			//Require the Help Intent and the door to be unwelded, can't even try to pry a welded door
 			if (interaction is { Intent: Intent.Help } && weldModule.IsWelded == false)
@@ -81,7 +81,7 @@ namespace Doors.Modules
 			return;
 		}
 
-		public override void BumpingInteraction(GameObject byPlayer, HashSet<DoorProcessingStates> States)
+		public override void BumpingInteraction(GameObject byPlayer, ref HashSet<DoorProcessingStates> States)
 		{
 			return;
 		}

--- a/UnityProject/Assets/Scripts/Objects/Doors/Modules/DoorModuleBase.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/Modules/DoorModuleBase.cs
@@ -14,18 +14,18 @@ namespace Doors.Modules
 
 
 		//Interactions when the doors open
-		public virtual void OpenInteraction(HandApply interaction, HashSet<DoorProcessingStates> States)
+		public virtual void OpenInteraction(HandApply interaction, ref HashSet<DoorProcessingStates> States)
 		{
 			return;
 		}
 
 		//Interactions when the door is closed
-		public virtual void ClosedInteraction(HandApply interaction, HashSet<DoorProcessingStates> States)
+		public virtual void ClosedInteraction(HandApply interaction, ref HashSet<DoorProcessingStates> States)
 		{
 			return;
 		}
 
-		public virtual void BumpingInteraction(GameObject byPlayer, HashSet<DoorProcessingStates> States)
+		public virtual void BumpingInteraction(GameObject byPlayer, ref HashSet<DoorProcessingStates> States)
 		{
 			return;
 		}

--- a/UnityProject/Assets/Scripts/Objects/Doors/Modules/ElectrifiedDoorModule.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/Modules/ElectrifiedDoorModule.cs
@@ -65,7 +65,7 @@ namespace Doors.Modules
 			master.UpdateGui();
 		}
 
-		public override void OpenInteraction(HandApply interaction, HashSet<DoorProcessingStates> States)
+		public override void OpenInteraction(HandApply interaction, ref HashSet<DoorProcessingStates> States)
 		{
 			if (interaction == null)
 			{
@@ -75,7 +75,7 @@ namespace Doors.Modules
 			CanElectricute(interaction.Performer);
 		}
 
-		public override void ClosedInteraction(HandApply interaction, HashSet<DoorProcessingStates> States)
+		public override void ClosedInteraction(HandApply interaction, ref HashSet<DoorProcessingStates> States)
 		{
 			if (interaction == null)
 			{
@@ -85,7 +85,7 @@ namespace Doors.Modules
 			CanElectricute(interaction.Performer);
 		}
 
-		public override void BumpingInteraction(GameObject mob, HashSet<DoorProcessingStates> States)
+		public override void BumpingInteraction(GameObject mob, ref HashSet<DoorProcessingStates> States)
 		{
 			CanElectricute(mob);
 		}

--- a/UnityProject/Assets/Scripts/Objects/Doors/Modules/EmagInteractionModule.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/Modules/EmagInteractionModule.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using Items;
+using Systems.Explosions;
 using UnityEngine;
 
 namespace Doors.Modules
@@ -16,7 +17,7 @@ namespace Doors.Modules
 			BoltsModule = GetComponent<BoltsModule>();
 		}
 
-		public override void ClosedInteraction(HandApply interaction, HashSet<DoorProcessingStates> States)
+		public override void ClosedInteraction(HandApply interaction, ref HashSet<DoorProcessingStates> States)
 		{
 			if (interaction == null) return;
 			var ItemStorage = interaction.Performer.GetComponent<DynamicItemStorage>();
@@ -28,16 +29,14 @@ namespace Doors.Modules
 					?.GetComponent<Emag>()?.OrNull();
 				if (hasEmag == null) return;
 			}
-			EmagChecks(ItemStorage, interaction, States);
-
-
+			EmagChecks(ItemStorage, interaction, ref States);
 		}
 
-		public override void BumpingInteraction(GameObject byPlayer, HashSet<DoorProcessingStates> States)
+		public override void BumpingInteraction(GameObject byPlayer, ref HashSet<DoorProcessingStates> States)
 		{
 			if (byPlayer == null) return; //null may appear if door wires are pulsed by EMP
 			var ItemStorage = byPlayer.GetComponent<DynamicItemStorage>();
-			EmagChecks(ItemStorage, null, States);
+			EmagChecks(ItemStorage, null, ref States);
 		}
 
 		/// <summary>
@@ -48,7 +47,7 @@ namespace Doors.Modules
 		/// <param name="States">Door process states</param>
 		/// <returns>Either hacked or ModuleSignal.Continue</returns>
 		private void EmagChecks(DynamicItemStorage itemStorage, HandApply interaction,
-			HashSet<DoorProcessingStates> States)
+			ref HashSet<DoorProcessingStates> States)
 		{
 			if (itemStorage != null)
 			{
@@ -59,14 +58,14 @@ namespace Doors.Modules
 					{
 						if (emagInHand.UseCharge(interaction))
 						{
-							EmagSuccessLogic(States);
+							EmagSuccessLogic(ref States);
 							return;
 						}
 					}
 
 					if (emagInHand.UseCharge(gameObject, itemStorage.registerPlayer.PlayerScript.gameObject))
 					{
-						EmagSuccessLogic(States);
+						EmagSuccessLogic(ref States);
 						return;
 					}
 
@@ -80,31 +79,33 @@ namespace Doors.Modules
 					{
 						if (emagInIdSlot.UseCharge(interaction))
 						{
-							EmagSuccessLogic(States);
+							EmagSuccessLogic(ref States);
 							return;
 						}
 					}
 
 					if (emagInIdSlot.UseCharge(gameObject, itemStorage.registerPlayer.PlayerScript.gameObject))
 					{
-						EmagSuccessLogic(States);
+						EmagSuccessLogic(ref States);
 						return;
 					}
 				}
 			}
-
-			return;
 		}
 
 		/// <summary>
 		/// What happens after a door gets emagged.
 		/// </summary>
 		/// <returns>ModuleSignal.Continue</returns>
-		private void EmagSuccessLogic(HashSet<DoorProcessingStates> States)
+		private void EmagSuccessLogic(ref HashSet<DoorProcessingStates> States)
 		{
 			States.Add(DoorProcessingStates.SoftwareHacked);
+			if (States.Contains(DoorProcessingStates.SoftwarePrevented))
+			{
+				States.Remove(DoorProcessingStates.SoftwarePrevented);
+			}
 			StartCoroutine(ToggleBolts());
-			return;
+			SparkUtil.TrySpark(master.gameObject);
 		}
 
 		private IEnumerator ToggleBolts()

--- a/UnityProject/Assets/Scripts/Objects/Doors/Modules/PowerModule.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/Modules/PowerModule.cs
@@ -29,7 +29,7 @@ namespace Doors.Modules
 			}
 		}
 		
-		public override void OpenInteraction(HandApply interaction, HashSet<DoorProcessingStates> States)
+		public override void OpenInteraction(HandApply interaction, ref HashSet<DoorProcessingStates> States)
 		{
 			if (HasPower == false)
 			{
@@ -37,7 +37,7 @@ namespace Doors.Modules
 			}
 		}
 		
-		public override void ClosedInteraction(HandApply interaction, HashSet<DoorProcessingStates> States)
+		public override void ClosedInteraction(HandApply interaction, ref HashSet<DoorProcessingStates> States)
 		{
 			if (HasPower == false)
 			{
@@ -45,7 +45,7 @@ namespace Doors.Modules
 			}
 		}
 		
-		public override void BumpingInteraction(GameObject byPlayer, HashSet<DoorProcessingStates> States)
+		public override void BumpingInteraction(GameObject byPlayer, ref HashSet<DoorProcessingStates> States)
 		{
 			if (HasPower == false)
 			{

--- a/UnityProject/Assets/Scripts/Objects/Doors/Modules/PressureModule.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/Modules/PressureModule.cs
@@ -60,12 +60,12 @@ namespace Doors.Modules
 			StartCoroutine(ResetWarning());
 		}
 
-		public override void ClosedInteraction(HandApply interaction, HashSet<DoorProcessingStates> States)
+		public override void ClosedInteraction(HandApply interaction, ref HashSet<DoorProcessingStates> States)
 		{
 			TryPressureWarning (States);
 		}
 
-		public override void BumpingInteraction(GameObject byPlayer, HashSet<DoorProcessingStates> States)
+		public override void BumpingInteraction(GameObject byPlayer, ref HashSet<DoorProcessingStates> States)
 		{
 
 			TryPressureWarning( States);

--- a/UnityProject/Assets/Scripts/Objects/Doors/Modules/WeldModule.cs
+++ b/UnityProject/Assets/Scripts/Objects/Doors/Modules/WeldModule.cs
@@ -25,7 +25,7 @@ namespace Doors.Modules
 			integrity = GetComponentInParent<Integrity>();
 		}
 
-		public override void OpenInteraction(HandApply interaction, HashSet<DoorProcessingStates> States)
+		public override void OpenInteraction(HandApply interaction, ref HashSet<DoorProcessingStates> States)
 		{
 			if (isWelded)
 			{
@@ -34,7 +34,7 @@ namespace Doors.Modules
 
 		}
 
-		public override void ClosedInteraction(HandApply interaction, HashSet<DoorProcessingStates> States)
+		public override void ClosedInteraction(HandApply interaction, ref HashSet<DoorProcessingStates> States)
 		{
 			if (interaction == null) return;
 			if (Validations.HasUsedActiveWelder(interaction))
@@ -48,7 +48,7 @@ namespace Doors.Modules
 			}
 		}
 
-		public override void BumpingInteraction(GameObject byPlayer, HashSet<DoorProcessingStates> States)
+		public override void BumpingInteraction(GameObject byPlayer, ref HashSet<DoorProcessingStates> States)
 		{
 			if (isWelded)
 			{


### PR DESCRIPTION
CL: [Improvement] Updated emag interaction text to be a bit clearer.
CL: [Fix] Fixed a case where changes to door states made by modules were overriden or ignored.
CL: [Fix] Fixed a case where the emag interaction text would say that the door is still closed and is rejecting the user, even though the emag successfully opened the door.