### PR TITLE
Fix NRE issues causing the AI to get yeeted out of the game + Round lobby fix

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Networking/AsyncMessageQueue/RequestHandlerConstants.cs
+++ b/UnityProject/Assets/Scripts/Core/Networking/AsyncMessageQueue/RequestHandlerConstants.cs
@@ -3,6 +3,6 @@
 	public static class RequestHandlerConstants
 	{
 		public const string REQUEST_ROUND_STATUS = "requestRoundStatus";
-		public const string REQUEST_SUPPORTERS = "requestRoundStatus";
+		public const string REQUEST_SUPPORTERS = "requestSupporters";
 	}
 }

--- a/UnityProject/Assets/Scripts/Core/Networking/AsyncMessageQueue/RpcMessageQueue.cs
+++ b/UnityProject/Assets/Scripts/Core/Networking/AsyncMessageQueue/RpcMessageQueue.cs
@@ -33,6 +33,7 @@ namespace Core.Networking.AsyncMessageQueue
 			}
 
 			Loggy.Error($"Request timed out for {requestedTicket} - {requestToken}");
+			_client_ReceivedMessages.Remove(requestToken);
 			return new QueuedMessage
 			{
 				Requester = null,

--- a/UnityProject/Assets/Scripts/Objects/SecurityCamera.cs
+++ b/UnityProject/Assets/Scripts/Objects/SecurityCamera.cs
@@ -131,6 +131,13 @@ namespace Objects
 			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, MotionSensingUpdate);
 		}
 
+		private void OnDestroy()
+		{
+			//(Max): Turn this into a serialized action!!
+			// Unity events suck major balls, and cause a lot of GC.
+			OnStateChange.RemoveAllListeners();
+		}
+
 		#region Ai Camera Switching Interaction
 
 		public bool WillInteract(AiActivate interaction, NetworkSide side)
@@ -148,7 +155,7 @@ namespace Objects
 		{
 			if (interaction.Performer.TryGetComponent<AiPlayer>(out var aiPlayer) == false) return;
 
-			if(aiPlayer.OpenNetworks.Contains(securityCameraChannel) == false) return;
+			if (aiPlayer.OpenNetworks.Contains(securityCameraChannel) == false) return;
 
 			if (cameraActive == false)
 			{
@@ -370,7 +377,7 @@ namespace Objects
 		{
 			cameraActive = newState;
 			spriteHandler.OrNull()?.SetCatalogueIndexSprite(cameraActive ? 1 : 0);
-			OnStateChange.Invoke(newState);
+			OnStateChange?.Invoke(newState);
 
 			//On state change, resync number of active cameras
 			SyncNumberOfCameras();

--- a/UnityProject/Assets/Scripts/Systems/Ai/AiPlayer.cs
+++ b/UnityProject/Assets/Scripts/Systems/Ai/AiPlayer.cs
@@ -15,6 +15,7 @@ using Objects.Research;
 using UI.Systems.MainHUD.UI_Bottom;
 using UnityEngine;
 using HealthV2;
+using Logs;
 using UniversalObjectPhysics = Core.Physics.UniversalObjectPhysics;
 
 namespace Systems.Ai
@@ -362,8 +363,19 @@ namespace Systems.Ai
 		#region Camera Stuff
 
 		[Server]
+		public void SendPlayerCameraToCore()
+		{
+			ServerSetCameraLocation(vesselObject);
+		}
+
+		[Server]
 		public void ServerSetCameraLocation(GameObject newObject, bool ignoreCardCheck = false, bool moveMessage = true)
 		{
+			if (newObject == null)
+			{
+				Loggy.Warning($"AiPlayer {gameObject} has passed a null newObject");
+				return;
+			}
 			//Cant switch cameras when carded
 			if (isCarded && ignoreCardCheck == false)
 			{
@@ -381,25 +393,23 @@ namespace Systems.Ai
 				}
 			}
 
-			if (newObject != null)
-			{
-				//Set location for validation checks
-				cameraLocation = newObject.transform;
+			//Set location for validation checks
+			cameraLocation = newObject.transform;
 
-				//This is to move the player object so we can see the Ai Eye sprite underneath us
-				//TODO for some reason this isnt always working the sprite sometimes stays on the core, or last position
-				playerScript.PlayerSync.AppearAtWorldPositionServer(cameraLocation.gameObject.AssumedWorldPosServer(), false);
-			}
-			else
-			{
-				cameraLocation = null;
-			}
+			//This is to move the player object so we can see the Ai Eye sprite underneath us
+			//TODO for some reason this isnt always working the sprite sometimes stays on the core, or last position
+			playerScript.PlayerSync.AppearAtWorldPositionServer(cameraLocation.gameObject.AssumedWorldPosServer(), false);
 
 			//Tell client to move their camera to this new camera
 			FollowCameraAiMessage.Send(gameObject, newObject);
 
+			if (cameraLocation == null)
+			{
+				Loggy.Warning($"AiPlayer {gameObject} trying to use a null camera location");
+				return;
+			}
 			//Add new listeners
-			if (newObject != null && cameraLocation.gameObject != newObject)
+			if (cameraLocation.gameObject != newObject)
 			{
 				//Add power listener
 				if (newObject.TryGetComponent<SecurityCamera>(out var securityCamera))
@@ -408,7 +418,7 @@ namespace Systems.Ai
 				}
 			}
 
-			if (newObject != null && isCarded == false && moveMessage)
+			if (isCarded == false && moveMessage)
 			{
 				Chat.AddExamineMsgFromServer(gameObject, $"You move to the {newObject.ExpensiveName()}");
 			}
@@ -435,11 +445,11 @@ namespace Systems.Ai
 			{
 				if (OpenNetworks.Contains(pairs.Key) == false && newState) continue;
 
-				foreach (var camera in pairs.Value)
+				foreach (var aiCam in pairs.Value)
 				{
-					if (camera.CameraActive || newState == false)
+					if (aiCam.CameraActive || newState == false)
 					{
-						camera.OrNull()?.ToggleAiSprite(newState);
+						aiCam.OrNull()?.ToggleAiSprite(newState);
 					}
 				}
 			}
@@ -529,6 +539,7 @@ namespace Systems.Ai
 		//Used by the Ai teleport tab to move camera
 		public void CmdTeleportToCamera(GameObject newCamera, bool moveMessage)
 		{
+			if (newCamera == null) return;
 			if(OnCoolDown(NetworkSide.Server)) return;
 			StartCoolDown(NetworkSide.Server);
 
@@ -538,9 +549,9 @@ namespace Systems.Ai
 				return;
 			}
 
-			if(newCamera == null || newCamera.TryGetComponent<SecurityCamera>(out var securityCamera) == false) return;
+			if (newCamera.TryGetComponent<SecurityCamera>(out var securityCamera) == false) return;
 
-			if(OpenNetworks.Contains(securityCamera.SecurityCameraChannel) == false) return;
+			if (OpenNetworks.Contains(securityCamera.SecurityCameraChannel) == false) return;
 
 			if (hasPower == false)
 			{
@@ -712,6 +723,7 @@ namespace Systems.Ai
 
 			foreach (var securityCamera in GetValidCameras())
 			{
+				if (securityCamera == null) continue;
 				var securityCameraLocation = securityCamera.gameObject.AssumedWorldPosServer();
 
 				var direction = securityCameraLocation - aiPlayerCameraLocation;


### PR DESCRIPTION
hi, please pretend I did not do a massive oopsie

![Screen_Shot_2022-09-23_at_10 40 58_AM](https://github.com/user-attachments/assets/292a9d40-ffaf-47ec-9b0f-62b6439c6d66)

# Changelog:

CL: [Fix] Fixed a game breaking issue that caused AI players to have the inability to move across the map without them getting kicked out.
CL: [Fix] Fixed a slight leak that caused despawned cameras to have some of their events continuing to exist even after death.
CL: [Fix] Fixed an issue with Async Messages not clearing tokens when they time out.
CL: [Fix] Fixed an issue with the lobby where players were unable to ready up for the round because the floating supporters kept overriding the round status check message.