### PR TITLE
Map lists per gamemode

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/GameModes/Blob.asset
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/Blob.asset
@@ -33,4 +33,8 @@ MonoBehaviour:
   possibleSicknesses:
   - {fileID: 11400000, guid: c277cb2e90e88e743ab2494b395ca8fa, type: 2}
   randomSicknessRatio: 0.01
-  mainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}
+  MainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}
+  AsteroidList: {fileID: 11400000, guid: b1d9059b8db83ab479c9dffdc939b281, type: 2}
+  AdditionalSceneList: {fileID: 11400000, guid: 6370dfaa39db5574aa7cc451537de4f1,
+    type: 2}
+  AwayWorldList: {fileID: 11400000, guid: 9336c6ca9dac2d94eb90f703a23a7484, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/GameModes/BloodBrothers.asset
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/BloodBrothers.asset
@@ -35,4 +35,8 @@ MonoBehaviour:
   possibleSicknesses:
   - {fileID: 11400000, guid: c277cb2e90e88e743ab2494b395ca8fa, type: 2}
   randomSicknessRatio: 0.01
-  mainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}
+  MainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}
+  AsteroidList: {fileID: 11400000, guid: b1d9059b8db83ab479c9dffdc939b281, type: 2}
+  AdditionalSceneList: {fileID: 11400000, guid: 6370dfaa39db5574aa7cc451537de4f1,
+    type: 2}
+  AwayWorldList: {fileID: 11400000, guid: 9336c6ca9dac2d94eb90f703a23a7484, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/GameModes/Cargonia.asset
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/Cargonia.asset
@@ -36,4 +36,8 @@ MonoBehaviour:
   possibleSicknesses:
   - {fileID: 11400000, guid: c277cb2e90e88e743ab2494b395ca8fa, type: 2}
   randomSicknessRatio: 0.01
-  mainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}
+  MainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}
+  AsteroidList: {fileID: 11400000, guid: b1d9059b8db83ab479c9dffdc939b281, type: 2}
+  AdditionalSceneList: {fileID: 11400000, guid: 6370dfaa39db5574aa7cc451537de4f1,
+    type: 2}
+  AwayWorldList: {fileID: 11400000, guid: 9336c6ca9dac2d94eb90f703a23a7484, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/GameModes/Changeling.asset
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/Changeling.asset
@@ -32,4 +32,8 @@ MonoBehaviour:
   possibleSicknesses:
   - {fileID: 11400000, guid: c277cb2e90e88e743ab2494b395ca8fa, type: 2}
   randomSicknessRatio: 0.01
-  mainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}
+  MainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}
+  AsteroidList: {fileID: 11400000, guid: b1d9059b8db83ab479c9dffdc939b281, type: 2}
+  AdditionalSceneList: {fileID: 11400000, guid: 6370dfaa39db5574aa7cc451537de4f1,
+    type: 2}
+  AwayWorldList: {fileID: 11400000, guid: 9336c6ca9dac2d94eb90f703a23a7484, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/GameModes/Extended.asset
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/Extended.asset
@@ -31,4 +31,8 @@ MonoBehaviour:
   possibleSicknesses:
   - {fileID: 11400000, guid: c277cb2e90e88e743ab2494b395ca8fa, type: 2}
   randomSicknessRatio: 0.1
-  mainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}
+  MainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}
+  AsteroidList: {fileID: 11400000, guid: b1d9059b8db83ab479c9dffdc939b281, type: 2}
+  AdditionalSceneList: {fileID: 11400000, guid: 6370dfaa39db5574aa7cc451537de4f1,
+    type: 2}
+  AwayWorldList: {fileID: 11400000, guid: 9336c6ca9dac2d94eb90f703a23a7484, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/GameModes/Highlander.asset
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/Highlander.asset
@@ -36,4 +36,8 @@ MonoBehaviour:
   randomSicknesses: 0
   possibleSicknesses: []
   randomSicknessRatio: 0.5
-  mainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}
+  MainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}
+  AsteroidList: {fileID: 11400000, guid: b1d9059b8db83ab479c9dffdc939b281, type: 2}
+  AdditionalSceneList: {fileID: 11400000, guid: 6370dfaa39db5574aa7cc451537de4f1,
+    type: 2}
+  AwayWorldList: {fileID: 11400000, guid: 9336c6ca9dac2d94eb90f703a23a7484, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/GameModes/MapEditor.asset
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/MapEditor.asset
@@ -30,4 +30,8 @@ MonoBehaviour:
   randomSicknesses: 0
   possibleSicknesses: []
   randomSicknessRatio: 0.5
-  mainStations: {fileID: 11400000, guid: be379146f7789d74d86dd7ba1e76ebbc, type: 2}
+  MainStations: {fileID: 11400000, guid: be379146f7789d74d86dd7ba1e76ebbc, type: 2}
+  AsteroidList: {fileID: 11400000, guid: b1d9059b8db83ab479c9dffdc939b281, type: 2}
+  AdditionalSceneList: {fileID: 11400000, guid: 6370dfaa39db5574aa7cc451537de4f1,
+    type: 2}
+  AwayWorldList: {fileID: 11400000, guid: 9336c6ca9dac2d94eb90f703a23a7484, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/GameModes/MixedRound.asset
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/MixedRound.asset
@@ -32,7 +32,11 @@ MonoBehaviour:
   possibleSicknesses:
   - {fileID: 11400000, guid: c277cb2e90e88e743ab2494b395ca8fa, type: 2}
   randomSicknessRatio: 0.01
-  mainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}
+  MainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}
+  AsteroidList: {fileID: 11400000, guid: b1d9059b8db83ab479c9dffdc939b281, type: 2}
+  AdditionalSceneList: {fileID: 11400000, guid: 6370dfaa39db5574aa7cc451537de4f1,
+    type: 2}
+  AwayWorldList: {fileID: 11400000, guid: 9336c6ca9dac2d94eb90f703a23a7484, type: 2}
   AntagonistDatas:
   - ratio: 0.75
     Antagonist: {fileID: 11400000, guid: c060c33698c0f81449f0735a800740ca, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/GameModes/NukeOps.asset
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/NukeOps.asset
@@ -33,4 +33,8 @@ MonoBehaviour:
   possibleSicknesses:
   - {fileID: 11400000, guid: c277cb2e90e88e743ab2494b395ca8fa, type: 2}
   randomSicknessRatio: 0.01
-  mainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}
+  MainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}
+  AsteroidList: {fileID: 11400000, guid: b1d9059b8db83ab479c9dffdc939b281, type: 2}
+  AdditionalSceneList: {fileID: 11400000, guid: 6370dfaa39db5574aa7cc451537de4f1,
+    type: 2}
+  AwayWorldList: {fileID: 11400000, guid: 9336c6ca9dac2d94eb90f703a23a7484, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/GameModes/Traitor.asset
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/Traitor.asset
@@ -33,4 +33,8 @@ MonoBehaviour:
   possibleSicknesses:
   - {fileID: 11400000, guid: c277cb2e90e88e743ab2494b395ca8fa, type: 2}
   randomSicknessRatio: 0.01
-  mainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}
+  MainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}
+  AsteroidList: {fileID: 11400000, guid: b1d9059b8db83ab479c9dffdc939b281, type: 2}
+  AdditionalSceneList: {fileID: 11400000, guid: 6370dfaa39db5574aa7cc451537de4f1,
+    type: 2}
+  AwayWorldList: {fileID: 11400000, guid: 9336c6ca9dac2d94eb90f703a23a7484, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/GameModes/Wizard.asset
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/Wizard.asset
@@ -37,4 +37,8 @@ MonoBehaviour:
   possibleSicknesses:
   - {fileID: 11400000, guid: c277cb2e90e88e743ab2494b395ca8fa, type: 2}
   randomSicknessRatio: 0.01
-  mainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}
+  MainStations: {fileID: 11400000, guid: 9b0018951af67314ca9e85705e0d2ce4, type: 2}
+  AsteroidList: {fileID: 11400000, guid: b1d9059b8db83ab479c9dffdc939b281, type: 2}
+  AdditionalSceneList: {fileID: 11400000, guid: 6370dfaa39db5574aa7cc451537de4f1,
+    type: 2}
+  AwayWorldList: {fileID: 11400000, guid: 9336c6ca9dac2d94eb90f703a23a7484, type: 2}

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/AsteroidListSO.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/AsteroidListSO.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using NaughtyAttributes;
 using UnityEngine;
 

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/MainStationListSO.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/MainStationListSO.cs
@@ -11,11 +11,12 @@ using UnityEngine.SceneManagement;
 public class MainStationListSO : ScriptableObject
 {
 	[Header("Provide the exact name of the scene in the fields below:")]
-	[InfoBox("Remember to also add your scene to " +
-	         "the build settings list",EInfoBoxType.Normal)]
 	public List<string> MainStations = new();
 
 	public string mapsConfig = "maps.json";
+
+	[Header("If these mainstations have their own set of unique asteroids, assign their list here:")]
+	public AsteroidListSO AsteroidListOverride = null;
 
 	public string GetRandomMainStation()
 	{

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.SceneList.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.SceneList.cs
@@ -35,7 +35,7 @@ public partial class SubSceneManager
 		ConnectionLoadedRecord.Clear(); //New round
 		var loadTimer = new SubsceneLoadTimer();
 		//calculate load time:
-		loadTimer.MaxLoadTime = 20f + (asteroidList.Asteroids.Count * 10f);
+		loadTimer.MaxLoadTime = 20f + (GameManager.Instance.GameMode.AsteroidList.Asteroids.Count * 10f);
 		loadTimer.IncrementLoadBar("Preparing..");
 
 		Loggy.Info(" waiting for addressables To load ");
@@ -122,7 +122,7 @@ public partial class SubSceneManager
 		}
 		else
 		{
-			serverChosenMainStation = GameManager.Instance.GameMode.mainStations.GetRandomMainStation();
+			serverChosenMainStation = GameManager.Instance.GameMode.MainStations.GetRandomMainStation();
 			Loggy.Info($"[SubSceneManager.SceneList] - Server has choosen {serverChosenMainStation} as main station. " +
 			          $"Previous admin forced: {AdminForcedMainStation}", Category.Round);
 		}
@@ -141,7 +141,7 @@ public partial class SubSceneManager
 	{
 		loadTimer.IncrementLoadBar("Loading Asteroids");
 
-		foreach (var asteroid in asteroidList.Asteroids)
+		foreach (var asteroid in GameManager.Instance.GameMode.AsteroidList.Asteroids)
 		{
 			Loggy.Info($" Loading Asteroid {asteroid} ");
 			yield return StartCoroutine(LoadSubScene(asteroid, loadTimer, default, SceneType.Asteroid));
@@ -153,7 +153,7 @@ public partial class SubSceneManager
 		loadTimer.IncrementLoadBar("Loading CentCom");
 
 		//CENTCOM
-		foreach (var centComData in additionalSceneList.CentComScenes)
+		foreach (var centComData in GameManager.Instance.GameMode.AdditionalSceneList.CentComScenes)
 		{
 			if (centComData.DependentScene == null || centComData.CentComSceneName == null) continue;
 
@@ -164,7 +164,7 @@ public partial class SubSceneManager
 			yield break;
 		}
 
-		var pickedMap = additionalSceneList.defaultCentComScenes.PickRandom();
+		var pickedMap = GameManager.Instance.GameMode.AdditionalSceneList.defaultCentComScenes.PickRandom();
 		if (string.IsNullOrEmpty(pickedMap)) yield break;
 		//If no special CentCom load default.
 		yield return StartCoroutine(LoadSubScene(pickedMap, loadTimer, default, SceneType.AdditionalScenes));
@@ -179,7 +179,7 @@ public partial class SubSceneManager
 		}
 
 		loadTimer.IncrementLoadBar("Loading Additional Scenes");
-		foreach (var additionalScene in additionalSceneList.AdditionalScenes)
+		foreach (var additionalScene in GameManager.Instance.GameMode.AdditionalSceneList.AdditionalScenes)
 		{
 			//LAVALAND
 			//only spawn if game config allows
@@ -235,9 +235,9 @@ public partial class SubSceneManager
 	public IEnumerator LoadSyndicate()
 	{
 		if (SyndicateLoaded) yield break;
-		var pickedMap = additionalSceneList.defaultSyndicateScenes.PickRandom();
+		var pickedMap = GameManager.Instance.GameMode.AdditionalSceneList.defaultSyndicateScenes.PickRandom();
 
-		foreach (var syndicateData in additionalSceneList.SyndicateScenes)
+		foreach (var syndicateData in GameManager.Instance.GameMode.AdditionalSceneList.SyndicateScenes)
 		{
 			if (syndicateData.DependentScene == null || syndicateData.SyndicateSceneName == null)
 				continue;
@@ -260,7 +260,7 @@ public partial class SubSceneManager
 	{
 		if (WizardLoaded) yield break;
 
-		string pickedScene = additionalSceneList.WizardScenes.PickRandom();
+		string pickedScene = GameManager.Instance.GameMode.AdditionalSceneList.WizardScenes.PickRandom();
 
 		yield return StartCoroutine(LoadSubScene(pickedScene));
 

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.SceneList.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.SceneList.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using Logs;
 using Managers;
 using Mirror;
@@ -9,7 +7,6 @@ using UI.Systems.PreRound;
 using UnityEditor;
 using UnityEngine.SceneManagement;
 using WebSocketSharp;
-using UnityEngine;
 
 //The scene list on the server
 public partial class SubSceneManager
@@ -26,6 +23,8 @@ public partial class SubSceneManager
 
 	public static Dictionary<string, HashSet<int>> ConnectionLoadedRecord = new Dictionary<string, HashSet<int>>();
 
+	private GameManager gameManager => GameManager.Instance;
+
 	public IEnumerator RoundStartServerLoadSequence()
 	{
 		SubSceneManagerNetworked.ScenesInitialLoadingComplete = false;
@@ -35,7 +34,7 @@ public partial class SubSceneManager
 		ConnectionLoadedRecord.Clear(); //New round
 		var loadTimer = new SubsceneLoadTimer();
 		//calculate load time:
-		loadTimer.MaxLoadTime = 20f + (GameManager.Instance.GameMode.AsteroidList.Asteroids.Count * 10f);
+		loadTimer.MaxLoadTime = 20f + (gameManager.GameMode.AsteroidList.Asteroids.Count * 10f);
 		loadTimer.IncrementLoadBar("Preparing..");
 
 		Loggy.Info(" waiting for addressables To load ");
@@ -55,7 +54,7 @@ public partial class SubSceneManager
 		//Load CentCom Scene:
 		yield return StartCoroutine(ServerLoadCentCom(loadTimer));
 
-		if (GameManager.Instance.QuickLoad == false)
+		if (gameManager.QuickLoad == false)
 		{
 			Loggy.Info(" Loading Asteroids ");
 			//Load Asteroids:
@@ -122,7 +121,7 @@ public partial class SubSceneManager
 		}
 		else
 		{
-			serverChosenMainStation = GameManager.Instance.GameMode.MainStations.GetRandomMainStation();
+			serverChosenMainStation = gameManager.GameMode.MainStations.GetRandomMainStation();
 			Loggy.Info($"[SubSceneManager.SceneList] - Server has choosen {serverChosenMainStation} as main station. " +
 			          $"Previous admin forced: {AdminForcedMainStation}", Category.Round);
 		}
@@ -139,21 +138,43 @@ public partial class SubSceneManager
 	//Load all the asteroids on the server
 	IEnumerator ServerLoadAsteroids(SubsceneLoadTimer loadTimer)
 	{
-		loadTimer.IncrementLoadBar("Loading Asteroids");
-
-		foreach (var asteroid in GameManager.Instance.GameMode.AsteroidList.Asteroids)
+		if (gameManager.GameMode.MainStations.AsteroidListOverride != null &&
+		    gameManager.GameMode.MainStations.AsteroidListOverride.Asteroids.Count > 0)
 		{
-			Loggy.Info($" Loading Asteroid {asteroid} ");
-			yield return StartCoroutine(LoadSubScene(asteroid, loadTimer, default, SceneType.Asteroid));
+			//Use the override asteroid list for this main station
+			loadTimer.IncrementLoadBar("Loading Asteroids");
+			yield return StartCoroutine(LoadAstroids(gameManager.GameMode.MainStations.AsteroidListOverride.Asteroids));
+			yield break;
+		}
+		if (gameManager.GameMode.AsteroidList == null || gameManager.GameMode.AsteroidList.Asteroids.Count <= 0)
+		{
+			yield break;
+		}
+		loadTimer.IncrementLoadBar("Loading Asteroids");
+		yield return StartCoroutine(LoadAstroids(gameManager.GameMode.AsteroidList.Asteroids));
+		yield break;
+
+		IEnumerator LoadAstroids(List<string> asteroids)
+		{
+			foreach (var asteroid in asteroids)
+			{
+				Loggy.Info($" Loading Asteroid {asteroid} ");
+				yield return StartCoroutine(LoadSubScene(asteroid, loadTimer, default, SceneType.Asteroid));
+			}
 		}
 	}
 
 	IEnumerator ServerLoadCentCom(SubsceneLoadTimer loadTimer)
 	{
+		if (gameManager.GameMode.AdditionalSceneList == null)
+		{
+			Loggy.Warning("This game mode has no additional scene list assigned! This may be intentional for non-standard SS13 game modes.", Category.Round);
+			yield break;
+		}
 		loadTimer.IncrementLoadBar("Loading CentCom");
 
 		//CENTCOM
-		foreach (var centComData in GameManager.Instance.GameMode.AdditionalSceneList.CentComScenes)
+		foreach (var centComData in gameManager.GameMode.AdditionalSceneList.CentComScenes)
 		{
 			if (centComData.DependentScene == null || centComData.CentComSceneName == null) continue;
 
@@ -164,7 +185,7 @@ public partial class SubSceneManager
 			yield break;
 		}
 
-		var pickedMap = GameManager.Instance.GameMode.AdditionalSceneList.defaultCentComScenes.PickRandom();
+		var pickedMap = gameManager.GameMode.AdditionalSceneList.defaultCentComScenes.PickRandom();
 		if (string.IsNullOrEmpty(pickedMap)) yield break;
 		//If no special CentCom load default.
 		yield return StartCoroutine(LoadSubScene(pickedMap, loadTimer, default, SceneType.AdditionalScenes));
@@ -173,13 +194,19 @@ public partial class SubSceneManager
 	//Load all the asteroids on the server
 	IEnumerator ServerLoadAdditionalScenes(SubsceneLoadTimer loadTimer)
 	{
-		if (GameManager.Instance.QuickLoad)
+		if (gameManager.GameMode.AdditionalSceneList == null)
 		{
+			Loggy.Warning("This game mode has no additional scene list assigned! This may be intentional for non-standard SS13 game modes.", Category.Round);
+			yield break;
+		}
+		if (gameManager.QuickLoad)
+		{
+			Loggy.Info("Quickload detected. Skipping additional scenes..", Category.Round);
 			yield break;
 		}
 
 		loadTimer.IncrementLoadBar("Loading Additional Scenes");
-		foreach (var additionalScene in GameManager.Instance.GameMode.AdditionalSceneList.AdditionalScenes)
+		foreach (var additionalScene in gameManager.GameMode.AdditionalSceneList.AdditionalScenes)
 		{
 			//LAVALAND
 			//only spawn if game config allows
@@ -206,20 +233,18 @@ public partial class SubSceneManager
 	//Load the away site on the server
 	IEnumerator ServerLoadAwaySite(SubsceneLoadTimer loadTimer)
 	{
-		if (GameManager.Instance.QuickLoad)
+		if (gameManager.GameMode.AwayWorldList == null)
 		{
+			Loggy.Warning("This game mode has no away world list assigned! This may be intentional for non-standard SS13 game modes.", Category.Round);
+			yield break;
+		}
+		if (gameManager.QuickLoad)
+		{
+			Loggy.Info("Quickload detected. Skipping away sites scenes..", Category.Round);
 			yield break;
 		}
 
-		if (AdminForcedAwaySite == "Random")
-		{
-			serverChosenAwaySite = awayWorldList.GetRandomAwaySite();
-		}
-		else
-		{
-			serverChosenAwaySite = AdminForcedAwaySite;
-		}
-
+		serverChosenAwaySite = AdminForcedAwaySite == "Random" ? gameManager.GameMode.AwayWorldList.GetRandomAwaySite() : AdminForcedAwaySite;
 		AdminForcedAwaySite = "Random";
 
 		loadTimer.IncrementLoadBar("Loading Away Site");
@@ -235,9 +260,9 @@ public partial class SubSceneManager
 	public IEnumerator LoadSyndicate()
 	{
 		if (SyndicateLoaded) yield break;
-		var pickedMap = GameManager.Instance.GameMode.AdditionalSceneList.defaultSyndicateScenes.PickRandom();
+		var pickedMap = gameManager.GameMode.AdditionalSceneList.defaultSyndicateScenes.PickRandom();
 
-		foreach (var syndicateData in GameManager.Instance.GameMode.AdditionalSceneList.SyndicateScenes)
+		foreach (var syndicateData in gameManager.GameMode.AdditionalSceneList.SyndicateScenes)
 		{
 			if (syndicateData.DependentScene == null || syndicateData.SyndicateSceneName == null)
 				continue;
@@ -260,7 +285,7 @@ public partial class SubSceneManager
 	{
 		if (WizardLoaded) yield break;
 
-		string pickedScene = GameManager.Instance.GameMode.AdditionalSceneList.WizardScenes.PickRandom();
+		string pickedScene = gameManager.GameMode.AdditionalSceneList.WizardScenes.PickRandom();
 
 		yield return StartCoroutine(LoadSubScene(pickedScene));
 

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.Server.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.Server.cs
@@ -12,8 +12,6 @@ using UnityEngine.SceneManagement;
 //Server
 public partial class SubSceneManager
 {
-
-
 	/// <summary>
 	/// Starts a collection of scenes that this connection is allowed to see
 	/// </summary>

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.cs
@@ -22,13 +22,9 @@ public partial class SubSceneManager : MonoBehaviour
 	public static SubSceneManager Instance;
 
 	public AwayWorldListSO awayWorldList;
-	[SerializeField] private MainStationListSO mainStationList = null;
-	[SerializeField] private AsteroidListSO asteroidList = null;
-	[SerializeField] private AdditionalSceneListSO additionalSceneList = null;
 
 	public ScenesSyncList loadedScenesList => SubSceneManagerNetworked.loadedScenesList;
-
-	public MainStationListSO MainStationList => mainStationList;
+	public MainStationListSO MainStationList => GameManager.Instance.GameMode.MainStations;
 
 	public bool AwaySiteLoaded { get; private set; }
 

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.cs
@@ -21,10 +21,9 @@ public partial class SubSceneManager : MonoBehaviour
 
 	public static SubSceneManager Instance;
 
-	public AwayWorldListSO awayWorldList;
-
 	public ScenesSyncList loadedScenesList => SubSceneManagerNetworked.loadedScenesList;
 	public MainStationListSO MainStationList => GameManager.Instance.GameMode.MainStations;
+	public AwayWorldListSO AwayWorlds => GameManager.Instance.GameMode.AwayWorldList;
 
 	public bool AwaySiteLoaded { get; private set; }
 

--- a/UnityProject/Assets/Scripts/Objects/Gateway/StationGateway.cs
+++ b/UnityProject/Assets/Scripts/Objects/Gateway/StationGateway.cs
@@ -109,7 +109,7 @@ namespace Objects
 				{
 					if (!string.IsNullOrEmpty(EditorPrefs.GetString("prevEditorScene")))
 					{
-						if (SubSceneManager.Instance.awayWorldList.AwayWorlds.Contains(
+						if (SubSceneManager.Instance.AwayWorlds.AwayWorlds.Contains(
 							    EditorPrefs.GetString("prevEditorScene")))
 						{
 							loadNormally = false;

--- a/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
+++ b/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
@@ -178,7 +178,10 @@ namespace GameModes
 		[ShowIf(nameof(randomSicknesses)), SerializeField] private List<Reagent> possibleSicknesses = new List<Reagent>();
 		[ShowIf(nameof(randomSicknesses)), SerializeField] private float randomSicknessRatio = 0.5f;
 
-		public MainStationListSO mainStations;
+		[FormerlySerializedAs("mainStations")] public MainStationListSO MainStations;
+		public AsteroidListSO AsteroidList = null;
+		public AdditionalSceneListSO AdditionalSceneList = null;
+		public AwayWorldListSO AwayWorldList;
 
 		#endregion
 

--- a/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventMobSpawn.cs
+++ b/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventMobSpawn.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Logs;
 using UnityEngine;

--- a/UnityProject/Assets/Scripts/Systems/Voting/VotingManager.cs
+++ b/UnityProject/Assets/Scripts/Systems/Voting/VotingManager.cs
@@ -83,7 +83,7 @@ public class VotingManager : NetworkBehaviour
 	private void Start()
 	{
 		MapList = SubSceneManager.Instance.MainStationList.GetMaps();
-		awaySiteList = SubSceneManager.Instance.awayWorldList.AwayWorlds;
+		awaySiteList = SubSceneManager.Instance.AwayWorlds.AwayWorlds;
 		GameModeList = GameManager.Instance.GetAvailableGameModeNames();
 		yesNoList.Add("Yes");
 		yesNoList.Add("No");

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/RoundManagerPage.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/RoundManagerPage.cs
@@ -139,7 +139,9 @@ public class RoundManagerPage : AdminPage
 			text = "Random"
 		});
 
-		foreach (var awaySiteName in SubSceneManager.Instance.awayWorldList.AwayWorlds)
+		//TODO: Admins can only pull from the available away worlds that are defined in the current game mode.
+		//Make this look for ALL away worlds in the AssetsStreaming folder
+		foreach (var awaySiteName in SubSceneManager.Instance.AwayWorlds.AwayWorlds)
 		{
 			optionData.Add(new Dropdown.OptionData
 			{


### PR DESCRIPTION
# Changelog:

CL: [New] Asteroids, Away Sites, and additional scenes, can now all be defined per game mode, just like main stations.
CL: [New] Main station lists can now override the asteroid list with their own custom one.