### PR TITLE
Playtest fixes

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/PlagueDoctorsHat.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Headwear/PlagueDoctorsHat.prefab
@@ -20,9 +20,20 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
       propertyPath: itemSprites.SpriteLeftHand
       value: 
       objectReference: {fileID: 11400000, guid: c708e4aee29f33048add240297211a29,
+        type: 2}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: 'initialTraits.Array.data[1]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 5a088ab3ae96cb145af5f61b61514ac8,
         type: 2}
     - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
@@ -33,6 +44,24 @@ PrefabInstance:
     - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: itemSprites.SpriteInventoryIcon
+      value: 
+      objectReference: {fileID: 11400000, guid: 25e6e1b22ba2eba44810503ab4743caa,
+        type: 2}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: InitialitemSprites.SpriteLeftHand
+      value: 
+      objectReference: {fileID: 11400000, guid: c708e4aee29f33048add240297211a29,
+        type: 2}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: InitialitemSprites.SpriteRightHand
+      value: 
+      objectReference: {fileID: 11400000, guid: f9812ad7ab0bc844fb45af99f9071fad,
+        type: 2}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: InitialitemSprites.SpriteInventoryIcon
       value: 
       objectReference: {fileID: 11400000, guid: 25e6e1b22ba2eba44810503ab4743caa,
         type: 2}

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Maskwear/PlagueDoctorMask.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Maskwear/PlagueDoctorMask.prefab
@@ -156,8 +156,14 @@ PrefabInstance:
     - target: {fileID: 6776931286767099191, guid: 996d62bfe3bf26c4e95c2a77cadabbd2,
         type: 3}
       propertyPath: initialTraits.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
+    - target: {fileID: 6776931286767099191, guid: 996d62bfe3bf26c4e95c2a77cadabbd2,
+        type: 3}
+      propertyPath: 'initialTraits.Array.data[1]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 5a088ab3ae96cb145af5f61b61514ac8,
+        type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/BioSuits/PlagueDoctorSuit.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Outerwear/BioSuits/PlagueDoctorSuit.prefab
@@ -21,7 +21,24 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3495234765619245072, guid: ab1e465a59765f84b8691daa8693f857,
         type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3495234765619245072, guid: ab1e465a59765f84b8691daa8693f857,
+        type: 3}
+      propertyPath: 'initialTraits.Array.data[1]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 5a088ab3ae96cb145af5f61b61514ac8,
+        type: 2}
+    - target: {fileID: 3495234765619245072, guid: ab1e465a59765f84b8691daa8693f857,
+        type: 3}
       propertyPath: itemSprites.SpriteInventoryIcon
+      value: 
+      objectReference: {fileID: 11400000, guid: 2264dcc16d2a5df45a51306528f5a915,
+        type: 2}
+    - target: {fileID: 3495234765619245072, guid: ab1e465a59765f84b8691daa8693f857,
+        type: 3}
+      propertyPath: InitialitemSprites.SpriteInventoryIcon
       value: 
       objectReference: {fileID: 11400000, guid: 2264dcc16d2a5df45a51306528f5a915,
         type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Effects/Sickness/GenericEmotes/RedPlagueMessages.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Effects/Sickness/GenericEmotes/RedPlagueMessages.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   overrideDisplayName: 
   hallucinationTime: 0
-  percentageChance: 5
+  percentageChance: 20
   harmIntentChance: 0
   nameForgetChance: 0
   ParanoidThoughts:
@@ -24,7 +24,13 @@ MonoBehaviour:
   - Your stomach rumbles violently.
   - You feel an immense sense of dread.
   - Your head hurts so much you are unable to think.
-  emoteChance: 25
+  - You feel bloated.
+  - You feel bloated.
+  - You feel bloated.
+  - You feel bloated.
+  - You feel swollen.
+  - You feel swollen.
+  emoteChance: 20
   possibleEmotes:
   - {fileID: 11400000, guid: c330a7cbe2059774fafd4a32d2eabecc, type: 2}
   - {fileID: 11400000, guid: 46f3f1cab09fa684d85d1fe9f0db0b7f, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Effects/Sickness/MiasmaEmit.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Effects/Sickness/MiasmaEmit.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0c48eb57f6f626041a1d537db5302073, type: 3}
+  m_Name: MiasmaEmit
+  m_EditorClassIdentifier: Assets::Chemistry.Effects.GasEmissionEffect
+  overrideDisplayName: 
+  gasToEmit: {fileID: 11400000, guid: ca89e986f14ca0d46b7cc46d462d905a, type: 2}
+  amountOfGas: 10
+  emissionChance: 15

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Effects/Sickness/MiasmaEmit.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Effects/Sickness/MiasmaEmit.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 984515492f6b0834cb46b0d02c72699f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Sicknesses/RedPlagueReaction.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Sicknesses/RedPlagueReaction.asset
@@ -45,7 +45,7 @@ MonoBehaviour:
   sicknessGrowthCharacteristic:
     SicknessGrowthChancePercent: 85
     SicknessGrowthBaseRate: 0.04
-    SicknessGrowthRelativeRate: 0.008
+    SicknessGrowthRelativeRate: 0.0055
   stages:
   - StageConcentrationThreshold: 0
     StageEffects:
@@ -58,16 +58,15 @@ MonoBehaviour:
     - {fileID: 11400000, guid: 45793ea50437e4a4e80170ec5fd0c3c6, type: 2}
   - StageConcentrationThreshold: 4
     StageEffects:
-    - {fileID: 11400000, guid: 5d0b7b3efbb3a33418ee59eb52ef4e14, type: 2}
     - {fileID: 11400000, guid: c1ed547e609ed734ea50a13a8e35f6f4, type: 2}
-    - {fileID: 11400000, guid: 4b495bfd5e5a6174db5e66d2c4ee407c, type: 2}
+    - {fileID: 11400000, guid: 686e61ed159f74341a43a89072dc5bfe, type: 2}
     - {fileID: 11400000, guid: 45793ea50437e4a4e80170ec5fd0c3c6, type: 2}
   - StageConcentrationThreshold: 8
     StageEffects:
     - {fileID: 11400000, guid: 5d0b7b3efbb3a33418ee59eb52ef4e14, type: 2}
-    - {fileID: 11400000, guid: ce00514859fcfbf4ebc18904aa14dcde, type: 2}
+    - {fileID: 11400000, guid: c1ed547e609ed734ea50a13a8e35f6f4, type: 2}
     - {fileID: 11400000, guid: 4b495bfd5e5a6174db5e66d2c4ee407c, type: 2}
-    - {fileID: 11400000, guid: 1efd831ebaa972e43b93dbcbc1382783, type: 2}
+    - {fileID: 11400000, guid: 984515492f6b0834cb46b0d02c72699f, type: 2}
   - StageConcentrationThreshold: 14
     StageEffects:
     - {fileID: 11400000, guid: cd22551c247e5d14dbef9724f827fe5a, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/MaintRooms/TinyRooms/IDCard.asset
+++ b/UnityProject/Assets/ScriptableObjects/MaintRooms/TinyRooms/IDCard.asset
@@ -12,5 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5b92f347601b3014e85b32c0bc64f6bd, type: 3}
   m_Name: IDCard
   m_EditorClassIdentifier: 
-  DoorDirections: 1
+  DoorDirections: 2
   roomFileName: 5x5IdCard

--- a/UnityProject/Assets/Scripts/Systems/ChemistryEffects/Body/GasEmissionEffect.cs
+++ b/UnityProject/Assets/Scripts/Systems/ChemistryEffects/Body/GasEmissionEffect.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using Chemistry;
+using HealthV2;
+using HealthV2.Living.PolymorphicSystems.Bodypart;
+using ScriptableObjects.Atmospherics;
+using UnityEngine;
+
+namespace Chemistry.Effects
+{
+	[CreateAssetMenu(fileName = "GasEmission",
+		menuName = "ScriptableObjects/Chemistry/Effects/GasEmissionEffect")]
+	public class GasEmissionEffect : Chemistry.Effect
+	{
+		[SerializeField] private GasSO gasToEmit = null;
+		[SerializeField] private float amountOfGas = 1;
+
+		[SerializeField] private float emissionChance = 15;
+
+		public override void Apply(MonoBehaviour sender, float amount)
+		{
+			if (DMMath.Prob(emissionChance) == false) return;
+
+			if (sender is MetabolismComponent metabolismComponent == false) return;
+			if (metabolismComponent.RelatedPart.HealthMaster == false) return;
+
+			LivingHealthMasterBase healthMaster = metabolismComponent.RelatedPart.HealthMaster;
+			Vector3 actorPos = healthMaster.gameObject.AssumedWorldPosServer();
+
+			//Add gas to area (Typically Miasma)
+			if (gasToEmit != null && amountOfGas > 0)
+			{
+				MetaDataNode node = MatrixManager.GetMetaDataAt(actorPos.CutToInt());
+				node.GasMixLocal.AddGasWithTemperature(gasToEmit, amountOfGas, node.GasMixLocal.Temperature);
+			}
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/ChemistryEffects/Body/GasEmissionEffect.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/ChemistryEffects/Body/GasEmissionEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0c48eb57f6f626041a1d537db5302073
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Systems/ChemistryEffects/Body/PlagueBomb.cs
+++ b/UnityProject/Assets/Scripts/Systems/ChemistryEffects/Body/PlagueBomb.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Chemistry;
 using HealthV2;
 using HealthV2.Living.PolymorphicSystems.Bodypart;
+using NUnit.Framework;
 using ScriptableObjects.Atmospherics;
 using UnityEngine;
 
@@ -68,6 +69,8 @@ namespace Chemistry.Effects
 			victimPos -= actorPosition;
 			int hitCount = Physics2D.Raycast(actorPosition, victimPos, filter, hits, victimDistance);
 			if (hitCount > 0) return;
+
+			if (HasBlockingSuit(player) == true) return;
 
 			float amountToAfflict = spreadCount * (1 - (victimDistance / spreadRange));
 			victim.Script.playerHealth.reagentPoolSystem.BloodPool.Add(reagentToSpread, amountToAfflict);

--- a/UnityProject/Assets/Scripts/Systems/MaintRooms/MaintGenerator.cs
+++ b/UnityProject/Assets/Scripts/Systems/MaintRooms/MaintGenerator.cs
@@ -54,6 +54,9 @@ namespace Systems.Scenes
 		[SerializeField, Range(1, MAX_DIMENSIONS)]
 		private int height = 20;
 
+		[SerializeField, Tooltip("Enabling this will cause the generator to still place rooms but not the underlying maze.")]
+		private bool skipMazeGeneration = false;
+
 		[SerializeField] private LayerTile wallTile;
 
 		[SerializeField, Range(0, MAX_PERCENT)]
@@ -103,6 +106,13 @@ namespace Systems.Scenes
 
 			foreach (var room in roomGenerators)
 			{
+				room.SelectRoom();
+			}
+
+			if (skipMazeGeneration) return;
+
+			foreach (var room in roomGenerators)
+			{
 				await room.ClearSpaceInMaze(this.gameObject.transform.localPosition, width, in mazeArray);
 			}
 
@@ -115,7 +125,7 @@ namespace Systems.Scenes
 
 			foreach (var room in roomGenerators)
 			{
-				room.CarveRoomDoors(this.gameObject.transform.localPosition, width, in mazeArray);
+				room.CarveRoomDoors(this.gameObject.transform.localPosition, width, ref mazeArray);
 			}
 		}
 
@@ -205,6 +215,8 @@ namespace Systems.Scenes
 
 		public void CreateTiles()
 		{
+			if (skipMazeGeneration) return;
+
 			for (int x = 0; x < width; x++)
 			{
 				for (int y = 0; y < height; y++)
@@ -261,6 +273,8 @@ namespace Systems.Scenes
 
 		public void PlaceObjects()
 		{
+			if (skipMazeGeneration) return;
+
 			for (int i = 0; i < width; i++)
 			{
 				for (int j = 0; j < height; j++)

--- a/UnityProject/Assets/Scripts/Systems/MaintRooms/MaintRoomGenerator.cs
+++ b/UnityProject/Assets/Scripts/Systems/MaintRooms/MaintRoomGenerator.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using Clothing;
 using InGameGizmos;
 using Logs;
 using MapSaver;
@@ -87,8 +88,12 @@ namespace MaintRooms
 				Array.Fill(maze, (short)MazeState.ExcludedCell, startIndex, roomWidth);
 			}
 
-			PickWeightedRoom(out selectedRoom);
 			return Task.CompletedTask;
+		}
+
+		public void SelectRoom()
+		{
+			PickWeightedRoom(out selectedRoom);
 		}
 
 		private bool PickWeightedRoom(out MaintRoomSO room)
@@ -117,12 +122,12 @@ namespace MaintRooms
 			return false;
 		}
 
-		public void CarveRoomDoors(Vector3 generatorOffset, int mazeWidth, in short[] maze)
+		public void CarveRoomDoors(Vector3 generatorOffset, int mazeWidth, ref short[] maze)
 		{
 			var pos = (transform.localPosition - generatorOffset).RoundTo2Int();
 
 			int halfX = (roomWidth - 1) / 2;
-			int halfY = (roomWidth - 1) / 2;
+			int halfY = (roomHeight - 1) / 2;
 
 			if (selectedRoom.DoorDirections.HasFlag(DirectionFlag.Up))
 			{


### PR DESCRIPTION
### Changelog:
CL: [Improvement] Added the ability to toggle off tile gen for maintgenerators
CL: [Improvement] Plague doctor clothing now has the ProtectsFromDisease trait and can protect you from infection
CL: [Balance] Nerfed the rate of progression for the red plague bomb. It should now take ~75% longer to reach its final stage.
CL: [Balance] Nerfed the intermediate symptoms of red plague, but adds a symptom that radiates miasma from the victim in later stages.
CL: [Fix] Actually enabled the code for biosuits protecting from plague bombs
CL: [Fix] Fixed maintrooms generating inaccessible doors for rectangular rooms