### PR TITLE
Solar Panel improvements

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Electricity/New SolarPanelController.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Electricity/New SolarPanelController.prefab
@@ -125,6 +125,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6943869364395329275, guid: f9025da3beb40304cb15babfc0a6cafa,
         type: 3}
+      propertyPath: spriteRenderer
+      value: 
+      objectReference: {fileID: 6841455438560793530}
+    - target: {fileID: 6943869364395329275, guid: f9025da3beb40304cb15babfc0a6cafa,
+        type: 3}
       propertyPath: PresentSpriteSet
       value: 
       objectReference: {fileID: 11400000, guid: c04c20dfad951fd4191fd35ca7d40732,
@@ -304,6 +309,7 @@ MonoBehaviour:
   syncInterval: 0.1
   ModuleSupply: {fileID: 5682924656864035169}
   UpdateRate: 10
+  MaxCurrent: 0.06
   connectedPanels: []
 --- !u!114 &5682924656864035169
 MonoBehaviour:
@@ -325,9 +331,15 @@ MonoBehaviour:
   PreviousSupplyingVoltage: 0
   SupplyingVoltage: 2400
   PreviousInternalResistance: 0
-  InternalResistance: 19000
+  InternalResistance: 10000000
   PreviousProducingWatts: 0
   ProducingWatts: 0
+--- !u!212 &6841455438560793530 stripped
+SpriteRenderer:
+  m_CorrespondingSourceObject: {fileID: 2408678487295248438, guid: f9025da3beb40304cb15babfc0a6cafa,
+    type: 3}
+  m_PrefabInstance: {fileID: 9195474316350675852}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &8452876085178655955 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 779761725270966111, guid: f9025da3beb40304cb15babfc0a6cafa,

--- a/UnityProject/Assets/Scripts/Systems/Electricity/NodeModules/ModuleSupplyingDevice.cs
+++ b/UnityProject/Assets/Scripts/Systems/Electricity/NodeModules/ModuleSupplyingDevice.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using Logs;
 using SecureStuff;
 using Systems.Electricity.Inheritance;
 using UnityEngine;

--- a/UnityProject/Assets/Scripts/Systems/Electricity/PowerSupplies/SolarPanel.cs
+++ b/UnityProject/Assets/Scripts/Systems/Electricity/PowerSupplies/SolarPanel.cs
@@ -1,9 +1,12 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using AddressableReferences;
 using Core;
+using Logs;
 using Messages.Server.SoundMessages;
 using Mirror;
+using NaughtyAttributes;
 using Shared.Systems.ObjectConnection;
 using UI.Systems.Tooltips.HoverTooltips;
 using UnityEngine;
@@ -13,15 +16,26 @@ using UniversalObjectPhysics = Core.Physics.UniversalObjectPhysics;
 namespace Systems.Electricity.PowerSupplies
 {
 	[RequireComponent(typeof(UniversalObjectPhysics))]
-	public class SolarPanel : NetworkBehaviour, ICheckedInteractable<HandApply>, IMultitoolSlaveable, IExaminable, IHoverTooltip
+	public sealed class SolarPanel : NetworkBehaviour, ICheckedInteractable<HandApply>, IMultitoolSlaveable, IExaminable, IHoverTooltip
 	{
-		[field: SerializeField] public UniversalObjectPhysics Physics { get; private set; }
-		[field: SerializeField] public int LastProducedWatts { get; private set; } = 0;
-		[SerializeField] private float updateRate = 16f;
-		[SerializeField] private int productionPowerPointsPerFreeAvaliableSide = 150;
-		[SerializeField] private bool isOn = true;
+		[BoxGroup("References")]
 		[SerializeField] private AddressableAudioSource warningBeeper;
 		[SerializeField] private AddressableAudioSource wrenchSound;
+		[field: SerializeField] public UniversalObjectPhysics Physics { get; private set; }
+
+		[BoxGroup("Power Production Settings")]
+		[SerializeField] private float updateRate = 16f;
+		[SerializeField] private int productionPowerPointsPerFreeAvaliableSide = 150;
+		[SerializeField] private int wattsMultiplierPerPowerPoint = 2;
+		[SerializeField] private bool isOn = true;
+
+		[BoxGroup("Misc")]
+		[SerializeField, Tooltip("This is in case the map saver is unable to serialize the controller link in the future.")]
+		private bool automaticallyLinkToNearestControllerOnStart = false;
+		[SerializeField, Tooltip("1 unit = 1 tile.\nThis is the radius the panel will search for a controller on start if autoLink is enabled.")]
+		private float searchRadiusForControllers = 250;
+
+		[field: SerializeField] public int LastProducedWatts { get; private set; } = 0;
 
 		private AudioSourceParameters beeperSettings = new AudioSourceParameters()
 		{
@@ -34,20 +48,6 @@ namespace Systems.Electricity.PowerSupplies
 		public IMultitoolMasterable Master { get; set; }
 		public SolarPanelController Controller;
 
-		public bool TrySetMaster(GameObject performer, IMultitoolMasterable master)
-		{
-			if (master.gameObject.TryGetComponent<SolarPanelController>(out var controller) == false) return false;
-			return controller.AddDevice(this);
-		}
-
-		public void SetMasterEditor(IMultitoolMasterable master)
-		{
-			if (master.gameObject.TryGetComponent<SolarPanelController>(out var controller) == false) return;
-			Master = controller;
-			Controller = controller;
-			controller.AddDevice(this);
-		}
-
 		private void Awake()
 		{
 			Physics ??= GetComponent<UniversalObjectPhysics>();
@@ -55,12 +55,17 @@ namespace Systems.Electricity.PowerSupplies
 			if (Controller != null)
 			{
 				Controller.AddDevice(this);
-				Master ??= Controller;
+				Master = Controller;
 			}
 			else
 			{
 				isOn = false;
 			}
+		}
+
+		private void Start()
+		{
+			GetNearestControllerAndSetIt();
 		}
 
 		private void OnDestroy()
@@ -72,7 +77,7 @@ namespace Systems.Electricity.PowerSupplies
 		{
 			if (isOn == false) return;
 			var points = CalculatePoints();
-			LastProducedWatts = points * 2;
+			LastProducedWatts = points * wattsMultiplierPerPowerPoint;
 			if (points == 0)
 			{
 				if (warningBeeper != null) SoundManager.PlayNetworkedAtPos(warningBeeper, gameObject.AssumedWorldPosServer(), beeperSettings);
@@ -124,6 +129,37 @@ namespace Systems.Electricity.PowerSupplies
 			}
 		}
 
+		public bool TrySetMaster(GameObject performer, IMultitoolMasterable master)
+		{
+			if (master.gameObject.TryGetComponent<SolarPanelController>(out var controller) == false) return false;
+			return controller.AddDevice(this);
+		}
+
+		public void SetMasterEditor(IMultitoolMasterable master)
+		{
+			if (master.gameObject.TryGetComponent<SolarPanelController>(out var controller) == false) return;
+			Master = controller;
+			Controller = controller;
+			controller.AddDevice(this);
+		}
+
+		private void GetNearestControllerAndSetIt()
+		{
+			if (automaticallyLinkToNearestControllerOnStart == false) return;
+			var nearbyControllers =
+				ComponentsTracker<SolarPanelController>.GetAllNearbyTypesToTarget(gameObject, searchRadiusForControllers);
+			var controller = nearbyControllers?.FirstOrDefault();
+			if (controller == null)
+			{
+				Loggy.Warning(
+					$"Attempted to auto-link Solar Panel '{gameObject.ExpensiveName()}' to nearest controller," +
+					$" but none were found in radius {searchRadiusForControllers}.");
+				return;
+			}
+			Master = controller;
+			controller.AddDevice(this);
+		}
+
 		private string OnOff()
 		{
 			return isOn ? "on" : "off";
@@ -139,12 +175,25 @@ namespace Systems.Electricity.PowerSupplies
 
 		public string HoverTip()
 		{
-			return "";
+			var hoverTips = new StringBuilder();
+			if (isOn)
+			{
+				hoverTips.AppendLine($"The panel produces energy every {updateRate} seconds.");
+			}
+			else
+			{
+				hoverTips.AppendLine("It is turned off due to it being unbolted, and does not produce energy.");
+			}
+			if (Controller == null)
+			{
+				hoverTips.AppendLine("This panel is not connected to any controllers to siphon the produced energy.".Italic());
+			}
+			return hoverTips.ToString();
 		}
 
 		public string CustomTitle()
 		{
-			return null;
+			return $"{gameObject.ExpensiveName()} [{OnOff()}]";
 		}
 
 		public Sprite CustomIcon()
@@ -160,14 +209,6 @@ namespace Systems.Electricity.PowerSupplies
 		public List<TextColor> InteractionsStrings()
 		{
 			List<TextColor> tips = new List<TextColor>();
-			if (isOn)
-			{
-				tips.Add(new TextColor() { Text = $"The panel produces energy every {updateRate} seconds.".Italic(), Color = Color.grey });
-			}
-			else
-			{
-				tips.Add(new TextColor() { Text = "An unbolted panel is turned off, and does not produce energy.".Italic(), Color = Color.grey });
-			}
 			tips.Add(new TextColor() { Text = "Use a wrench to bolt this panel down/up.", Color = Color.green });
 			if (Controller == null) tips.Add(new TextColor(){ Text = "Use a multi-tool to connect this panel to a Solar Panel Controller.", Color = Color.green});
 			return tips;

--- a/UnityProject/Assets/Scripts/Systems/Electricity/PowerSupplies/SolarPanelController.cs
+++ b/UnityProject/Assets/Scripts/Systems/Electricity/PowerSupplies/SolarPanelController.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using Core;
 using Mirror;
 using Shared.Systems.ObjectConnection;
 using Systems.Electricity.NodeModules;
@@ -10,12 +12,18 @@ namespace Systems.Electricity.PowerSupplies
 	{
 		public ModuleSupplyingDevice ModuleSupply;
 		public float UpdateRate = 10f;
+		public float MaxCurrent = 0.06f;
 		[SerializeField] private List<SolarPanel> connectedPanels;
 
 		public MultitoolConnectionType ConType { get; } = MultitoolConnectionType.SolarPanel;
 		public bool CanRelink { get; } = true;
 		public int MaxDistance { get; } = 64;
 		public bool IgnoreMaxDistanceMapper { get; } = false;
+
+		private void Awake()
+		{
+			ComponentsTracker<SolarPanelController>.RegisterInstance(this);
+		}
 
 		private void Start()
 		{
@@ -25,6 +33,7 @@ namespace Systems.Electricity.PowerSupplies
 
 		private void OnDestroy()
 		{
+			ComponentsTracker<SolarPanelController>.UnregisterInstance(this);
 			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, UpdateMe);
 		}
 
@@ -36,6 +45,7 @@ namespace Systems.Electricity.PowerSupplies
 				watts += panel.LastProducedWatts;
 			}
 			ModuleSupply.ProducingWatts = watts;
+			ModuleSupply.Maxcurrent = MaxCurrent;
 		}
 
 		public bool AddDevice(SolarPanel panel)

--- a/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
+++ b/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
@@ -95,7 +95,7 @@ public static class SweetExtensions
 			return Script.visibleName;
 		}
 
-		return go?.name.Replace("NPC_", "").Replace("_", " ").Replace("(Clone)","");
+		return go?.name.Replace("NPC_", "").Replace("_", " ").Replace("(Clone)","").Replace("gameObject", "");
 	}
 
 	public static T GetRandom<T>(this List<T> list)


### PR DESCRIPTION
CL: [New] Added the ability for mappers to toggle a setting that would cause solar panels to automatically register themselves to the nearest Solar Panel Controller upon spawning.
CL: [New] The multiplier that is used to define how many total watts is generated for solar panels is now configurable for mappers.
CL: [Balance] Increased the resistance of solar panel controllers to match the same numbers as a plasma generator.
CL: [Improvement] Cleaned up several text elements inside hover tooltips for solar panels. 