### PR TITLE
Fix bug that would not untrack unowned buttons correctly

### DIFF
--- a/UnityProject/Assets/Scripts/Actions/V2/ActionManager.cs
+++ b/UnityProject/Assets/Scripts/Actions/V2/ActionManager.cs
@@ -89,27 +89,21 @@ namespace Actions.V2
 
 		private void UICheckMind()
 		{
-			if (PlayerManager.LocalMindScript && PlayerManager.LocalMindScript.gameObject.NetWorkIdentity() ==
-			    cachedNetIdentity)
+			if (PlayerManager.LocalMindScript == null ||
+			    PlayerManager.LocalMindScript.gameObject.NetWorkIdentity() != cachedNetIdentity)
 			{
-				ActionButtonManager.Instance.RefreshButtonsMind(ActionButtons, cachedNetIdentity);
+				return;
 			}
-			else
-			{
-				ActionButtonManager.Instance.DeleteSpawnedMindUIActions(cachedNetIdentity);
-			}
+			ActionButtonManager.Instance.RefreshButtonsMind(ActionButtons, cachedNetIdentity);
 		}
 
 		private void UICheckBody()
 		{
-			if (PlayerManager.LocalMindScript?.GetRelatedBodies().Contains(cachedNetIdentity) == true)
+			if (PlayerManager.LocalMindScript?.GetRelatedBodies().Contains(cachedNetIdentity) == false)
 			{
-				ActionButtonManager.Instance.RefreshButtonsBody(ActionButtons, cachedNetIdentity);
+				return;
 			}
-			else
-			{
-				ActionButtonManager.Instance.DeleteSpawnedBodyUIActions(cachedNetIdentity);
-			}
+			ActionButtonManager.Instance.RefreshButtonsBody(ActionButtons, cachedNetIdentity);
 		}
 
 		private void OnActionButtonsChanged(SyncList<ActionButtonData>.Operation op, int index, ActionButtonData oldItem, ActionButtonData newItem)

--- a/UnityProject/Assets/Scripts/Actions/V2/UI/ActionButtonManager.cs
+++ b/UnityProject/Assets/Scripts/Actions/V2/UI/ActionButtonManager.cs
@@ -27,12 +27,18 @@ namespace Actions.V2.UI
             foreach (var buttonData in actionButtons)
             {
 	            if (buttonData == null || !PlayerManager.LocalMindScript) continue;
-                if (buttonData.TrackingObject &&
-                    (PlayerManager.LocalMindScript.netIdentity.netId != buttonData.TrackingObject.netId
-                     && PlayerManager.LocalMindScript.GetDeepestBody().netId != buttonData.TrackingObject.netId))
-                {
-					continue;
-                }
+	            if (buttonData.TrackingObject == null) continue;
+	            if (isMindAction)
+	            {
+		            if (buttonData.TrackingObject.netId != PlayerManager.LocalMindScript.netIdentity.netId)
+		            {
+			            continue;
+		            }
+	            }
+	            else
+	            {
+		            if (PlayerManager.LocalMindScript.GetDeepestBody().netId != buttonData.TrackingObject.netId) continue;
+	            }
 
                 trackedItems.Add(buttonData.ID);
                 if (spawnedButtons.Exists(b => b.name == buttonData.ID))
@@ -59,6 +65,7 @@ namespace Actions.V2.UI
 
         public void DeleteSpawnedBodyUIActions(NetworkIdentity ownerRequest)
         {
+	        if (spawnedButtonsBody.Count == 0) return;
 	        foreach (var button in spawnedButtonsBody.ToList())
 	        {
 		        if (button.Owner != ownerRequest) continue;
@@ -72,6 +79,7 @@ namespace Actions.V2.UI
 
         public void DeleteSpawnedMindUIActions(NetworkIdentity ownerRequest)
 		{
+			if (spawnedButtonsMind.Count == 0) return;
 	        foreach (var button in spawnedButtonsMind.ToList())
 	        {
 		        if (button.Owner != ownerRequest) continue;


### PR DESCRIPTION
CL: [Fix] Fixed a bug that would not remove unowned V2 actions correctly during the refresh process.