### PR TITLE
Add the ability for V2 actions to use an object's SpriteHandler to set its button's icon

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/PDA/PDAs/PDABase.prefab
+++ b/UnityProject/Assets/Prefabs/Items/PDA/PDAs/PDABase.prefab
@@ -53,6 +53,8 @@ SpriteRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -74,6 +76,7 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: -1463207863
   m_SortingLayer: 13
   m_SortingOrder: 42
@@ -221,6 +224,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -242,6 +247,7 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
@@ -308,6 +314,8 @@ SpriteRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -329,6 +337,7 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: -1463207863
   m_SortingLayer: 13
   m_SortingOrder: 41
@@ -421,6 +430,8 @@ SpriteRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -442,6 +453,7 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: -1463207863
   m_SortingLayer: 13
   m_SortingOrder: 41
@@ -534,6 +546,8 @@ SpriteRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -555,6 +569,7 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: -1463207863
   m_SortingLayer: 13
   m_SortingOrder: 41
@@ -647,6 +662,8 @@ SpriteRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -668,6 +685,7 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: -1463207863
   m_SortingLayer: 13
   m_SortingOrder: 41
@@ -985,6 +1003,7 @@ MonoBehaviour:
   hidesSlots: 0
   hideClothingFlags: 0
   disallowConsume: 0
+  Colour: {r: 1, g: 1, b: 1, a: 1}
 --- !u!114 &-2461206429612825053
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1136,19 +1155,24 @@ MonoBehaviour:
       Description: Light the way!
       TriggerType: 0
       Type: 0
-      AnimatedIconCatalogue:
-      - {fileID: 11400000, guid: f319abe1054c0a44f818e35c9ab66460, type: 2}
       CooldownTime: 0
       CanUseWhileGhosting: 0
+      AnimatedIconCatalogue:
+      - {fileID: 11400000, guid: f319abe1054c0a44f818e35c9ab66460, type: 2}
+      TryToGrabSpritesFromRelatedObject: 1
+      HasCustomCursorOffset: 0
       HasCustomCursor: 0
       OffsetType: 0
       CursorOffset: {x: 0, y: 0}
       CursorTexture: {fileID: 0}
       TrackingObject: {fileID: 0}
+      ObjectRelatedToThisAction: {fileID: 0}
     m_values:
     - target: {fileID: 1293357877581254245}
       methodName: ToggleFlashlight
       parameterType: 
+  requiresSpecificSlots: 0
+  possibleSlots: 9
 --- !u!4 &239048463826641235 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298,

--- a/UnityProject/Assets/Scripts/Actions/V2/ActionButtonData.cs
+++ b/UnityProject/Assets/Scripts/Actions/V2/ActionButtonData.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Mirror;
+using NaughtyAttributes;
 using UnityEngine;
 
 namespace Actions.V2
@@ -23,18 +24,21 @@ namespace Actions.V2
 		public string ID;
 		public string DisplayName;
 		[TextArea(2, 4)] public string Description;
-		public ActionTriggerType TriggerType;
-		public ActionType Type;
-		public List<SpriteDataSO> AnimatedIconCatalogue;
-		public float CooldownTime;
-		public bool CanUseWhileGhosting = false;
 
-		public bool HasCustomCursorOffset { get; set; }
-		public bool HasCustomCursor;
-		public CursorOffsetType OffsetType;
-		public Vector2 CursorOffset;
-		public SpriteDataSO CursorTexture;
+		[BoxGroup("Interaction Settings")] public ActionTriggerType TriggerType;
+		[BoxGroup("Interaction Settings")] public ActionType Type;
+		[BoxGroup("Interaction Settings")] public float CooldownTime;
+		[BoxGroup("Interaction Settings")] public bool CanUseWhileGhosting = false;
+		[BoxGroup("Sprites")] public List<SpriteDataSO> AnimatedIconCatalogue;
+		[BoxGroup("Sprites")] public bool TryToGrabSpritesFromRelatedObject = false;
+
+		[BoxGroup("Cursor Settings")] public bool HasCustomCursorOffset;
+		[BoxGroup("Cursor Settings")] public bool HasCustomCursor;
+		[BoxGroup("Cursor Settings")] public CursorOffsetType OffsetType;
+		[BoxGroup("Cursor Settings")] public Vector2 CursorOffset;
+		[BoxGroup("Cursor Settings")] public SpriteDataSO CursorTexture;
 
 		[HideInInspector] public NetworkIdentity TrackingObject;
+		[HideInInspector] public GameObject ObjectRelatedToThisAction;
 	}
 }

--- a/UnityProject/Assets/Scripts/Actions/V2/ActionManager.cs
+++ b/UnityProject/Assets/Scripts/Actions/V2/ActionManager.cs
@@ -20,32 +20,6 @@ namespace Actions.V2
 
 		private const float MINIMUM_COOLDOWN_TIME = 0.085f;
 
-		[Serializable]
-		public class CooldownInfo : NetworkMessage
-		{
-			public string ActionId { get; private set; }
-			public DateTime CooldownEnd { get; private set; }
-
-			public CooldownInfo() { }
-			public CooldownInfo(string actionId, DateTime cooldownEnd)
-			{
-				ActionId = actionId;
-				CooldownEnd = cooldownEnd;
-			}
-
-			public void Serialize(NetworkWriter writer)
-			{
-				writer.WriteString(ActionId);
-				writer.WriteLong(CooldownEnd.Ticks);
-			}
-
-			public void Deserialize(NetworkReader reader)
-			{
-				ActionId = reader.ReadString();
-				CooldownEnd = new DateTime(reader.ReadLong());
-			}
-		}
-
 		public enum OnType
 		{
 			Body,

--- a/UnityProject/Assets/Scripts/Actions/V2/Cooldown.cs
+++ b/UnityProject/Assets/Scripts/Actions/V2/Cooldown.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Mirror;
+
+namespace Actions.V2
+{
+	[Serializable]
+	public class CooldownInfo : NetworkMessage
+	{
+		public string ActionId { get; private set; }
+		public DateTime CooldownEnd { get; private set; }
+
+		public CooldownInfo() { }
+		public CooldownInfo(string actionId, DateTime cooldownEnd)
+		{
+			ActionId = actionId;
+			CooldownEnd = cooldownEnd;
+		}
+
+		public void Serialize(NetworkWriter writer)
+		{
+			writer.WriteString(ActionId);
+			writer.WriteLong(CooldownEnd.Ticks);
+		}
+
+		public void Deserialize(NetworkReader reader)
+		{
+			ActionId = reader.ReadString();
+			CooldownEnd = new DateTime(reader.ReadLong());
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Actions/V2/Cooldown.cs.meta
+++ b/UnityProject/Assets/Scripts/Actions/V2/Cooldown.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 032a0441a14d4a91bc62cf9d252b3097
+timeCreated: 1766740793

--- a/UnityProject/Assets/Scripts/Actions/V2/Trackers/ItemSlotActionTracker.cs
+++ b/UnityProject/Assets/Scripts/Actions/V2/Trackers/ItemSlotActionTracker.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using Logs;
+﻿using Logs;
 using NaughtyAttributes;
 using SecureStuff;
 using UnityEngine;
-using UnityEngine.Events;
-using UnityEngine.Serialization;
 
 namespace Actions.V2.Trackers
 {
@@ -28,10 +25,13 @@ namespace Actions.V2.Trackers
 				Debug.LogError("ItemSlotActionTracker requires a Pickupable component.");
 				return;
 			}
+
+			// lets the manager know what object this action is on.
+			foreach (var action in ActionData.Keys)
+			{
+				action.ObjectRelatedToThisAction = gameObject;
+			}
 		}
-
-
-
 
 		public void OnInventoryMoveServer(InventoryMove info)
 		{

--- a/UnityProject/Assets/Scripts/Actions/V2/UI/UIActionButton.cs
+++ b/UnityProject/Assets/Scripts/Actions/V2/UI/UIActionButton.cs
@@ -137,8 +137,29 @@ namespace Actions.V2.UI
 
 		private void TrySetIcon()
 		{
+			if (TryGetIconFromTrackingObject()) return;
 			if (ActionData.AnimatedIconCatalogue == null || ActionData.AnimatedIconCatalogue.Count == 0) return;
 			iconHandler.SetSpriteSO(ActionData.AnimatedIconCatalogue[0]);
+		}
+
+		private bool TryGetIconFromTrackingObject()
+		{
+			if (ActionData.TryToGrabSpritesFromRelatedObject == false) return false;
+			if (ActionData.ObjectRelatedToThisAction == null) return false;
+			var handlers = ActionData.ObjectRelatedToThisAction.GetComponentsInChildren<SpriteHandler>();
+			if (handlers == null || handlers.Length == 0) return false;
+			SpriteDataSO sprite = null;
+			foreach (var handler in handlers)
+			{
+				var currentSpriteSo = handler.GetCurrentSpriteSO();
+				if (currentSpriteSo == null) continue;
+				if (currentSpriteSo.Variance.Count == 0) continue;
+				sprite = currentSpriteSo;
+				break;
+			}
+			if (sprite == null) return false;
+			iconHandler.SetSpriteSO(sprite);
+			return true;
 		}
 
 		private void TrySetCustomCursor()


### PR DESCRIPTION
CL: [Improvement] V2 Actions now have the option to grab an object's sprite to set as its icon in its button UI.
CL: [Improvement] PDA action buttons will now display the PDA's actual sprite instead of the default one.
