### PR TITLE
Add new objective for antagonists: Starving Crew

### DIFF
--- a/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogConsole.cs
+++ b/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogConsole.cs
@@ -3,7 +3,10 @@ using System.Reflection;
 using System.Collections.Generic;
 using System.Text;
 using System;
+using System.Linq;
+using Cysharp.Threading.Tasks;
 using Logs;
+using Mirror;
 using SecureStuff;
 
 namespace IngameDebugConsole
@@ -55,12 +58,54 @@ namespace IngameDebugConsole
 		/// <summary>
 		/// All the parse functions
 		/// </summary>
-		private static Dictionary<Type, ParseFunction> parseFunctions;
+		private static Dictionary<Type, ParseFunction> parseFunctions = new Dictionary<Type, ParseFunction>()
+		{
+			{typeof(string), ParseString},
+			{typeof(bool), ParseBool},
+			{typeof(int), ParseInt},
+			{typeof(uint), ParseUInt},
+			{typeof(long), ParseLong},
+			{typeof(ulong), ParseULong},
+			{typeof(byte), ParseByte},
+			{typeof(sbyte), ParseSByte},
+			{typeof(short), ParseShort},
+			{typeof(ushort), ParseUShort},
+			{typeof(char), ParseChar},
+			{typeof(float), ParseFloat},
+			{typeof(double), ParseDouble},
+			{typeof(decimal), ParseDecimal},
+			{typeof(Vector2), ParseVector2},
+			{typeof(Vector3), ParseVector3},
+			{typeof(Vector4), ParseVector4},
+			{typeof(GameObject), ParseGameObject},
+			{typeof(NetworkConnectionToClient), ParseNetworkConnectionToClient}
+		};
 
 		/// <summary>
 		/// All the readable names of accepted types
 		/// </summary>
-		private static Dictionary<Type, string> typeReadableNames;
+		private static Dictionary<Type, string> typeReadableNames = new Dictionary<Type, string>()
+		{
+			{typeof(string), "String"},
+			{typeof(bool), "Boolean"},
+			{typeof(int), "Integer"},
+			{typeof(uint), "Unsigned Integer"},
+			{typeof(long), "Long"},
+			{typeof(ulong), "Unsigned Long"},
+			{typeof(byte), "Byte"},
+			{typeof(sbyte), "Short Byte"},
+			{typeof(short), "Short"},
+			{typeof(ushort), "Unsigned Short"},
+			{typeof(char), "Char"},
+			{typeof(float), "Float"},
+			{typeof(double), "Double"},
+			{typeof(decimal), "Decimal"},
+			{typeof(Vector2), "Vector2"},
+			{typeof(Vector3), "Vector3"},
+			{typeof(Vector4), "Vector4"},
+			{typeof(GameObject), "GameObject"},
+			{typeof(NetworkConnectionToClient), "NetworkConnectionToClient"}
+		};
 
 		/// <summary>
 		/// Split arguments of an entered command
@@ -72,55 +117,18 @@ namespace IngameDebugConsole
 		/// </summary>
 		private static readonly string[] inputDelimiters = new string[] {"\"\"", "{}", "()", "[]"};
 
+		public static bool isInitialized = false;
+
 		static DebugLogConsole()
 		{
-			parseFunctions = new Dictionary<Type, ParseFunction>()
-			{
-				{typeof(string), ParseString},
-				{typeof(bool), ParseBool},
-				{typeof(int), ParseInt},
-				{typeof(uint), ParseUInt},
-				{typeof(long), ParseLong},
-				{typeof(ulong), ParseULong},
-				{typeof(byte), ParseByte},
-				{typeof(sbyte), ParseSByte},
-				{typeof(short), ParseShort},
-				{typeof(ushort), ParseUShort},
-				{typeof(char), ParseChar},
-				{typeof(float), ParseFloat},
-				{typeof(double), ParseDouble},
-				{typeof(decimal), ParseDecimal},
-				{typeof(Vector2), ParseVector2},
-				{typeof(Vector3), ParseVector3},
-				{typeof(Vector4), ParseVector4},
-				{typeof(GameObject), ParseGameObject}
-			};
+			InitializeAsync();
+		}
 
-			typeReadableNames = new Dictionary<Type, string>()
-			{
-				{typeof(string), "String"},
-				{typeof(bool), "Boolean"},
-				{typeof(int), "Integer"},
-				{typeof(uint), "Unsigned Integer"},
-				{typeof(long), "Long"},
-				{typeof(ulong), "Unsigned Long"},
-				{typeof(byte), "Byte"},
-				{typeof(sbyte), "Short Byte"},
-				{typeof(short), "Short"},
-				{typeof(ushort), "Unsigned Short"},
-				{typeof(char), "Char"},
-				{typeof(float), "Float"},
-				{typeof(double), "Double"},
-				{typeof(decimal), "Decimal"},
-				{typeof(Vector2), "Vector2"},
-				{typeof(Vector3), "Vector3"},
-				{typeof(Vector4), "Vector4"},
-				{typeof(GameObject), "GameObject"}
-			};
-
-#if UNITY_EDITOR || !NETFX_CORE
-
+		public static void InitializeAsync()
+		{
+			if (isInitialized) return;
 			var data = AllowedReflection.GetFunctionsWithAttribute<ConsoleMethodAttribute>();
+			Debug.Log($"Attempting to register {data.Count} console commands");
 
 			foreach (var MonoBehaviourAndMethodInfo in data)
 			{
@@ -129,10 +137,7 @@ namespace IngameDebugConsole
 					AddCommand(type.Attribute.Command, type.Attribute.Description, type.MethodInfo);
 				}
 			}
-#else
-			AddCommandStatic( "help", "Prints all commands", "LogAllCommands", typeof( DebugLogConsole ) );
-			AddCommandStatic( "sysinfo", "Prints system information", "LogSystemInfo", typeof( DebugLogConsole ) );
-#endif
+			isInitialized = true;
 		}
 
 		/// <summary>
@@ -265,10 +270,9 @@ namespace IngameDebugConsole
 		/// <param name="instance">Object instance for instance functions</param>
 		private static void AddCommand(string command, string description, MethodInfo method, object instance = null)
 		{
+			Loggy.Info($"Adding command: {command}\n instance: {instance}\n methodInfo: {method.Name}", Category.DebugConsole);
 			// Fetch the parameters of the class
 			ParameterInfo[] parameters = method.GetParameters();
-			if (parameters == null)
-				parameters = new ParameterInfo[0];
 
 			bool isMethodValid = true;
 
@@ -278,9 +282,14 @@ namespace IngameDebugConsole
 			{
 				Type parameterType = parameters[k].ParameterType;
 				if (parseFunctions.ContainsKey(parameterType))
+				{
 					parameterTypes[k] = parameterType;
+				}
 				else
 				{
+					Loggy.Error(
+						$"command: {command} has unsupported parameter type: {parameterType.Name}",
+						Category.DebugConsole);
 					isMethodValid = false;
 					break;
 				}
@@ -322,6 +331,10 @@ namespace IngameDebugConsole
 				}
 
 				methods[command] = new ConsoleMethodInfo(method, parameterTypes, instance, methodSignature.ToString());
+			}
+			else
+			{
+				Loggy.Error($"command: {command} is not valid.", Category.DebugConsole);
 			}
 		}
 
@@ -618,6 +631,20 @@ namespace IngameDebugConsole
 		{
 			output = GameObject.Find(input);
 			return true;
+		}
+
+		private static bool ParseNetworkConnectionToClient(string input, out object output)
+		{
+			output = null;
+			foreach (var player in PlayerList.Instance.AllPlayers)
+			{
+				if (player.ClientId == input || player.Username == input)
+				{
+					output = player.Connection;
+					return true;
+				}
+			}
+			return false;
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogManager.cs
+++ b/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogManager.cs
@@ -357,6 +357,7 @@ namespace IngameDebugConsole
 				if (text.Length > 0)
 				{
 					// Execute the command
+					DebugLogConsole.InitializeAsync();
 					DebugLogConsole.ExecuteCommand(text);
 
 					// Snap to bottom and select the latest entry

--- a/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
+++ b/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Text;
 using AdminCommands;
 using Core;
 using UnityEngine;
@@ -9,6 +10,7 @@ using Systems.Atmospherics;
 using Random = UnityEngine.Random;
 using Core.Accounts;
 using HealthV2;
+using Items.Implants.Organs;
 using Learning;
 using Logs;
 using Messages.Server;
@@ -16,6 +18,7 @@ using Messages.Server.HealthMessages;
 using ScriptableObjects;
 using Systems.Character;
 using Systems.Score;
+using Systems.StatusesAndEffects;
 using UniversalObjectPhysics = Core.Physics.UniversalObjectPhysics;
 
 namespace IngameDebugConsole
@@ -723,6 +726,50 @@ namespace IngameDebugConsole
 			PlayerManager.LocalPlayerScript.PlayerNetworkActions.CmdResetMovementForSelf();
 			Loggy.Info("[Console Command] - Movement Reset Successfully. " +
 			           "If you're still stuck, please report this and any errors you might find in the console on github/discord.", Category.DebugConsole);
+		}
+
+		[ConsoleMethod("bodyfat.becomeskinny", "Sets the body fat absorbed amount to 0 for everything.")]
+		public static void MakeEveryoneSkinny()
+		{
+			if (CustomNetworkManager.IsServer == false)
+			{
+				Loggy.Error("Cannot execute this command from client.", Category.DebugConsole);
+				return;
+			}
+			var fats = GameObject.FindObjectsByType<BodyFat>(sortMode: FindObjectsSortMode.InstanceID);
+			foreach (var fat in fats)
+			{
+				if (fat == null) continue;
+				fat.BecomeSkinny();
+			}
+			Loggy.Info($"{fats.Length} BodyFat components have executed BecomeSkinny()", Category.DebugConsole);
+		}
+
+		[ConsoleMethod("check-all-status-effects", "Prints all status effects on the StatusEffectsManager on MobV2s.")]
+		public static void CheckAllStatusEffects()
+		{
+			if (CustomNetworkManager.IsServer == false)
+			{
+				Loggy.Error("Cannot execute this command from client.", Category.DebugConsole);
+				return;
+			}
+			var managers = GameObject.FindObjectsByType<StatusEffectManager>(sortMode: FindObjectsSortMode.InstanceID);
+			StringBuilder sb = new StringBuilder();
+			foreach (var effectManager in managers)
+			{
+				if (effectManager == null) continue;
+				sb.AppendLine($"Status effects on {effectManager.gameObject.name} (ID: {effectManager.gameObject.GetInstanceID()}):");
+				if (effectManager.Statuses.Count == 0)
+				{
+					sb.AppendLine("- None");
+					continue;
+				}
+				foreach (var statusEffect in effectManager.Statuses)
+				{
+					sb.AppendLine($"- {statusEffect.name}");
+				}
+			}
+			Loggy.Info($"{sb}", Category.DebugConsole);
 		}
 	}
 }

--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Felinid/Felinid.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Felinid/Felinid.asset
@@ -126,6 +126,15 @@ MonoBehaviour:
         BodyNutriment: {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237,
           type: 2}
         CashedHungerState: 1
+        HungerStatusEffects:
+          NotHungryStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
+            type: 2}
+          StravingStatusEffect: {fileID: 11400000, guid: 8526c1e024fdd1e4d8bc35595159d8a4,
+            type: 2}
+          HungryStatusEffect: {fileID: 11400000, guid: a7b8118c2b73a574cbb4425327020959,
+            type: 2}
+          FatStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
+            type: 2}
     - rid: 5920833068371804166
       type: {class: NaturalChemicalReleaseSystem, ns: HealthV2.Living.PolymorphicSystems,
         asm: Assets}

--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Hellspawn/Tiefling.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Hellspawn/Tiefling.asset
@@ -113,17 +113,164 @@ MonoBehaviour:
         ExternalMetabolismPerSecond: 2
         MetabolismReactionSets:
         - {fileID: 11400000, guid: c489a27500b5c5b4392c5f90d1d2fce9, type: 2}
-        ALLMetabolismReactions: []
+        ALLMetabolismReactions:
+        - {fileID: 11400000, guid: ac0c760ad1cbab341b756545ba0586a4, type: 2}
+        - {fileID: 11400000, guid: 764107d010af362458271da1cae0b721, type: 2}
+        - {fileID: 11400000, guid: be96438d1ece65d42ac82b073c5b0dbd, type: 2}
+        - {fileID: 11400000, guid: f3831b1acebd1cc49b8bedc1d561da2d, type: 2}
+        - {fileID: 11400000, guid: b68a4df01ef69964596c5dc9daa503fc, type: 2}
+        - {fileID: 11400000, guid: 2314f18e5395f214ca02e5976e2ac99e, type: 2}
+        - {fileID: 11400000, guid: e0148fad25511cf4282cedc206ee507a, type: 2}
+        - {fileID: 11400000, guid: 2bb9f5c33f1a9cf4ea2a004aa7873462, type: 2}
+        - {fileID: 11400000, guid: a1c4a4720b715e84ab247305a46e923a, type: 2}
+        - {fileID: 11400000, guid: 70f22bab240e3b3468ad4b1509c90e9f, type: 2}
+        - {fileID: 11400000, guid: 132f2cd5d79066e46af78ea80a196713, type: 2}
+        - {fileID: 11400000, guid: e83c05c9c83ddfc4c84a80bff9a2cc8c, type: 2}
+        - {fileID: 11400000, guid: 11e70b972f4994f40ba26c72d9bc4b5e, type: 2}
+        - {fileID: 11400000, guid: d6d894f88c77aa54e814bcd831ff6eab, type: 2}
+        - {fileID: 11400000, guid: c3c30039428d04945891a05a5b24d90b, type: 2}
+        - {fileID: 11400000, guid: a6633049f2276744bb1debe8b7a4f1fb, type: 2}
+        - {fileID: 11400000, guid: 9d9fccd4b659b2e45a6089eb7fd5a8ec, type: 2}
+        - {fileID: 11400000, guid: 467467a8d844a53429f385bc1d11d6b3, type: 2}
+        - {fileID: 11400000, guid: cdad4fded4aa182459103c9a59012dc8, type: 2}
+        - {fileID: 11400000, guid: 6783e379d47680046abcc3d47d62c03a, type: 2}
+        - {fileID: 11400000, guid: 1d6fd38b48113c8448800db674a5110c, type: 2}
+        - {fileID: 11400000, guid: 7b8e80a904cafcf41a634682976c06a0, type: 2}
+        - {fileID: 11400000, guid: 85b402a852ad1ad49b64886cd42e93ce, type: 2}
+        - {fileID: 11400000, guid: 3ea6d21ecff38954a9e1b05795f3f45e, type: 2}
+        - {fileID: 11400000, guid: b7d0a552223af4d4d9f3eb3217df9183, type: 2}
+        - {fileID: 11400000, guid: 2902beb621ef39d42b6f061978844fc3, type: 2}
+        - {fileID: 11400000, guid: 13adffb9ac3eeb24fa7ea444c2d4dc1f, type: 2}
+        - {fileID: 11400000, guid: c08bfc7b09a88c34d9be46b34e311204, type: 2}
+        - {fileID: 11400000, guid: b987033982fda254ab8d08cc1db71c09, type: 2}
+        - {fileID: 11400000, guid: 183626486b5659147b9ab76c37f755d1, type: 2}
+        - {fileID: 11400000, guid: ddca67217442d154e9994c3f3d196a73, type: 2}
+        - {fileID: 11400000, guid: 0dfeb25a3a262dd4ba264ecd21677a89, type: 2}
+        - {fileID: 11400000, guid: 05c8e04a8fe70914aa5e63d428883354, type: 2}
+        - {fileID: 11400000, guid: 3533ed8321683a3428451e8f2ee995f2, type: 2}
+        - {fileID: 11400000, guid: 8e96fe2ff0e8ddf4e97fa2f0938c9c6c, type: 2}
+        - {fileID: 11400000, guid: 16d3d8f04337c9c44823b8d8b0666dd6, type: 2}
+        - {fileID: 11400000, guid: 941454b59dbb7574ebf6b82391ebc80f, type: 2}
+        - {fileID: 11400000, guid: a9860fe5bfce35d43b2c1dc83d4c6211, type: 2}
+        - {fileID: 11400000, guid: 2a156963331704e49841caa9ef659464, type: 2}
+        - {fileID: 11400000, guid: 2a156963331704e49841caa9ef659464, type: 2}
+        - {fileID: 11400000, guid: 835fcc0dc78094f45b31addbccdc6eb0, type: 2}
+        - {fileID: 11400000, guid: 7bda111492637234ab1e114d3a939b4e, type: 2}
+        - {fileID: 11400000, guid: 91fcd6eb40cc5d240a0972c81d84c70f, type: 2}
+        - {fileID: 11400000, guid: fd3db9618034ca147bd595eec13a25e0, type: 2}
+        - {fileID: 11400000, guid: 9bdffcb3fab09f141a0a9bb1f700c83e, type: 2}
+        - {fileID: 11400000, guid: ea51010fffe43f9439f86c093ea8402f, type: 2}
+        - {fileID: 11400000, guid: ac0c760ad1cbab341b756545ba0586a4, type: 2}
+        - {fileID: 11400000, guid: 764107d010af362458271da1cae0b721, type: 2}
+        - {fileID: 11400000, guid: be96438d1ece65d42ac82b073c5b0dbd, type: 2}
+        - {fileID: 11400000, guid: f3831b1acebd1cc49b8bedc1d561da2d, type: 2}
+        - {fileID: 11400000, guid: b68a4df01ef69964596c5dc9daa503fc, type: 2}
+        - {fileID: 11400000, guid: 2314f18e5395f214ca02e5976e2ac99e, type: 2}
+        - {fileID: 11400000, guid: e0148fad25511cf4282cedc206ee507a, type: 2}
+        - {fileID: 11400000, guid: 2bb9f5c33f1a9cf4ea2a004aa7873462, type: 2}
+        - {fileID: 11400000, guid: a1c4a4720b715e84ab247305a46e923a, type: 2}
+        - {fileID: 11400000, guid: 70f22bab240e3b3468ad4b1509c90e9f, type: 2}
+        - {fileID: 11400000, guid: 132f2cd5d79066e46af78ea80a196713, type: 2}
+        - {fileID: 11400000, guid: e83c05c9c83ddfc4c84a80bff9a2cc8c, type: 2}
+        - {fileID: 11400000, guid: 11e70b972f4994f40ba26c72d9bc4b5e, type: 2}
+        - {fileID: 11400000, guid: d6d894f88c77aa54e814bcd831ff6eab, type: 2}
+        - {fileID: 11400000, guid: c3c30039428d04945891a05a5b24d90b, type: 2}
+        - {fileID: 11400000, guid: a6633049f2276744bb1debe8b7a4f1fb, type: 2}
+        - {fileID: 11400000, guid: 9d9fccd4b659b2e45a6089eb7fd5a8ec, type: 2}
+        - {fileID: 11400000, guid: 467467a8d844a53429f385bc1d11d6b3, type: 2}
+        - {fileID: 11400000, guid: cdad4fded4aa182459103c9a59012dc8, type: 2}
+        - {fileID: 11400000, guid: 6783e379d47680046abcc3d47d62c03a, type: 2}
+        - {fileID: 11400000, guid: 1d6fd38b48113c8448800db674a5110c, type: 2}
+        - {fileID: 11400000, guid: 7b8e80a904cafcf41a634682976c06a0, type: 2}
+        - {fileID: 11400000, guid: 85b402a852ad1ad49b64886cd42e93ce, type: 2}
+        - {fileID: 11400000, guid: 3ea6d21ecff38954a9e1b05795f3f45e, type: 2}
+        - {fileID: 11400000, guid: b7d0a552223af4d4d9f3eb3217df9183, type: 2}
+        - {fileID: 11400000, guid: 2902beb621ef39d42b6f061978844fc3, type: 2}
+        - {fileID: 11400000, guid: 13adffb9ac3eeb24fa7ea444c2d4dc1f, type: 2}
+        - {fileID: 11400000, guid: c08bfc7b09a88c34d9be46b34e311204, type: 2}
+        - {fileID: 11400000, guid: b987033982fda254ab8d08cc1db71c09, type: 2}
+        - {fileID: 11400000, guid: 183626486b5659147b9ab76c37f755d1, type: 2}
+        - {fileID: 11400000, guid: ddca67217442d154e9994c3f3d196a73, type: 2}
+        - {fileID: 11400000, guid: 0dfeb25a3a262dd4ba264ecd21677a89, type: 2}
+        - {fileID: 11400000, guid: 05c8e04a8fe70914aa5e63d428883354, type: 2}
+        - {fileID: 11400000, guid: 3533ed8321683a3428451e8f2ee995f2, type: 2}
+        - {fileID: 11400000, guid: 8e96fe2ff0e8ddf4e97fa2f0938c9c6c, type: 2}
+        - {fileID: 11400000, guid: 16d3d8f04337c9c44823b8d8b0666dd6, type: 2}
+        - {fileID: 11400000, guid: 941454b59dbb7574ebf6b82391ebc80f, type: 2}
+        - {fileID: 11400000, guid: a9860fe5bfce35d43b2c1dc83d4c6211, type: 2}
+        - {fileID: 11400000, guid: 2a156963331704e49841caa9ef659464, type: 2}
+        - {fileID: 11400000, guid: 2a156963331704e49841caa9ef659464, type: 2}
+        - {fileID: 11400000, guid: 835fcc0dc78094f45b31addbccdc6eb0, type: 2}
+        - {fileID: 11400000, guid: 7bda111492637234ab1e114d3a939b4e, type: 2}
+        - {fileID: 11400000, guid: 91fcd6eb40cc5d240a0972c81d84c70f, type: 2}
+        - {fileID: 11400000, guid: fd3db9618034ca147bd595eec13a25e0, type: 2}
+        - {fileID: 11400000, guid: 9bdffcb3fab09f141a0a9bb1f700c83e, type: 2}
+        - {fileID: 11400000, guid: ea51010fffe43f9439f86c093ea8402f, type: 2}
+        - {fileID: 11400000, guid: ac0c760ad1cbab341b756545ba0586a4, type: 2}
+        - {fileID: 11400000, guid: 764107d010af362458271da1cae0b721, type: 2}
+        - {fileID: 11400000, guid: be96438d1ece65d42ac82b073c5b0dbd, type: 2}
+        - {fileID: 11400000, guid: f3831b1acebd1cc49b8bedc1d561da2d, type: 2}
+        - {fileID: 11400000, guid: b68a4df01ef69964596c5dc9daa503fc, type: 2}
+        - {fileID: 11400000, guid: 2314f18e5395f214ca02e5976e2ac99e, type: 2}
+        - {fileID: 11400000, guid: e0148fad25511cf4282cedc206ee507a, type: 2}
+        - {fileID: 11400000, guid: 2bb9f5c33f1a9cf4ea2a004aa7873462, type: 2}
+        - {fileID: 11400000, guid: a1c4a4720b715e84ab247305a46e923a, type: 2}
+        - {fileID: 11400000, guid: 70f22bab240e3b3468ad4b1509c90e9f, type: 2}
+        - {fileID: 11400000, guid: 132f2cd5d79066e46af78ea80a196713, type: 2}
+        - {fileID: 11400000, guid: e83c05c9c83ddfc4c84a80bff9a2cc8c, type: 2}
+        - {fileID: 11400000, guid: 11e70b972f4994f40ba26c72d9bc4b5e, type: 2}
+        - {fileID: 11400000, guid: d6d894f88c77aa54e814bcd831ff6eab, type: 2}
+        - {fileID: 11400000, guid: c3c30039428d04945891a05a5b24d90b, type: 2}
+        - {fileID: 11400000, guid: a6633049f2276744bb1debe8b7a4f1fb, type: 2}
+        - {fileID: 11400000, guid: 9d9fccd4b659b2e45a6089eb7fd5a8ec, type: 2}
+        - {fileID: 11400000, guid: 467467a8d844a53429f385bc1d11d6b3, type: 2}
+        - {fileID: 11400000, guid: cdad4fded4aa182459103c9a59012dc8, type: 2}
+        - {fileID: 11400000, guid: 6783e379d47680046abcc3d47d62c03a, type: 2}
+        - {fileID: 11400000, guid: 1d6fd38b48113c8448800db674a5110c, type: 2}
+        - {fileID: 11400000, guid: 7b8e80a904cafcf41a634682976c06a0, type: 2}
+        - {fileID: 11400000, guid: 85b402a852ad1ad49b64886cd42e93ce, type: 2}
+        - {fileID: 11400000, guid: 3ea6d21ecff38954a9e1b05795f3f45e, type: 2}
+        - {fileID: 11400000, guid: b7d0a552223af4d4d9f3eb3217df9183, type: 2}
+        - {fileID: 11400000, guid: 2902beb621ef39d42b6f061978844fc3, type: 2}
+        - {fileID: 11400000, guid: 13adffb9ac3eeb24fa7ea444c2d4dc1f, type: 2}
+        - {fileID: 11400000, guid: c08bfc7b09a88c34d9be46b34e311204, type: 2}
+        - {fileID: 11400000, guid: b987033982fda254ab8d08cc1db71c09, type: 2}
+        - {fileID: 11400000, guid: 183626486b5659147b9ab76c37f755d1, type: 2}
+        - {fileID: 11400000, guid: ddca67217442d154e9994c3f3d196a73, type: 2}
+        - {fileID: 11400000, guid: 0dfeb25a3a262dd4ba264ecd21677a89, type: 2}
+        - {fileID: 11400000, guid: 05c8e04a8fe70914aa5e63d428883354, type: 2}
+        - {fileID: 11400000, guid: 3533ed8321683a3428451e8f2ee995f2, type: 2}
+        - {fileID: 11400000, guid: 8e96fe2ff0e8ddf4e97fa2f0938c9c6c, type: 2}
+        - {fileID: 11400000, guid: 16d3d8f04337c9c44823b8d8b0666dd6, type: 2}
+        - {fileID: 11400000, guid: 941454b59dbb7574ebf6b82391ebc80f, type: 2}
+        - {fileID: 11400000, guid: a9860fe5bfce35d43b2c1dc83d4c6211, type: 2}
+        - {fileID: 11400000, guid: 2a156963331704e49841caa9ef659464, type: 2}
+        - {fileID: 11400000, guid: 2a156963331704e49841caa9ef659464, type: 2}
+        - {fileID: 11400000, guid: 835fcc0dc78094f45b31addbccdc6eb0, type: 2}
+        - {fileID: 11400000, guid: 7bda111492637234ab1e114d3a939b4e, type: 2}
+        - {fileID: 11400000, guid: 91fcd6eb40cc5d240a0972c81d84c70f, type: 2}
+        - {fileID: 11400000, guid: fd3db9618034ca147bd595eec13a25e0, type: 2}
+        - {fileID: 11400000, guid: 9bdffcb3fab09f141a0a9bb1f700c83e, type: 2}
+        - {fileID: 11400000, guid: ea51010fffe43f9439f86c093ea8402f, type: 2}
         MetabolismComponents: []
     - rid: 5920833068371804164
       type: {class: HungerSystem, ns: HealthV2.Living.PolymorphicSystems, asm: Assets}
       data:
         Base: {fileID: 0}
         BodyParts: []
-        NumberOfMinutesBeforeStarving: 30
+        NumberOfMinutesBeforeStarving: 31
         BodyNutriment: {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237,
           type: 2}
         CashedHungerState: 1
+        HungerStatusEffects:
+          NotHungryStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
+            type: 2}
+          StravingStatusEffect: {fileID: 11400000, guid: 8526c1e024fdd1e4d8bc35595159d8a4,
+            type: 2}
+          HungryStatusEffect: {fileID: 11400000, guid: a7b8118c2b73a574cbb4425327020959,
+            type: 2}
+          FatStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
+            type: 2}
     - rid: 5920833068371804166
       type: {class: NaturalChemicalReleaseSystem, ns: HealthV2.Living.PolymorphicSystems,
         asm: Assets}

--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Human/Alien.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Human/Alien.asset
@@ -98,6 +98,15 @@ MonoBehaviour:
         BodyNutriment: {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237,
           type: 2}
         CashedHungerState: 1
+        HungerStatusEffects:
+          NotHungryStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
+            type: 2}
+          StravingStatusEffect: {fileID: 11400000, guid: 8526c1e024fdd1e4d8bc35595159d8a4,
+            type: 2}
+          HungryStatusEffect: {fileID: 11400000, guid: a7b8118c2b73a574cbb4425327020959,
+            type: 2}
+          FatStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
+            type: 2}
     - rid: 5920833068371804166
       type: {class: NaturalChemicalReleaseSystem, ns: HealthV2.Living.PolymorphicSystems,
         asm: Assets}

--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Human/Human.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Human/Human.asset
@@ -216,6 +216,15 @@ MonoBehaviour:
         BodyNutriment: {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237,
           type: 2}
         CashedHungerState: 1
+        HungerStatusEffects:
+          NotHungryStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
+            type: 2}
+          StravingStatusEffect: {fileID: 11400000, guid: 8526c1e024fdd1e4d8bc35595159d8a4,
+            type: 2}
+          HungryStatusEffect: {fileID: 11400000, guid: a7b8118c2b73a574cbb4425327020959,
+            type: 2}
+          FatStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
+            type: 2}
     - rid: 5920833068371804166
       type: {class: NaturalChemicalReleaseSystem, ns: HealthV2.Living.PolymorphicSystems,
         asm: Assets}

--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Human/The Welder.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Human/The Welder.asset
@@ -125,6 +125,15 @@ MonoBehaviour:
         BodyNutriment: {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237,
           type: 2}
         CashedHungerState: 1
+        HungerStatusEffects:
+          NotHungryStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
+            type: 2}
+          StravingStatusEffect: {fileID: 11400000, guid: 8526c1e024fdd1e4d8bc35595159d8a4,
+            type: 2}
+          HungryStatusEffect: {fileID: 11400000, guid: a7b8118c2b73a574cbb4425327020959,
+            type: 2}
+          FatStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
+            type: 2}
     - rid: 5920833068371804166
       type: {class: NaturalChemicalReleaseSystem, ns: HealthV2.Living.PolymorphicSystems,
         asm: Assets}

--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Lizard/Ashwalker.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Lizard/Ashwalker.asset
@@ -109,6 +109,15 @@ MonoBehaviour:
         BodyNutriment: {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237,
           type: 2}
         CashedHungerState: 1
+        HungerStatusEffects:
+          NotHungryStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
+            type: 2}
+          StravingStatusEffect: {fileID: 11400000, guid: 8526c1e024fdd1e4d8bc35595159d8a4,
+            type: 2}
+          HungryStatusEffect: {fileID: 11400000, guid: a7b8118c2b73a574cbb4425327020959,
+            type: 2}
+          FatStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
+            type: 2}
     - rid: 5920833068371804166
       type: {class: NaturalChemicalReleaseSystem, ns: HealthV2.Living.PolymorphicSystems,
         asm: Assets}

--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Lizard/Lizard.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Lizard/Lizard.asset
@@ -109,6 +109,15 @@ MonoBehaviour:
         BodyNutriment: {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237,
           type: 2}
         CashedHungerState: 1
+        HungerStatusEffects:
+          NotHungryStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
+            type: 2}
+          StravingStatusEffect: {fileID: 11400000, guid: 8526c1e024fdd1e4d8bc35595159d8a4,
+            type: 2}
+          HungryStatusEffect: {fileID: 11400000, guid: a7b8118c2b73a574cbb4425327020959,
+            type: 2}
+          FatStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
+            type: 2}
     - rid: 5920833068371804166
       type: {class: NaturalChemicalReleaseSystem, ns: HealthV2.Living.PolymorphicSystems,
         asm: Assets}

--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Monkey/Monkey.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Monkey/Monkey.asset
@@ -102,6 +102,15 @@ MonoBehaviour:
         BodyNutriment: {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237,
           type: 2}
         CashedHungerState: 1
+        HungerStatusEffects:
+          NotHungryStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
+            type: 2}
+          StravingStatusEffect: {fileID: 11400000, guid: 8526c1e024fdd1e4d8bc35595159d8a4,
+            type: 2}
+          HungryStatusEffect: {fileID: 11400000, guid: a7b8118c2b73a574cbb4425327020959,
+            type: 2}
+          FatStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
+            type: 2}
     - rid: 7896866705837654029
       type: {class: NaturalChemicalReleaseSystem, ns: HealthV2.Living.PolymorphicSystems,
         asm: Assets}

--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Moth/Moth.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Moth/Moth.asset
@@ -103,6 +103,15 @@ MonoBehaviour:
         BodyNutriment: {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237,
           type: 2}
         CashedHungerState: 1
+        HungerStatusEffects:
+          NotHungryStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
+            type: 2}
+          StravingStatusEffect: {fileID: 11400000, guid: 8526c1e024fdd1e4d8bc35595159d8a4,
+            type: 2}
+          HungryStatusEffect: {fileID: 11400000, guid: a7b8118c2b73a574cbb4425327020959,
+            type: 2}
+          FatStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
+            type: 2}
     - rid: 5920833068371804166
       type: {class: NaturalChemicalReleaseSystem, ns: HealthV2.Living.PolymorphicSystems,
         asm: Assets}

--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Vulpkanin/Vulpkanin.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Vulpkanin/Vulpkanin.asset
@@ -115,6 +115,15 @@ MonoBehaviour:
         BodyNutriment: {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237,
           type: 2}
         CashedHungerState: 1
+        HungerStatusEffects:
+          NotHungryStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
+            type: 2}
+          StravingStatusEffect: {fileID: 11400000, guid: 8526c1e024fdd1e4d8bc35595159d8a4,
+            type: 2}
+          HungryStatusEffect: {fileID: 11400000, guid: a7b8118c2b73a574cbb4425327020959,
+            type: 2}
+          FatStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
+            type: 2}
     - rid: 5920833068371804166
       type: {class: NaturalChemicalReleaseSystem, ns: HealthV2.Living.PolymorphicSystems,
         asm: Assets}

--- a/UnityProject/Assets/ScriptableObjects/Antagonists/AntagData.asset
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/AntagData.asset
@@ -26,6 +26,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 180a8d8c464973b4ebcf1d9778e8b895, type: 2}
   - {fileID: 11400000, guid: 62560f1cff23ba84b9fe8e661f199730, type: 2}
   - {fileID: 11400000, guid: 0523fbd67f14a494e9e594128625c77b, type: 2}
+  - {fileID: 11400000, guid: ceb5e6db3c8aa9042a71a8f13ad1aa2f, type: 2}
   teamDatas:
   - {fileID: 11400000, guid: 2141a211de715694b9dbb3be5903112a, type: 2}
   - {fileID: 11400000, guid: 32ad576ba509ead4d8a7db46f6e9ef5a, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/GimmickObjectives/HungryCrew.asset
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/GimmickObjectives/HungryCrew.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b58bfc19ca2d4ddcae3eaac2950de97d, type: 3}
+  m_Name: HungryCrew
+  m_EditorClassIdentifier: Assets::Systems.Antagonists.Objectives.CrewHasStatusEffect
+  attributes: []
+  isEndRoundObjective: 0
+  objectiveName: Starving Crew
+  IsUnique: 1
+  description: Make sure at least half the crew are starving before they reach the
+    end.
+  aiCanHave: 0
+  CountDeadPlayersAsStatusEffectHavers: 1
+  StatusEffectToCheck: {fileID: 11400000, guid: 8526c1e024fdd1e4d8bc35595159d8a4,
+    type: 2}
+  PercentageOfCrewRequired: 0.4

--- a/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/GimmickObjectives/HungryCrew.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/GimmickObjectives/HungryCrew.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ceb5e6db3c8aa9042a71a8f13ad1aa2f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Statuses/Hunger.meta
+++ b/UnityProject/Assets/ScriptableObjects/Statuses/Hunger.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: af8c1434309c0b84f8e917b68f0dbbf1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Statuses/Hunger/Full.asset
+++ b/UnityProject/Assets/ScriptableObjects/Statuses/Hunger/Full.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57ba74246e3a41e2b0a713c2ba3d28d8, type: 3}
+  m_Name: Full
+  m_EditorClassIdentifier: Assets::Systems.StatusesAndEffects.Implementations.Hunger.BaseHungerStatusEffect

--- a/UnityProject/Assets/ScriptableObjects/Statuses/Hunger/Full.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Statuses/Hunger/Full.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8a92c094201a758498a79523323565eb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Statuses/Hunger/Hungry.asset
+++ b/UnityProject/Assets/ScriptableObjects/Statuses/Hunger/Hungry.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57ba74246e3a41e2b0a713c2ba3d28d8, type: 3}
+  m_Name: Hungry
+  m_EditorClassIdentifier: Assets::Systems.StatusesAndEffects.Implementations.Hunger.BaseHungerStatusEffect

--- a/UnityProject/Assets/ScriptableObjects/Statuses/Hunger/Hungry.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Statuses/Hunger/Hungry.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a7b8118c2b73a574cbb4425327020959
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Statuses/Hunger/Malnoruished.asset
+++ b/UnityProject/Assets/ScriptableObjects/Statuses/Hunger/Malnoruished.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57ba74246e3a41e2b0a713c2ba3d28d8, type: 3}
+  m_Name: Malnoruished
+  m_EditorClassIdentifier: Assets::Systems.StatusesAndEffects.Implementations.Hunger.BaseHungerStatusEffect

--- a/UnityProject/Assets/ScriptableObjects/Statuses/Hunger/Malnoruished.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Statuses/Hunger/Malnoruished.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 65e82252aea90134a8bbed1894004066
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/Statuses/Hunger/Starving.asset
+++ b/UnityProject/Assets/ScriptableObjects/Statuses/Hunger/Starving.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57ba74246e3a41e2b0a713c2ba3d28d8, type: 3}
+  m_Name: Starving
+  m_EditorClassIdentifier: Assets::Systems.StatusesAndEffects.Implementations.Hunger.BaseHungerStatusEffect

--- a/UnityProject/Assets/ScriptableObjects/Statuses/Hunger/Starving.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Statuses/Hunger/Starving.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8526c1e024fdd1e4d8bc35595159d8a4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Core/SecureStuff/AllowedReflection.cs
+++ b/UnityProject/Assets/Scripts/Core/SecureStuff/AllowedReflection.cs
@@ -21,7 +21,7 @@ namespace SecureStuff
 	{
 	}
 
-	
+
 	public struct MethodsAndAttributee<T> where T : BaseAttribute
 	{
 		public MethodInfo MethodInfo;
@@ -363,7 +363,7 @@ namespace SecureStuff
 			{
 				var attributedMethodsForType = componentType.GetMethods(BindingFlags.Instance | BindingFlags.NonPublic |
 				                                                        BindingFlags.Public |
-				                                                        BindingFlags.FlattenHierarchy)
+				                                                        BindingFlags.FlattenHierarchy | BindingFlags.Static)
 					.Where(m => m.GetCustomAttribute<T>(true) != null)
 					.ToList();
 				foreach (var Method in attributedMethodsForType)

--- a/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/LivingHealthMasterBase.cs
@@ -20,7 +20,6 @@ using HealthV2.Living.PolymorphicSystems;
 using HealthV2.Living.PolymorphicSystems.Bodypart;
 using Items.Implants.Organs;
 using JetBrains.Annotations;
-using Logs;
 using NaughtyAttributes;
 using Player;
 using ScriptableObjects.RP;
@@ -30,6 +29,7 @@ using UI.Systems.Tooltips.HoverTooltips;
 using UnityEngine.Serialization;
 using Random = UnityEngine.Random;
 using Systems.Character;
+using UI.Core.Alerts;
 using Util.Independent.FluentRichText;
 using UniversalObjectPhysics = Core.Physics.UniversalObjectPhysics;
 

--- a/UnityProject/Assets/Scripts/HealthV2/Living/PolymorphicSystems/BatterySystem.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/PolymorphicSystems/BatterySystem.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using HealthV2.Living.Cyborg;
 using HealthV2.Living.PolymorphicSystems.Bodypart;
 using Systems.Construction.Parts;
+using UI.Core.Alerts;
 using UnityEngine;
 
 namespace HealthV2.Living.PolymorphicSystems

--- a/UnityProject/Assets/Scripts/HealthV2/Living/PolymorphicSystems/HealthSystemBase.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/PolymorphicSystems/HealthSystemBase.cs
@@ -56,6 +56,11 @@ namespace HealthV2.Living.PolymorphicSystems
 
 		}
 
+		/// <summary>
+		/// The method that is used to grab the configuration of the system from the HealthSO or similar data source points.
+		/// Make sure to properly set this up in inherited classes, or all your stuff will always use the default/null values.
+		/// </summary>
+		/// <returns>HealthSystemBase</returns>
 		public abstract HealthSystemBase CloneThisSystem();
 	}
 }

--- a/UnityProject/Assets/Scripts/HealthV2/Living/PolymorphicSystems/HungerSystem.cs
+++ b/UnityProject/Assets/Scripts/HealthV2/Living/PolymorphicSystems/HungerSystem.cs
@@ -1,18 +1,21 @@
+using System;
 using System.Collections.Generic;
 using Chemistry;
 using HealthV2.Living.PolymorphicSystems.Bodypart;
+using Logs;
+using Systems.StatusesAndEffects;
+using UI.Core.Alerts;
 using UnityEngine;
 
 namespace HealthV2.Living.PolymorphicSystems
 {
 	public class HungerSystem : HealthSystemBase
 	{
-		public Dictionary<Reagent, ReagentWithBodyParts> NutrimentToConsume =
-			new Dictionary<Reagent, ReagentWithBodyParts>();
-
+		public Dictionary<Reagent, ReagentWithBodyParts> NutrimentToConsume = new();
 		public List<HungerComponent> BodyParts = new List<HungerComponent>();
 
-		private BodyAlertManager BodyAlertManager;
+		private BodyAlertManager bodyAlertManager;
+		private StatusEffectManager statusEffectManager;
 
 		public float NumberOfMinutesBeforeStarving = 30;
 
@@ -39,6 +42,8 @@ namespace HealthV2.Living.PolymorphicSystems
 		private HungerState HungerState => CalculateHungerState();
 
 		public HungerState CashedHungerState = HungerState.Normal;
+
+		public HungerStatuesEffects HungerStatusEffects = new();
 
 		public HungerState CalculateHungerState()
 		{
@@ -81,16 +86,32 @@ namespace HealthV2.Living.PolymorphicSystems
 			}
 		}
 
+		public StatusEffect GetStatusEffectFromHunger(HungerState hungerState)
+		{
+			switch (hungerState)
+			{
+				case HungerState.Full:
+					return HungerStatusEffects.FatStatusEffect;
+				case HungerState.Hungry:
+					return HungerStatusEffects.HungryStatusEffect;
+				case HungerState.Starving:
+					return HungerStatusEffects.StravingStatusEffect;
+				case HungerState.Malnourished:
+				default:
+					return HungerStatusEffects.NotHungryStatusEffect;
+			}
+		}
+
 		public override void InIt()
 		{
 			base.InIt();
-			BodyAlertManager = Base.GetComponent<BodyAlertManager>();
+			bodyAlertManager = Base.GetComponent<BodyAlertManager>();
+			statusEffectManager = Base.GetComponent<StatusEffectManager>();
 		}
 
 		public override void BodyPartAdded(BodyPart bodyPart)
 		{
 			var component = bodyPart.GetComponent<HungerComponent>();
-
 
 			if (component != null)
 			{
@@ -193,31 +214,59 @@ namespace HealthV2.Living.PolymorphicSystems
 
 		public override void SystemUpdate()
 		{
-			var State = HungerState;
-			float HeartEfficiency = 0;
-			foreach (var Heart in reagentPoolSystem.PumpingDevices)
+			var state = HungerState;
+			float heartEfficiency = 0;
+			foreach (var heart in reagentPoolSystem.PumpingDevices)
 			{
-				HeartEfficiency += Heart.CalculateHeartbeat();
+				heartEfficiency += heart.CalculateHeartbeat();
 			}
 
-			NutrimentCalculation(HeartEfficiency);
+			NutrimentCalculation(heartEfficiency);
 
 			//TODO HungerState should properly have a cash optimisation here!!
-			if (State != CashedHungerState)
+			//(Max): Have you considered maybe just using an event driven approach instead of checking every update?
+			if (state != CashedHungerState)
 			{
-				var old = GetAlertSOFromHunger(CashedHungerState);
-				if (old != null)
+				try
 				{
-					BodyAlertManager?.UnRegisterAlert(old);
+					UpdateAlerts(CashedHungerState, state);
+					UpdateStatusEffects(CashedHungerState, state);
 				}
-
-				CashedHungerState = State;
-
-				var newOne = GetAlertSOFromHunger(State);
-				if (newOne != null)
+				catch (Exception e)
 				{
-					BodyAlertManager?.RegisterAlert(newOne);
+					Loggy.Error($"An issue happened while updating hunger state changes: {e}");
 				}
+				CashedHungerState = state;
+			}
+		}
+
+		private void UpdateAlerts(HungerState oldState, HungerState newState)
+		{
+			var oldAlert = GetAlertSOFromHunger(oldState);
+			if (oldAlert != null)
+			{
+				bodyAlertManager?.UnRegisterAlert(oldAlert);
+			}
+
+			var newOne = GetAlertSOFromHunger(newState);
+			if (newOne != null)
+			{
+				bodyAlertManager?.RegisterAlert(newOne);
+			}
+		}
+
+		private void UpdateStatusEffects(HungerState oldState, HungerState newState)
+		{
+			var oldStatusEffect = GetStatusEffectFromHunger(oldState);
+			if (oldStatusEffect != null)
+			{
+				statusEffectManager?.RemoveStatus(oldStatusEffect);
+			}
+
+			var newStatusEffect = GetStatusEffectFromHunger(newState);
+			if (newStatusEffect != null)
+			{
+				statusEffectManager?.AddStatus(newStatusEffect);
 			}
 		}
 
@@ -323,7 +372,14 @@ namespace HealthV2.Living.PolymorphicSystems
 
 		public override HealthSystemBase CloneThisSystem()
 		{
-			return new HungerSystem();
+			return new HungerSystem
+			{
+				HungerStatusEffects = HungerStatusEffects,
+				NumberOfMinutesBeforeStarving = NumberOfMinutesBeforeStarving,
+				BodyParts = BodyParts,
+				BodyNutriment = BodyNutriment,
+				NutrimentToConsume = NutrimentToConsume
+			};
 		}
 
 
@@ -333,6 +389,15 @@ namespace HealthV2.Living.PolymorphicSystems
 			public float TotalNeeded;
 			public List<HungerComponent> RelatedBodyParts = new List<HungerComponent>();
 			public Dictionary<Reagent, ReagentWithBodyParts> ReplacesWith = new Dictionary<Reagent, ReagentWithBodyParts>();
+		}
+
+		[Serializable]
+		public class HungerStatuesEffects
+		{
+			public StatusEffect NotHungryStatusEffect;
+			public StatusEffect StravingStatusEffect;
+			public StatusEffect HungryStatusEffect;
+			public StatusEffect FatStatusEffect;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Implants/Organs/RemotelyControlledBrain.cs
+++ b/UnityProject/Assets/Scripts/Items/Implants/Organs/RemotelyControlledBrain.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using HealthV2;
 using Systems.Clearance;
+using UI.Core.Alerts;
 using UnityEngine;
 
 public class RemotelyControlledBrain : BodyPartFunctionality

--- a/UnityProject/Assets/Scripts/Player/EmoteScripts/Vomit.cs
+++ b/UnityProject/Assets/Scripts/Player/EmoteScripts/Vomit.cs
@@ -33,6 +33,7 @@ namespace Player.EmoteScripts
 			var bodyParts = health.BodyPartList;
 			foreach (var part in bodyParts)
 			{
+				if (part == null) continue;
 				if (part.TryGetComponent<StomachExpulsion>(out var stomach) == false) continue;
 				if (stomach.WillDryHeave()) continue;
 				stomach.Vomit();

--- a/UnityProject/Assets/Scripts/Player/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerScript.cs
@@ -26,6 +26,7 @@ using Logs;
 using Messages.Server.LocalGuiMessages;
 using Mobs.Traversal;
 using Systems.Faith;
+using UI.Core.Alerts;
 using UniversalObjectPhysics = Core.Physics.UniversalObjectPhysics;
 
 public class PlayerScript : NetworkBehaviour, IAdminInfo, IPlayerPossessable, IHoverTooltip

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/AntagManager.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/AntagManager.cs
@@ -269,13 +269,13 @@ namespace Antagonists
 		{
 			foreach (var x in PlayerList.Instance.AllPlayers)
 			{
-				if (x?.Mind?.AntagPublic?.Antagonist != null && x?.Mind?.AntagPublic?.Objectives?.Any() == true)
+				if (x?.Mind?.AntagPublic?.Objectives?.Any() == true)
 				{
-					foreach (var Objective in x.Mind.AntagPublic.Objectives)
+					foreach (var objective in x.Mind.AntagPublic.Objectives)
 					{
 						try
 						{
-							Objective.OnRoundEnd();
+							objective.OnRoundEnd();
 						}
 						catch (Exception e)
 						{
@@ -287,7 +287,6 @@ namespace Antagonists
 
 
 			List<SpawnedAntag> AlreadyPrinted = new List<SpawnedAntag>();
-
 			StringBuilder statusSB = new StringBuilder();
 
 			var message = new StringBuilder();
@@ -330,8 +329,7 @@ namespace Antagonists
 			{
 				try
 				{
-					if (x.Mind?.AntagPublic?.Antagonist != null
-					    && x.Mind?.AntagPublic?.CurTeam == null
+					if (x.Mind?.AntagPublic?.CurTeam == null
 					    && x.Mind?.AntagPublic?.Objectives.Any() == true
 					    && AlreadyPrinted.Contains(x?.Mind?.AntagPublic) == false)
 					{

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/CrewHasStatusEffect.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/CrewHasStatusEffect.cs
@@ -1,0 +1,56 @@
+﻿using Antagonists;
+using Logs;
+using Systems.StatusesAndEffects;
+using UnityEngine;
+
+namespace Systems.Antagonists.Objectives
+{
+	[CreateAssetMenu(menuName="ScriptableObjects/AntagObjectives/CrewHasStatusEffect")]
+	public class CrewHasStatusEffect : Objective
+	{
+		public bool CountDeadPlayersAsStatusEffectHavers = true;
+		public StatusEffect StatusEffectToCheck;
+
+		[Range(0f,1f)]
+		public float PercentageOfCrewRequired = 0.5f;
+
+		protected override void Setup()
+		{
+			// Nothing needs to be done here.
+		}
+
+		protected override bool CheckCompletion()
+		{
+			var allPlayers = PlayerList.Instance.InGamePlayers;
+			if (allPlayers == null || allPlayers.Count == 0)
+			{
+				Loggy.Error("[Objective/CrewHasStatusEffect] - No in-game players found! Failing objective.");
+				return false;
+			}
+
+			var countedPlayersWithStatusEffect = 0;
+			foreach (var player in allPlayers)
+			{
+				if (HasStatusEffect(player)) countedPlayersWithStatusEffect++;
+			}
+			var requiredCount = Mathf.CeilToInt(PercentageOfCrewRequired * allPlayers.Count);
+			Chat.AddGameWideSystemMsgToChat($"{countedPlayersWithStatusEffect} out of {allPlayers.Count} players " +
+			                                $"have the {StatusEffectToCheck.name} status effect. {requiredCount} required to complete objective.");
+			return countedPlayersWithStatusEffect >= requiredCount;
+		}
+
+		private bool HasStatusEffect(PlayerInfo player)
+		{
+			if (player == null || player.Mind == null || player.Mind.Body == null || player.Mind.Body.StatusEffectManager == null)
+			{
+				return false; // Skip null players or players without a body.
+			}
+			if (player.Mind.Body.IsDeadOrGhost && CountDeadPlayersAsStatusEffectHavers)
+			{
+				return true; // Count dead players as a "yes" in the final score.
+			}
+
+			return player.Mind.Body.StatusEffectManager.HasStatusByName(StatusEffectToCheck.name);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/CrewHasStatusEffect.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/CrewHasStatusEffect.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b58bfc19ca2d4ddcae3eaac2950de97d
+timeCreated: 1767724985

--- a/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Implementations/Hunger.meta
+++ b/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Implementations/Hunger.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 30d6a88463024aa79bd8ceb802198b9e
+timeCreated: 1767729593

--- a/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Implementations/Hunger/BaseHungerStatusEffect.cs
+++ b/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Implementations/Hunger/BaseHungerStatusEffect.cs
@@ -1,0 +1,10 @@
+﻿using UnityEngine;
+
+namespace Systems.StatusesAndEffects.Implementations.Hunger
+{
+	[CreateAssetMenu(fileName = "Hunger", menuName = "ScriptableObjects/StatusEffects/Hunger")]
+	public class BaseHungerStatusEffect : StatusEffect
+	{
+		// does nothing, for now.
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Implementations/Hunger/BaseHungerStatusEffect.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/Implementations/Hunger/BaseHungerStatusEffect.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 57ba74246e3a41e2b0a713c2ba3d28d8
+timeCreated: 1767729661

--- a/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/StatusEffectManager.cs
+++ b/UnityProject/Assets/Scripts/Systems/StatusesAndEffects/StatusEffectManager.cs
@@ -10,6 +10,7 @@ namespace Systems.StatusesAndEffects
 
 		public void AddStatus(StatusEffect status)
 		{
+			if (status == null) return;
 			HandleExpirableStatusAddition(status);
 			HandleStackableStatusAddition(status);
 			HandleImmediateStatusAddition(status);
@@ -51,6 +52,7 @@ namespace Systems.StatusesAndEffects
 
 		public void RemoveStatus(StatusEffect status)
 		{
+			if (status == null) return;
 			status.OnRemoved();
 			Statuses.Remove(status);
 		}
@@ -68,6 +70,15 @@ namespace Systems.StatusesAndEffects
 		public bool HasStatus(StatusEffect status)
 		{
 			return Statuses.Contains(status);
+		}
+
+		public bool HasStatusByName(string statusName)
+		{
+			foreach (var status in Statuses)
+			{
+				if (status.name == statusName) return true;
+			}
+			return false;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Core/Alerts/BodyAlertManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/Alerts/BodyAlertManager.cs
@@ -1,44 +1,62 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
+using Logs;
 using Mirror;
 using Newtonsoft.Json;
-using UnityEngine;
 
-
-public class BodyAlertManager : NetworkBehaviour, IClientPlayerLeaveBody, IClientPlayerTransferProcess
+namespace UI.Core.Alerts
 {
-	[SyncVar(hook = nameof(SyncActiTheons))] public string PresentAlertsJson = "[]";
-
-
-	public void Awake()
+	public class BodyAlertManager : NetworkBehaviour, IClientPlayerLeaveBody, IClientPlayerTransferProcess
 	{
-		SyncActiTheons( "[]",  "[]");
-	}
+		//This is a json list of integers that correspond to record indexes in AlertSOs.Instance.AllAlertSOs
+		//this is code from our lead developer btw
+		[SyncVar(hook = nameof(SyncActiTheons))] public string PresentAlertsJson = "[]";
 
-
-	public void RegisterAlert(AlertSO AlertSO, bool noDuplicates = true)
-	{
-		var List = JsonConvert.DeserializeObject<List<int>>(PresentAlertsJson); //TODO Make this more optimal sometime
-		var alertToAdd = AlertSO.GetIndexed();
-		if (noDuplicates && List.Contains(alertToAdd) == false)
+		public void Awake()
 		{
-			List.Add(AlertSO.GetIndexed());
+			SyncActiTheons( "[]",  "[]");
 		}
-		SyncActiTheons(PresentAlertsJson, PresentAlertsJson = JsonConvert.SerializeObject(List));
-	}
 
-	public void UnRegisterAlert(AlertSO AlertSO)
-	{
-		var List = JsonConvert.DeserializeObject<List<int>>(PresentAlertsJson); //TODO Make this more optimal sometime
-		List.Remove(AlertSO.GetIndexed());
-		SyncActiTheons(PresentAlertsJson, PresentAlertsJson = JsonConvert.SerializeObject(List));
-	}
+		public void RegisterAlert(AlertSO AlertSO, bool noDuplicates = true)
+		{
+			var List = JsonConvert.DeserializeObject<List<int>>(PresentAlertsJson); //TODO Make this more optimal sometime
+			var alertToAdd = AlertSO.GetIndexed();
+			if (noDuplicates && List.Contains(alertToAdd) == false)
+			{
+				List.Add(AlertSO.GetIndexed());
+			}
+			SyncActiTheons(PresentAlertsJson, PresentAlertsJson = JsonConvert.SerializeObject(List));
+		}
 
-	public void SyncActiTheons(string OldData, string NewData)
-	{
-		PresentAlertsJson = NewData;
-		if (isOwned && PlayerManager.LocalPlayerObject == this.gameObject)
+		public void UnRegisterAlert(AlertSO AlertSO)
+		{
+			var List = JsonConvert.DeserializeObject<List<int>>(PresentAlertsJson); //TODO Make this more optimal sometime
+			List.Remove(AlertSO.GetIndexed());
+			SyncActiTheons(PresentAlertsJson, PresentAlertsJson = JsonConvert.SerializeObject(List));
+		}
+
+		public void SyncActiTheons(string OldData, string NewData)
+		{
+			PresentAlertsJson = NewData;
+			if (isOwned && PlayerManager.LocalPlayerObject == this.gameObject)
+			{
+				var List = JsonConvert.DeserializeObject<List<int>>(PresentAlertsJson);
+				UIManager.Instance.ClientAlertManager.UnRegisterAlertALL(); //TODO Suboptimal but easy
+
+				foreach (var NewAlert in List)
+				{
+					UIManager.Instance.ClientAlertManager.RegisterAlert(AlertSOs.Instance.AllAlertSOs[NewAlert]);
+				}
+			}
+		}
+
+
+		public void ClientOnPlayerLeaveBody()
+		{
+			UIManager.Instance.ClientAlertManager.UnRegisterAlertALL();
+		}
+
+		public void ClientOnPlayerTransferProcess()
 		{
 			var List = JsonConvert.DeserializeObject<List<int>>(PresentAlertsJson);
 			UIManager.Instance.ClientAlertManager.UnRegisterAlertALL(); //TODO Suboptimal but easy
@@ -48,22 +66,27 @@ public class BodyAlertManager : NetworkBehaviour, IClientPlayerLeaveBody, IClien
 				UIManager.Instance.ClientAlertManager.RegisterAlert(AlertSOs.Instance.AllAlertSOs[NewAlert]);
 			}
 		}
-	}
 
-
-	public void ClientOnPlayerLeaveBody()
-	{
-		UIManager.Instance.ClientAlertManager.UnRegisterAlertALL();
-	}
-
-	public void ClientOnPlayerTransferProcess()
-	{
-		var List = JsonConvert.DeserializeObject<List<int>>(PresentAlertsJson);
-		UIManager.Instance.ClientAlertManager.UnRegisterAlertALL(); //TODO Suboptimal but easy
-
-		foreach (var NewAlert in List)
+		public List<AlertSO> GetPresentAlerts()
 		{
-			UIManager.Instance.ClientAlertManager.RegisterAlert(AlertSOs.Instance.AllAlertSOs[NewAlert]);
+			var presentAlerts = new List<AlertSO>();
+			var list = JsonConvert.DeserializeObject<List<int>>(PresentAlertsJson);
+			foreach (var newAlert in list)
+			{
+				try
+				{
+					if (AlertSOs.Instance.AllAlertSOs[newAlert] != null)
+					{
+						presentAlerts.Add(AlertSOs.Instance.AllAlertSOs[newAlert]);
+					}
+				}
+				catch (Exception e)
+				{
+					Loggy.Error($"(Max): This fucked up shit is broken, who would have thought?: {e}");
+				}
+			}
+
+			return presentAlerts;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Core/Alerts/BodyPartAlerts.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/Alerts/BodyPartAlerts.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using HealthV2;
+using UI.Core.Alerts;
 using UnityEngine;
 
 public class BodyPartAlerts : BodyPartFunctionality


### PR DESCRIPTION
### Changelog:

CL: [New] Added new objective for antagonists. The "Starving Crew" objective.
CL: [New] Players who did not spawn as antagonists, but had objectives, will now have their greentext counted at the end of the round.
CL: [New] Added the ability for console commands to accept in `NetworkConnectionToClient` types as arguments.
CL: [New] Added 2 new server-only console commands to test hunger related functionality. (`check-all-status-effects`, and `bodyfat.becomeskinny`)
CL: [New] Species can now adopt their own hunger behavior for each hunger state.
CL: [Improvement] Hunger states are now tracked internally by proper status effects.
CL: [Fix] Fixed a massive issue where species were unable to copy their hunger system configuration, causing all species to functionality behave the same way as humans.
CL: [Fix] Fixed the debug console and restored all console commands.
CL: [Fix] Fixed a rare case where the vomit emote would attempt to use a stomach that no longer exists, causing the player to get stunned for no apparent reason.