### PR TITLE
fix: fixed highlight on non 32x32 sprites

### DIFF
--- a/UnityProject/Assets/Materials/PostProcessNew/Post-FloorFovGenerator Material.mat
+++ b/UnityProject/Assets/Materials/PostProcessNew/Post-FloorFovGenerator Material.mat
@@ -71,7 +71,7 @@ Material:
     - _GlossyReflections: 1
     - _Metallic: 0
     - _Mode: 0
-    - _OcclusionSpread: 0
+    - _OcclusionSpread: 0.1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _SmoothnessTextureChannel: 0

--- a/UnityProject/Assets/Materials/Resources/OverlayCritHole.mat
+++ b/UnityProject/Assets/Materials/Resources/OverlayCritHole.mat
@@ -30,7 +30,7 @@ Material:
         m_Offset: {x: 0, y: 0}
     m_Ints: []
     m_Floats:
-    - _Radius: 3.0000012
+    - _Radius: 3.000001
     - _Shape: 1
     m_Colors:
     - _Center: {r: 0.5, g: 0.5, b: 0, a: 0}

--- a/UnityProject/Assets/Materials/Sprites_Outline.mat
+++ b/UnityProject/Assets/Materials/Sprites_Outline.mat
@@ -42,7 +42,7 @@ Material:
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _Flip: {r: 1, g: 1, b: 1, a: 1}
-    - _OutlineColor: {r: 0, g: 1, b: 0, a: 1}
+    - _OutlineColor: {r: 1, g: 0.647, b: 0, a: 1}
     - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
   m_BuildTextureStacks: []
   m_AllowLocking: 1

--- a/UnityProject/Assets/Resources/ScriptableObjectsSingletons/SpriteCatalogueSingleton.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjectsSingletons/SpriteCatalogueSingleton.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 42d925a3e4120a44b8a89c110fc770b2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Core/Highlight/Highlight.cs
+++ b/UnityProject/Assets/Scripts/Core/Highlight/Highlight.cs
@@ -20,6 +20,9 @@ namespace Core.Highlight
 
 		private static List<SpriteHandler> subscribeSpriteHandlers = new();
 		private static readonly int OutlineColor = Shader.PropertyToID("_OutlineColor");
+		private static GameObject cachedTarget;
+		private static Vector2Int cachedMaxSpriteSize;
+		private static bool cachedSizeValid;
 
 
 		public InitialisationSystems Subsystem => InitialisationSystems.Highlight;
@@ -119,6 +122,8 @@ namespace Core.Highlight
 				mainTex.SetPixels(data);
 				mainTex.Apply();
 				instance.TargetObject = null;
+				cachedTarget = null;
+				cachedSizeValid = false;
 			}
 		}
 
@@ -165,6 +170,7 @@ namespace Core.Highlight
 			{
 				if (handler == null) continue;
 				handler.OnSpriteUpdated -= (UpdateCurrentHighlight);
+				handler.OnSpriteUpdated -= (InvalidateCachedSize);
 			}
 
 			subscribeSpriteHandlers = highlightobject.GetComponentsInChildren<SpriteHandler>().ToList();
@@ -172,10 +178,23 @@ namespace Core.Highlight
 			{
 				if (handler == null) continue;
 				handler.OnSpriteUpdated += (UpdateCurrentHighlight);
+				handler.OnSpriteUpdated += (InvalidateCachedSize);
 			}
 
 			spriteRenderers = spriteRenderers.Where(x => x.sprite != null && x != instance.spriteRenderer && x.CompareTag("DontHighlightSpecial") == false).ToArray();
-			var maxSpriteSize = GetMaxSpriteRectSize(spriteRenderers);
+			if (cachedTarget != highlightobject)
+			{
+				cachedTarget = highlightobject;
+				cachedSizeValid = false;
+			}
+
+			if (!cachedSizeValid)
+			{
+				cachedMaxSpriteSize = GetMaxSpriteRectSize(spriteRenderers);
+				cachedSizeValid = true;
+			}
+
+			var maxSpriteSize = cachedMaxSpriteSize;
 			var mainTex = EnsureHighlightTexture(instance.spriteRenderer, maxSpriteSize.x, maxSpriteSize.y, HighlightPadding);
 			ClearTexture(mainTex);
 
@@ -371,6 +390,11 @@ namespace Core.Highlight
 			}
 
 			return foundBL && foundTL && foundBR && foundTR;
+		}
+
+		private static void InvalidateCachedSize()
+		{
+			cachedSizeValid = false;
 		}
 
 		public void OnDestroy()

--- a/UnityProject/Assets/Scripts/Core/Highlight/Highlight.cs
+++ b/UnityProject/Assets/Scripts/Core/Highlight/Highlight.cs
@@ -1,368 +1,514 @@
-﻿using System;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Initialisation;
 using Logs;
+using UnityEngine;
 
-public class Highlight : MonoBehaviour, IInitialise
+namespace Core.Highlight
 {
-	public static bool HighlightEnabled;
-	public static Highlight instance;
-
-	public GameObject TargetObject;
-
-	public SpriteRenderer prefabSpriteRenderer;
-	public SpriteRenderer spriteRenderer;
-	public Material material;
-
-	private static List<SpriteHandler> subscribeSpriteHandlers = new List<SpriteHandler>();
-
-
-
-	public InitialisationSystems Subsystem => InitialisationSystems.Highlight;
-
-	void IInitialise.Initialise()
+	public class Highlight : MonoBehaviour, IInitialise
 	{
-		if (PlayerPrefs.HasKey(PlayerPrefKeys.EnableHighlights))
+		private const int HighlightPadding = 3;
+		public static bool HighlightEnabled;
+		public static Highlight instance;
+
+		public GameObject TargetObject;
+
+		public SpriteRenderer prefabSpriteRenderer;
+		public SpriteRenderer spriteRenderer;
+		public Material material;
+
+		private static List<SpriteHandler> subscribeSpriteHandlers = new();
+		private static readonly int OutlineColor = Shader.PropertyToID("_OutlineColor");
+
+
+		public InitialisationSystems Subsystem => InitialisationSystems.Highlight;
+
+		void IInitialise.Initialise()
 		{
-			if (PlayerPrefs.GetInt(PlayerPrefKeys.EnableHighlights) == 1)
+			if (PlayerPrefs.HasKey(PlayerPrefKeys.EnableHighlights))
 			{
+				if (PlayerPrefs.GetInt(PlayerPrefKeys.EnableHighlights) == 1)
+				{
+					HighlightEnabled = true;
+				}
+				else
+				{
+					HighlightEnabled = false;
+				}
+			}
+			else
+			{
+				PlayerPrefs.SetInt(PlayerPrefKeys.EnableHighlights, 1);
+				PlayerPrefs.Save();
+			}
+		}
+
+		public static void SetPreference(bool preference)
+		{
+			if (preference)
+			{
+				PlayerPrefs.SetInt(PlayerPrefKeys.EnableHighlights, 1);
 				HighlightEnabled = true;
 			}
 			else
 			{
+				PlayerPrefs.SetInt(PlayerPrefKeys.EnableHighlights, 0);
 				HighlightEnabled = false;
 			}
-		}
-		else
-		{
-			PlayerPrefs.SetInt(PlayerPrefKeys.EnableHighlights, 1);
+
 			PlayerPrefs.Save();
 		}
-	}
 
-	public static void SetPreference(bool preference)
-	{
-		if (preference)
+		private void Awake()
 		{
-			PlayerPrefs.SetInt(PlayerPrefKeys.EnableHighlights, 1);
-			HighlightEnabled = true;
-		}
-		else
-		{
-			PlayerPrefs.SetInt(PlayerPrefKeys.EnableHighlights, 0);
-			HighlightEnabled = false;
-		}
-
-		PlayerPrefs.Save();
-	}
-
-	private void Awake()
-	{
-		if (instance == null)
-		{
-			instance = this;
-		}
-		else
-		{
-			Destroy(gameObject);
-		}
-	}
-
-	public static void UpdateCurrentHighlight()
-	{
-		if (instance == null) return;
-		if (HighlightEnabled && instance.TargetObject != null)
-		{
-			HighlightThis(instance.TargetObject);
-		}
-		else
-		{
-			foreach (var SH in subscribeSpriteHandlers)
+			if (instance == null)
 			{
-				if (SH == null) continue;
-				SH.OnSpriteUpdated -= (UpdateCurrentHighlight);
+				instance = this;
 			}
-
-			subscribeSpriteHandlers.Clear();
+			else
+			{
+				Destroy(gameObject);
+			}
 		}
-	}
+
+		public static void UpdateCurrentHighlight()
+		{
+			if (instance == null) return;
+			if (HighlightEnabled && instance.TargetObject != null)
+			{
+				HighlightThis(instance.TargetObject);
+			}
+			else
+			{
+				foreach (var handler in subscribeSpriteHandlers)
+				{
+					if (handler == null) continue;
+					handler.OnSpriteUpdated -= (UpdateCurrentHighlight);
+				}
+
+				subscribeSpriteHandlers.Clear();
+			}
+		}
 
 
-	public static void DeHighlight()
-	{
-		if (HighlightEnabled)
+		public static void DeHighlight()
+		{
+			if (HighlightEnabled)
+			{
+				if (instance.spriteRenderer == null)
+				{
+					instance.spriteRenderer = Instantiate(instance.prefabSpriteRenderer);
+				}
+
+				foreach (var handler in subscribeSpriteHandlers)
+				{
+					if (handler == null) continue;
+					handler.OnSpriteUpdated -= (UpdateCurrentHighlight);
+				}
+
+				subscribeSpriteHandlers.Clear();
+
+				Texture2D mainTex = instance.spriteRenderer.sprite.texture;
+				var data = mainTex.GetPixels();
+				for (int xy = 0; xy < data.Length; xy++)
+				{
+					data[xy] = new Color32(0, 0, 0, 0);
+				}
+
+				mainTex.SetPixels(data);
+				mainTex.Apply();
+				instance.TargetObject = null;
+			}
+		}
+
+		public static void HighlightThis(GameObject highlightobject)
+		{
+			if (PlayerManager.LocalPlayerScript.IsNormal && HighlightEnabled)
+			{
+				if (highlightobject.TryGetComponent<Attributes>(out var attributes))
+				{
+					if (attributes.NoMouseHighlight) return;
+				}
+
+				ShowHighlight(highlightobject);
+			}
+		}
+
+
+
+		public static void ShowHighlight(GameObject highlightobject, bool ignoreHandApply = false)
 		{
 			if (instance.spriteRenderer == null)
 			{
 				instance.spriteRenderer = Instantiate(instance.prefabSpriteRenderer);
 			}
 
-			foreach (var SH in subscribeSpriteHandlers)
+			instance.TargetObject = highlightobject;
+			instance.spriteRenderer.gameObject.SetActive(true);
+			instance.spriteRenderer.enabled = true;
+			var spriteRenderers = highlightobject.GetComponentsInChildren<SpriteRenderer>();
+			SpriteRenderer rootRenderer = spriteRenderers.FirstOrDefault(x => x.sprite != null);
+			if (rootRenderer == null)
 			{
-				if (SH == null) continue;
-				SH.OnSpriteUpdated -= (UpdateCurrentHighlight);
+				return;
+			}
+			Transform trans = instance.spriteRenderer.transform;
+
+			trans.SetParent(rootRenderer.transform, false);
+			trans.localPosition = Vector3.zero;
+			trans.transform.localRotation = Quaternion.Euler(0, 0, 0);
+			trans.localScale = Vector3.one;
+			instance.spriteRenderer.sortingLayerID = rootRenderer.sortingLayerID;
+
+			foreach (var handler in subscribeSpriteHandlers)
+			{
+				if (handler == null) continue;
+				handler.OnSpriteUpdated -= (UpdateCurrentHighlight);
 			}
 
-			subscribeSpriteHandlers.Clear();
-
-			Texture2D mainTex = instance.spriteRenderer.sprite.texture;
-			var data = mainTex.GetPixels();
-			for (int xy = 0; xy < data.Length; xy++)
+			subscribeSpriteHandlers = highlightobject.GetComponentsInChildren<SpriteHandler>().ToList();
+			foreach (var handler in subscribeSpriteHandlers)
 			{
-				data[xy] = new Color32(0, 0, 0, 0);
+				if (handler == null) continue;
+				handler.OnSpriteUpdated += (UpdateCurrentHighlight);
 			}
 
-			mainTex.SetPixels(data);
-			mainTex.Apply();
-			instance.TargetObject = null;
-		}
-	}
+			spriteRenderers = spriteRenderers.Where(x => x.sprite != null && x != instance.spriteRenderer && x.CompareTag("DontHighlightSpecial") == false).ToArray();
+			var maxSpriteSize = GetMaxSpriteRectSize(spriteRenderers);
+			var mainTex = EnsureHighlightTexture(instance.spriteRenderer, maxSpriteSize.x, maxSpriteSize.y, HighlightPadding);
+			ClearTexture(mainTex);
 
-	public static void HighlightThis(GameObject Highlightobject)
-	{
-		if (PlayerManager.LocalPlayerScript.IsNormal && HighlightEnabled)
-		{
-			if (Highlightobject.TryGetComponent<Attributes>(out var attributes))
+			bool canHighlight = ignoreHandApply || CheckHandApply(highlightobject);
+			if (!canHighlight)
 			{
-				if (attributes.NoMouseHighlight) return;
+				mainTex.Apply();
+				instance.spriteRenderer.enabled = false;
+				return;
 			}
 
-			ShowHighlight(Highlightobject);
-		}
-	}
-
-
-
-	public static void ShowHighlight(GameObject Highlightobject, bool ignoreHandApply = false)
-	{
-		if (instance.spriteRenderer == null)
-		{
-			instance.spriteRenderer = Instantiate(instance.prefabSpriteRenderer);
-		}
-
-		Texture2D mainTex = instance.spriteRenderer.sprite.texture;
-		var data = mainTex.GetPixels();
-		for (int xy = 0; xy < data.Length; xy++)
-		{
-			data[xy] = new Color32(0, 0, 0, 0);
-		}
-
-		mainTex.SetPixels(data);
-
-		instance.TargetObject = Highlightobject;
-		instance.spriteRenderer.gameObject.SetActive(true);
-		instance.spriteRenderer.enabled = true;
-		var SpriteRenderers = Highlightobject.GetComponentsInChildren<SpriteRenderer>();
-		var trans = instance.spriteRenderer.transform;
-
-		trans.SetParent(SpriteRenderers[0].transform, false);
-		trans.localPosition = Vector3.zero;
-		trans.transform.localRotation = Quaternion.Euler(0, 0, 0);
-		trans.localScale = Vector3.one;
-		instance.spriteRenderer.sortingLayerID = SpriteRenderers[0].sortingLayerID;
-
-		foreach (var SH in subscribeSpriteHandlers)
-		{
-			if (SH == null) continue;
-			SH.OnSpriteUpdated -= (UpdateCurrentHighlight);
-		}
-
-		subscribeSpriteHandlers = Highlightobject.GetComponentsInChildren<SpriteHandler>().ToList();
-		foreach (var SH in subscribeSpriteHandlers)
-		{
-			if (SH == null) continue;
-			SH.OnSpriteUpdated += (UpdateCurrentHighlight);
-		}
-
-		SpriteRenderers = SpriteRenderers.Where(x => x.sprite != null && x != instance.spriteRenderer && x.CompareTag("DontHighlightSpecial") == false).ToArray();
-
-		if (ignoreHandApply || CheckHandApply(Highlightobject))
-		{
 			if (ignoreHandApply)
 			{
-				instance.material.SetColor("_OutlineColor", Color.green);
+				instance.material.SetColor(OutlineColor, Color.green);
 			}
 
-			foreach (var T in SpriteRenderers)
+			foreach (var T in spriteRenderers)
 			{
 				if (DevCameraControls.ObjecIsVisible(T.gameObject) == false) continue;
 				if (T.sortingLayerName == "Preview") continue;
-				RecursiveTextureStack(mainTex, T);
+				RecursiveTextureStack(mainTex, T, HighlightPadding);
 			}
 
 			mainTex.Apply();
+			instance.spriteRenderer.enabled = true;
 			instance.spriteRenderer.sprite = Sprite.Create(mainTex, new Rect(0, 0, mainTex.width, mainTex.height),
-				new Vector2(0.5f, 0.5f), 32, 1, SpriteMeshType.FullRect, new Vector4(32, 32, 32, 32));
+				new Vector2(0.5f, 0.5f), instance.spriteRenderer.sprite.pixelsPerUnit, 1, SpriteMeshType.FullRect, Vector4.zero);
 		}
-	}
 
 
-	static void RecursiveTextureStack(Texture2D mainTex, SpriteRenderer SpriteRenderers)
-	{
-		int xx = 3;
-		int yy = 3;
-
-		for (int x = (int) SpriteRenderers.sprite.textureRect.position.x;
-		     x < (int) SpriteRenderers.sprite.textureRect.position.x + SpriteRenderers.sprite.rect.width;
-		     x++)
+		static void RecursiveTextureStack(Texture2D mainTex, SpriteRenderer spriteRenderers, int padding)
 		{
-			for (int y = (int) SpriteRenderers.sprite.textureRect.position.y;
-			     y < SpriteRenderers.sprite.textureRect.position.y + SpriteRenderers.sprite.rect.height;
-			     y++)
-			{
-				if (SpriteRenderers.gameObject.activeInHierarchy == false) continue;
-				//Loggy.Log(yy + " <XX YY> " + xx + "   " +  x + " <X Y> " + y  );
-				if (SpriteRenderers.sprite.texture.GetPixel(x, y).a != 0)
-				{
-					mainTex.SetPixel(xx, yy, SpriteRenderers.sprite.texture.GetPixel(x, y));
-				}
+			if (spriteRenderers.gameObject.activeInHierarchy == false) return;
+			Sprite sprite = spriteRenderers.sprite;
+			Texture2D texture = sprite.texture;
+			if (texture == null) return;
 
-				yy += 1;
+			int width = Mathf.RoundToInt(sprite.rect.width);
+			int height = Mathf.RoundToInt(sprite.rect.height);
+			if (width <= 0 || height <= 0) return;
+
+			int maxX = mainTex.width - padding;
+			int maxY = mainTex.height - padding;
+
+			bool hasUvCorners = TryGetSpriteUvCorners(sprite, out var uvCorners);
+			Rect rect = sprite.textureRect;
+
+			for (int x = 0; x < width; x++)
+			{
+				int xx = padding + x;
+				if (xx >= maxX) break;
+
+				for (int y = 0; y < height; y++)
+				{
+					int yy = padding + y;
+					if (yy >= maxY) break;
+
+					Color color;
+					if (hasUvCorners)
+					{
+						float u = (x + 0.5f) / width;
+						float v = (y + 0.5f) / height;
+						Vector2 uv = Vector2.Lerp(
+							Vector2.Lerp(uvCorners.BottomLeft, uvCorners.BottomRight, u),
+							Vector2.Lerp(uvCorners.TopLeft, uvCorners.TopRight, u),
+							v);
+						color = texture.GetPixelBilinear(uv.x, uv.y);
+					}
+					else
+					{
+						int texX = Mathf.FloorToInt(rect.x) + x;
+						int texY = Mathf.FloorToInt(rect.y) + y;
+						color = texture.GetPixel(texX, texY);
+					}
+
+					if (color.a != 0)
+					{
+						mainTex.SetPixel(xx, yy, color);
+					}
+				}
+			}
+		}
+
+		private static Vector2Int GetMaxSpriteRectSize(SpriteRenderer[] renderers)
+		{
+			int maxW = 0;
+			int maxH = 0;
+
+			foreach (SpriteRenderer renderer in renderers)
+			{
+				if (renderer == null || renderer.sprite == null) continue;
+				maxW = Mathf.Max(maxW, Mathf.RoundToInt(renderer.sprite.rect.width));
+				maxH = Mathf.Max(maxH, Mathf.RoundToInt(renderer.sprite.rect.height));
 			}
 
-			yy = 3;
-			xx += 1;
-		}
-	}
-
-	public void OnDestroy()
-	{
-		foreach (var SH in subscribeSpriteHandlers)
-		{
-			if (SH == null) continue;
-			SH.OnSpriteUpdated -= (UpdateCurrentHighlight);
+			return new Vector2Int(maxW, maxH);
 		}
 
-		subscribeSpriteHandlers.Clear();
-	}
-
-
-	public static bool CheckHandApply(GameObject target)
-	{
-		//call the used object's handapply interaction methods if it has any, for each object we are applying to
-		var handApply = HandApply.ByLocalPlayer(target);
-		var posHandApply = PositionalHandApply.ByLocalPlayer(target);
-
-		handApply.IsHighlight = true;
-		posHandApply.IsHighlight = true;
-
-		//if handobj is null, then its an empty hand apply so we only need to check the receiving object
-		if (handApply.HandObject != null)
+		private static Texture2D EnsureHighlightTexture(SpriteRenderer renderer, int spriteWidth, int spriteHeight, int padding)
 		{
-			//get all components that can handapply or PositionalHandApply
-			var handAppliables = handApply.HandObject.GetComponents<MonoBehaviour>()
-				.Where(c => c != null && c.enabled &&
-				            (c is IBaseInteractable<HandApply> || c is IBaseInteractable<PositionalHandApply>));
-			Loggy.Trace().Format("Checking HandApply / PositionalHandApply interactions from {0} targeting {1}",
-				Category.Interaction, handApply.HandObject.name, target.name);
+			Sprite currentSprite = renderer.sprite;
+			Texture2D currentTexture = currentSprite != null ? currentSprite.texture : null;
+			int targetWidth = Mathf.Max(1, spriteWidth + padding * 2);
+			int targetHeight = Mathf.Max(1, spriteHeight + padding * 2);
 
-			foreach (var handAppliable in handAppliables.Reverse())
+			if (currentTexture != null && currentTexture.width == targetWidth && currentTexture.height == targetHeight)
 			{
-				if (handAppliable is IBaseInteractable<HandApply>)
+				return currentTexture;
+			}
+
+			TextureFormat format = currentTexture != null ? currentTexture.format : TextureFormat.RGBA32;
+			var newTexture = new Texture2D(targetWidth, targetHeight, format, false)
+			{
+				filterMode = currentTexture != null ? currentTexture.filterMode : FilterMode.Point,
+				wrapMode = currentTexture != null ? currentTexture.wrapMode : TextureWrapMode.Clamp,
+				name = "HighlightTexture"
+			};
+
+			float pixelsPerUnit = currentSprite != null ? currentSprite.pixelsPerUnit : 32f;
+			renderer.sprite = Sprite.Create(newTexture, new Rect(0, 0, targetWidth, targetHeight),
+				new Vector2(0.5f, 0.5f), pixelsPerUnit, 1, SpriteMeshType.FullRect, Vector4.zero);
+			return newTexture;
+		}
+
+		private static void ClearTexture(Texture2D texture)
+		{
+			var data = new Color32[texture.width * texture.height];
+			texture.SetPixels32(data);
+		}
+
+		private struct SpriteUvCorners
+		{
+			public Vector2 BottomLeft;
+			public Vector2 TopLeft;
+			public Vector2 BottomRight;
+			public Vector2 TopRight;
+		}
+
+		private static bool TryGetSpriteUvCorners(Sprite sprite, out SpriteUvCorners corners)
+		{
+			corners = default;
+			var verts = sprite.vertices;
+			var uvs = sprite.uv;
+			if (verts == null || uvs == null || verts.Length != uvs.Length || verts.Length < 4)
+			{
+				return false;
+			}
+
+			float minX = float.PositiveInfinity;
+			float maxX = float.NegativeInfinity;
+			float minY = float.PositiveInfinity;
+			float maxY = float.NegativeInfinity;
+
+			for (int i = 0; i < verts.Length; i++)
+			{
+				var v = verts[i];
+				minX = Mathf.Min(minX, v.x);
+				maxX = Mathf.Max(maxX, v.x);
+				minY = Mathf.Min(minY, v.y);
+				maxY = Mathf.Max(maxY, v.y);
+			}
+
+			const float epsilon = 0.0001f;
+			bool foundBL = false;
+			bool foundTL = false;
+			bool foundBR = false;
+			bool foundTR = false;
+
+			for (int i = 0; i < verts.Length; i++)
+			{
+				Vector2 v = verts[i];
+				Vector2 uv = uvs[i];
+				if (Mathf.Abs(v.x - minX) < epsilon && Mathf.Abs(v.y - minY) < epsilon)
 				{
-					var hap = handAppliable as IBaseInteractable<HandApply>;
-					if (CheckInteractInternal(hap, handApply, NetworkSide.Client))
+					corners.BottomLeft = uv;
+					foundBL = true;
+				}
+				else if (Mathf.Abs(v.x - minX) < epsilon && Mathf.Abs(v.y - maxY) < epsilon)
+				{
+					corners.TopLeft = uv;
+					foundTL = true;
+				}
+				else if (Mathf.Abs(v.x - maxX) < epsilon && Mathf.Abs(v.y - minY) < epsilon)
+				{
+					corners.BottomRight = uv;
+					foundBR = true;
+				}
+				else if (Mathf.Abs(v.x - maxX) < epsilon && Mathf.Abs(v.y - maxY) < epsilon)
+				{
+					corners.TopRight = uv;
+					foundTR = true;
+				}
+			}
+
+			return foundBL && foundTL && foundBR && foundTR;
+		}
+
+		public void OnDestroy()
+		{
+			foreach (SpriteHandler handler in subscribeSpriteHandlers)
+			{
+				if (handler == null) continue;
+				handler.OnSpriteUpdated -= (UpdateCurrentHighlight);
+			}
+
+			subscribeSpriteHandlers.Clear();
+		}
+
+
+		public static bool CheckHandApply(GameObject target)
+		{
+			//call the used object's handapply interaction methods if it has any, for each object we are applying to
+			HandApply handApply = HandApply.ByLocalPlayer(target);
+			PositionalHandApply posHandApply = PositionalHandApply.ByLocalPlayer(target);
+
+			handApply.IsHighlight = true;
+			posHandApply.IsHighlight = true;
+
+			//if handobj is null, then its an empty hand apply so we only need to check the receiving object
+			if (handApply.HandObject != null)
+			{
+				//get all components that can handapply or PositionalHandApply
+				var handAppliables = handApply.HandObject.GetComponents<MonoBehaviour>()
+					.Where(c => c != null && c.enabled &&
+								c is IBaseInteractable<HandApply> or IBaseInteractable<PositionalHandApply>);
+				Loggy.Trace().Format("Checking HandApply / PositionalHandApply interactions from {0} targeting {1}",
+					Category.Interaction, handApply.HandObject.name, target.name);
+
+				foreach (var handAppliable in handAppliables.Reverse())
+				{
+					if (handAppliable is IBaseInteractable<HandApply>)
 					{
-						instance.material.SetColor("_OutlineColor", Color.cyan);
+						var hap = handAppliable as IBaseInteractable<HandApply>;
+						if (CheckInteractInternal(hap, handApply, NetworkSide.Client))
+						{
+							instance.material.SetColor(OutlineColor, Color.cyan);
+							return true;
+						}
+					}
+					else
+					{
+						var hap = handAppliable as IBaseInteractable<PositionalHandApply>;
+						if (CheckInteractInternal(hap, posHandApply, NetworkSide.Client))
+						{
+							instance.material.SetColor(OutlineColor, Color.magenta);
+							return true;
+						}
+					}
+				}
+			}
+
+
+			//call the hand apply interaction methods on the target object if it has any
+			var targetHandAppliables = handApply.TargetObject.GetComponents<MonoBehaviour>()
+				.Where(c => c != null && c.enabled &&
+							c is IBaseInteractable<HandApply> or IBaseInteractable<PositionalHandApply>);
+			foreach (MonoBehaviour targetHandAppliable in targetHandAppliables.Reverse())
+			{
+				if (targetHandAppliable is IBaseInteractable<HandApply> interactable)
+				{
+					//var hap = targetHandAppliable as IBaseInteractable<HandApply>;
+					if (CheckInteractInternal(interactable, handApply, NetworkSide.Client))
+					{
+						instance.material.SetColor(OutlineColor, Color.green);
 						return true;
 					}
 				}
 				else
 				{
-					var hap = handAppliable as IBaseInteractable<PositionalHandApply>;
+					var hap = targetHandAppliable as IBaseInteractable<PositionalHandApply>;
 					if (CheckInteractInternal(hap, posHandApply, NetworkSide.Client))
 					{
-						instance.material.SetColor("_OutlineColor", Color.magenta);
+						instance.material.SetColor(OutlineColor, new Color(1, 0.647f, 0));
 						return true;
 					}
 				}
 			}
+
+			return false;
 		}
 
 
-		//call the hand apply interaction methods on the target object if it has any
-		var targetHandAppliables = handApply.TargetObject.GetComponents<MonoBehaviour>()
-			.Where(c => c != null && c.enabled &&
-			            (c is IBaseInteractable<HandApply> || c is IBaseInteractable<PositionalHandApply>));
-		foreach (var targetHandAppliable in targetHandAppliables.Reverse())
+		private static bool CheckInteractInternal<T>(IBaseInteractable<T> interactable, T interaction,
+			NetworkSide side)
+			where T : Interaction
 		{
-			if (targetHandAppliable is IBaseInteractable<HandApply> Hap)
+			if (Cooldowns.IsOn(interaction, CooldownID.Asset(CommonCooldowns.Instance.Interaction, side))) return false;
+			var result = false;
+			//check if client side interaction should be triggered
+			if (side == NetworkSide.Client && interactable is IClientInteractable<T> clientInteractable)
 			{
-				//var hap = targetHandAppliable as IBaseInteractable<HandApply>;
-				if (CheckInteractInternal(Hap, handApply, NetworkSide.Client))
+				result = clientInteractable.Interact(interaction);
+				if (result)
 				{
-					instance.material.SetColor("_OutlineColor", Color.green);
+					Loggy.Trace().Format("ClientInteractable triggered from {0} on {1} for object {2}",
+						Category.Interaction, typeof(T).Name, clientInteractable.GetType().Name,
+						(clientInteractable as Component)?.gameObject.name);
+					Cooldowns.TryStartClient(interaction, CommonCooldowns.Instance.Interaction);
 					return true;
 				}
 			}
-			else
+
+			//check other kinds of interactions
+			if (interactable is ICheckable<T> checkable)
 			{
-				var hap = targetHandAppliable as IBaseInteractable<PositionalHandApply>;
-				if (CheckInteractInternal(hap, posHandApply, NetworkSide.Client))
+				result = checkable.WillInteract(interaction, side);
+				if (result)
 				{
-					instance.material.SetColor("_OutlineColor", new Color(1, 0.647f, 0));
+					Loggy.Trace().Format("WillInteract triggered from {0} on {1} for object {2}", Category.Interaction,
+						typeof(T).Name, checkable.GetType().Name,
+						(checkable as Component)?.gameObject.name);
 					return true;
 				}
 			}
-		}
-
-		//instance.material.SetColor("_OutlineColor", Color.grey);
-		return false;
-	}
-
-
-	private static bool CheckInteractInternal<T>(IBaseInteractable<T> interactable, T interaction,
-		NetworkSide side)
-		where T : Interaction
-	{
-		if (Cooldowns.IsOn(interaction, CooldownID.Asset(CommonCooldowns.Instance.Interaction, side))) return false;
-		var result = false;
-		//check if client side interaction should be triggered
-		if (side == NetworkSide.Client && interactable is IClientInteractable<T> clientInteractable)
-		{
-			result = clientInteractable.Interact(interaction);
-			if (result)
+			else if (interactable is IInteractable<T>)
 			{
-				Loggy.Trace().Format("ClientInteractable triggered from {0} on {1} for object {2}",
-					Category.Interaction, typeof(T).Name, clientInteractable.GetType().Name,
-					(clientInteractable as Component).gameObject.name);
-				Cooldowns.TryStartClient(interaction, CommonCooldowns.Instance.Interaction);
-				return true;
+				//use default logic
+				result = DefaultWillInteract.Default(interaction, side);
+				if (result)
+				{
+					Loggy.Trace().Format("WillInteract triggered from {0} on {1} for object {2}", Category.Interaction,
+						typeof(T).Name, interactable.GetType().Name,
+						(interactable as Component)?.gameObject.name);
+
+					return true;
+				}
 			}
+
+			Loggy.Trace().Format("No interaction triggered from {0} on {1} for object {2}", Category.Interaction,
+				typeof(T).Name, interactable.GetType().Name,
+				(interactable as Component)?.gameObject.name);
+
+			return false;
 		}
-
-		//check other kinds of interactions
-		if (interactable is ICheckable<T> checkable)
-		{
-			result = checkable.WillInteract(interaction, side);
-			if (result)
-			{
-				Loggy.Trace().Format("WillInteract triggered from {0} on {1} for object {2}", Category.Interaction,
-					typeof(T).Name, checkable.GetType().Name,
-					(checkable as Component).gameObject.name);
-				return true;
-			}
-		}
-		else if (interactable is IInteractable<T>)
-		{
-			//use default logic
-			result = DefaultWillInteract.Default(interaction, side);
-			if (result)
-			{
-				Loggy.Trace().Format("WillInteract triggered from {0} on {1} for object {2}", Category.Interaction,
-					typeof(T).Name, interactable.GetType().Name,
-					(interactable as Component).gameObject.name);
-
-				return true;
-			}
-		}
-
-		Loggy.Trace().Format("No interaction triggered from {0} on {1} for object {2}", Category.Interaction,
-			typeof(T).Name, interactable.GetType().Name,
-			(interactable as Component).gameObject.name);
-
-		return false;
 	}
 }

--- a/UnityProject/Assets/Scripts/Objects/Directionals/HeadRotatable.cs
+++ b/UnityProject/Assets/Scripts/Objects/Directionals/HeadRotatable.cs
@@ -1,3 +1,4 @@
+using Core.Highlight;
 using Mirror;
 using Player;
 using UnityEngine;
@@ -5,94 +6,94 @@ using UnityEngine;
 namespace PlayerSpritesStuff
 {
 	public class HeadRotatable : NetworkBehaviour
-    {
+	{
 
-    	public Rotatable Rotatable;
+		public Rotatable Rotatable;
 
-    	public PlayerSprites PlayerSprites;
+		public PlayerSprites PlayerSprites;
 
-    	public OrientationEnum Cdirection;
-    	[HideInInspector, SyncVar(hook = nameof(SyncServerDirection))]
-    	public OrientationEnum SynchroniseCurrentDirection;
+		public OrientationEnum Cdirection;
+		[HideInInspector, SyncVar(hook = nameof(SyncServerDirection))]
+		public OrientationEnum SynchroniseCurrentDirection;
 
-    	private void SyncServerDirection(OrientationEnum oldDir, OrientationEnum dir)
-    	{
-    		if (isOwned)
-    		{
-    			return;
-    		}
-    		//Seems like headless is running the hook when it shouldn't be
-    		//(Mirror bug or our custom code broke something?)
-    		if (CustomNetworkManager.IsHeadless) return;
-
-
-    		SetDirectionInternal(oldDir, dir);
-    	}
-
-    	public void SetDirectionInternal(OrientationEnum oldDir, OrientationEnum dir)
-    	{
-    		switch (Rotatable.CurrentDirection )
-    		{
-    			case OrientationEnum.Up_By0:
-    				if (dir == OrientationEnum.Down_By180)
-    				{
-    					dir = OrientationEnum.Left_By90;
-    				}
-    				break;
-    			case OrientationEnum.Down_By180:
-    				if (dir == OrientationEnum.Up_By0)
-    				{
-    					dir = OrientationEnum.Right_By270;
-    				}
-    				break;
-    			case OrientationEnum.Left_By90:
-    				if (dir == OrientationEnum.Right_By270)
-    				{
-    					dir = OrientationEnum.Down_By180;
-    				}
-    				break;
-    			case OrientationEnum.Right_By270:
-    				if (dir == OrientationEnum.Left_By90)
-    				{
-    					dir = OrientationEnum.Down_By180;
-    				}
-    				break;
-    		}
+		private void SyncServerDirection(OrientationEnum oldDir, OrientationEnum dir)
+		{
+			if (isOwned)
+			{
+				return;
+			}
+			//Seems like headless is running the hook when it shouldn't be
+			//(Mirror bug or our custom code broke something?)
+			if (CustomNetworkManager.IsHeadless) return;
 
 
+			SetDirectionInternal(oldDir, dir);
+		}
 
-    		Cdirection = dir;
-    		SynchroniseCurrentDirection = dir;
-    		PlayerSprites.OnDirectionChangeHead(dir);
+		public void SetDirectionInternal(OrientationEnum oldDir, OrientationEnum dir)
+		{
+			switch (Rotatable.CurrentDirection )
+			{
+				case OrientationEnum.Up_By0:
+					if (dir == OrientationEnum.Down_By180)
+					{
+						dir = OrientationEnum.Left_By90;
+					}
+					break;
+				case OrientationEnum.Down_By180:
+					if (dir == OrientationEnum.Up_By0)
+					{
+						dir = OrientationEnum.Right_By270;
+					}
+					break;
+				case OrientationEnum.Left_By90:
+					if (dir == OrientationEnum.Right_By270)
+					{
+						dir = OrientationEnum.Down_By180;
+					}
+					break;
+				case OrientationEnum.Right_By270:
+					if (dir == OrientationEnum.Left_By90)
+					{
+						dir = OrientationEnum.Down_By180;
+					}
+					break;
+			}
 
-    		if (oldDir != dir)
-    		{
-    			if (
-    #if UNITY_EDITOR
-    				Application.isPlaying &&
-    #endif
-    				CustomNetworkManager.IsServer == false && isOwned)
-    			{
-    				CmdChangeDirection(dir);
-    			}
-
-    			Highlight.UpdateCurrentHighlight();
-    		}
-    	}
-
-    	//client requests the server to change serverDirection
-    	[Command]
-    	private void CmdChangeDirection(OrientationEnum direction)
-    	{
-    		SetDirectionInternal(Cdirection,direction);
-    	}
-
-    	public void SetFaceDirectionLocalVector(Vector2Int direction)
-    	{
-    		SetDirectionInternal(Cdirection, direction.ToOrientationEnum());
-    	}
 
 
-    }
+			Cdirection = dir;
+			SynchroniseCurrentDirection = dir;
+			PlayerSprites.OnDirectionChangeHead(dir);
+
+			if (oldDir != dir)
+			{
+				if (
+#if UNITY_EDITOR
+					Application.isPlaying &&
+#endif
+					CustomNetworkManager.IsServer == false && isOwned)
+				{
+					CmdChangeDirection(dir);
+				}
+
+				Highlight.UpdateCurrentHighlight();
+			}
+		}
+
+		//client requests the server to change serverDirection
+		[Command]
+		private void CmdChangeDirection(OrientationEnum direction)
+		{
+			SetDirectionInternal(Cdirection,direction);
+		}
+
+		public void SetFaceDirectionLocalVector(Vector2Int direction)
+		{
+			SetDirectionInternal(Cdirection, direction.ToOrientationEnum());
+		}
+
+
+	}
 
 }

--- a/UnityProject/Assets/Scripts/Objects/Directionals/Rotatable.cs
+++ b/UnityProject/Assets/Scripts/Objects/Directionals/Rotatable.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Core.Highlight;
 using Logs;
 using Mirror;
 using NaughtyAttributes;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 using System.Linq;
+using Core.Highlight;
 using UnityEngine;
 using TileManagement;
 using Mirror;
@@ -373,6 +374,9 @@ public class InteractableTiles : MonoBehaviour, IClientInteractable<PositionalHa
 
 		// get object at target position
 		GameObject hit = MouseUtils.GetOrderedObjectsAtPoint(message.targetWorldPosition).FirstOrDefault();
+
+		if (hit == null) return;
+
 		// get matrix
 		Matrix matrix = hit.GetComponentInChildren<Matrix>();
 
@@ -621,8 +625,8 @@ public class InteractableTiles : MonoBehaviour, IClientInteractable<PositionalHa
 				}
 				else if(orientation == OrientationEnum.Left_By90)
 				{
-						spritePos.x -= 0.5f;
-						Highlight.instance.spriteRenderer.transform.rotation = Quaternion.Euler(0,0,90);
+					spritePos.x -= 0.5f;
+					Highlight.instance.spriteRenderer.transform.rotation = Quaternion.Euler(0,0,90);
 				}
 				else if(orientation == OrientationEnum.Up_By0)
 				{

--- a/UnityProject/Assets/Scripts/UI/Core/OptionsMenu/ThemeOptions/ThemeOptions.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/OptionsMenu/ThemeOptions/ThemeOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Core.Highlight;
 using Core.Utils;
 using Logs;
 using Managers.SettingsManager;

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemImage.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemImage.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Core.Highlight;
 using Items;
 using UnityEngine;
 using UnityEngine.UI;
@@ -10,6 +11,9 @@ using UnityEngine.UI;
 /// </summary>
 public class UI_ItemImage
 {
+	private static readonly int IsPaletted = Shader.PropertyToID("_IsPaletted");
+	private static readonly int PaletteSize = Shader.PropertyToID("_PaletteSize");
+	private static readonly int ColorPalette = Shader.PropertyToID("_ColorPalette");
 	private readonly GameObject root;
 	private bool hidden;
 
@@ -102,13 +106,13 @@ public class UI_ItemImage
 			var itemAttrs = item.GetComponent<ItemAttributesV2>();
 			if (itemAttrs.ItemSprites.IsPaletted)
 			{
-				image.material.SetInt("_IsPaletted", 1);
-				image.material.SetInt("_PaletteSize", itemAttrs.ItemSprites.Palette.Count);
-				image.material.SetColorArray("_ColorPalette", itemAttrs.ItemSprites.Palette.ToArray());
+				image.material.SetInt(IsPaletted, 1);
+				image.material.SetInt(PaletteSize, itemAttrs.ItemSprites.Palette.Count);
+				image.material.SetColorArray(ColorPalette, itemAttrs.ItemSprites.Palette.ToArray());
 			}
 			else
 			{
-				image.material.SetInt("_IsPaletted", 0);
+				image.material.SetInt(IsPaletted, 0);
 			}
 
 			var colorSync = item.GetComponent<SpriteColorSync>();
@@ -222,7 +226,7 @@ public class UI_ItemImage
 	/// </summary>
 	public class ImageAndHandler
 	{
-		public static List<System.WeakReference<ImageAndHandler>> item_list = new List<System.WeakReference<ImageAndHandler>>();
+		public static readonly List<System.WeakReference<ImageAndHandler>> ItemList = new();
 
 		System.WeakReference<Image> _img;
 
@@ -249,7 +253,7 @@ public class UI_ItemImage
 
 		public static void ClearAll()
 		{
-			foreach (var a in item_list)
+			foreach (var a in ItemList)
 			{
 				ImageAndHandler iah;
 
@@ -266,12 +270,12 @@ public class UI_ItemImage
 				}
 			}
 
-			item_list.Clear();
+			ItemList.Clear();
 		}
 
 		public ImageAndHandler(Image image)
 		{
-			item_list.Add(new System.WeakReference<ImageAndHandler>(this));
+			ItemList.Add(new System.WeakReference<ImageAndHandler>(this));
 			UIImage = image;
 		}
 


### PR DESCRIPTION
### Purpose
removed the hard coded rect size for sprites to compute their highlight shader. Highlights will now work with any sprite, even if it is irregular (32x18 or whatever)

### Media Preview:
<img width="454" height="476" alt="imagen" src="https://github.com/user-attachments/assets/1753f2d5-edbe-414e-871a-c089bc3f6756" />

<img width="294" height="398" alt="imagen" src="https://github.com/user-attachments/assets/9991af74-84a2-4ad5-bc05-b5db8eb562f0" />

<img width="484" height="321" alt="imagen" src="https://github.com/user-attachments/assets/529aa9a7-191b-400c-8e6e-9bd090bcff03" />


### Changelog:
CL: [Fix] Fixed highlight effect on irregular sprites, such as lockers
