### PR TITLE
Liquids properly extinguish fires when evaporating

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -56,6 +56,7 @@ public class MetaDataLayer : MonoBehaviour
 
 	private const float REAGENT_LIMIT_PER_CELL = 10f;
 	private const float EVAPORATE_TICK_DURATION = 64f;
+	private const float MINIMUM_TEMPERATURE_TO_EVAPORATE_CELSIUS = 29f;
 
 	public void OnEnable()
 	{
@@ -117,10 +118,10 @@ public class MetaDataLayer : MonoBehaviour
 			if (trackedTilesWithReagentsOnThem == null || trackedTilesWithReagentsOnThem.Count == 0) break;
 			var toRemove = safeList[i];
 			if (trackedTilesWithReagentsOnThem.Contains(toRemove) == false) continue;
-			if (TemperatureUtils.FromKelvin(toRemove.GasMixLocal.Temperature, TemeratureUnits.C) >= 29f)
+			if (TemperatureUtils.FromKelvin(toRemove.GasMixLocal.Temperature, TemeratureUnits.C) >= MINIMUM_TEMPERATURE_TO_EVAPORATE_CELSIUS)
 			{
 				if (toRemove.ReagentsOnTile == null) continue;
-				if (toRemove.ReagentsOnTile.MixState != ReagentState.Liquid) continue;
+				if (toRemove.ReagentsOnTile.MixState == ReagentState.Solid) continue;
 				if (toRemove.GasMixLocal != null)
 				{
 					toRemove.GasMixLocal.AddGas(Gas.WaterVapor, toRemove.ReagentsOnTile.Total * 2,

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -2,10 +2,12 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Systems.Atmospherics;
 using Chemistry;
 using Chemistry.Components;
 using Core.Factories;
+using Cysharp.Threading.Tasks;
 using Doors;
 using HealthV2;
 using InGameGizmos;
@@ -49,6 +51,8 @@ public class MetaDataLayer : MonoBehaviour
 
 	private List<MetaDataNode> trackedTilesWithReagentsOnThem = new List<MetaDataNode>();
 	public bool DebugGizmos = false;
+
+	private CancellationToken EvaporationCancellationToken = CancellationToken.None;
 
 	private const float REAGENT_LIMIT_PER_CELL = 10f;
 	private const float EVAPORATE_TICK_DURATION = 64f;
@@ -95,32 +99,36 @@ public class MetaDataLayer : MonoBehaviour
 
 	public void EvaporationTick()
 	{
-		StartCoroutine(EvaporateCheck());
+		if (EvaporationCancellationToken.IsCancellationRequested)
+		{
+			EvaporationCancellationToken = new CancellationTokenSource().Token;
+		}
+		_ = EvaporationCheck();
 	}
 
-	private IEnumerator EvaporateCheck()
+	private async UniTask EvaporationCheck()
 	{
 		var safeList = trackedTilesWithReagentsOnThem.Shuffle().ToList();
 		for (int i = 0; i < safeList.Count - 1; i++)
 		{
-			yield return WaitFor.EndOfFrame;
+			await UniTask.WaitForEndOfFrame(cancellationToken: EvaporationCancellationToken);
+			if (EvaporationCancellationToken.IsCancellationRequested) return;
 			if (safeList.Count <= 0) break;
 			if (trackedTilesWithReagentsOnThem == null || trackedTilesWithReagentsOnThem.Count == 0) break;
 			var toRemove = safeList[i];
 			if (trackedTilesWithReagentsOnThem.Contains(toRemove) == false) continue;
-			if (TemperatureUtils.FromKelvin(toRemove.GasMixLocal.Temperature, TemeratureUnits.C) >= 32f)
+			if (TemperatureUtils.FromKelvin(toRemove.GasMixLocal.Temperature, TemeratureUnits.C) >= 29f)
 			{
-				if (toRemove.ReagentsOnTile == null) 	continue;
-				if (toRemove.ReagentsOnTile.MixState == ReagentState.Solid) continue;
+				if (toRemove.ReagentsOnTile == null) continue;
+				if (toRemove.ReagentsOnTile.MixState != ReagentState.Liquid) continue;
 				if (toRemove.GasMixLocal != null)
 				{
-					toRemove.GasMixLocal.AddGas(CommonGasses.Instance.WaterVapor, toRemove.ReagentsOnTile.Total * 2,
+					toRemove.GasMixLocal.AddGas(Gas.WaterVapor, toRemove.ReagentsOnTile.Total * 2,
 						toRemove.ReagentsOnTile.InternalEnergy / 2);
 				}
-
+				matrix.ReactionManager.ExtinguishHotspot(toRemove.LocalPosition);
 				RemoveLiquidOnTile(toRemove.LocalPosition, toRemove);
 				trackedTilesWithReagentsOnThem.Remove(toRemove);
-				continue;
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
@@ -398,6 +398,11 @@ namespace Systems.Atmospherics
 			return Pressure * (GetMoles(gas) / Moles);
 		}
 
+		/// <summary>
+		/// Returns the moles of the specified gas in the mix.
+		/// </summary>
+		/// <param name="gas">The gas that you want checked. (Example: Gas.WaterVapor)</param>
+		/// <returns>The amount of moles of a Gas that is within a GasMix.</returns>
 		public float GetMoles(GasSO gas)
 		{
 			return GasData.GetGasMoles(gas);

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
@@ -389,6 +389,12 @@ namespace Systems.Atmospherics
 				return false;
 			}
 
+			//Too much water vapor to sustain a hotspot
+			if (gasMix.GasRatio(Gas.WaterVapor) >= 0.25f)
+			{
+				return false;
+			}
+
 			//Passed all checks, this position is allowed a hotspot
 			return true;
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
@@ -45,6 +45,7 @@ namespace Systems.Atmospherics
 		private List<WindEffectData> windEffectNodes = new List<WindEffectData>(30);
 
 		private const float WindParticleBlockTime = 3f;
+		private const float MINIMUM_AMOUNT_OF_DAMPNESS_IN_THE_AIR = 0.25f;
 
 
 		public enum WindStrength
@@ -390,7 +391,7 @@ namespace Systems.Atmospherics
 			}
 
 			//Too much water vapor to sustain a hotspot
-			if (gasMix.GasRatio(Gas.WaterVapor) >= 0.25f)
+			if (gasMix.GasRatio(Gas.WaterVapor) >= MINIMUM_AMOUNT_OF_DAMPNESS_IN_THE_AIR)
 			{
 				return false;
 			}


### PR DESCRIPTION
CL: [New] Water Vapor acts now as a fire deterrent.
CL: [Fix] Fixed an edge-case where liquids would organically put out fires, but would not have the ability to properly disable a tile's hotspot status; which resulted in fires immediately starting up once again.
