### PR TITLE
fix: adds another unharmful but useful attribute to codescan whitelist

### DIFF
--- a/CodeScanList.json
+++ b/CodeScanList.json
@@ -73,7 +73,10 @@
             "IDeserializationCallback": {
                 "All": true
             },
-            "StreamingContext": {}
+            "StreamingContext": {},
+            "IgnoreDataMemberAttribute": {
+                "All": true
+            }
         },
         "System.Security.Principal": {
             "IIdentity": {


### PR DESCRIPTION
### Purpose

All this attribute does is telling serializers to ignore a property or variable in a model definition. This is useful for computed properties or something you will fill during deserialization