### PR TITLE
Defib Harm Interaction + Better interaction clarity

### DIFF
--- a/UnityProject/Assets/Scripts/US13/Items/AddBackToStorageOnDropOrThrow.cs
+++ b/UnityProject/Assets/Scripts/US13/Items/AddBackToStorageOnDropOrThrow.cs
@@ -7,7 +7,7 @@ using Util;
 namespace US13.Items
 {
 	/// <summary>
-	/// Component that houses functionality for the OnDrop and OnThrow events too hook onto via the unity inspector,
+	/// Component that houses functionality for the OnDrop and OnThrow events to hook onto via the unity inspector,
 	/// or dynamically. Does not do anything on its own and requires the OnDropOrThrow function to be subscribed to an event.
 	/// Re-adds this item back to an item storage when dropped, mainly used for things like the Defib Paddles.
 	/// </summary>
@@ -18,24 +18,42 @@ namespace US13.Items
 
 		private void Start()
 		{
-			if (storage == null) storage = gameObject.PickupableOrNull().ItemSlot.ItemStorage;
+			if (storage == null) Setup();
+		}
+
+		private void Setup()
+		{
+			var itemSlot = gameObject.PickupableOrNull()?.ItemSlot;
+			if (itemSlot == null)
+			{
+				Loggy.Error($"No ItemSlot defined on {gameObject.name} for AddBackToStorageOnDropOrThrow");
+				return;
+			}
+			storage = itemSlot.ItemStorage;
+			if (storage == null)
+			{
+				Loggy.Error($"No ItemStorage defined on {gameObject.name} for AddBackToStorageOnDropOrThrow.");
+			}
 		}
 
 		void IServerInventoryMove.OnInventoryMoveServer(InventoryMove info)
 		{
-			//TODO forever loop?!?!
-			if (storage == null) return;
-			if (info?.MovedObject.OrNull()?.gameObject == this.gameObject && info?.ToSlot?.ItemStorage != storage)
+			if (storage == null)
 			{
-				if ((info?.ToSlot?.NamedSlot is NamedSlot.leftHand or NamedSlot.rightHand) == false)
-				{
-					if (storage.ServerTryAdd(gameObject))
-					{
-						Chat.AddActionMsgToChat(gameObject, OnAddBackMessage);
-						return;
-					}
+				Setup();
+				return;
+			}
 
-					Loggy.Error($"[{gameObject.name}/AddBackToStorageOnDropOrThrow] - Something went wrong while trying to re-add this item back to their item storage.");
+			if (info?.MovedObject.OrNull()?.gameObject != this.gameObject || info?.ToSlot?.ItemStorage == storage) return;
+			if (info?.ToSlot?.NamedSlot is not (NamedSlot.leftHand or NamedSlot.rightHand))
+			{
+				if (storage.ServerTryAdd(gameObject))
+				{
+					Chat.AddActionMsgToChat(gameObject, OnAddBackMessage);
+				}
+				else
+				{
+					Loggy.Error($"Something went wrong while trying to re-add this item back to their item storage on {gameObject.name}.\n {InventoryMove.ToString(info)}");
 				}
 			}
 		}

--- a/UnityProject/Assets/Scripts/US13/Items/Medical/DefibrillatorPaddles.cs
+++ b/UnityProject/Assets/Scripts/US13/Items/Medical/DefibrillatorPaddles.cs
@@ -1,23 +1,32 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
+using System.Text;
 using UnityEngine;
 using US13.Core.Addressables.Types;
 using US13.Core.Chat;
 using US13.Core.Input_System.InteractionV2;
 using US13.Core.Input_System.InteractionV2.Interactions;
 using US13.Core.Input_System.InteractionV2.Interfaces;
+using US13.Core.Physics;
+using US13.Health.Objects;
+using US13.HealthV2;
 using US13.HealthV2.Living;
 using US13.Items.Traits;
 using US13.Managers;
 using US13.Messages.Server.SoundMessages;
 using US13.Mobs.Equipment;
+using US13.Player.MovementV2;
+using US13.Systems.Explosions;
 using US13.Systems.Inventory;
 using US13.UI.Core.ProgressBar;
+using US13.UI.Systems.MainHUD.UI_Bottom;
+using US13.UI.Systems.Tooltips.HoverTooltips;
 using Util;
 using Util.Independent.FluentRichText;
 
 namespace US13.Items.Medical
 {
-	public class DefibrillatorPaddles : MonoBehaviour, ICheckedInteractable<HandApply>, IInteractable<HandActivate>
+	public class DefibrillatorPaddles : MonoBehaviour, ICheckedInteractable<HandApply>, IInteractable<HandActivate>, IHoverTooltip, IExaminable
 	{
 		public ItemTrait DefibrillatorTrait;
 
@@ -35,14 +44,18 @@ namespace US13.Items.Medical
 		private bool onCooldown;
 		private readonly float cooldown = 5;
 
+		private const float PUSHBACK_FORCE = 5550f;
+		private const float SPIN_FACTOR = 10f;
+		private const float INAIR_TIME = 0.1f;
+		private const float DAMAGE_AMOUNT = 25f;
+
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
-			if (DefaultWillInteract.Default(interaction, side) == false)
-				return false;
+			if (DefaultWillInteract.Default(interaction, side) == false) return false;
+			if (interaction.Intent == Intent.Harm) return true;
 			if (interaction.TargetObject.TryGetComponent<LivingHealthMasterBase>(out var livingHealthMaster) is false) return false;
 			if (side == NetworkSide.Server && DoesntRequireBackpack == false)
 			{
-
 				var equipment = interaction.Performer.GetComponent<Equipment>();
 				var ObjectInSlot = equipment.GetClothingItem(NamedSlot.back).ServerGameObjectReference;
 				if (Validations.HasItemTrait(ObjectInSlot, DefibrillatorTrait) == false)
@@ -80,6 +93,11 @@ namespace US13.Items.Medical
 
 		public void ServerPerformInteraction(HandApply interaction)
 		{
+			if (interaction.Intent == Intent.Harm)
+			{
+				HarmInteraction(interaction);
+				return;
+			}
 			void Perform()
 			{
 				var livingHealthMaster = interaction.TargetObject.GetComponent<LivingHealthMasterBase>();
@@ -143,6 +161,106 @@ namespace US13.Items.Medical
 
 			Chat.AddExamineMsg(interaction.Performer,
 				$"<color=green>The {gameObject.ExpensiveName()} is charged and ready to be used.</color>");
+		}
+
+		private void HarmInteraction(HandApply interaction)
+		{
+			if (interaction.Intent != Intent.Harm) return;
+			if (onCooldown)
+			{
+				Chat.AddExamineMsg(interaction.Performer, $"The {gameObject.ExpensiveName()} is still charging!".Color(RichTextColor.Yellow));
+				return;
+			}
+			if (isReady is false)
+			{
+				Chat.AddExamineMsg(interaction.Performer, $"You need to prepare the {gameObject.ExpensiveName()} first!".Color(RichTextColor.Yellow));
+				return;
+			}
+			if (interaction.TargetObject.TryGetComponent<LivingHealthMasterBase>(out var livingHealthMaster) == false) return;
+			if (interaction.Performer.TryGetComponent<UniversalObjectPhysics>(out var interactor) == false) return;
+			var targetPos = livingHealthMaster.playerScript.AssumedWorldPos;
+			var interactorPos = interaction.PerformerPlayerScript.AssumedWorldPos;
+			var pushVector = (interactorPos - targetPos).To2();
+
+			SparkUtil.TrySpark(interaction.Performer);
+			interactor.NewtonianNewtonPush( pushVector, PUSHBACK_FORCE, inAirTime: INAIR_TIME, spinFactor: SPIN_FACTOR );
+
+			//push perpetrator and victim away from each other
+			livingHealthMaster.ApplyDamageToBodyPart(interaction.PerformerPlayerScript.gameObject, DAMAGE_AMOUNT,
+				AttackType.Energy, DamageType.Burn, interaction.TargetBodyPart);
+			livingHealthMaster.playerScript.playerMove.NewtonianNewtonPush(-pushVector, PUSHBACK_FORCE, inAirTime: INAIR_TIME, spinFactor: SPIN_FACTOR);
+
+			HandlePullingActorsDuringHarmInteraction(livingHealthMaster, pushVector, interactor);
+			StartCoroutine(Cooldown());
+			Chat.AddAttackMsgToChat(interactor.gameObject, livingHealthMaster.gameObject, interaction.TargetBodyPart, gameObject, "shocked");
+		}
+
+		private void HandlePullingActorsDuringHarmInteraction(LivingHealthMasterBase victim, Vector2 pushVector, UniversalObjectPhysics perp)
+		{
+			if (victim.playerScript.playerMove.PulledBy.HasComponent == false) return;
+			victim.playerScript.playerMove.PulledBy.Component.NewtonianNewtonPush(-pushVector, PUSHBACK_FORCE, inAirTime: INAIR_TIME, spinFactor: SPIN_FACTOR);
+			if (victim.playerScript.playerMove.PulledBy.Component is MovementSynchronisation sync && sync == perp)
+			{
+				sync.playerScript.playerHealth.ApplyDamageToBodyPart(sync.gameObject, DAMAGE_AMOUNT,
+					AttackType.Energy, DamageType.Burn);
+			}
+		}
+
+		public string HoverTip()
+		{
+			return Examine();
+		}
+
+		public string CustomTitle()
+		{
+			return null;
+		}
+
+		public Sprite CustomIcon()
+		{
+			return null;
+		}
+
+		public List<Sprite> IconIndicators()
+		{
+			return null;
+		}
+
+		public List<TextColor> InteractionsStrings()
+		{
+			return new List<TextColor>()
+			{
+				new TextColor()
+				{
+					Text = "Hand-Activate to prepare the paddles.".Color(Color.green),
+					Color = Color.green
+				},
+				new TextColor()
+				{
+					Text = "Apply on a person to attempt to revive them while charged.".Color(Color.green),
+					Color = Color.green
+				},
+				new TextColor()
+				{
+					Text = "Attack while charged to shock your victim.".Color(Color.red),
+					Color = Color.red
+				}
+			};
+		}
+
+		public string Examine(Vector3 worldPos = default)
+		{
+			var SB = new StringBuilder();
+			if (DoesntRequireBackpack)
+			{
+				SB.AppendLine("It doesn't require its unit to be placed on your back or belt to be used.".Color(Color.yellow));
+			}
+			else
+			{
+				SB.AppendLine("It requires the unit to be equipped on your back or belt to be used.".Color(Color.yellow));
+			}
+
+			return SB.ToString();
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/US13/Items/Medical/DefibrillatorPaddles.cs
+++ b/UnityProject/Assets/Scripts/US13/Items/Medical/DefibrillatorPaddles.cs
@@ -13,6 +13,7 @@ using US13.Mobs.Equipment;
 using US13.Systems.Inventory;
 using US13.UI.Core.ProgressBar;
 using Util;
+using Util.Independent.FluentRichText;
 
 namespace US13.Items.Medical
 {
@@ -38,9 +39,7 @@ namespace US13.Items.Medical
 		{
 			if (DefaultWillInteract.Default(interaction, side) == false)
 				return false;
-			var livingHealthMaster = interaction.TargetObject.GetComponent<LivingHealthMasterBase>();
-			if (livingHealthMaster == null)
-				return false;
+			if (interaction.TargetObject.TryGetComponent<LivingHealthMasterBase>(out var livingHealthMaster) is false) return false;
 			if (side == NetworkSide.Server && DoesntRequireBackpack == false)
 			{
 
@@ -51,11 +50,11 @@ namespace US13.Items.Medical
 					ObjectInSlot = equipment.GetClothingItem(NamedSlot.belt).ServerGameObjectReference;
 					if (Validations.HasItemTrait(ObjectInSlot, DefibrillatorTrait) == false)
 					{
+						Chat.AddExamineMsg(interaction.Performer, "You need to place the defibrillator unit on your back or belt to use the paddles!".Color(Color.yellow));
 						return false;
 					}
 				}
 			}
-
 
 			if (CanDefibrillate(livingHealthMaster, interaction.Performer) == false && side == NetworkSide.Server)
 			{

--- a/UnityProject/Assets/Scripts/US13/Systems/Inventory/InventoryMoveType.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/Inventory/InventoryMoveType.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Logs;
 using UnityEngine;
 using US13.HealthV2;
@@ -193,6 +194,13 @@ namespace US13.Systems.Inventory
 		public static InventoryMove Throw(ItemSlot fromSlot, Vector2 worldTargetVector, BodyPartType aim = BodyPartType.Chest)
 		{
 			return new InventoryMove(InventoryMoveType.Remove, fromSlot.Item, fromSlot, null, InventoryRemoveType.Throw, aim, worldTargetVector);
+		}
+
+		public static string ToString(InventoryMove move)
+		{
+			StringBuilder sb = new StringBuilder();
+			sb.AppendFormat("InventoryMove of type {0} for object {1} from slot {2} to slot {3}. ", move.InventoryMoveType, move.MovedObject, move.FromSlot, move.ToSlot);
+			return sb.ToString();
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/US13/UI/Systems/AdminTools/DevTools/GUI_DevDestroyer.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Systems/AdminTools/DevTools/GUI_DevDestroyer.cs
@@ -51,7 +51,7 @@ namespace US13.UI.Systems.AdminTools.DevTools
 				var hits = MouseUtils.GetOrderedObjectsUnderMouse(layerMask,
 					go => go.GetComponent<UniversalObjectPhysics>() != null, useMappedItems : DevCameraControls.Instance.MappingItemState).ToArray();
 				if (hits.Any() == false) return;
-				var target = hits.First().GetComponentInParent<UniversalObjectPhysics>().gameObject;
+				var target = hits.First().GetComponentInParent<UniversalObjectPhysics>()?.gameObject;
 				if (target == null) return;
 				if (CustomNetworkManager.IsServer)
 				{


### PR DESCRIPTION
<img width="326" height="229" alt="image" src="https://github.com/user-attachments/assets/fc353f0b-1518-4f20-a0f9-054f00004b68" />

CL: [New] Defibs now have the ability to cause harm with a special interaction on harm intents.
CL: [Improvement] Added interaction hints to make it clear how to use defibs properly.
CL: [Fix] Fixed a rare issue where items that use the `AddBackToStorageOnDropOrThrow` component (like defibrillators) would remain locked out usage if the initial start setup was unable to find its parent storage component due to Unity lifecycle shenanigans.
CL: [Fix] Fixed NRE for admin delete tool that would occur when they accidentally try to delete the entire station.