### PR TITLE
make speedloaders reusable/reloadable.

### DIFF
--- a/UnityProject/Assets/Prefabs/Projectiles/AmmoBoxes/SpeedLoader.357.prefab
+++ b/UnityProject/Assets/Prefabs/Projectiles/AmmoBoxes/SpeedLoader.357.prefab
@@ -186,6 +186,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8354550959241077266, guid: 3fae459459df71d4999b6618dc06f219,
         type: 3}
+      propertyPath: magType
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8354550959241077266, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
       propertyPath: ammoType
       value: 11
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Projectiles/AmmoBoxes/SpeedLoader.357.prefab
+++ b/UnityProject/Assets/Prefabs/Projectiles/AmmoBoxes/SpeedLoader.357.prefab
@@ -187,7 +187,7 @@ PrefabInstance:
     - target: {fileID: 8354550959241077266, guid: 3fae459459df71d4999b6618dc06f219,
         type: 3}
       propertyPath: magType
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8354550959241077266, guid: 3fae459459df71d4999b6618dc06f219,
         type: 3}
@@ -211,6 +211,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1011412119081755325, guid: f1e541b806000994b970a77f497619ca,
         type: 3}
+    - target: {fileID: 8354550959241077266, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: clipDespawnWhenEmpty
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/UnityProject/Assets/Prefabs/Projectiles/AmmoBoxes/SpeedLoader.38.prefab
+++ b/UnityProject/Assets/Prefabs/Projectiles/AmmoBoxes/SpeedLoader.38.prefab
@@ -181,7 +181,7 @@ PrefabInstance:
     - target: {fileID: 8354550959241077266, guid: 3fae459459df71d4999b6618dc06f219,
         type: 3}
       propertyPath: magType
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8354550959241077266, guid: 3fae459459df71d4999b6618dc06f219,
         type: 3}
@@ -205,6 +205,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 5028489969333880017, guid: 7b41205052d6c7e4895869394631a735,
         type: 3}
+    - target: {fileID: 8354550959241077266, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: clipDespawnWhenEmpty
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/UnityProject/Assets/Prefabs/Projectiles/AmmoBoxes/SpeedLoader.38.prefab
+++ b/UnityProject/Assets/Prefabs/Projectiles/AmmoBoxes/SpeedLoader.38.prefab
@@ -180,6 +180,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8354550959241077266, guid: 3fae459459df71d4999b6618dc06f219,
         type: 3}
+      propertyPath: magType
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8354550959241077266, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
       propertyPath: ammoType
       value: 8
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Scripts/US13/Items/Weapons/MagazineBehaviour.cs
+++ b/UnityProject/Assets/Scripts/US13/Items/Weapons/MagazineBehaviour.cs
@@ -53,6 +53,9 @@ namespace US13.Items.Weapons
 		/// </summary>
 		public MagType magType;
 
+		[Tooltip("If true, a clip type magazine despawns when its ammo reaches zero. For keeping empty speedloaders but deleting stripper clips.")]
+		public bool clipDespawnWhenEmpty = true;
+
 		[SerializeField, FormerlySerializedAs("Projectile")]
 		public GameObject initalProjectile;
 		public int ProjectilesFired = 1;
@@ -117,6 +120,12 @@ namespace US13.Items.Weapons
 			serverAmmoRemains = newAmmo;
 			clientAmmoRemains = serverAmmoRemains;
 			OnServerAmmoChanged?.Invoke(oldAmmo, newAmmo);
+
+			// If a clip becomes empty on the server and the clip type is configured to despawn,
+			if (isServer && magType == MagType.Clip && serverAmmoRemains == 0 && clipDespawnWhenEmpty)
+			{
+				_ = Despawn.ServerSingle(gameObject);
+			}
 		}
 
 		/// <summary>
@@ -127,7 +136,7 @@ namespace US13.Items.Weapons
 		{
 			if (amount < 0)
 			{
-				Loggy.Warning("Attempted to expend a negitive amount of ammo", Category.Firearms); // dont use this method to replenish ammo
+				Loggy.Warning("Attempted to expend a negative amount of ammo", Category.Firearms); // dont use this method to replenish ammo
 			}
 
 			if (ClientAmmoRemains < amount)
@@ -158,10 +167,6 @@ namespace US13.Items.Weapons
 							containedBullets.RemoveAt(0); //remove shot projectile
 							containedProjectilesFired.RemoveAt(0);
 						}
-					}
-					if (magType == MagType.Clip && serverAmmoRemains == 0)
-					{
-						_ = Despawn.ServerSingle(gameObject);
 					}
 				}
 


### PR DESCRIPTION


### Purpose

This PR fixes a small issue with clip type magazines such as speedloaders. Before, when they reach 0 ammo, they would all delete themselves. this was problematic for speedloaders, which are supposed to persist and be reusable. This adds a check to clips to ensure only stripper clips get deleted while speedloaders don't.

### Notes:

Tested in editor.

### Changelog:

CL: [Fix] revolver speedloaders will not automatically despawn once out of bullets, and can be reloaded and reused.
