### PR TITLE
feat: add a mention to admins when someone ahelps and no admins are online

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,0 @@
-root = true
-
-[*.cs]
-indent_size = 4
-indent_style = tab
-trim_trailing_whitespace = true

--- a/UnityProject/.editorconfig
+++ b/UnityProject/.editorconfig
@@ -1,0 +1,62 @@
+root = true
+
+[*.cs]
+indent_size = 4
+indent_style = tab
+trim_trailing_whitespace = true
+
+# Private fields: camelCase (no underscore prefix)
+dotnet_naming_rule.private_fields_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.private_fields_should_be_camel_case.symbols = private_fields
+dotnet_naming_rule.private_fields_should_be_camel_case.style = camel_case_style
+
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private, protected, private_protected
+
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+
+# Properties: PascalCase
+dotnet_naming_rule.properties_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.properties_should_be_pascal_case.symbols = properties
+dotnet_naming_rule.properties_should_be_pascal_case.style = pascal_case_style
+
+dotnet_naming_symbols.properties.applicable_kinds = property
+dotnet_naming_symbols.properties.applicable_accessibilities = *
+
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# Methods: PascalCase
+dotnet_naming_rule.methods_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.methods_should_be_pascal_case.symbols = methods
+dotnet_naming_rule.methods_should_be_pascal_case.style = pascal_case_style
+
+dotnet_naming_symbols.methods.applicable_kinds = method
+dotnet_naming_symbols.methods.applicable_accessibilities = *
+
+# Public fields: PascalCase
+dotnet_naming_rule.public_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.public_fields_should_be_pascal_case.symbols = public_fields
+dotnet_naming_rule.public_fields_should_be_pascal_case.style = pascal_case_style
+
+dotnet_naming_symbols.public_fields.applicable_kinds = field
+dotnet_naming_symbols.public_fields.applicable_accessibilities = public, internal
+
+# Parameters: camelCase
+dotnet_naming_rule.parameters_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.parameters_should_be_camel_case.symbols = parameters
+dotnet_naming_rule.parameters_should_be_camel_case.style = camel_case_style
+
+dotnet_naming_symbols.parameters.applicable_kinds = parameter
+dotnet_naming_symbols.parameters.applicable_accessibilities = *
+
+# Local variables: camelCase
+dotnet_naming_rule.locals_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.locals_should_be_camel_case.symbols = locals
+dotnet_naming_rule.locals_should_be_camel_case.style = camel_case_style
+
+dotnet_naming_symbols.locals.applicable_kinds = local
+dotnet_naming_symbols.locals.applicable_accessibilities = *
+
+# Allow explicit comparison with true/false (project convention)
+dotnet_style_prefer_simplified_boolean_expressions = false:none
+resharper_simplify_negative_expression_highlighting = none

--- a/UnityProject/Assets/Prefabs/UI/AdminUI.prefab
+++ b/UnityProject/Assets/Prefabs/UI/AdminUI.prefab
@@ -5130,7 +5130,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 4721178495299449939}
         m_TargetAssemblyTypeName: AdminTools.AdminPlayerChat, Assets
-        m_MethodName: getMessagesForRound
+        m_MethodName: GetMessagesForRound
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/UnityProject/Assets/Scripts/US13/Managers/PlayerList.Admin.cs
+++ b/UnityProject/Assets/Scripts/US13/Managers/PlayerList.Admin.cs
@@ -140,6 +140,28 @@ namespace US13.Managers
 		}
 
 		[Server]
+		public bool AnyWithTAG(string tag)
+		{
+			if (LoggedInWithTag.ContainsKey(tag))
+			{
+				foreach (var a in LoggedInWithTag[tag])
+				{
+					if (TryGetOnlineByUserID(a, out _)) return true;
+				}
+			}
+
+			if (LoggedInWithTag.ContainsKey("*"))
+			{
+				foreach (var a in LoggedInWithTag["*"])
+				{
+					if (TryGetOnlineByUserID(a, out _)) return true;
+				}
+			}
+
+			return false;
+		}
+
+		[Server]
 		public List<PlayerInfo> GetAllWithTAG(string tag)
 		{
 			var admins = new List<PlayerInfo>();

--- a/UnityProject/Assets/Scripts/US13/UI/Systems/AdminTools/AdminPlayerChat.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Systems/AdminTools/AdminPlayerChat.cs
@@ -202,7 +202,7 @@ namespace US13.UI.Systems.AdminTools
 			AdminCheckMessages.Send(playerId, currentCount, roundID);
 		}
 
-		public void getMessagesForRound()
+		public void GetMessagesForRound()
 		{
 			clientAdminPlayerChatLogs.TryAdd(selectedPlayer.uid, new Dictionary<int, List<AdminChatMessage>>());
 
@@ -249,33 +249,41 @@ namespace US13.UI.Systems.AdminTools
 			var update = JsonConvert.DeserializeObject<AdminChatUpdate>(unreadMessagesJson);
 			clientAdminPlayerChatLogs[playerId][roundID].AddRange(update.messages);
 
-			if ((selectedPlayer != null
-			     && selectedPlayer.uid == playerId
-			     && (RoundIDsDropDown.options.Count == 0 || (int.Parse(ParseRoundId(RoundIDsDropDown.options[RoundIDsDropDown.value].text)) == roundID))
-			     )
-				|| forceShow)
-			{
-				if (RoundIDsDropDown.options.Count > 0 && forceShow && int.Parse(ParseRoundId(RoundIDsDropDown.options[RoundIDsDropDown.value].text)) !=
-				    roundID)
-				{
-					var match = RoundIDsDropDown.options
-						.Select((option, index) => (option, index))
-						.FirstOrDefault(x => ParseRoundId(x.option.text) == roundID.ToString());
+			bool isViewingThisPlayer = selectedPlayer != null && selectedPlayer.uid == playerId;
+			int selectedRoundID = GetSelectedDropdownRoundID();
+			bool isViewingThisRound = RoundIDsDropDown.options.Count == 0 || selectedRoundID == roundID;
 
-					if (match.option != null)
-					{
-						RoundIDsDropDown.value = match.index;
-					}
-					else
-					{
-						AdminChatRequestRounds.Send(playerId);
-						chatScroll.LoadChatEntries(update.messages.Cast<ChatEntryData>().ToList());
-					}
-				}
-				else
-				{
-					chatScroll.AppendChatEntries(update.messages.Cast<ChatEntryData>().ToList());
-				}
+			if (forceShow == false && (isViewingThisPlayer == false || isViewingThisRound == false)) return;
+
+			if (forceShow && RoundIDsDropDown.options.Count > 0 && selectedRoundID != roundID)
+			{
+				SwitchToRound(playerId, roundID, update);
+				return;
+			}
+
+			chatScroll.AppendChatEntries(update.messages.Cast<ChatEntryData>().ToList());
+		}
+
+		private int GetSelectedDropdownRoundID()
+		{
+			if (RoundIDsDropDown.options.Count == 0) return -1;
+			return int.Parse(ParseRoundId(RoundIDsDropDown.options[RoundIDsDropDown.value].text));
+		}
+
+		private void SwitchToRound(string playerId, int roundID, AdminChatUpdate update)
+		{
+			var match = RoundIDsDropDown.options
+				.Select((option, index) => (option, index))
+				.FirstOrDefault(x => ParseRoundId(x.option.text) == roundID.ToString());
+
+			if (match.option != null)
+			{
+				RoundIDsDropDown.value = match.index;
+			}
+			else
+			{
+				AdminChatRequestRounds.Send(playerId);
+				chatScroll.LoadChatEntries(update.messages.Cast<ChatEntryData>().ToList());
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/US13/UI/Systems/AdminTools/AdminPlayerChat.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Systems/AdminTools/AdminPlayerChat.cs
@@ -11,6 +11,7 @@ using TMPro;
 using UnityEngine;
 using US13.Core.Chat;
 using US13.Core.Chat.ChatScrollRect;
+using US13.Core.Database;
 using US13.Managers;
 using US13.Messages.Client.Admin;
 using US13.Messages.Server.AdminTools;
@@ -21,10 +22,7 @@ namespace US13.UI.Systems.AdminTools
 	{
 		[SerializeField] protected ChatScroll chatScroll = null;
 		protected AdminPlayerEntryData selectedPlayer;
-		public AdminPlayerEntryData SelectedPlayer
-		{
-			get { return selectedPlayer; }
-		}
+		public AdminPlayerEntryData SelectedPlayer => selectedPlayer;
 
 
 		public TMP_Dropdown RoundIDsDropDown;
@@ -48,7 +46,7 @@ namespace US13.UI.Systems.AdminTools
 
 		public void ClearLogs()
 		{
-
+			clientAdminPlayerChatLogs.Clear();
 		}
 
 		public virtual void ServerAddChatRecord(string message, PlayerInfo player, PlayerInfo admin = default)
@@ -85,8 +83,6 @@ namespace US13.UI.Systems.AdminTools
 
 		public void ServerMessageRecording(string playerId, AdminChatMessage entry)
 		{
-
-
 			var filePath = GetFilePath(GameManager.RoundID, playerId);
 
 			if (AccessFile.Exists(filePath, true, FolderType.Logs) == false)
@@ -115,55 +111,70 @@ namespace US13.UI.Systems.AdminTools
 				entryName = "[A] " + adminPlayer.Name;
 			}
 
-			DiscordWebhookMessage.Instance.AddWebHookMessageToQueue(DiscordWebhookURLs.DiscordWebhookAdminURL, entry.Message, entryName);
+			string mentionID = null;
+			var discordMessage = entry.Message;
+
+			bool isPlayerMessage = entry.wasFromAdmin == false;
+			bool noAdminsOnline = PlayerList.Instance.AnyWithTAG(TAG.ADMIN_CHAT) == false;
+
+			if (isPlayerMessage && noAdminsOnline)
+			{
+				mentionID = ServerData.ServerConfig.DiscordWebhookOOCMentionsID;
+				discordMessage = $"@ServerAdmin someone needs help in game and there are no admins online!\n{entry.Message}";
+			}
+
+			DiscordWebhookMessage.Instance.AddWebHookMessageToQueue(DiscordWebhookURLs.DiscordWebhookAdminURL, discordMessage, entryName, mentionID);
 
 			AccessFile.AppendAllText(filePath, JsonConvert.SerializeObject(entry) + "\n", FolderType.Logs);
 		}
 
-		public string GetFilePath(int RoundID, string playerId)
+		public string GetFilePath(int roundID, string playerId)
 		{
-			return Path.Combine(ChatLogsFolder, playerId, $"{RoundID}.txt");
+			return Path.Combine(ChatLogsFolder, playerId, $"{roundID}.txt");
+		}
+
+		private static string ParseRoundId(string fileName)
+		{
+			return fileName.Replace(".txt", "");
 		}
 
 		public string LoadData(string filePath)
 		{
-			var data = "";
 			try
 			{
-				data = AccessFile.Load(filePath, FolderType.Logs, false);
+				return AccessFile.Load(filePath, FolderType.Logs, false);
 			}
 			catch (Exception e)
 			{
 				Loggy.Error($"Exception during file read: {e}");
+				return string.Empty;
 			}
-
-			return data;
 		}
 
 		public void ServerGetMessageRound(string playerId, NetworkConnection requestee)
 		{
-			if (AccessFile.Exists(Path.Combine(ChatLogsFolder, playerId),  false, FolderType.Logs))
+			var playerLogPath = Path.Combine(ChatLogsFolder, playerId);
+			if (AccessFile.Exists(playerLogPath, false, FolderType.Logs))
 			{
-				var Rounds = AccessFile.DirectoriesOrFilesIn(Path.Combine(ChatLogsFolder, playerId), FolderType.Logs);
-
-				AdminPlayerChatRoundsMessage.SendAvailableRoundsToAdmin(requestee, playerId, Rounds);
+				var rounds = AccessFile.DirectoriesOrFilesIn(playerLogPath, FolderType.Logs);
+				AdminPlayerChatRoundsMessage.SendAvailableRoundsToAdmin(requestee, playerId, rounds);
 			}
 		}
 
-		public void ServerGetUnreadMessages(string playerId, int currentCount, int RoundID, NetworkConnection requestee)
+		public void ServerGetUnreadMessages(string playerId, int currentCount, int roundID, NetworkConnection requestee)
 		{
-			bool ForceShow = false;
-			if (RoundID == -1)
+			bool forceShow = false;
+			if (roundID == -1)
 			{
-				ForceShow = true;
-				if ( AccessFile.Exists(Path.Combine(ChatLogsFolder, playerId),  false, FolderType.Logs) == false) return;
+				forceShow = true;
+				if (AccessFile.Exists(Path.Combine(ChatLogsFolder, playerId), false, FolderType.Logs) == false) return;
 
-				var Rounds = AccessFile.DirectoriesOrFilesIn(Path.Combine(ChatLogsFolder, playerId), FolderType.Logs).OrderByDescending(x => x);
-				var data = Rounds.First().Replace(".txt", "");
-				RoundID = int.Parse( data, NumberStyles.Integer);
+				var rounds = AccessFile.DirectoriesOrFilesIn(Path.Combine(ChatLogsFolder, playerId), FolderType.Logs).OrderByDescending(x => x);
+				var data = ParseRoundId(rounds.First());
+				roundID = int.Parse(data, NumberStyles.Integer);
 			}
 
-			var filePath = GetFilePath(RoundID, playerId);
+			var filePath = GetFilePath(roundID, playerId);
 			if (AccessFile.Exists(filePath, true, FolderType.Logs, false) == false)
 			{
 				return;
@@ -180,32 +191,23 @@ namespace US13.UI.Systems.AdminTools
 					logLines.Length - currentCount).Select(JsonConvert.DeserializeObject<AdminChatMessage>).ToList()
 			};
 
-			AdminPlayerChatUpdateMessage.SendLogUpdateToAdmin(requestee, update, playerId, RoundID, ForceShow);
+			AdminPlayerChatUpdateMessage.SendLogUpdateToAdmin(requestee, update, playerId, roundID, forceShow);
 		}
 
-		protected void ClientGetUnreadAdminPlayerMessages(string playerId, int CurrentCount, int RoundID)
+		protected void ClientGetUnreadAdminPlayerMessages(string playerId, int currentCount, int roundID)
 		{
-			if (clientAdminPlayerChatLogs.ContainsKey(playerId) == false)
-			{
-				clientAdminPlayerChatLogs.Add(playerId, new Dictionary<int, List<AdminChatMessage>>( ));
-			}
+			clientAdminPlayerChatLogs.TryAdd(playerId, new Dictionary<int, List<AdminChatMessage>>());
 
 			AdminChatRequestRounds.Send(playerId);
-			AdminCheckMessages.Send(playerId,CurrentCount, RoundID);
+			AdminCheckMessages.Send(playerId, currentCount, roundID);
 		}
 
 		public void getMessagesForRound()
 		{
-			if (clientAdminPlayerChatLogs.ContainsKey(selectedPlayer.uid) == false)
-			{
-				clientAdminPlayerChatLogs[selectedPlayer.uid] = new Dictionary<int, List<AdminChatMessage>>();
-			}
+			clientAdminPlayerChatLogs.TryAdd(selectedPlayer.uid, new Dictionary<int, List<AdminChatMessage>>());
 
-			int roundID = int.Parse(RoundIDsDropDown.options[RoundIDsDropDown.value].text.Replace(".txt", ""));
-			if (clientAdminPlayerChatLogs[selectedPlayer.uid].ContainsKey(roundID) == false)
-			{
-				clientAdminPlayerChatLogs[selectedPlayer.uid][roundID] = new List<AdminChatMessage>();
-			}
+			int roundID = int.Parse(ParseRoundId(RoundIDsDropDown.options[RoundIDsDropDown.value].text));
+			clientAdminPlayerChatLogs[selectedPlayer.uid].TryAdd(roundID, new List<AdminChatMessage>());
 
 
 			AdminCheckMessages.Send(selectedPlayer.uid,
@@ -215,17 +217,17 @@ namespace US13.UI.Systems.AdminTools
 			chatScroll.LoadChatEntries(clientAdminPlayerChatLogs[selectedPlayer.uid][roundID].Cast<ChatEntryData>().ToList());
 		}
 
-		public void ClientUpdateAvailableRounds( string playerId, string[] RoundIDs)
+		public void ClientUpdateAvailableRounds(string playerId, string[] roundIDs)
 		{
 			if (selectedPlayer.uid == playerId)
 			{
-				RoundIDs = RoundIDs.OrderByDescending(x => x).ToArray();
+				roundIDs = roundIDs.OrderByDescending(x => x).ToArray();
 				List<TMP_Dropdown.OptionData> optionDatas = new List<TMP_Dropdown.OptionData>();
-				foreach (var RoundID in RoundIDs)
+				foreach (var roundID in roundIDs)
 				{
 					optionDatas.Add(new TMP_Dropdown.OptionData
 					{
-						text = RoundID
+						text = roundID
 					});
 
 
@@ -237,39 +239,30 @@ namespace US13.UI.Systems.AdminTools
 		}
 
 
-		public void ClientUpdateChatLog(string unreadMessagesJson, string playerId, int RoundID, bool ForceShow)
+		public void ClientUpdateChatLog(string unreadMessagesJson, string playerId, int roundID, bool forceShow)
 		{
-
 			if (string.IsNullOrEmpty(unreadMessagesJson)) return;
 
-			if (clientAdminPlayerChatLogs.ContainsKey(playerId) == false)
-			{
-				clientAdminPlayerChatLogs.Add(playerId, new Dictionary<int, List<AdminChatMessage>>());
-			}
-
-			if (clientAdminPlayerChatLogs[playerId].ContainsKey(RoundID) == false)
-			{
-				clientAdminPlayerChatLogs[playerId].Add(RoundID, new List<AdminChatMessage>());
-			}
+			clientAdminPlayerChatLogs.TryAdd(playerId, new Dictionary<int, List<AdminChatMessage>>());
+			clientAdminPlayerChatLogs[playerId].TryAdd(roundID, new List<AdminChatMessage>());
 
 			var update = JsonConvert.DeserializeObject<AdminChatUpdate>(unreadMessagesJson);
-			clientAdminPlayerChatLogs[playerId][RoundID].AddRange(update.messages);
+			clientAdminPlayerChatLogs[playerId][roundID].AddRange(update.messages);
 
 			if ((selectedPlayer != null
 			     && selectedPlayer.uid == playerId
-			     &&  (RoundIDsDropDown.options.Count == 0 || (int.Parse(RoundIDsDropDown.options[RoundIDsDropDown.value].text.Replace(".txt", "")) == RoundID))
+			     && (RoundIDsDropDown.options.Count == 0 || (int.Parse(ParseRoundId(RoundIDsDropDown.options[RoundIDsDropDown.value].text)) == roundID))
 			     )
-				|| ForceShow)
+				|| forceShow)
 			{
-
-				if (RoundIDsDropDown.options.Count > 0 && ForceShow && int.Parse(RoundIDsDropDown.options[RoundIDsDropDown.value].text.Replace(".txt", "")) !=
-				    RoundID)
+				if (RoundIDsDropDown.options.Count > 0 && forceShow && int.Parse(ParseRoundId(RoundIDsDropDown.options[RoundIDsDropDown.value].text)) !=
+				    roundID)
 				{
 					var match = RoundIDsDropDown.options
-						.Select((Option, index) => (Option, index))
-						.FirstOrDefault(x => x.Option.text.Replace(".txt", "") == RoundID.ToString());
+						.Select((option, index) => (option, index))
+						.FirstOrDefault(x => ParseRoundId(x.option.text) == roundID.ToString());
 
-					if (match.Option != null) // Check if a match was found
+					if (match.option != null)
 					{
 						RoundIDsDropDown.value = match.index;
 					}
@@ -290,10 +283,7 @@ namespace US13.UI.Systems.AdminTools
 		{
 			selectedPlayer = playerData;
 
-			if (clientAdminPlayerChatLogs.ContainsKey(playerData.uid) == false)
-			{
-				clientAdminPlayerChatLogs.Add(playerData.uid, new Dictionary<int, List<AdminChatMessage>>( ));
-			}
+			clientAdminPlayerChatLogs.TryAdd(playerData.uid, new Dictionary<int, List<AdminChatMessage>>());
 
 			var firstOrDefault = clientAdminPlayerChatLogs[playerData.uid].OrderByDescending(x => x.Key).FirstOrDefault();
 
@@ -308,7 +298,7 @@ namespace US13.UI.Systems.AdminTools
 				ClientGetUnreadAdminPlayerMessages(playerData.uid, firstOrDefault.Value.Count, firstOrDefault.Key);
 			}
 
- 			chatScroll.LoadChatEntries(firstOrDefault.Value.Cast<ChatEntryData>().ToList());
+			chatScroll.LoadChatEntries(firstOrDefault.Value.Cast<ChatEntryData>().ToList());
 		}
 
 		protected void OnEnable()


### PR DESCRIPTION
### Notes:
For this to work, the `secrets.json` file needs to have `DiscordWebhookOOCMentionsID` with the mentionID.

Disregard the name, that's like that because of another feature that allows people to ping admins from OOC. I just didn't rename it to make it more general because that's out of the scope.

### Changelog:

CL: [New] Discord webhook integration can now mention admins when someone sends a message on ahelp and no admins are online