### PR TITLE
minor additions to deep-fryer PRs

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/Systems/Research/R&DProductionInitialDesigns/CircuitImprinter.asset
+++ b/UnityProject/Assets/ScriptableObjects/Systems/Research/R&DProductionInitialDesigns/CircuitImprinter.asset
@@ -100,3 +100,4 @@ MonoBehaviour:
   - board_sequence_analyzer
   - board_portable_scrubber
   - board_heater
+  - board_deep_fryer

--- a/UnityProject/Assets/Scripts/US13/Core/Physics/UniversalObjectPhysics.cs
+++ b/UnityProject/Assets/Scripts/US13/Core/Physics/UniversalObjectPhysics.cs
@@ -1459,7 +1459,10 @@ namespace US13.Core.Physics
 					}
 
 					livingHealthMasterBase.ApplyDamageToBodyPart(ddamagedBy, damage, AttackType.Melee, DamageType.Brute, currentAim);
-					if (currentAim == BodyPartType.Mouth && gameObject.TryGetEnabledComponent(out Edible edible)) edible.TryConsume(null, hit.gameObject, true);
+					if (currentAim == BodyPartType.Mouth && gameObject.TryGetCachedComponent(out Edible edible, includeDisabled: false))
+					{
+						edible.TryConsume(null, hit.gameObject, true);
+					}
 
 					LastHitContext.perpetrator = ddamagedBy;
 					LastHitContext.target = hit.gameObject;

--- a/UnityProject/Assets/Scripts/US13/Items/Food/Edible.cs
+++ b/UnityProject/Assets/Scripts/US13/Items/Food/Edible.cs
@@ -343,6 +343,7 @@ namespace US13.Items.Food
 
 		public string HoverTip()
 		{
+			if (enabled == false) return "";
 			var biteStatus = "";
 			if (currentBites == maxBites) biteStatus = "it is untouched.";
 			if (currentBites < maxBites) biteStatus = "someone took a bite out of it.";
@@ -356,6 +357,7 @@ namespace US13.Items.Food
 
 		public List<TextColor> InteractionsStrings()
 		{
+			if (enabled == false) return null;
 			var list = new List<TextColor>();
 			list.Add(new TextColor { Color = Color.green, Text = "Click on target to feed." });
 			list.Add(new TextColor { Color = Color.green,

--- a/UnityProject/Assets/Scripts/US13/Items/Food/Feedable.cs
+++ b/UnityProject/Assets/Scripts/US13/Items/Food/Feedable.cs
@@ -18,12 +18,12 @@ namespace US13.Items.Food
 			if (interaction.TargetBodyPart != BodyPartType.Mouth) return false;
 			if (DefaultWillInteract.Default(interaction, side) == false) return false;
 			if (interaction.HandObject == null) return false;
-			return interaction.HandObject.TryGetEnabledComponent<Edible>(out _);
+			return interaction.HandObject.TryGetCachedComponent<Edible>(out _, includeDisabled: false);
 		}
 
 		public void ServerPerformInteraction(HandApply interaction)
 		{
-			var edible = interaction.HandObject.GetEnabledComponent<Edible>();
+			var edible = interaction.HandObject.GetCachedComponent<Edible>(includeDisabled: false);
 			edible.TryConsume(interaction.Performer, interaction.TargetObject);
 		}
 	}

--- a/UnityProject/Assets/Scripts/US13/Items/Implants/Organs/SlimeEat.cs
+++ b/UnityProject/Assets/Scripts/US13/Items/Implants/Organs/SlimeEat.cs
@@ -70,7 +70,7 @@ namespace US13.Items.Implants.Organs
 			if ( RelatedPart.HealthMaster.ObjectBehaviour.BuckledToObject != null || RelatedPart.HealthMaster.ObjectBehaviour.ObjectIsBuckling != null ) return;
 
 
-			var Edible = ToEat.GetEnabledComponent<Edible>();
+			var Edible = ToEat.GetCachedComponent<Edible>(includeDisabled: false);
 
 			if (Edible != null)
 			{
@@ -130,9 +130,9 @@ namespace US13.Items.Implants.Organs
 			//TODO check buckling instead of this!!!
 			//Problem is determining intent, Since you can be riding something without eating it, So you have to set here
 			//Also the get component for edible and Living health , Could be fixed by common component reference in universal object physics
-			if (EdibleCurrentlyEating != null && EdibleCurrentlyEating.GetEnabledComponent<Edible>() != null)
+			if (EdibleCurrentlyEating != null && EdibleCurrentlyEating.GetCachedComponent<Edible>(includeDisabled: false) != null)
 			{
-				var food = EdibleCurrentlyEating.GetEnabledComponent<Edible>().GetMixForBite(null);
+				var food = EdibleCurrentlyEating.GetCachedComponent<Edible>(includeDisabled: false).GetMixForBite(null);
 				var Nutriments =  food[Nutriment];
 				food.Remove(Nutriment, Nutriments);
 				food.Add(SlimeJelly,Nutriments);

--- a/UnityProject/Assets/Scripts/US13/Items/Storage/PillBottle.cs
+++ b/UnityProject/Assets/Scripts/US13/Items/Storage/PillBottle.cs
@@ -36,7 +36,7 @@ namespace US13.Items.Storage
 		public void ServerPerformInteraction(HandApply interaction)
 		{
 			var pill = ItemStorage.GetFirstOccupiedSlot();
-			var PillEdible = pill.Item.GetEnabledComponent<Edible>();
+			var PillEdible = pill.Item.GetCachedComponent<Edible>(includeDisabled: false);
 			PillEdible.ServerPerformInteraction(interaction);
 		}
 

--- a/UnityProject/Assets/Scripts/US13/Mobs/BrainAI/States/BrainSlime.cs
+++ b/UnityProject/Assets/Scripts/US13/Mobs/BrainAI/States/BrainSlime.cs
@@ -179,7 +179,7 @@ namespace US13.Mobs.BrainAI.States
 
 		public bool IsInFoodPreferences(ItemAttributesV2 food)
 		{
-			return food.gameObject.GetEnabledComponent<Edible>() != null;
+			return food.gameObject.GetCachedComponent<Edible>(includeDisabled: false) != null;
 		}
 
 

--- a/UnityProject/Assets/Scripts/US13/NPC/AI/MobExplore.cs
+++ b/UnityProject/Assets/Scripts/US13/NPC/AI/MobExplore.cs
@@ -154,7 +154,7 @@ namespace US13.NPC.AI
 		{
 			if (hasFoodPrefereces == false)
 			{
-				return food.gameObject.GetEnabledComponent<Edible>() != null;
+				return food.gameObject.GetCachedComponent<Edible>(includeDisabled: false) != null;
 			}
 
 			return foodPreferences.Any(food.HasTrait);

--- a/UnityProject/Assets/Scripts/US13/Systems/Construction/MachineCircuitBoard.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/Construction/MachineCircuitBoard.cs
@@ -31,12 +31,12 @@ namespace US13.Systems.Construction
 		public string HoverTip()
 		{
 			if (machineParts == null) return null;
-			var ingrediants = "Ingridents:\n";
+			var ingredients = "Ingredients:\n";
 			foreach (var machinePart in machineParts.machineParts)
 			{
-				ingrediants += $"{machinePart.itemTrait.Name} (x{machinePart.amountOfThisPart})\n".Color(Color.magenta);
+				ingredients += $"{machinePart.itemTrait.Name} (x{machinePart.amountOfThisPart})\n".Color(Color.magenta);
 			}
-			return ingrediants;
+			return ingredients;
 		}
 
 		public string CustomTitle()

--- a/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
+++ b/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
@@ -386,14 +386,20 @@ namespace Util
 		/// <param name="go"></param>
 		/// <typeparam name="T"></typeparam>
 		/// <returns></returns>
-		public static T GetCachedComponent<T>(this Component go)  where T : Component
+		public static T GetCachedComponent<T>(this Component go, bool includeDisabled = true)  where T : Component
 		{
+			T component;
 			if (ComponentManager.TryGetCommonComponent(go.gameObject, out  var commonComponent))
 			{
-				return commonComponent.SafeGetComponent<T>();
+				component = commonComponent.SafeGetComponent<T>();
+			}
+			else
+			{
+				component = go == null ? null : go.gameObject.GetComponent<T>();
 			}
 
-			return go == null ? null : go.gameObject.GetComponent<T>();
+			if (includeDisabled == false && component is Behaviour behaviour && behaviour.enabled == false) return null;
+			return component;
 		}
 
 		/// <summary>
@@ -402,83 +408,70 @@ namespace Util
 		/// <param name="go"></param>
 		/// <typeparam name="T"></typeparam>
 		/// <returns></returns>
-		public static T GetCachedComponent<T>(this GameObject go)  where T : Component
+		public static T GetCachedComponent<T>(this GameObject go, bool includeDisabled = true)  where T : Component
 		{
+			T component;
 			if (ComponentManager.TryGetCommonComponent(go, out  var commonComponent))
 			{
-				return commonComponent.SafeGetComponent<T>();
+				component = commonComponent.SafeGetComponent<T>();
+			}
+			else
+			{
+				component = go == null ? null : go.GetComponent<T>();
 			}
 
-			return go == null ? null : go.GetComponent<T>();
+			if (includeDisabled == false && component is Behaviour behaviour && behaviour.enabled == false) return null;
+			return component;
 		}
 
 		/// <summary>
 		/// Try-pattern version of <see cref="GetCachedComponent{T}(GameObject)"/>.
 		/// Returns true if the component was found, with the result in <paramref name="component"/>.
 		/// </summary>
-		public static bool TryGetCachedComponent<T>(this Component go, out T component) where T : Component
+		public static bool TryGetCachedComponent<T>(this Component go, out T component, bool includeDisabled = true) where T : Component
 		{
 			if (ComponentManager.TryGetCommonComponent(go.gameObject, out  var commonComponent))
 			{
-				return commonComponent.TrySafeGetComponent<T>(out component);
+				if (commonComponent.TrySafeGetComponent<T>(out component) == false) return false;
 			}
 			else
 			{
 				component = null;
 				return false;
 			}
+
+			if (includeDisabled == false && component is Behaviour behaviour && behaviour.enabled == false)
+			{
+				component = null;
+				return false;
+			}
+
+			return true;
 		}
 
 		/// <summary>
 		/// Try-pattern version of <see cref="GetCachedComponent{T}(GameObject)"/>.
 		/// Returns true if the component was found, with the result in <paramref name="component"/>.
 		/// </summary>
-		public static bool TryGetCachedComponent<T>(this GameObject go, out T component)  where T : Component
+		public static bool TryGetCachedComponent<T>(this GameObject go, out T component, bool includeDisabled = true)  where T : Component
 		{
 			if (ComponentManager.TryGetCommonComponent(go, out  var commonComponent))
 			{
-				return commonComponent.TrySafeGetComponent<T>(out component);
+				if (commonComponent.TrySafeGetComponent<T>(out component) == false) return false;
 			}
 			else
 			{
 				component = null;
 				return false;
 			}
-		}
 
-
-		/// <summary>
-		/// Like <see cref="TryGetCachedComponent{T}(GameObject, out T)"/>, but only returns the component if it is enabled.
-		/// </summary>
-		public static bool TryGetEnabledComponent<T>(this GameObject go, out T component) where T : Behaviour
-		{
-			if (go.TryGetCachedComponent(out component) && component.enabled)
+			if (includeDisabled == false && component is Behaviour behaviour && behaviour.enabled == false)
 			{
-				return true;
+				component = null;
+				return false;
 			}
 
-			component = null;
-			return false;
-		}
-
-		/// <summary>
-		/// Like <see cref="GetCachedComponent{T}(GameObject)"/>, but only returns the component if it is enabled.
-		/// </summary>
-		public static T GetEnabledComponent<T>(this GameObject go) where T : Behaviour
-		{
-			var component = go.GetCachedComponent<T>();
-			if (component != null && component.enabled) return component;
-			return null;
-		}
-
-		/// <summary>
-		/// Like <see cref="GetCachedComponent{T}(GameObject)"/>, but only returns the component if it is enabled.
-		/// </summary>
-		public static T GetEnabledComponent<T>(this Component go) where T : Behaviour
-		{
-			var component = go.GetCachedComponent<T>();
-			if (component != null && component.enabled) return component;
-			return null;
+			return true;
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/StreamingAssets/Config/TechWeb/Designs/MachineDesigns.json
+++ b/UnityProject/Assets/StreamingAssets/Config/TechWeb/Designs/MachineDesigns.json
@@ -169,6 +169,25 @@
         "Item_ID": "sizzlesticks"
     },
     {
+        "Internal_ID": "board_deep_fryer",
+        "Description": "A circuit board used in the construction of the deep-fryer for the kitchen.",
+        "Category": [
+          "Misc. Machinery"
+        ],
+        "Materials": {
+          "Glass": 1000
+        },
+        "Machinery_type": [
+          "CircuitImprinter"
+        ],
+        "Compatible_machinery": [
+          "Engineering",
+          "Science"
+        ],
+        "name": "Deep Fryer Board",
+        "Item_ID": "aacfbeae58c121b45b5cfcff503a0955"
+    },
+    {
         "Internal_ID": "board_jukebox",
         "Description": "A circuit board used in the construction of certain machines.",
         "Category": [

--- a/UnityProject/Assets/Tests/Asset/TechWebDesignsTests.cs
+++ b/UnityProject/Assets/Tests/Asset/TechWebDesignsTests.cs
@@ -1,0 +1,133 @@
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Tests.Asset
+{
+	[Category(nameof(Asset))]
+	public class TechWebDesignsTests
+	{
+		private static readonly string[] RequiredFields =
+		{
+			"Internal_ID", "name", "Item_ID", "Machinery_type"
+		};
+
+		private static string DesignsFolder =>
+			Path.Combine(Application.dataPath, "StreamingAssets", "Config", "TechWeb", "Designs");
+
+		private static List<(string file, Dictionary<string, object> entry)> LoadAllDesigns()
+		{
+			var designs = new List<(string, Dictionary<string, object>)>();
+			foreach (var filePath in Directory.GetFiles(DesignsFolder, "*.json"))
+			{
+				var json = File.ReadAllText(filePath);
+				var entries = JsonConvert.DeserializeObject<List<Dictionary<string, object>>>(json);
+				var fileName = Path.GetFileName(filePath);
+				foreach (var entry in entries)
+				{
+					designs.Add((fileName, entry));
+				}
+			}
+
+			return designs;
+		}
+
+		[Test]
+		public void AllDesignFilesAreValidJson()
+		{
+			var report = new TestReport();
+
+			foreach (var filePath in Directory.GetFiles(DesignsFolder, "*.json"))
+			{
+				var fileName = Path.GetFileName(filePath);
+				var json = File.ReadAllText(filePath);
+				try
+				{
+					JsonConvert.DeserializeObject<List<Dictionary<string, object>>>(json);
+				}
+				catch (JsonException e)
+				{
+					report.Fail().AppendLine($"{fileName}: Invalid JSON - {e.Message}");
+				}
+			}
+
+			report.AssertPassed();
+		}
+
+		[Test]
+		public void AllDesignsHaveRequiredFields()
+		{
+			var report = new TestReport();
+
+			foreach (var (file, entry) in LoadAllDesigns())
+			{
+				var id = entry.ContainsKey("Internal_ID") ? entry["Internal_ID"].ToString() : "UNKNOWN";
+				foreach (var field in RequiredFields)
+				{
+					report.FailIf(entry.ContainsKey(field) == false)
+						.AppendLine($"{file} -> '{id}': Missing required field '{field}'");
+				}
+			}
+
+			report.AssertPassed();
+		}
+
+		[Test]
+		public void NoDuplicateInternalIDs()
+		{
+			var report = new TestReport();
+			var seenIDs = new Dictionary<string, string>();
+
+			foreach (var (file, entry) in LoadAllDesigns())
+			{
+				if (entry.ContainsKey("Internal_ID") == false) continue;
+
+				var id = entry["Internal_ID"].ToString();
+				report.FailIf(seenIDs.TryGetValue(id, out var existingFile))
+					.AppendLine($"Duplicate Internal_ID '{id}' found in '{file}' and '{existingFile}'");
+
+				seenIDs.TryAdd(id, file);
+			}
+
+			report.AssertPassed();
+		}
+
+		[Test]
+		public void AllItemIDsReferenceValidPrefabs()
+		{
+			var report = new TestReport();
+			var prefabs = Utils.FindPrefabs();
+			var foreverIDs = new HashSet<string>();
+
+			foreach (var prefab in prefabs)
+			{
+				if (prefab.TryGetComponent<US13.UI.Core.PrefabTracker>(out var tracker))
+				{
+					foreverIDs.Add(tracker.ForeverID);
+				}
+			}
+
+			foreach (var (file, entry) in LoadAllDesigns())
+			{
+				if (entry.ContainsKey("Item_ID") == false) continue;
+				if (entry.ContainsKey("Category") && entry["Category"].ToString().Contains("NonProducable")) continue;
+
+				var itemID = entry["Item_ID"].ToString();
+				var id = entry.ContainsKey("Internal_ID") ? entry["Internal_ID"].ToString() : "UNKNOWN";
+
+				if (itemID.Contains("/"))
+				{
+					Debug.LogWarning($"{file} -> '{id}': Item_ID '{itemID}' is a TG placeholder path, skipping validation");
+					continue;
+				}
+
+				report.FailIf(foreverIDs.Contains(itemID) == false)
+					.AppendLine($"{file} -> '{id}': Item_ID '{itemID}' does not match any prefab's ForeverID");
+			}
+
+			report.AssertPassed();
+		}
+	}
+}

--- a/UnityProject/Assets/Tests/Asset/TechWebDesignsTests.cs.meta
+++ b/UnityProject/Assets/Tests/Asset/TechWebDesignsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b10555fc361994b458a4a34629bbe0c3


### PR DESCRIPTION
### Purpose
This PR: 
- Refactors the `GetCachedComponent` to have a new `includeDisabled` argument, true by default. 
- Removes the `GetEnabledComponent` extensions and use the new default argument in `GetCachedComponent` instead for stuff that interacts with Edible.
- Adds the deep-fryer circuit board to the imprinter so people can build the thing.
- Fixes some minor tooltip bugs. Since every item now has the edible component, we were always seeing edible interaction strings despite the item not being edible yet.
- - 
### Changelog:
CL: [Improvement] Added the deep-fryer circuit board to the imprinter, so it is buildable in-game.

