### PR TITLE
refactor: facade for SoundManager.PlaySound*

### DIFF
--- a/UnityProject/Assets/Scripts/US13/Items/Food/DrinkableContainer.cs
+++ b/UnityProject/Assets/Scripts/US13/Items/Food/DrinkableContainer.cs
@@ -8,12 +8,10 @@ using US13.Core.Chat;
 using US13.HealthV2.Living.Metabolism;
 using US13.Items.Implants.Organs;
 using US13.Managers;
-using US13.Messages.Server.SoundMessages;
 using US13.Player;
 using US13.Tilemaps.Behaviours.Objects;
 using US13.UI.Core.ProgressBar;
 using Util;
-using Random = UnityEngine.Random;
 
 namespace US13.Items.Food
 {
@@ -26,8 +24,6 @@ namespace US13.Items.Food
 		/// </summary>
 		[Tooltip("The name of the sound the player makes when drinking (must be in soundmanager")]
 		[SerializeField] private AddressableAudioSource drinkSound = null;
-
-		private float RandomPitch => Random.Range( 0.7f, 1.3f );
 
 		private ReagentContainer container;
 		private ItemAttributesV2 itemAttributes;
@@ -141,8 +137,9 @@ namespace US13.Items.Food
 			// Play sound
 			if (item && drinkSound != null)
 			{
-				AudioSourceParameters audioSourceParameters = new AudioSourceParameters(RandomPitch, spatialBlend: 2f);
-				SoundManager.PlayNetworkedAtPos(drinkSound, eater.WorldPos, audioSourceParameters, sourceObj: eater.gameObject);
+				Sound.At(drinkSound, eater.gameObject)
+					.WithRandomPitch(0.7f, 1.3f)
+					.PlayNetworked();
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/US13/Managers/Sound.cs
+++ b/UnityProject/Assets/Scripts/US13/Managers/Sound.cs
@@ -1,0 +1,412 @@
+using System.Collections.Generic;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+using US13.Core.Addressables.Types;
+using US13.Messages.Server.SoundMessages;
+using Util;
+
+namespace US13.Managers
+{
+	/// <summary>
+	/// Ergonomic facade for playing sounds. Wraps SoundManager with a fluent builder pattern.
+	/// Defaults to 3D spatial sound for positional audio.
+	///
+	/// Usage:
+	///   Sound.At(sound, gameObject).PlayNetworked();
+	///   Sound.At(sound, gameObject).WithRandomPitch(0.8f, 1.2f).PlayNetworked();
+	///   Sound.Global(sound).PlayNetworked();
+	///   var token = await Sound.At(sound, gameObject).WithLooping().PlayNetworkedAsync();
+	///   Sound.Stop(token);
+	///   Sound.Fade(token, 0f, 2f).AndStop().Send();
+	/// </summary>
+	public static class Sound
+	{
+		/// <summary>
+		/// Start building a positional sound at a GameObject's location.
+		/// The sound is 3D spatial by default and attaches to the source object.
+		/// </summary>
+		public static SoundBuilder At(AddressableAudioSource sound, GameObject source)
+		{
+			return new SoundBuilder(sound, source.AssumedWorldPosServer(), source, isGlobal: false);
+		}
+
+		/// <summary>
+		/// Start building a positional sound at a world position.
+		/// The sound is 3D spatial by default. Use .WithSource() to attach to an object.
+		/// </summary>
+		public static SoundBuilder At(AddressableAudioSource sound, Vector3 worldPos)
+		{
+			return new SoundBuilder(sound, worldPos, sourceObj: null, isGlobal: false);
+		}
+
+		/// <summary>
+		/// Start building a positional sound from a list (one picked at random) at a GameObject's location.
+		/// </summary>
+		public static SoundBuilder At(List<AddressableAudioSource> sounds, GameObject source)
+		{
+			return new SoundBuilder(sounds.PickRandom(), source.AssumedWorldPosServer(), source, isGlobal: false);
+		}
+
+		/// <summary>
+		/// Start building a positional sound from a list (one picked at random) at a world position.
+		/// </summary>
+		public static SoundBuilder At(List<AddressableAudioSource> sounds, Vector3 worldPos)
+		{
+			return new SoundBuilder(sounds.PickRandom(), worldPos, sourceObj: null, isGlobal: false);
+		}
+
+		/// <summary>
+		/// Start building a global sound heard by everyone regardless of position.
+		/// </summary>
+		public static SoundBuilder Global(AddressableAudioSource sound)
+		{
+			return new SoundBuilder(sound, Vector3.zero, sourceObj: null, isGlobal: true);
+		}
+
+		/// <summary>
+		/// Start building a global sound from a list (one picked at random).
+		/// </summary>
+		public static SoundBuilder Global(List<AddressableAudioSource> sounds)
+		{
+			return new SoundBuilder(sounds.PickRandom(), Vector3.zero, sourceObj: null, isGlobal: true);
+		}
+
+		/// <summary>
+		/// Stop a currently playing sound by its token (networked, tells all clients).
+		/// </summary>
+		public static void Stop(string token)
+		{
+			SoundManager.StopNetworked(token);
+		}
+
+		/// <summary>
+		/// Stop a sound locally and return it to the pool.
+		/// </summary>
+		public static void StopLocal(string token)
+		{
+			SoundManager.ClientStop(token, true);
+		}
+
+		/// <summary>
+		/// Pause a sound locally without returning it to the pool, so it can be resumed later.
+		/// </summary>
+		public static void PauseLocal(string token)
+		{
+			SoundManager.ClientStop(token, false);
+		}
+
+		/// <summary>
+		/// Start building a fade operation on an already-playing sound.
+		/// Chain .AndStop() if desired, then call a terminal: .Send(), .SendTo(player), or .Local().
+		/// </summary>
+		public static FadeBuilder Fade(string token, float targetVolume, float duration)
+		{
+			return new FadeBuilder(token, targetVolume, duration);
+		}
+
+	}
+
+	/// <summary>
+	/// Fluent builder for fade operations on already-playing sounds.
+	/// Use Sound.Fade() to create, optionally chain .AndStop(), then call a terminal.
+	/// </summary>
+	public struct FadeBuilder
+	{
+		private readonly string token;
+		private readonly float targetVolume;
+		private readonly float duration;
+		private bool stopOnComplete;
+
+		internal FadeBuilder(string token, float targetVolume, float duration)
+		{
+			this.token = token;
+			this.targetVolume = targetVolume;
+			this.duration = duration;
+			stopOnComplete = false;
+		}
+
+		/// <summary>
+		/// Stop and pool the sound after the fade completes.
+		/// </summary>
+		public FadeBuilder AndStop()
+		{
+			stopOnComplete = true;
+			return this;
+		}
+
+		/// <summary>
+		/// Send the fade to all clients (networked).
+		/// </summary>
+		public void SendToAll()
+		{
+			FadeSoundMessage.SendToAll(token, targetVolume, duration, stopOnComplete);
+		}
+
+		/// <summary>
+		/// Send the fade to a specific player only.
+		/// </summary>
+		public void SendTo(GameObject recipient)
+		{
+			FadeSoundMessage.Send(recipient, token, targetVolume, duration, stopOnComplete);
+		}
+
+		/// <summary>
+		/// Run the fade locally (client-side only, no network message).
+		/// </summary>
+		public void Local()
+		{
+			SoundManager.ClientFade(token, targetVolume, duration, stopOnComplete);
+		}
+	}
+
+	/// <summary>
+	/// Fluent builder for configuring and playing sounds.
+	/// Use Sound.At() or Sound.Global() to create, chain .With*() methods, then call a Play*() terminal.
+	/// </summary>
+	public struct SoundBuilder
+	{
+		private readonly AddressableAudioSource sound;
+		private readonly Vector3 worldPos;
+		private GameObject sourceObj;
+		private bool isGlobal;
+		private bool polyphonic;
+
+		private float pitch;
+		private bool pitchSet;
+		private float volume;
+		private bool volumeSet;
+		private MixerType mixerType;
+		private bool mixerSet;
+		private float maxDistance;
+		private bool maxDistanceSet;
+		private float minDistance;
+		private bool minDistanceSet;
+		private bool loops;
+		private bool isMute;
+		private float fadeInDuration;
+
+		internal SoundBuilder(AddressableAudioSource sound, Vector3 worldPos, GameObject sourceObj, bool isGlobal)
+		{
+			this.sound = sound;
+			this.worldPos = worldPos;
+			this.sourceObj = sourceObj;
+			this.isGlobal = isGlobal;
+			polyphonic = false;
+			pitch = 0;
+			pitchSet = false;
+			volume = 0;
+			volumeSet = false;
+			mixerType = MixerType.Master;
+			mixerSet = false;
+			maxDistance = 0;
+			maxDistanceSet = false;
+			minDistance = 0;
+			minDistanceSet = false;
+			loops = false;
+			isMute = false;
+			fadeInDuration = 0;
+		}
+
+		/// <summary>
+		/// Set a random pitch between min and max (e.g. 0.8f, 1.2f).
+		/// </summary>
+		public SoundBuilder WithRandomPitch(float min, float max)
+		{
+			pitch = Random.Range(min, max);
+			pitchSet = true;
+			return this;
+		}
+
+		/// <summary>
+		/// Set pitch variation around 1.0 (e.g. 0.05f means pitch between 0.95 and 1.05).
+		/// </summary>
+		public SoundBuilder WithPitchVariation(float variation)
+		{
+			pitch = Random.Range(1f - variation, 1f + variation);
+			pitchSet = true;
+			return this;
+		}
+
+		/// <summary>
+		/// Set a fixed pitch value (1.0 = normal, lower = slower, higher = faster).
+		/// </summary>
+		public SoundBuilder WithPitch(float value)
+		{
+			pitch = value;
+			pitchSet = true;
+			return this;
+		}
+
+		/// <summary>
+		/// Set volume (0-1, clamped).
+		/// </summary>
+		public SoundBuilder WithVolume(float vol)
+		{
+			volume = Mathf.Clamp(vol, 0f, 1f);
+			volumeSet = true;
+			return this;
+		}
+
+		/// <summary>
+		/// Set the output mixer (SoundFX, Ambient, Music, etc.).
+		/// </summary>
+		public SoundBuilder WithMixer(MixerType mixer)
+		{
+			mixerType = mixer;
+			mixerSet = true;
+			return this;
+		}
+
+		/// <summary>
+		/// Set maximum distance the sound can be heard.
+		/// </summary>
+		public SoundBuilder WithMaxDistance(float distance)
+		{
+			maxDistance = distance;
+			maxDistanceSet = true;
+			return this;
+		}
+
+		/// <summary>
+		/// Set minimum distance (sound is at full volume within this range).
+		/// </summary>
+		public SoundBuilder WithMinDistance(float distance)
+		{
+			minDistance = distance;
+			minDistanceSet = true;
+			return this;
+		}
+
+		/// <summary>
+		/// Make the sound loop until stopped via Sound.Stop(token).
+		/// </summary>
+		public SoundBuilder WithLooping()
+		{
+			loops = true;
+			return this;
+		}
+
+		/// <summary>
+		/// Attach the sound to a source object (follows the object).
+		/// Useful with Sound.At(sound, vector3) when position and source differ.
+		/// </summary>
+		public SoundBuilder WithSource(GameObject source)
+		{
+			sourceObj = source;
+			return this;
+		}
+
+		/// <summary>
+		/// Allow overlapping instances of this sound.
+		/// </summary>
+		public SoundBuilder AsPolyphonic()
+		{
+			polyphonic = true;
+			return this;
+		}
+
+		/// <summary>
+		/// Fade in from silence to target volume over the given duration after playing.
+		/// Automatically starts the sound muted. The fade is dispatched to match the
+		/// terminal method used (networked, targeted, or local).
+		/// </summary>
+		public SoundBuilder WithFadeIn(float duration)
+		{
+			fadeInDuration = duration;
+			isMute = true;
+			return this;
+		}
+
+		private AudioSourceParameters BuildParameters()
+		{
+			var parameters = new AudioSourceParameters();
+
+			if (isGlobal)
+			{
+				parameters = parameters.MakeSoundGlobal();
+			}
+			else
+			{
+				// Default to 3D spatial for positional sounds
+				parameters.SpatialBlend = 2;
+			}
+
+			if (pitchSet) parameters.Pitch = pitch;
+			if (volumeSet) parameters.Volume = volume;
+			if (mixerSet) parameters.MixerType = mixerType;
+			if (maxDistanceSet) parameters.MaxDistance = maxDistance;
+			if (minDistanceSet) parameters.MinDistance = minDistance;
+			if (loops) parameters.Loops = true;
+			if (isMute) parameters.IsMute = true;
+
+			return parameters;
+		}
+
+		private float FadeTargetVolume => volumeSet ? volume : 1f;
+
+		/// <summary>
+		/// Play the sound for all clients. Fire-and-forget (no token returned).
+		/// Use PlayNetworkedAsync() if you need the token to stop the sound later.
+		/// </summary>
+		public void PlayNetworked()
+		{
+			if (fadeInDuration > 0)
+			{
+				PlayNetworkedAsync().Forget();
+				return;
+			}
+
+			var parameters = BuildParameters();
+			SoundManager.PlayNetworkedAtPos(sound, worldPos, parameters, polyphonic,
+				global: isGlobal, sourceObj: sourceObj);
+		}
+
+		/// <summary>
+		/// Play the sound for all clients and return a token for later stopping.
+		/// If WithFadeIn() was called, a fade message is sent to all clients automatically.
+		/// </summary>
+		public async UniTask<string> PlayNetworkedAsync()
+		{
+			var parameters = BuildParameters();
+			var token = await SoundManager.PlayNetworkedAtPosAsync(sound, worldPos, parameters, polyphonic,
+				global: isGlobal, sourceObj: sourceObj);
+
+			if (fadeInDuration > 0)
+			{
+				FadeSoundMessage.SendToAll(token, FadeTargetVolume, fadeInDuration);
+			}
+
+			return token;
+		}
+
+		/// <summary>
+		/// Play the sound for a specific player only.
+		/// Note: WithFadeIn() is not supported here because the underlying API does not return a token.
+		/// For targeted fade-in, use PlayNetworkedAsync() + Sound.Fade(token, ...).SendTo(recipient).
+		/// </summary>
+		public void PlayNetworkedFor(GameObject recipient)
+		{
+			var parameters = BuildParameters();
+			_ = SoundManager.PlayNetworkedForPlayerAtPos(recipient, worldPos, sound, parameters,
+				polyphonic, sourceObj: sourceObj);
+		}
+
+		/// <summary>
+		/// Play the sound locally (client-side only).
+		/// If WithFadeIn() was called, the fade runs locally without any network message.
+		/// </summary>
+		public async UniTaskVoid PlayLocal()
+		{
+			var parameters = BuildParameters();
+			string token = fadeInDuration > 0 ? System.Guid.NewGuid().ToString() : "";
+
+			await SoundManager.PlayAtPosition(sound, worldPos, sourceObj, soundSpawnToken: token,
+				audioSourceParameters: parameters, polyphonic: polyphonic, isGlobal: isGlobal);
+
+			if (fadeInDuration > 0)
+			{
+				SoundManager.ClientFade(token, FadeTargetVolume, fadeInDuration, false);
+			}
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/US13/Managers/Sound.cs.meta
+++ b/UnityProject/Assets/Scripts/US13/Managers/Sound.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 790106aa34c1b194583a31413a06eb23

--- a/UnityProject/Assets/Scripts/US13/Managers/SoundManager.cs
+++ b/UnityProject/Assets/Scripts/US13/Managers/SoundManager.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
 using Logs;
 using Mirror;
 using Shared.Util;
@@ -729,6 +730,45 @@ namespace US13.Managers
 						Sound.AudioSource.Stop();
 					}
 				}
+			}
+		}
+
+		/// <summary>
+		/// Fades a sound's volume locally over the given duration.
+		/// If stopOnComplete is true, the sound is stopped and pooled after the fade.
+		/// </summary>
+		public static void ClientFade(string soundSpawnToken, float targetVolume, float duration, bool stopOnComplete)
+		{
+			if (Instance.SoundSpawns.TryGetValue(soundSpawnToken, out var spawn) == false) return;
+
+			RunClientFade(spawn, targetVolume, duration, stopOnComplete, soundSpawnToken).Forget();
+		}
+
+		private static async UniTaskVoid RunClientFade(SoundSpawn spawn, float target, float duration, bool stopOnComplete, string token)
+		{
+			var audioSource = spawn.AudioSource;
+			if (audioSource == null) return;
+
+			float start = audioSource.volume;
+			audioSource.mute = false;
+			float elapsed = 0f;
+
+			while (elapsed < duration)
+			{
+				if (audioSource == null) return;
+
+				elapsed += Time.deltaTime;
+				float t = Mathf.Clamp01(elapsed / duration);
+				audioSource.volume = Mathf.Lerp(start, target, t);
+				await UniTask.Yield();
+			}
+
+			if (audioSource == null) return;
+			audioSource.volume = target;
+
+			if (stopOnComplete)
+			{
+				ClientStop(token, true);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/US13/Messages/Server/SoundMessages/FadeSoundMessage.cs
+++ b/UnityProject/Assets/Scripts/US13/Messages/Server/SoundMessages/FadeSoundMessage.cs
@@ -1,0 +1,55 @@
+using Mirror;
+using UnityEngine;
+using US13.Managers;
+
+namespace US13.Messages.Server.SoundMessages
+{
+	/// <summary>
+	/// Message that tells a client to fade a sound's volume over time.
+	/// The fade runs entirely client-side, only one network message is sent.
+	/// The actual fade logic lives in SoundManager.ClientFade.
+	/// </summary>
+	public class FadeSoundMessage : ServerMessage<FadeSoundMessage.NetMessage>
+	{
+		public struct NetMessage : NetworkMessage
+		{
+			public string SoundSpawnToken;
+			public float TargetVolume;
+			public float Duration;
+			public bool StopOnComplete;
+		}
+
+		public override void Process(NetMessage msg)
+		{
+			SoundManager.ClientFade(msg.SoundSpawnToken, msg.TargetVolume, msg.Duration, msg.StopOnComplete);
+		}
+
+		public static NetMessage SendToAll(string soundSpawnToken, float targetVolume, float duration, bool stopOnComplete = false)
+		{
+			NetMessage msg = new NetMessage
+			{
+				SoundSpawnToken = soundSpawnToken,
+				TargetVolume = targetVolume,
+				Duration = duration,
+				StopOnComplete = stopOnComplete
+			};
+
+			SendToAll(msg);
+			return msg;
+		}
+
+		public static NetMessage Send(GameObject recipient, string soundSpawnToken, float targetVolume, float duration, bool stopOnComplete = false)
+		{
+			NetMessage msg = new NetMessage
+			{
+				SoundSpawnToken = soundSpawnToken,
+				TargetVolume = targetVolume,
+				Duration = duration,
+				StopOnComplete = stopOnComplete
+			};
+
+			SendTo(recipient, msg);
+			return msg;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/US13/Messages/Server/SoundMessages/FadeSoundMessage.cs.meta
+++ b/UnityProject/Assets/Scripts/US13/Messages/Server/SoundMessages/FadeSoundMessage.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7a480be8eddfc0a4a9b2cd5da0119810

--- a/UnityProject/Assets/Scripts/US13/Objects/Machines/AIOGrinder.cs
+++ b/UnityProject/Assets/Scripts/US13/Objects/Machines/AIOGrinder.cs
@@ -95,7 +95,7 @@ namespace US13.Objects.Machines
 
 		public void Activate()
 		{
-			SoundManager.PlayNetworkedAtPos(grindSound, WorldPosition, audioSourceParameters: new AudioSourceParameters(spatialBlend: 2) , sourceObj: gameObject);
+			Sound.At(grindSound, gameObject).PlayNetworked();
 			foreach (var slot in itemStorage.GetItemSlots())
 			{
 				if (slot == itemSlot) continue;

--- a/UnityProject/Assets/Scripts/US13/Objects/Machines/DeepFryer.cs
+++ b/UnityProject/Assets/Scripts/US13/Objects/Machines/DeepFryer.cs
@@ -11,7 +11,6 @@ using US13.Core.Sprite_Handler;
 using US13.Items.Tool;
 using US13.Managers;
 using US13.Managers.UpdateManager;
-using US13.Messages.Server.SoundMessages;
 using US13.Objects.Engineering;
 using US13.Systems.Construction;
 using US13.Systems.Electricity.Interfaces;
@@ -40,7 +39,7 @@ namespace US13.Objects.Machines
 		[SerializeField] private AddressableAudioSource dingSfx;
 
 		[Tooltip("How long the frying loop takes to fade in from silence.")]
-		[SerializeField] private float crossfadeDuration = 0.75f;
+		[SerializeField] private float fadeInDuration = 0.75f;
 
 		[SerializeField] private SpriteHandler greaseOverlay;
 		[SerializeField] private SpriteHandler leftBasketSprite;
@@ -231,22 +230,6 @@ namespace US13.Objects.Machines
 			loopingBaskets = newLoopState;
 		}
 
-		#region Play sounds!
-
-		public void PlayEmerge()
-		{
-			SoundManager.PlayNetworkedAtPos(emergeSfx, registerTile.WorldPosition, sourceObj: gameObject);
-		}
-
-		public void PlayDing()
-		{
-			SoundManager.PlayNetworkedAtPos(dingSfx, registerTile.WorldPosition, sourceObj: gameObject);
-		}
-
-		#endregion
-
-		#region Grease
-
 		[Server]
 		private void AccumulateGrease()
 		{
@@ -266,42 +249,37 @@ namespace US13.Objects.Machines
 			greaseOverlay.SetCatalogueIndexSprite(newLevel >= 1f ? 1 : 0);
 		}
 
-		#endregion
+		#region Play sounds!
 
-		#region Audio
+		public void PlayEmerge()
+		{
+			Sound.At(emergeSfx, gameObject).PlayNetworked();
+		}
+
+		public void PlayDing()
+		{
+			Sound.At(dingSfx, gameObject).PlayNetworked();
+		}
 
 		/// <summary>
 		/// Starts the frying loop muted and fades it in over crossfadeDuration.
 		/// </summary>
 		private async UniTaskVoid StartLoopWithFadeIn(int basketIndex, CancellationToken ct)
 		{
-			var loopSfx = UnityEngine.Random.value > 0.5f ? fryingLoopSfx1 : fryingLoopSfx2;
-			basketLoopGUIDs[basketIndex] = await SoundManager.PlayNetworkedAtPosAsync(loopSfx,
-				registerTile.WorldPosition,
-				audioSourceParameters: new AudioSourceParameters(pitch: VoltageModifier, isMute: true, loops: true),
-				sourceObj: gameObject);
-
-			if (ct.IsCancellationRequested) return;
-
-			// Fade in with discrete volume steps sent to all clients.
-			const int steps = 5;
-			float stepDuration = crossfadeDuration / steps;
-			for (int step = 1; step <= steps; step++)
-			{
-				if (ct.IsCancellationRequested) return;
-				await UniTask.WaitForSeconds(stepDuration, cancellationToken: ct);
-
-				float volume = (float)step / steps;
-				ChangeAudioSourceParametersMessage.SendToAll(basketLoopGUIDs[basketIndex],
-					new AudioSourceParameters(volume: volume, pitch: VoltageModifier, loops: true));
-			}
+			List<AddressableAudioSource> sounds = new() {fryingLoopSfx1, fryingLoopSfx2};
+			basketLoopGUIDs[basketIndex] = await Sound.At(sounds, gameObject)
+				.WithPitch(VoltageModifier)
+				.WithVolume(0.3f) // original sound is loud af
+				.WithLooping()
+				.WithFadeIn(fadeInDuration)
+				.PlayNetworkedAsync();
 		}
 
 		private void StopBasketLoop(int basketIndex)
 		{
 			if (string.IsNullOrEmpty(basketLoopGUIDs[basketIndex]) == false)
 			{
-				SoundManager.StopNetworked(basketLoopGUIDs[basketIndex]);
+				Sound.Stop(basketLoopGUIDs[basketIndex]);
 				basketLoopGUIDs[basketIndex] = "";
 			}
 		}

--- a/docs/development/Playing-Sounds.md
+++ b/docs/development/Playing-Sounds.md
@@ -1,0 +1,202 @@
+# Playing Sounds
+
+Use the `Sound` facade (`US13.Managers.Sound`) for all sound playback. It wraps the internal `SoundManager` with a fluent builder pattern that is concise, readable, and defaults to sensible settings.
+
+**Do not use `SoundManager` directly in new code.**
+
+## Quick Reference
+
+```csharp
+using US13.Managers;
+
+// Play a sound at a GameObject's position (3D spatial by default)
+Sound.At(mySound, gameObject).PlayNetworked();
+
+// Play a random sound from a list
+Sound.At(mySoundList, gameObject).PlayNetworked();
+
+// Play a global sound (heard everywhere)
+Sound.Global(mySound).PlayNetworked();
+
+// Stop a looping sound
+var token = await Sound.At(mySound, gameObject).WithLooping().PlayNetworkedAsync();
+Sound.Stop(token);
+
+// Fade out and stop
+Sound.Fade(token, 0f, 2f).AndStop().SendToAll();
+```
+
+## Entry Points
+
+| Method | Description |
+|--------|-------------|
+| `Sound.At(sound, gameObject)` | Positional sound at the object's location. Automatically 3D spatial. Also sets the object as the sound source. |
+| `Sound.At(sound, vector3)` | Positional sound at a world position. Use `.WithSource(obj)` if you need to attach it to an object. |
+| `Sound.At(soundList, ...)` | Same as above but picks one sound at random from the list. |
+| `Sound.Global(sound)` | Non-positional sound heard by everyone regardless of distance. |
+| `Sound.Stop(token)` | Stop a playing sound by its token (networked, tells all clients). |
+| `Sound.StopLocal(token)` | Stop a sound locally and return it to the pool. |
+| `Sound.PauseLocal(token)` | Pause a sound locally without pooling it, so it can be resumed later. |
+| `Sound.Fade(token, targetVolume, duration)` | Fade an already-playing sound from its current volume to `targetVolume` over `duration` seconds. Returns a `FadeBuilder`. |
+
+## Builder Methods
+
+Chain these between the entry point and the terminal method to configure the sound:
+
+| Method | Description |
+|--------|-------------|
+| `.WithPitch(float)` | Fixed pitch (1.0 = normal). |
+| `.WithRandomPitch(min, max)` | Random pitch in range (e.g. `0.8f, 1.2f`). |
+| `.WithPitchVariation(float)` | Random pitch around 1.0 (e.g. `0.05f` = range 0.95–1.05). |
+| `.WithVolume(float)` | Volume from 0 to 1. |
+| `.WithMixer(MixerType)` | Output mixer (`SoundFX`, `Ambient`, `Music`, `JukeBox`, `Muffled`). |
+| `.WithMaxDistance(float)` | Maximum distance the sound can be heard. |
+| `.WithMinDistance(float)` | Distance at which the sound is at full volume. |
+| `.WithLooping()` | Loop until stopped with `Sound.Stop(token)`. |
+| `.WithSource(gameObject)` | Attach sound to an object. Useful with `Sound.At(sound, vector3)` when the position and source object differ. |
+| `.AsPolyphonic()` | Allow overlapping instances (e.g. rapid footsteps). |
+| `.WithFadeIn(duration)` | Fade from silence to target volume after playing. Automatically handles muting. The fade matches the terminal used — networked terminals send a fade message, `PlayLocal()` fades client-side. |
+
+## Terminal Methods
+
+These trigger playback. Call exactly one to finish the chain:
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `.PlayNetworked()` | `void` | Fire-and-forget. Plays for all clients. |
+| `.PlayNetworkedAsync()` | `UniTask<string>` | Returns a token for stopping or modifying the sound later. |
+| `.PlayNetworkedFor(player)` | `void` | Play only for a specific player. Does not support `WithFadeIn`. |
+| `.PlayLocal()` | `UniTaskVoid` | Client-side only, not networked. |
+
+## Fading Already-Playing Sounds
+
+Use `Sound.Fade(token, targetVolume, duration)` to build a fade operation, optionally chain `.AndStop()`, then pick a delivery terminal:
+
+| Terminal | Description |
+|----------|-------------|
+| `.SendToAll()` | Send fade to all clients (networked). |
+| `.SendTo(recipient)` | Send fade to a specific player only. |
+| `.Local()` | Run the fade client-side only (no network message). |
+
+```csharp
+// Fade out and stop (networked)
+Sound.Fade(token, 0f, 2f).AndStop().SendToAll();
+
+// Fade to half volume (networked)
+Sound.Fade(token, 0.5f, 1f).SendToAll();
+
+// Fade out for a specific player
+Sound.Fade(token, 0f, 2f).AndStop().SendTo(player);
+
+// Fade locally (no networking)
+Sound.Fade(token, 0f, 1f).AndStop().Local();
+```
+
+## Common Patterns
+
+### Simple sound at a position
+
+```csharp
+Sound.At(clickSound, gameObject).PlayNetworked();
+```
+
+### Sound with random pitch variation (e.g. impacts, hits)
+
+```csharp
+Sound.At(hitSound, gameObject).WithRandomPitch(0.8f, 1.2f).PlayNetworked();
+```
+
+### Global announcement
+
+```csharp
+Sound.Global(alarmSound).WithVolume(0.8f).PlayNetworked();
+```
+
+### Sound for a specific player
+
+```csharp
+Sound.At(bwoinkSound, gameObject).PlayNetworkedFor(player);
+```
+
+### Looping sound with fade-in (e.g. machines)
+
+```csharp
+// Start looping with a fade-in, keep the token to stop it later
+loopToken = await Sound.At(humSound, gameObject)
+    .WithPitch(voltageModifier)
+    .WithLooping()
+    .WithFadeIn(fadeInDuration)
+    .PlayNetworkedAsync();
+
+// Later, stop it abruptly
+Sound.Stop(loopToken);
+
+// Or fade it out gracefully over 2 seconds, then stop
+Sound.Fade(loopToken, 0f, 2f).AndStop().SendToAll();
+
+// Or fade to half volume without stopping
+Sound.Fade(loopToken, 0.5f, 1f).SendToAll();
+```
+
+### Crossfading between tracks (e.g. a DJ mixing songs)
+
+```csharp
+// Fade out the current track while fading in the next one over 3 seconds.
+Sound.Fade(trackToken, 0f, 3f).AndStop().SendToAll();
+trackToken = await Sound.At(nextTrack, jukeboxObject)
+    .WithMixer(MixerType.JukeBox)
+    .WithFadeIn(3f)
+    .PlayNetworkedAsync();
+```
+
+This composes `Fade` and `WithFadeIn`, two independent operations that can each use any terminal (networked, targeted, or local).
+
+### Pausing and resuming a local loop (e.g. toggling a light or vendor)
+
+```csharp
+// Pause the loop without pooling it — can be resumed later
+Sound.PauseLocal(loopKey);
+
+// Or stop it entirely and return to pool
+Sound.StopLocal(loopKey);
+```
+
+### Position differs from source object
+
+```csharp
+// Sound plays at the interaction target but is attached to the performer
+Sound.At(sound, interaction.WorldPositionTarget)
+    .WithSource(interaction.Performer)
+    .PlayNetworked();
+```
+
+### Random sound from a list
+
+```csharp
+[SerializeField] private List<AddressableAudioSource> impactSounds;
+
+Sound.At(impactSounds, gameObject).PlayNetworked();
+```
+
+## Sound Assets
+
+Sound assets are `AddressableAudioSource` references. Common sounds are available via `CommonSounds.Instance`:
+
+```csharp
+Sound.At(CommonSounds.Instance.Click01, gameObject).PlayNetworked();
+```
+
+For custom sounds, add a serialized field to your component:
+
+```csharp
+[SerializeField] private AddressableAudioSource myCustomSound;
+```
+
+Then assign the sound asset in the Unity Inspector.
+
+## Defaults
+
+- `Sound.At()` defaults to **3D spatial** sound, it attenuates with distance automatically.
+- `Sound.Global()` defaults to **no spatialization**, heard at full volume everywhere.
+- Volume and pitch default to the audio prefab's settings unless overridden.
+- Sounds are **not polyphonic** by default, playing the same sound again stops the previous instance.


### PR DESCRIPTION
### Purpose
This PR adds a new class that works as a facade for SoundManager.PlaySound*. The idea is having a more ergonomic API and less prone to mistakes (like all of those sounds that play globally when they shouldn't).

Why a facade and not rework the SoundManager directly? The blast radius would be way too big. With the facade we can gradually move stuff to make them more readable, less verbose and less error prone without modifying all of the ~500 consumers of SoundManager.

3 files were migrated, just to demonstrate in-situ how it works and how much it simplifies the code.

I have also included documentation so new contributors know how to play sounds and also, hopefully, don't use the SoundManager directly.

### Changelog:
No changes facing the player.

