### PR TITLE
refactor: clean up the itents logic in ChangeTileWhenItemUsed

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/CatwalkToLattice.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/CatwalkToLattice.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: CatwalkToLattice
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: a78723f619e4a41f3ae170507ca20644, type: 2}
-  harmIntentRequired: 0
+  requiredIntent: 0
   performerStartActionMessage: 
   othersStartActionMessage: 
   seconds: 1

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/DigWithShovelAsteroid.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/DigWithShovelAsteroid.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: DigWithShovelAsteroid
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: b336a4abd9d45924cb48b49a49fdea2b, type: 2}
-  harmIntentRequired: 0
+  requiredIntent: 0
   performerStartActionMessage: You start digging...
   othersStartActionMessage: '{performer} starts digging..'
   seconds: 4

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/DigWithShovelIronSand.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/DigWithShovelIronSand.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: DigWithShovelIronSand
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: b336a4abd9d45924cb48b49a49fdea2b, type: 2}
-  harmIntentRequired: 0
+  requiredIntent: 0
   performerStartActionMessage: You start digging...
   othersStartActionMessage: '{performer} starts digging..'
   seconds: 4

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/DigWithShovelVolcanic.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/DigWithShovelVolcanic.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: DigWithShovelVolcanic
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: b336a4abd9d45924cb48b49a49fdea2b, type: 2}
-  harmIntentRequired: 0
+  requiredIntent: 0
   performerStartActionMessage: You start digging...
   othersStartActionMessage: '{performer} starts digging..'
   seconds: 4

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/ReinforcedWall/RWallAnchorBoltsConstruct.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/ReinforcedWall/RWallAnchorBoltsConstruct.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: RWallAnchorBoltsConstruct
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 5524008e9372c468aacfb95c83179a91, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You start to pry the cover back into place...
   othersStartActionMessage: '{performer} starts to pry the cover back into place...'
   seconds: 2

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/ReinforcedWall/RWallAnchorBoltsDeconstruct.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/ReinforcedWall/RWallAnchorBoltsDeconstruct.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: RWallAnchorBoltsDeconstruct
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 024541a41c4ab42a499f8e49374496d4, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You start loosening the anchoring bolts which secure
     the support rods to their frame...
   othersStartActionMessage: '{performer} starts loosening the anchoring bolts which

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/ReinforcedWall/RWallCoverConstruct.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/ReinforcedWall/RWallCoverConstruct.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: RWallCoverConstruct
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 98ad76bb152404a11aed28bf6fa703d6, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You begin securing the support lines...
   othersStartActionMessage: '{performer} begins securing the support lines...'
   seconds: 4

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/ReinforcedWall/RWallCoverDeconstruct.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/ReinforcedWall/RWallCoverDeconstruct.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: RWallCoverDeconstruct
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: aaed69546e98a47d8b488a046d00ebe7, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You begin slicing through the metal cover...
   othersStartActionMessage: '{performer} begins slicing through the metal cover...'
   seconds: 6

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/ReinforcedWall/RWallCutCoverConstruct.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/ReinforcedWall/RWallCutCoverConstruct.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: RWallCutCoverConstruct
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: aaed69546e98a47d8b488a046d00ebe7, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You begin welding the metal cover back to the frame...
   othersStartActionMessage: '{performer} begins welding the metal cover back to the
     frame...'

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/ReinforcedWall/RWallCutCoverDeconstruct.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/ReinforcedWall/RWallCutCoverDeconstruct.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: RWallCutCoverDeconstruct
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 5524008e9372c468aacfb95c83179a91, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You struggle to pry off the cover...
   othersStartActionMessage: '{performer} struggles to pry off the cover...'
   seconds: 10

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/ReinforcedWall/RWallIntact.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/ReinforcedWall/RWallIntact.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: RWallIntact
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: a78723f619e4a41f3ae170507ca20644, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You cut the outer grille.
   othersStartActionMessage: '{performer} cuts the outer grille.'
   seconds: 0

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/ReinforcedWall/RWallSheathConstruct.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/ReinforcedWall/RWallSheathConstruct.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: RWallSheathConstruct
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: aaed69546e98a47d8b488a046d00ebe7, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You begin welding the support rods back together...
   othersStartActionMessage: '{performer} begins welding the support rods back together...'
   seconds: 10

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/ReinforcedWall/RWallSupportLinesConstruct.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/ReinforcedWall/RWallSupportLinesConstruct.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: RWallSupportLinesConstruct
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: a78723f619e4a41f3ae170507ca20644, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You repair the outer grille.
   othersStartActionMessage: '{performer} repairs the outer grille.'
   seconds: 0

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/ReinforcedWall/RWallSupportLinesDeconstruct.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/ReinforcedWall/RWallSupportLinesDeconstruct.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: RWallSupportLinesDeconstruct
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 98ad76bb152404a11aed28bf6fa703d6, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You begin unsecuring the support lines...
   othersStartActionMessage: '{performer} begins unsecuring the support lines...'
   seconds: 4

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/ReinforcedWall/RWallSupportRodsConstruct.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/ReinforcedWall/RWallSupportRodsConstruct.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: RWallSupportRodsConstruct
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 024541a41c4ab42a499f8e49374496d4, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You start tightening the bolts which secure the support
     rods to their frame...
   othersStartActionMessage: '{performer} starts tightening the bolts which secure

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/ReinforcedWall/RWallSupportRodsDeconstruct.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/ReinforcedWall/RWallSupportRodsDeconstruct.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: RWallSupportRodsDeconstruct
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: aaed69546e98a47d8b488a046d00ebe7, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You begin slicing through the support rods...
   othersStartActionMessage: '{performer} begins slicing through the support rods...'
   seconds: 10

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/RustyReinforcedWall/RustyRWallAnchorBoltsConstruct.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/RustyReinforcedWall/RustyRWallAnchorBoltsConstruct.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: RustyRWallAnchorBoltsConstruct
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 5524008e9372c468aacfb95c83179a91, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You start to pry the cover back into place...
   othersStartActionMessage: '{performer} starts to pry the cover back into place...'
   seconds: 2

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/RustyReinforcedWall/RustyRWallAnchorBoltsDeconstruct.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/RustyReinforcedWall/RustyRWallAnchorBoltsDeconstruct.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: RustyRWallAnchorBoltsDeconstruct
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 024541a41c4ab42a499f8e49374496d4, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You start loosening the anchoring bolts which secure
     the support rods to their frame...
   othersStartActionMessage: '{performer} starts loosening the anchoring bolts which

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/RustyReinforcedWall/RustyRWallCoverConstruct.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/RustyReinforcedWall/RustyRWallCoverConstruct.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: RustyRWallCoverConstruct
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 98ad76bb152404a11aed28bf6fa703d6, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You begin securing the support lines...
   othersStartActionMessage: '{performer} begins securing the support lines...'
   seconds: 4

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/RustyReinforcedWall/RustyRWallCoverDeconstruct.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/RustyReinforcedWall/RustyRWallCoverDeconstruct.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: RustyRWallCoverDeconstruct
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: aaed69546e98a47d8b488a046d00ebe7, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You begin slicing through the metal cover...
   othersStartActionMessage: '{performer} begins slicing through the metal cover...'
   seconds: 6

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/RustyReinforcedWall/RustyRWallCutCoverConstruct.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/RustyReinforcedWall/RustyRWallCutCoverConstruct.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: RustyRWallCutCoverConstruct
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: aaed69546e98a47d8b488a046d00ebe7, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You begin welding the metal cover back to the frame...
   othersStartActionMessage: '{performer} begins welding the metal cover back to the
     frame...'

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/RustyReinforcedWall/RustyRWallCutCoverDeconstruct.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/RustyReinforcedWall/RustyRWallCutCoverDeconstruct.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: RustyRWallCutCoverDeconstruct
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 5524008e9372c468aacfb95c83179a91, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You struggle to pry off the cover...
   othersStartActionMessage: '{performer} struggles to pry off the cover...'
   seconds: 10

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/RustyReinforcedWall/RustyRWallIntact.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/RustyReinforcedWall/RustyRWallIntact.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: RustyRWallIntact
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: a78723f619e4a41f3ae170507ca20644, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You cut the outer grille.
   othersStartActionMessage: '{performer} cuts the outer grille.'
   seconds: 0

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/RustyReinforcedWall/RustyRWallSheathConstruct.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/RustyReinforcedWall/RustyRWallSheathConstruct.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: RustyRWallSheathConstruct
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: aaed69546e98a47d8b488a046d00ebe7, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You begin welding the support rods back together...
   othersStartActionMessage: '{performer} begins welding the support rods back together...'
   seconds: 10

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/RustyReinforcedWall/RustyRWallSupportLinesConstruct.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/RustyReinforcedWall/RustyRWallSupportLinesConstruct.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: RustyRWallSupportLinesConstruct
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: a78723f619e4a41f3ae170507ca20644, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You repair the outer grille.
   othersStartActionMessage: '{performer} repairs the outer grille.'
   seconds: 0

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/RustyReinforcedWall/RustyRWallSupportLinesDeconstruct.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/RustyReinforcedWall/RustyRWallSupportLinesDeconstruct.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: RustyRWallSupportLinesDeconstruct
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 98ad76bb152404a11aed28bf6fa703d6, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You begin unsecuring the support lines...
   othersStartActionMessage: '{performer} begins unsecuring the support lines...'
   seconds: 4

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/RustyReinforcedWall/RustyRWallSupportRodsConstruct.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/RustyReinforcedWall/RustyRWallSupportRodsConstruct.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: RustyRWallSupportRodsConstruct
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 024541a41c4ab42a499f8e49374496d4, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You start tightening the bolts which secure the support
     rods to their frame...
   othersStartActionMessage: '{performer} starts tightening the bolts which secure

--- a/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/RustyReinforcedWall/RustyRWallSupportRodsDeconstruct.asset
+++ b/UnityProject/Assets/ScriptableObjects/Interaction/TileInteraction/RustyReinforcedWall/RustyRWallSupportRodsDeconstruct.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: RustyRWallSupportRodsDeconstruct
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: aaed69546e98a47d8b488a046d00ebe7, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You begin slicing through the support rods...
   othersStartActionMessage: '{performer} begins slicing through the support rods...'
   seconds: 10

--- a/UnityProject/Assets/Scripts/US13/Core/Input System/InteractionV2/TileInteraction/ChangeTileWhenItemUsed.cs
+++ b/UnityProject/Assets/Scripts/US13/Core/Input System/InteractionV2/TileInteraction/ChangeTileWhenItemUsed.cs
@@ -22,16 +22,9 @@ namespace US13.Core.Input_System.InteractionV2.TileInteraction
 		[SerializeField]
 		private ItemTrait requiredTrait = null;
 
-		//First implemented for allowing players to both repair and unsecure reinforced windows using welders depending on intent.
-		[Tooltip("Do you need to be on harm intent to perform this interaction?")]
+		[Tooltip("What intent is required to perform this interaction? None means any intent works.")]
 		[SerializeField]
-		private bool harmIntentRequired = false;
-
-		//First implemented for allowing players to both repair and unsecure reinforced windows using welders depending on intent.
-		[Tooltip("Do you need to be on harm intent to perform this interaction?")]
-		[SerializeField]
-		private Intent RequiredIntent = Intent.None;
-
+		private Intent requiredIntent = Intent.Disarm;
 
 		[Tooltip("Action message to performer when they begin this interaction.")]
 		[SerializeField]
@@ -65,15 +58,7 @@ namespace US13.Core.Input_System.InteractionV2.TileInteraction
 		{
 			if (!DefaultWillInteract.Default(interaction, side)) return false;
 
-			if (harmIntentRequired == true && RequiredIntent == Intent.None)
-			{
-				if (interaction.Intent != Intent.Harm) return false;
-			}
-
-			if (RequiredIntent != Intent.None)
-			{
-				if (interaction.Intent != RequiredIntent) return false;
-			}
+			if (requiredIntent != Intent.None && interaction.Intent != requiredIntent) return false;
 
 			if (requiredTrait == CommonTraits.Instance.Welder)
 			{

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Tables/Reinforced Table/Table_reinforced_unwelding.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Tables/Reinforced Table/Table_reinforced_unwelding.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Table_reinforced_unwelding
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: aaed69546e98a47d8b488a046d00ebe7, type: 2}
-  harmIntentRequired: 0
+  requiredIntent: 0
   performerStartActionMessage: You begin unwelding the support lines...
   othersStartActionMessage: '{performer} begins  unwelding the support lines...'
   seconds: 6

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Tables/Reinforced Table/Table_reinforced_welding.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Tables/Reinforced Table/Table_reinforced_welding.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Table_reinforced_welding
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: aaed69546e98a47d8b488a046d00ebe7, type: 2}
-  harmIntentRequired: 0
+  requiredIntent: 0
   performerStartActionMessage: You begin welding the support lines...
   othersStartActionMessage: '{performer} begins  welding the support lines...'
   seconds: 3

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowPlastitanium/Resecuring_WindowPlastitanium_Step_2_To_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowPlastitanium/Resecuring_WindowPlastitanium_Step_2_To_0.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Resecuring_WindowPlastitanium_Step_2_To_0
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 98ad76bb152404a11aed28bf6fa703d6, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You start driving the screws back into place...
   othersStartActionMessage: '{performer} starts driving the screws back into place...'
   seconds: 3

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowPlastitanium/Resecuring_WindowPlastitanium_Step_4_To_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowPlastitanium/Resecuring_WindowPlastitanium_Step_4_To_0.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Resecuring_WindowPlastitanium_Step_4_To_0
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 5524008e9372c468aacfb95c83179a91, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You begin to lever the reinforced window into the
     frame...
   othersStartActionMessage: '{performer} begins to lever the reinforced window into

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowPlastitanium/Unsecuring_WindowPlastitanium_Step_0_To_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowPlastitanium/Unsecuring_WindowPlastitanium_Step_0_To_1.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Unsecuring_WindowPlastitanium_Step_0_To_1
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: aaed69546e98a47d8b488a046d00ebe7, type: 2}
-  harmIntentRequired: 1
-  RequiredIntent: 1
+  requiredIntent: 3
   performerStartActionMessage: You begin heating the security screws on the reinforced
     window...
   othersStartActionMessage: '{performer} holds the welder to the security screws

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowPlastitanium/Unsecuring_WindowPlastitanium_Step_1_To_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowPlastitanium/Unsecuring_WindowPlastitanium_Step_1_To_2.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Unsecuring_WindowPlastitanium_Step_1_To_2
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 98ad76bb152404a11aed28bf6fa703d6, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You dig into the heated screws hard and they start
     turning...
   othersStartActionMessage: '{performer} digs into the heated security screws and

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowPlastitanium/Unsecuring_WindowPlastitanium_Step_2_To_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowPlastitanium/Unsecuring_WindowPlastitanium_Step_2_To_3.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Unsecuring_WindowPlastitanium_Step_2_To_3
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 5524008e9372c468aacfb95c83179a91, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You wedge the crowbar into the gap in the frame and
     start prying...
   othersStartActionMessage: '{performer} wedges the crowbar into the gap in the frame

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowPlastitanium/Unsecuring_WindowPlastitanium_Step_3_To_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowPlastitanium/Unsecuring_WindowPlastitanium_Step_3_To_4.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Unsecuring_WindowPlastitanium_Step_3_To_4
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: a78723f619e4a41f3ae170507ca20644, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You start cutting the exposed bars on the reinforced
     window...
   othersStartActionMessage: '{performer} starts cutting the exposed bars on the reinforced

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowPod/Resecuring_WindowPod_Step_2_To_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowPod/Resecuring_WindowPod_Step_2_To_0.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Resecuring_WindowPod_Step_2_To_0
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 98ad76bb152404a11aed28bf6fa703d6, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You start driving the screws back into place...
   othersStartActionMessage: '{performer} starts driving the screws back into place...'
   seconds: 3

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowPod/Resecuring_WindowPod_Step_4_To_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowPod/Resecuring_WindowPod_Step_4_To_0.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Resecuring_WindowPod_Step_4_To_0
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 5524008e9372c468aacfb95c83179a91, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You begin to lever the reinforced window into the
     frame...
   othersStartActionMessage: '{performer} begins to lever the reinforced window into

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowPod/Unsecuring_WindowPod_Step_0_To_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowPod/Unsecuring_WindowPod_Step_0_To_1.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Unsecuring_WindowPod_Step_0_To_1
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: aaed69546e98a47d8b488a046d00ebe7, type: 2}
-  harmIntentRequired: 1
-  RequiredIntent: 1
+  requiredIntent: 3
   performerStartActionMessage: You begin heating the security screws on the reinforced
     window...
   othersStartActionMessage: '{performer} holds the welder to the security screws

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowPod/Unsecuring_WindowPod_Step_1_To_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowPod/Unsecuring_WindowPod_Step_1_To_2.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Unsecuring_WindowPod_Step_1_To_2
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 98ad76bb152404a11aed28bf6fa703d6, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You dig into the heated screws hard and they start
     turning...
   othersStartActionMessage: '{performer} digs into the heated security screws and

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowPod/Unsecuring_WindowPod_Step_2_To_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowPod/Unsecuring_WindowPod_Step_2_To_3.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Unsecuring_WindowPod_Step_2_To_3
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 5524008e9372c468aacfb95c83179a91, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You wedge the crowbar into the gap in the frame and
     start prying...
   othersStartActionMessage: '{performer} wedges the crowbar into the gap in the frame

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowPod/Unsecuring_WindowPod_Step_3_To_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowPod/Unsecuring_WindowPod_Step_3_To_4.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Unsecuring_WindowPod_Step_3_To_4
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: a78723f619e4a41f3ae170507ca20644, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You start cutting the exposed bars on the reinforced
     window...
   othersStartActionMessage: '{performer} starts cutting the exposed bars on the reinforced

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced/Resecuring_WindowReinforced_Step_2_To_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced/Resecuring_WindowReinforced_Step_2_To_0.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Resecuring_WindowReinforced_Step_2_To_0
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 98ad76bb152404a11aed28bf6fa703d6, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You start driving the screws back into place...
   othersStartActionMessage: '{performer} starts driving the screws back into place...'
   seconds: 3

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced/Resecuring_WindowReinforced_Step_4_To_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced/Resecuring_WindowReinforced_Step_4_To_0.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Resecuring_WindowReinforced_Step_4_To_0
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 5524008e9372c468aacfb95c83179a91, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You begin to lever the reinforced window into the
     frame...
   othersStartActionMessage: '{performer} begins to lever the reinforced window into

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced/Unsecuring_WindowReinforced_Step_0_To_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced/Unsecuring_WindowReinforced_Step_0_To_1.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Unsecuring_WindowReinforced_Step_0_To_1
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: aaed69546e98a47d8b488a046d00ebe7, type: 2}
-  harmIntentRequired: 1
-  RequiredIntent: 1
+  requiredIntent: 3
   performerStartActionMessage: You begin heating the security screws on the reinforced
     window...
   othersStartActionMessage: '{performer} holds the welder to the security screws

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced/Unsecuring_WindowReinforced_Step_1_To_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced/Unsecuring_WindowReinforced_Step_1_To_2.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Unsecuring_WindowReinforced_Step_1_To_2
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 98ad76bb152404a11aed28bf6fa703d6, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You dig into the heated screws hard and they start
     turning...
   othersStartActionMessage: '{performer} digs into the heated security screws and

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced/Unsecuring_WindowReinforced_Step_2_To_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced/Unsecuring_WindowReinforced_Step_2_To_3.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Unsecuring_WindowReinforced_Step_2_To_3
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 5524008e9372c468aacfb95c83179a91, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You wedge the crowbar into the gap in the frame and
     start prying...
   othersStartActionMessage: '{performer} wedges the crowbar into the gap in the frame

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced/Unsecuring_WindowReinforced_Step_3_To_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced/Unsecuring_WindowReinforced_Step_3_To_4.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Unsecuring_WindowReinforced_Step_3_To_4
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: a78723f619e4a41f3ae170507ca20644, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You start cutting the exposed bars on the reinforced
     window...
   othersStartActionMessage: '{performer} starts cutting the exposed bars on the reinforced

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforcedPlasma/Resecuring_WindowReinforcedPlasma_Step_2_To_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforcedPlasma/Resecuring_WindowReinforcedPlasma_Step_2_To_0.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Resecuring_WindowReinforcedPlasma_Step_2_To_0
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 98ad76bb152404a11aed28bf6fa703d6, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You start driving the screws back into place...
   othersStartActionMessage: '{performer} starts driving the screws back into place...'
   seconds: 3

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforcedPlasma/Resecuring_WindowReinforcedPlasma_Step_4_To_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforcedPlasma/Resecuring_WindowReinforcedPlasma_Step_4_To_0.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Resecuring_WindowReinforcedPlasma_Step_4_To_0
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 5524008e9372c468aacfb95c83179a91, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You begin to lever the reinforced window into the
     frame...
   othersStartActionMessage: '{performer} begins to lever the reinforced window into

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforcedPlasma/Unsecuring_WindowReinforcedPlasma_Step_0_To_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforcedPlasma/Unsecuring_WindowReinforcedPlasma_Step_0_To_1.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Unsecuring_WindowReinforcedPlasma_Step_0_To_1
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: aaed69546e98a47d8b488a046d00ebe7, type: 2}
-  harmIntentRequired: 1
-  RequiredIntent: 1
+  requiredIntent: 3
   performerStartActionMessage: You begin heating the security screws on the reinforced
     window...
   othersStartActionMessage: '{performer} holds the welder to the security screws

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforcedPlasma/Unsecuring_WindowReinforcedPlasma_Step_1_To_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforcedPlasma/Unsecuring_WindowReinforcedPlasma_Step_1_To_2.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Unsecuring_WindowReinforcedPlasma_Step_1_To_2
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 98ad76bb152404a11aed28bf6fa703d6, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You dig into the heated screws hard and they start
     turning...
   othersStartActionMessage: '{performer} digs into the heated security screws and

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforcedPlasma/Unsecuring_WindowReinforcedPlasma_Step_2_To_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforcedPlasma/Unsecuring_WindowReinforcedPlasma_Step_2_To_3.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Unsecuring_WindowReinforcedPlasma_Step_2_To_3
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 5524008e9372c468aacfb95c83179a91, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You wedge the crowbar into the gap in the frame and
     start prying...
   othersStartActionMessage: '{performer} wedges the crowbar into the gap in the frame

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforcedPlasma/Unsecuring_WindowReinforcedPlasma_Step_3_To_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforcedPlasma/Unsecuring_WindowReinforcedPlasma_Step_3_To_4.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Unsecuring_WindowReinforcedPlasma_Step_3_To_4
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: a78723f619e4a41f3ae170507ca20644, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You start cutting the exposed bars on the reinforced
     window...
   othersStartActionMessage: '{performer} starts cutting the exposed bars on the reinforced

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowShuttle/Resecuring_WindowShuttle_Step_2_To_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowShuttle/Resecuring_WindowShuttle_Step_2_To_0.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Resecuring_WindowShuttle_Step_2_To_0
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 98ad76bb152404a11aed28bf6fa703d6, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You start driving the screws back into place...
   othersStartActionMessage: '{performer} starts driving the screws back into place...'
   seconds: 3

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowShuttle/Resecuring_WindowShuttle_Step_4_To_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowShuttle/Resecuring_WindowShuttle_Step_4_To_0.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Resecuring_WindowShuttle_Step_4_To_0
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 5524008e9372c468aacfb95c83179a91, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You begin to lever the reinforced window into the
     frame...
   othersStartActionMessage: '{performer} begins to lever the reinforced window into

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowShuttle/Unsecuring_WindowShuttle_Step_0_To_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowShuttle/Unsecuring_WindowShuttle_Step_0_To_1.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Unsecuring_WindowShuttle_Step_0_To_1
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: aaed69546e98a47d8b488a046d00ebe7, type: 2}
-  harmIntentRequired: 1
-  RequiredIntent: 1
+  requiredIntent: 3
   performerStartActionMessage: You begin heating the security screws on the reinforced
     window...
   othersStartActionMessage: '{performer} holds the welder to the security screws

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowShuttle/Unsecuring_WindowShuttle_Step_1_To_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowShuttle/Unsecuring_WindowShuttle_Step_1_To_2.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Unsecuring_WindowShuttle_Step_1_To_2
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 98ad76bb152404a11aed28bf6fa703d6, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You dig into the heated screws hard and they start
     turning...
   othersStartActionMessage: '{performer} digs into the heated security screws and

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowShuttle/Unsecuring_WindowShuttle_Step_2_To_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowShuttle/Unsecuring_WindowShuttle_Step_2_To_3.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Unsecuring_WindowShuttle_Step_2_To_3
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 5524008e9372c468aacfb95c83179a91, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You wedge the crowbar into the gap in the frame and
     start prying...
   othersStartActionMessage: '{performer} wedges the crowbar into the gap in the frame

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowShuttle/Unsecuring_WindowShuttle_Step_3_To_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowShuttle/Unsecuring_WindowShuttle_Step_3_To_4.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Unsecuring_WindowShuttle_Step_3_To_4
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: a78723f619e4a41f3ae170507ca20644, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You start cutting the exposed bars on the reinforced
     window...
   othersStartActionMessage: '{performer} starts cutting the exposed bars on the reinforced

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowTinted/Resecuring_WindowTinted_Step_2_To_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowTinted/Resecuring_WindowTinted_Step_2_To_0.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Resecuring_WindowTinted_Step_2_To_0
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 98ad76bb152404a11aed28bf6fa703d6, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You start driving the screws back into place...
   othersStartActionMessage: '{performer} starts driving the screws back into place...'
   seconds: 3

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowTinted/Resecuring_WindowTinted_Step_4_To_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowTinted/Resecuring_WindowTinted_Step_4_To_0.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Resecuring_WindowTinted_Step_4_To_0
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 5524008e9372c468aacfb95c83179a91, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You begin to lever the reinforced window into the
     frame...
   othersStartActionMessage: '{performer} begins to lever the reinforced window into

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowTinted/Unsecuring_WindowTinted_Step_0_To_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowTinted/Unsecuring_WindowTinted_Step_0_To_1.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Unsecuring_WindowTinted_Step_0_To_1
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: aaed69546e98a47d8b488a046d00ebe7, type: 2}
-  harmIntentRequired: 1
-  RequiredIntent: 1
+  requiredIntent: 3
   performerStartActionMessage: You begin heating the security screws on the reinforced
     window...
   othersStartActionMessage: '{performer} holds the welder to the security screws

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowTinted/Unsecuring_WindowTinted_Step_1_To_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowTinted/Unsecuring_WindowTinted_Step_1_To_2.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Unsecuring_WindowTinted_Step_1_To_2
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 98ad76bb152404a11aed28bf6fa703d6, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You dig into the heated screws hard and they start
     turning...
   othersStartActionMessage: '{performer} digs into the heated security screws and

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowTinted/Unsecuring_WindowTinted_Step_2_To_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowTinted/Unsecuring_WindowTinted_Step_2_To_3.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Unsecuring_WindowTinted_Step_2_To_3
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: 5524008e9372c468aacfb95c83179a91, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You wedge the crowbar into the gap in the frame and
     start prying...
   othersStartActionMessage: '{performer} wedges the crowbar into the gap in the frame

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowTinted/Unsecuring_WindowTinted_Step_3_To_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowTinted/Unsecuring_WindowTinted_Step_3_To_4.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Unsecuring_WindowTinted_Step_3_To_4
   m_EditorClassIdentifier: 
   requiredTrait: {fileID: 11400000, guid: a78723f619e4a41f3ae170507ca20644, type: 2}
-  harmIntentRequired: 0
-  RequiredIntent: 1
+  requiredIntent: 1
   performerStartActionMessage: You start cutting the exposed bars on the reinforced
     window...
   othersStartActionMessage: '{performer} starts cutting the exposed bars on the reinforced


### PR DESCRIPTION
### Purpose
Previously the SO had both `harmIntentRequired` boolean and `requiredIntent` enum with all the intents. Bollocks and made no sense, so I just left the enum.

Updated all the usages of the SO so they set `Harm` when they used the bool with value `true` and made `Disarm` the default intent since everyone else had it set to `Disarm`. The six cases that had `harmIntentRequired` and no `requiredIntent` are left as `None` so they work with any intent, like they used to.

### Changelog:
__nothing facing the user__
