### PR TITLE
hotfix: Adds vampires to admin respawn job list

### DIFF
--- a/UnityProject/Assets/Resources/ScriptableObjectsSingletons/adminJobsList.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjectsSingletons/adminJobsList.asset
@@ -36,14 +36,15 @@ MonoBehaviour:
   - {fileID: 11400000, guid: aafe8bd761e215b4d8af3394211f6db2, type: 2}
   - {fileID: 11400000, guid: 9c03eddcbbe336d4690e089a486ad4be, type: 2}
   antags:
-  - {fileID: 11400000, guid: 8e452e9949d197548ad09c2b68d7d879, type: 2}
-  - {fileID: 11400000, guid: 4bc36e6d8aa946c4081073eabc2472eb, type: 2}
   - {fileID: 11400000, guid: c060c33698c0f81449f0735a800740ca, type: 2}
+  - {fileID: 11400000, guid: 4bc36e6d8aa946c4081073eabc2472eb, type: 2}
+  - {fileID: 11400000, guid: 054c3003e031e0a4c9146f6b0f806940, type: 2}
+  - {fileID: 11400000, guid: 4f52429999025fe4f948ae027370d6ec, type: 2}
+  - {fileID: 11400000, guid: 8e452e9949d197548ad09c2b68d7d879, type: 2}
   - {fileID: 11400000, guid: 7325a4893b19676439a5fdb39d2cc069, type: 2}
   - {fileID: 11400000, guid: 4e33e3c5bcb99b34cbab164bcfa68951, type: 2}
   - {fileID: 11400000, guid: 1d7227f39af36094bb76b5a52d690ad3, type: 2}
   - {fileID: 11400000, guid: 0f19f9b747ac2ee499c57e02517aed37, type: 2}
   - {fileID: 11400000, guid: 47b1b2dfe2f734c4a9b5785a7768807b, type: 2}
-  - {fileID: 11400000, guid: 054c3003e031e0a4c9146f6b0f806940, type: 2}
   - {fileID: 11400000, guid: 7977e2d7465279a419fe55b27ecca5df, type: 2}
   - {fileID: 11400000, guid: 613f4c1efe110a34e858e8ccbdea6b04, type: 2}


### PR DESCRIPTION
### Changelog:
CL: [Improvement] Small rearranging on the admin respawn job list to put more prevelant antags like traitors closer to the top
CL: [Fix] Fixed admins being unable to respawn players as vampires

