### PR TITLE
enforce `destroyGrenade` condition even when no `explosionPrefab` is defined

### DIFF
--- a/UnityProject/Assets/Scripts/US13/Items/Weapons/Grenade.cs
+++ b/UnityProject/Assets/Scripts/US13/Items/Weapons/Grenade.cs
@@ -269,16 +269,23 @@ namespace US13.Items.Weapons
 				var explosionMatrix = registerItem.Matrix;
 				var worldPos = objectPhysics.registerTile.WorldPosition;
 
-				if (destroyGrenade)
-				{
-					// Despawn grenade
-					_ = Despawn.ServerSingle(gameObject);
-				}
-
+				DespawnGrenade();
 				// Explosion here
 				var explosionGO = Instantiate(explosionPrefab, explosionMatrix.transform);
 				explosionGO.transform.position = worldPos;
 				explosionGO.Explode();
+			}
+			else
+			{
+				DespawnGrenade();
+			}
+		}
+
+		private void DespawnGrenade()
+		{
+			if (destroyGrenade)
+			{
+				_ = Despawn.ServerSingle(gameObject);
 			}
 		}
 


### PR DESCRIPTION
CL: [Fix] Fixed an issue with grenades, where the `destroyGrenade` condition after an explosion was never triggered due to a missing requirement.
