### PR TITLE
Horizontal Behaviors for Status effects, and re-adding negative hunger feedback

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/Statuses/Hunger/Full.asset
+++ b/UnityProject/Assets/ScriptableObjects/Statuses/Hunger/Full.asset
@@ -12,5 +12,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 57ba74246e3a41e2b0a713c2ba3d28d8, type: 3}
   m_Name: Full
   m_EditorClassIdentifier: Assets::Systems.StatusesAndEffects.Implementations.Hunger.BaseHungerStatusEffect
+  CustomBehaviors:
+  - rid: 4619252273578246202
   StatusAlert: {fileID: 11400000, guid: 9dcf0f63efe865449a8efde4713b5348, type: 2}
   MessageOnEnteringStatus: Your stomach feels bloated and full.
+  references:
+    version: 2
+    RefIds:
+    - rid: 4619252273578246202
+      type: {class: ControlLimbEfficiency, ns: US13.Systems.StatusesAndEffects.Implementations.HorizontalStatusEffectBehaviors,
+        asm: Assets}
+      data:
+        LimbEfficiency: 0.75

--- a/UnityProject/Assets/ScriptableObjects/Statuses/Hunger/Hungry.asset
+++ b/UnityProject/Assets/ScriptableObjects/Statuses/Hunger/Hungry.asset
@@ -12,5 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 57ba74246e3a41e2b0a713c2ba3d28d8, type: 3}
   m_Name: Hungry
   m_EditorClassIdentifier: Assets::Systems.StatusesAndEffects.Implementations.Hunger.BaseHungerStatusEffect
+  CustomBehaviors: []
   StatusAlert: {fileID: 11400000, guid: 3803e6aed03ceaf4190e5fdbd1e27dbb, type: 2}
   MessageOnEnteringStatus: You could go for a bite.
+  references:
+    version: 2
+    RefIds: []

--- a/UnityProject/Assets/ScriptableObjects/Statuses/Hunger/Malnoruished.asset
+++ b/UnityProject/Assets/ScriptableObjects/Statuses/Hunger/Malnoruished.asset
@@ -12,5 +12,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 57ba74246e3a41e2b0a713c2ba3d28d8, type: 3}
   m_Name: Malnoruished
   m_EditorClassIdentifier: Assets::Systems.StatusesAndEffects.Implementations.Hunger.BaseHungerStatusEffect
+  CustomBehaviors:
+  - rid: 4619252273578246204
+  - rid: 4619252273578246206
   StatusAlert: {fileID: 11400000, guid: 756fa4a7b0404794a9db193e0514e2b5, type: 2}
   MessageOnEnteringStatus: <color=yellow>You're malnoruished..</color>
+  references:
+    version: 2
+    RefIds:
+    - rid: 4619252273578246204
+      type: {class: ControlLimbEfficiency, ns: US13.Systems.StatusesAndEffects.Implementations.HorizontalStatusEffectBehaviors,
+        asm: Assets}
+      data:
+        LimbEfficiency: 0.9
+    - rid: 4619252273578246206
+      type: {class: AddToBlurryVision, ns: US13.Systems.StatusesAndEffects.Implementations.HorizontalStatusEffectBehaviors,
+        asm: Assets}
+      data:
+        BlurrinessToAdd: 10

--- a/UnityProject/Assets/ScriptableObjects/Statuses/Hunger/Starving.asset
+++ b/UnityProject/Assets/ScriptableObjects/Statuses/Hunger/Starving.asset
@@ -12,5 +12,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 57ba74246e3a41e2b0a713c2ba3d28d8, type: 3}
   m_Name: Starving
   m_EditorClassIdentifier: Assets::Systems.StatusesAndEffects.Implementations.Hunger.BaseHungerStatusEffect
+  CustomBehaviors:
+  - rid: 4619252273578246201
+  - rid: 4619252273578246205
   StatusAlert: {fileID: 11400000, guid: 37880884910e549479c706e04e015105, type: 2}
   MessageOnEnteringStatus: <color=yellow>You're straving..</color>
+  references:
+    version: 2
+    RefIds:
+    - rid: 4619252273578246201
+      type: {class: ControlLimbEfficiency, ns: US13.Systems.StatusesAndEffects.Implementations.HorizontalStatusEffectBehaviors,
+        asm: Assets}
+      data:
+        LimbEfficiency: 0.4
+    - rid: 4619252273578246205
+      type: {class: AddToBlurryVision, ns: US13.Systems.StatusesAndEffects.Implementations.HorizontalStatusEffectBehaviors,
+        asm: Assets}
+      data:
+        BlurrinessToAdd: 20

--- a/UnityProject/Assets/Scripts/US13/Core/Camera/BlurryVision.cs
+++ b/UnityProject/Assets/Scripts/US13/Core/Camera/BlurryVision.cs
@@ -18,8 +18,6 @@ namespace US13.Core.Camera
 
 		public void SetBlurStrength(int InStrength)
 		{
-
-
 			if (InStrength <= 0)
 			{
 				_BlurryStrength = 1;

--- a/UnityProject/Assets/Scripts/US13/HealthV2/Living/Mutations/Eyes/BlurryVisionMutation.cs
+++ b/UnityProject/Assets/Scripts/US13/HealthV2/Living/Mutations/Eyes/BlurryVisionMutation.cs
@@ -8,7 +8,6 @@ namespace US13.HealthV2.Living.Mutations.Eyes
 	[CreateAssetMenu(fileName = "BlurryVisionMutation", menuName = "ScriptableObjects/Mutations/BlurryVisionMutation")]
 	public class BlurryVisionMutation  : MutationSO
 	{
-
 		public int BlurrinessStrength = 30;
 		public override Mutation GetMutation(BodyPart BodyPart,MutationSO _RelatedMutationSO)
 		{

--- a/UnityProject/Assets/Scripts/US13/HealthV2/Living/PolymorphicSystems/Hunger/HungerSystem.cs
+++ b/UnityProject/Assets/Scripts/US13/HealthV2/Living/PolymorphicSystems/Hunger/HungerSystem.cs
@@ -7,7 +7,6 @@ using US13.Core.Attributes;
 using US13.HealthV2.Living.BodyParts;
 using US13.HealthV2.Living.Metabolism;
 using US13.HealthV2.Living.PolymorphicSystems.Bodypart;
-using US13.HealthV2.Living.PolymorphicSystems.Hunger.HungerCalculationMethods;
 using US13.Systems.StatusesAndEffects;
 using US13.UI.Core.Alerts;
 

--- a/UnityProject/Assets/Scripts/US13/Items/Implants/Organs/Eye.cs
+++ b/UnityProject/Assets/Scripts/US13/Items/Implants/Organs/Eye.cs
@@ -142,6 +142,8 @@ namespace US13.Items.Implants.Organs
 		public int BadEyesight = 0;
 		private int DefaultBadEyesight = 0;
 
+		public MultiInterestFloat BadEyesightRecord = new MultiInterestFloat(0, InSetFloatBehaviour: MultiInterestFloat.FloatBehaviour.PickTop);
+
 		[SyncVar(hook = nameof(SyncColourBlindMode))]
 		public ColourBlindMode CurrentColourblindness = ColourBlindMode.None;
 		public ColourBlindMode DefaultColourblindness = ColourBlindMode.None;
@@ -149,7 +151,6 @@ namespace US13.Items.Implants.Organs
 		[SyncVar(hook = nameof(SyncXrayState))]
 		public bool HasXray = false;
 		public bool DefaultHasXray = false;
-
 
 
 		public void SyncOnPlayer(uint PreviouslyOn, uint CurrentlyOn)
@@ -220,9 +221,6 @@ namespace US13.Items.Implants.Organs
 			Camera.main.GetComponent<CameraEffectControlScript>().colourblindEmulationEffect
 				.SetColourMode(newState);
 		}
-
-
-
 
 		public void SyncXrayState(bool old, bool newState)
 		{

--- a/UnityProject/Assets/Scripts/US13/Systems/Chemistry/ReagentMix.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/Chemistry/ReagentMix.cs
@@ -739,7 +739,22 @@ namespace Chemistry
 			var amount = 0f;
 			if (reagent)
 			{
-				amount = reagents.m_dict[reagent];
+				try
+				{
+					amount = reagents.m_dict[reagent];
+				}
+				catch (Exception e)
+				{
+					if (e is KeyNotFoundException)
+					{
+						return 0;
+					}
+					else
+					{
+						Loggy.Error($"An error occured while trying to get {reagent.Name} from {MixName}.\n {e}");
+						return 0;
+					}
+				}
 			}
 			else
 			{

--- a/UnityProject/Assets/Scripts/US13/Systems/Faith/FaithProperties/PurgeCorruption.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/Faith/FaithProperties/PurgeCorruption.cs
@@ -45,7 +45,7 @@ namespace US13.Systems.Faith.FaithProperties
 		{
 			foreach (var antag in AntagManager.Instance.ActiveAntags)
 			{
-				if (antag.CurTeam.Data != vampireTeam) continue;
+				if (antag.CurTeam?.Data != vampireTeam) continue;
 				if (antag.Owner?.Body?.playerHealth?.IsDead == true)
 				{
 					FaithManager.AwardPoints(deadVampireRewardPoints, AssociatedFaith.Faith.FaithName);

--- a/UnityProject/Assets/Scripts/US13/Systems/StatusesAndEffects/Implementations/HorizontalStatusEffectBehaviors.meta
+++ b/UnityProject/Assets/Scripts/US13/Systems/StatusesAndEffects/Implementations/HorizontalStatusEffectBehaviors.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 73239228edc346519a96234235c92de0
+timeCreated: 1776881646

--- a/UnityProject/Assets/Scripts/US13/Systems/StatusesAndEffects/Implementations/HorizontalStatusEffectBehaviors/AddToBlurryVision.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/StatusesAndEffects/Implementations/HorizontalStatusEffectBehaviors/AddToBlurryVision.cs
@@ -1,0 +1,47 @@
+﻿using Logs;
+using UnityEngine;
+using US13.Items.Implants.Organs;
+using US13.Player;
+using US13.Systems.StatusesAndEffects.Interfaces;
+using Util;
+
+namespace US13.Systems.StatusesAndEffects.Implementations.HorizontalStatusEffectBehaviors
+{
+	public class AddToBlurryVision : ICustomStatusEffectBehavior
+	{
+		public int BlurrinessToAdd = 1;
+
+		public void ExtendedOnAdded(GameObject target)
+		{
+			if (target.TryGetCachedComponent<PlayerScript>(out var player) == false) return;
+			var eyes = player.playerHealth.GetBodyFunctionsOfType<Eye>();
+			foreach (var eye in eyes)
+			{
+				Loggy.Info($"Adding {eye.BadEyesight + BlurrinessToAdd} to {eye.name}");
+				eye.BadEyesight = BlurrinessToAdd;
+			}
+		}
+
+		public void ExtendedOnRemoved(GameObject target)
+		{
+			if (target.TryGetCachedComponent<PlayerScript>(out var player) == false) return;
+			var eyes = player.playerHealth.GetBodyFunctionsOfType<Eye>();
+			foreach (var eye in eyes)
+			{
+				eye.BadEyesight = 0;
+			}
+		}
+
+		// nothing to do for now.
+		public void ExtendedDoEffect(GameObject target)
+		{
+			return;
+		}
+
+		// nothing to do for now.
+		public void ExtendedDoEffectTick(GameObject target)
+		{
+			return;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/US13/Systems/StatusesAndEffects/Implementations/HorizontalStatusEffectBehaviors/AddToBlurryVision.cs.meta
+++ b/UnityProject/Assets/Scripts/US13/Systems/StatusesAndEffects/Implementations/HorizontalStatusEffectBehaviors/AddToBlurryVision.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cf461706b2ec4a7f9e8772e243fb9ec7
+timeCreated: 1776884361

--- a/UnityProject/Assets/Scripts/US13/Systems/StatusesAndEffects/Implementations/HorizontalStatusEffectBehaviors/ControlLimbEfficiency.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/StatusesAndEffects/Implementations/HorizontalStatusEffectBehaviors/ControlLimbEfficiency.cs
@@ -1,0 +1,48 @@
+﻿using Logs;
+using UnityEngine;
+using US13.Items.Implants;
+using US13.Player;
+using US13.Systems.StatusesAndEffects.Interfaces;
+
+namespace US13.Systems.StatusesAndEffects.Implementations.HorizontalStatusEffectBehaviors
+{
+	public class ControlLimbEfficiency : ICustomStatusEffectBehavior
+	{
+		public float LimbEfficiency = 1f;
+
+		public void ExtendedOnAdded(GameObject target)
+		{
+			PlayerScript playerBase = target.GetComponent<PlayerScript>();
+			if (playerBase == null)
+			{
+				Loggy.Warning($"Oi govna, can't make an inanimate object ({target}) belt it.");
+				return;
+			}
+			foreach (var limb in playerBase.playerHealth.GetBodyFunctionsOfType<Limb>())
+			{
+				limb.SetNewEfficiency(LimbEfficiency, this);
+			}
+		}
+
+		public void ExtendedOnRemoved(GameObject target)
+		{
+			if (target.TryGetComponent<PlayerScript>(out var playerBase) == false) return;
+			foreach (var limb in playerBase.playerHealth.GetBodyFunctionsOfType<Limb>())
+			{
+				limb.RemoveEfficiency(this);
+			}
+		}
+
+		/// nothing needed to be done here
+		public void ExtendedDoEffect(GameObject target)
+		{
+			return;
+		}
+
+		/// nothing needed to be done here
+		public void ExtendedDoEffectTick(GameObject target)
+		{
+			return;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/US13/Systems/StatusesAndEffects/Implementations/HorizontalStatusEffectBehaviors/ControlLimbEfficiency.cs.meta
+++ b/UnityProject/Assets/Scripts/US13/Systems/StatusesAndEffects/Implementations/HorizontalStatusEffectBehaviors/ControlLimbEfficiency.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a1c49b40b6a64ae1b85b51d825f001c4
+timeCreated: 1776881682

--- a/UnityProject/Assets/Scripts/US13/Systems/StatusesAndEffects/Implementations/SpeedBuff.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/StatusesAndEffects/Implementations/SpeedBuff.cs
@@ -19,16 +19,14 @@ namespace US13.Systems.StatusesAndEffects.Implementations
 		public float Buff = 1.25f;
 		public AlertSO SpeedBuffAlert;
 
-		private PlayerScript PlayerBase { get; set; }
-
 		public override void OnAdded(GameObject target)
 		{
 			DeathTime = DateTime.Now.AddSeconds(Duration);
-			PlayerBase = target.GetComponent<PlayerScript>();
+			PlayerScript PlayerBase = target.GetComponent<PlayerScript>();
 			UpdateManager.Add(CheckExpiration, 1f);
 			if (PlayerBase == null)
 			{
-				Loggy.Warning($"[SpeedBuff] - Oi govna, can't make an inanimate object ({target}) belt it.");
+				Loggy.Warning($"Oi govna, can't make an inanimate object ({target}) belt it.");
 				return;
 			}
 			foreach (var limb in PlayerBase.playerHealth.GetBodyFunctionsOfType<Limb>())
@@ -42,9 +40,9 @@ namespace US13.Systems.StatusesAndEffects.Implementations
 		{
 			base.OnRemoved(target);
 			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, CheckExpiration);
-			PlayerBase?.BodyAlerts.UnRegisterAlert(SpeedBuffAlert);
-			if (PlayerBase == null) return;
-			foreach (var limb in PlayerBase.playerHealth.GetBodyFunctionsOfType<Limb>())
+			if (target.TryGetComponent<PlayerScript>(out var playerBase) == false) return;
+			playerBase.BodyAlerts.UnRegisterAlert(SpeedBuffAlert);
+			foreach (var limb in playerBase.playerHealth.GetBodyFunctionsOfType<Limb>())
 			{
 				limb.RemoveEfficiency(this);
 			}

--- a/UnityProject/Assets/Scripts/US13/Systems/StatusesAndEffects/Interfaces/ICustomStatusEffectBehavior.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/StatusesAndEffects/Interfaces/ICustomStatusEffectBehavior.cs
@@ -1,0 +1,28 @@
+﻿using UnityEngine;
+
+namespace US13.Systems.StatusesAndEffects.Interfaces
+{
+	public interface ICustomStatusEffectBehavior
+	{
+		/// <summary>
+		/// What should happen when this status is added to a manager.
+		/// </summary>
+		public void ExtendedOnAdded(GameObject target);
+
+		/// <summary>
+		/// What should ahppen when this status is removed from the manager
+		/// </summary>
+		public void ExtendedOnRemoved(GameObject target);
+
+		/// <summary>
+		/// What should happen when this status does its effect.
+		/// </summary>
+		public void ExtendedDoEffect(GameObject target);
+
+		/// <summary>
+		/// What should happen every update tick when this status does its effect?
+		/// </summary>
+		/// <param name="target"></param>
+		public void ExtendedDoEffectTick(GameObject target);
+	}
+}

--- a/UnityProject/Assets/Scripts/US13/Systems/StatusesAndEffects/Interfaces/ICustomStatusEffectBehavior.cs.meta
+++ b/UnityProject/Assets/Scripts/US13/Systems/StatusesAndEffects/Interfaces/ICustomStatusEffectBehavior.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6b6018d4fa0d46d7915881452a3c1f5e
+timeCreated: 1776880955

--- a/UnityProject/Assets/Scripts/US13/Systems/StatusesAndEffects/StatusEffect.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/StatusesAndEffects/StatusEffect.cs
@@ -1,9 +1,15 @@
+using System.Collections.Generic;
 using UnityEngine;
+using US13.Core.Attributes;
+using US13.Systems.StatusesAndEffects.Interfaces;
 
 namespace US13.Systems.StatusesAndEffects
 {
 	public abstract class StatusEffect : ScriptableObject
 	{
+		[SerializeReference, SelectImplementation(typeof(ICustomStatusEffectBehavior))]
+		public List<ICustomStatusEffectBehavior> CustomBehaviors = new();
+
 		public void Initialize(GameObject go)
 		{
 			OnAdded(go);
@@ -12,23 +18,38 @@ namespace US13.Systems.StatusesAndEffects
 		/// <summary>
 		/// What should happen when this status is added to a manager.
 		/// </summary>
-		public virtual void OnAdded(GameObject target) {}
+		public virtual void OnAdded(GameObject target)
+		{
+			foreach (var behavior in CustomBehaviors)
+			{
+				behavior.ExtendedOnAdded(target);
+			}
+		}
 
 		/// <summary>
 		/// What should ahppen when this status is removed from the manager
 		/// </summary>
-		public virtual void OnRemoved(GameObject target) {}
+		public virtual void OnRemoved(GameObject target)
+		{
+			foreach (var behavior in CustomBehaviors) behavior.ExtendedOnRemoved(target);
+		}
 
 		/// <summary>
 		/// What should happen when this status does its effect.
 		/// </summary>
-		public virtual void DoEffect(GameObject target) {}
+		public virtual void DoEffect(GameObject target)
+		{
+			foreach (var behavior in CustomBehaviors) behavior.ExtendedDoEffect(target);
+		}
 
 		/// <summary>
 		/// What should happen every update tick when this status does its effect?
 		/// </summary>
 		/// <param name="target"></param>
-		public virtual void DoEffectTick(GameObject target) {}
+		public virtual void DoEffectTick(GameObject target)
+		{
+			foreach (var behavior in CustomBehaviors) behavior.ExtendedDoEffectTick(target);
+		}
 
 		public override bool Equals(object other)
 		{


### PR DESCRIPTION
CL: [Improvement] Re-added hunger/starvation feedback through the hunger status effects, and made them more reliable than before.
CL: [Fix] Fixed an instance where the game would throw a bunch of NREs when attempting to access a reagent that was not available in a `ReagentMix`.
CL: [Fix] Fixed an NRE on the `PurgeCorruption` faith property that would occur when attempting to look up team data that did not exist.
CL: [Fix] Fixed an issue with the Speed Buff status effect, where it would attempt to apply/remove the effect on the wrong player reference due to scriptable object shenanigans.