### PR TITLE
Hunger fixes

### DIFF
--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Felinid/Felinid.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Felinid/Felinid.asset
@@ -85,25 +85,12 @@ MonoBehaviour:
   references:
     version: 2
     RefIds:
-    - rid: 4619251886771667012
-      type: {class: NutrimentInBlood, ns: US13.HealthV2.Living.PolymorphicSystems.Hunger.HungerCalculationMethods,
+    - rid: 4552862688837107714
+      type: {class: DefaultUnityStationHungerCalculation, ns: US13.HealthV2.Living.PolymorphicSystems.Hunger.HungerCalculationMethods,
         asm: Assets}
       data:
-        NutrimentThresholdForStarving: 10
-        NutrimentThresholdForMalnourished: 15
-        NutrimentThresholdForHunger: 20
-        NutrimentThresholdForNormal: 40
-        NutrimentConsumedPerTick: 0.01
-        healingPerTick: 0.0085
-        StartingNutritionAmountInBlood: 30
-        StartingNutrimentInStomachs:
-          temperature: 294.15
-          reagents:
-            m_keys:
-            - {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237, type: 2}
-            m_values:
-            - 5
-          reagentKeys: []
+        MinutesThresholdForHunger: 5
+        MinutesThresholdForNormal: 10
     - rid: 5920833068371804161
       type: {class: ReagentPoolSystem, ns: US13.HealthV2.Living.PolymorphicSystems,
         asm: Assets}
@@ -143,13 +130,13 @@ MonoBehaviour:
       data:
         Base: {fileID: 0}
         BodyParts: []
+        BodyFats: []
         NumberOfMinutesBeforeStarving: 30
         BodyNutriment: {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237,
           type: 2}
         CashedHungerState: 1
         HungerStatusEffects:
-          NotHungryStatusEffect: {fileID: 11400000, guid: a2cf78c09e3073c44bfbe12e9789cd05,
-            type: 2}
+          NotHungryStatusEffect: {fileID: 0}
           StravingStatusEffect: {fileID: 11400000, guid: 8526c1e024fdd1e4d8bc35595159d8a4,
             type: 2}
           HungryStatusEffect: {fileID: 11400000, guid: a7b8118c2b73a574cbb4425327020959,
@@ -159,7 +146,7 @@ MonoBehaviour:
           FatStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
             type: 2}
         HungerCalculationMethod:
-          rid: 4619251886771667012
+          rid: 4552862688837107714
     - rid: 5920833068371804166
       type: {class: NaturalChemicalReleaseSystem, ns: US13.HealthV2.Living.PolymorphicSystems,
         asm: Assets}

--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Hellspawn/Tiefling.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Hellspawn/Tiefling.asset
@@ -83,25 +83,12 @@ MonoBehaviour:
   references:
     version: 2
     RefIds:
-    - rid: 4619251886771667001
-      type: {class: NutrimentInBlood, ns: US13.HealthV2.Living.PolymorphicSystems.Hunger.HungerCalculationMethods,
+    - rid: 4552862688837107715
+      type: {class: DefaultUnityStationHungerCalculation, ns: US13.HealthV2.Living.PolymorphicSystems.Hunger.HungerCalculationMethods,
         asm: Assets}
       data:
-        NutrimentThresholdForStarving: 10
-        NutrimentThresholdForMalnourished: 15
-        NutrimentThresholdForHunger: 20
-        NutrimentThresholdForNormal: 40
-        NutrimentConsumedPerTick: 0.01
-        healingPerTick: 0.0085
-        StartingNutritionAmountInBlood: 30
-        StartingNutrimentInStomachs:
-          temperature: 294.15
-          reagents:
-            m_keys:
-            - {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237, type: 2}
-            m_values:
-            - 5
-          reagentKeys: []
+        MinutesThresholdForHunger: 5
+        MinutesThresholdForNormal: 10
     - rid: 5920833068371804161
       type: {class: ReagentPoolSystem, ns: US13.HealthV2.Living.PolymorphicSystems,
         asm: Assets}
@@ -1877,13 +1864,13 @@ MonoBehaviour:
       data:
         Base: {fileID: 0}
         BodyParts: []
+        BodyFats: []
         NumberOfMinutesBeforeStarving: 31
         BodyNutriment: {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237,
           type: 2}
         CashedHungerState: 1
         HungerStatusEffects:
-          NotHungryStatusEffect: {fileID: 11400000, guid: a2cf78c09e3073c44bfbe12e9789cd05,
-            type: 2}
+          NotHungryStatusEffect: {fileID: 0}
           StravingStatusEffect: {fileID: 11400000, guid: 8526c1e024fdd1e4d8bc35595159d8a4,
             type: 2}
           HungryStatusEffect: {fileID: 11400000, guid: a7b8118c2b73a574cbb4425327020959,
@@ -1893,7 +1880,7 @@ MonoBehaviour:
           FatStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
             type: 2}
         HungerCalculationMethod:
-          rid: 4619251886771667001
+          rid: 4552862688837107715
     - rid: 5920833068371804166
       type: {class: NaturalChemicalReleaseSystem, ns: US13.HealthV2.Living.PolymorphicSystems,
         asm: Assets}

--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Human/Alien.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Human/Alien.asset
@@ -57,25 +57,12 @@ MonoBehaviour:
   references:
     version: 2
     RefIds:
-    - rid: 4619251886771667009
-      type: {class: NutrimentInBlood, ns: US13.HealthV2.Living.PolymorphicSystems.Hunger.HungerCalculationMethods,
+    - rid: 4552862688837107713
+      type: {class: DefaultUnityStationHungerCalculation, ns: US13.HealthV2.Living.PolymorphicSystems.Hunger.HungerCalculationMethods,
         asm: Assets}
       data:
-        NutrimentThresholdForStarving: 10
-        NutrimentThresholdForMalnourished: 15
-        NutrimentThresholdForHunger: 20
-        NutrimentThresholdForNormal: 40
-        NutrimentConsumedPerTick: 0.01
-        healingPerTick: 0.0085
-        StartingNutritionAmountInBlood: 30
-        StartingNutrimentInStomachs:
-          temperature: 294.15
-          reagents:
-            m_keys:
-            - {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237, type: 2}
-            m_values:
-            - 5
-          reagentKeys: []
+        MinutesThresholdForHunger: 5
+        MinutesThresholdForNormal: 10
     - rid: 5920833068371804161
       type: {class: ReagentPoolSystem, ns: US13.HealthV2.Living.PolymorphicSystems,
         asm: Assets}
@@ -115,13 +102,13 @@ MonoBehaviour:
       data:
         Base: {fileID: 0}
         BodyParts: []
+        BodyFats: []
         NumberOfMinutesBeforeStarving: 30
         BodyNutriment: {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237,
           type: 2}
         CashedHungerState: 1
         HungerStatusEffects:
-          NotHungryStatusEffect: {fileID: 11400000, guid: a2cf78c09e3073c44bfbe12e9789cd05,
-            type: 2}
+          NotHungryStatusEffect: {fileID: 0}
           StravingStatusEffect: {fileID: 11400000, guid: 8526c1e024fdd1e4d8bc35595159d8a4,
             type: 2}
           HungryStatusEffect: {fileID: 11400000, guid: a7b8118c2b73a574cbb4425327020959,
@@ -131,7 +118,7 @@ MonoBehaviour:
           FatStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
             type: 2}
         HungerCalculationMethod:
-          rid: 4619251886771667009
+          rid: 4552862688837107713
     - rid: 5920833068371804166
       type: {class: NaturalChemicalReleaseSystem, ns: US13.HealthV2.Living.PolymorphicSystems,
         asm: Assets}

--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Human/The Welder.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Human/The Welder.asset
@@ -84,25 +84,12 @@ MonoBehaviour:
   references:
     version: 2
     RefIds:
-    - rid: 4619251886771667011
-      type: {class: NutrimentInBlood, ns: US13.HealthV2.Living.PolymorphicSystems.Hunger.HungerCalculationMethods,
+    - rid: 4552862688837107712
+      type: {class: DefaultUnityStationHungerCalculation, ns: US13.HealthV2.Living.PolymorphicSystems.Hunger.HungerCalculationMethods,
         asm: Assets}
       data:
-        NutrimentThresholdForStarving: 10
-        NutrimentThresholdForMalnourished: 15
-        NutrimentThresholdForHunger: 20
-        NutrimentThresholdForNormal: 40
-        NutrimentConsumedPerTick: 0.01
-        healingPerTick: 0.0085
-        StartingNutritionAmountInBlood: 30
-        StartingNutrimentInStomachs:
-          temperature: 294.15
-          reagents:
-            m_keys:
-            - {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237, type: 2}
-            m_values:
-            - 5
-          reagentKeys: []
+        MinutesThresholdForHunger: 5
+        MinutesThresholdForNormal: 10
     - rid: 5920833068371804161
       type: {class: ReagentPoolSystem, ns: US13.HealthV2.Living.PolymorphicSystems,
         asm: Assets}
@@ -142,13 +129,13 @@ MonoBehaviour:
       data:
         Base: {fileID: 0}
         BodyParts: []
+        BodyFats: []
         NumberOfMinutesBeforeStarving: 30
         BodyNutriment: {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237,
           type: 2}
         CashedHungerState: 1
         HungerStatusEffects:
-          NotHungryStatusEffect: {fileID: 11400000, guid: a2cf78c09e3073c44bfbe12e9789cd05,
-            type: 2}
+          NotHungryStatusEffect: {fileID: 0}
           StravingStatusEffect: {fileID: 11400000, guid: 8526c1e024fdd1e4d8bc35595159d8a4,
             type: 2}
           HungryStatusEffect: {fileID: 11400000, guid: a7b8118c2b73a574cbb4425327020959,
@@ -158,7 +145,7 @@ MonoBehaviour:
           FatStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
             type: 2}
         HungerCalculationMethod:
-          rid: 4619251886771667011
+          rid: 4552862688837107712
     - rid: 5920833068371804166
       type: {class: NaturalChemicalReleaseSystem, ns: US13.HealthV2.Living.PolymorphicSystems,
         asm: Assets}

--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Lizard/Ashwalker.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Lizard/Ashwalker.asset
@@ -68,23 +68,12 @@ MonoBehaviour:
   references:
     version: 2
     RefIds:
-    - rid: 4619251886771667007
-      type: {class: NutrimentInBlood, ns: US13.HealthV2.Living.PolymorphicSystems.Hunger.HungerCalculationMethods,
+    - rid: 4552862688837107716
+      type: {class: DefaultUnityStationHungerCalculation, ns: US13.HealthV2.Living.PolymorphicSystems.Hunger.HungerCalculationMethods,
         asm: Assets}
       data:
-        NutrimentThresholdForStarving: 10
-        NutrimentThresholdForMalnourished: 15
-        NutrimentThresholdForHunger: 20
-        NutrimentThresholdForNormal: 40
-        NutrimentConsumedPerTick: 0.01
-        healingPerTick: 0.0085
-        StartingNutritionAmountInBlood: 30
-        StartingNutrimentInStomachs:
-          temperature: 273.15
-          reagents:
-            m_keys: []
-            m_values: []
-          reagentKeys: []
+        MinutesThresholdForHunger: 5
+        MinutesThresholdForNormal: 10
     - rid: 5920833068371804161
       type: {class: ReagentPoolSystem, ns: US13.HealthV2.Living.PolymorphicSystems,
         asm: Assets}
@@ -124,13 +113,13 @@ MonoBehaviour:
       data:
         Base: {fileID: 0}
         BodyParts: []
+        BodyFats: []
         NumberOfMinutesBeforeStarving: 30
         BodyNutriment: {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237,
           type: 2}
         CashedHungerState: 1
         HungerStatusEffects:
-          NotHungryStatusEffect: {fileID: 11400000, guid: a2cf78c09e3073c44bfbe12e9789cd05,
-            type: 2}
+          NotHungryStatusEffect: {fileID: 0}
           StravingStatusEffect: {fileID: 11400000, guid: 8526c1e024fdd1e4d8bc35595159d8a4,
             type: 2}
           HungryStatusEffect: {fileID: 11400000, guid: a7b8118c2b73a574cbb4425327020959,
@@ -140,7 +129,7 @@ MonoBehaviour:
           FatStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
             type: 2}
         HungerCalculationMethod:
-          rid: 4619251886771667007
+          rid: 4552862688837107716
     - rid: 5920833068371804166
       type: {class: NaturalChemicalReleaseSystem, ns: US13.HealthV2.Living.PolymorphicSystems,
         asm: Assets}

--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Lizard/Lizard.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Lizard/Lizard.asset
@@ -68,23 +68,12 @@ MonoBehaviour:
   references:
     version: 2
     RefIds:
-    - rid: 4619251886771667008
-      type: {class: NutrimentInBlood, ns: US13.HealthV2.Living.PolymorphicSystems.Hunger.HungerCalculationMethods,
+    - rid: 4552862688837107717
+      type: {class: DefaultUnityStationHungerCalculation, ns: US13.HealthV2.Living.PolymorphicSystems.Hunger.HungerCalculationMethods,
         asm: Assets}
       data:
-        NutrimentThresholdForStarving: 10
-        NutrimentThresholdForMalnourished: 15
-        NutrimentThresholdForHunger: 20
-        NutrimentThresholdForNormal: 40
-        NutrimentConsumedPerTick: 0.01
-        healingPerTick: 0.0085
-        StartingNutritionAmountInBlood: 30
-        StartingNutrimentInStomachs:
-          temperature: 273.15
-          reagents:
-            m_keys: []
-            m_values: []
-          reagentKeys: []
+        MinutesThresholdForHunger: 5
+        MinutesThresholdForNormal: 10
     - rid: 5920833068371804161
       type: {class: ReagentPoolSystem, ns: US13.HealthV2.Living.PolymorphicSystems,
         asm: Assets}
@@ -124,13 +113,13 @@ MonoBehaviour:
       data:
         Base: {fileID: 0}
         BodyParts: []
+        BodyFats: []
         NumberOfMinutesBeforeStarving: 30
         BodyNutriment: {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237,
           type: 2}
         CashedHungerState: 1
         HungerStatusEffects:
-          NotHungryStatusEffect: {fileID: 11400000, guid: a2cf78c09e3073c44bfbe12e9789cd05,
-            type: 2}
+          NotHungryStatusEffect: {fileID: 0}
           StravingStatusEffect: {fileID: 11400000, guid: 8526c1e024fdd1e4d8bc35595159d8a4,
             type: 2}
           HungryStatusEffect: {fileID: 11400000, guid: a7b8118c2b73a574cbb4425327020959,
@@ -140,7 +129,7 @@ MonoBehaviour:
           FatStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
             type: 2}
         HungerCalculationMethod:
-          rid: 4619251886771667008
+          rid: 4552862688837107717
     - rid: 5920833068371804166
       type: {class: NaturalChemicalReleaseSystem, ns: US13.HealthV2.Living.PolymorphicSystems,
         asm: Assets}

--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Monkey/Monkey.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Monkey/Monkey.asset
@@ -61,25 +61,12 @@ MonoBehaviour:
   references:
     version: 2
     RefIds:
-    - rid: 4619251886771667006
-      type: {class: NutrimentInBlood, ns: US13.HealthV2.Living.PolymorphicSystems.Hunger.HungerCalculationMethods,
+    - rid: 4552862688837107718
+      type: {class: DefaultUnityStationHungerCalculation, ns: US13.HealthV2.Living.PolymorphicSystems.Hunger.HungerCalculationMethods,
         asm: Assets}
       data:
-        NutrimentThresholdForStarving: 10
-        NutrimentThresholdForMalnourished: 15
-        NutrimentThresholdForHunger: 20
-        NutrimentThresholdForNormal: 40
-        NutrimentConsumedPerTick: 0.01
-        healingPerTick: 0.0085
-        StartingNutritionAmountInBlood: 30
-        StartingNutrimentInStomachs:
-          temperature: 294.15
-          reagents:
-            m_keys:
-            - {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237, type: 2}
-            m_values:
-            - 5
-          reagentKeys: []
+        MinutesThresholdForHunger: 5
+        MinutesThresholdForNormal: 10
     - rid: 7896866705837654025
       type: {class: ReagentPoolSystem, ns: US13.HealthV2.Living.PolymorphicSystems,
         asm: Assets}
@@ -1059,13 +1046,13 @@ MonoBehaviour:
       data:
         Base: {fileID: 0}
         BodyParts: []
+        BodyFats: []
         NumberOfMinutesBeforeStarving: 30
         BodyNutriment: {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237,
           type: 2}
         CashedHungerState: 1
         HungerStatusEffects:
-          NotHungryStatusEffect: {fileID: 11400000, guid: a2cf78c09e3073c44bfbe12e9789cd05,
-            type: 2}
+          NotHungryStatusEffect: {fileID: 0}
           StravingStatusEffect: {fileID: 11400000, guid: 8526c1e024fdd1e4d8bc35595159d8a4,
             type: 2}
           HungryStatusEffect: {fileID: 11400000, guid: a7b8118c2b73a574cbb4425327020959,
@@ -1075,7 +1062,7 @@ MonoBehaviour:
           FatStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
             type: 2}
         HungerCalculationMethod:
-          rid: 4619251886771667006
+          rid: 4552862688837107718
     - rid: 7896866705837654029
       type: {class: NaturalChemicalReleaseSystem, ns: US13.HealthV2.Living.PolymorphicSystems,
         asm: Assets}

--- a/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Moth/Moth.asset
+++ b/UnityProject/Assets/Prefabs/Player/Resources/BodyParts/Moth/Moth.asset
@@ -62,25 +62,12 @@ MonoBehaviour:
   references:
     version: 2
     RefIds:
-    - rid: 4619251886771667005
-      type: {class: NutrimentInBlood, ns: US13.HealthV2.Living.PolymorphicSystems.Hunger.HungerCalculationMethods,
+    - rid: 4552862688837107719
+      type: {class: DefaultUnityStationHungerCalculation, ns: US13.HealthV2.Living.PolymorphicSystems.Hunger.HungerCalculationMethods,
         asm: Assets}
       data:
-        NutrimentThresholdForStarving: 10
-        NutrimentThresholdForMalnourished: 15
-        NutrimentThresholdForHunger: 20
-        NutrimentThresholdForNormal: 40
-        NutrimentConsumedPerTick: 0.01
-        healingPerTick: 0.0085
-        StartingNutritionAmountInBlood: 30
-        StartingNutrimentInStomachs:
-          temperature: 294.15
-          reagents:
-            m_keys:
-            - {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237, type: 2}
-            m_values:
-            - 5
-          reagentKeys: []
+        MinutesThresholdForHunger: 5
+        MinutesThresholdForNormal: 10
     - rid: 5920833068371804161
       type: {class: ReagentPoolSystem, ns: US13.HealthV2.Living.PolymorphicSystems,
         asm: Assets}
@@ -120,13 +107,13 @@ MonoBehaviour:
       data:
         Base: {fileID: 0}
         BodyParts: []
+        BodyFats: []
         NumberOfMinutesBeforeStarving: 30
         BodyNutriment: {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237,
           type: 2}
         CashedHungerState: 1
         HungerStatusEffects:
-          NotHungryStatusEffect: {fileID: 11400000, guid: a2cf78c09e3073c44bfbe12e9789cd05,
-            type: 2}
+          NotHungryStatusEffect: {fileID: 0}
           StravingStatusEffect: {fileID: 11400000, guid: 8526c1e024fdd1e4d8bc35595159d8a4,
             type: 2}
           HungryStatusEffect: {fileID: 11400000, guid: a7b8118c2b73a574cbb4425327020959,
@@ -136,7 +123,7 @@ MonoBehaviour:
           FatStatusEffect: {fileID: 11400000, guid: 8a92c094201a758498a79523323565eb,
             type: 2}
         HungerCalculationMethod:
-          rid: 4619251886771667005
+          rid: 4552862688837107719
     - rid: 5920833068371804166
       type: {class: NaturalChemicalReleaseSystem, ns: US13.HealthV2.Living.PolymorphicSystems,
         asm: Assets}

--- a/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
+++ b/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
@@ -1173,7 +1173,7 @@ MonoBehaviour:
   UsedZones: 000000000100000003000000020000000500000004000000
   meatProduce: {fileID: 0}
   skinProduce: {fileID: 0}
-  updateTime: 1.25
+  updateTime: 1
   allExternalMetabolismReactions:
   - {fileID: 11400000, guid: 305eafe3e2fbc9e4283aee243b3edb51, type: 2}
   - {fileID: 11400000, guid: c0ceb2d6f23ad014bbab88285b3815e3, type: 2}

--- a/UnityProject/Assets/Scripts/US13/HealthV2/Living/PolymorphicSystems/Hunger/HungerCalculationMethods/DefaultUnityStationHungerCalculation.cs
+++ b/UnityProject/Assets/Scripts/US13/HealthV2/Living/PolymorphicSystems/Hunger/HungerCalculationMethods/DefaultUnityStationHungerCalculation.cs
@@ -50,6 +50,7 @@ namespace US13.HealthV2.Living.PolymorphicSystems.Hunger.HungerCalculationMethod
 		/// <param name="hungerSystem">the hunger system that's calling this initialization</param>
 		public void Initialize(LivingHealthMasterBase creatureHealth, HungerSystem hungerSystem)
 		{
+			hungerSystem.ApplyStatusAffectsEffects = false;
 			// Step 1: Total blood throughput across all hunger-participating body parts.
 			var totalBloodThroughput = 0f;
 			foreach (var bodyPart in hungerSystem.BodyParts)

--- a/UnityProject/Assets/Scripts/US13/HealthV2/Living/PolymorphicSystems/Hunger/HungerCalculationMethods/NutrimentInBlood.cs
+++ b/UnityProject/Assets/Scripts/US13/HealthV2/Living/PolymorphicSystems/Hunger/HungerCalculationMethods/NutrimentInBlood.cs
@@ -20,6 +20,7 @@ namespace US13.HealthV2.Living.PolymorphicSystems.Hunger.HungerCalculationMethod
 
 		public void Initialize(LivingHealthMasterBase creatureHealth, HungerSystem hungerSystem)
 		{
+			hungerSystem.ApplyStatusAffectsEffects = true;
 			creatureHealth.reagentPoolSystem.BloodPool.Add(hungerSystem.BodyNutriment, StartingNutritionAmountInBlood);
 			foreach (Stomach stomach in creatureHealth.GetStomachs())
 			{

--- a/UnityProject/Assets/Scripts/US13/HealthV2/Living/PolymorphicSystems/Hunger/HungerSystem.cs
+++ b/UnityProject/Assets/Scripts/US13/HealthV2/Living/PolymorphicSystems/Hunger/HungerSystem.cs
@@ -21,6 +21,9 @@ namespace US13.HealthV2.Living.PolymorphicSystems.Hunger
 	/// </summary>
 	public class HungerSystem : HealthSystemBase
 	{
+
+		[NonSerialized] public bool ApplyStatusAffectsEffects = true;
+
 		/// <summary>
 		/// Maps each required reagent (nutriment type) to the body parts that consume it
 		/// and the total amount needed per update tick.
@@ -258,13 +261,13 @@ namespace US13.HealthV2.Living.PolymorphicSystems.Hunger
 			var oldStatusEffect = GetStatusEffectFromHunger(oldState);
 			if (oldStatusEffect != null)
 			{
-				statusEffectManager?.RemoveStatus(oldStatusEffect);
+				statusEffectManager?.RemoveStatus(oldStatusEffect, ApplyStatusAffectsEffects);
 			}
 
 			var newStatusEffect = GetStatusEffectFromHunger(newState);
 			if (newStatusEffect != null)
 			{
-				statusEffectManager?.AddStatus(newStatusEffect);
+				statusEffectManager?.AddStatus(newStatusEffect, ApplyStatusAffectsEffects);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/US13/Systems/Spells/Mime/MimeWallBig.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/Spells/Mime/MimeWallBig.cs
@@ -46,7 +46,7 @@ namespace Mime
 
 		public override bool CastSpellServer(PlayerInfo caster)
 		{
-			Vector3Int[] obstructions = new Vector3Int[3];
+			Vector3Int[] obstructions = new Vector3Int[3]{ TransformState.HiddenPos, TransformState.HiddenPos,TransformState.HiddenPos};
 
 			var Matrix = MatrixManager.AtPoint(caster.Script.WorldPos, true);
 
@@ -69,7 +69,7 @@ namespace Mime
 
 					if (Matrix.MetaTileMap.HasTile(Local2, LayerType.Walls) == false)
 					{
-						obstructions[1] = Local;
+						obstructions[1] = Local2;
 						Matrix.MetaTileMap.SetTile(Local2, obstructionTile);
 					}
 
@@ -96,7 +96,7 @@ namespace Mime
 
 					if (Matrix.MetaTileMap.HasTile(Local2, LayerType.Walls) == false)
 					{
-						obstructions[1] = Local;
+						obstructions[1] = Local2;
 						Matrix.MetaTileMap.SetTile(Local2, obstructionTile);
 					}
 
@@ -119,6 +119,7 @@ namespace Mime
 
 			foreach (var Position in Positions)
 			{
+				if (Position == TransformState.HiddenPos) continue;
 				MatrixInfo.TileChangeManager.MetaTileMap.RemoveTileWithlayer(Position, obstructionTile.LayerType);
 			}
 		}

--- a/UnityProject/Assets/Scripts/US13/Systems/StatusesAndEffects/StatusEffectManager.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/StatusesAndEffects/StatusEffectManager.cs
@@ -29,7 +29,7 @@ namespace US13.Systems.StatusesAndEffects
 			}
 		}
 
-		public void AddStatus(StatusEffect status)
+		public void AddStatus(StatusEffect status, bool ApplyStatusAffectsEffects = true)
 		{
 			if (status == null) return;
 			HandleExpirableStatusAddition(status);
@@ -37,7 +37,11 @@ namespace US13.Systems.StatusesAndEffects
 			HandleImmediateStatusAddition(status);
 
 			if (HasStatus(status)) return;
-			status.Initialize(gameObject);
+			if (ApplyStatusAffectsEffects)
+			{
+				status.Initialize(gameObject);
+			}
+
 			Statuses.Add(status);
 		}
 
@@ -71,10 +75,13 @@ namespace US13.Systems.StatusesAndEffects
 			status.DoEffect(gameObject);
 		}
 
-		public void RemoveStatus(StatusEffect status)
+		public void RemoveStatus(StatusEffect status, bool RemoveStatusAffectsEffects = true)
 		{
 			if (status == false) return;
-			status.OnRemoved(gameObject);
+			if (RemoveStatusAffectsEffects)
+			{
+				status.OnRemoved(gameObject);
+			}
 			Statuses.Remove(status);
 		}
 


### PR DESCRIPTION
Sets the default to the old hunger
Fixes overlapping with status effects
fixes 1u Not equalling one minute of hunger Saturation (Was an issue on the base prefab with the update rate being changed)


### Changelog:
CL: [Fix] Fixes big mime walls not cleaning up properly