### PR TITLE
deepfryer and secbarrier stuff for box outpost, square, starshipstation

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Machines/VendingMachines/AmmoTech.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Machines/VendingMachines/AmmoTech.prefab
@@ -58,7 +58,7 @@ PrefabInstance:
     - target: {fileID: 5120633959521883907, guid: bb2d0192db81c7d469ced45d96e3629e,
         type: 3}
       propertyPath: InitialVendorContent.Array.size
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 5120633959521883907, guid: bb2d0192db81c7d469ced45d96e3629e,
         type: 3}
@@ -94,6 +94,12 @@ PrefabInstance:
         type: 3}
       propertyPath: InitialVendorContent.Array.data[5].Item
       value: 
+      objectReference: {fileID: 2172550263312996936, guid: 3b9158ca86c60e747a9b5b17f42e5388,
+        type: 3}
+    - target: {fileID: 5120633959521883907, guid: bb2d0192db81c7d469ced45d96e3629e,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[6].Item
+      value: 
       objectReference: {fileID: 5998552595617439364, guid: 69bad92cd7ffa0245a1615e65fc7ff1a,
         type: 3}
     - target: {fileID: 5120633959521883907, guid: bb2d0192db81c7d469ced45d96e3629e,
@@ -124,6 +130,11 @@ PrefabInstance:
     - target: {fileID: 5120633959521883907, guid: bb2d0192db81c7d469ced45d96e3629e,
         type: 3}
       propertyPath: InitialVendorContent.Array.data[5].Stock
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5120633959521883907, guid: bb2d0192db81c7d469ced45d96e3629e,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[6].Stock
       value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 5120633959521883907, guid: bb2d0192db81c7d469ced45d96e3629e,
@@ -154,6 +165,11 @@ PrefabInstance:
     - target: {fileID: 5120633959521883907, guid: bb2d0192db81c7d469ced45d96e3629e,
         type: 3}
       propertyPath: InitialVendorContent.Array.data[5].ItemName
+      value: deployable barrier grenade
+      objectReference: {fileID: 0}
+    - target: {fileID: 5120633959521883907, guid: bb2d0192db81c7d469ced45d96e3629e,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[6].ItemName
       value: 40mm Riot Grenade shell box
       objectReference: {fileID: 0}
     - target: {fileID: 5523991133008900239, guid: bb2d0192db81c7d469ced45d96e3629e,

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/BoxStationV1.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/BoxStationV1.json
@@ -125170,7 +125170,7 @@
             "Key": "X-194Y33",
             "Value": [
               {
-                "Tel": "whitebluecorner_1"
+                "Tel": "whiteredcorner_1"
               },
               {
                 "Tel": "Plating"
@@ -125187,7 +125187,7 @@
             "Key": "X-194Y34",
             "Value": [
               {
-                "Tel": "whiteblue_3"
+                "Tel": "whitered_3"
               },
               {
                 "Tel": "Plating"
@@ -125205,7 +125205,7 @@
             "Key": "X-194Y35",
             "Value": [
               {
-                "Tel": "whitebluecorner_3"
+                "Tel": "whiteredcorner_3"
               },
               {
                 "Tel": "Plating"
@@ -214235,7 +214235,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -214383,12 +214383,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -214440,7 +214440,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -214491,7 +214491,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -214594,7 +214594,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -214830,7 +214830,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -214866,12 +214866,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -214916,7 +214916,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -214976,7 +214976,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -215215,12 +215215,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -215304,7 +215304,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-293┼87┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-293┼87┼0┼"
           },
@@ -215355,7 +215354,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -215848,12 +215847,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -216310,7 +216309,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -216464,7 +216463,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -216529,7 +216528,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -216583,7 +216582,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -216721,7 +216720,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -216884,7 +216883,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -217086,12 +217085,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -217215,14 +217214,13 @@
           {
             "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_-284┼81┼0┼",
             "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
-            "NameMatches": true,
             "Name": "New Department Battery",
             "LocalPRS": "-284┼81┼0┼",
             "Object": {
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -217232,7 +217230,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-284┼82┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-284┼82┼0┼"
           },
@@ -217566,7 +217563,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -217602,12 +217599,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -217661,7 +217658,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -217726,12 +217723,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -217767,7 +217764,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -217877,12 +217874,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -217936,7 +217933,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -218021,7 +218018,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-282┼75┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-282┼75┼0┼"
           },
@@ -219082,28 +219078,24 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-280┼49┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-280┼49┼0┼"
           },
           {
             "GitID": "856296105f077014ca9e533266df237a_-280┼50┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-280┼50┼0┼"
           },
           {
             "GitID": "856296105f077014ca9e533266df237a_-280┼51┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-280┼51┼0┼"
           },
           {
             "GitID": "856296105f077014ca9e533266df237a_-280┼52┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-280┼52┼0┼"
           },
@@ -219174,7 +219166,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -219344,7 +219336,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-280┼76┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-280┼76┼0┼"
           },
@@ -219489,14 +219480,12 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-279┼52┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-279┼52┼0┼"
           },
           {
             "GitID": "856296105f077014ca9e533266df237a_-279┼53┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-279┼53┼0┼"
           },
@@ -219594,14 +219583,12 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-279┼74┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-279┼74┼0┼"
           },
           {
             "GitID": "cab73e460ee8bf24e88988add17a2be5_-278┼48┼0┼",
             "PrefabID": "cab73e460ee8bf24e88988add17a2be5",
-            "NameMatches": true,
             "Name": "New ConveyorSwitch",
             "LocalPRS": "-278┼48┼0┼"
           },
@@ -219699,14 +219686,12 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-278┼52┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-278┼52┼0┼"
           },
           {
             "GitID": "856296105f077014ca9e533266df237a_-278┼53┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-278┼53┼0┼"
           },
@@ -219757,7 +219742,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -219942,12 +219927,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -220066,21 +220051,18 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-277┼51┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-277┼51┼0┼"
           },
           {
             "GitID": "856296105f077014ca9e533266df237a_-277┼52┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-277┼52┼0┼"
           },
           {
             "GitID": "856296105f077014ca9e533266df237a_-277┼53┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-277┼53┼0┼"
           },
@@ -220104,12 +220086,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -220119,7 +220101,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-277┼61┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-277┼61┼0┼"
           },
@@ -220200,6 +220181,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Security"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -220280,7 +220265,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -220367,7 +220352,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -220418,7 +220403,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -220428,14 +220413,12 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-276┼52┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-276┼52┼0┼"
           },
           {
             "GitID": "856296105f077014ca9e533266df237a_-276┼53┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-276┼53┼0┼"
           },
@@ -221049,7 +221032,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -221098,7 +221081,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-275┼76┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-275┼76┼0┼"
           },
@@ -221209,7 +221191,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-274┼52┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-274┼52┼0┼"
           },
@@ -221239,12 +221220,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -221289,7 +221270,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -221870,7 +221851,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -221906,12 +221887,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -222008,7 +221989,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -222109,7 +222090,6 @@
           {
             "GitID": "3edf81f4a32c4c348bad5bfe43e263fd_-272.94┼61┼0┼",
             "PrefabID": "3edf81f4a32c4c348bad5bfe43e263fd",
-            "NameMatches": true,
             "Name": "Paper Bin1",
             "LocalPRS": "-272.94┼61┼0┼"
           },
@@ -222233,7 +222213,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-272┼70┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-272┼70┼0┼"
           },
@@ -222458,7 +222437,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-271┼56┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-271┼56┼0┼"
           },
@@ -222676,7 +222654,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -223304,7 +223282,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-270┼85┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-270┼85┼0┼"
           },
@@ -223604,7 +223581,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-269┼44┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-269┼44┼0┼",
             "Object": {
@@ -223624,7 +223600,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-269┼45┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-269┼45┼0┼",
             "Object": {
@@ -223694,7 +223669,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-269┼46┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-269┼46┼0┼",
             "Object": {
@@ -223714,7 +223688,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-269┼47┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-269┼47┼0┼",
             "Object": {
@@ -223778,7 +223751,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -223788,7 +223761,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-269┼48┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-269┼48┼0┼",
             "Object": {
@@ -223808,7 +223780,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-269┼49┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-269┼49┼0┼",
             "Object": {
@@ -223828,7 +223799,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-269┼50┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-269┼50┼0┼",
             "Object": {
@@ -223892,7 +223862,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -223977,12 +223947,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -224036,7 +224006,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -224046,21 +224016,19 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-269┼90┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-269┼90┼0┼"
           },
           {
             "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_-269┼91┼0┼",
             "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
-            "NameMatches": true,
             "Name": "New Department Battery",
             "LocalPRS": "-269┼91┼0┼",
             "Object": {
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -224163,7 +224131,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-268┼50┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-268┼50┼0┼",
             "Object": {
@@ -224560,7 +224527,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-267┼50┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-267┼50┼0┼",
             "Object": {
@@ -224657,7 +224623,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -224744,7 +224710,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -224831,7 +224797,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -224861,7 +224827,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-267┼68┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-267┼68┼0┼"
           },
@@ -225080,7 +225045,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -225141,7 +225106,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -225232,7 +225197,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -225345,7 +225310,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-266┼50┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-266┼50┼0┼",
             "Object": {
@@ -225382,12 +225346,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -225536,7 +225500,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -225875,14 +225839,12 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-265┼44┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-265┼44┼0┼"
           },
           {
             "GitID": "856296105f077014ca9e533266df237a_-265┼45┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-265┼45┼0┼"
           },
@@ -225939,14 +225901,12 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-265┼46┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-265┼46┼0┼"
           },
           {
             "GitID": "856296105f077014ca9e533266df237a_-265┼47┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-265┼47┼0┼",
             "Object": {
@@ -225966,7 +225926,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-265┼50┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-265┼50┼0┼",
             "Object": {
@@ -226233,7 +226192,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -226417,7 +226376,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-264┼47┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-264┼47┼0┼",
             "Object": {
@@ -226437,7 +226395,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-264┼50┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-264┼50┼0┼",
             "Object": {
@@ -226501,7 +226458,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -226555,7 +226512,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -226976,7 +226933,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-263┼47┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-263┼47┼0┼",
             "Object": {
@@ -226996,7 +226952,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-263┼50┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-263┼50┼0┼",
             "Object": {
@@ -227082,7 +227037,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-263┼64┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-263┼64┼0┼"
           },
@@ -227124,7 +227078,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -227177,7 +227131,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-263┼74┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-263┼74┼0┼"
           },
@@ -227435,7 +227388,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-262┼47┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-262┼47┼0┼",
             "Object": {
@@ -227455,7 +227407,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-262┼50┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-262┼50┼0┼",
             "Object": {
@@ -227535,12 +227486,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -227683,7 +227634,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -227811,12 +227762,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -227826,7 +227777,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-261┼47┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-261┼47┼0┼",
             "Object": {
@@ -227874,7 +227824,6 @@
           {
             "GitID": "cab73e460ee8bf24e88988add17a2be5_-261┼49┼0┼",
             "PrefabID": "cab73e460ee8bf24e88988add17a2be5",
-            "NameMatches": true,
             "Name": "New ConveyorSwitch",
             "LocalPRS": "-261┼49┼0┼",
             "Object": {
@@ -227954,7 +227903,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-261┼50┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-261┼50┼0┼",
             "Object": {
@@ -228009,7 +227957,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -228101,12 +228049,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -228214,7 +228162,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-260┼47┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-260┼47┼0┼",
             "Object": {
@@ -228234,7 +228181,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-260┼50┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-260┼50┼0┼",
             "Object": {
@@ -228521,7 +228467,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-259┼47┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-259┼47┼0┼",
             "Object": {
@@ -228813,7 +228758,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-258┼43┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-258┼43┼0┼",
             "Object": {
@@ -228833,7 +228777,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-258┼44┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-258┼44┼0┼",
             "Object": {
@@ -228853,7 +228796,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-258┼45┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-258┼45┼0┼",
             "Object": {
@@ -228873,7 +228815,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-258┼46┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-258┼46┼0┼",
             "Object": {
@@ -228893,7 +228834,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-258┼47┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-258┼47┼0┼",
             "Object": {
@@ -228949,7 +228889,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-258┼53┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-258┼53┼0┼"
           },
@@ -229232,12 +229171,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -229321,7 +229260,6 @@
           {
             "GitID": "Food Processor_-257┼10┼0┼",
             "PrefabID": "Food Processor",
-            "NameMatches": true,
             "Name": "New Food Processor",
             "LocalPRS": "-257┼10┼0┼",
             "Object": {
@@ -229375,7 +229313,6 @@
           {
             "GitID": "cab73e460ee8bf24e88988add17a2be5_-257┼46┼0┼",
             "PrefabID": "cab73e460ee8bf24e88988add17a2be5",
-            "NameMatches": true,
             "Name": "New ConveyorSwitch",
             "LocalPRS": "-257┼46┼0┼",
             "Object": {
@@ -229863,14 +229800,13 @@
           {
             "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_-256┼6┼0┼",
             "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
-            "NameMatches": true,
             "Name": "New Department Battery",
             "LocalPRS": "-256┼6┼0┼",
             "Object": {
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -229924,7 +229860,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -229969,7 +229905,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -230043,7 +229979,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -230180,7 +230116,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -230210,7 +230146,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-256┼74┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-256┼74┼0┼"
           },
@@ -230318,7 +230253,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-255┼6┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-255┼6┼0┼"
           },
@@ -230365,7 +230299,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -230548,7 +230482,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -230646,12 +230580,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -230712,7 +230646,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -230801,7 +230735,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -230884,7 +230818,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -231991,7 +231925,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -232001,7 +231935,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-253┼11┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-253┼11┼0┼"
           },
@@ -232078,7 +232011,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-253┼41┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-253┼41┼0┼"
           },
@@ -232281,21 +232213,18 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-253┼52┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-253┼52┼0┼"
           },
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-253┼56┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-253┼56┼0┼"
           },
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-253┼59┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-253┼59┼0┼"
           },
@@ -232505,7 +232434,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-252┼20┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-252┼20┼0┼"
           },
@@ -232612,12 +232540,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -232730,7 +232658,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-252┼60┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-252┼60┼0┼"
           },
@@ -232794,7 +232721,6 @@
           {
             "GitID": "3edf81f4a32c4c348bad5bfe43e263fd_-252┼62┼0┼",
             "PrefabID": "3edf81f4a32c4c348bad5bfe43e263fd",
-            "NameMatches": true,
             "Name": "Paper Bin1",
             "LocalPRS": "-252┼62┼0┼",
             "Object": {
@@ -232873,7 +232799,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -232979,6 +232905,13 @@
             "LocalPRS": "-251.59┼62┼0┼"
           },
           {
+            "GitID": "e96cbada8cec9cf4880b0a3b196dc465_-251.01┼55┼0┼",
+            "PrefabID": "e96cbada8cec9cf4880b0a3b196dc465",
+            "NameMatches": true,
+            "Name": "RandomCrate",
+            "LocalPRS": "-251.01┼55┼0┼"
+          },
+          {
             "GitID": "ec6860fc0ee631a4e861a29f42bcacbb_-251┼-6┼0┼",
             "PrefabID": "ec6860fc0ee631a4e861a29f42bcacbb",
             "Name": "RandomCrowbar (16)",
@@ -233037,7 +232970,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -233091,7 +233024,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -233136,7 +233069,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -233224,7 +233157,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -233381,7 +233314,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -233537,7 +233470,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -233605,23 +233538,6 @@
             "NameMatches": true,
             "Name": "RandomMedicalSuppliesSpawner",
             "LocalPRS": "-251┼54┼0┼"
-          },
-          {
-            "GitID": "1d35052f4fc2cad4d8226d1a63e4a1b3_-251┼55┼0┼",
-            "PrefabID": "1d35052f4fc2cad4d8226d1a63e4a1b3",
-            "NameMatches": true,
-            "Name": "CrateBase",
-            "LocalPRS": "-251┼55┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,2",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
           },
           {
             "GitID": "b07f56e690bc4445bcddfb624c3fa181_-251┼58┼0┼",
@@ -233697,12 +233613,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -233756,7 +233672,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -233860,12 +233776,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -234272,12 +234188,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -234360,12 +234276,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -234449,7 +234365,6 @@
           {
             "GitID": "2534979989212594f9dccf67a7400686_-250┼74┼0┼",
             "PrefabID": "2534979989212594f9dccf67a7400686",
-            "NameMatches": true,
             "Name": "New Station Self Destruct",
             "LocalPRS": "-250┼74┼0┼"
           },
@@ -234492,6 +234407,12 @@
                 }
               ]
             }
+          },
+          {
+            "GitID": "e96cbada8cec9cf4880b0a3b196dc465_-249.01┼36.99┼0┼",
+            "PrefabID": "e96cbada8cec9cf4880b0a3b196dc465",
+            "Name": "RandomCrate (1)",
+            "LocalPRS": "-249.01┼36.99┼0┼"
           },
           {
             "GitID": "642aa305b6e36804ca123bab080adccb_-249.01┼40.99┼0┼",
@@ -234553,7 +234474,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -234747,24 +234668,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
-          },
-          {
-            "GitID": "1d35052f4fc2cad4d8226d1a63e4a1b3_-249┼37┼0┼",
-            "PrefabID": "1d35052f4fc2cad4d8226d1a63e4a1b3",
-            "NameMatches": true,
-            "Name": "CrateBase",
-            "LocalPRS": "-249┼37┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -234836,12 +234740,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -234851,7 +234755,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-249┼44┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-249┼44┼0┼"
           },
@@ -235056,7 +234959,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-249┼52┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-249┼52┼0┼"
           },
@@ -235148,7 +235050,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-249┼75┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-249┼75┼0┼"
           },
@@ -235459,7 +235360,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -236015,14 +235916,13 @@
           {
             "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_-248┼52┼0┼",
             "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
-            "NameMatches": true,
             "Name": "New Department Battery",
             "LocalPRS": "-248┼52┼0┼",
             "Object": {
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -236137,7 +236037,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -236207,7 +236107,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-248┼60┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-248┼60┼0┼"
           },
@@ -236298,7 +236197,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -236394,7 +236293,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -236611,7 +236510,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -236647,7 +236546,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-247┼40┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-247┼40┼0┼"
           },
@@ -236704,7 +236602,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -236721,7 +236619,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-247┼50┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-247┼50┼0┼"
           },
@@ -236958,12 +236855,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -237121,7 +237018,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -237191,14 +237088,12 @@
           {
             "GitID": "bb684284e149a524d9f53b039e51b806_-245┼-2┼0┼",
             "PrefabID": "bb684284e149a524d9f53b039e51b806",
-            "NameMatches": true,
             "Name": "New Medium Machine Connector",
             "LocalPRS": "-245┼-2┼0┼"
           },
           {
             "GitID": "bb684284e149a524d9f53b039e51b806_-245┼0┼0┼",
             "PrefabID": "bb684284e149a524d9f53b039e51b806",
-            "NameMatches": true,
             "Name": "New Medium Machine Connector",
             "LocalPRS": "-245┼0┼0┼"
           },
@@ -237231,12 +237126,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -237365,7 +237260,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-245┼35┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-245┼35┼0┼"
           },
@@ -237513,7 +237407,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -237729,28 +237623,24 @@
           {
             "GitID": "170e72b76e0da9645995a9bac3f49cb2_-244┼-2┼0┼",
             "PrefabID": "170e72b76e0da9645995a9bac3f49cb2",
-            "NameMatches": true,
             "Name": "New SMES",
             "LocalPRS": "-244┼-2┼0┼"
           },
           {
             "GitID": "170e72b76e0da9645995a9bac3f49cb2_-244┼0┼0┼",
             "PrefabID": "170e72b76e0da9645995a9bac3f49cb2",
-            "NameMatches": true,
             "Name": "New SMES",
             "LocalPRS": "-244┼0┼0┼"
           },
           {
             "GitID": "170e72b76e0da9645995a9bac3f49cb2_-244┼2┼0┼",
             "PrefabID": "170e72b76e0da9645995a9bac3f49cb2",
-            "NameMatches": true,
             "Name": "New SMES",
             "LocalPRS": "-244┼2┼0┼"
           },
           {
             "GitID": "bb684284e149a524d9f53b039e51b806_-244┼3┼0┼",
             "PrefabID": "bb684284e149a524d9f53b039e51b806",
-            "NameMatches": true,
             "Name": "New Medium Machine Connector",
             "LocalPRS": "-244┼3┼0┼"
           },
@@ -238046,7 +237936,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -238096,21 +237986,19 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-244┼62┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-244┼62┼0┼"
           },
           {
             "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_-244┼63┼0┼",
             "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
-            "NameMatches": true,
             "Name": "New Department Battery",
             "LocalPRS": "-244┼63┼0┼",
             "Object": {
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -238366,7 +238254,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-243┼-3┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-243┼-3┼0┼"
           },
@@ -238408,7 +238295,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -238462,7 +238349,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -238537,7 +238424,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -238591,7 +238478,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -238713,7 +238600,6 @@
           {
             "GitID": "3edf81f4a32c4c348bad5bfe43e263fd_-243┼47┼0┼",
             "PrefabID": "3edf81f4a32c4c348bad5bfe43e263fd",
-            "NameMatches": true,
             "Name": "Paper Bin1",
             "LocalPRS": "-243┼47┼0┼",
             "Object": {
@@ -238809,6 +238695,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Cargo"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -238820,14 +238710,12 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-243┼53┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-243┼53┼0┼"
           },
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-243┼57┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-243┼57┼0┼"
           },
@@ -238860,12 +238748,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -239033,7 +238921,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -239256,14 +239144,12 @@
           {
             "GitID": "170e72b76e0da9645995a9bac3f49cb2_-242┼2┼0┼",
             "PrefabID": "170e72b76e0da9645995a9bac3f49cb2",
-            "NameMatches": true,
             "Name": "New SMES",
             "LocalPRS": "-242┼2┼0┼"
           },
           {
             "GitID": "bb684284e149a524d9f53b039e51b806_-242┼3┼0┼",
             "PrefabID": "bb684284e149a524d9f53b039e51b806",
-            "NameMatches": true,
             "Name": "New Medium Machine Connector",
             "LocalPRS": "-242┼3┼0┼"
           },
@@ -239276,7 +239162,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-242┼30┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-242┼30┼0┼"
           },
@@ -239309,12 +239194,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -239579,6 +239464,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Cargo"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -239671,7 +239560,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -239681,7 +239570,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-242┼53┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-242┼53┼0┼"
           },
@@ -239727,7 +239615,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-242┼63┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-242┼63┼0┼"
           },
@@ -240025,14 +239912,12 @@
           {
             "GitID": "224479214b5ed414193fdcb20d96678f_-241┼-2┼0┼",
             "PrefabID": "224479214b5ed414193fdcb20d96678f",
-            "NameMatches": true,
             "Name": "New Transformer",
             "LocalPRS": "-241┼-2┼0┼"
           },
           {
             "GitID": "224479214b5ed414193fdcb20d96678f_-241┼0┼0┼",
             "PrefabID": "224479214b5ed414193fdcb20d96678f",
-            "NameMatches": true,
             "Name": "New Transformer",
             "LocalPRS": "-241┼0┼0┼"
           },
@@ -240243,7 +240128,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-241┼53┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-241┼53┼0┼"
           },
@@ -240267,12 +240151,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -240317,7 +240201,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -240697,7 +240581,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -240947,7 +240831,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -241173,14 +241057,12 @@
           {
             "GitID": "cab73e460ee8bf24e88988add17a2be5_-240┼52┼0┼",
             "PrefabID": "cab73e460ee8bf24e88988add17a2be5",
-            "NameMatches": true,
             "Name": "New ConveyorSwitch",
             "LocalPRS": "-240┼52┼0┼"
           },
           {
             "GitID": "856296105f077014ca9e533266df237a_-240┼53┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-240┼53┼0┼"
           },
@@ -241286,7 +241168,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -241462,6 +241344,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Gateway"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -241473,7 +241359,6 @@
           {
             "GitID": "StationGateway_-240┼75┼0┼",
             "PrefabID": "StationGateway",
-            "NameMatches": true,
             "Name": "New StationGateway",
             "LocalPRS": "-240┼75┼0┼",
             "Object": {
@@ -241533,6 +241418,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Security"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -241789,7 +241678,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -241854,7 +241743,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-239┼35┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-239┼35┼0┼"
           },
@@ -242023,12 +241911,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -242156,7 +242044,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-239┼49┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-239┼49┼0┼"
           },
@@ -242205,7 +242092,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-239┼53┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-239┼53┼0┼"
           },
@@ -242837,12 +242723,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -242902,7 +242788,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -242973,7 +242859,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -243196,7 +243082,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-238┼59┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-238┼59┼0┼"
           },
@@ -243227,12 +243112,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -243406,7 +243291,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -243467,12 +243352,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -243590,7 +243475,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -243602,20 +243487,6 @@
             "PrefabID": "91d832be818283a4188516804e8d5ef0",
             "Name": "Closet_Emergency_Oxygen",
             "LocalPRS": "-238┼88┼0┼"
-          },
-          {
-            "GitID": "J5UF3VXxKdTV9iopbA17_-238┼92┼0┼",
-            "PrefabID": "J5UF3VXxKdTV9iopbA17",
-            "NameMatches": true,
-            "Name": "SecBarrier",
-            "LocalPRS": "-238┼92┼0┼"
-          },
-          {
-            "GitID": "J5UF3VXxKdTV9iopbA17_-238┼93┼0┼",
-            "PrefabID": "J5UF3VXxKdTV9iopbA17",
-            "NameMatches": true,
-            "Name": "SecBarrier",
-            "LocalPRS": "-238┼93┼0┼"
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_-238┼95┼0┼",
@@ -243664,7 +243535,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -243734,7 +243605,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -243870,7 +243741,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -244230,6 +244101,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Cargo"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -244982,14 +244857,13 @@
           {
             "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_-237┼85┼0┼",
             "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
-            "NameMatches": true,
             "Name": "New Department Battery",
             "LocalPRS": "-237┼85┼0┼",
             "Object": {
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -244999,7 +244873,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-237┼86┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-237┼86┼0┼"
           },
@@ -245249,7 +245122,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-237┼102┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-237┼102┼0┼"
           },
@@ -245374,6 +245246,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Brig"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -245563,7 +245439,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -245602,7 +245478,6 @@
           {
             "GitID": "Flaps_-236┼2┼0┼",
             "PrefabID": "Flaps",
-            "NameMatches": true,
             "Name": "New Flaps",
             "LocalPRS": "-236┼2┼0┼"
           },
@@ -245711,7 +245586,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -245747,12 +245622,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -245806,7 +245681,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -245898,7 +245773,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -245932,14 +245807,12 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-236┼76┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-236┼76┼0┼"
           },
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-236┼80┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-236┼80┼0┼"
           },
@@ -246534,7 +246407,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -246645,12 +246518,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -246966,7 +246839,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -247056,7 +246929,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -247092,12 +246965,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -247399,12 +247272,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -247636,7 +247509,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-234┼82┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-234┼82┼0┼"
           },
@@ -248138,7 +248010,6 @@
           {
             "GitID": "1442b4dd7f8a6714a914b861519721c1_-234┼114┼0┼",
             "PrefabID": "1442b4dd7f8a6714a914b861519721c1",
-            "NameMatches": true,
             "Name": "New Empty Bookshelf",
             "LocalPRS": "-234┼114┼0┼"
           },
@@ -248417,7 +248288,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -248791,7 +248662,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -248882,7 +248753,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -248991,7 +248862,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -249055,12 +248926,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -249252,7 +249123,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -249350,7 +249221,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -249523,7 +249394,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -249681,12 +249552,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -249696,14 +249567,12 @@
           {
             "GitID": "93d1f95a33757fe4fa3e2771e3f5bd67_-232┼2┼0┼",
             "PrefabID": "93d1f95a33757fe4fa3e2771e3f5bd67",
-            "NameMatches": true,
             "Name": "New PowerGeneratorPlasma",
             "LocalPRS": "-232┼2┼0┼"
           },
           {
             "GitID": "93d1f95a33757fe4fa3e2771e3f5bd67_-232┼3┼0┼",
             "PrefabID": "93d1f95a33757fe4fa3e2771e3f5bd67",
-            "NameMatches": true,
             "Name": "New PowerGeneratorPlasma",
             "LocalPRS": "-232┼3┼0┼"
           },
@@ -249760,7 +249629,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -249881,7 +249750,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -249910,7 +249779,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-232┼19┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-232┼19┼0┼"
           },
@@ -249961,7 +249829,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -250219,7 +250087,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -250358,7 +250226,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -250368,7 +250236,6 @@
           {
             "GitID": "Flaps_-232┼51┼0┼",
             "PrefabID": "Flaps",
-            "NameMatches": true,
             "Name": "New Flaps",
             "LocalPRS": "-232┼51┼0┼"
           },
@@ -250418,6 +250285,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Heads"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -250524,12 +250395,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -250796,7 +250667,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -250952,7 +250823,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -251020,7 +250891,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-232┼96┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-232┼96┼0┼"
           },
@@ -251412,7 +251282,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -251500,7 +251370,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -251557,7 +251427,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-231┼-4┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-231┼-4┼0┼"
           },
@@ -251608,7 +251477,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -251826,12 +251695,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -252050,6 +251919,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Hop"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -252287,14 +252160,12 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-231┼49┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-231┼49┼0┼"
           },
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-231┼50┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-231┼50┼0┼"
           },
@@ -252453,7 +252324,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -252672,7 +252543,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-231┼78┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-231┼78┼0┼"
           },
@@ -252782,7 +252652,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -252908,7 +252778,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -253425,7 +253295,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-230┼47┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-230┼47┼0┼"
           },
@@ -253476,7 +253345,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -253741,7 +253610,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-230┼78┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-230┼78┼0┼"
           },
@@ -254192,7 +254060,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -254248,12 +254116,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -254354,12 +254222,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -254580,7 +254448,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -254889,14 +254757,13 @@
           {
             "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_-229┼49┼0┼",
             "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
-            "NameMatches": true,
             "Name": "New Department Battery",
             "LocalPRS": "-229┼49┼0┼",
             "Object": {
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -254913,7 +254780,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-229┼50┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-229┼50┼0┼"
           },
@@ -255103,7 +254969,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-229┼82┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-229┼82┼0┼"
           },
@@ -255305,7 +255170,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -255406,12 +255271,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -255694,7 +255559,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -255748,7 +255613,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -256318,7 +256183,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -256613,6 +256478,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Brig"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -256712,7 +256581,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -256752,12 +256621,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -256835,7 +256704,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -257268,7 +257137,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -257686,7 +257555,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -257768,12 +257637,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -257800,12 +257669,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -257863,12 +257732,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -257970,7 +257839,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-227┼82┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-227┼82┼0┼"
           },
@@ -258006,7 +257874,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-227┼84┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-227┼84┼0┼"
           },
@@ -258057,7 +257924,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -258215,7 +258082,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -258284,12 +258151,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -258727,12 +258594,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -258769,7 +258636,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-226┼7┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-226┼7┼0┼"
           },
@@ -259166,12 +259032,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -259255,7 +259121,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-226┼23┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-226┼23┼0┼"
           },
@@ -259362,7 +259227,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -259398,12 +259263,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -259552,7 +259417,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -259739,12 +259604,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -259865,7 +259730,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -260214,7 +260079,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -260268,7 +260133,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -260331,7 +260196,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-225┼11┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-225┼11┼0┼"
           },
@@ -260397,7 +260261,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -260506,7 +260370,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -260610,7 +260474,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-225┼21┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-225┼21┼0┼"
           },
@@ -260726,7 +260589,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -260852,7 +260715,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-225┼35┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-225┼35┼0┼"
           },
@@ -261004,7 +260866,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -261208,7 +261070,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -261218,7 +261080,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-225┼55┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-225┼55┼0┼"
           },
@@ -261242,12 +261103,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -261297,7 +261158,6 @@
           {
             "GitID": "e6fef14b66545db41939986bb7911c4d_-225┼65┼0┼",
             "PrefabID": "e6fef14b66545db41939986bb7911c4d",
-            "NameMatches": true,
             "Name": "New UnityStationSign",
             "LocalPRS": "-225┼65┼0┼",
             "Object": {
@@ -261475,7 +261335,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -261788,6 +261648,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Security"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -261833,6 +261697,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Security"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -261946,7 +261814,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -261994,7 +261862,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -262107,7 +261975,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -262117,7 +261985,6 @@
           {
             "GitID": "SeedExtractor_-225┼116┼0┼",
             "PrefabID": "SeedExtractor",
-            "NameMatches": true,
             "Name": "New SeedExtractor",
             "LocalPRS": "-225┼116┼0┼",
             "Object": {
@@ -262137,7 +262004,6 @@
           {
             "GitID": "bedb438dca3e2724ab966daa0c0a507f_-225┼117┼0┼",
             "PrefabID": "bedb438dca3e2724ab966daa0c0a507f",
-            "NameMatches": true,
             "Name": "New BioGenerator",
             "LocalPRS": "-225┼117┼0┼"
           },
@@ -262226,12 +262092,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -262616,14 +262482,13 @@
           {
             "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_-224┼11┼0┼",
             "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
-            "NameMatches": true,
             "Name": "New Department Battery",
             "LocalPRS": "-224┼11┼0┼",
             "Object": {
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -262723,7 +262588,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -262897,7 +262762,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -263048,12 +262913,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -263199,6 +263064,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Brig"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -263425,7 +263294,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -263509,7 +263378,6 @@
           {
             "GitID": "93d1f95a33757fe4fa3e2771e3f5bd67_-223┼-19┼0┼",
             "PrefabID": "93d1f95a33757fe4fa3e2771e3f5bd67",
-            "NameMatches": true,
             "Name": "New PowerGeneratorPlasma",
             "LocalPRS": "-223┼-19┼0┼"
           },
@@ -263551,7 +263419,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -263878,7 +263746,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -264141,7 +264009,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-223┼35┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-223┼35┼0┼"
           },
@@ -264274,7 +264141,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -264352,7 +264219,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -264527,7 +264394,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -264845,7 +264712,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -264855,7 +264722,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-223┼100┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-223┼100┼0┼"
           },
@@ -264995,7 +264861,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-223┼105┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-223┼105┼0┼"
           },
@@ -265096,7 +264961,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -265210,7 +265075,6 @@
           {
             "GitID": "93d1f95a33757fe4fa3e2771e3f5bd67_-222┼-19┼0┼",
             "PrefabID": "93d1f95a33757fe4fa3e2771e3f5bd67",
-            "NameMatches": true,
             "Name": "New PowerGeneratorPlasma",
             "LocalPRS": "-222┼-19┼0┼"
           },
@@ -265326,7 +265190,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -265498,12 +265362,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -265539,12 +265403,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -265599,12 +265463,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -265614,14 +265478,13 @@
           {
             "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_-222┼35┼0┼",
             "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
-            "NameMatches": true,
             "Name": "New Department Battery",
             "LocalPRS": "-222┼35┼0┼",
             "Object": {
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -265982,7 +265845,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -266167,7 +266030,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -266356,7 +266219,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -266461,7 +266324,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -267247,12 +267110,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -267317,7 +267180,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -267927,7 +267790,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-221┼45┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-221┼45┼0┼"
           },
@@ -268115,7 +267977,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -268636,6 +268498,13 @@
             "LocalPRS": "-221┼99┼0┼"
           },
           {
+            "GitID": "6b7563f69c76a2a4a9dd785f88e80c19_-221┼102┼0┼",
+            "PrefabID": "6b7563f69c76a2a4a9dd785f88e80c19",
+            "NameMatches": true,
+            "Name": "DeployableSecurityBarrier",
+            "LocalPRS": "-221┼102┼0┼"
+          },
+          {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_-221┼102┼0┼",
             "PrefabID": "fde32c02abddc814f9366ff1fb21f234",
             "NameMatches": true,
@@ -268682,19 +268551,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
               ]
             }
-          },
-          {
-            "GitID": "J5UF3VXxKdTV9iopbA17_-221┼102┼0┼",
-            "PrefabID": "J5UF3VXxKdTV9iopbA17",
-            "NameMatches": true,
-            "Name": "SecBarrier",
-            "LocalPRS": "-221┼102┼0┼"
           },
           {
             "GitID": "4d2d20453d200b04e9e461991b4f2de4_-221┼106┼0┼",
@@ -268966,7 +268828,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -269015,14 +268877,13 @@
           {
             "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_-220┼7┼0┼",
             "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
-            "NameMatches": true,
             "Name": "New Department Battery",
             "LocalPRS": "-220┼7┼0┼",
             "Object": {
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -269182,7 +269043,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -269192,7 +269053,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-220┼22┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-220┼22┼0┼"
           },
@@ -269243,7 +269103,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -269574,12 +269434,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -269703,7 +269563,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-220┼82┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-220┼82┼0┼"
           },
@@ -269801,6 +269660,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Brig"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -269869,12 +269732,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -270353,7 +270216,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-219┼-19┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-219┼-19┼0┼"
           },
@@ -270529,7 +270391,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -270545,7 +270407,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-219┼7┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-219┼7┼0┼"
           },
@@ -270587,7 +270448,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -270932,7 +270793,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -271076,7 +270937,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-219┼54┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-219┼54┼0┼"
           },
@@ -271371,7 +271231,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -271436,6 +271296,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Armory"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -271673,6 +271537,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Security"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -272002,7 +271870,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -272237,7 +272105,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -272322,12 +272190,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -272424,7 +272292,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -272729,7 +272597,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -272802,12 +272670,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -272861,7 +272729,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -273047,17 +272915,10 @@
             }
           },
           {
-            "GitID": "J5UF3VXxKdTV9iopbA17_-218┼99┼0┼",
-            "PrefabID": "J5UF3VXxKdTV9iopbA17",
+            "GitID": "6b7563f69c76a2a4a9dd785f88e80c19_-218┼102┼0┼",
+            "PrefabID": "6b7563f69c76a2a4a9dd785f88e80c19",
             "NameMatches": true,
-            "Name": "SecBarrier",
-            "LocalPRS": "-218┼99┼0┼"
-          },
-          {
-            "GitID": "J5UF3VXxKdTV9iopbA17_-218┼102┼0┼",
-            "PrefabID": "J5UF3VXxKdTV9iopbA17",
-            "NameMatches": true,
-            "Name": "SecBarrier",
+            "Name": "DeployableSecurityBarrier",
             "LocalPRS": "-218┼102┼0┼"
           },
           {
@@ -273230,12 +273091,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -273300,7 +273161,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -273327,12 +273188,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -273401,12 +273262,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -273543,7 +273404,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -273830,14 +273691,13 @@
           {
             "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_-217┼45┼0┼",
             "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
-            "NameMatches": true,
             "Name": "New Department Battery",
             "LocalPRS": "-217┼45┼0┼",
             "Object": {
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -273847,7 +273707,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-217┼46┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-217┼46┼0┼"
           },
@@ -273898,7 +273757,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -273934,12 +273793,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -274116,12 +273975,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -274442,12 +274301,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -274501,7 +274360,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -274685,6 +274544,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Armory"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -274782,7 +274645,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -274955,7 +274818,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -275247,7 +275110,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -275495,7 +275358,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -275663,6 +275526,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Atmospherics"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -275674,7 +275541,6 @@
           {
             "GitID": "Flaps_-216┼26┼0┼",
             "PrefabID": "Flaps",
-            "NameMatches": true,
             "Name": "New Flaps",
             "LocalPRS": "-216┼26┼0┼"
           },
@@ -275755,7 +275621,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -275902,7 +275768,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -275929,12 +275795,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -276365,6 +276231,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Armory"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -276699,7 +276569,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -276933,7 +276803,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-215┼14┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-215┼14┼0┼"
           },
@@ -277036,14 +276905,13 @@
           {
             "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_-215┼20┼0┼",
             "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
-            "NameMatches": true,
             "Name": "New Department Battery",
             "LocalPRS": "-215┼20┼0┼",
             "Object": {
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -277097,7 +276965,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -277107,7 +276975,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-215┼21┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-215┼21┼0┼"
           },
@@ -277224,6 +277091,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Atmospherics"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -277422,7 +277293,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -277630,7 +277501,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-215┼60┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-215┼60┼0┼"
           },
@@ -277672,7 +277542,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -278063,7 +277933,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-215┼99┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-215┼99┼0┼"
           },
@@ -278089,7 +277958,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-215┼102┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-215┼102┼0┼"
           },
@@ -278308,12 +278176,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -278662,7 +278530,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-214┼9┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-214┼9┼0┼"
           },
@@ -278806,7 +278673,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-214┼33┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-214┼33┼0┼"
           },
@@ -278848,7 +278714,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -278945,7 +278811,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-214┼59┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-214┼59┼0┼"
           },
@@ -279079,7 +278944,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -279190,7 +279055,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -279301,7 +279166,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -279412,7 +279277,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -279649,12 +279514,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -279664,14 +279529,13 @@
           {
             "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_-214┼102┼0┼",
             "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
-            "NameMatches": true,
             "Name": "New Department Battery",
             "LocalPRS": "-214┼102┼0┼",
             "Object": {
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -279730,7 +279594,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-214┼107┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-214┼107┼0┼"
           },
@@ -279770,7 +279633,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-213┼-19┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-213┼-19┼0┼"
           },
@@ -279801,14 +279663,13 @@
           {
             "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_-213┼-18┼0┼",
             "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
-            "NameMatches": true,
             "Name": "New Department Battery",
             "LocalPRS": "-213┼-18┼0┼",
             "Object": {
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -279905,7 +279766,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -279959,7 +279820,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -280055,7 +279916,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -280071,7 +279932,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-213┼9┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-213┼9┼0┼"
           },
@@ -280416,7 +280276,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -280452,7 +280312,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,3",
+                  "ID": "0,4",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -280502,7 +280362,6 @@
           {
             "GitID": "e6fef14b66545db41939986bb7911c4d_-213┼65┼0┼",
             "PrefabID": "e6fef14b66545db41939986bb7911c4d",
-            "NameMatches": true,
             "Name": "New UnityStationSign",
             "LocalPRS": "-213┼65┼0┼",
             "Object": {
@@ -280979,12 +280838,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -281314,6 +281173,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Armory"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -281326,8 +281189,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -281553,6 +281448,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Security"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -281565,8 +281464,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -281787,7 +281718,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -282454,12 +282385,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -282533,7 +282464,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-212┼43┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-212┼43┼0┼"
           },
@@ -282660,7 +282590,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -282696,12 +282626,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -282952,7 +282882,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -283432,7 +283362,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -283572,7 +283502,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -283966,12 +283896,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -284406,7 +284336,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-211┼18┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-211┼18┼0┼"
           },
@@ -284480,7 +284409,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-211┼23┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-211┼23┼0┼"
           },
@@ -284531,7 +284459,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -284614,7 +284542,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -284650,12 +284578,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -285112,12 +285040,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -285555,7 +285483,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -286285,6 +286213,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Captain"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -286584,12 +286516,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -286643,7 +286575,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -286697,7 +286629,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -286763,12 +286695,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -286849,6 +286781,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Brig"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -287018,12 +286954,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -287232,7 +287168,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -287262,7 +287198,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-209┼0┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-209┼0┼0┼"
           },
@@ -287465,7 +287400,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -287582,7 +287517,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -287592,7 +287527,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-209┼13┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-209┼13┼0┼"
           },
@@ -287637,12 +287571,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -287725,7 +287659,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -287798,7 +287732,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -287892,7 +287826,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -288208,12 +288142,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -288267,7 +288201,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -288520,7 +288454,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -288755,7 +288689,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -288897,7 +288831,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -289775,7 +289709,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-208┼32┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-208┼32┼0┼"
           },
@@ -289826,7 +289759,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -289918,7 +289851,6 @@
           {
             "GitID": "Flaps_-208┼35┼0┼",
             "PrefabID": "Flaps",
-            "NameMatches": true,
             "Name": "New Flaps",
             "LocalPRS": "-208┼35┼0┼"
           },
@@ -289958,7 +289890,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-208┼44┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-208┼44┼0┼"
           },
@@ -290047,7 +289978,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -290560,7 +290491,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -290701,7 +290632,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -290737,12 +290668,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -290816,7 +290747,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -290946,12 +290877,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -291026,7 +290957,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-207┼16┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-207┼16┼0┼"
           },
@@ -291120,7 +291050,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-207┼34┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-207┼34┼0┼"
           },
@@ -291162,7 +291091,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -291282,7 +291211,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-207┼57┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-207┼57┼0┼"
           },
@@ -291627,12 +291555,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -291714,7 +291642,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -291971,7 +291899,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -291998,12 +291926,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -292373,7 +292301,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -292409,12 +292337,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -292494,7 +292422,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -292586,12 +292514,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -292829,7 +292757,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -292846,7 +292774,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-206┼55┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-206┼55┼0┼"
           },
@@ -292879,12 +292806,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -293386,7 +293313,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-206┼59┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-206┼59┼0┼"
           },
@@ -293410,12 +293336,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -293442,12 +293368,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -293457,7 +293383,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-206┼73┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-206┼73┼0┼"
           },
@@ -293621,7 +293546,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -293804,7 +293729,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-206┼106┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-206┼106┼0┼"
           },
@@ -293905,12 +293829,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -294042,7 +293966,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -294087,7 +294011,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -294665,7 +294589,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -294719,7 +294643,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -295510,7 +295434,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-204┼28┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-204┼28┼0┼"
           },
@@ -295632,7 +295555,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -295686,7 +295609,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -295871,7 +295794,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -296365,7 +296288,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -296493,7 +296416,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -296564,7 +296487,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -297052,7 +296975,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -297145,7 +297068,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -297300,7 +297223,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -297643,7 +297566,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -297737,7 +297660,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -297879,7 +297802,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -297889,7 +297812,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-202┼33┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-202┼33┼0┼"
           },
@@ -297960,12 +297882,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -298019,7 +297941,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -298093,12 +298015,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -298190,7 +298112,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -298288,7 +298210,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -298464,7 +298386,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -298724,7 +298646,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-202┼86┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-202┼86┼0┼"
           },
@@ -298876,12 +298797,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -298944,7 +298865,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-202┼106┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-202┼106┼0┼"
           },
@@ -299020,7 +298940,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -299077,7 +298997,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -299490,7 +299410,6 @@
           {
             "GitID": "Flaps_-201┼41┼0┼",
             "PrefabID": "Flaps",
-            "NameMatches": true,
             "Name": "New Flaps",
             "LocalPRS": "-201┼41┼0┼"
           },
@@ -300087,7 +300006,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -300134,12 +300053,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -300241,7 +300160,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-201┼87┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-201┼87┼0┼"
           },
@@ -300759,12 +300677,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -301034,12 +300952,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -301268,7 +301186,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -301381,7 +301299,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -301435,7 +301353,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -301445,7 +301363,6 @@
           {
             "GitID": "7bb3f38189983e9468b4f3f16be75bed_-200┼65┼0┼",
             "PrefabID": "7bb3f38189983e9468b4f3f16be75bed",
-            "NameMatches": true,
             "Name": "New Jukebox",
             "LocalPRS": "-200┼65┼0┼",
             "Object": {
@@ -301491,12 +301408,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -301605,7 +301522,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -301848,12 +301765,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -301907,7 +301824,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -301941,6 +301858,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Court"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -301981,7 +301902,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-200┼100┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-200┼100┼0┼"
           },
@@ -302069,7 +301989,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -302464,12 +302384,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -302625,7 +302545,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-199┼52┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-199┼52┼0┼"
           },
@@ -302795,12 +302714,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -303289,6 +303208,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Security"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -303307,7 +303230,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-199┼105┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-199┼105┼0┼"
           },
@@ -303437,7 +303359,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -303861,7 +303783,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -303975,7 +303897,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -303991,7 +303913,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-198┼84┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-198┼84┼0┼"
           },
@@ -304018,7 +303939,6 @@
           {
             "GitID": "Flaps_-198┼101┼0┼",
             "PrefabID": "Flaps",
-            "NameMatches": true,
             "Name": "New Flaps",
             "LocalPRS": "-198┼101┼0┼"
           },
@@ -304132,7 +304052,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -304477,7 +304397,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -304569,7 +304489,6 @@
           {
             "GitID": "ChemDispenser_-197┼48┼0┼",
             "PrefabID": "ChemDispenser",
-            "NameMatches": true,
             "Name": "New ChemDispenser",
             "LocalPRS": "-197┼48┼0┼",
             "Object": {
@@ -304589,14 +304508,12 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-197┼50┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-197┼50┼0┼"
           },
           {
             "GitID": "ChemDispenser_-197┼52┼0┼",
             "PrefabID": "ChemDispenser",
-            "NameMatches": true,
             "Name": "New ChemDispenser",
             "LocalPRS": "-197┼52┼0┼",
             "Object": {
@@ -304666,12 +304583,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -304716,7 +304633,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -305431,7 +305348,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-197┼86┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-197┼86┼0┼"
           },
@@ -305482,7 +305398,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -305590,7 +305506,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -305798,12 +305714,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -305857,7 +305773,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -305913,12 +305829,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -305992,7 +305908,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -306066,7 +305982,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -306171,7 +306087,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -306193,7 +306109,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-196┼41┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-196┼41┼0┼"
           },
@@ -306320,12 +306235,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -306335,7 +306250,6 @@
           {
             "GitID": "ChemMaster_-196┼48┼0┼",
             "PrefabID": "ChemMaster",
-            "NameMatches": true,
             "Name": "New ChemMaster",
             "LocalPRS": "-196┼48┼0┼"
           },
@@ -306470,7 +306384,6 @@
           {
             "GitID": "ChemMaster_-196┼52┼0┼",
             "PrefabID": "ChemMaster",
-            "NameMatches": true,
             "Name": "New ChemMaster",
             "LocalPRS": "-196┼52┼0┼"
           },
@@ -306606,11 +306519,11 @@
                   "ClassID": "ItemSlotActionTracker@0",
                   "Data": [
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "SecureStuff.SerializedAction"
                     },
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "#removed#"
                     }
                   ]
@@ -306635,11 +306548,11 @@
                   "ClassID": "ItemSlotActionTracker@0",
                   "Data": [
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "SecureStuff.SerializedAction"
                     },
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "#removed#"
                     }
                   ]
@@ -306663,7 +306576,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-196┼73┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-196┼73┼0┼"
           },
@@ -306865,7 +306777,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -307440,7 +307352,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -307632,6 +307544,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Chemistry"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -307821,6 +307737,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Chemistry"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -307867,7 +307787,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -308147,7 +308067,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -308404,7 +308324,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -308497,7 +308417,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -308765,6 +308685,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Theatre"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -308814,7 +308738,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-194┼71┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-194┼71┼0┼"
           },
@@ -309075,21 +308998,19 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-194┼86┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-194┼86┼0┼"
           },
           {
             "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_-194┼87┼0┼",
             "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
-            "NameMatches": true,
             "Name": "New Department Battery",
             "LocalPRS": "-194┼87┼0┼",
             "Object": {
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -309381,7 +309302,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -309697,7 +309618,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -310509,12 +310430,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -310982,7 +310903,6 @@
           {
             "GitID": "Slot Machine_-191┼66┼0┼",
             "PrefabID": "Slot Machine",
-            "NameMatches": true,
             "Name": "New SlotMachine",
             "LocalPRS": "-191┼66┼0┼"
           },
@@ -311033,7 +310953,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -311043,21 +310963,18 @@
           {
             "GitID": "Slot Machine_-191┼67┼0┼",
             "PrefabID": "Slot Machine",
-            "NameMatches": true,
             "Name": "New SlotMachine",
             "LocalPRS": "-191┼67┼0┼"
           },
           {
             "GitID": "Slot Machine_-191┼68┼0┼",
             "PrefabID": "Slot Machine",
-            "NameMatches": true,
             "Name": "New SlotMachine",
             "LocalPRS": "-191┼68┼0┼"
           },
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-191┼69┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-191┼69┼0┼"
           },
@@ -311282,7 +311199,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-191┼71┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-191┼71┼0┼"
           },
@@ -311491,7 +311407,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -311545,7 +311461,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -311599,7 +311515,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -311653,7 +311569,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -311705,7 +311621,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -311732,12 +311648,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -312267,12 +312183,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -312307,12 +312223,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -312959,7 +312875,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -312996,7 +312912,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-188┼-23┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-188┼-23┼0┼"
           },
@@ -313028,12 +312943,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -313179,7 +313094,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -313286,7 +313201,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -313320,6 +313235,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Bar"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -313852,7 +313771,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -313879,12 +313798,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -314015,7 +313934,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -314100,12 +314019,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -314223,7 +314142,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -314666,7 +314585,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -314708,7 +314627,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-186┼9┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-186┼9┼0┼"
           },
@@ -314793,7 +314711,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -314809,7 +314727,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-186┼49┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-186┼49┼0┼"
           },
@@ -315192,7 +315109,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -315246,12 +315163,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -315295,7 +315212,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -315411,7 +315328,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -315656,7 +315573,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-185┼9┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-185┼9┼0┼"
           },
@@ -315707,7 +315623,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -316027,7 +315943,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -316037,7 +315953,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-185┼36┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-185┼36┼0┼"
           },
@@ -316218,12 +316133,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -316303,6 +316218,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Bar"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -316314,7 +316233,6 @@
           {
             "GitID": "Flaps_-185┼71┼0┼",
             "PrefabID": "Flaps",
-            "NameMatches": true,
             "Name": "New Flaps",
             "LocalPRS": "-185┼71┼0┼"
           },
@@ -316411,12 +316329,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -316488,7 +316406,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -316562,12 +316480,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -316611,7 +316529,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -316767,7 +316685,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -316868,12 +316786,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -316920,14 +316838,13 @@
           {
             "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_-184┼9┼0┼",
             "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
-            "NameMatches": true,
             "Name": "New Department Battery",
             "LocalPRS": "-184┼9┼0┼",
             "Object": {
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -317027,7 +316944,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -317044,7 +316961,6 @@
           {
             "GitID": "All-In-One Grinder_-184┼24┼0┼",
             "PrefabID": "All-In-One Grinder",
-            "NameMatches": true,
             "Name": "new All-In-One Grinder",
             "LocalPRS": "-184┼24┼0┼"
           },
@@ -317077,7 +316993,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -317377,7 +317293,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -317400,16 +317316,39 @@
                       "Data": "cd57203a8d3f54f478446e9b0ced6cf9_-187┼49┼0┼@0@APC@0"
                     }
                   ]
+                },
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Left_By90"
+                    }
+                  ]
                 }
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,0",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "3"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -317491,7 +317430,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -317583,12 +317522,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -317648,7 +317587,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -317931,12 +317870,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -317971,7 +317910,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -318099,7 +318038,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -318244,7 +318183,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -318328,12 +318267,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -318424,7 +318363,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -318434,14 +318373,13 @@
           {
             "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_-183┼30┼0┼",
             "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
-            "NameMatches": true,
             "Name": "New Department Battery",
             "LocalPRS": "-183┼30┼0┼",
             "Object": {
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -318530,7 +318468,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -318566,12 +318504,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -318863,7 +318801,6 @@
           {
             "GitID": "14f7a658310344a43913f9474477dc37_-183┼67┼0┼",
             "PrefabID": "14f7a658310344a43913f9474477dc37",
-            "NameMatches": true,
             "Name": "New IcecreamCart",
             "LocalPRS": "-183┼67┼0┼"
           },
@@ -318914,7 +318851,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -318938,7 +318875,6 @@
           {
             "GitID": "6632299223265324f8ad6b9a74159e0c_-183┼69┼0┼",
             "PrefabID": "6632299223265324f8ad6b9a74159e0c",
-            "NameMatches": true,
             "Name": "New FoodCart",
             "LocalPRS": "-183┼69┼0┼"
           },
@@ -318987,6 +318923,10 @@
                 {
                   "ClassID": "APC@0",
                   "Data": [
+                    {
+                      "Name": "connectedDevices#40",
+                      "Data": "cb0f8eeade0559b4eab161558c5c1645_-181┼61┼0┼@0@APCPoweredDevice@0"
+                    },
                     {
                       "Name": "connectedDevices#39",
                       "Data": "Gibber_-179┼66┼0┼@0@APCPoweredDevice@0"
@@ -319155,7 +319095,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-183┼71┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-183┼71┼0┼"
           },
@@ -319467,12 +319406,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -319482,28 +319421,25 @@
           {
             "GitID": "170e72b76e0da9645995a9bac3f49cb2_-182┼-48┼0┼",
             "PrefabID": "170e72b76e0da9645995a9bac3f49cb2",
-            "NameMatches": true,
             "Name": "New SMES",
             "LocalPRS": "-182┼-48┼0┼"
           },
           {
             "GitID": "bb684284e149a524d9f53b039e51b806_-182┼-47┼0┼",
             "PrefabID": "bb684284e149a524d9f53b039e51b806",
-            "NameMatches": true,
             "Name": "New Medium Machine Connector",
             "LocalPRS": "-182┼-47┼0┼"
           },
           {
             "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_-182┼-46┼0┼",
             "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
-            "NameMatches": true,
             "Name": "New Department Battery",
             "LocalPRS": "-182┼-46┼0┼",
             "Object": {
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -319513,7 +319449,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-182┼-45┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-182┼-45┼0┼"
           },
@@ -319943,7 +319878,6 @@
           {
             "GitID": "bb684284e149a524d9f53b039e51b806_-182┼9┼0┼",
             "PrefabID": "bb684284e149a524d9f53b039e51b806",
-            "NameMatches": true,
             "Name": "New Medium Machine Connector",
             "LocalPRS": "-182┼9┼0┼"
           },
@@ -320061,7 +319995,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-182┼30┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-182┼30┼0┼"
           },
@@ -320224,7 +320157,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -320415,7 +320348,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -320673,14 +320606,13 @@
           {
             "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_-182┼74┼0┼",
             "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
-            "NameMatches": true,
             "Name": "New Department Battery",
             "LocalPRS": "-182┼74┼0┼",
             "Object": {
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -320690,7 +320622,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-182┼75┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-182┼75┼0┼"
           },
@@ -321021,7 +320952,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-181┼-43┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-181┼-43┼0┼"
           },
@@ -321161,7 +321091,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -321278,12 +321208,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -321327,7 +321257,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -321368,12 +321298,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -321483,7 +321413,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -321573,7 +321503,6 @@
           {
             "GitID": "170e72b76e0da9645995a9bac3f49cb2_-181┼9┼0┼",
             "PrefabID": "170e72b76e0da9645995a9bac3f49cb2",
-            "NameMatches": true,
             "Name": "New SMES",
             "LocalPRS": "-181┼9┼0┼"
           },
@@ -321787,7 +321716,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -321856,7 +321785,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-181┼29┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-181┼29┼0┼"
           },
@@ -322118,12 +322046,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -322202,6 +322130,26 @@
                     }
                   ]
                 },
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_-183┼70┼0┼@0@APC@0"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "cb0f8eeade0559b4eab161558c5c1645_-181┼61┼0┼",
+            "PrefabID": "cb0f8eeade0559b4eab161558c5c1645",
+            "NameMatches": true,
+            "Name": "DeepFryer",
+            "LocalPRS": "-181┼61┼0┼",
+            "Object": {
+              "ClassDatas": [
                 {
                   "ClassID": "APCPoweredDevice@0",
                   "Data": [
@@ -322548,12 +322496,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -322673,7 +322621,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-180┼-33┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-180┼-33┼0┼"
           },
@@ -322714,7 +322661,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -322854,7 +322801,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-180┼-18┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-180┼-18┼0┼"
           },
@@ -322983,7 +322929,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -323047,12 +322993,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -323698,12 +323644,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -323757,7 +323703,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -323976,7 +323922,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -324122,7 +324068,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -324176,7 +324122,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -324293,6 +324239,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Kitchen"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -324304,7 +324254,6 @@
           {
             "GitID": "Flaps_-180┼70┼0┼",
             "PrefabID": "Flaps",
-            "NameMatches": true,
             "Name": "New Flaps",
             "LocalPRS": "-180┼70┼0┼"
           },
@@ -324454,7 +324403,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -324508,12 +324457,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -324557,7 +324506,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -324686,7 +324635,6 @@
           {
             "GitID": "93d1f95a33757fe4fa3e2771e3f5bd67_-179┼-24┼0┼",
             "PrefabID": "93d1f95a33757fe4fa3e2771e3f5bd67",
-            "NameMatches": true,
             "Name": "New PowerGeneratorPlasma",
             "LocalPRS": "-179┼-24┼0┼"
           },
@@ -324727,7 +324675,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -324737,7 +324685,6 @@
           {
             "GitID": "170e72b76e0da9645995a9bac3f49cb2_-179┼-21┼0┼",
             "PrefabID": "170e72b76e0da9645995a9bac3f49cb2",
-            "NameMatches": true,
             "Name": "New SMES",
             "LocalPRS": "-179┼-21┼0┼"
           },
@@ -325232,7 +325179,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -325305,12 +325252,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -325320,7 +325267,6 @@
           {
             "GitID": "baeafe1b5e8214344a5acf3315766acc_-179┼39┼0┼",
             "PrefabID": "baeafe1b5e8214344a5acf3315766acc",
-            "NameMatches": true,
             "Name": "New DNA Scanner",
             "LocalPRS": "-179┼39┼0┼",
             "Object": {
@@ -325507,7 +325453,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -325552,7 +325498,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -325789,7 +325735,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,3",
+                  "ID": "0,4",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -325799,7 +325745,6 @@
           {
             "GitID": "Gibber_-179┼66┼0┼",
             "PrefabID": "Gibber",
-            "NameMatches": true,
             "Name": "New Gibber",
             "LocalPRS": "-179┼66┼0┼",
             "Object": {
@@ -325892,7 +325837,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -326163,7 +326108,6 @@
           {
             "GitID": "bb684284e149a524d9f53b039e51b806_-178┼-21┼0┼",
             "PrefabID": "bb684284e149a524d9f53b039e51b806",
-            "NameMatches": true,
             "Name": "New Medium Machine Connector",
             "LocalPRS": "-178┼-21┼0┼"
           },
@@ -326223,12 +326167,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -326347,7 +326291,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -326921,21 +326865,18 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-178┼59┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-178┼59┼0┼"
           },
           {
             "GitID": "All-In-One Grinder_-178┼60┼0┼",
             "PrefabID": "All-In-One Grinder",
-            "NameMatches": true,
             "Name": "new All-In-One Grinder",
             "LocalPRS": "-178┼60┼0┼"
           },
           {
             "GitID": "Food Processor_-178┼61┼0┼",
             "PrefabID": "Food Processor",
-            "NameMatches": true,
             "Name": "New Food Processor",
             "LocalPRS": "-178┼61┼0┼",
             "Object": {
@@ -327033,6 +326974,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Hydroponics"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -327044,7 +326989,6 @@
           {
             "GitID": "Flaps_-178┼70┼0┼",
             "PrefabID": "Flaps",
-            "NameMatches": true,
             "Name": "New Flaps",
             "LocalPRS": "-178┼70┼0┼"
           },
@@ -327231,7 +327175,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -327330,7 +327274,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-177┼18┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-177┼18┼0┼"
           },
@@ -327462,7 +327405,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -327472,7 +327415,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-177┼37┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-177┼37┼0┼"
           },
@@ -327523,7 +327465,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -327533,7 +327475,6 @@
           {
             "GitID": "4ca7e9a3bb55005418ddd62621ac8667_-177┼39┼0┼",
             "PrefabID": "4ca7e9a3bb55005418ddd62621ac8667",
-            "NameMatches": true,
             "Name": "New Cloning Pod",
             "LocalPRS": "-177┼39┼0┼",
             "Object": {
@@ -327616,7 +327557,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-177┼52┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-177┼52┼0┼"
           },
@@ -328297,7 +328237,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-176┼-23┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-176┼-23┼0┼"
           },
@@ -328329,12 +328268,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -328344,21 +328283,19 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-176┼-22┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-176┼-22┼0┼"
           },
           {
             "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_-176┼-21┼0┼",
             "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
-            "NameMatches": true,
             "Name": "New Department Battery",
             "LocalPRS": "-176┼-21┼0┼",
             "Object": {
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -328492,7 +328429,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -328508,7 +328445,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-176┼23┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-176┼23┼0┼"
           },
@@ -328978,12 +328914,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -329037,7 +328973,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -329054,14 +328990,12 @@
           {
             "GitID": "c0d35a75ba9aa4c4fab141f0fac245f6_-176┼60┼0┼",
             "PrefabID": "c0d35a75ba9aa4c4fab141f0fac245f6",
-            "NameMatches": true,
             "Name": "New HydroponicsTray",
             "LocalPRS": "-176┼60┼0┼"
           },
           {
             "GitID": "c0d35a75ba9aa4c4fab141f0fac245f6_-176┼61┼0┼",
             "PrefabID": "c0d35a75ba9aa4c4fab141f0fac245f6",
-            "NameMatches": true,
             "Name": "New HydroponicsTray",
             "LocalPRS": "-176┼61┼0┼"
           },
@@ -329112,7 +329046,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -329122,14 +329056,12 @@
           {
             "GitID": "c0d35a75ba9aa4c4fab141f0fac245f6_-176┼64┼0┼",
             "PrefabID": "c0d35a75ba9aa4c4fab141f0fac245f6",
-            "NameMatches": true,
             "Name": "New HydroponicsTray",
             "LocalPRS": "-176┼64┼0┼"
           },
           {
             "GitID": "c0d35a75ba9aa4c4fab141f0fac245f6_-176┼65┼0┼",
             "PrefabID": "c0d35a75ba9aa4c4fab141f0fac245f6",
-            "NameMatches": true,
             "Name": "New HydroponicsTray",
             "LocalPRS": "-176┼65┼0┼"
           },
@@ -329162,12 +329094,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -329203,12 +329135,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -329393,7 +329325,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -329403,7 +329335,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-176┼77┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-176┼77┼0┼"
           },
@@ -329545,7 +329476,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -329689,12 +329620,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -329729,12 +329660,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -330179,7 +330110,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-175┼39┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-175┼39┼0┼"
           },
@@ -330223,7 +330153,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-175┼46┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-175┼46┼0┼"
           },
@@ -330790,7 +330719,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -331148,7 +331077,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -331289,7 +331218,6 @@
           {
             "GitID": "c0d35a75ba9aa4c4fab141f0fac245f6_-174┼66┼0┼",
             "PrefabID": "c0d35a75ba9aa4c4fab141f0fac245f6",
-            "NameMatches": true,
             "Name": "New HydroponicsTray",
             "LocalPRS": "-174┼66┼0┼"
           },
@@ -331465,7 +331393,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -331475,7 +331403,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-173┼30┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-173┼30┼0┼"
           },
@@ -331688,7 +331615,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -331724,12 +331651,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -331807,14 +331734,12 @@
           {
             "GitID": "c0d35a75ba9aa4c4fab141f0fac245f6_-173┼59┼0┼",
             "PrefabID": "c0d35a75ba9aa4c4fab141f0fac245f6",
-            "NameMatches": true,
             "Name": "New HydroponicsTray",
             "LocalPRS": "-173┼59┼0┼"
           },
           {
             "GitID": "SeedExtractor_-173┼63┼0┼",
             "PrefabID": "SeedExtractor",
-            "NameMatches": true,
             "Name": "New SeedExtractor",
             "LocalPRS": "-173┼63┼0┼",
             "Object": {
@@ -331834,7 +331759,6 @@
           {
             "GitID": "c0d35a75ba9aa4c4fab141f0fac245f6_-173┼66┼0┼",
             "PrefabID": "c0d35a75ba9aa4c4fab141f0fac245f6",
-            "NameMatches": true,
             "Name": "New HydroponicsTray",
             "LocalPRS": "-173┼66┼0┼"
           },
@@ -332110,7 +332034,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -332372,7 +332296,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -332408,12 +332332,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -332423,7 +332347,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-172┼37┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-172┼37┼0┼"
           },
@@ -332580,6 +332503,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Genetics"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -332592,8 +332519,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -332745,7 +332704,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-172┼48┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-172┼48┼0┼"
           },
@@ -332978,7 +332936,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-172┼53┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-172┼53┼0┼"
           },
@@ -333020,7 +332977,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -333030,7 +332987,6 @@
           {
             "GitID": "c0d35a75ba9aa4c4fab141f0fac245f6_-172┼59┼0┼",
             "PrefabID": "c0d35a75ba9aa4c4fab141f0fac245f6",
-            "NameMatches": true,
             "Name": "New HydroponicsTray",
             "LocalPRS": "-172┼59┼0┼"
           },
@@ -333066,7 +333022,6 @@
           {
             "GitID": "c0d35a75ba9aa4c4fab141f0fac245f6_-172┼66┼0┼",
             "PrefabID": "c0d35a75ba9aa4c4fab141f0fac245f6",
-            "NameMatches": true,
             "Name": "New HydroponicsTray",
             "LocalPRS": "-172┼66┼0┼"
           },
@@ -333276,7 +333231,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-172┼71┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-172┼71┼0┼"
           },
@@ -333373,7 +333327,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-172┼85┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-172┼85┼0┼"
           },
@@ -333465,21 +333418,19 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-172┼87┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-172┼87┼0┼"
           },
           {
             "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_-172┼88┼0┼",
             "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
-            "NameMatches": true,
             "Name": "New Department Battery",
             "LocalPRS": "-172┼88┼0┼",
             "Object": {
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -333646,7 +333597,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -333761,7 +333712,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -333883,12 +333834,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -334114,6 +334065,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Hydroponics"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -334211,7 +334166,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -334444,7 +334399,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -334622,6 +334577,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Hydroponics"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -334785,7 +334744,6 @@
           {
             "GitID": "PlantDNAManipulator_-170┼70┼0┼",
             "PrefabID": "PlantDNAManipulator",
-            "NameMatches": true,
             "Name": "New PlantDNAManipulator",
             "LocalPRS": "-170┼70┼0┼"
           },
@@ -334856,7 +334814,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -334953,7 +334911,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -335130,7 +335088,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-169┼51┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-169┼51┼0┼"
           },
@@ -335164,14 +335121,12 @@
           {
             "GitID": "c0d35a75ba9aa4c4fab141f0fac245f6_-169┼60┼0┼",
             "PrefabID": "c0d35a75ba9aa4c4fab141f0fac245f6",
-            "NameMatches": true,
             "Name": "New HydroponicsTray",
             "LocalPRS": "-169┼60┼0┼"
           },
           {
             "GitID": "c0d35a75ba9aa4c4fab141f0fac245f6_-169┼61┼0┼",
             "PrefabID": "c0d35a75ba9aa4c4fab141f0fac245f6",
-            "NameMatches": true,
             "Name": "New HydroponicsTray",
             "LocalPRS": "-169┼61┼0┼"
           },
@@ -335222,7 +335177,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -335232,35 +335187,30 @@
           {
             "GitID": "c0d35a75ba9aa4c4fab141f0fac245f6_-169┼62┼0┼",
             "PrefabID": "c0d35a75ba9aa4c4fab141f0fac245f6",
-            "NameMatches": true,
             "Name": "New HydroponicsTray",
             "LocalPRS": "-169┼62┼0┼"
           },
           {
             "GitID": "c0d35a75ba9aa4c4fab141f0fac245f6_-169┼63┼0┼",
             "PrefabID": "c0d35a75ba9aa4c4fab141f0fac245f6",
-            "NameMatches": true,
             "Name": "New HydroponicsTray",
             "LocalPRS": "-169┼63┼0┼"
           },
           {
             "GitID": "c0d35a75ba9aa4c4fab141f0fac245f6_-169┼64┼0┼",
             "PrefabID": "c0d35a75ba9aa4c4fab141f0fac245f6",
-            "NameMatches": true,
             "Name": "New HydroponicsTray",
             "LocalPRS": "-169┼64┼0┼"
           },
           {
             "GitID": "c0d35a75ba9aa4c4fab141f0fac245f6_-169┼65┼0┼",
             "PrefabID": "c0d35a75ba9aa4c4fab141f0fac245f6",
-            "NameMatches": true,
             "Name": "New HydroponicsTray",
             "LocalPRS": "-169┼65┼0┼"
           },
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-169┼66┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-169┼66┼0┼"
           },
@@ -335957,7 +335907,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -336111,12 +336061,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -336359,7 +336309,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -336410,7 +336360,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -336461,7 +336411,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -336524,7 +336474,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-167┼26┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-167┼26┼0┼"
           },
@@ -336557,12 +336506,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -336572,7 +336521,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-167┼29┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-167┼29┼0┼"
           },
@@ -336725,12 +336673,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -336878,7 +336826,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -336908,7 +336856,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-167┼65┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-167┼65┼0┼"
           },
@@ -337045,7 +336992,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -337158,7 +337105,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -337839,7 +337786,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -338182,7 +338129,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -338240,7 +338187,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -338296,14 +338243,12 @@
           {
             "GitID": "1442b4dd7f8a6714a914b861519721c1_-165┼62┼0┼",
             "PrefabID": "1442b4dd7f8a6714a914b861519721c1",
-            "NameMatches": true,
             "Name": "New Empty Bookshelf",
             "LocalPRS": "-165┼62┼0┼"
           },
           {
             "GitID": "1442b4dd7f8a6714a914b861519721c1_-165┼64┼0┼",
             "PrefabID": "1442b4dd7f8a6714a914b861519721c1",
-            "NameMatches": true,
             "Name": "New Empty Bookshelf",
             "LocalPRS": "-165┼64┼0┼"
           },
@@ -338354,7 +338299,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -338364,7 +338309,6 @@
           {
             "GitID": "1442b4dd7f8a6714a914b861519721c1_-165┼66┼0┼",
             "PrefabID": "1442b4dd7f8a6714a914b861519721c1",
-            "NameMatches": true,
             "Name": "New Empty Bookshelf",
             "LocalPRS": "-165┼66┼0┼"
           },
@@ -338397,12 +338341,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -338456,7 +338400,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -339340,6 +339284,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Xenobiology"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -339453,6 +339401,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Xenobiology"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -339508,7 +339460,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -339620,7 +339572,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -339878,21 +339830,18 @@
           {
             "GitID": "1442b4dd7f8a6714a914b861519721c1_-164┼62┼0┼",
             "PrefabID": "1442b4dd7f8a6714a914b861519721c1",
-            "NameMatches": true,
             "Name": "New Empty Bookshelf",
             "LocalPRS": "-164┼62┼0┼"
           },
           {
             "GitID": "1442b4dd7f8a6714a914b861519721c1_-164┼64┼0┼",
             "PrefabID": "1442b4dd7f8a6714a914b861519721c1",
-            "NameMatches": true,
             "Name": "New Empty Bookshelf",
             "LocalPRS": "-164┼64┼0┼"
           },
           {
             "GitID": "1442b4dd7f8a6714a914b861519721c1_-164┼66┼0┼",
             "PrefabID": "1442b4dd7f8a6714a914b861519721c1",
-            "NameMatches": true,
             "Name": "New Empty Bookshelf",
             "LocalPRS": "-164┼66┼0┼"
           },
@@ -340378,7 +340327,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -340431,6 +340380,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Xenobiology"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -340442,7 +340395,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-163┼16┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-163┼16┼0┼"
           },
@@ -340611,6 +340563,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Xenobiology"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -340622,7 +340578,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-163┼20┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-163┼20┼0┼"
           },
@@ -340791,6 +340746,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Xenobiology"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -340802,7 +340761,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-163┼24┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-163┼24┼0┼"
           },
@@ -340865,7 +340823,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-163┼30┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-163┼30┼0┼"
           },
@@ -341144,6 +341101,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Robotics"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -341607,7 +341568,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -341649,12 +341610,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -341708,7 +341669,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -341869,7 +341830,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-162┼39┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-162┼39┼0┼"
           },
@@ -342552,12 +342512,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -342617,7 +342577,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -342627,21 +342587,19 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-161┼38┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-161┼38┼0┼"
           },
           {
             "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_-161┼39┼0┼",
             "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
-            "NameMatches": true,
             "Name": "New Department Battery",
             "LocalPRS": "-161┼39┼0┼",
             "Object": {
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -342705,12 +342663,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -342746,12 +342704,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -342761,7 +342719,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-161┼47┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-161┼47┼0┼"
           },
@@ -342822,7 +342779,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -342885,7 +342842,6 @@
           {
             "GitID": "1442b4dd7f8a6714a914b861519721c1_-161┼66┼0┼",
             "PrefabID": "1442b4dd7f8a6714a914b861519721c1",
-            "NameMatches": true,
             "Name": "New Empty Bookshelf",
             "LocalPRS": "-161┼66┼0┼"
           },
@@ -343115,7 +343071,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -343151,12 +343107,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -343414,7 +343370,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -343506,7 +343462,6 @@
           {
             "GitID": "cab73e460ee8bf24e88988add17a2be5_-160┼46┼0┼",
             "PrefabID": "cab73e460ee8bf24e88988add17a2be5",
-            "NameMatches": true,
             "Name": "New ConveyorSwitch",
             "LocalPRS": "-160┼46┼0┼"
           },
@@ -343550,7 +343505,6 @@
           {
             "GitID": "cab73e460ee8bf24e88988add17a2be5_-160┼49┼0┼",
             "PrefabID": "cab73e460ee8bf24e88988add17a2be5",
-            "NameMatches": true,
             "Name": "New ConveyorSwitch",
             "LocalPRS": "-160┼49┼0┼"
           },
@@ -343601,7 +343555,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -343648,7 +343602,6 @@
           {
             "GitID": "1442b4dd7f8a6714a914b861519721c1_-160┼66┼0┼",
             "PrefabID": "1442b4dd7f8a6714a914b861519721c1",
-            "NameMatches": true,
             "Name": "New Empty Bookshelf",
             "LocalPRS": "-160┼66┼0┼"
           },
@@ -343736,7 +343689,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -343783,7 +343736,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-160┼72┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-160┼72┼0┼"
           },
@@ -343825,7 +343777,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-159┼14┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-159┼14┼0┼"
           },
@@ -343911,6 +343862,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Xenobiology"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -344064,7 +344019,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-159┼18┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-159┼18┼0┼"
           },
@@ -344150,6 +344104,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Xenobiology"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -344244,7 +344202,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-159┼22┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-159┼22┼0┼"
           },
@@ -344330,6 +344287,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Xenobiology"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -344517,12 +344478,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -344532,7 +344493,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-159┼33┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-159┼33┼0┼"
           },
@@ -344571,12 +344531,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -344630,7 +344590,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -344705,7 +344665,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -344715,7 +344675,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-159┼45┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-159┼45┼0┼"
           },
@@ -344742,7 +344701,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-159┼48┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-159┼48┼0┼"
           },
@@ -344873,7 +344831,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -345680,7 +345638,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-158┼37┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-158┼37┼0┼"
           },
@@ -345786,7 +345743,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-158┼45┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-158┼45┼0┼"
           },
@@ -345800,7 +345756,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-158┼48┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-158┼48┼0┼"
           },
@@ -345943,7 +345898,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -345996,6 +345951,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Library"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -346125,7 +346084,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-158┼73┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-158┼73┼0┼"
           },
@@ -346222,7 +346180,6 @@
           {
             "GitID": "ChemMaster_-157┼26┼0┼",
             "PrefabID": "ChemMaster",
-            "NameMatches": true,
             "Name": "New ChemMaster",
             "LocalPRS": "-157┼26┼0┼"
           },
@@ -346264,7 +346221,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -346274,7 +346231,6 @@
           {
             "GitID": "All-In-One Grinder_-157┼29┼0┼",
             "PrefabID": "All-In-One Grinder",
-            "NameMatches": true,
             "Name": "new All-In-One Grinder",
             "LocalPRS": "-157┼29┼0┼"
           },
@@ -346402,7 +346358,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -346719,7 +346675,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -346729,7 +346685,6 @@
           {
             "GitID": "1442b4dd7f8a6714a914b861519721c1_-157┼66┼0┼",
             "PrefabID": "1442b4dd7f8a6714a914b861519721c1",
-            "NameMatches": true,
             "Name": "New Empty Bookshelf",
             "LocalPRS": "-157┼66┼0┼"
           },
@@ -346808,7 +346763,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -347299,6 +347254,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Robotics"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -347643,7 +347602,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -347707,7 +347666,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -347771,7 +347730,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -348069,7 +348028,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-155┼50┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-155┼50┼0┼"
           },
@@ -348120,7 +348078,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -348156,12 +348114,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -348243,12 +348201,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -348348,7 +348306,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-155┼71┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-155┼71┼0┼"
           },
@@ -349281,6 +349238,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Robotics"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -349785,7 +349746,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -349891,7 +349852,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -350077,12 +350038,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -350136,7 +350097,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -350228,7 +350189,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -350339,12 +350300,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -350354,7 +350315,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-153┼34┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-153┼34┼0┼"
           },
@@ -350405,7 +350365,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -350479,12 +350439,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -350538,7 +350498,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -350700,12 +350660,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -350787,7 +350747,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -350823,12 +350783,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -351131,7 +351091,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-153┼74┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-153┼74┼0┼"
           },
@@ -352011,14 +351970,12 @@
           {
             "GitID": "170e72b76e0da9645995a9bac3f49cb2_-152┼77┼0┼",
             "PrefabID": "170e72b76e0da9645995a9bac3f49cb2",
-            "NameMatches": true,
             "Name": "New SMES",
             "LocalPRS": "-152┼77┼0┼"
           },
           {
             "GitID": "bb684284e149a524d9f53b039e51b806_-152┼78┼0┼",
             "PrefabID": "bb684284e149a524d9f53b039e51b806",
-            "NameMatches": true,
             "Name": "New Medium Machine Connector",
             "LocalPRS": "-152┼78┼0┼"
           },
@@ -352051,7 +352008,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-152┼83┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-152┼83┼0┼"
           },
@@ -352486,7 +352442,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -352680,6 +352636,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "ChapelOffice"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -352804,14 +352764,13 @@
           {
             "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_-151┼83┼0┼",
             "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
-            "NameMatches": true,
             "Name": "New Department Battery",
             "LocalPRS": "-151┼83┼0┼",
             "Object": {
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -352973,7 +352932,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-150┼15┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-150┼15┼0┼"
           },
@@ -353015,7 +352973,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -353116,7 +353074,6 @@
           {
             "GitID": "e6fef14b66545db41939986bb7911c4d_-150┼30┼0┼",
             "PrefabID": "e6fef14b66545db41939986bb7911c4d",
-            "NameMatches": true,
             "Name": "New UnityStationSign",
             "LocalPRS": "-150┼30┼0┼0ø0ø90ø",
             "Object": {
@@ -353582,7 +353539,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-150┼44┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-150┼44┼0┼"
           },
@@ -353925,7 +353881,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -354101,6 +354057,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "ChapelOffice"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -354169,7 +354129,6 @@
           {
             "GitID": "93d1f95a33757fe4fa3e2771e3f5bd67_-150┼83┼0┼",
             "PrefabID": "93d1f95a33757fe4fa3e2771e3f5bd67",
-            "NameMatches": true,
             "Name": "New PowerGeneratorPlasma",
             "LocalPRS": "-150┼83┼0┼"
           },
@@ -354358,7 +354317,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-149┼31┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-149┼31┼0┼"
           },
@@ -354686,7 +354644,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -354733,7 +354691,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-149┼81┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-149┼81┼0┼"
           },
@@ -354982,7 +354939,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -355063,12 +355020,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -355098,7 +355055,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-148┼25┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-148┼25┼0┼"
           },
@@ -355340,7 +355296,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -355661,6 +355617,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Rnd"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -355869,7 +355829,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -356217,7 +356177,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -356511,7 +356471,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -356565,7 +356525,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -356743,12 +356703,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -356790,12 +356750,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -356859,12 +356819,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -356983,7 +356943,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -356993,14 +356953,12 @@
           {
             "GitID": "170e72b76e0da9645995a9bac3f49cb2_-146┼77┼0┼",
             "PrefabID": "170e72b76e0da9645995a9bac3f49cb2",
-            "NameMatches": true,
             "Name": "New SMES",
             "LocalPRS": "-146┼77┼0┼"
           },
           {
             "GitID": "bb684284e149a524d9f53b039e51b806_-146┼78┼0┼",
             "PrefabID": "bb684284e149a524d9f53b039e51b806",
-            "NameMatches": true,
             "Name": "New Medium Machine Connector",
             "LocalPRS": "-146┼78┼0┼"
           },
@@ -357076,7 +357034,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -357252,12 +357210,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -357356,7 +357314,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -357414,7 +357372,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-145┼31┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-145┼31┼0┼"
           },
@@ -357702,7 +357659,6 @@
           {
             "GitID": "e6fef14b66545db41939986bb7911c4d_-145┼57┼0┼",
             "PrefabID": "e6fef14b66545db41939986bb7911c4d",
-            "NameMatches": true,
             "Name": "New UnityStationSign",
             "LocalPRS": "-145┼57┼0┼0ø0ø270ø",
             "Object": {
@@ -358151,12 +358107,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -358248,7 +358204,6 @@
           {
             "GitID": "e6fef14b66545db41939986bb7911c4d_-144.999┼57┼0┼",
             "PrefabID": "e6fef14b66545db41939986bb7911c4d",
-            "NameMatches": true,
             "Name": "New UnityStationSign",
             "LocalPRS": "-144.999┼57┼0┼0ø0ø180ø"
           },
@@ -358357,7 +358312,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -358463,7 +358418,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-144┼18┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-144┼18┼0┼"
           },
@@ -358635,7 +358589,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -358689,7 +358643,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -358711,14 +358665,12 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-144┼43┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-144┼43┼0┼"
           },
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-144┼48┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-144┼48┼0┼"
           },
@@ -358769,7 +358721,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -358805,7 +358757,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-144┼51┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-144┼51┼0┼"
           },
@@ -358856,7 +358807,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -358899,7 +358850,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-144┼58┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-144┼58┼0┼"
           },
@@ -358941,7 +358891,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,3",
+                  "ID": "0,4",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -359145,7 +359095,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -360388,7 +360338,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -360819,7 +360769,6 @@
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_-142┼42┼0┼",
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
-            "NameMatches": true,
             "Name": "New Disposal Bin",
             "LocalPRS": "-142┼42┼0┼"
           },
@@ -360940,12 +360889,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -361410,7 +361359,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -361557,7 +361506,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -361567,7 +361516,6 @@
           {
             "GitID": "Flaps_-141┼47┼0┼",
             "PrefabID": "Flaps",
-            "NameMatches": true,
             "Name": "New Flaps",
             "LocalPRS": "-141┼47┼0┼"
           },
@@ -361672,7 +361620,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -361831,7 +361779,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -361983,7 +361931,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -362077,12 +362025,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -362092,7 +362040,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-140┼34┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-140┼34┼0┼"
           },
@@ -362213,7 +362160,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -362829,12 +362776,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -363153,7 +363100,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -363296,7 +363243,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -363375,14 +363322,13 @@
           {
             "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_-138┼4┼0┼",
             "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
-            "NameMatches": true,
             "Name": "New Department Battery",
             "LocalPRS": "-138┼4┼0┼",
             "Object": {
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -363392,7 +363338,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-138┼5┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-138┼5┼0┼"
           },
@@ -363445,7 +363390,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-138┼7┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-138┼7┼0┼"
           },
@@ -363565,7 +363509,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -363606,6 +363550,12 @@
             "LocalPRS": "-138┼29┼0┼"
           },
           {
+            "GitID": "6381156cbaf58b243a81a5979d2c532b_-138┼34.91┼0┼",
+            "PrefabID": "6381156cbaf58b243a81a5979d2c532b",
+            "Name": "RandomGloves (11)",
+            "LocalPRS": "-138┼34.91┼0┼"
+          },
+          {
             "GitID": "1d35052f4fc2cad4d8226d1a63e4a1b3_-138┼35┼0┼",
             "PrefabID": "1d35052f4fc2cad4d8226d1a63e4a1b3",
             "NameMatches": true,
@@ -363621,12 +363571,6 @@
                 }
               ]
             }
-          },
-          {
-            "GitID": "6381156cbaf58b243a81a5979d2c532b_-138┼36┼0┼",
-            "PrefabID": "6381156cbaf58b243a81a5979d2c532b",
-            "Name": "RandomGloves (11)",
-            "LocalPRS": "-138┼36┼0┼"
           },
           {
             "GitID": "79cea07a5f8e66f49a554df1a003ecba_-138┼41┼0┼",
@@ -363771,12 +363715,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -364115,12 +364059,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -364208,7 +364152,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -364287,7 +364231,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -364398,7 +364342,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -364541,7 +364485,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -364607,7 +364551,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -364742,7 +364686,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-136┼44┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-136┼44┼0┼"
           },
@@ -365407,7 +365350,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -365483,6 +365426,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Rnd"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -365557,12 +365504,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -366004,7 +365951,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -366137,7 +366084,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -366294,7 +366241,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -366413,7 +366360,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -366788,7 +366735,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -366798,7 +366745,6 @@
           {
             "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_-130┼39┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "NameMatches": true,
             "Name": "New Low Machine  Connector Variant",
             "LocalPRS": "-130┼39┼0┼"
           },
@@ -366869,7 +366815,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -366936,7 +366882,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -366972,12 +366918,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -367347,7 +367293,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -367401,7 +367347,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -370393,7 +370339,6 @@
           {
             "GitID": "5dc175b07f639e9439bf9848d50f44ab_37┼-12┼0┼",
             "PrefabID": "5dc175b07f639e9439bf9848d50f44ab",
-            "NameMatches": true,
             "Name": "New Ornamental Shuttle_engine_w",
             "LocalPRS": "37┼-12┼0┼",
             "Object": {
@@ -370413,7 +370358,6 @@
           {
             "GitID": "3877ffa8e067d124ba52802dde6f2d34_37┼-11┼0┼",
             "PrefabID": "3877ffa8e067d124ba52802dde6f2d34",
-            "NameMatches": true,
             "Name": "New Ornamental Shuttle_engine_center",
             "LocalPRS": "37┼-11┼0┼",
             "Object": {
@@ -370433,7 +370377,6 @@
           {
             "GitID": "3877ffa8e067d124ba52802dde6f2d34_37┼-10┼0┼",
             "PrefabID": "3877ffa8e067d124ba52802dde6f2d34",
-            "NameMatches": true,
             "Name": "New Ornamental Shuttle_engine_center",
             "LocalPRS": "37┼-10┼0┼",
             "Object": {
@@ -370453,7 +370396,6 @@
           {
             "GitID": "3877ffa8e067d124ba52802dde6f2d34_37┼-9┼0┼",
             "PrefabID": "3877ffa8e067d124ba52802dde6f2d34",
-            "NameMatches": true,
             "Name": "New Ornamental Shuttle_engine_center",
             "LocalPRS": "37┼-9┼0┼",
             "Object": {
@@ -370473,7 +370415,6 @@
           {
             "GitID": "3877ffa8e067d124ba52802dde6f2d34_37┼-8┼0┼",
             "PrefabID": "3877ffa8e067d124ba52802dde6f2d34",
-            "NameMatches": true,
             "Name": "New Ornamental Shuttle_engine_center",
             "LocalPRS": "37┼-8┼0┼",
             "Object": {
@@ -370493,7 +370434,6 @@
           {
             "GitID": "3877ffa8e067d124ba52802dde6f2d34_37┼-7┼0┼",
             "PrefabID": "3877ffa8e067d124ba52802dde6f2d34",
-            "NameMatches": true,
             "Name": "New Ornamental Shuttle_engine_center",
             "LocalPRS": "37┼-7┼0┼",
             "Object": {
@@ -370513,7 +370453,6 @@
           {
             "GitID": "61ed2c97b2f99834bbf58cd765b4c8c7_37┼-6┼0┼",
             "PrefabID": "61ed2c97b2f99834bbf58cd765b4c8c7",
-            "NameMatches": true,
             "Name": "New Ornamental Shuttle_engine_E",
             "LocalPRS": "37┼-6┼0┼",
             "Object": {
@@ -370533,7 +370472,6 @@
           {
             "GitID": "4825f602d82135245a7d68a4b493f90b_38┼-12┼0┼",
             "PrefabID": "4825f602d82135245a7d68a4b493f90b",
-            "NameMatches": true,
             "Name": "New Ornamental ShuttleHeater",
             "LocalPRS": "38┼-12┼0┼",
             "Object": {
@@ -370553,7 +370491,6 @@
           {
             "GitID": "4825f602d82135245a7d68a4b493f90b_38┼-11┼0┼",
             "PrefabID": "4825f602d82135245a7d68a4b493f90b",
-            "NameMatches": true,
             "Name": "New Ornamental ShuttleHeater",
             "LocalPRS": "38┼-11┼0┼",
             "Object": {
@@ -370573,7 +370510,6 @@
           {
             "GitID": "4825f602d82135245a7d68a4b493f90b_38┼-10┼0┼",
             "PrefabID": "4825f602d82135245a7d68a4b493f90b",
-            "NameMatches": true,
             "Name": "New Ornamental ShuttleHeater",
             "LocalPRS": "38┼-10┼0┼",
             "Object": {
@@ -370593,7 +370529,6 @@
           {
             "GitID": "4825f602d82135245a7d68a4b493f90b_38┼-9┼0┼",
             "PrefabID": "4825f602d82135245a7d68a4b493f90b",
-            "NameMatches": true,
             "Name": "New Ornamental ShuttleHeater",
             "LocalPRS": "38┼-9┼0┼",
             "Object": {
@@ -370613,7 +370548,6 @@
           {
             "GitID": "4825f602d82135245a7d68a4b493f90b_38┼-8┼0┼",
             "PrefabID": "4825f602d82135245a7d68a4b493f90b",
-            "NameMatches": true,
             "Name": "New Ornamental ShuttleHeater",
             "LocalPRS": "38┼-8┼0┼",
             "Object": {
@@ -370633,7 +370567,6 @@
           {
             "GitID": "4825f602d82135245a7d68a4b493f90b_38┼-7┼0┼",
             "PrefabID": "4825f602d82135245a7d68a4b493f90b",
-            "NameMatches": true,
             "Name": "New Ornamental ShuttleHeater",
             "LocalPRS": "38┼-7┼0┼",
             "Object": {
@@ -370653,7 +370586,6 @@
           {
             "GitID": "4825f602d82135245a7d68a4b493f90b_38┼-6┼0┼",
             "PrefabID": "4825f602d82135245a7d68a4b493f90b",
-            "NameMatches": true,
             "Name": "New Ornamental ShuttleHeater",
             "LocalPRS": "38┼-6┼0┼",
             "Object": {
@@ -370734,7 +370666,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -370823,7 +370755,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -370896,7 +370828,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -371424,7 +371356,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -372125,7 +372057,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -372239,7 +372171,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -372519,7 +372451,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -372573,7 +372505,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -373086,7 +373018,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -374010,7 +373942,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -374020,7 +373952,6 @@
           {
             "GitID": "cab73e460ee8bf24e88988add17a2be5_-3┼3┼0┼",
             "PrefabID": "cab73e460ee8bf24e88988add17a2be5",
-            "NameMatches": true,
             "Name": "New ConveyorSwitch",
             "LocalPRS": "-3┼3┼0┼",
             "Object": {
@@ -374044,7 +373975,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-3┼4┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-3┼4┼0┼",
             "Object": {
@@ -374064,7 +373994,6 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_-3┼5┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "-3┼5┼0┼",
             "Object": {
@@ -374130,14 +374059,12 @@
           {
             "GitID": "61ed2c97b2f99834bbf58cd765b4c8c7_-2┼-6┼0┼",
             "PrefabID": "61ed2c97b2f99834bbf58cd765b4c8c7",
-            "NameMatches": true,
             "Name": "New Ornamental Shuttle_engine_E",
             "LocalPRS": "-2┼-6┼0┼"
           },
           {
             "GitID": "4825f602d82135245a7d68a4b493f90b_-2┼-5┼0┼",
             "PrefabID": "4825f602d82135245a7d68a4b493f90b",
-            "NameMatches": true,
             "Name": "New Ornamental ShuttleHeater",
             "LocalPRS": "-2┼-5┼0┼",
             "Object": {
@@ -374193,14 +374120,12 @@
           {
             "GitID": "3877ffa8e067d124ba52802dde6f2d34_-1┼-6┼0┼",
             "PrefabID": "3877ffa8e067d124ba52802dde6f2d34",
-            "NameMatches": true,
             "Name": "New Ornamental Shuttle_engine_center",
             "LocalPRS": "-1┼-6┼0┼"
           },
           {
             "GitID": "4825f602d82135245a7d68a4b493f90b_-1┼-5┼0┼",
             "PrefabID": "4825f602d82135245a7d68a4b493f90b",
-            "NameMatches": true,
             "Name": "New Ornamental ShuttleHeater",
             "LocalPRS": "-1┼-5┼0┼",
             "Object": {
@@ -374255,7 +374180,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -374271,14 +374196,12 @@
           {
             "GitID": "5dc175b07f639e9439bf9848d50f44ab_0┼-6┼0┼",
             "PrefabID": "5dc175b07f639e9439bf9848d50f44ab",
-            "NameMatches": true,
             "Name": "New Ornamental Shuttle_engine_w",
             "LocalPRS": "0┼-6┼0┼"
           },
           {
             "GitID": "4825f602d82135245a7d68a4b493f90b_0┼-5┼0┼",
             "PrefabID": "4825f602d82135245a7d68a4b493f90b",
-            "NameMatches": true,
             "Name": "New Ornamental ShuttleHeater",
             "LocalPRS": "0┼-5┼0┼",
             "Object": {
@@ -374405,7 +374328,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -374415,7 +374338,6 @@
           {
             "GitID": "cab73e460ee8bf24e88988add17a2be5_1┼3┼0┼",
             "PrefabID": "cab73e460ee8bf24e88988add17a2be5",
-            "NameMatches": true,
             "Name": "New ConveyorSwitch",
             "LocalPRS": "1┼3┼0┼",
             "Object": {
@@ -374439,14 +374361,12 @@
           {
             "GitID": "856296105f077014ca9e533266df237a_1┼4┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "1┼4┼0┼"
           },
           {
             "GitID": "856296105f077014ca9e533266df237a_1┼5┼0┼",
             "PrefabID": "856296105f077014ca9e533266df237a",
-            "NameMatches": true,
             "Name": "New ConveyorBelt",
             "LocalPRS": "1┼5┼0┼"
           },
@@ -375190,7 +375110,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -375348,7 +375268,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -376154,7 +376074,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -376318,7 +376238,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -377123,7 +377043,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -377287,7 +377207,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -378092,7 +378012,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -378250,7 +378170,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -379579,7 +379499,6 @@
           {
             "GitID": "5dc175b07f639e9439bf9848d50f44ab_-5┼-1┼0┼",
             "PrefabID": "5dc175b07f639e9439bf9848d50f44ab",
-            "NameMatches": true,
             "Name": "New Ornamental Shuttle_engine_w",
             "LocalPRS": "-5┼-1┼0┼",
             "Object": {
@@ -379599,7 +379518,6 @@
           {
             "GitID": "3877ffa8e067d124ba52802dde6f2d34_-5┼0┼0┼",
             "PrefabID": "3877ffa8e067d124ba52802dde6f2d34",
-            "NameMatches": true,
             "Name": "New Ornamental Shuttle_engine_center",
             "LocalPRS": "-5┼0┼0┼",
             "Object": {
@@ -379619,7 +379537,6 @@
           {
             "GitID": "61ed2c97b2f99834bbf58cd765b4c8c7_-5┼1┼0┼",
             "PrefabID": "61ed2c97b2f99834bbf58cd765b4c8c7",
-            "NameMatches": true,
             "Name": "New Ornamental Shuttle_engine_E",
             "LocalPRS": "-5┼1┼0┼",
             "Object": {
@@ -379639,7 +379556,6 @@
           {
             "GitID": "4825f602d82135245a7d68a4b493f90b_-4┼-1┼0┼",
             "PrefabID": "4825f602d82135245a7d68a4b493f90b",
-            "NameMatches": true,
             "Name": "New Ornamental ShuttleHeater",
             "LocalPRS": "-4┼-1┼0┼",
             "Object": {
@@ -379659,7 +379575,6 @@
           {
             "GitID": "4825f602d82135245a7d68a4b493f90b_-4┼0┼0┼",
             "PrefabID": "4825f602d82135245a7d68a4b493f90b",
-            "NameMatches": true,
             "Name": "New Ornamental ShuttleHeater",
             "LocalPRS": "-4┼0┼0┼",
             "Object": {
@@ -379679,7 +379594,6 @@
           {
             "GitID": "4825f602d82135245a7d68a4b493f90b_-4┼1┼0┼",
             "PrefabID": "4825f602d82135245a7d68a4b493f90b",
-            "NameMatches": true,
             "Name": "New Ornamental ShuttleHeater",
             "LocalPRS": "-4┼1┼0┼",
             "Object": {
@@ -379750,7 +379664,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -380444,7 +380358,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -380681,7 +380595,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -380908,7 +380822,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/OutpostStation.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/OutpostStation.json
@@ -31790,10 +31790,13 @@
             "Key": "X22Y46",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "WindowReinforced"
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "Grille"
               }
             ]
           },
@@ -41259,6 +41262,9 @@
               {
                 "Tel": "NS-Low_Voltage_Cable",
                 "Z": 1
+              },
+              {
+                "Tel": "NE-Low_Voltage_Cable"
               }
             ]
           },
@@ -42856,6 +42862,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "WE-Low_Voltage_Cable",
+                "Z": 1
               }
             ]
           },
@@ -44820,7 +44830,7 @@
             "Key": "X32Y15",
             "Value": [
               {
-                "Tel": "whitepurple_2"
+                "Tel": "whitepurple_4"
               },
               {
                 "Tel": "Plating"
@@ -44852,10 +44862,14 @@
             "Key": "X32Y17",
             "Value": [
               {
-                "Tel": "whitepurple_2"
+                "Tel": "white"
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "WE-Low_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "FluidStraightPipe",
@@ -44868,7 +44882,7 @@
             "Key": "X32Y18",
             "Value": [
               {
-                "Tel": "whitepurple_2"
+                "Tel": "white"
               },
               {
                 "Tel": "Plating"
@@ -46759,28 +46773,6 @@
             "Key": "X33Y16",
             "Value": [
               {
-                "Tel": "ReinforcedWall"
-              },
-              {
-                "Tel": "Plating"
-              }
-            ]
-          },
-          {
-            "Key": "X33Y17",
-            "Value": [
-              {
-                "Tel": "ReinforcedWall"
-              },
-              {
-                "Tel": "Plating"
-              }
-            ]
-          },
-          {
-            "Key": "X33Y18",
-            "Value": [
-              {
                 "Tel": "WindowReinforced"
               },
               {
@@ -46788,6 +46780,32 @@
               },
               {
                 "Tel": "Grille"
+              }
+            ]
+          },
+          {
+            "Key": "X33Y17",
+            "Value": [
+              {
+                "Tel": "white"
+              },
+              {
+                "Tel": "Plating"
+              },
+              {
+                "Tel": "WE-Low_Voltage_Cable",
+                "Z": 1
+              }
+            ]
+          },
+          {
+            "Key": "X33Y18",
+            "Value": [
+              {
+                "Tel": "white"
+              },
+              {
+                "Tel": "Plating"
               }
             ]
           },
@@ -46809,13 +46827,10 @@
             "Key": "X33Y20",
             "Value": [
               {
-                "Tel": "WindowReinforced"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
-              },
-              {
-                "Tel": "Grille"
               }
             ]
           },
@@ -46823,13 +46838,10 @@
             "Key": "X33Y21",
             "Value": [
               {
-                "Tel": "WindowReinforced"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
-              },
-              {
-                "Tel": "Grille"
               }
             ]
           },
@@ -48497,7 +48509,44 @@
             "Key": "X34Y15",
             "Value": [
               {
-                "Tel": "Lattice"
+                "Tel": "whitepurple_5"
+              },
+              {
+                "Tel": "Plating"
+              },
+              {
+                "Tel": "NE-Low_Voltage_Cable",
+                "Z": 1
+              }
+            ]
+          },
+          {
+            "Key": "X34Y16",
+            "Value": [
+              {
+                "Tel": "white"
+              },
+              {
+                "Tel": "Plating"
+              },
+              {
+                "Tel": "NS-Low_Voltage_Cable",
+                "Z": 1
+              }
+            ]
+          },
+          {
+            "Key": "X34Y17",
+            "Value": [
+              {
+                "Tel": "white"
+              },
+              {
+                "Tel": "Plating"
+              },
+              {
+                "Tel": "SW-Low_Voltage_Cable",
+                "Z": 1
               }
             ]
           },
@@ -48505,7 +48554,10 @@
             "Key": "X34Y18",
             "Value": [
               {
-                "Tel": "Lattice"
+                "Tel": "white"
+              },
+              {
+                "Tel": "Plating"
               }
             ]
           },
@@ -48513,7 +48565,10 @@
             "Key": "X34Y19",
             "Value": [
               {
-                "Tel": "Lattice"
+                "Tel": "white"
+              },
+              {
+                "Tel": "Plating"
               }
             ]
           },
@@ -48521,7 +48576,10 @@
             "Key": "X34Y20",
             "Value": [
               {
-                "Tel": "Lattice"
+                "Tel": "whitepurple_7"
+              },
+              {
+                "Tel": "Plating"
               }
             ]
           },
@@ -49978,7 +50036,14 @@
             "Key": "X35Y15",
             "Value": [
               {
-                "Tel": "Lattice"
+                "Tel": "white"
+              },
+              {
+                "Tel": "Plating"
+              },
+              {
+                "Tel": "WO-Low_Voltage_Cable",
+                "Z": 1
               }
             ]
           },
@@ -49986,7 +50051,10 @@
             "Key": "X35Y16",
             "Value": [
               {
-                "Tel": "Lattice"
+                "Tel": "white"
+              },
+              {
+                "Tel": "Plating"
               }
             ]
           },
@@ -49994,7 +50062,10 @@
             "Key": "X35Y17",
             "Value": [
               {
-                "Tel": "Lattice"
+                "Tel": "white"
+              },
+              {
+                "Tel": "Plating"
               }
             ]
           },
@@ -50002,7 +50073,10 @@
             "Key": "X35Y18",
             "Value": [
               {
-                "Tel": "Lattice"
+                "Tel": "white"
+              },
+              {
+                "Tel": "Plating"
               }
             ]
           },
@@ -50010,7 +50084,10 @@
             "Key": "X35Y19",
             "Value": [
               {
-                "Tel": "Lattice"
+                "Tel": "white"
+              },
+              {
+                "Tel": "Plating"
               }
             ]
           },
@@ -50018,7 +50095,10 @@
             "Key": "X35Y20",
             "Value": [
               {
-                "Tel": "Lattice"
+                "Tel": "white"
+              },
+              {
+                "Tel": "Plating"
               }
             ]
           },
@@ -51538,7 +51618,10 @@
             "Key": "X36Y15",
             "Value": [
               {
-                "Tel": "Lattice"
+                "Tel": "whitepurple_4"
+              },
+              {
+                "Tel": "Plating"
               }
             ]
           },
@@ -51546,7 +51629,10 @@
             "Key": "X36Y16",
             "Value": [
               {
-                "Tel": "Lattice"
+                "Tel": "white"
+              },
+              {
+                "Tel": "Plating"
               }
             ]
           },
@@ -51554,7 +51640,16 @@
             "Key": "X36Y17",
             "Value": [
               {
-                "Tel": "Lattice"
+                "Tel": "white"
+              },
+              {
+                "Tel": "Plating"
+              },
+              {
+                "Tel": "FluidStraightPipe",
+                "Z": 1,
+                "Col": "#0057FFFF",
+                "Tf": "5.960464E-08,-0.9999999,0,0,0.9999999,5.960464E-08,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -51562,7 +51657,16 @@
             "Key": "X36Y18",
             "Value": [
               {
-                "Tel": "Lattice"
+                "Tel": "white"
+              },
+              {
+                "Tel": "Plating"
+              },
+              {
+                "Tel": "FluidStraightPipe",
+                "Z": 1,
+                "Col": "#FF0031FF",
+                "Tf": "5.960464E-08,-0.9999999,0,0,0.9999999,5.960464E-08,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -51570,7 +51674,7 @@
             "Key": "X36Y19",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "white"
               },
               {
                 "Tel": "Plating"
@@ -51581,7 +51685,7 @@
             "Key": "X36Y20",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "whitepurple_6"
               },
               {
                 "Tel": "Plating"
@@ -53050,7 +53154,7 @@
             "Key": "X37Y15",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -53061,7 +53165,7 @@
             "Key": "X37Y16",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -53072,13 +53176,16 @@
             "Key": "X37Y17",
             "Value": [
               {
-                "Tel": "WindowReinforced"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
               },
               {
-                "Tel": "Grille"
+                "Tel": "FluidStraightPipe",
+                "Z": 1,
+                "Col": "#0057FFFF",
+                "Tf": "5.960464E-08,-0.9999999,0,0,0.9999999,5.960464E-08,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -53086,13 +53193,16 @@
             "Key": "X37Y18",
             "Value": [
               {
-                "Tel": "WindowReinforced"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
               },
               {
-                "Tel": "Grille"
+                "Tel": "FluidStraightPipe",
+                "Z": 1,
+                "Col": "#FF0031FF",
+                "Tf": "5.960464E-08,-0.9999999,0,0,0.9999999,5.960464E-08,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -53100,7 +53210,7 @@
             "Key": "X37Y19",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -53111,6 +53221,9 @@
             "Key": "X37Y20",
             "Value": [
               {
+                "Tel": "ReinforcedWall"
+              },
+              {
                 "Tel": "Plating"
               }
             ]
@@ -53118,6 +53231,9 @@
           {
             "Key": "X37Y21",
             "Value": [
+              {
+                "Tel": "ReinforcedWall"
+              },
               {
                 "Tel": "Plating"
               }
@@ -53144,7 +53260,7 @@
             "Key": "X37Y23",
             "Value": [
               {
-                "Tel": "whitered_2"
+                "Tel": "white"
               },
               {
                 "Tel": "Plating"
@@ -54577,9 +54693,10 @@
                 "Tel": "Plating"
               },
               {
-                "Tel": "FluidStraightPipe",
+                "Tel": "3WayManifold",
                 "Z": 1,
-                "Col": "#0057FFFF"
+                "Col": "#0057FFFF",
+                "Tf": "5.960464E-08,-0.9999999,0,0,0.9999999,5.960464E-08,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -54593,6 +54710,11 @@
                 "Tel": "FluidStraightPipe",
                 "Z": 1,
                 "Col": "#0057FFFF"
+              },
+              {
+                "Tel": "FluidStraightPipe",
+                "Col": "#FF0031FF",
+                "Tf": "5.960464E-08,-0.9999999,0,0,0.9999999,5.960464E-08,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -54658,9 +54780,6 @@
           {
             "Key": "X38Y23",
             "Value": [
-              {
-                "Tel": "ReinforcedWall"
-              },
               {
                 "Tel": "Plating"
               },
@@ -56149,6 +56268,12 @@
             "Value": [
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "FluidStraightPipe",
+                "Z": 1,
+                "Col": "#FF0031FF",
+                "Tf": "5.960464E-08,-0.9999999,0,0,0.9999999,5.960464E-08,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -57685,9 +57810,10 @@
                 "Tel": "Plating"
               },
               {
-                "Tel": "FluidStraightPipe",
+                "Tel": "3WayManifold",
                 "Z": 1,
-                "Col": "#FF0031FF"
+                "Col": "#FF0031FF",
+                "Tf": "5.960464E-08,-0.9999999,0,0,0.9999999,5.960464E-08,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -79577,13 +79703,13 @@
             "Key": "X53Y72",
             "Value": [
               {
-                "Tel": "Wall"
-              },
-              {
-                "Tel": "whiteblue_3"
+                "Tel": "WindowReinforced"
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "Grille"
               },
               {
                 "Tel": "FluidStraightPipe",
@@ -79608,13 +79734,13 @@
             "Key": "X53Y74",
             "Value": [
               {
-                "Tel": "Wall"
-              },
-              {
-                "Tel": "whiteblue_3"
+                "Tel": "WindowReinforced"
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "Grille"
               }
             ]
           },
@@ -81432,13 +81558,13 @@
             "Key": "X54Y72",
             "Value": [
               {
-                "Tel": "Wall"
-              },
-              {
-                "Tel": "white"
+                "Tel": "WindowReinforced"
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "Grille"
               },
               {
                 "Tel": "NS-Low_Voltage_Cable",
@@ -81470,13 +81596,13 @@
             "Key": "X54Y74",
             "Value": [
               {
-                "Tel": "Wall"
-              },
-              {
-                "Tel": "white"
+                "Tel": "WindowReinforced"
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "Grille"
               },
               {
                 "Tel": "NS-Low_Voltage_Cable",
@@ -81646,9 +81772,6 @@
           {
             "Key": "X54Y88",
             "Value": [
-              {
-                "Tel": "ReinforcedWall"
-              },
               {
                 "Tel": "Plating"
               },
@@ -83140,13 +83263,13 @@
             "Key": "X55Y72",
             "Value": [
               {
-                "Tel": "Wall"
-              },
-              {
-                "Tel": "white"
+                "Tel": "WindowReinforced"
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "Grille"
               },
               {
                 "Tel": "FluidStraightPipe",
@@ -83171,13 +83294,13 @@
             "Key": "X55Y74",
             "Value": [
               {
-                "Tel": "Wall"
-              },
-              {
-                "Tel": "white"
+                "Tel": "WindowReinforced"
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "Grille"
               }
             ]
           },
@@ -83336,7 +83459,7 @@
                 "Tel": "Plating"
               },
               {
-                "Tel": "EO-Low_Voltage_Cable",
+                "Tel": "NE-Low_Voltage_Cable",
                 "Z": 1
               }
             ]
@@ -83345,10 +83468,11 @@
             "Key": "X55Y88",
             "Value": [
               {
-                "Tel": "ReinforcedWall"
+                "Tel": "Plating"
               },
               {
-                "Tel": "Plating"
+                "Tel": "SO-Low_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "FluidStraightPipe",
@@ -83362,7 +83486,7 @@
             "Key": "X55Y89",
             "Value": [
               {
-                "Tel": "dark"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -84561,9 +84685,6 @@
             "Key": "X56Y48",
             "Value": [
               {
-                "Tel": "darkredfull"
-              },
-              {
                 "Tel": "Plating"
               },
               {
@@ -84578,9 +84699,6 @@
           {
             "Key": "X56Y49",
             "Value": [
-              {
-                "Tel": "darkredfull"
-              },
               {
                 "Tel": "Plating"
               },
@@ -84909,12 +85027,6 @@
               },
               {
                 "Tel": "Plating"
-              },
-              {
-                "Tel": "FluidStraightPipe",
-                "Z": 1,
-                "Col": "#FF0031FF",
-                "Tf": "5.960464E-08,-0.9999999,0,0,0.9999999,5.960464E-08,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -85097,9 +85209,6 @@
           {
             "Key": "X56Y88",
             "Value": [
-              {
-                "Tel": "ReinforcedWall"
-              },
               {
                 "Tel": "Plating"
               },
@@ -86304,9 +86413,6 @@
           {
             "Key": "X57Y48",
             "Value": [
-              {
-                "Tel": "darkredfull"
-              },
               {
                 "Tel": "Plating"
               },
@@ -88767,9 +88873,6 @@
           {
             "Key": "X58Y94",
             "Value": [
-              {
-                "Tel": "Wall"
-              },
               {
                 "Tel": "dark"
               },
@@ -99394,7 +99497,7 @@
             "Key": "X64Y77",
             "Value": [
               {
-                "Tel": "whiteblue_2"
+                "Tel": "white"
               },
               {
                 "Tel": "Plating"
@@ -99409,7 +99512,7 @@
             "Key": "X64Y78",
             "Value": [
               {
-                "Tel": "whiteblue_2"
+                "Tel": "white"
               },
               {
                 "Tel": "Plating"
@@ -101065,7 +101168,13 @@
             "Key": "X65Y75",
             "Value": [
               {
+                "Tel": "WindowReinforced"
+              },
+              {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "Grille"
               },
               {
                 "Tel": "WE-Low_Voltage_Cable",
@@ -101077,17 +101186,6 @@
             "Key": "X65Y76",
             "Value": [
               {
-                "Tel": "Wall"
-              },
-              {
-                "Tel": "Plating"
-              }
-            ]
-          },
-          {
-            "Key": "X65Y77",
-            "Value": [
-              {
                 "Tel": "WindowReinforced"
               },
               {
@@ -101095,6 +101193,17 @@
               },
               {
                 "Tel": "Grille"
+              }
+            ]
+          },
+          {
+            "Key": "X65Y77",
+            "Value": [
+              {
+                "Tel": "white"
+              },
+              {
+                "Tel": "Plating"
               },
               {
                 "Tel": "WE-Low_Voltage_Cable",
@@ -103010,6 +103119,9 @@
             "Key": "X66Y75",
             "Value": [
               {
+                "Tel": "white"
+              },
+              {
                 "Tel": "Plating"
               },
               {
@@ -103022,7 +103134,7 @@
             "Key": "X66Y76",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "white"
               },
               {
                 "Tel": "Plating"
@@ -103033,7 +103145,7 @@
             "Key": "X66Y77",
             "Value": [
               {
-                "Tel": "whiteblue_0"
+                "Tel": "white"
               },
               {
                 "Tel": "Plating"
@@ -104934,6 +105046,9 @@
             "Key": "X67Y75",
             "Value": [
               {
+                "Tel": "white"
+              },
+              {
                 "Tel": "Plating"
               },
               {
@@ -104946,7 +105061,7 @@
             "Key": "X67Y76",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "white"
               },
               {
                 "Tel": "Plating"
@@ -104957,13 +105072,13 @@
             "Key": "X67Y77",
             "Value": [
               {
-                "Tel": "whiteblue_0"
+                "Tel": "white"
               },
               {
                 "Tel": "Plating"
               },
               {
-                "Tel": "WO-Low_Voltage_Cable",
+                "Tel": "WE-Low_Voltage_Cable",
                 "Z": 1
               }
             ]
@@ -106860,6 +106975,9 @@
             "Key": "X68Y75",
             "Value": [
               {
+                "Tel": "white"
+              },
+              {
                 "Tel": "Plating"
               },
               {
@@ -106875,7 +106993,7 @@
             "Key": "X68Y76",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "white"
               },
               {
                 "Tel": "Plating"
@@ -106890,10 +107008,14 @@
             "Key": "X68Y77",
             "Value": [
               {
-                "Tel": "whiteblue_0"
+                "Tel": "white"
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "NW-Low_Voltage_Cable",
+                "Z": 1
               }
             ]
           },
@@ -106905,6 +107027,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "NS-Low_Voltage_Cable",
+                "Z": 1
               }
             ]
           },
@@ -106916,6 +107042,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "SO-Low_Voltage_Cable",
+                "Z": 1
               },
               {
                 "Tel": "FluidStraightPipe",
@@ -108841,6 +108971,9 @@
             "Key": "X69Y75",
             "Value": [
               {
+                "Tel": "Wall"
+              },
+              {
                 "Tel": "Plating"
               },
               {
@@ -108868,7 +109001,7 @@
             "Key": "X69Y77",
             "Value": [
               {
-                "Tel": "whiteblue_0"
+                "Tel": "Wall"
               },
               {
                 "Tel": "Plating"
@@ -108879,7 +109012,7 @@
             "Key": "X69Y78",
             "Value": [
               {
-                "Tel": "white"
+                "Tel": "Wall"
               },
               {
                 "Tel": "Plating"
@@ -110806,7 +110939,7 @@
                 "Tel": "Plating"
               },
               {
-                "Tel": "WO-Low_Voltage_Cable",
+                "Tel": "WE-Low_Voltage_Cable",
                 "Z": 1
               }
             ]
@@ -110814,9 +110947,6 @@
           {
             "Key": "X70Y76",
             "Value": [
-              {
-                "Tel": "Wall"
-              },
               {
                 "Tel": "Plating"
               },
@@ -110829,9 +110959,6 @@
           {
             "Key": "X70Y77",
             "Value": [
-              {
-                "Tel": "Wall"
-              },
               {
                 "Tel": "Plating"
               }
@@ -113024,6 +113151,10 @@
             "Value": [
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "NO-Low_Voltage_Cable",
+                "Z": 1
               }
             ]
           },
@@ -113032,6 +113163,10 @@
             "Value": [
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "SW-Low_Voltage_Cable",
+                "Z": 1
               }
             ]
           },
@@ -113050,12 +113185,6 @@
           {
             "Key": "X71Y77",
             "Value": [
-              {
-                "Tel": "Wall"
-              },
-              {
-                "Tel": "white"
-              },
               {
                 "Tel": "Plating"
               }
@@ -125551,7 +125680,7 @@
             "Key": "X76Y128",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -125562,7 +125691,7 @@
             "Key": "X76Y129",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -125573,7 +125702,7 @@
             "Key": "X76Y130",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -125584,7 +125713,7 @@
             "Key": "X76Y131",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -127666,7 +127795,7 @@
             "Key": "X77Y128",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -127699,7 +127828,7 @@
             "Key": "X77Y131",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -127710,7 +127839,7 @@
             "Key": "X77Y132",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -131793,13 +131922,10 @@
             "Key": "X79Y132",
             "Value": [
               {
-                "Tel": "WindowReinforced"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
-              },
-              {
-                "Tel": "Grille"
               }
             ]
           },
@@ -133666,7 +133792,7 @@
             "Key": "X80Y128",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -133715,7 +133841,7 @@
             "Key": "X80Y132",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -135339,7 +135465,7 @@
             "Key": "X81Y128",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -135350,7 +135476,7 @@
             "Key": "X81Y129",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -135361,7 +135487,7 @@
             "Key": "X81Y130",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -135372,7 +135498,7 @@
             "Key": "X81Y131",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -135383,7 +135509,7 @@
             "Key": "X81Y132",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -164910,13 +165036,10 @@
             "Key": "X100Y58",
             "Value": [
               {
-                "Tel": "WindowReinforced"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
-              },
-              {
-                "Tel": "Grille"
               }
             ]
           },
@@ -165052,6 +165175,12 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "FluidBentPipe",
+                "Z": 1,
+                "Col": "#0057FFFF",
+                "Tf": "5.960464E-08,-0.9999999,0,0,0.9999999,5.960464E-08,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -165063,6 +165192,11 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "FluidStraightPipe",
+                "Z": 1,
+                "Col": "#0057FFFF"
               }
             ]
           },
@@ -165074,6 +165208,11 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "FluidStraightPipe",
+                "Z": 1,
+                "Col": "#0057FFFF"
               }
             ]
           },
@@ -165088,6 +165227,10 @@
                 "Z": 1,
                 "Col": "#FF0031FF",
                 "Tf": "5.960464E-08,-0.9999999,0,0,0.9999999,5.960464E-08,0,0,0,0,1,0,0,0,0,1"
+              },
+              {
+                "Tel": "FluidStraightPipe",
+                "Col": "#0057FFFF"
               }
             ]
           },
@@ -165098,10 +165241,10 @@
                 "Tel": "Plating"
               },
               {
-                "Tel": "FluidStraightPipe",
+                "Tel": "3WayManifold",
                 "Z": 1,
                 "Col": "#0057FFFF",
-                "Tf": "5.960464E-08,-0.9999999,0,0,0.9999999,5.960464E-08,0,0,0,0,1,0,0,0,0,1"
+                "Tf": "-1,8.742278E-08,0,0,-8.742278E-08,-1,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -166356,9 +166499,6 @@
             "Key": "X101Y57",
             "Value": [
               {
-                "Tel": "Floor"
-              },
-              {
                 "Tel": "Plating"
               },
               {
@@ -166370,9 +166510,6 @@
           {
             "Key": "X101Y58",
             "Value": [
-              {
-                "Tel": "Floor"
-              },
               {
                 "Tel": "Plating"
               },
@@ -166478,7 +166615,7 @@
             "Key": "X101Y64",
             "Value": [
               {
-                "Tel": "Floor"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -166552,6 +166689,11 @@
                 "Tel": "FluidStraightPipe",
                 "Z": 1,
                 "Col": "#FF0031FF"
+              },
+              {
+                "Tel": "FluidStraightPipe",
+                "Col": "#0057FFFF",
+                "Tf": "5.960464E-08,-0.9999999,0,0,0.9999999,5.960464E-08,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -167929,9 +168071,6 @@
             "Key": "X102Y57",
             "Value": [
               {
-                "Tel": "ReinforcedWall"
-              },
-              {
                 "Tel": "Plating"
               }
             ]
@@ -167940,7 +168079,7 @@
             "Key": "X102Y58",
             "Value": [
               {
-                "Tel": "Floor"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -167963,7 +168102,7 @@
                 "Tel": "Plating"
               },
               {
-                "Tel": "NW-Medium_Voltage_Cable",
+                "Tel": "WE-Medium_Voltage_Cable",
                 "Z": 1
               }
             ]
@@ -167976,10 +168115,6 @@
               },
               {
                 "Tel": "Plating"
-              },
-              {
-                "Tel": "NS-Medium_Voltage_Cable",
-                "Z": 1
               }
             ]
           },
@@ -167991,10 +168126,6 @@
               },
               {
                 "Tel": "Plating"
-              },
-              {
-                "Tel": "NS-Medium_Voltage_Cable",
-                "Z": 1
               }
             ]
           },
@@ -168010,9 +168141,6 @@
               {
                 "Tel": "WE-Low_Voltage_Cable",
                 "Z": 1
-              },
-              {
-                "Tel": "NS-Medium_Voltage_Cable"
               }
             ]
           },
@@ -168024,10 +168152,6 @@
               },
               {
                 "Tel": "Plating"
-              },
-              {
-                "Tel": "S_NE-Medium_Voltage_Cable",
-                "Z": 1
               }
             ]
           },
@@ -168035,7 +168159,7 @@
             "Key": "X102Y64",
             "Value": [
               {
-                "Tel": "Floor"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -169417,7 +169541,7 @@
             "Key": "X103Y56",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -169462,6 +169586,10 @@
                 "Tel": "Plating"
               },
               {
+                "Tel": "W_SE-Medium_Voltage_Cable",
+                "Z": 1
+              },
+              {
                 "Tel": "FluidBentPipe",
                 "Z": 1,
                 "Col": "#FF0031FF",
@@ -169495,9 +169623,10 @@
                 "Tel": "Plating"
               },
               {
-                "Tel": "FluidStraightPipe",
+                "Tel": "3WayManifold",
                 "Z": 1,
-                "Col": "#FF0031FF"
+                "Col": "#FF0031FF",
+                "Tf": "5.960464E-08,-0.9999999,0,0,0.9999999,5.960464E-08,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -169546,14 +169675,9 @@
                 "Tel": "Plating"
               },
               {
-                "Tel": "E_SW-Medium_Voltage_Cable",
-                "Z": -1
-              },
-              {
-                "Tel": "3WayManifold",
+                "Tel": "FluidStraightPipe",
                 "Z": 1,
-                "Col": "#FF0031FF",
-                "Tf": "5.960464E-08,-0.9999999,0,0,0.9999999,5.960464E-08,0,0,0,0,1,0,0,0,0,1"
+                "Col": "#FF0031FF"
               }
             ]
           },
@@ -169583,9 +169707,10 @@
                 "Tel": "Plating"
               },
               {
-                "Tel": "FluidStraightPipe",
+                "Tel": "3WayManifold",
                 "Z": 1,
-                "Col": "#FF0031FF"
+                "Col": "#FF0031FF",
+                "Tf": "5.960464E-08,-0.9999999,0,0,0.9999999,5.960464E-08,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -170994,7 +171119,7 @@
             "Key": "X104Y56",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -171006,6 +171131,10 @@
             "Value": [
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "NO-Medium_Voltage_Cable",
+                "Z": 1
               }
             ]
           },
@@ -171013,10 +171142,14 @@
             "Key": "X104Y58",
             "Value": [
               {
-                "Tel": "ReinforcedWall"
+                "Tel": "Plating"
               },
               {
-                "Tel": "Plating"
+                "Tel": "S_NW-Medium_Voltage_Cable",
+                "Z": 1
+              },
+              {
+                "Tel": "NO-Low_Voltage_Cable"
               },
               {
                 "Tel": "FluidStraightPipe",
@@ -171036,6 +171169,13 @@
                 "Tel": "Plating"
               },
               {
+                "Tel": "SE-Low_Voltage_Cable",
+                "Z": 1
+              },
+              {
+                "Tel": "NS-Low_Voltage_Cable"
+              },
+              {
                 "Tel": "FluidStraightPipe",
                 "Z": 1,
                 "Col": "#FF0031FF",
@@ -171047,13 +171187,14 @@
             "Key": "X104Y60",
             "Value": [
               {
-                "Tel": "Wall"
-              },
-              {
                 "Tel": "Floor"
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "NS-Low_Voltage_Cable",
+                "Z": 1
               }
             ]
           },
@@ -171065,6 +171206,10 @@
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "NS-Low_Voltage_Cable",
+                "Z": 1
               }
             ]
           },
@@ -171078,11 +171223,8 @@
                 "Tel": "Plating"
               },
               {
-                "Tel": "NW-Low_Voltage_Cable",
+                "Tel": "SW-Low_Voltage_Cable",
                 "Z": 1
-              },
-              {
-                "Tel": "NE-Low_Voltage_Cable"
               }
             ]
           },
@@ -171094,10 +171236,6 @@
               },
               {
                 "Tel": "Plating"
-              },
-              {
-                "Tel": "SO-Low_Voltage_Cable",
-                "Z": 1
               }
             ]
           },
@@ -171109,19 +171247,12 @@
               },
               {
                 "Tel": "Plating"
-              },
-              {
-                "Tel": "WO-Medium_Voltage_Cable",
-                "Z": 1
               }
             ]
           },
           {
             "Key": "X104Y65",
             "Value": [
-              {
-                "Tel": "Wall"
-              },
               {
                 "Tel": "Floor"
               },
@@ -172470,7 +172601,7 @@
             "Key": "X105Y56",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -172480,6 +172611,9 @@
           {
             "Key": "X105Y57",
             "Value": [
+              {
+                "Tel": "ReinforcedWall"
+              },
               {
                 "Tel": "Plating"
               }
@@ -172512,11 +172646,12 @@
                 "Tel": "Plating"
               },
               {
-                "Tel": "EO-Low_Voltage_Cable",
+                "Tel": "WO-Low_Voltage_Cable",
                 "Z": 1
               },
               {
                 "Tel": "FluidStraightPipe",
+                "Z": 1,
                 "Col": "#FF0031FF",
                 "Tf": "5.960464E-08,-0.9999999,0,0,0.9999999,5.960464E-08,0,0,0,0,1,0,0,0,0,1"
               }
@@ -172526,17 +172661,10 @@
             "Key": "X105Y60",
             "Value": [
               {
-                "Tel": "Wall"
-              },
-              {
                 "Tel": "Floor"
               },
               {
                 "Tel": "Plating"
-              },
-              {
-                "Tel": "NE-Low_Voltage_Cable",
-                "Z": 1
               }
             ]
           },
@@ -172544,17 +172672,10 @@
             "Key": "X105Y61",
             "Value": [
               {
-                "Tel": "Wall"
-              },
-              {
                 "Tel": "Floor"
               },
               {
                 "Tel": "Plating"
-              },
-              {
-                "Tel": "NS-Low_Voltage_Cable",
-                "Z": 1
               }
             ]
           },
@@ -172562,26 +172683,16 @@
             "Key": "X105Y62",
             "Value": [
               {
-                "Tel": "Wall"
-              },
-              {
                 "Tel": "Floor"
               },
               {
                 "Tel": "Plating"
-              },
-              {
-                "Tel": "SW-Low_Voltage_Cable",
-                "Z": 1
               }
             ]
           },
           {
             "Key": "X105Y63",
             "Value": [
-              {
-                "Tel": "Wall"
-              },
               {
                 "Tel": "Floor"
               },
@@ -172594,10 +172705,7 @@
             "Key": "X105Y64",
             "Value": [
               {
-                "Tel": "Wall"
-              },
-              {
-                "Tel": "Floor"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -172607,9 +172715,6 @@
           {
             "Key": "X105Y65",
             "Value": [
-              {
-                "Tel": "Wall"
-              },
               {
                 "Tel": "Floor"
               },
@@ -173915,17 +174020,14 @@
             "Key": "X106Y59",
             "Value": [
               {
-                "Tel": "Floor"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
               },
               {
-                "Tel": "NW-Low_Voltage_Cable",
-                "Z": 1
-              },
-              {
                 "Tel": "FluidStraightPipe",
+                "Z": 1,
                 "Col": "#FF0031FF",
                 "Tf": "5.960464E-08,-0.9999999,0,0,0.9999999,5.960464E-08,0,0,0,0,1,0,0,0,0,1"
               }
@@ -173935,14 +174037,13 @@
             "Key": "X106Y60",
             "Value": [
               {
-                "Tel": "Floor"
+                "Tel": "WindowReinforced"
               },
               {
                 "Tel": "Plating"
               },
               {
-                "Tel": "SW-Low_Voltage_Cable",
-                "Z": 1
+                "Tel": "Grille"
               }
             ]
           },
@@ -173950,10 +174051,13 @@
             "Key": "X106Y61",
             "Value": [
               {
-                "Tel": "Floor"
+                "Tel": "WindowReinforced"
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "Grille"
               }
             ]
           },
@@ -173961,10 +174065,13 @@
             "Key": "X106Y62",
             "Value": [
               {
-                "Tel": "Floor"
+                "Tel": "WindowReinforced"
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "Grille"
               }
             ]
           },
@@ -173972,7 +174079,7 @@
             "Key": "X106Y63",
             "Value": [
               {
-                "Tel": "Floor"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -173983,7 +174090,7 @@
             "Key": "X106Y64",
             "Value": [
               {
-                "Tel": "Floor"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
@@ -174535,17 +174642,6 @@
           },
           {
             "Key": "X106Y124",
-            "Value": [
-              {
-                "Tel": "Floor"
-              },
-              {
-                "Tel": "Plating"
-              }
-            ]
-          },
-          {
-            "Key": "X106Y125",
             "Value": [
               {
                 "Tel": "WindowReinforced"
@@ -179061,7 +179157,7 @@
             "Key": "X110Y57",
             "Value": [
               {
-                "Tel": "ReinforcedWall"
+                "Tel": "Wall"
               },
               {
                 "Tel": "Plating"
@@ -180261,7 +180357,7 @@
             "Key": "X111Y57",
             "Value": [
               {
-                "Tel": "ReinforcedWall"
+                "Tel": "Wall"
               },
               {
                 "Tel": "Plating"
@@ -180271,6 +180367,9 @@
           {
             "Key": "X111Y58",
             "Value": [
+              {
+                "Tel": "ReinforcedWall"
+              },
               {
                 "Tel": "Plating"
               }
@@ -181401,7 +181500,7 @@
             "Key": "X112Y57",
             "Value": [
               {
-                "Tel": "ReinforcedWall"
+                "Tel": "Wall"
               },
               {
                 "Tel": "Plating"
@@ -181411,6 +181510,9 @@
           {
             "Key": "X112Y58",
             "Value": [
+              {
+                "Tel": "ReinforcedWall"
+              },
               {
                 "Tel": "Plating"
               }
@@ -182318,7 +182420,7 @@
             "Key": "X113Y57",
             "Value": [
               {
-                "Tel": "ReinforcedWall"
+                "Tel": "Wall"
               },
               {
                 "Tel": "Plating"
@@ -182328,6 +182430,9 @@
           {
             "Key": "X113Y58",
             "Value": [
+              {
+                "Tel": "ReinforcedWall"
+              },
               {
                 "Tel": "Plating"
               }
@@ -190718,7 +190823,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -191338,7 +191443,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -191505,12 +191610,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -191801,7 +191906,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -191885,8 +191990,8 @@
                       "ClassID": "ClearanceRestricted@0",
                       "Data": [
                         {
-                          "Name": "requiredClearance#0",
-                          "Data": "#removed#"
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -191961,7 +192066,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -192025,7 +192130,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -192086,7 +192191,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -192128,7 +192233,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -192740,7 +192845,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -192990,7 +193095,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -193064,12 +193169,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -193180,7 +193285,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -193225,7 +193330,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -193344,7 +193449,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -193882,7 +193987,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -193916,12 +194021,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -193957,7 +194062,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -194022,7 +194127,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -194138,7 +194243,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -194192,7 +194297,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -194228,12 +194333,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -194287,7 +194392,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -194399,7 +194504,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -195007,7 +195112,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -195068,7 +195173,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -195111,12 +195216,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -195181,12 +195286,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -195708,7 +195813,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -195734,7 +195839,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -196263,12 +196368,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -196465,7 +196570,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -196819,7 +196924,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -196931,12 +197036,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -196990,7 +197095,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -197042,7 +197147,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -197140,12 +197245,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -197199,7 +197304,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -197253,7 +197358,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -197352,7 +197457,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -197451,12 +197556,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -197558,7 +197663,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -197591,7 +197696,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -197979,7 +198084,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -198144,12 +198249,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -198331,10 +198436,6 @@
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
-                    {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
                     }
@@ -198506,7 +198607,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -199102,11 +199203,11 @@
                   "ClassID": "ItemSlotActionTracker@0",
                   "Data": [
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "SecureStuff.SerializedAction"
                     },
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "#removed#"
                     }
                   ]
@@ -199167,7 +199268,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -199221,7 +199322,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -199337,7 +199438,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -199463,7 +199564,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -199788,6 +199889,7 @@
           {
             "GitID": "6632299223265324f8ad6b9a74159e0c_8┼37┼0┼",
             "PrefabID": "6632299223265324f8ad6b9a74159e0c",
+            "NameMatches": true,
             "Name": "FoodCart",
             "LocalPRS": "8┼37┼0┼"
           },
@@ -200287,11 +200389,11 @@
                   "ClassID": "ItemSlotActionTracker@0",
                   "Data": [
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "SecureStuff.SerializedAction"
                     },
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "#removed#"
                     }
                   ]
@@ -200682,7 +200784,61 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
+                  "Active": false,
+                  "ClassDatas": []
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "fde32c02abddc814f9366ff1fb21f234_8┼79┼0┼",
+            "PrefabID": "fde32c02abddc814f9366ff1fb21f234",
+            "NameMatches": true,
+            "Name": "LightTubeFixture",
+            "LocalPRS": "8┼79┼0┼0ø0ø270ø",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "Integrity@0",
+                  "Data": [
+                    {
+                      "Name": "Armor@Melee",
+                      "Data": "0"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_15┼72┼0┼@0@APC@0"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Right_By270"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "LightSource@0",
+                  "Data": [
+                    {
+                      "Name": "relatedLightSwitch",
+                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_11┼68┼0┼@0@LightSwitchV2@0"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -201016,7 +201172,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -201052,11 +201208,11 @@
                   "ClassID": "ItemSlotActionTracker@0",
                   "Data": [
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "SecureStuff.SerializedAction"
                     },
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "#removed#"
                     }
                   ]
@@ -201090,12 +201246,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -201255,7 +201411,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -201391,7 +201547,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -201468,7 +201624,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -201659,11 +201815,11 @@
                   "ClassID": "ItemSlotActionTracker@0",
                   "Data": [
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "SecureStuff.SerializedAction"
                     },
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "#removed#"
                     }
                   ]
@@ -201715,7 +201871,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -201802,12 +201958,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -201861,7 +202017,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -201904,12 +202060,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -202254,7 +202410,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -202363,7 +202519,7 @@
                     },
                     {
                       "Name": "listOfLights#4",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_14┼74┼0┼@0@LightSource@0"
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_8┼79┼0┼@0@LightSource@0"
                     },
                     {
                       "Name": "listOfLights#3",
@@ -202551,12 +202707,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -203088,7 +203244,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -203120,7 +203276,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -203174,7 +203330,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -203201,12 +203357,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -203315,7 +203471,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -203360,7 +203516,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -203869,7 +204025,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -203972,12 +204128,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -204045,7 +204201,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -204083,60 +204239,6 @@
             "LocalPRS": "14┼74┼0┼"
           },
           {
-            "GitID": "fde32c02abddc814f9366ff1fb21f234_14┼74┼0┼",
-            "PrefabID": "fde32c02abddc814f9366ff1fb21f234",
-            "NameMatches": true,
-            "Name": "LightTubeFixture",
-            "LocalPRS": "14┼74┼0┼0ø0ø90ø",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "Integrity@0",
-                  "Data": [
-                    {
-                      "Name": "Armor@Melee",
-                      "Data": "0"
-                    }
-                  ]
-                },
-                {
-                  "ClassID": "APCPoweredDevice@0",
-                  "Data": [
-                    {
-                      "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_15┼72┼0┼@0@APC@0"
-                    }
-                  ]
-                },
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Left_By90"
-                    }
-                  ]
-                },
-                {
-                  "ClassID": "LightSource@0",
-                  "Data": [
-                    {
-                      "Name": "relatedLightSwitch",
-                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_11┼68┼0┼@0@LightSwitchV2@0"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,2",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
-          },
-          {
             "GitID": "08a623262084bdb49909620b1fcef62a_14┼75┼0┼",
             "PrefabID": "08a623262084bdb49909620b1fcef62a",
             "Name": "MiningWinterCoat (3)",
@@ -204167,7 +204269,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -204203,12 +204305,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -204268,7 +204370,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -204313,7 +204415,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -204398,7 +204500,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -204433,7 +204535,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -204468,7 +204570,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -204528,7 +204630,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -204595,7 +204697,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -204809,7 +204911,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -204880,7 +204982,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -204986,12 +205088,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -205085,7 +205187,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -205109,10 +205211,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -205233,7 +205331,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -205443,7 +205541,7 @@
                     },
                     {
                       "Name": "connectedDevices#8",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_14┼74┼0┼@0@APCPoweredDevice@0"
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_8┼79┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#7",
@@ -205584,7 +205682,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -205783,12 +205881,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -205860,7 +205958,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -205883,7 +205981,6 @@
           {
             "GitID": "3edf81f4a32c4c348bad5bfe43e263fd_16┼29┼0┼",
             "PrefabID": "3edf81f4a32c4c348bad5bfe43e263fd",
-            "NameMatches": true,
             "Name": "Paper Bin1",
             "LocalPRS": "16┼29┼0┼"
           },
@@ -205906,7 +206003,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -206206,7 +206303,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -206393,7 +206490,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -206548,7 +206645,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -206648,7 +206745,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -206674,7 +206771,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -206728,7 +206825,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -206781,6 +206878,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Cargo"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -206812,10 +206913,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -207003,7 +207100,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -207093,7 +207190,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -207182,7 +207279,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -207294,7 +207391,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -207406,7 +207503,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -207564,7 +207661,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -207610,10 +207707,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -207730,12 +207823,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -208162,7 +208255,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -208247,7 +208340,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -208504,7 +208597,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -208636,7 +208729,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -208678,12 +208771,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -208816,7 +208909,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -208939,7 +209032,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -209021,12 +209114,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -209099,12 +209192,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -209158,7 +209251,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -209194,12 +209287,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -209273,7 +209366,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -209708,7 +209801,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -209759,7 +209852,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -210263,7 +210356,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -210391,7 +210484,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -210407,7 +210500,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -210753,12 +210846,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -210812,7 +210905,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -210876,7 +210969,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -210975,6 +211068,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Cargo"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -210994,10 +211091,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -211078,7 +211171,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -211255,7 +211348,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -211281,7 +211374,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -211335,7 +211428,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -211420,7 +211513,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -211511,7 +211604,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -211547,12 +211640,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -211672,7 +211765,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -211762,12 +211855,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -211828,7 +211921,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -211838,7 +211931,6 @@
           {
             "GitID": "3edf81f4a32c4c348bad5bfe43e263fd_21┼72┼0┼",
             "PrefabID": "3edf81f4a32c4c348bad5bfe43e263fd",
-            "NameMatches": true,
             "Name": "Paper Bin1",
             "LocalPRS": "21┼72┼0┼"
           },
@@ -212009,12 +212101,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -212047,12 +212139,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -212088,12 +212180,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -212119,7 +212211,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -212532,7 +212624,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -212599,7 +212691,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -212690,7 +212782,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -212791,12 +212883,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -212859,7 +212951,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -212902,12 +212994,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -212971,7 +213063,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -213182,7 +213274,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -213242,7 +213334,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -213307,7 +213399,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -213351,7 +213443,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -213442,7 +213534,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -213551,7 +213643,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -213628,7 +213720,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -213707,7 +213799,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -213751,7 +213843,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -213795,7 +213887,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -213921,7 +214013,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -213985,7 +214077,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -214290,7 +214382,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -214783,7 +214875,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -214845,12 +214937,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -214954,7 +215046,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -214990,12 +215082,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -215055,7 +215147,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -215128,7 +215220,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -215182,7 +215274,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -215462,6 +215554,7 @@
           {
             "GitID": "7bb3f38189983e9468b4f3f16be75bed_26┼56┼0┼",
             "PrefabID": "7bb3f38189983e9468b4f3f16be75bed",
+            "NameMatches": true,
             "Name": "Jukebox",
             "LocalPRS": "26┼56┼0┼",
             "Object": {
@@ -215525,7 +215618,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -215639,7 +215732,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -215683,6 +215776,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Bar"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -215767,7 +215864,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -215994,7 +216091,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -216112,8 +216209,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -216202,7 +216331,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -216424,12 +216553,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -216489,7 +216618,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -216680,7 +216809,7 @@
                     },
                     {
                       "Name": "connectedDevices#8",
-                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_36┼21┼0┼@0@APCPoweredDevice@0"
+                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_37┼21┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#7",
@@ -216851,12 +216980,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -216998,12 +217127,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -217095,7 +217224,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -217360,11 +217489,11 @@
                   "ClassID": "ItemSlotActionTracker@0",
                   "Data": [
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "SecureStuff.SerializedAction"
                     },
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "#removed#"
                     }
                   ]
@@ -217506,7 +217635,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -217903,12 +218032,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -218153,7 +218282,6 @@
           {
             "GitID": "3edf81f4a32c4c348bad5bfe43e263fd_29┼41.12┼0┼",
             "PrefabID": "3edf81f4a32c4c348bad5bfe43e263fd",
-            "NameMatches": true,
             "Name": "Paper Bin1",
             "LocalPRS": "29┼41.12┼0┼"
           },
@@ -218204,7 +218332,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -218394,7 +218522,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -218589,7 +218717,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -218673,12 +218801,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -218732,7 +218860,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -218758,7 +218886,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -218812,7 +218940,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -218866,7 +218994,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -219007,7 +219135,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -219206,7 +219334,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -219251,7 +219379,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -219278,12 +219406,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -219359,12 +219487,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -219539,7 +219667,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -219602,7 +219730,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -219653,7 +219781,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -219873,7 +220001,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -219899,7 +220027,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -220046,7 +220174,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -220072,7 +220200,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -220108,12 +220236,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -220204,7 +220332,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -220611,7 +220739,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -220765,7 +220893,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -221267,12 +221395,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -221377,7 +221505,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -221484,23 +221612,17 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
               ]
             }
-          },
-          {
-            "GitID": "qzrxnKhVH-wOK6EQpbMn_32┼33┼0┼",
-            "PrefabID": "qzrxnKhVH-wOK6EQpbMn",
-            "Name": "TankDispenser (3)",
-            "LocalPRS": "32┼33┼0┼"
           },
           {
             "GitID": "y9sE1$maUPtNfaksxX_Y_32┼35┼0┼",
@@ -221534,12 +221656,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -221603,7 +221725,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -221621,10 +221743,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -221999,7 +222117,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -222089,12 +222207,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -222175,7 +222293,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -222247,12 +222365,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -222306,7 +222424,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -222377,7 +222495,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -222624,6 +222742,10 @@
                   "ClassID": "DoorSwitch@0",
                   "Data": [
                     {
+                      "Name": "NewdoorControllers#1",
+                      "Data": "e838f08ba052aa84698c5c15b7bf2996_33┼17┼0┼@0@DoorMasterController@0"
+                    },
+                    {
                       "Name": "NewdoorControllers#0",
                       "Data": "f2441585d37f1914395df59a57c5e925_33┼7┼0┼@0@DoorMasterController@0"
                     }
@@ -222829,14 +222951,93 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "f2432d244a6b7774ea00ff013beb7dcb_33┼15┼0┼",
+            "PrefabID": "f2432d244a6b7774ea00ff013beb7dcb",
+            "Name": "LightSwitch (2)",
+            "LocalPRS": "33┼15┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_35┼14┼0┼@0@APC@0"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Right_By270"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "LightSwitchV2@0",
+                  "Data": [
+                    {
+                      "Name": "listOfLights#1",
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_36┼20┼0┼@0@LightSource@0"
+                    },
+                    {
+                      "Name": "listOfLights#0",
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_36┼15┼0┼@0@LightSource@0"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "e838f08ba052aa84698c5c15b7bf2996_33┼17┼0┼",
+            "PrefabID": "e838f08ba052aa84698c5c15b7bf2996",
+            "Name": "AirlockScienceOpaque (2)",
+            "LocalPRS": "33┼17┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_35┼14┼0┼@0@APC@0"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "e838f08ba052aa84698c5c15b7bf2996_33┼18┼0┼",
+            "PrefabID": "e838f08ba052aa84698c5c15b7bf2996",
+            "Name": "AirlockScienceOpaque (1)",
+            "LocalPRS": "33┼18┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_35┼14┼0┼@0@APC@0"
+                    }
+                  ]
                 }
               ]
             }
@@ -222860,7 +223061,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -222965,12 +223166,18 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
               ]
             }
+          },
+          {
+            "GitID": "qzrxnKhVH-wOK6EQpbMn_33┼29┼0┼",
+            "PrefabID": "qzrxnKhVH-wOK6EQpbMn",
+            "Name": "TankDispenser (3)",
+            "LocalPRS": "33┼29┼0┼"
           },
           {
             "GitID": "dd553da79275dac409d269c0d6ec571c_33┼30┼0┼",
@@ -223214,7 +223421,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -223274,7 +223481,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -223310,12 +223517,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -223369,7 +223576,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -223889,10 +224096,6 @@
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
-                    {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
                     }
@@ -224018,7 +224221,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -224130,7 +224333,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -224182,7 +224385,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -224717,7 +224920,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -224777,7 +224980,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -224851,7 +225054,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -224887,7 +225090,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -225182,10 +225385,6 @@
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
-                    {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
                     }
@@ -225266,7 +225465,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -225409,12 +225608,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -225533,6 +225732,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Hydroponics"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -225546,41 +225749,6 @@
             "PrefabID": "e33403c0371fc174aa03640734665a15",
             "Name": "HandTele (1)",
             "LocalPRS": "34.03┼102.21┼0┼"
-          },
-          {
-            "GitID": "e58e1fd483fe772468ad2aab4259397d_34.08┼19.25┼0┼",
-            "PrefabID": "e58e1fd483fe772468ad2aab4259397d",
-            "Name": "SpaceExterior at 35 20",
-            "LocalPRS": "34.08┼19.25┼0┼",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "SpawnPoint@0",
-                  "Data": [
-                    {
-                      "Name": "category",
-                      "Data": "SpaceExterior"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "8672bf8dd479a434cbfe8daac215b223"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
           },
           {
             "GitID": "dba4afe66472bda4999773fdac6810f1_34.1┼13┼0┼",
@@ -225633,6 +225801,163 @@
             "LocalPRS": "35┼13┼0┼"
           },
           {
+            "GitID": "cd57203a8d3f54f478446e9b0ced6cf9_35┼14┼0┼",
+            "PrefabID": "cd57203a8d3f54f478446e9b0ced6cf9",
+            "NameMatches": true,
+            "Name": "APC",
+            "LocalPRS": "35┼14┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Up_By0"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "APC@0",
+                  "Data": [
+                    {
+                      "Name": "connectedDevices#7",
+                      "Data": "e838f08ba052aa84698c5c15b7bf2996_33┼18┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#6",
+                      "Data": "e838f08ba052aa84698c5c15b7bf2996_33┼17┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#5",
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_36┼15┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#4",
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_36┼20┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#3",
+                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_33┼15┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#2",
+                      "Data": "0d553281bdfc0fd438b3f6c7db58688c_35┼17┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#1",
+                      "Data": "cb2f847ef3b8b754181a970a4032c552_35┼18┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#0",
+                      "Data": "a50474d976314462a79602e20a762520_35┼21┼0┼@0@APCPoweredDevice@0"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_35┼15┼0┼",
+            "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
+            "NameMatches": true,
+            "Name": "Low Machine Connector",
+            "LocalPRS": "35┼15┼0┼"
+          },
+          {
+            "GitID": "0d553281bdfc0fd438b3f6c7db58688c_35┼17┼0┼",
+            "PrefabID": "0d553281bdfc0fd438b3f6c7db58688c",
+            "Name": "AirVent (73)",
+            "LocalPRS": "35┼17┼0┼0ø0ø270ø",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_35┼14┼0┼@0@APC@0"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Right_By270"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "AcuDevice@0",
+                  "Data": [
+                    {
+                      "Name": "Controller",
+                      "Data": "a50474d976314462a79602e20a762520_35┼21┼0┼@0@AirController@0"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "cb2f847ef3b8b754181a970a4032c552_35┼18┼0┼",
+            "PrefabID": "cb2f847ef3b8b754181a970a4032c552",
+            "Name": "AirScrubber (108)",
+            "LocalPRS": "35┼18┼0┼0ø0ø270ø",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_35┼14┼0┼@0@APC@0"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Right_By270"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "AcuDevice@0",
+                  "Data": [
+                    {
+                      "Name": "Controller",
+                      "Data": "a50474d976314462a79602e20a762520_35┼21┼0┼@0@AirController@0"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "a50474d976314462a79602e20a762520_35┼21┼0┼",
+            "PrefabID": "a50474d976314462a79602e20a762520",
+            "Name": "ACU (3)",
+            "LocalPRS": "35┼21┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_35┼14┼0┼@0@APC@0"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
             "GitID": "b5e5d6463b96de0458a195cebc18a3e2_35┼24┼0┼",
             "PrefabID": "b5e5d6463b96de0458a195cebc18a3e2",
             "Name": "SecurityRecordsConsole (5)",
@@ -225680,12 +226005,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -225739,7 +226064,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -225793,7 +226118,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -226062,10 +226387,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -226385,10 +226706,6 @@
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
-                    {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
                     }
@@ -226548,6 +226865,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Security"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -226559,6 +226880,7 @@
           {
             "GitID": "ChemDispenser_36┼11┼0┼",
             "PrefabID": "ChemDispenser",
+            "NameMatches": true,
             "Name": "ChemDispenser",
             "LocalPRS": "36┼11┼0┼",
             "Object": {
@@ -226576,28 +226898,18 @@
             }
           },
           {
-            "GitID": "f2432d244a6b7774ea00ff013beb7dcb_36┼21┼0┼",
-            "PrefabID": "f2432d244a6b7774ea00ff013beb7dcb",
-            "NameMatches": true,
-            "Name": "LightSwitch",
-            "LocalPRS": "36┼21┼0┼",
+            "GitID": "fde32c02abddc814f9366ff1fb21f234_36┼15┼0┼",
+            "PrefabID": "fde32c02abddc814f9366ff1fb21f234",
+            "Name": "LightTubeFixture (5)",
+            "LocalPRS": "36┼15┼0┼0ø0ø90ø",
             "Object": {
               "ClassDatas": [
-                {
-                  "ClassID": "Integrity@0",
-                  "Data": [
-                    {
-                      "Name": "Armor@Melee",
-                      "Data": "0"
-                    }
-                  ]
-                },
                 {
                   "ClassID": "APCPoweredDevice@0",
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_28┼23┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_35┼14┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -226606,18 +226918,69 @@
                   "Data": [
                     {
                       "Name": "CurrentDirection",
-                      "Data": "Up_By0"
+                      "Data": "Left_By90"
                     }
                   ]
                 },
                 {
-                  "ClassID": "LightSwitchV2@0",
+                  "ClassID": "LightSource@0",
                   "Data": [
                     {
-                      "Name": "listOfLights#0",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_37┼24┼0┼@0@LightSource@0"
+                      "Name": "relatedLightSwitch",
+                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_33┼15┼0┼@0@LightSwitchV2@0"
                     }
                   ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,3",
+                  "Active": false,
+                  "ClassDatas": []
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "fde32c02abddc814f9366ff1fb21f234_36┼20┼0┼",
+            "PrefabID": "fde32c02abddc814f9366ff1fb21f234",
+            "Name": "LightTubeFixture (6)",
+            "LocalPRS": "36┼20┼0┼0ø0ø90ø",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_35┼14┼0┼@0@APC@0"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Left_By90"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "LightSource@0",
+                  "Data": [
+                    {
+                      "Name": "relatedLightSwitch",
+                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_33┼15┼0┼@0@LightSwitchV2@0"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,3",
+                  "Active": false,
+                  "ClassDatas": []
                 }
               ]
             }
@@ -226633,10 +226996,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -226871,7 +227230,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -226981,7 +227340,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -227120,7 +227479,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -227165,7 +227524,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -227232,7 +227591,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -227264,7 +227623,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -227317,6 +227676,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Captain"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -227362,7 +227725,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -227378,7 +227741,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -227393,19 +227756,46 @@
             "LocalPRS": "36.99┼93.02┼0┼"
           },
           {
-            "GitID": "74c59d7cb720be945a7c5606d962c05a_37┼21┼0┼",
-            "PrefabID": "74c59d7cb720be945a7c5606d962c05a",
+            "GitID": "f2432d244a6b7774ea00ff013beb7dcb_37┼21┼0┼",
+            "PrefabID": "f2432d244a6b7774ea00ff013beb7dcb",
             "NameMatches": true,
-            "Name": "AirlockSecurityOpaque",
+            "Name": "LightSwitch",
             "LocalPRS": "37┼21┼0┼",
             "Object": {
               "ClassDatas": [
+                {
+                  "ClassID": "Integrity@0",
+                  "Data": [
+                    {
+                      "Name": "Armor@Melee",
+                      "Data": "0"
+                    }
+                  ]
+                },
                 {
                   "ClassID": "APCPoweredDevice@0",
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_38┼22┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_28┼23┼0┼@0@APC@0"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Up_By0"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "LightSwitchV2@0",
+                  "Data": [
+                    {
+                      "Name": "listOfLights#0",
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_37┼24┼0┼@0@LightSource@0"
                     }
                   ]
                 }
@@ -227441,12 +227831,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -227506,14 +227896,14 @@
                   "Data": [
                     {
                       "Name": "relatedLightSwitch",
-                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_36┼21┼0┼@0@LightSwitchV2@0"
+                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_37┼21┼0┼@0@LightSwitchV2@0"
                     }
                   ]
                 }
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -227573,7 +227963,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -227599,7 +227989,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -227635,12 +228025,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -227700,7 +228090,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -227760,7 +228150,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -227796,12 +228186,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -227929,12 +228319,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -227990,12 +228380,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -228061,7 +228451,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -228257,12 +228647,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -228316,7 +228706,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -228380,7 +228770,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -228416,12 +228806,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -228531,7 +228921,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -228735,12 +229125,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -228776,12 +229166,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -228817,7 +229207,27 @@
                     },
                     {
                       "Name": "connectedDevices#0",
-                      "Data": "74c59d7cb720be945a7c5606d962c05a_37┼21┼0┼@0@APCPoweredDevice@0"
+                      "Data": "74c59d7cb720be945a7c5606d962c05a_38┼23┼0┼@0@APCPoweredDevice@0"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "74c59d7cb720be945a7c5606d962c05a_38┼23┼0┼",
+            "PrefabID": "74c59d7cb720be945a7c5606d962c05a",
+            "NameMatches": true,
+            "Name": "AirlockSecurityOpaque",
+            "LocalPRS": "38┼23┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_38┼22┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -229451,7 +229861,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -229573,7 +229983,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -229873,6 +230283,7 @@
           {
             "GitID": "2739875c64cce824bac79817bf3eaa32_38┼111┼0┼",
             "PrefabID": "2739875c64cce824bac79817bf3eaa32",
+            "NameMatches": true,
             "Name": "UnitystationSign2",
             "LocalPRS": "38┼111┼0┼0ø0ø180ø"
           },
@@ -230020,7 +230431,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -230091,12 +230502,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -230208,7 +230619,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -230268,7 +230679,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -230304,12 +230715,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -230782,7 +231193,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -230821,7 +231232,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -230874,12 +231285,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -231033,7 +231444,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -231312,7 +231723,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -231439,12 +231850,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -232178,7 +232589,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -232312,7 +232723,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -232474,7 +232885,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -232565,7 +232976,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -232591,7 +233002,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -232682,7 +233093,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -232718,12 +233129,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -232797,6 +233208,41 @@
             "PrefabID": "6bd9037fbb19a79409aab54675bc363e",
             "Name": "ComputerBoardShuttlePilotingConsole (1)",
             "LocalPRS": "40.99┼49.91┼0┼"
+          },
+          {
+            "GitID": "e58e1fd483fe772468ad2aab4259397d_41┼10.82┼0┼",
+            "PrefabID": "e58e1fd483fe772468ad2aab4259397d",
+            "Name": "SpaceExterior at 35 20",
+            "LocalPRS": "41┼10.82┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "SpawnPoint@0",
+                  "Data": [
+                    {
+                      "Name": "category",
+                      "Data": "SpaceExterior"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,1",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "InitialPresentSpriteSet",
+                          "Data": "8672bf8dd479a434cbfe8daac215b223"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           },
           {
             "GitID": "8fb9b82aab871a54fb9bdb7e4a985821_41┼23┼0┼",
@@ -233377,6 +233823,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Hydroponics"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -233438,7 +233888,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -233504,7 +233954,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -233556,7 +234006,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -233781,7 +234231,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -233808,12 +234258,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -233929,7 +234379,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -234174,7 +234624,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -234542,6 +234992,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Kitchen"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -234608,7 +235062,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -234738,7 +235192,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -234840,7 +235294,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -234958,7 +235412,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -235305,7 +235759,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -235337,7 +235791,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -235403,6 +235857,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Hydroponics"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -235584,7 +236042,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -235713,7 +236171,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -235768,10 +236226,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -235952,7 +236406,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -236025,12 +236479,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -236084,7 +236538,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -236133,6 +236587,10 @@
                 {
                   "ClassID": "APC@0",
                   "Data": [
+                    {
+                      "Name": "connectedDevices#22",
+                      "Data": "cb0f8eeade0559b4eab161558c5c1645_45┼59┼0┼@0@APCPoweredDevice@0"
+                    },
                     {
                       "Name": "connectedDevices#21",
                       "Data": "a50474d976314462a79602e20a762520_42┼63┼0┼@0@APCPoweredDevice@0"
@@ -236271,7 +236729,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -236344,12 +236802,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -236463,7 +236921,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -236594,7 +237052,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -236655,7 +237113,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -236673,10 +237131,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -236740,12 +237194,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -236819,7 +237273,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -237106,7 +237560,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -238298,7 +238752,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -238334,9 +238788,29 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "cb0f8eeade0559b4eab161558c5c1645_45┼59┼0┼",
+            "PrefabID": "cb0f8eeade0559b4eab161558c5c1645",
+            "NameMatches": true,
+            "Name": "DeepFryer",
+            "LocalPRS": "45┼59┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_43┼65┼0┼@0@APC@0"
+                    }
+                  ]
                 }
               ]
             }
@@ -238589,7 +239063,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -238615,7 +239089,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -238651,12 +239125,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -238716,7 +239190,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -238790,7 +239264,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -238953,7 +239427,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -239065,7 +239539,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -239091,7 +239565,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -239133,12 +239607,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -239192,7 +239666,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -239260,6 +239734,7 @@
           {
             "GitID": "All-In-One Grinder_46┼56┼0┼",
             "PrefabID": "All-In-One Grinder",
+            "NameMatches": true,
             "Name": "All-In-One Grinder",
             "LocalPRS": "46┼56┼0┼"
           },
@@ -239346,7 +239821,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,3",
+                  "ID": "0,4",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -239394,6 +239869,7 @@
           {
             "GitID": "6632299223265324f8ad6b9a74159e0c_46┼66┼0┼",
             "PrefabID": "6632299223265324f8ad6b9a74159e0c",
+            "NameMatches": true,
             "Name": "FoodCart",
             "LocalPRS": "46┼66┼0┼"
           },
@@ -239464,7 +239940,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -239585,7 +240061,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -239634,12 +240110,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -239693,7 +240169,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -239834,7 +240310,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -240078,7 +240554,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -240161,7 +240637,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -240532,7 +241008,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -240738,7 +241214,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -240847,7 +241323,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -240865,10 +241341,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -241012,7 +241484,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -241122,7 +241594,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -241158,12 +241630,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -241217,7 +241689,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -241311,12 +241783,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -241370,7 +241842,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -241396,7 +241868,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -242004,7 +242476,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -242076,7 +242548,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -242129,6 +242601,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Hop"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -242194,10 +242670,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -242296,12 +242768,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -242614,7 +243086,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -242632,7 +243104,17 @@
             "GitID": "6f371050bff8b32438f91c7c680900bb_48┼115┼0┼",
             "PrefabID": "6f371050bff8b32438f91c7c680900bb",
             "Name": "Handheld Torch (1)",
-            "LocalPRS": "48┼115┼0┼"
+            "LocalPRS": "48┼115┼0┼",
+            "Object": {
+              "ClassDatas": [],
+              "Children": [
+                {
+                  "ID": "0,1",
+                  "Active": false,
+                  "ClassDatas": []
+                }
+              ]
+            }
           },
           {
             "GitID": "c21551dd992a57349973e4b5af103ca6_48┼117┼0┼",
@@ -242663,12 +243145,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -242695,12 +243177,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -242774,7 +243256,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -243692,12 +244174,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -243751,7 +244233,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -243966,7 +244448,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -243976,6 +244458,7 @@
           {
             "GitID": "2739875c64cce824bac79817bf3eaa32_49┼107┼0┼",
             "PrefabID": "2739875c64cce824bac79817bf3eaa32",
+            "NameMatches": true,
             "Name": "UnitystationSign2",
             "LocalPRS": "49┼107┼0┼0ø0ø180ø"
           },
@@ -244072,7 +244555,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -244119,6 +244602,7 @@
           {
             "GitID": "2739875c64cce824bac79817bf3eaa32_49┼114┼0┼",
             "PrefabID": "2739875c64cce824bac79817bf3eaa32",
+            "NameMatches": true,
             "Name": "UnitystationSign2",
             "LocalPRS": "49┼114┼0┼0ø0ø180ø"
           },
@@ -244206,7 +244690,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -244574,7 +245058,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -244600,7 +245084,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -244654,7 +245138,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -244726,12 +245210,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -244785,7 +245269,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -244839,7 +245323,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -244893,7 +245377,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -244947,7 +245431,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -245001,7 +245485,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -245055,7 +245539,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -245559,7 +246043,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -245585,7 +246069,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -245630,7 +246114,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -245659,7 +246143,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -245971,10 +246455,6 @@
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
-                    {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
                     }
@@ -246027,10 +246507,6 @@
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
-                    {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
                     }
@@ -246077,7 +246553,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -246169,7 +246645,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -246195,7 +246671,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -246275,7 +246751,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -246311,12 +246787,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -246370,7 +246846,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -246659,12 +247135,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -246700,7 +247176,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -247352,10 +247828,6 @@
                     {
                       "Name": "NewdoorControllers#0",
                       "Data": "54a552cbe4002ac44ae29b958a90e545_52┼33┼0┼@0@DoorMasterController@0"
-                    },
-                    {
-                      "Name": "channel",
-                      "Data": "DoorTimer"
                     }
                   ]
                 }
@@ -247430,10 +247902,6 @@
                     {
                       "Name": "NewdoorControllers#0",
                       "Data": "54a552cbe4002ac44ae29b958a90e545_52┼37┼0┼@0@DoorMasterController@0"
-                    },
-                    {
-                      "Name": "channel",
-                      "Data": "DoorTimer"
                     }
                   ]
                 }
@@ -247508,10 +247976,6 @@
                     {
                       "Name": "NewdoorControllers#0",
                       "Data": "54a552cbe4002ac44ae29b958a90e545_52┼41┼0┼@0@DoorMasterController@0"
-                    },
-                    {
-                      "Name": "channel",
-                      "Data": "DoorTimer"
                     }
                   ]
                 }
@@ -247586,10 +248050,6 @@
                     {
                       "Name": "NewdoorControllers#0",
                       "Data": "54a552cbe4002ac44ae29b958a90e545_52┼45┼0┼@0@DoorMasterController@0"
-                    },
-                    {
-                      "Name": "channel",
-                      "Data": "DoorTimer"
                     }
                   ]
                 }
@@ -247644,10 +248104,6 @@
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
-                    {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
                     }
@@ -247696,7 +248152,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -248196,7 +248652,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -248250,7 +248706,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -248331,7 +248787,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -248367,12 +248823,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -248426,7 +248882,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -248444,10 +248900,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -248580,7 +249032,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -248961,12 +249413,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -249020,7 +249472,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -249074,7 +249526,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -249198,7 +249650,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -249228,32 +249680,6 @@
             "PrefabID": "9a4638db3f1fdcc44b7e61537fc7946b",
             "Name": "Closet_Locker_Security",
             "LocalPRS": "53┼25┼0┼"
-          },
-          {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_53┼25┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights",
-            "LocalPRS": "53┼25┼0┼0ø0ø180ø",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Down_By180"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
           },
           {
             "GitID": "bc0cd2a586c78b846a43622b6ea5c953_53┼26┼0┼",
@@ -249317,11 +249743,11 @@
                   "ClassID": "ItemSlotActionTracker@0",
                   "Data": [
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "SecureStuff.SerializedAction"
                     },
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "#removed#"
                     }
                   ]
@@ -249404,7 +249830,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -249800,7 +250226,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -249873,7 +250299,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -250016,7 +250442,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼88┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼89┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -250062,7 +250488,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼88┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼89┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -250103,7 +250529,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼88┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼89┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -250154,7 +250580,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼88┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼89┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -250248,7 +250674,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -250324,12 +250750,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -250432,12 +250858,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -250547,7 +250973,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -250638,7 +251064,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -250662,11 +251088,11 @@
                   "ClassID": "ItemSlotActionTracker@0",
                   "Data": [
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "SecureStuff.SerializedAction"
                     },
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "#removed#"
                     }
                   ]
@@ -250698,11 +251124,11 @@
                   "ClassID": "ItemSlotActionTracker@0",
                   "Data": [
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "SecureStuff.SerializedAction"
                     },
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "#removed#"
                     }
                   ]
@@ -250727,11 +251153,11 @@
                   "ClassID": "ItemSlotActionTracker@0",
                   "Data": [
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "SecureStuff.SerializedAction"
                     },
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "#removed#"
                     }
                   ]
@@ -250756,11 +251182,11 @@
                   "ClassID": "ItemSlotActionTracker@0",
                   "Data": [
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "SecureStuff.SerializedAction"
                     },
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "#removed#"
                     }
                   ]
@@ -250895,12 +251321,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -251056,7 +251482,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -251109,12 +251535,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -251168,23 +251594,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
-          },
-          {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_54┼60┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights",
-            "LocalPRS": "54┼60┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,1",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -251237,12 +251647,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -251296,7 +251706,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼88┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼89┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -251314,7 +251724,7 @@
                   "Data": [
                     {
                       "Name": "listOfLights#2",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_58┼93┼0┼@0@LightSource@0"
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_58┼94┼0┼@0@LightSource@0"
                     },
                     {
                       "Name": "listOfLights#1",
@@ -251351,7 +251761,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼88┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼89┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -251367,7 +251777,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -251408,7 +251818,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼88┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼89┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -251752,12 +252162,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -251793,12 +252203,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -251876,7 +252286,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -251988,7 +252398,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -252240,7 +252650,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -252282,12 +252692,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -252341,7 +252751,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -252402,7 +252812,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -252611,12 +253021,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -252667,7 +253077,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -252867,7 +253277,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -252922,12 +253332,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -252947,43 +253357,6 @@
                     {
                       "Name": "RelatedAPC",
                       "Data": "cd57203a8d3f54f478446e9b0ced6cf9_56┼70┼0┼@0@APC@0"
-                    }
-                  ]
-                }
-              ]
-            }
-          },
-          {
-            "GitID": "cb2f847ef3b8b754181a970a4032c552_55┼73┼0┼",
-            "PrefabID": "cb2f847ef3b8b754181a970a4032c552",
-            "Name": "AirScrubber (99)",
-            "LocalPRS": "55┼73┼0┼0ø0ø270ø",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "APCPoweredDevice@0",
-                  "Data": [
-                    {
-                      "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_56┼70┼0┼@0@APC@0"
-                    }
-                  ]
-                },
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Right_By270"
-                    }
-                  ]
-                },
-                {
-                  "ClassID": "AcuDevice@0",
-                  "Data": [
-                    {
-                      "Name": "Controller",
-                      "Data": "a50474d976314462a79602e20a762520_57┼70┼0┼@0@AirController@0"
                     }
                   ]
                 }
@@ -253047,7 +253420,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -253083,12 +253456,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -253152,16 +253525,16 @@
             }
           },
           {
-            "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_55┼87┼0┼",
+            "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_55┼88┼0┼",
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
             "Name": "VIR_LowVoltageMachineConnector",
-            "LocalPRS": "55┼87┼0┼"
+            "LocalPRS": "55┼88┼0┼"
           },
           {
-            "GitID": "cd57203a8d3f54f478446e9b0ced6cf9_55┼88┼0┼",
+            "GitID": "cd57203a8d3f54f478446e9b0ced6cf9_55┼89┼0┼",
             "PrefabID": "cd57203a8d3f54f478446e9b0ced6cf9",
             "Name": "APC - EVA",
-            "LocalPRS": "55┼88┼0┼",
+            "LocalPRS": "55┼89┼0┼",
             "Object": {
               "ClassDatas": [
                 {
@@ -253248,7 +253621,7 @@
                     },
                     {
                       "Name": "connectedDevices#7",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_58┼93┼0┼@0@APCPoweredDevice@0"
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_58┼94┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#6",
@@ -253284,10 +253657,10 @@
             }
           },
           {
-            "GitID": "8b23406984f2ff757ab3d52e9f67116d_55┼89┼0┼",
+            "GitID": "8b23406984f2ff757ab3d52e9f67116d_55┼90┼0┼",
             "PrefabID": "8b23406984f2ff757ab3d52e9f67116d",
             "Name": "TankDispenserOxyOnly (2)",
-            "LocalPRS": "55┼89┼0┼"
+            "LocalPRS": "55┼90┼0┼"
           },
           {
             "GitID": "ed4e62dc12dca724ba1e5f374965096b_55┼94┼0┼",
@@ -253382,12 +253755,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -253441,7 +253814,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -253515,7 +253888,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -253691,12 +254064,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -253779,7 +254152,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -254349,7 +254722,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -254426,12 +254799,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -254597,12 +254970,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -254684,7 +255057,7 @@
                     },
                     {
                       "Name": "connectedDevices#5",
-                      "Data": "cb2f847ef3b8b754181a970a4032c552_55┼73┼0┼@0@APCPoweredDevice@0"
+                      "Data": "cb2f847ef3b8b754181a970a4032c552_56┼73┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#4",
@@ -254718,6 +255091,43 @@
             "LocalPRS": "56┼71┼0┼"
           },
           {
+            "GitID": "cb2f847ef3b8b754181a970a4032c552_56┼73┼0┼",
+            "PrefabID": "cb2f847ef3b8b754181a970a4032c552",
+            "Name": "AirScrubber (99)",
+            "LocalPRS": "56┼73┼0┼0ø0ø270ø",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_56┼70┼0┼@0@APC@0"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Right_By270"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "AcuDevice@0",
+                  "Data": [
+                    {
+                      "Name": "Controller",
+                      "Data": "a50474d976314462a79602e20a762520_57┼70┼0┼@0@AirController@0"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_56┼80┼0┼",
             "PrefabID": "fde32c02abddc814f9366ff1fb21f234",
             "NameMatches": true,
@@ -254746,7 +255156,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -254821,7 +255231,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -254841,7 +255251,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼88┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼89┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -254928,7 +255338,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -254964,7 +255374,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -255063,7 +255473,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -255125,12 +255535,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -255241,8 +255651,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -255496,7 +255938,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -255584,12 +256026,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -255839,7 +256281,7 @@
                     },
                     {
                       "Name": "connectedDevices#14",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_57┼48┼0┼@0@APCPoweredDevice@0"
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_58┼47┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#13",
@@ -255903,51 +256345,6 @@
             }
           },
           {
-            "GitID": "fde32c02abddc814f9366ff1fb21f234_57┼48┼0┼",
-            "PrefabID": "fde32c02abddc814f9366ff1fb21f234",
-            "NameMatches": true,
-            "Name": "LightTubeFixture",
-            "LocalPRS": "57┼48┼0┼",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "Integrity@0",
-                  "Data": [
-                    {
-                      "Name": "Armor@Melee",
-                      "Data": "0"
-                    }
-                  ]
-                },
-                {
-                  "ClassID": "APCPoweredDevice@0",
-                  "Data": [
-                    {
-                      "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_57┼46┼0┼@0@APC@0"
-                    }
-                  ]
-                },
-                {
-                  "ClassID": "LightSource@0",
-                  "Data": [
-                    {
-                      "Name": "relatedLightSwitch",
-                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_57┼49┼0┼@0@LightSwitchV2@0"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,2",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
-          },
-          {
             "GitID": "f2432d244a6b7774ea00ff013beb7dcb_57┼49┼0┼",
             "PrefabID": "f2432d244a6b7774ea00ff013beb7dcb",
             "NameMatches": true,
@@ -255978,7 +256375,7 @@
                   "Data": [
                     {
                       "Name": "listOfLights#1",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_57┼48┼0┼@0@LightSource@0"
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_58┼47┼0┼@0@LightSource@0"
                     },
                     {
                       "Name": "listOfLights#0",
@@ -256027,7 +256424,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -256368,22 +256765,6 @@
             }
           },
           {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_57┼71┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights",
-            "LocalPRS": "57┼71┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
-          },
-          {
             "GitID": "9f6a082ba93c5684b808b09619c08044_57┼76┼0┼",
             "PrefabID": "9f6a082ba93c5684b808b09619c08044",
             "Name": "AirlockMedicalWindowed (4)",
@@ -256450,7 +256831,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼88┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼89┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -256469,7 +256850,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼88┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼89┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -256642,7 +257023,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -256705,7 +257086,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -256779,7 +257160,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -256846,6 +257227,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Armory"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -256858,8 +257243,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -257073,7 +257490,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -257156,7 +257573,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -257216,7 +257633,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -257294,7 +257711,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -257486,10 +257903,6 @@
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
-                    {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
                     }
@@ -257535,10 +257948,6 @@
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
-                    {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
                     }
@@ -257583,10 +257992,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -257663,6 +258068,60 @@
             "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
             "Name": "VIR_LowVoltageMachineConnector",
             "LocalPRS": "58┼46┼0┼"
+          },
+          {
+            "GitID": "fde32c02abddc814f9366ff1fb21f234_58┼47┼0┼",
+            "PrefabID": "fde32c02abddc814f9366ff1fb21f234",
+            "NameMatches": true,
+            "Name": "LightTubeFixture",
+            "LocalPRS": "58┼47┼0┼0ø0ø270ø",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "Integrity@0",
+                  "Data": [
+                    {
+                      "Name": "Armor@Melee",
+                      "Data": "0"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_57┼46┼0┼@0@APC@0"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Right_By270"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "LightSource@0",
+                  "Data": [
+                    {
+                      "Name": "relatedLightSwitch",
+                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_57┼49┼0┼@0@LightSwitchV2@0"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,3",
+                  "Active": false,
+                  "ClassDatas": []
+                }
+              ]
+            }
           },
           {
             "GitID": "74c59d7cb720be945a7c5606d962c05a_58┼49┼0┼",
@@ -257774,7 +258233,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -257854,7 +258313,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -257963,12 +258422,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -258143,7 +258602,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼88┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼89┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -258151,11 +258610,11 @@
             }
           },
           {
-            "GitID": "fde32c02abddc814f9366ff1fb21f234_58┼93┼0┼",
+            "GitID": "fde32c02abddc814f9366ff1fb21f234_58┼94┼0┼",
             "PrefabID": "fde32c02abddc814f9366ff1fb21f234",
             "NameMatches": true,
             "Name": "LightTubeFixture",
-            "LocalPRS": "58┼93┼0┼0ø0ø180ø",
+            "LocalPRS": "58┼94┼0┼0ø0ø180ø",
             "Object": {
               "ClassDatas": [
                 {
@@ -258172,7 +258631,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼88┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼89┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -258197,7 +258656,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -258250,12 +258709,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -258517,7 +258976,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -258600,12 +259059,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -259031,10 +259490,6 @@
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
-                    {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
                     }
@@ -259086,10 +259541,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -259265,7 +259716,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -259433,25 +259884,9 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼88┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼89┼0┼@0@APC@0"
                     }
                   ]
-                }
-              ]
-            }
-          },
-          {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_59┼90┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights",
-            "LocalPRS": "59┼90┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "Active": false,
-                  "ClassDatas": []
                 }
               ]
             }
@@ -259541,7 +259976,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -259595,7 +260030,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -259697,7 +260132,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -259724,32 +260159,6 @@
             "LocalPRS": "60┼12┼0┼"
           },
           {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_60┼19┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights",
-            "LocalPRS": "60┼19┼0┼0ø0ø180ø",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Down_By180"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
-          },
-          {
             "GitID": "aef082ffdd3b51f45bd9a56c6afda863_60┼23┼0┼",
             "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
             "Name": "emergency_lights",
@@ -259758,7 +260167,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -259890,8 +260299,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -260187,7 +260628,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -260242,10 +260683,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -260395,10 +260832,6 @@
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
-                    {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
                     }
@@ -260443,10 +260876,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -260493,10 +260922,6 @@
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
-                    {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
                     }
@@ -260526,32 +260951,6 @@
                       ]
                     }
                   ]
-                }
-              ]
-            }
-          },
-          {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_60┼47┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights (4)",
-            "LocalPRS": "60┼47┼0┼0ø0ø180ø",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Down_By180"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "Active": false,
-                  "ClassDatas": []
                 }
               ]
             }
@@ -260723,7 +261122,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -260796,38 +261195,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
-          },
-          {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_60┼66┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights",
-            "LocalPRS": "60┼66┼0┼0ø0ø90ø",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Left_By90"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,1",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -260976,7 +261349,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -261054,7 +261427,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -261090,12 +261463,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -261140,7 +261513,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -261159,7 +261532,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼88┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼89┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -261178,7 +261551,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼88┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼89┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -261254,7 +261627,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -261373,7 +261746,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -261423,12 +261796,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -261454,7 +261827,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -261472,10 +261845,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -261887,7 +262256,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -261970,7 +262339,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -262644,12 +263013,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -262703,7 +263072,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -262828,7 +263197,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -262854,7 +263223,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -262930,12 +263299,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -263303,7 +263672,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼88┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼89┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -263422,7 +263791,6 @@
           {
             "GitID": "3edf81f4a32c4c348bad5bfe43e263fd_61┼114.99┼0┼",
             "PrefabID": "3edf81f4a32c4c348bad5bfe43e263fd",
-            "NameMatches": true,
             "Name": "Paper Bin1",
             "LocalPRS": "61┼114.99┼0┼"
           },
@@ -263473,7 +263841,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -263821,7 +264189,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -263882,13 +264250,6 @@
                 }
               ]
             }
-          },
-          {
-            "GitID": "J5UF3VXxKdTV9iopbA17_62┼27┼0┼",
-            "PrefabID": "J5UF3VXxKdTV9iopbA17",
-            "NameMatches": true,
-            "Name": "SecBarrier",
-            "LocalPRS": "62┼27┼0┼"
           },
           {
             "GitID": "74c59d7cb720be945a7c5606d962c05a_62┼37┼0┼",
@@ -264089,10 +264450,6 @@
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
-                    {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
                     }
@@ -264248,12 +264605,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -264365,7 +264722,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -264401,12 +264758,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -264460,7 +264817,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -264505,7 +264862,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼88┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼89┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -264530,7 +264887,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -264550,7 +264907,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼88┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼89┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -264566,12 +264923,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -264650,12 +265007,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -265052,19 +265409,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
               ]
             }
-          },
-          {
-            "GitID": "J5UF3VXxKdTV9iopbA17_63┼27┼0┼",
-            "PrefabID": "J5UF3VXxKdTV9iopbA17",
-            "NameMatches": true,
-            "Name": "SecBarrier",
-            "LocalPRS": "63┼27┼0┼"
           },
           {
             "GitID": "70d3024fe9d901346a2e42c43833ceba_63┼29┼0┼",
@@ -265126,7 +265476,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -265199,12 +265549,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -265284,7 +265634,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -265446,7 +265796,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -265475,32 +265825,6 @@
                       "Data": "cd57203a8d3f54f478446e9b0ced6cf9_57┼46┼0┼@0@APC@0"
                     }
                   ]
-                }
-              ]
-            }
-          },
-          {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_63┼49┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights",
-            "LocalPRS": "63┼49┼0┼0ø0ø90ø",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Left_By90"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "Active": false,
-                  "ClassDatas": []
                 }
               ]
             }
@@ -265543,7 +265867,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -265666,10 +265990,6 @@
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
-                    {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
                     }
@@ -265725,7 +266045,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -265776,7 +266096,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -265898,7 +266218,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -266033,7 +266353,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -266085,7 +266405,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼88┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_55┼89┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -266150,12 +266470,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -266294,12 +266614,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -266705,7 +267025,6 @@
           {
             "GitID": "3edf81f4a32c4c348bad5bfe43e263fd_64┼31┼0┼",
             "PrefabID": "3edf81f4a32c4c348bad5bfe43e263fd",
-            "NameMatches": true,
             "Name": "Paper Bin1",
             "LocalPRS": "64┼31┼0┼"
           },
@@ -266808,7 +267127,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -267158,7 +267477,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -267311,7 +267630,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -267507,7 +267826,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -267543,12 +267862,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -267658,7 +267977,7 @@
             "PrefabID": "fde32c02abddc814f9366ff1fb21f234",
             "NameMatches": true,
             "Name": "LightTubeFixture",
-            "LocalPRS": "64┼106┼0┼",
+            "LocalPRS": "64┼106┼0┼0ø0ø180ø",
             "Object": {
               "ClassDatas": [
                 {
@@ -267680,6 +267999,15 @@
                   ]
                 },
                 {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Down_By180"
+                    }
+                  ]
+                },
+                {
                   "ClassID": "LightSource@0",
                   "Data": [
                     {
@@ -267691,7 +268019,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -267908,7 +268236,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -268027,12 +268355,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -268367,12 +268695,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -268390,10 +268718,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -268570,7 +268894,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -269201,11 +269525,11 @@
             }
           },
           {
-            "GitID": "30fb7ca3bc404684697f10534d3eee73_65┼75┼0┼",
+            "GitID": "30fb7ca3bc404684697f10534d3eee73_65┼77┼0┼",
             "PrefabID": "30fb7ca3bc404684697f10534d3eee73",
             "NameMatches": true,
             "Name": "AirlockMedicalOpaque",
-            "LocalPRS": "65┼75┼0┼",
+            "LocalPRS": "65┼77┼0┼",
             "Object": {
               "ClassDatas": [
                 {
@@ -269213,7 +269537,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_67┼76┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_69┼79┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -269233,7 +269557,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_67┼76┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_69┼79┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -269269,12 +269593,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -269357,7 +269681,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -269490,11 +269814,11 @@
                   "ClassID": "ItemSlotActionTracker@0",
                   "Data": [
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "SecureStuff.SerializedAction"
                     },
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "#removed#"
                     }
                   ]
@@ -269823,12 +270147,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -270159,7 +270483,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -270389,7 +270713,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -270416,12 +270740,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -270457,12 +270781,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -270507,7 +270831,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -270807,7 +271131,6 @@
           {
             "GitID": "3edf81f4a32c4c348bad5bfe43e263fd_66┼69┼0┼",
             "PrefabID": "3edf81f4a32c4c348bad5bfe43e263fd",
-            "NameMatches": true,
             "Name": "Paper Bin1",
             "LocalPRS": "66┼69┼0┼"
           },
@@ -270883,7 +271206,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -270897,28 +271220,19 @@
             "LocalPRS": "66┼73┼0┼"
           },
           {
-            "GitID": "f2432d244a6b7774ea00ff013beb7dcb_66┼76┼0┼",
-            "PrefabID": "f2432d244a6b7774ea00ff013beb7dcb",
+            "GitID": "a50474d976314462a79602e20a762520_66┼74┼0┼",
+            "PrefabID": "a50474d976314462a79602e20a762520",
             "NameMatches": true,
-            "Name": "LightSwitch",
-            "LocalPRS": "66┼76┼0┼",
+            "Name": "ACU",
+            "LocalPRS": "66┼74┼0┼",
             "Object": {
               "ClassDatas": [
-                {
-                  "ClassID": "Integrity@0",
-                  "Data": [
-                    {
-                      "Name": "Armor@Melee",
-                      "Data": "0"
-                    }
-                  ]
-                },
                 {
                   "ClassID": "APCPoweredDevice@0",
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_67┼76┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_69┼79┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -270930,15 +271244,47 @@
                       "Data": "Up_By0"
                     }
                   ]
-                },
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "c21551dd992a57349973e4b5af103ca6_66┼75┼0┼",
+            "PrefabID": "c21551dd992a57349973e4b5af103ca6",
+            "NameMatches": true,
+            "Name": "SecurityCamera",
+            "LocalPRS": "66┼75┼0┼",
+            "Object": {
+              "ClassDatas": [
                 {
-                  "ClassID": "LightSwitchV2@0",
+                  "ClassID": "APCPoweredDevice@0",
                   "Data": [
                     {
-                      "Name": "listOfLights#0",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_69┼77┼0┼@0@LightSource@0"
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_69┼79┼0┼@0@APC@0"
                     }
                   ]
+                },
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Up_By0"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,2",
+                  "Active": false,
+                  "ClassDatas": []
+                },
+                {
+                  "ID": "0,3",
+                  "Active": false,
+                  "ClassDatas": []
                 }
               ]
             }
@@ -271071,12 +271417,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -271421,7 +271767,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -271562,10 +271908,10 @@
             "LocalPRS": "66.78┼80.19┼0┼"
           },
           {
-            "GitID": "e58e1fd483fe772468ad2aab4259397d_66.97┼77┼0┼",
+            "GitID": "e58e1fd483fe772468ad2aab4259397d_66.97┼76.24┼0┼",
             "PrefabID": "e58e1fd483fe772468ad2aab4259397d",
             "Name": "Medical at 68 78",
-            "LocalPRS": "66.97┼77┼0┼",
+            "LocalPRS": "66.97┼76.24┼0┼",
             "Object": {
               "ClassDatas": [
                 {
@@ -271615,7 +271961,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -271718,7 +272064,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -272016,12 +272362,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -272144,7 +272490,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -272226,7 +272572,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -272403,92 +272749,10 @@
             "LocalPRS": "67┼73┼0┼"
           },
           {
-            "GitID": "cd57203a8d3f54f478446e9b0ced6cf9_67┼76┼0┼",
-            "PrefabID": "cd57203a8d3f54f478446e9b0ced6cf9",
-            "Name": "APC - Medbay02",
-            "LocalPRS": "67┼76┼0┼",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "Integrity@0",
-                  "Data": [
-                    {
-                      "Name": "Armor@Melee",
-                      "Data": "0"
-                    },
-                    {
-                      "Name": "Resistances@FireProof",
-                      "Data": "False"
-                    }
-                  ]
-                },
-                {
-                  "ClassID": "ObjectAttributes@0",
-                  "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "APC"
-                    },
-                    {
-                      "Name": "initialDescription",
-                      "Data": "Area Power Controller"
-                    }
-                  ]
-                },
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Up_By0"
-                    }
-                  ]
-                },
-                {
-                  "ClassID": "APC@0",
-                  "Data": [
-                    {
-                      "Name": "connectedDevices#7",
-                      "Data": "a50474d976314462a79602e20a762520_68┼76┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#6",
-                      "Data": "0d553281bdfc0fd438b3f6c7db58688c_68┼78┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#5",
-                      "Data": "cb2f847ef3b8b754181a970a4032c552_67┼78┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#4",
-                      "Data": "c21551dd992a57349973e4b5af103ca6_68┼77┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#3",
-                      "Data": "9f6a082ba93c5684b808b09619c08044_65┼78┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#2",
-                      "Data": "30fb7ca3bc404684697f10534d3eee73_65┼75┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#1",
-                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_66┼76┼0┼@0@APCPoweredDevice@0"
-                    },
-                    {
-                      "Name": "connectedDevices#0",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_69┼77┼0┼@0@APCPoweredDevice@0"
-                    }
-                  ]
-                }
-              ]
-            }
-          },
-          {
-            "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_67┼77┼0┼",
-            "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "Name": "VIR_LowVoltageMachineConnector",
-            "LocalPRS": "67┼77┼0┼"
+            "GitID": "69b2a032b40410c4aace843d93130385_67┼75┼0┼",
+            "PrefabID": "69b2a032b40410c4aace843d93130385",
+            "Name": "Closet_Locker_Medical_Blue",
+            "LocalPRS": "67┼75┼0┼"
           },
           {
             "GitID": "cb2f847ef3b8b754181a970a4032c552_67┼78┼0┼",
@@ -272502,7 +272766,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_67┼76┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_69┼79┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -272511,7 +272775,7 @@
                   "Data": [
                     {
                       "Name": "Controller",
-                      "Data": "a50474d976314462a79602e20a762520_68┼76┼0┼@0@AirController@0"
+                      "Data": "a50474d976314462a79602e20a762520_66┼74┼0┼@0@AirController@0"
                     }
                   ]
                 }
@@ -272920,12 +273184,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -273133,12 +273397,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -273243,10 +273507,24 @@
             "LocalPRS": "67.04┼79.98┼0┼"
           },
           {
+            "GitID": "dd33a51f8c440da4cb4273b8954c03b3_67.06┼75.05┼0┼",
+            "PrefabID": "dd33a51f8c440da4cb4273b8954c03b3",
+            "NameMatches": true,
+            "Name": "RandomMedicalSuppliesSpawner",
+            "LocalPRS": "67.06┼75.05┼0┼"
+          },
+          {
             "GitID": "28e04200f63c4714f8608d921b156edd_67.23┼80.24┼0┼",
             "PrefabID": "28e04200f63c4714f8608d921b156edd",
             "Name": "RadiationTreatmentKit (1)",
             "LocalPRS": "67.23┼80.24┼0┼"
+          },
+          {
+            "GitID": "dd33a51f8c440da4cb4273b8954c03b3_67.93┼74.96┼0┼",
+            "PrefabID": "dd33a51f8c440da4cb4273b8954c03b3",
+            "NameMatches": true,
+            "Name": "RandomMedicalSuppliesSpawner",
+            "LocalPRS": "67.93┼74.96┼0┼"
           },
           {
             "GitID": "45bc971bfed45ba469181751ada0051f_68┼-1┼0┼",
@@ -273341,7 +273619,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -273547,11 +273825,11 @@
                   "ClassID": "ItemSlotActionTracker@0",
                   "Data": [
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "SecureStuff.SerializedAction"
                     },
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "#removed#"
                     }
                   ]
@@ -273568,7 +273846,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -273683,22 +273961,6 @@
             }
           },
           {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_68┼59┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights",
-            "LocalPRS": "68┼59┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
-          },
-          {
             "GitID": "ab0aa8f76b409df4484ece26230ffdd2_68┼61┼0┼",
             "PrefabID": "ab0aa8f76b409df4484ece26230ffdd2",
             "Name": "BlueprintMedBot (2)",
@@ -273808,48 +274070,34 @@
             }
           },
           {
-            "GitID": "a50474d976314462a79602e20a762520_68┼76┼0┼",
-            "PrefabID": "a50474d976314462a79602e20a762520",
-            "NameMatches": true,
-            "Name": "ACU",
-            "LocalPRS": "68┼76┼0┼",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "APCPoweredDevice@0",
-                  "Data": [
-                    {
-                      "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_67┼76┼0┼@0@APC@0"
-                    }
-                  ]
-                },
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Up_By0"
-                    }
-                  ]
-                }
-              ]
-            }
+            "GitID": "69b2a032b40410c4aace843d93130385_68┼75┼0┼",
+            "PrefabID": "69b2a032b40410c4aace843d93130385",
+            "Name": "Closet_Locker_Medical_Blue",
+            "LocalPRS": "68┼75┼0┼"
           },
           {
-            "GitID": "c21551dd992a57349973e4b5af103ca6_68┼77┼0┼",
-            "PrefabID": "c21551dd992a57349973e4b5af103ca6",
+            "GitID": "fde32c02abddc814f9366ff1fb21f234_68┼77┼0┼",
+            "PrefabID": "fde32c02abddc814f9366ff1fb21f234",
             "NameMatches": true,
-            "Name": "SecurityCamera",
-            "LocalPRS": "68┼77┼0┼",
+            "Name": "LightTubeFixture",
+            "LocalPRS": "68┼77┼0┼0ø0ø90ø",
             "Object": {
               "ClassDatas": [
+                {
+                  "ClassID": "Integrity@0",
+                  "Data": [
+                    {
+                      "Name": "Armor@Melee",
+                      "Data": "0"
+                    }
+                  ]
+                },
                 {
                   "ClassID": "APCPoweredDevice@0",
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_67┼76┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_69┼79┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -273858,19 +274106,23 @@
                   "Data": [
                     {
                       "Name": "CurrentDirection",
-                      "Data": "Up_By0"
+                      "Data": "Left_By90"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "LightSource@0",
+                  "Data": [
+                    {
+                      "Name": "relatedLightSwitch",
+                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_69┼76┼0┼@0@LightSwitchV2@0"
                     }
                   ]
                 }
               ],
               "Children": [
                 {
-                  "ID": "0,1",
-                  "Active": false,
-                  "ClassDatas": []
-                },
-                {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -273889,7 +274141,7 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_67┼76┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_69┼79┼0┼@0@APC@0"
                     }
                   ]
                 },
@@ -273907,12 +274159,18 @@
                   "Data": [
                     {
                       "Name": "Controller",
-                      "Data": "a50474d976314462a79602e20a762520_68┼76┼0┼@0@AirController@0"
+                      "Data": "a50474d976314462a79602e20a762520_66┼74┼0┼@0@AirController@0"
                     }
                   ]
                 }
               ]
             }
+          },
+          {
+            "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_68┼79┼0┼",
+            "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
+            "Name": "VIR_LowVoltageMachineConnector",
+            "LocalPRS": "68┼79┼0┼"
           },
           {
             "GitID": "69b2a032b40410c4aace843d93130385_68┼80┼0┼",
@@ -273973,7 +274231,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -273985,32 +274243,6 @@
             "PrefabID": "e0e2a6ad88a88af43944d68f8140d27a",
             "Name": "Closet_Locker_White_Blue",
             "LocalPRS": "68┼83┼0┼"
-          },
-          {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_68┼84┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights",
-            "LocalPRS": "68┼84┼0┼0ø0ø90ø",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Left_By90"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
           },
           {
             "GitID": "e0e2a6ad88a88af43944d68f8140d27a_68┼84┼0┼",
@@ -274169,7 +274401,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -274264,12 +274496,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -274324,12 +274556,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -274353,11 +274585,11 @@
                   "ClassID": "ItemSlotActionTracker@0",
                   "Data": [
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "SecureStuff.SerializedAction"
                     },
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "#removed#"
                     }
                   ]
@@ -274382,11 +274614,11 @@
                   "ClassID": "ItemSlotActionTracker@0",
                   "Data": [
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "SecureStuff.SerializedAction"
                     },
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "#removed#"
                     }
                   ]
@@ -274411,11 +274643,11 @@
                   "ClassID": "ItemSlotActionTracker@0",
                   "Data": [
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "SecureStuff.SerializedAction"
                     },
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "#removed#"
                     }
                   ]
@@ -274490,7 +274722,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -274893,7 +275125,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -274962,12 +275194,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -275094,24 +275326,11 @@
             }
           },
           {
-            "GitID": "69b2a032b40410c4aace843d93130385_69┼77┼0┼",
-            "PrefabID": "69b2a032b40410c4aace843d93130385",
-            "Name": "Closet_Locker_Medical_Blue",
-            "LocalPRS": "69┼77┼0┼"
-          },
-          {
-            "GitID": "dd33a51f8c440da4cb4273b8954c03b3_69┼77┼0┼",
-            "PrefabID": "dd33a51f8c440da4cb4273b8954c03b3",
+            "GitID": "f2432d244a6b7774ea00ff013beb7dcb_69┼76┼0┼",
+            "PrefabID": "f2432d244a6b7774ea00ff013beb7dcb",
             "NameMatches": true,
-            "Name": "RandomMedicalSuppliesSpawner",
-            "LocalPRS": "69┼77┼0┼"
-          },
-          {
-            "GitID": "fde32c02abddc814f9366ff1fb21f234_69┼77┼0┼",
-            "PrefabID": "fde32c02abddc814f9366ff1fb21f234",
-            "NameMatches": true,
-            "Name": "LightTubeFixture",
-            "LocalPRS": "69┼77┼0┼",
+            "Name": "LightSwitch",
+            "LocalPRS": "69┼76┼0┼",
             "Object": {
               "ClassDatas": [
                 {
@@ -275128,41 +275347,112 @@
                   "Data": [
                     {
                       "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_67┼76┼0┼@0@APC@0"
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_69┼79┼0┼@0@APC@0"
                     }
                   ]
                 },
                 {
-                  "ClassID": "LightSource@0",
+                  "ClassID": "Rotatable@0",
                   "Data": [
                     {
-                      "Name": "relatedLightSwitch",
-                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_66┼76┼0┼@0@LightSwitchV2@0"
+                      "Name": "CurrentDirection",
+                      "Data": "Left_By90"
                     }
                   ]
-                }
-              ],
-              "Children": [
+                },
                 {
-                  "ID": "0,2",
-                  "Active": false,
-                  "ClassDatas": []
+                  "ClassID": "LightSwitchV2@0",
+                  "Data": [
+                    {
+                      "Name": "listOfLights#0",
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_68┼77┼0┼@0@LightSource@0"
+                    }
+                  ]
                 }
               ]
             }
           },
           {
-            "GitID": "69b2a032b40410c4aace843d93130385_69┼78┼0┼",
-            "PrefabID": "69b2a032b40410c4aace843d93130385",
-            "Name": "Closet_Locker_Medical_Blue",
-            "LocalPRS": "69┼78┼0┼"
-          },
-          {
-            "GitID": "dd33a51f8c440da4cb4273b8954c03b3_69┼78┼0┼",
-            "PrefabID": "dd33a51f8c440da4cb4273b8954c03b3",
-            "NameMatches": true,
-            "Name": "RandomMedicalSuppliesSpawner",
-            "LocalPRS": "69┼78┼0┼"
+            "GitID": "cd57203a8d3f54f478446e9b0ced6cf9_69┼79┼0┼",
+            "PrefabID": "cd57203a8d3f54f478446e9b0ced6cf9",
+            "Name": "APC - Medbay02",
+            "LocalPRS": "69┼79┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "Integrity@0",
+                  "Data": [
+                    {
+                      "Name": "Armor@Melee",
+                      "Data": "0"
+                    },
+                    {
+                      "Name": "Resistances@FireProof",
+                      "Data": "False"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "ObjectAttributes@0",
+                  "Data": [
+                    {
+                      "Name": "initialName",
+                      "Data": "APC"
+                    },
+                    {
+                      "Name": "initialDescription",
+                      "Data": "Area Power Controller"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Left_By90"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "APC@0",
+                  "Data": [
+                    {
+                      "Name": "connectedDevices#7",
+                      "Data": "a50474d976314462a79602e20a762520_66┼74┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#6",
+                      "Data": "0d553281bdfc0fd438b3f6c7db58688c_68┼78┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#5",
+                      "Data": "cb2f847ef3b8b754181a970a4032c552_67┼78┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#4",
+                      "Data": "c21551dd992a57349973e4b5af103ca6_66┼75┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#3",
+                      "Data": "9f6a082ba93c5684b808b09619c08044_65┼78┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#2",
+                      "Data": "30fb7ca3bc404684697f10534d3eee73_65┼77┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#1",
+                      "Data": "f2432d244a6b7774ea00ff013beb7dcb_69┼76┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#0",
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_68┼77┼0┼@0@APCPoweredDevice@0"
+                    }
+                  ]
+                }
+              ]
+            }
           },
           {
             "GitID": "38246cd9491b4c248abb2e296cc6c76f_69┼88┼0┼",
@@ -275848,12 +276138,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -275972,7 +276262,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -276032,7 +276322,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -276086,7 +276376,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -276094,10 +276384,10 @@
             }
           },
           {
-            "GitID": "J5UF3VXxKdTV9iopbA17_70┼48┼0┼",
-            "PrefabID": "J5UF3VXxKdTV9iopbA17",
+            "GitID": "6b7563f69c76a2a4a9dd785f88e80c19_70┼48┼0┼",
+            "PrefabID": "6b7563f69c76a2a4a9dd785f88e80c19",
             "NameMatches": true,
-            "Name": "SecBarrier",
+            "Name": "DeployableSecurityBarrier",
             "LocalPRS": "70┼48┼0┼"
           },
           {
@@ -276205,7 +276495,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -276463,18 +276753,12 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
               ]
             }
-          },
-          {
-            "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_70┼75┼0┼",
-            "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "Name": "VIR_LowVoltageMachineConnector",
-            "LocalPRS": "70┼75┼0┼"
           },
           {
             "GitID": "31d7f641274343343b94e59bce361843_70┼80┼0┼",
@@ -276535,7 +276819,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -276648,7 +276932,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -277290,12 +277574,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -277331,12 +277615,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -277362,6 +277646,12 @@
                 }
               ]
             }
+          },
+          {
+            "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_71┼74┼0┼",
+            "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
+            "Name": "VIR_LowVoltageMachineConnector",
+            "LocalPRS": "71┼74┼0┼"
           },
           {
             "GitID": "ed4e62dc12dca724ba1e5f374965096b_71┼85┼0┼",
@@ -277397,7 +277687,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -277421,11 +277711,11 @@
                   "ClassID": "ItemSlotActionTracker@0",
                   "Data": [
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "SecureStuff.SerializedAction"
                     },
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "#removed#"
                     }
                   ]
@@ -277563,7 +277853,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -277617,7 +277907,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -277653,12 +277943,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -277823,12 +278113,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -278017,7 +278307,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -278053,12 +278343,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -278124,7 +278414,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -278718,7 +279008,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -278754,12 +279044,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -278815,12 +279105,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -278987,12 +279277,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -279376,12 +279666,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -279519,7 +279809,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -279995,7 +280285,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -280040,7 +280330,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -280155,7 +280445,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -280226,7 +280516,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -280282,7 +280572,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -280309,12 +280599,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -280407,12 +280697,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -280621,7 +280911,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -280672,7 +280962,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -280745,7 +281035,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -280899,7 +281189,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -281089,33 +281379,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
-          },
-          {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_74┼62┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights",
-            "LocalPRS": "74┼62┼0┼0ø0ø90ø",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Left_By90"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,1",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -281175,7 +281439,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -281211,12 +281475,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -281270,7 +281534,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -281296,7 +281560,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -281614,12 +281878,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -281931,7 +282195,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -282023,7 +282287,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -282087,12 +282351,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -282162,22 +282426,6 @@
             }
           },
           {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_75┼52┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights",
-            "LocalPRS": "75┼52┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
-          },
-          {
             "GitID": "aef082ffdd3b51f45bd9a56c6afda863_75┼54┼0┼",
             "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
             "Name": "emergency_lights",
@@ -282196,7 +282444,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -282923,7 +283171,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -283094,12 +283342,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -283153,7 +283401,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -283207,7 +283455,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -283261,7 +283509,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -283387,7 +283635,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -283440,6 +283688,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Chemistry"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -283535,7 +283787,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -283613,12 +283865,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -283702,32 +283954,6 @@
             "PrefabID": "2534979989212594f9dccf67a7400686",
             "Name": "nuke_terminal",
             "LocalPRS": "76┼26┼0┼"
-          },
-          {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_76┼27┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights",
-            "LocalPRS": "76┼27┼0┼0ø0ø180ø",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Down_By180"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
           },
           {
             "GitID": "c0d35a75ba9aa4c4fab141f0fac245f6_76┼34┼0┼",
@@ -283905,7 +284131,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -284101,6 +284327,7 @@
           {
             "GitID": "ChemMaster_76┼56┼0┼",
             "PrefabID": "ChemMaster",
+            "NameMatches": true,
             "Name": "ChemMaster",
             "LocalPRS": "76┼56┼0┼"
           },
@@ -284115,10 +284342,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -284156,6 +284379,7 @@
           {
             "GitID": "ChemDispenser_76┼58┼0┼",
             "PrefabID": "ChemDispenser",
+            "NameMatches": true,
             "Name": "ChemDispenser",
             "LocalPRS": "76┼58┼0┼",
             "Object": {
@@ -284192,12 +284416,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -284303,12 +284527,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -284362,10 +284586,6 @@
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
-                    {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
                     }
@@ -284410,10 +284630,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -284470,7 +284686,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -284777,12 +284993,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -284837,12 +285053,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -284884,6 +285100,19 @@
             "NameMatches": true,
             "Name": "Paper",
             "LocalPRS": "76.3┼74.25┼0┼"
+          },
+          {
+            "GitID": "9eaebd66cb3e3d145a9bb373c42925e7_76.97┼127┼0┼",
+            "PrefabID": "9eaebd66cb3e3d145a9bb373c42925e7",
+            "Name": "Rolled Poster",
+            "LocalPRS": "76.97┼127┼0┼"
+          },
+          {
+            "GitID": "61891de53a1487e4bbfb60ce0c686c6c_76.99┼130.14┼0┼",
+            "PrefabID": "61891de53a1487e4bbfb60ce0c686c6c",
+            "NameMatches": true,
+            "Name": "SmugglersSatchelContraband",
+            "LocalPRS": "76.99┼130.14┼0┼"
           },
           {
             "GitID": "0d553281bdfc0fd438b3f6c7db58688c_77┼1┼0┼",
@@ -285089,7 +285318,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -285201,7 +285430,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -285286,12 +285515,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -285386,7 +285615,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -285882,10 +286111,6 @@
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
-                    {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
                     }
@@ -285977,7 +286202,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -286031,7 +286256,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -286097,7 +286322,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -286139,12 +286364,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -286220,12 +286445,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -286279,7 +286504,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -286311,30 +286536,6 @@
             }
           },
           {
-            "GitID": "1fd462b8cc81049fea75a1339d87a3da_77┼130┼0┼",
-            "PrefabID": "1fd462b8cc81049fea75a1339d87a3da",
-            "NameMatches": true,
-            "Name": "SyndicateCombatUniform",
-            "LocalPRS": "77┼130┼0┼",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "ItemSlotActionTracker@0",
-                  "Data": [
-                    {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
-                      "Data": "SecureStuff.SerializedAction"
-                    },
-                    {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
-                      "Data": "#removed#"
-                    }
-                  ]
-                }
-              ]
-            }
-          },
-          {
             "GitID": "68a3eee06f0a8cf4da5d8ab811ce1c73_77┼130┼0┼",
             "PrefabID": "68a3eee06f0a8cf4da5d8ab811ce1c73",
             "NameMatches": true,
@@ -286342,10 +286543,28 @@
             "LocalPRS": "77┼130┼0┼"
           },
           {
-            "GitID": "9eaebd66cb3e3d145a9bb373c42925e7_77┼130┼0┼",
-            "PrefabID": "9eaebd66cb3e3d145a9bb373c42925e7",
-            "Name": "Rolled Poster",
-            "LocalPRS": "77┼130┼0┼"
+            "GitID": "1fd462b8cc81049fea75a1339d87a3da_77┼130.01┼0┼",
+            "PrefabID": "1fd462b8cc81049fea75a1339d87a3da",
+            "NameMatches": true,
+            "Name": "SyndicateCombatUniform",
+            "LocalPRS": "77┼130.01┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "ItemSlotActionTracker@0",
+                  "Data": [
+                    {
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
+                      "Data": "SecureStuff.SerializedAction"
+                    },
+                    {
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
+                      "Data": "#removed#"
+                    }
+                  ]
+                }
+              ]
+            }
           },
           {
             "GitID": "0d553281bdfc0fd438b3f6c7db58688c_77┼152┼0┼",
@@ -286404,12 +286623,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -286509,16 +286728,20 @@
             }
           },
           {
-            "GitID": "9eaebd66cb3e3d145a9bb373c42925e7_77.001┼130┼0┼",
-            "PrefabID": "9eaebd66cb3e3d145a9bb373c42925e7",
-            "Name": "Rolled Poster",
-            "LocalPRS": "77.001┼130┼0┼"
-          },
-          {
             "GitID": "6f371050bff8b32438f91c7c680900bb_77.01┼110┼0┼",
             "PrefabID": "6f371050bff8b32438f91c7c680900bb",
             "Name": "Handheld Torch (1)",
-            "LocalPRS": "77.01┼110┼0┼"
+            "LocalPRS": "77.01┼110┼0┼",
+            "Object": {
+              "ClassDatas": [],
+              "Children": [
+                {
+                  "ID": "0,1",
+                  "Active": false,
+                  "ClassDatas": []
+                }
+              ]
+            }
           },
           {
             "GitID": "f6b4337f71037664e83de378d446ca98_77.02┼60.95┼0┼",
@@ -286733,12 +286956,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -286896,7 +287119,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -287049,12 +287272,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -287108,7 +287331,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -287191,7 +287414,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -287383,10 +287606,6 @@
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
-                    {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
                     }
@@ -287453,7 +287672,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -287507,7 +287726,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -287615,7 +287834,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -287698,7 +287917,17 @@
             "GitID": "6f371050bff8b32438f91c7c680900bb_78┼110┼0┼",
             "PrefabID": "6f371050bff8b32438f91c7c680900bb",
             "Name": "Handheld Torch (2)",
-            "LocalPRS": "78┼110┼0┼"
+            "LocalPRS": "78┼110┼0┼",
+            "Object": {
+              "ClassDatas": [],
+              "Children": [
+                {
+                  "ID": "0,1",
+                  "Active": false,
+                  "ClassDatas": []
+                }
+              ]
+            }
           },
           {
             "GitID": "68a3eee06f0a8cf4da5d8ab811ce1c73_78┼121┼0┼",
@@ -287750,6 +287979,7 @@
           {
             "GitID": "3edf81f4a32c4c348bad5bfe43e263fd_78┼131┼0┼",
             "PrefabID": "3edf81f4a32c4c348bad5bfe43e263fd",
+            "NameMatches": true,
             "Name": "Paper Bin",
             "LocalPRS": "78┼131┼0┼"
           },
@@ -287851,6 +288081,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Chemistry"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -288051,12 +288285,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -288357,7 +288591,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -288419,12 +288653,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -288539,7 +288773,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -288600,7 +288834,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -288677,12 +288911,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -288838,10 +289072,6 @@
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
-                    {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
                     }
@@ -288886,10 +289116,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -288975,7 +289201,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -289058,12 +289284,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -289165,7 +289391,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -289191,7 +289417,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -289245,7 +289471,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -289339,12 +289565,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -289744,7 +289970,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -289857,7 +290083,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -290368,12 +290594,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -290514,7 +290740,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -290541,12 +290767,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -290631,12 +290857,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -290870,7 +291096,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -290930,7 +291156,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -291424,7 +291650,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -291469,7 +291695,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -291551,7 +291777,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -291688,12 +291914,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -291866,7 +292092,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -292005,7 +292231,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -292087,7 +292313,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -292287,7 +292513,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -292341,7 +292567,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -292877,7 +293103,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -292895,10 +293121,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -292950,10 +293172,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -293489,7 +293707,6 @@
           {
             "GitID": "3edf81f4a32c4c348bad5bfe43e263fd_83┼100.08┼0┼",
             "PrefabID": "3edf81f4a32c4c348bad5bfe43e263fd",
-            "NameMatches": true,
             "Name": "Paper Bin1",
             "LocalPRS": "83┼100.08┼0┼"
           },
@@ -293519,7 +293736,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -293695,7 +293912,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -293783,7 +294000,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -294948,7 +295165,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -295033,7 +295250,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -295089,12 +295306,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -295139,7 +295356,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -295233,12 +295450,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -295350,7 +295567,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -295376,7 +295593,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -295408,7 +295625,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -295444,12 +295661,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -295475,7 +295692,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -295511,12 +295728,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -295614,7 +295831,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -295640,7 +295857,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -295694,7 +295911,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -295730,12 +295947,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -295789,7 +296006,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -295843,7 +296060,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -295879,12 +296096,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -295996,7 +296213,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -296022,7 +296239,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -296076,7 +296293,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -296112,12 +296329,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -296657,12 +296874,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -296716,7 +296933,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -296770,7 +296987,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -296796,7 +297013,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -296908,7 +297125,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -296944,12 +297161,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -297003,7 +297220,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -297057,7 +297274,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -297111,7 +297328,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -297165,7 +297382,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -297257,7 +297474,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -297293,12 +297510,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -297324,7 +297541,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -297350,7 +297567,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -299490,33 +299707,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
-          },
-          {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_88┼96┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights",
-            "LocalPRS": "88┼96┼0┼0ø0ø90ø",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Left_By90"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,1",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -299589,6 +299780,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Atmospherics"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -299607,7 +299802,6 @@
           {
             "GitID": "3edf81f4a32c4c348bad5bfe43e263fd_88.85┼23.1┼0┼",
             "PrefabID": "3edf81f4a32c4c348bad5bfe43e263fd",
-            "NameMatches": true,
             "Name": "Paper Bin1",
             "LocalPRS": "88.85┼23.1┼0┼"
           },
@@ -299712,7 +299906,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -299748,12 +299942,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -299771,10 +299965,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -299848,38 +300038,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
-          },
-          {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_89┼37┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights",
-            "LocalPRS": "89┼37┼0┼0ø0ø180ø",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Down_By180"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,1",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -299924,7 +300088,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -300042,7 +300206,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -300109,7 +300273,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -300163,7 +300327,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -300269,7 +300433,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -300293,10 +300457,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -300622,7 +300782,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -300826,7 +300986,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -300862,38 +301022,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
-          },
-          {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_89┼111┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights",
-            "LocalPRS": "89┼111┼0┼0ø0ø90ø",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Left_By90"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,1",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -300947,7 +301081,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -301101,7 +301235,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -301407,7 +301541,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -301485,6 +301619,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Library"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -301587,7 +301725,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -301632,7 +301770,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -301835,12 +301973,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -301876,12 +302014,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -301984,7 +302122,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -302079,7 +302217,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -302183,7 +302321,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -302292,7 +302430,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -302402,12 +302540,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -302424,7 +302562,6 @@
           {
             "GitID": "3edf81f4a32c4c348bad5bfe43e263fd_90┼100┼0┼",
             "PrefabID": "3edf81f4a32c4c348bad5bfe43e263fd",
-            "NameMatches": true,
             "Name": "Paper Bin1",
             "LocalPRS": "90┼100┼0┼"
           },
@@ -302502,7 +302639,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -302606,6 +302743,18 @@
             "LocalPRS": "90.74┼84.36┼0┼"
           },
           {
+            "GitID": "b735ab74dab174a4f90c79558cd51e43_90.987┼63┼0┼",
+            "PrefabID": "b735ab74dab174a4f90c79558cd51e43",
+            "Name": "Welder (2)",
+            "LocalPRS": "90.987┼63┼0┼"
+          },
+          {
+            "GitID": "b735ab74dab174a4f90c79558cd51e43_90.99┼63┼0┼",
+            "PrefabID": "b735ab74dab174a4f90c79558cd51e43",
+            "Name": "Welder (1)",
+            "LocalPRS": "90.99┼63┼0┼"
+          },
+          {
             "GitID": "1442b4dd7f8a6714a914b861519721c1_91┼17┼0┼",
             "PrefabID": "1442b4dd7f8a6714a914b861519721c1",
             "Name": "library_17",
@@ -302701,7 +302850,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -302847,12 +302996,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -302874,7 +303023,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -302919,7 +303068,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -302939,15 +303088,15 @@
             "LocalPRS": "91┼61┼0┼"
           },
           {
+            "GitID": "e6fef14b66545db41939986bb7911c4d_91┼62┼0┼",
+            "PrefabID": "e6fef14b66545db41939986bb7911c4d",
+            "Name": "UnitystationSign",
+            "LocalPRS": "91┼62┼0┼0ø0ø180ø"
+          },
+          {
             "GitID": "764cc89fcad4df74f92d294e87d2a8de_91┼63┼0┼",
             "PrefabID": "764cc89fcad4df74f92d294e87d2a8de",
             "Name": "Ointment (2)",
-            "LocalPRS": "91┼63┼0┼"
-          },
-          {
-            "GitID": "b735ab74dab174a4f90c79558cd51e43_91┼63┼0┼",
-            "PrefabID": "b735ab74dab174a4f90c79558cd51e43",
-            "Name": "Welder (1)",
             "LocalPRS": "91┼63┼0┼"
           },
           {
@@ -303003,7 +303152,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -303175,7 +303324,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -303370,18 +303519,6 @@
             "LocalPRS": "91┼126┼0┼"
           },
           {
-            "GitID": "764cc89fcad4df74f92d294e87d2a8de_91.001┼63┼0┼",
-            "PrefabID": "764cc89fcad4df74f92d294e87d2a8de",
-            "Name": "Ointment (1)",
-            "LocalPRS": "91.001┼63┼0┼"
-          },
-          {
-            "GitID": "b735ab74dab174a4f90c79558cd51e43_91.001┼63┼0┼",
-            "PrefabID": "b735ab74dab174a4f90c79558cd51e43",
-            "Name": "Welder (2)",
-            "LocalPRS": "91.001┼63┼0┼"
-          },
-          {
             "GitID": "cf93667e32e15bc43b0347cd102fef98_91.001┼102┼0┼",
             "PrefabID": "cf93667e32e15bc43b0347cd102fef98",
             "NameMatches": true,
@@ -303409,6 +303546,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Security"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -303702,32 +303843,6 @@
             }
           },
           {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_92┼15┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights",
-            "LocalPRS": "92┼15┼0┼0ø0ø180ø",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Down_By180"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
-          },
-          {
             "GitID": "1442b4dd7f8a6714a914b861519721c1_92┼17┼0┼",
             "PrefabID": "1442b4dd7f8a6714a914b861519721c1",
             "Name": "library_17",
@@ -303948,7 +304063,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -304053,7 +304168,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -304829,12 +304944,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -304947,7 +305062,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -305034,7 +305149,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -305509,7 +305624,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -305787,7 +305902,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -305841,7 +305956,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -305961,6 +306076,13 @@
             }
           },
           {
+            "GitID": "bde2e04457efae9448181975599790a5_93┼65┼0┼",
+            "PrefabID": "bde2e04457efae9448181975599790a5",
+            "NameMatches": true,
+            "Name": "PortableAirScrubber",
+            "LocalPRS": "93┼65┼0┼"
+          },
+          {
             "GitID": "c21551dd992a57349973e4b5af103ca6_93┼65┼0┼",
             "PrefabID": "c21551dd992a57349973e4b5af103ca6",
             "NameMatches": true,
@@ -305989,12 +306111,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -306103,22 +306225,6 @@
                       ]
                     }
                   ]
-                }
-              ]
-            }
-          },
-          {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_93┼80┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights",
-            "LocalPRS": "93┼80┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "Active": false,
-                  "ClassDatas": []
                 }
               ]
             }
@@ -306317,12 +306423,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -306440,7 +306546,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -306987,12 +307093,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -307037,7 +307143,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -307120,7 +307226,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -307341,12 +307447,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -307575,7 +307681,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -307652,12 +307758,6 @@
             }
           },
           {
-            "GitID": "e6fef14b66545db41939986bb7911c4d_94┼62┼0┼",
-            "PrefabID": "e6fef14b66545db41939986bb7911c4d",
-            "Name": "UnitystationSign",
-            "LocalPRS": "94┼62┼0┼0ø0ø180ø"
-          },
-          {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_94┼75┼0┼",
             "PrefabID": "fde32c02abddc814f9366ff1fb21f234",
             "NameMatches": true,
@@ -307704,7 +307804,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -307740,12 +307840,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -307827,7 +307927,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -308002,7 +308102,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -308093,7 +308193,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -308220,7 +308320,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -308285,7 +308385,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -308303,10 +308403,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -308398,7 +308494,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -308748,12 +308844,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -309007,22 +309103,6 @@
             }
           },
           {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_95┼57┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights (39)",
-            "LocalPRS": "95┼57┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
-          },
-          {
             "GitID": "1a00e842e154f7d43811c5d45328988c_95┼58┼0┼",
             "PrefabID": "1a00e842e154f7d43811c5d45328988c",
             "NameMatches": true,
@@ -309124,7 +309204,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -309212,7 +309292,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -309262,12 +309342,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -309610,7 +309690,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -309675,12 +309755,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -309818,7 +309898,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -310124,7 +310204,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -310148,32 +310228,6 @@
             "PrefabID": "419b53e1dfc68534c874d417a070b675",
             "Name": "library_22",
             "LocalPRS": "96┼21┼0┼"
-          },
-          {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_96┼22┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights",
-            "LocalPRS": "96┼22┼0┼0ø0ø180ø",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Down_By180"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
           },
           {
             "GitID": "38246cd9491b4c248abb2e296cc6c76f_96┼24┼0┼",
@@ -310333,7 +310387,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -310424,10 +310478,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -310797,7 +310847,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -311102,7 +311152,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -311222,6 +311272,12 @@
             "NameMatches": true,
             "Name": "Randomtoolboxspawner",
             "LocalPRS": "96.96┼127.95┼0┼"
+          },
+          {
+            "GitID": "9eaebd66cb3e3d145a9bb373c42925e7_96.99┼128.04┼0┼",
+            "PrefabID": "9eaebd66cb3e3d145a9bb373c42925e7",
+            "Name": "Rolled Poster",
+            "LocalPRS": "96.99┼128.04┼0┼"
           },
           {
             "GitID": "419b53e1dfc68534c874d417a070b675_97┼17┼0┼",
@@ -311448,7 +311504,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -311577,7 +311633,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -311643,7 +311699,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -311689,6 +311745,7 @@
           {
             "GitID": "93d1f95a33757fe4fa3e2771e3f5bd67_97┼52┼0┼",
             "PrefabID": "93d1f95a33757fe4fa3e2771e3f5bd67",
+            "NameMatches": true,
             "Name": "PowerGeneratorPlasma",
             "LocalPRS": "97┼52┼0┼"
           },
@@ -311819,7 +311876,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -311877,7 +311934,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -311940,12 +311997,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -311958,32 +312015,6 @@
             "NameMatches": true,
             "Name": "ComputerBoardShuttlePilotingConsole",
             "LocalPRS": "97┼87┼0┼"
-          },
-          {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_97┼87┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights",
-            "LocalPRS": "97┼87┼0┼0ø0ø180ø",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Down_By180"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
           },
           {
             "GitID": "ed4e62dc12dca724ba1e5f374965096b_97┼87┼0┼",
@@ -312005,22 +312036,6 @@
                       "Data": "to store stuff onto"
                     }
                   ]
-                }
-              ]
-            }
-          },
-          {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_97┼94┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights",
-            "LocalPRS": "97┼94┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "Active": false,
-                  "ClassDatas": []
                 }
               ]
             }
@@ -312094,7 +312109,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -312277,7 +312292,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -312678,7 +312693,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -312775,6 +312790,47 @@
             "PrefabID": "f709eab732189d6429ae3fa5beaf3fd3",
             "Name": "Crowbar (1)",
             "LocalPRS": "98┼63.23┼0┼"
+          },
+          {
+            "GitID": "c21551dd992a57349973e4b5af103ca6_98┼68┼0┼",
+            "PrefabID": "c21551dd992a57349973e4b5af103ca6",
+            "NameMatches": true,
+            "Name": "SecurityCamera",
+            "LocalPRS": "98┼68┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼58┼0┼@0@APC@0"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Up_By0"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,2",
+                  "Active": false,
+                  "ClassDatas": []
+                },
+                {
+                  "ID": "0,3",
+                  "Active": false,
+                  "ClassDatas": []
+                }
+              ]
+            }
           },
           {
             "GitID": "cd57a2813ebc4ff4caf28b5fb793b3eb_98┼72┼0┼",
@@ -312905,7 +312961,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -313165,12 +313221,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -313242,12 +313298,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -313300,7 +313356,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -313344,7 +313400,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -313374,7 +313430,7 @@
             "PrefabID": "c937e0abe85aca9499d09951de736ec6",
             "NameMatches": true,
             "Name": "LightBulbFixture",
-            "LocalPRS": "99┼47┼0┼",
+            "LocalPRS": "99┼47┼0┼0ø0ø270ø",
             "Object": {
               "ClassDatas": [
                 {
@@ -313396,6 +313452,15 @@
                   ]
                 },
                 {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Right_By270"
+                    }
+                  ]
+                },
+                {
                   "ClassID": "LightSource@0",
                   "Data": [
                     {
@@ -313407,7 +313472,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -313625,12 +313690,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -313675,7 +313740,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -313962,6 +314027,10 @@
                   "ClassID": "DoorSwitch@0",
                   "Data": [
                     {
+                      "Name": "NewdoorControllers#4",
+                      "Data": "faeb065acf677894a9699942fdc1b49c_103┼64┼0┼@0@DoorMasterController@0"
+                    },
+                    {
                       "Name": "NewdoorControllers#3",
                       "Data": "f2441585d37f1914395df59a57c5e925_99┼68┼0┼@0@DoorMasterController@0"
                     },
@@ -314228,7 +314297,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -314264,12 +314333,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -314325,12 +314394,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -314489,32 +314558,6 @@
             }
           },
           {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_100┼55┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights (38)",
-            "LocalPRS": "100┼55┼0┼0ø0ø180ø",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Down_By180"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
-          },
-          {
             "GitID": "faeb065acf677894a9699942fdc1b49c_100┼60┼0┼",
             "PrefabID": "faeb065acf677894a9699942fdc1b49c",
             "NameMatches": true,
@@ -314548,25 +314591,6 @@
                     {
                       "Name": "RelatedAPC",
                       "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼58┼0┼@0@APC@0"
-                    }
-                  ]
-                }
-              ]
-            }
-          },
-          {
-            "GitID": "e6fef14b66545db41939986bb7911c4d_100┼64┼0┼",
-            "PrefabID": "e6fef14b66545db41939986bb7911c4d",
-            "Name": "UnitystationSign",
-            "LocalPRS": "100┼64┼0┼0ø0ø270ø",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Right_By270"
                     }
                   ]
                 }
@@ -314620,7 +314644,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -314656,12 +314680,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -314706,7 +314730,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -314811,7 +314835,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -314937,7 +314961,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -315521,7 +315545,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -315529,11 +315553,11 @@
             }
           },
           {
-            "GitID": "38246cd9491b4c248abb2e296cc6c76f_101┼57┼0┼",
+            "GitID": "38246cd9491b4c248abb2e296cc6c76f_101┼58┼0┼",
             "PrefabID": "38246cd9491b4c248abb2e296cc6c76f",
             "NameMatches": true,
             "Name": "AirlockMaintenanceOpaque",
-            "LocalPRS": "101┼57┼0┼",
+            "LocalPRS": "101┼58┼0┼",
             "Object": {
               "ClassDatas": [
                 {
@@ -315565,6 +315589,12 @@
             }
           },
           {
+            "GitID": "qzrxnKhVH-wOK6EQpbMn_101┼63┼0┼",
+            "PrefabID": "qzrxnKhVH-wOK6EQpbMn",
+            "Name": "TankDispenser (1)",
+            "LocalPRS": "101┼63┼0┼"
+          },
+          {
             "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_101┼78┼0┼",
             "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
             "Name": "DepartmentBattery",
@@ -315573,7 +315603,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -315656,32 +315686,6 @@
             "PrefabID": "fa63846bcecd1d14b8644f96e78f9888",
             "Name": "MaintLootx3 (2)",
             "LocalPRS": "101┼100┼0┼"
-          },
-          {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_101┼119┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights",
-            "LocalPRS": "101┼119┼0┼0ø0ø180ø",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Down_By180"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
           },
           {
             "GitID": "f2432d244a6b7774ea00ff013beb7dcb_101┼120┼0┼",
@@ -315950,11 +315954,11 @@
                   "ClassID": "ItemSlotActionTracker@0",
                   "Data": [
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "SecureStuff.SerializedAction"
                     },
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "#removed#"
                     }
                   ]
@@ -315978,7 +315982,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -316043,7 +316047,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -316097,7 +316101,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -316190,7 +316194,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -316207,7 +316211,17 @@
             "GitID": "6f371050bff8b32438f91c7c680900bb_102┼47.01┼0┼",
             "PrefabID": "6f371050bff8b32438f91c7c680900bb",
             "Name": "Handheld Torch (1)",
-            "LocalPRS": "102┼47.01┼0┼"
+            "LocalPRS": "102┼47.01┼0┼",
+            "Object": {
+              "ClassDatas": [],
+              "Children": [
+                {
+                  "ID": "0,1",
+                  "Active": false,
+                  "ClassDatas": []
+                }
+              ]
+            }
           },
           {
             "GitID": "c432d0b09f765e440a39dea62e9a423e_102┼47.02┼0┼",
@@ -316337,7 +316351,7 @@
                   "Data": [
                     {
                       "Name": "Controller",
-                      "Data": "a50474d976314462a79602e20a762520_105┼63┼0┼@0@AirController@0"
+                      "Data": "a50474d976314462a79602e20a762520_106┼59┼0┼@0@AirController@0"
                     }
                   ]
                 }
@@ -316345,10 +316359,10 @@
             }
           },
           {
-            "GitID": "cb2f847ef3b8b754181a970a4032c552_102┼64┼0┼",
+            "GitID": "cb2f847ef3b8b754181a970a4032c552_102┼61┼0┼",
             "PrefabID": "cb2f847ef3b8b754181a970a4032c552",
             "Name": "AirScrubber (59)",
-            "LocalPRS": "102┼64┼0┼0ø0ø270ø",
+            "LocalPRS": "102┼61┼0┼0ø0ø270ø",
             "Object": {
               "ClassDatas": [
                 {
@@ -316374,7 +316388,164 @@
                   "Data": [
                     {
                       "Name": "Controller",
-                      "Data": "a50474d976314462a79602e20a762520_105┼63┼0┼@0@AirController@0"
+                      "Data": "a50474d976314462a79602e20a762520_106┼59┼0┼@0@AirController@0"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "fde32c02abddc814f9366ff1fb21f234_102┼63┼0┼",
+            "PrefabID": "fde32c02abddc814f9366ff1fb21f234",
+            "NameMatches": true,
+            "Name": "LightTubeFixture",
+            "LocalPRS": "102┼63┼0┼0ø0ø180ø",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "Integrity@0",
+                  "Data": [
+                    {
+                      "Name": "Armor@Melee",
+                      "Data": "0"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼58┼0┼@0@APC@0"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Down_By180"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "LightSource@0",
+                  "Data": [
+                    {
+                      "Name": "isWithoutSwitch",
+                      "Data": "True"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,3",
+                  "Active": false,
+                  "ClassDatas": []
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "a50474d976314462a79602e20a762520_102┼64┼0┼",
+            "PrefabID": "a50474d976314462a79602e20a762520",
+            "Name": "ACU (2)",
+            "LocalPRS": "102┼64┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼58┼0┼@0@APC@0"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Up_By0"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "cb2f847ef3b8b754181a970a4032c552_102┼66┼0┼",
+            "PrefabID": "cb2f847ef3b8b754181a970a4032c552",
+            "Name": "AirScrubber (107)",
+            "LocalPRS": "102┼66┼0┼0ø0ø270ø",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼58┼0┼@0@APC@0"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Right_By270"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "AcuDevice@0",
+                  "Data": [
+                    {
+                      "Name": "Controller",
+                      "Data": "a50474d976314462a79602e20a762520_102┼64┼0┼@0@AirController@0"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "0d553281bdfc0fd438b3f6c7db58688c_102┼68┼0┼",
+            "PrefabID": "0d553281bdfc0fd438b3f6c7db58688c",
+            "NameMatches": true,
+            "Name": "AirVent",
+            "LocalPRS": "102┼68┼0┼0ø0ø90ø",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼58┼0┼@0@APC@0"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Left_By90"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "AcuDevice@0",
+                  "Data": [
+                    {
+                      "Name": "Controller",
+                      "Data": "a50474d976314462a79602e20a762520_102┼64┼0┼@0@AirController@0"
                     }
                   ]
                 }
@@ -316691,7 +316862,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -316863,10 +317034,10 @@
             "LocalPRS": "102.001┼88┼0┼"
           },
           {
-            "GitID": "d84249389f927e543b57338753276fce_102.01┼66.65┼0┼",
+            "GitID": "d84249389f927e543b57338753276fce_102.01┼61.72┼0┼",
             "PrefabID": "d84249389f927e543b57338753276fce",
             "Name": "TrackingBeaconAtmospherics (1)",
-            "LocalPRS": "102.01┼66.65┼0┼"
+            "LocalPRS": "102.01┼61.72┼0┼"
           },
           {
             "GitID": "8fb9b82aab871a54fb9bdb7e4a985821_102.02┼56.02┼0┼",
@@ -316996,7 +317167,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -317167,7 +317338,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -317312,7 +317483,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -317366,7 +317537,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -317504,7 +317675,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -317521,7 +317692,17 @@
             "GitID": "6f371050bff8b32438f91c7c680900bb_103┼47┼0┼",
             "PrefabID": "6f371050bff8b32438f91c7c680900bb",
             "Name": "Handheld Torch (2)",
-            "LocalPRS": "103┼47┼0┼"
+            "LocalPRS": "103┼47┼0┼",
+            "Object": {
+              "ClassDatas": [],
+              "Children": [
+                {
+                  "ID": "0,1",
+                  "Active": false,
+                  "ClassDatas": []
+                }
+              ]
+            }
           },
           {
             "GitID": "c432d0b09f765e440a39dea62e9a423e_103┼47┼0┼",
@@ -317584,11 +317765,11 @@
             }
           },
           {
-            "GitID": "fde32c02abddc814f9366ff1fb21f234_103┼60┼0┼",
+            "GitID": "fde32c02abddc814f9366ff1fb21f234_103┼59┼0┼",
             "PrefabID": "fde32c02abddc814f9366ff1fb21f234",
             "NameMatches": true,
             "Name": "LightTubeFixture",
-            "LocalPRS": "103┼60┼0┼0ø0ø90ø",
+            "LocalPRS": "103┼59┼0┼",
             "Object": {
               "ClassDatas": [
                 {
@@ -317610,15 +317791,6 @@
                   ]
                 },
                 {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Left_By90"
-                    }
-                  ]
-                },
-                {
                   "ClassID": "LightSource@0",
                   "Data": [
                     {
@@ -317630,7 +317802,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -317638,22 +317810,12 @@
             }
           },
           {
-            "GitID": "fde32c02abddc814f9366ff1fb21f234_103┼65┼0┼",
-            "PrefabID": "fde32c02abddc814f9366ff1fb21f234",
-            "NameMatches": true,
-            "Name": "LightTubeFixture",
-            "LocalPRS": "103┼65┼0┼0ø0ø90ø",
+            "GitID": "faeb065acf677894a9699942fdc1b49c_103┼64┼0┼",
+            "PrefabID": "faeb065acf677894a9699942fdc1b49c",
+            "Name": "AirlockAtmosphericsWindowed (1)",
+            "LocalPRS": "103┼64┼0┼",
             "Object": {
               "ClassDatas": [
-                {
-                  "ClassID": "Integrity@0",
-                  "Data": [
-                    {
-                      "Name": "Armor@Melee",
-                      "Data": "0"
-                    }
-                  ]
-                },
                 {
                   "ClassID": "APCPoweredDevice@0",
                   "Data": [
@@ -317662,40 +317824,9 @@
                       "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼58┼0┼@0@APC@0"
                     }
                   ]
-                },
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Left_By90"
-                    }
-                  ]
-                },
-                {
-                  "ClassID": "LightSource@0",
-                  "Data": [
-                    {
-                      "Name": "isWithoutSwitch",
-                      "Data": "True"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,2",
-                  "Active": false,
-                  "ClassDatas": []
                 }
               ]
             }
-          },
-          {
-            "GitID": "qzrxnKhVH-wOK6EQpbMn_103┼66┼0┼",
-            "PrefabID": "qzrxnKhVH-wOK6EQpbMn",
-            "Name": "TankDispenser (1)",
-            "LocalPRS": "103┼66┼0┼"
           },
           {
             "GitID": "d243343741d540446b159becf769231a_103┼71┼0┼",
@@ -317733,12 +317864,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -317995,12 +318126,6 @@
             }
           },
           {
-            "GitID": "8fb9b82aab871a54fb9bdb7e4a985821_103.94┼57.01┼0┼",
-            "PrefabID": "8fb9b82aab871a54fb9bdb7e4a985821",
-            "Name": "MaintLoot (36)",
-            "LocalPRS": "103.94┼57.01┼0┼"
-          },
-          {
             "GitID": "0d553281bdfc0fd438b3f6c7db58688c_104┼9┼0┼",
             "PrefabID": "0d553281bdfc0fd438b3f6c7db58688c",
             "Name": "AirVent (35)",
@@ -318075,7 +318200,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -318248,7 +318373,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -318308,7 +318433,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -318334,7 +318459,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -318344,6 +318469,7 @@
           {
             "GitID": "93d1f95a33757fe4fa3e2771e3f5bd67_104┼42┼0┼",
             "PrefabID": "93d1f95a33757fe4fa3e2771e3f5bd67",
+            "NameMatches": true,
             "Name": "PowerGeneratorPlasma",
             "LocalPRS": "104┼42┼0┼"
           },
@@ -318357,7 +318483,17 @@
             "GitID": "6f371050bff8b32438f91c7c680900bb_104┼47┼0┼",
             "PrefabID": "6f371050bff8b32438f91c7c680900bb",
             "Name": "Handheld Torch (3)",
-            "LocalPRS": "104┼47┼0┼"
+            "LocalPRS": "104┼47┼0┼",
+            "Object": {
+              "ClassDatas": [],
+              "Children": [
+                {
+                  "ID": "0,1",
+                  "Active": false,
+                  "ClassDatas": []
+                }
+              ]
+            }
           },
           {
             "GitID": "c432d0b09f765e440a39dea62e9a423e_104┼47┼0┼",
@@ -318507,25 +318643,26 @@
             "LocalPRS": "104┼55┼0┼"
           },
           {
-            "GitID": "68a3eee06f0a8cf4da5d8ab811ce1c73_104┼57┼0┼",
-            "PrefabID": "68a3eee06f0a8cf4da5d8ab811ce1c73",
-            "NameMatches": true,
-            "Name": "ClosetBase",
-            "LocalPRS": "104┼57┼0┼"
+            "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_104┼57┼0┼",
+            "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
+            "Name": "DepartmentBattery",
+            "LocalPRS": "104┼57┼0┼",
+            "Object": {
+              "ClassDatas": [],
+              "Children": [
+                {
+                  "ID": "0,3",
+                  "Active": false,
+                  "ClassDatas": []
+                }
+              ]
+            }
           },
           {
-            "GitID": "64b0546c6b2243241846fced5f70f123_104┼61┼0┼",
-            "PrefabID": "64b0546c6b2243241846fced5f70f123",
-            "NameMatches": true,
-            "Name": "PipeDispenser",
-            "LocalPRS": "104┼61┼0┼"
-          },
-          {
-            "GitID": "c21551dd992a57349973e4b5af103ca6_104┼62┼0┼",
-            "PrefabID": "c21551dd992a57349973e4b5af103ca6",
-            "NameMatches": true,
-            "Name": "SecurityCamera",
-            "LocalPRS": "104┼62┼0┼",
+            "GitID": "4d76ade90a370ca43ab3c9a765236a26_104┼58┼0┼",
+            "PrefabID": "4d76ade90a370ca43ab3c9a765236a26",
+            "Name": "AirlockEngineeringOpaque (1)",
+            "LocalPRS": "104┼58┼0┼",
             "Object": {
               "ClassDatas": [
                 {
@@ -318536,52 +318673,41 @@
                       "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼58┼0┼@0@APC@0"
                     }
                   ]
-                },
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_104┼58┼0┼",
+            "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
+            "Name": "VIR_LowVoltageMachineConnector",
+            "LocalPRS": "104┼58┼0┼"
+          },
+          {
+            "GitID": "faeb065acf677894a9699942fdc1b49c_104┼64┼0┼",
+            "PrefabID": "faeb065acf677894a9699942fdc1b49c",
+            "Name": "AirlockAtmosphericsWindowed (2)",
+            "LocalPRS": "104┼64┼0┼",
+            "Object": {
+              "ClassDatas": [
                 {
-                  "ClassID": "Rotatable@0",
+                  "ClassID": "APCPoweredDevice@0",
                   "Data": [
                     {
-                      "Name": "CurrentDirection",
-                      "Data": "Left_By90"
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼58┼0┼@0@APC@0"
                     }
                   ]
                 }
-              ],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "Active": false,
-                  "ClassDatas": []
-                },
-                {
-                  "ID": "0,2",
-                  "Active": false,
-                  "ClassDatas": []
-                }
               ]
             }
           },
           {
-            "GitID": "e8ac2c5a2a017e44b903b5359c43e2f5_104┼63┼0┼",
-            "PrefabID": "e8ac2c5a2a017e44b903b5359c43e2f5",
-            "Name": "VIR_LowVoltageMachineConnector",
-            "LocalPRS": "104┼63┼0┼"
-          },
-          {
-            "GitID": "9c3a6c9c953a49941aa32b5ad9400d89_104┼64┼0┼",
-            "PrefabID": "9c3a6c9c953a49941aa32b5ad9400d89",
-            "Name": "DepartmentBattery",
-            "LocalPRS": "104┼64┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,2",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
+            "GitID": "c0e96760c016b6140ba8c3979e9213f7_104┼74┼0┼",
+            "PrefabID": "c0e96760c016b6140ba8c3979e9213f7",
+            "NameMatches": true,
+            "Name": "CanisterBase",
+            "LocalPRS": "104┼74┼0┼"
           },
           {
             "GitID": "68a3eee06f0a8cf4da5d8ab811ce1c73_104┼90┼0┼",
@@ -318893,7 +319019,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -318911,10 +319037,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -319117,7 +319239,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -319165,7 +319287,17 @@
             "GitID": "6f371050bff8b32438f91c7c680900bb_105┼47┼0┼",
             "PrefabID": "6f371050bff8b32438f91c7c680900bb",
             "Name": "Handheld Torch (4)",
-            "LocalPRS": "105┼47┼0┼"
+            "LocalPRS": "105┼47┼0┼",
+            "Object": {
+              "ClassDatas": [],
+              "Children": [
+                {
+                  "ID": "0,1",
+                  "Active": false,
+                  "ClassDatas": []
+                }
+              ]
+            }
           },
           {
             "GitID": "c432d0b09f765e440a39dea62e9a423e_105┼47.02┼0┼",
@@ -319222,12 +319354,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -319287,7 +319419,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -319360,12 +319492,36 @@
                   "ClassID": "APC@0",
                   "Data": [
                     {
+                      "Name": "connectedDevices#72",
+                      "Data": "cb2f847ef3b8b754181a970a4032c552_102┼66┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#71",
+                      "Data": "0d553281bdfc0fd438b3f6c7db58688c_102┼68┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#70",
+                      "Data": "a50474d976314462a79602e20a762520_102┼64┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#69",
+                      "Data": "faeb065acf677894a9699942fdc1b49c_104┼64┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#68",
+                      "Data": "faeb065acf677894a9699942fdc1b49c_103┼64┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
+                      "Name": "connectedDevices#67",
+                      "Data": "4d76ade90a370ca43ab3c9a765236a26_104┼58┼0┼@0@APCPoweredDevice@0"
+                    },
+                    {
                       "Name": "connectedDevices#66",
                       "Data": "3a970e04e0e65974eb038a3aaaa451b4_110┼65┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#65",
-                      "Data": "a50474d976314462a79602e20a762520_105┼63┼0┼@0@APCPoweredDevice@0"
+                      "Data": "a50474d976314462a79602e20a762520_106┼59┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#64",
@@ -319481,7 +319637,7 @@
                     },
                     {
                       "Name": "connectedDevices#36",
-                      "Data": "cb2f847ef3b8b754181a970a4032c552_102┼64┼0┼@0@APCPoweredDevice@0"
+                      "Data": "cb2f847ef3b8b754181a970a4032c552_102┼61┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#35",
@@ -319505,11 +319661,11 @@
                     },
                     {
                       "Name": "connectedDevices#30",
-                      "Data": "c21551dd992a57349973e4b5af103ca6_105┼66┼0┼@0@APCPoweredDevice@0"
+                      "Data": "c21551dd992a57349973e4b5af103ca6_98┼68┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#29",
-                      "Data": "c21551dd992a57349973e4b5af103ca6_104┼62┼0┼@0@APCPoweredDevice@0"
+                      "Data": "c21551dd992a57349973e4b5af103ca6_105┼63┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#28",
@@ -319529,7 +319685,7 @@
                     },
                     {
                       "Name": "connectedDevices#24",
-                      "Data": "38246cd9491b4c248abb2e296cc6c76f_101┼57┼0┼@0@APCPoweredDevice@0"
+                      "Data": "38246cd9491b4c248abb2e296cc6c76f_101┼58┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#23",
@@ -319541,11 +319697,11 @@
                     },
                     {
                       "Name": "connectedDevices#21",
-                      "Data": "2e9158e054df40f4b9f6d33d168fa00a_106┼64┼0┼@0@APCPoweredDevice@0"
+                      "Data": "2e9158e054df40f4b9f6d33d168fa00a_105┼63┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#20",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_103┼60┼0┼@0@APCPoweredDevice@0"
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_103┼59┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#19",
@@ -319569,7 +319725,7 @@
                     },
                     {
                       "Name": "connectedDevices#14",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_106┼65┼0┼@0@APCPoweredDevice@0"
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_107┼64┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#13",
@@ -319601,7 +319757,7 @@
                     },
                     {
                       "Name": "connectedDevices#6",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_103┼65┼0┼@0@APCPoweredDevice@0"
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_102┼63┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#5",
@@ -319613,19 +319769,19 @@
                     },
                     {
                       "Name": "connectedDevices#3",
-                      "Data": "fde32c02abddc814f9366ff1fb21f234_106┼60┼0┼@0@APCPoweredDevice@0"
+                      "Data": "fde32c02abddc814f9366ff1fb21f234_105┼65┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#2",
-                      "Data": "2e9158e054df40f4b9f6d33d168fa00a_106┼63┼0┼@0@APCPoweredDevice@0"
+                      "Data": "2e9158e054df40f4b9f6d33d168fa00a_105┼62┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#1",
-                      "Data": "2e9158e054df40f4b9f6d33d168fa00a_106┼62┼0┼@0@APCPoweredDevice@0"
+                      "Data": "2e9158e054df40f4b9f6d33d168fa00a_105┼61┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#0",
-                      "Data": "2e9158e054df40f4b9f6d33d168fa00a_106┼61┼0┼@0@APCPoweredDevice@0"
+                      "Data": "2e9158e054df40f4b9f6d33d168fa00a_105┼60┼0┼@0@APCPoweredDevice@0"
                     }
                   ]
                 }
@@ -319639,18 +319795,18 @@
             "LocalPRS": "105┼59┼0┼"
           },
           {
-            "GitID": "QbW3jmyv9HMTMrjUp!qB_105┼62┼0┼",
-            "PrefabID": "QbW3jmyv9HMTMrjUp!qB",
-            "Name": "FireAxeCabinet (1)",
-            "LocalPRS": "105┼62┼0┼",
+            "GitID": "2e9158e054df40f4b9f6d33d168fa00a_105┼60┼0┼",
+            "PrefabID": "2e9158e054df40f4b9f6d33d168fa00a",
+            "Name": "SuitStorageUnitAtmos (1)",
+            "LocalPRS": "105┼60┼0┼",
             "Object": {
               "ClassDatas": [
                 {
-                  "ClassID": "Rotatable@0",
+                  "ClassID": "APCPoweredDevice@0",
                   "Data": [
                     {
-                      "Name": "CurrentDirection",
-                      "Data": "Left_By90"
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼58┼0┼@0@APC@0"
                     }
                   ]
                 }
@@ -319658,10 +319814,86 @@
             }
           },
           {
-            "GitID": "a50474d976314462a79602e20a762520_105┼63┼0┼",
-            "PrefabID": "a50474d976314462a79602e20a762520",
+            "GitID": "2e9158e054df40f4b9f6d33d168fa00a_105┼61┼0┼",
+            "PrefabID": "2e9158e054df40f4b9f6d33d168fa00a",
+            "Name": "SuitStorageUnitAtmos (2)",
+            "LocalPRS": "105┼61┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼58┼0┼@0@APC@0"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "2e9158e054df40f4b9f6d33d168fa00a_105┼62┼0┼",
+            "PrefabID": "2e9158e054df40f4b9f6d33d168fa00a",
+            "Name": "SuitStorageUnitAtmos (3)",
+            "LocalPRS": "105┼62┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼58┼0┼@0@APC@0"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "ClosetControl@0",
+                  "Data": [
+                    {
+                      "Name": "soundOnClose@AssetAddress",
+                      "Data": "null"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "2e9158e054df40f4b9f6d33d168fa00a_105┼63┼0┼",
+            "PrefabID": "2e9158e054df40f4b9f6d33d168fa00a",
             "NameMatches": true,
-            "Name": "ACU",
+            "Name": "SuitStorageUnitAtmos",
+            "LocalPRS": "105┼63┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼58┼0┼@0@APC@0"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "ClosetControl@0",
+                  "Data": [
+                    {
+                      "Name": "soundOnClose@AssetAddress",
+                      "Data": "null"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "GitID": "c21551dd992a57349973e4b5af103ca6_105┼63┼0┼",
+            "PrefabID": "c21551dd992a57349973e4b5af103ca6",
+            "NameMatches": true,
+            "Name": "SecurityCamera",
             "LocalPRS": "105┼63┼0┼",
             "Object": {
               "ClassDatas": [
@@ -319683,17 +319915,38 @@
                     }
                   ]
                 }
+              ],
+              "Children": [
+                {
+                  "ID": "0,2",
+                  "Active": false,
+                  "ClassDatas": []
+                },
+                {
+                  "ID": "0,3",
+                  "Active": false,
+                  "ClassDatas": []
+                }
               ]
             }
           },
           {
-            "GitID": "c21551dd992a57349973e4b5af103ca6_105┼66┼0┼",
-            "PrefabID": "c21551dd992a57349973e4b5af103ca6",
+            "GitID": "fde32c02abddc814f9366ff1fb21f234_105┼65┼0┼",
+            "PrefabID": "fde32c02abddc814f9366ff1fb21f234",
             "NameMatches": true,
-            "Name": "SecurityCamera",
-            "LocalPRS": "105┼66┼0┼",
+            "Name": "LightTubeFixture",
+            "LocalPRS": "105┼65┼0┼",
             "Object": {
               "ClassDatas": [
+                {
+                  "ClassID": "Integrity@0",
+                  "Data": [
+                    {
+                      "Name": "Armor@Melee",
+                      "Data": "0"
+                    }
+                  ]
+                },
                 {
                   "ClassID": "APCPoweredDevice@0",
                   "Data": [
@@ -319704,23 +319957,18 @@
                   ]
                 },
                 {
-                  "ClassID": "Rotatable@0",
+                  "ClassID": "LightSource@0",
                   "Data": [
                     {
-                      "Name": "CurrentDirection",
-                      "Data": "Up_By0"
+                      "Name": "isWithoutSwitch",
+                      "Data": "True"
                     }
                   ]
                 }
               ],
               "Children": [
                 {
-                  "ID": "0,1",
-                  "Active": false,
-                  "ClassDatas": []
-                },
-                {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -319746,6 +319994,13 @@
                 }
               ]
             }
+          },
+          {
+            "GitID": "c0e96760c016b6140ba8c3979e9213f7_105┼74┼0┼",
+            "PrefabID": "c0e96760c016b6140ba8c3979e9213f7",
+            "NameMatches": true,
+            "Name": "CanisterBase",
+            "LocalPRS": "105┼74┼0┼"
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_105┼74┼0┼",
@@ -319794,7 +320049,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -319839,7 +320094,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -319884,7 +320139,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -319920,12 +320175,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -319970,7 +320225,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -320538,12 +320793,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -320598,10 +320853,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -320707,7 +320958,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -320767,22 +321018,13 @@
             }
           },
           {
-            "GitID": "fde32c02abddc814f9366ff1fb21f234_106┼60┼0┼",
-            "PrefabID": "fde32c02abddc814f9366ff1fb21f234",
+            "GitID": "a50474d976314462a79602e20a762520_106┼59┼0┼",
+            "PrefabID": "a50474d976314462a79602e20a762520",
             "NameMatches": true,
-            "Name": "LightTubeFixture",
-            "LocalPRS": "106┼60┼0┼0ø0ø270ø",
+            "Name": "ACU",
+            "LocalPRS": "106┼59┼0┼",
             "Object": {
               "ClassDatas": [
-                {
-                  "ClassID": "Integrity@0",
-                  "Data": [
-                    {
-                      "Name": "Armor@Melee",
-                      "Data": "0"
-                    }
-                  ]
-                },
                 {
                   "ClassID": "APCPoweredDevice@0",
                   "Data": [
@@ -320797,42 +321039,7 @@
                   "Data": [
                     {
                       "Name": "CurrentDirection",
-                      "Data": "Right_By270"
-                    }
-                  ]
-                },
-                {
-                  "ClassID": "LightSource@0",
-                  "Data": [
-                    {
-                      "Name": "isWithoutSwitch",
-                      "Data": "True"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,2",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
-          },
-          {
-            "GitID": "2e9158e054df40f4b9f6d33d168fa00a_106┼61┼0┼",
-            "PrefabID": "2e9158e054df40f4b9f6d33d168fa00a",
-            "Name": "SuitStorageUnitAtmos (1)",
-            "LocalPRS": "106┼61┼0┼",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "APCPoweredDevice@0",
-                  "Data": [
-                    {
-                      "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼58┼0┼@0@APC@0"
+                      "Data": "Left_By90"
                     }
                   ]
                 }
@@ -320840,108 +321047,13 @@
             }
           },
           {
-            "GitID": "2e9158e054df40f4b9f6d33d168fa00a_106┼62┼0┼",
-            "PrefabID": "2e9158e054df40f4b9f6d33d168fa00a",
-            "Name": "SuitStorageUnitAtmos (2)",
-            "LocalPRS": "106┼62┼0┼",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "APCPoweredDevice@0",
-                  "Data": [
-                    {
-                      "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼58┼0┼@0@APC@0"
-                    }
-                  ]
-                }
-              ]
-            }
-          },
-          {
-            "GitID": "2e9158e054df40f4b9f6d33d168fa00a_106┼63┼0┼",
-            "PrefabID": "2e9158e054df40f4b9f6d33d168fa00a",
-            "Name": "SuitStorageUnitAtmos (3)",
+            "GitID": "QbW3jmyv9HMTMrjUp!qB_106┼63┼0┼",
+            "PrefabID": "QbW3jmyv9HMTMrjUp!qB",
+            "Name": "FireAxeCabinet (1)",
             "LocalPRS": "106┼63┼0┼",
             "Object": {
               "ClassDatas": [
                 {
-                  "ClassID": "APCPoweredDevice@0",
-                  "Data": [
-                    {
-                      "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼58┼0┼@0@APC@0"
-                    }
-                  ]
-                },
-                {
-                  "ClassID": "ClosetControl@0",
-                  "Data": [
-                    {
-                      "Name": "soundOnClose@AssetAddress",
-                      "Data": "null"
-                    }
-                  ]
-                }
-              ]
-            }
-          },
-          {
-            "GitID": "2e9158e054df40f4b9f6d33d168fa00a_106┼64┼0┼",
-            "PrefabID": "2e9158e054df40f4b9f6d33d168fa00a",
-            "NameMatches": true,
-            "Name": "SuitStorageUnitAtmos",
-            "LocalPRS": "106┼64┼0┼",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "APCPoweredDevice@0",
-                  "Data": [
-                    {
-                      "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼58┼0┼@0@APC@0"
-                    }
-                  ]
-                },
-                {
-                  "ClassID": "ClosetControl@0",
-                  "Data": [
-                    {
-                      "Name": "soundOnClose@AssetAddress",
-                      "Data": "null"
-                    }
-                  ]
-                }
-              ]
-            }
-          },
-          {
-            "GitID": "fde32c02abddc814f9366ff1fb21f234_106┼65┼0┼",
-            "PrefabID": "fde32c02abddc814f9366ff1fb21f234",
-            "NameMatches": true,
-            "Name": "LightTubeFixture",
-            "LocalPRS": "106┼65┼0┼0ø0ø270ø",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "Integrity@0",
-                  "Data": [
-                    {
-                      "Name": "Armor@Melee",
-                      "Data": "0"
-                    }
-                  ]
-                },
-                {
-                  "ClassID": "APCPoweredDevice@0",
-                  "Data": [
-                    {
-                      "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼58┼0┼@0@APC@0"
-                    }
-                  ]
-                },
-                {
                   "ClassID": "Rotatable@0",
                   "Data": [
                     {
@@ -320949,25 +321061,16 @@
                       "Data": "Right_By270"
                     }
                   ]
-                },
-                {
-                  "ClassID": "LightSource@0",
-                  "Data": [
-                    {
-                      "Name": "isWithoutSwitch",
-                      "Data": "True"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,2",
-                  "Active": false,
-                  "ClassDatas": []
                 }
               ]
             }
+          },
+          {
+            "GitID": "c0e96760c016b6140ba8c3979e9213f7_106┼74┼0┼",
+            "PrefabID": "c0e96760c016b6140ba8c3979e9213f7",
+            "NameMatches": true,
+            "Name": "CanisterBase",
+            "LocalPRS": "106┼74┼0┼"
           },
           {
             "GitID": "91d832be818283a4188516804e8d5ef0_106┼86┼0┼",
@@ -321087,12 +321190,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -321265,7 +321368,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -321315,15 +321418,60 @@
             }
           },
           {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_107┼59┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights (42)",
-            "LocalPRS": "107┼59┼0┼",
+            "GitID": "64b0546c6b2243241846fced5f70f123_107┼61┼0┼",
+            "PrefabID": "64b0546c6b2243241846fced5f70f123",
+            "NameMatches": true,
+            "Name": "PipeDispenser",
+            "LocalPRS": "107┼61┼0┼"
+          },
+          {
+            "GitID": "fde32c02abddc814f9366ff1fb21f234_107┼64┼0┼",
+            "PrefabID": "fde32c02abddc814f9366ff1fb21f234",
+            "NameMatches": true,
+            "Name": "LightTubeFixture",
+            "LocalPRS": "107┼64┼0┼0ø0ø270ø",
             "Object": {
-              "ClassDatas": [],
+              "ClassDatas": [
+                {
+                  "ClassID": "Integrity@0",
+                  "Data": [
+                    {
+                      "Name": "Armor@Melee",
+                      "Data": "0"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_105┼58┼0┼@0@APC@0"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Right_By270"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "LightSource@0",
+                  "Data": [
+                    {
+                      "Name": "isWithoutSwitch",
+                      "Data": "True"
+                    }
+                  ]
+                }
+              ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -321436,12 +321584,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -321486,7 +321634,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -321573,32 +321721,6 @@
             "PrefabID": "a96bbdda86a78074aaff58c8aff59a57",
             "Name": "Cremator (1)",
             "LocalPRS": "108┼11┼0┼"
-          },
-          {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_108┼11┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights",
-            "LocalPRS": "108┼11┼0┼0ø0ø180ø",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Down_By180"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
           },
           {
             "GitID": "68a3eee06f0a8cf4da5d8ab811ce1c73_108┼25┼0┼",
@@ -321817,12 +321939,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -322443,7 +322565,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -322488,7 +322610,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -322810,7 +322932,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -322901,7 +323023,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -322937,12 +323059,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -322996,7 +323118,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -323274,7 +323396,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -323944,7 +324066,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -324032,7 +324154,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -324112,7 +324234,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -324166,7 +324288,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -324192,13 +324314,6 @@
                 }
               ]
             }
-          },
-          {
-            "GitID": "c0e96760c016b6140ba8c3979e9213f7_111┼58┼0┼",
-            "PrefabID": "c0e96760c016b6140ba8c3979e9213f7",
-            "NameMatches": true,
-            "Name": "CanisterBase",
-            "LocalPRS": "111┼58┼0┼"
           },
           {
             "GitID": "9b996da43261266449d4ad99b2ddac7f_111┼60┼0┼",
@@ -324641,13 +324756,6 @@
             }
           },
           {
-            "GitID": "c0e96760c016b6140ba8c3979e9213f7_112┼58┼0┼",
-            "PrefabID": "c0e96760c016b6140ba8c3979e9213f7",
-            "NameMatches": true,
-            "Name": "CanisterBase",
-            "LocalPRS": "112┼58┼0┼"
-          },
-          {
             "GitID": "9b996da43261266449d4ad99b2ddac7f_112┼61┼0┼",
             "PrefabID": "9b996da43261266449d4ad99b2ddac7f",
             "NameMatches": true,
@@ -324794,7 +324902,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -325068,13 +325176,6 @@
             }
           },
           {
-            "GitID": "c0e96760c016b6140ba8c3979e9213f7_113┼58┼0┼",
-            "PrefabID": "c0e96760c016b6140ba8c3979e9213f7",
-            "NameMatches": true,
-            "Name": "CanisterBase",
-            "LocalPRS": "113┼58┼0┼"
-          },
-          {
             "GitID": "b8fb81ca58d782b49bf75a15183aa0e6_113┼59┼0┼",
             "PrefabID": "b8fb81ca58d782b49bf75a15183aa0e6",
             "NameMatches": true,
@@ -325134,12 +325235,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -325303,12 +325404,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -325344,12 +325445,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -325428,12 +325529,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -325619,7 +325720,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -325632,32 +325733,6 @@
             "NameMatches": true,
             "Name": "Stool",
             "LocalPRS": "114┼94┼0┼"
-          },
-          {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_114┼95┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights",
-            "LocalPRS": "114┼95┼0┼0ø0ø180ø",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Down_By180"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
           },
           {
             "GitID": "f2432d244a6b7774ea00ff013beb7dcb_114┼96┼0┼",
@@ -325849,7 +325924,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -325894,7 +325969,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -325939,7 +326014,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -325984,7 +326059,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -326191,7 +326266,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -326361,7 +326436,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -326451,22 +326526,6 @@
             "PrefabID": "3e091c8c2a970a74e915174840cd98bb",
             "Name": "Poster (8)",
             "LocalPRS": "116┼96┼0┼"
-          },
-          {
-            "GitID": "aef082ffdd3b51f45bd9a56c6afda863_116┼97┼0┼",
-            "PrefabID": "aef082ffdd3b51f45bd9a56c6afda863",
-            "Name": "emergency_lights",
-            "LocalPRS": "116┼97┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
           },
           {
             "GitID": "07ffe5b392cddcd41b0ddc71c497130d_117┼31┼0┼",
@@ -326665,7 +326724,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -326710,7 +326769,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -326824,7 +326883,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -327095,7 +327154,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -327189,7 +327248,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -327293,6 +327352,12 @@
                 }
               ]
             }
+          },
+          {
+            "GitID": "8fb9b82aab871a54fb9bdb7e4a985821_118.98┼89┼0┼",
+            "PrefabID": "8fb9b82aab871a54fb9bdb7e4a985821",
+            "Name": "MaintLoot (36)",
+            "LocalPRS": "118.98┼89┼0┼"
           },
           {
             "GitID": "07ffe5b392cddcd41b0ddc71c497130d_119┼31┼0┼",
@@ -327420,12 +327485,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -327549,6 +327614,13 @@
             }
           },
           {
+            "GitID": "68a3eee06f0a8cf4da5d8ab811ce1c73_119┼89┼0┼",
+            "PrefabID": "68a3eee06f0a8cf4da5d8ab811ce1c73",
+            "NameMatches": true,
+            "Name": "ClosetBase",
+            "LocalPRS": "119┼89┼0┼"
+          },
+          {
             "GitID": "c21551dd992a57349973e4b5af103ca6_119┼89┼0┼",
             "PrefabID": "c21551dd992a57349973e4b5af103ca6",
             "NameMatches": true,
@@ -327577,12 +327649,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -328136,7 +328208,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -328190,7 +328262,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -328599,12 +328671,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -328751,7 +328823,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -328842,7 +328914,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -328932,7 +329004,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -329019,7 +329091,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -333660,7 +333732,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -333743,7 +333815,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -333795,7 +333867,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -333932,10 +334004,6 @@
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
-                    {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
                     }
@@ -333998,7 +334066,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -334072,10 +334140,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "office chair"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "For sitting down or getting strapped onto."
@@ -334197,7 +334261,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -334604,7 +334668,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -334784,7 +334848,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -336228,7 +336292,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -336608,7 +336672,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -337078,7 +337142,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -337429,7 +337493,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -337724,7 +337788,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -338280,7 +338344,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -338354,7 +338418,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -338448,7 +338512,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -338527,7 +338591,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -338581,7 +338645,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -339308,7 +339372,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -340364,7 +340428,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -340468,7 +340532,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -340547,7 +340611,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -340557,6 +340621,7 @@
           {
             "GitID": "cab73e460ee8bf24e88988add17a2be5_1┼-3┼0┼",
             "PrefabID": "cab73e460ee8bf24e88988add17a2be5",
+            "NameMatches": true,
             "Name": "ConveyorSwitch",
             "LocalPRS": "1┼-3┼0┼",
             "Object": {
@@ -340618,6 +340683,7 @@
           {
             "GitID": "cab73e460ee8bf24e88988add17a2be5_1┼3┼0┼",
             "PrefabID": "cab73e460ee8bf24e88988add17a2be5",
+            "NameMatches": true,
             "Name": "ConveyorSwitch",
             "LocalPRS": "1┼3┼0┼",
             "Object": {
@@ -341617,7 +341683,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -341846,6 +341912,7 @@
           {
             "GitID": "c78251c7c2182e34988023aca9b23d4b_0.99┼0.95┼0┼",
             "PrefabID": "c78251c7c2182e34988023aca9b23d4b",
+            "NameMatches": true,
             "Name": "Hatchet",
             "LocalPRS": "0.99┼0.95┼0┼"
           },
@@ -341927,7 +341994,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -342853,7 +342920,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -343012,7 +343079,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -343922,7 +343989,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -344081,7 +344148,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -345033,7 +345100,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -345299,7 +345366,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -345407,7 +345474,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -346860,7 +346927,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -347531,7 +347598,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -347774,7 +347841,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -348030,7 +348097,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -348556,7 +348623,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -351210,7 +351277,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -351505,7 +351572,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -351726,7 +351793,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -352003,7 +352070,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -352048,7 +352115,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -352315,7 +352382,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -352681,7 +352748,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -352775,7 +352842,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -352929,7 +352996,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -353128,7 +353195,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -355227,6 +355294,7 @@
           {
             "GitID": "25b12bb335be903439c592e66148f943_-3┼-2┼0┼",
             "PrefabID": "25b12bb335be903439c592e66148f943",
+            "NameMatches": true,
             "Name": "Apiary",
             "LocalPRS": "-3┼-2┼0┼"
           },
@@ -355330,7 +355398,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -355352,7 +355420,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/SquareStation.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/SquareStation.json
@@ -14535,7 +14535,42 @@
             "Key": "X42Y64",
             "Value": [
               {
+                "Tel": "Wall"
+              },
+              {
                 "Tel": "Lattice"
+              }
+            ]
+          },
+          {
+            "Key": "X42Y65",
+            "Value": [
+              {
+                "Tel": "Plating"
+              }
+            ]
+          },
+          {
+            "Key": "X42Y66",
+            "Value": [
+              {
+                "Tel": "Plating"
+              }
+            ]
+          },
+          {
+            "Key": "X42Y67",
+            "Value": [
+              {
+                "Tel": "Plating"
+              }
+            ]
+          },
+          {
+            "Key": "X42Y68",
+            "Value": [
+              {
+                "Tel": "Plating"
               }
             ]
           },
@@ -14543,7 +14578,7 @@
             "Key": "X42Y69",
             "Value": [
               {
-                "Tel": "Lattice"
+                "Tel": "Plating"
               }
             ]
           },
@@ -14551,16 +14586,29 @@
             "Key": "X42Y70",
             "Value": [
               {
-                "Tel": "Lattice"
+                "Tel": "Plating"
+              }
+            ]
+          },
+          {
+            "Key": "X42Y71",
+            "Value": [
+              {
+                "Tel": "Plating"
+              }
+            ]
+          },
+          {
+            "Key": "X42Y72",
+            "Value": [
+              {
+                "Tel": "Plating"
               }
             ]
           },
           {
             "Key": "X42Y73",
             "Value": [
-              {
-                "Tel": "Wall"
-              },
               {
                 "Tel": "Plating"
               }
@@ -15031,6 +15079,90 @@
               {
                 "Tel": "ReinforcedWall"
               },
+              {
+                "Tel": "Plating"
+              }
+            ]
+          },
+          {
+            "Key": "X43Y64",
+            "Value": [
+              {
+                "Tel": "Wall"
+              },
+              {
+                "Tel": "Plating"
+              }
+            ]
+          },
+          {
+            "Key": "X43Y65",
+            "Value": [
+              {
+                "Tel": "Wall"
+              },
+              {
+                "Tel": "Plating"
+              }
+            ]
+          },
+          {
+            "Key": "X43Y66",
+            "Value": [
+              {
+                "Tel": "Plating"
+              }
+            ]
+          },
+          {
+            "Key": "X43Y67",
+            "Value": [
+              {
+                "Tel": "Plating"
+              }
+            ]
+          },
+          {
+            "Key": "X43Y68",
+            "Value": [
+              {
+                "Tel": "Plating"
+              },
+              {
+                "Tel": "Table"
+              }
+            ]
+          },
+          {
+            "Key": "X43Y69",
+            "Value": [
+              {
+                "Tel": "Wall"
+              },
+              {
+                "Tel": "Plating"
+              }
+            ]
+          },
+          {
+            "Key": "X43Y70",
+            "Value": [
+              {
+                "Tel": "Plating"
+              }
+            ]
+          },
+          {
+            "Key": "X43Y71",
+            "Value": [
+              {
+                "Tel": "Plating"
+              }
+            ]
+          },
+          {
+            "Key": "X43Y72",
+            "Value": [
               {
                 "Tel": "Plating"
               }
@@ -15584,10 +15716,35 @@
             ]
           },
           {
+            "Key": "X44Y65",
+            "Value": [
+              {
+                "Tel": "Wall"
+              },
+              {
+                "Tel": "Plating"
+              }
+            ]
+          },
+          {
+            "Key": "X44Y66",
+            "Value": [
+              {
+                "Tel": "Wall"
+              },
+              {
+                "Tel": "Plating"
+              }
+            ]
+          },
+          {
             "Key": "X44Y67",
             "Value": [
               {
-                "Tel": "Grille"
+                "Tel": "Wall"
+              },
+              {
+                "Tel": "Plating"
               }
             ]
           },
@@ -15595,10 +15752,10 @@
             "Key": "X44Y68",
             "Value": [
               {
-                "Tel": "Lattice"
+                "Tel": "Wall"
               },
               {
-                "Tel": "Grille"
+                "Tel": "Plating"
               }
             ]
           },
@@ -15606,7 +15763,43 @@
             "Key": "X44Y69",
             "Value": [
               {
-                "Tel": "Grille"
+                "Tel": "Wall"
+              },
+              {
+                "Tel": "Plating"
+              }
+            ]
+          },
+          {
+            "Key": "X44Y70",
+            "Value": [
+              {
+                "Tel": "Wall"
+              },
+              {
+                "Tel": "Plating"
+              }
+            ]
+          },
+          {
+            "Key": "X44Y71",
+            "Value": [
+              {
+                "Tel": "Wall"
+              },
+              {
+                "Tel": "Plating"
+              }
+            ]
+          },
+          {
+            "Key": "X44Y72",
+            "Value": [
+              {
+                "Tel": "Wall"
+              },
+              {
+                "Tel": "Plating"
               }
             ]
           },
@@ -45101,13 +45294,10 @@
             "Key": "X65Y57",
             "Value": [
               {
-                "Tel": "WindowReinforced"
+                "Tel": "ReinforcedWall"
               },
               {
                 "Tel": "Plating"
-              },
-              {
-                "Tel": "Grille"
               }
             ]
           },
@@ -46484,10 +46674,13 @@
             "Key": "X66Y57",
             "Value": [
               {
-                "Tel": "ReinforcedWall"
+                "Tel": "WindowReinforced"
               },
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "Grille"
               }
             ]
           },
@@ -64678,6 +64871,9 @@
             "Key": "X84Y117",
             "Value": [
               {
+                "Tel": "Wall"
+              },
+              {
                 "Tel": "Lattice"
               }
             ]
@@ -65777,7 +65973,7 @@
             "Key": "X85Y116",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "dark"
               },
               {
                 "Tel": "Plating"
@@ -74726,13 +74922,10 @@
             "Key": "X93Y47",
             "Value": [
               {
-                "Tel": "WindowReinforced"
+                "Tel": "Wall"
               },
               {
                 "Tel": "Plating"
-              },
-              {
-                "Tel": "Grille"
               }
             ]
           },
@@ -76113,7 +76306,7 @@
             ]
           },
           {
-            "Key": "X94Y48",
+            "Key": "X94Y47",
             "Value": [
               {
                 "Tel": "WindowReinforced"
@@ -76123,6 +76316,17 @@
               },
               {
                 "Tel": "Grille"
+              }
+            ]
+          },
+          {
+            "Key": "X94Y48",
+            "Value": [
+              {
+                "Tel": "whitered_5"
+              },
+              {
+                "Tel": "Plating"
               }
             ]
           },
@@ -76158,7 +76362,7 @@
             "Key": "X94Y51",
             "Value": [
               {
-                "Tel": "white"
+                "Tel": "whitered_7"
               },
               {
                 "Tel": "Plating"
@@ -76282,7 +76486,7 @@
             "Key": "X94Y59",
             "Value": [
               {
-                "Tel": "whitepurplecorner_2"
+                "Tel": "whiteyellowcorner_2"
               },
               {
                 "Tel": "Plating"
@@ -76302,7 +76506,7 @@
             "Key": "X94Y60",
             "Value": [
               {
-                "Tel": "whitepurple_2"
+                "Tel": "whiteyellow_2"
               },
               {
                 "Tel": "Plating"
@@ -76329,7 +76533,7 @@
             "Key": "X94Y61",
             "Value": [
               {
-                "Tel": "whitepurplecorner_0"
+                "Tel": "whiteyellowcorner_0"
               },
               {
                 "Tel": "Plating"
@@ -77824,7 +78028,7 @@
             ]
           },
           {
-            "Key": "X95Y48",
+            "Key": "X95Y47",
             "Value": [
               {
                 "Tel": "WindowReinforced"
@@ -77834,6 +78038,17 @@
               },
               {
                 "Tel": "Grille"
+              }
+            ]
+          },
+          {
+            "Key": "X95Y48",
+            "Value": [
+              {
+                "Tel": "white"
+              },
+              {
+                "Tel": "Plating"
               }
             ]
           },
@@ -79192,6 +79407,9 @@
             "Key": "X96Y47",
             "Value": [
               {
+                "Tel": "Wall"
+              },
+              {
                 "Tel": "Lattice"
               }
             ]
@@ -79200,7 +79418,7 @@
             "Key": "X96Y48",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "white"
               },
               {
                 "Tel": "Plating"
@@ -79436,7 +79654,7 @@
             "Key": "X96Y65",
             "Value": [
               {
-                "Tel": "white"
+                "Tel": "whiteyellow_0"
               },
               {
                 "Tel": "Plating"
@@ -81058,6 +81276,9 @@
             "Key": "X97Y47",
             "Value": [
               {
+                "Tel": "Wall"
+              },
+              {
                 "Tel": "Lattice"
               }
             ]
@@ -81066,7 +81287,7 @@
             "Key": "X97Y48",
             "Value": [
               {
-                "Tel": "Wall"
+                "Tel": "white"
               },
               {
                 "Tel": "Plating"
@@ -81125,7 +81346,7 @@
             "Key": "X97Y53",
             "Value": [
               {
-                "Tel": "white"
+                "Tel": "whitered_0"
               },
               {
                 "Tel": "Plating"
@@ -81290,7 +81511,7 @@
             "Key": "X97Y65",
             "Value": [
               {
-                "Tel": "white"
+                "Tel": "whiteyellow_0"
               },
               {
                 "Tel": "Plating"
@@ -82257,7 +82478,7 @@
             ]
           },
           {
-            "Key": "X98Y48",
+            "Key": "X98Y47",
             "Value": [
               {
                 "Tel": "WindowReinforced"
@@ -82267,6 +82488,17 @@
               },
               {
                 "Tel": "Grille"
+              }
+            ]
+          },
+          {
+            "Key": "X98Y48",
+            "Value": [
+              {
+                "Tel": "white"
+              },
+              {
+                "Tel": "Plating"
               }
             ]
           },
@@ -82326,7 +82558,7 @@
             "Key": "X98Y53",
             "Value": [
               {
-                "Tel": "white"
+                "Tel": "whitered_0"
               },
               {
                 "Tel": "Plating"
@@ -82511,7 +82743,7 @@
             "Key": "X98Y65",
             "Value": [
               {
-                "Tel": "white"
+                "Tel": "whiteyellow_0"
               },
               {
                 "Tel": "Plating"
@@ -83460,7 +83692,7 @@
             ]
           },
           {
-            "Key": "X99Y48",
+            "Key": "X99Y47",
             "Value": [
               {
                 "Tel": "WindowReinforced"
@@ -83470,6 +83702,20 @@
               },
               {
                 "Tel": "Grille"
+              }
+            ]
+          },
+          {
+            "Key": "X99Y48",
+            "Value": [
+              {
+                "Tel": "whitered_4"
+              },
+              {
+                "Tel": "Plating"
+              },
+              {
+                "Tel": "table_glass"
               }
             ]
           },
@@ -83505,13 +83751,10 @@
             "Key": "X99Y51",
             "Value": [
               {
-                "Tel": "white"
+                "Tel": "whitered_6"
               },
               {
                 "Tel": "Plating"
-              },
-              {
-                "Tel": "table_glass"
               }
             ]
           },
@@ -84726,6 +84969,9 @@
           {
             "Key": "X100Y47",
             "Value": [
+              {
+                "Tel": "Wall"
+              },
               {
                 "Tel": "Lattice"
               }
@@ -132613,6 +132859,9 @@
             "Value": [
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "Table"
               }
             ]
           },
@@ -141905,7 +142154,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -142518,12 +142767,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -142567,7 +142816,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -142804,7 +143053,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -142933,7 +143182,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -143304,7 +143553,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -143434,7 +143683,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -143516,7 +143765,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -143658,12 +143907,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -143723,7 +143972,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -143767,7 +144016,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -143949,7 +144198,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -144203,12 +144452,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -144342,7 +144591,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -144647,7 +144896,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -144691,7 +144940,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -145002,7 +145251,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -145043,7 +145292,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -145156,7 +145405,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -145200,7 +145449,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -145378,7 +145627,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -145673,12 +145922,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -145728,7 +145977,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -146004,7 +146253,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -146064,12 +146313,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -146104,7 +146353,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -146198,7 +146447,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -146360,7 +146609,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -146571,7 +146820,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -146664,12 +146913,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -146735,7 +146984,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -146791,12 +147040,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -146890,12 +147139,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -147470,7 +147719,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -147505,12 +147754,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -147536,7 +147785,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -147623,7 +147872,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -147707,7 +147956,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -147784,6 +148033,41 @@
             "PrefabID": "c7a0601b9d5567942bd6c4d26a735b61",
             "Name": "PurgeModule (1)",
             "LocalPRS": "42.85┼39.92┼0┼"
+          },
+          {
+            "GitID": "e58e1fd483fe772468ad2aab4259397d_42.89┼70.03┼0┼",
+            "PrefabID": "e58e1fd483fe772468ad2aab4259397d",
+            "Name": "MaintSpawns at 46 77",
+            "LocalPRS": "42.89┼70.03┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "SpawnPoint@0",
+                  "Data": [
+                    {
+                      "Name": "category",
+                      "Data": "MaintSpawns"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,1",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "InitialPresentSpriteSet",
+                          "Data": "6f2180fedef59fb41bf603daa92a001c"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           },
           {
             "GitID": "3f5f2064c9c427440b81c0133ffd6dc5_42.93┼31.93┼0┼",
@@ -148121,12 +148405,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -148318,6 +148602,12 @@
             "LocalPRS": "43.04┼48┼0┼"
           },
           {
+            "GitID": "ec6860fc0ee631a4e861a29f42bcacbb_43.04┼68.09┼0┼",
+            "PrefabID": "ec6860fc0ee631a4e861a29f42bcacbb",
+            "Name": "RandomCrowbarSpawner (1)",
+            "LocalPRS": "43.04┼68.09┼0┼"
+          },
+          {
             "GitID": "34aa485f5e6ca814c9a0f3d3ecb2d352_43.09┼39.97┼0┼",
             "PrefabID": "34aa485f5e6ca814c9a0f3d3ecb2d352",
             "Name": "ResetModule (1)",
@@ -148471,7 +148761,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -148597,41 +148887,6 @@
             "LocalPRS": "44.81┼39.84┼0┼"
           },
           {
-            "GitID": "e58e1fd483fe772468ad2aab4259397d_44.95┼75.99┼0┼",
-            "PrefabID": "e58e1fd483fe772468ad2aab4259397d",
-            "Name": "MaintSpawns at 46 77",
-            "LocalPRS": "44.95┼75.99┼0┼",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "SpawnPoint@0",
-                  "Data": [
-                    {
-                      "Name": "category",
-                      "Data": "MaintSpawns"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "6f2180fedef59fb41bf603daa92a001c"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          },
-          {
             "GitID": "d3f188523932602479ba29efd8061dca_44.96┼40.21┼0┼",
             "PrefabID": "d3f188523932602479ba29efd8061dca",
             "Name": "Ian'sBirthdayModule (1)",
@@ -148662,12 +148917,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -148703,7 +148958,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -148739,7 +148994,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -149127,12 +149382,6 @@
             "LocalPRS": "46.23┼40.21┼0┼"
           },
           {
-            "GitID": "ec6860fc0ee631a4e861a29f42bcacbb_46.96┼76.07┼0┼",
-            "PrefabID": "ec6860fc0ee631a4e861a29f42bcacbb",
-            "Name": "RandomCrowbarSpawner (1)",
-            "LocalPRS": "46.96┼76.07┼0┼"
-          },
-          {
             "GitID": "f10c70de452d8b84ba9d9fd4c169f205_47┼33┼0┼",
             "PrefabID": "f10c70de452d8b84ba9d9fd4c169f205",
             "Name": "AiCoreTurret (3)",
@@ -149188,7 +149437,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -149232,7 +149481,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -149411,7 +149660,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -149666,23 +149915,6 @@
             }
           },
           {
-            "GitID": "1d35052f4fc2cad4d8226d1a63e4a1b3_47┼147┼0┼",
-            "PrefabID": "1d35052f4fc2cad4d8226d1a63e4a1b3",
-            "NameMatches": true,
-            "Name": "CrateBase",
-            "LocalPRS": "47┼147┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,2",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
-          },
-          {
             "GitID": "007d9f81d20c55d479d86a1d7d4343db_47┼148┼0┼",
             "PrefabID": "007d9f81d20c55d479d86a1d7d4343db",
             "NameMatches": true,
@@ -149755,21 +149987,17 @@
             }
           },
           {
-            "GitID": "1d35052f4fc2cad4d8226d1a63e4a1b3_47┼151┼0┼",
-            "PrefabID": "1d35052f4fc2cad4d8226d1a63e4a1b3",
+            "GitID": "e96cbada8cec9cf4880b0a3b196dc465_47.01┼147.03┼0┼",
+            "PrefabID": "e96cbada8cec9cf4880b0a3b196dc465",
             "NameMatches": true,
-            "Name": "CrateBase",
-            "LocalPRS": "47┼151┼0┼",
-            "Object": {
-              "ClassDatas": [],
-              "Children": [
-                {
-                  "ID": "0,2",
-                  "Active": false,
-                  "ClassDatas": []
-                }
-              ]
-            }
+            "Name": "RandomCrate",
+            "LocalPRS": "47.01┼147.03┼0┼"
+          },
+          {
+            "GitID": "e96cbada8cec9cf4880b0a3b196dc465_47.01┼151.02┼0┼",
+            "PrefabID": "e96cbada8cec9cf4880b0a3b196dc465",
+            "Name": "RandomCrate (1)",
+            "LocalPRS": "47.01┼151.02┼0┼"
           },
           {
             "GitID": "ea7280b49083dfa469fb176f6a7e4772_47.02┼140.78┼0┼",
@@ -150489,7 +150717,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -150691,7 +150919,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -150855,7 +151083,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -150922,7 +151150,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -151001,7 +151229,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -151013,12 +151241,6 @@
             "PrefabID": "75714a236b0522844b47ac0e27cd2487",
             "Name": "SurgicalDrill (1)",
             "LocalPRS": "48.02┼72.17┼0┼"
-          },
-          {
-            "GitID": "c05c071c51fbfec408e4c9f6240dc824_48.02┼81.94┼0┼",
-            "PrefabID": "c05c071c51fbfec408e4c9f6240dc824",
-            "Name": "ArmoryContrabandGunSpawner (1)",
-            "LocalPRS": "48.02┼81.94┼0┼0ø0ø260ø"
           },
           {
             "GitID": "8fb9b82aab871a54fb9bdb7e4a985821_48.02┼149.97┼0┼",
@@ -151033,6 +151255,13 @@
             "NameMatches": true,
             "Name": "MaintLoot",
             "LocalPRS": "48.04┼151┼0┼"
+          },
+          {
+            "GitID": "61891de53a1487e4bbfb60ce0c686c6c_48.06┼81.98┼0┼",
+            "PrefabID": "61891de53a1487e4bbfb60ce0c686c6c",
+            "NameMatches": true,
+            "Name": "SmugglersSatchelContraband",
+            "LocalPRS": "48.06┼81.98┼0┼0ø0ø150ø"
           },
           {
             "GitID": "83442ea1bc97ef04db1f9962a2f7021d_48.23┼135.91┼0┼",
@@ -151168,12 +151397,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -151421,12 +151650,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -151699,12 +151928,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -151894,7 +152123,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -152076,7 +152305,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -152314,7 +152543,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -152494,12 +152723,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -152543,7 +152772,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -152703,7 +152932,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -152767,7 +152996,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -152925,12 +153154,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -153076,7 +153305,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -153150,7 +153379,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -153461,12 +153690,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -153690,12 +153919,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -153759,7 +153988,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -153844,7 +154073,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -153942,7 +154171,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -154050,12 +154279,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -154323,7 +154552,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -154362,7 +154591,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -154736,7 +154965,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -155617,7 +155846,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -156199,7 +156428,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -156243,7 +156472,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -156391,7 +156620,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -156524,7 +156753,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -156646,7 +156875,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -156769,7 +156998,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -156853,7 +157082,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -156943,7 +157172,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -157027,12 +157256,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -157093,7 +157322,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -157269,7 +157498,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -157324,7 +157553,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -157552,12 +157781,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -158055,7 +158284,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -158248,12 +158477,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -158288,12 +158517,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -158319,12 +158548,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -158472,12 +158701,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -158600,7 +158829,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -158648,7 +158877,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -158696,7 +158925,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -158832,7 +159061,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -158913,7 +159142,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -158986,7 +159215,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -159021,12 +159250,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -159276,12 +159505,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -159366,7 +159595,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -160106,7 +160335,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -160197,7 +160426,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -160359,7 +160588,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -160414,12 +160643,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -160596,6 +160825,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Cargo"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -161416,6 +161649,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Robotics"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -161798,6 +162035,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Security"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -161904,7 +162145,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -162007,7 +162248,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -162063,7 +162304,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -162107,7 +162348,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -162203,7 +162444,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -162362,7 +162603,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -162426,7 +162667,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -162760,12 +163001,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -162924,12 +163165,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -163014,12 +163255,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -163183,7 +163424,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -163454,7 +163695,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -163517,7 +163758,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -163601,7 +163842,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -163693,7 +163934,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -163852,12 +164093,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -163940,7 +164181,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -164072,12 +164313,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -164118,12 +164359,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -164230,12 +164471,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -164289,12 +164530,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -164349,7 +164590,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -164515,7 +164756,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -164601,7 +164842,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -164684,7 +164925,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -165145,7 +165386,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -165452,7 +165693,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -165516,7 +165757,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -165766,7 +166007,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -165936,7 +166177,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -166070,6 +166311,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Rnd"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -166167,7 +166412,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -166211,7 +166456,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -166306,12 +166551,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -166355,7 +166600,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -166418,7 +166663,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -166616,7 +166861,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -166661,7 +166906,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -166727,12 +166972,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -166926,7 +167171,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -167225,7 +167470,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -167806,7 +168051,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -167874,7 +168119,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,3",
+                  "ID": "0,4",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -167940,7 +168185,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -168405,7 +168650,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -168463,7 +168708,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -168518,7 +168763,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -168604,41 +168849,6 @@
                     {
                       "Name": "CurrentDirection",
                       "Data": "Left_By90"
-                    }
-                  ]
-                }
-              ]
-            }
-          },
-          {
-            "GitID": "e58e1fd483fe772468ad2aab4259397d_67.91┼58.02┼0┼",
-            "PrefabID": "e58e1fd483fe772468ad2aab4259397d",
-            "Name": "SpaceExterior at 69 59",
-            "LocalPRS": "67.91┼58.02┼0┼",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "SpawnPoint@0",
-                  "Data": [
-                    {
-                      "Name": "category",
-                      "Data": "SpaceExterior"
-                    }
-                  ]
-                }
-              ],
-              "Children": [
-                {
-                  "ID": "0,1",
-                  "ClassDatas": [
-                    {
-                      "ClassID": "SpriteHandler@0",
-                      "Data": [
-                        {
-                          "Name": "InitialPresentSpriteSet",
-                          "Data": "8672bf8dd479a434cbfe8daac215b223"
-                        }
-                      ]
                     }
                   ]
                 }
@@ -169706,7 +169916,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -169890,12 +170100,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -169969,12 +170179,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -170018,7 +170228,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -170044,7 +170254,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -170106,7 +170316,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -170132,12 +170342,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -170172,12 +170382,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -170500,7 +170710,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -170733,7 +170943,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -170882,7 +171092,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -171115,7 +171325,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -171166,7 +171376,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -171572,7 +171782,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -171769,6 +171979,41 @@
             "NameMatches": true,
             "Name": "MaintLoot",
             "LocalPRS": "73.03┼95.96┼0┼"
+          },
+          {
+            "GitID": "e58e1fd483fe772468ad2aab4259397d_73.04┼57.94┼0┼",
+            "PrefabID": "e58e1fd483fe772468ad2aab4259397d",
+            "Name": "SpaceExterior at 69 59",
+            "LocalPRS": "73.04┼57.94┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "SpawnPoint@0",
+                  "Data": [
+                    {
+                      "Name": "category",
+                      "Data": "SpaceExterior"
+                    }
+                  ]
+                }
+              ],
+              "Children": [
+                {
+                  "ID": "0,1",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "InitialPresentSpriteSet",
+                          "Data": "8672bf8dd479a434cbfe8daac215b223"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           },
           {
             "GitID": "b9c954894479b5146a8bf34dd8622f00_73.04┼93.03┼0┼",
@@ -171986,7 +172231,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -172030,7 +172275,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -172074,7 +172319,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -172109,7 +172354,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -172160,7 +172405,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -172326,12 +172571,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -172375,7 +172620,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -172438,7 +172683,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -172473,12 +172718,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -173147,7 +173392,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -173226,12 +173471,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -173368,7 +173613,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,3",
+                  "ID": "0,4",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -173465,7 +173710,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,3",
+                  "ID": "0,4",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -173606,7 +173851,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -173673,8 +173918,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -173865,7 +174142,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -174131,7 +174408,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -174319,7 +174596,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -174412,7 +174689,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -175092,7 +175369,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -175422,12 +175699,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -175568,6 +175845,26 @@
             "PrefabID": "c73942e301ad48a4c87343bc6f8b20f7",
             "Name": "New Disposal Bin",
             "LocalPRS": "85┼112┼0┼"
+          },
+          {
+            "GitID": "16c6881fecb34104d91e663e39a403f0_85┼116┼0┼",
+            "PrefabID": "16c6881fecb34104d91e663e39a403f0",
+            "NameMatches": true,
+            "Name": "JaniDrobe",
+            "LocalPRS": "85┼116┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼117┼0┼@0@APC@0"
+                    }
+                  ]
+                }
+              ]
+            }
           },
           {
             "GitID": "38246cd9491b4c248abb2e296cc6c76f_85┼131┼0┼",
@@ -175788,7 +176085,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -176088,7 +176385,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -176132,6 +176429,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Bar"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -176181,7 +176482,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -176241,24 +176542,11 @@
             "LocalPRS": "86┼114┼0┼"
           },
           {
-            "GitID": "16c6881fecb34104d91e663e39a403f0_86┼116┼0┼",
-            "PrefabID": "16c6881fecb34104d91e663e39a403f0",
+            "GitID": "1c994b643c4713a46b842815dd9faaf1_86┼116┼0┼",
+            "PrefabID": "1c994b643c4713a46b842815dd9faaf1",
             "NameMatches": true,
-            "Name": "JaniDrobe",
-            "LocalPRS": "86┼116┼0┼",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "APCPoweredDevice@0",
-                  "Data": [
-                    {
-                      "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_90┼117┼0┼@0@APC@0"
-                    }
-                  ]
-                }
-              ]
-            }
+            "Name": "Closet_Janitor",
+            "LocalPRS": "86┼116┼0┼"
           },
           {
             "GitID": "c73942e301ad48a4c87343bc6f8b20f7_86┼145┼0┼",
@@ -176305,12 +176593,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -176407,12 +176695,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -176648,7 +176936,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -176683,12 +176971,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -176765,7 +177053,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -176800,7 +177088,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -177180,13 +177468,6 @@
             "LocalPRS": "87┼114┼0┼"
           },
           {
-            "GitID": "39f11c8504eb6b7409e8dba3179a52ca_87┼116┼0┼",
-            "PrefabID": "39f11c8504eb6b7409e8dba3179a52ca",
-            "NameMatches": true,
-            "Name": "JanitorialCart",
-            "LocalPRS": "87┼116┼0┼"
-          },
-          {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_87┼116┼0┼",
             "PrefabID": "fde32c02abddc814f9366ff1fb21f234",
             "NameMatches": true,
@@ -177233,7 +177514,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -177311,7 +177592,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -177496,7 +177777,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -177654,6 +177935,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Armory"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -177666,8 +177951,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -177852,7 +178169,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -177946,7 +178263,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -177987,12 +178304,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -178040,7 +178357,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -178135,7 +178452,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -178156,9 +178473,10 @@
             "LocalPRS": "88┼111┼0┼"
           },
           {
-            "GitID": "c3b1e85e5c3e2e740bb058b62c306be4_88┼116┼0┼",
-            "PrefabID": "c3b1e85e5c3e2e740bb058b62c306be4",
-            "Name": "CanisterWaterVapour (1)",
+            "GitID": "39f11c8504eb6b7409e8dba3179a52ca_88┼116┼0┼",
+            "PrefabID": "39f11c8504eb6b7409e8dba3179a52ca",
+            "NameMatches": true,
+            "Name": "JanitorialCart",
             "LocalPRS": "88┼116┼0┼"
           },
           {
@@ -178246,7 +178564,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -178278,7 +178596,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -178544,7 +178862,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -178623,7 +178941,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -178669,12 +178987,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -178778,12 +179096,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -178827,7 +179145,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -178942,10 +179260,9 @@
             "LocalPRS": "89┼112┼0┼"
           },
           {
-            "GitID": "1c994b643c4713a46b842815dd9faaf1_89┼116┼0┼",
-            "PrefabID": "1c994b643c4713a46b842815dd9faaf1",
-            "NameMatches": true,
-            "Name": "Closet_Janitor",
+            "GitID": "c3b1e85e5c3e2e740bb058b62c306be4_89┼116┼0┼",
+            "PrefabID": "c3b1e85e5c3e2e740bb058b62c306be4",
+            "Name": "CanisterWaterVapour (1)",
             "LocalPRS": "89┼116┼0┼"
           },
           {
@@ -179023,7 +179340,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -179058,12 +179375,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -179117,7 +179434,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -179212,7 +179529,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -179699,12 +180016,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -179771,7 +180088,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -180095,7 +180412,7 @@
                     },
                     {
                       "Name": "connectedDevices#0",
-                      "Data": "16c6881fecb34104d91e663e39a403f0_86┼116┼0┼@0@APCPoweredDevice@0"
+                      "Data": "16c6881fecb34104d91e663e39a403f0_85┼116┼0┼@0@APCPoweredDevice@0"
                     }
                   ]
                 }
@@ -180318,12 +180635,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -180377,7 +180694,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -180508,12 +180825,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -180644,6 +180961,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Bar"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -180748,7 +181069,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -181078,7 +181399,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -181086,17 +181407,10 @@
             }
           },
           {
-            "GitID": "J5UF3VXxKdTV9iopbA17_91┼154┼0┼",
-            "PrefabID": "J5UF3VXxKdTV9iopbA17",
+            "GitID": "6b7563f69c76a2a4a9dd785f88e80c19_91┼155┼0┼",
+            "PrefabID": "6b7563f69c76a2a4a9dd785f88e80c19",
             "NameMatches": true,
-            "Name": "SecBarrier",
-            "LocalPRS": "91┼154┼0┼"
-          },
-          {
-            "GitID": "J5UF3VXxKdTV9iopbA17_91┼155┼0┼",
-            "PrefabID": "J5UF3VXxKdTV9iopbA17",
-            "NameMatches": true,
-            "Name": "SecBarrier",
+            "Name": "DeployableSecurityBarrier",
             "LocalPRS": "91┼155┼0┼"
           },
           {
@@ -181544,6 +181858,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Armory"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -181634,12 +181952,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -181774,13 +182092,6 @@
             }
           },
           {
-            "GitID": "J5UF3VXxKdTV9iopbA17_92┼155┼0┼",
-            "PrefabID": "J5UF3VXxKdTV9iopbA17",
-            "NameMatches": true,
-            "Name": "SecBarrier",
-            "LocalPRS": "92┼155┼0┼"
-          },
-          {
             "GitID": "f366650cffd96f94fba163684087ba01_92.17┼50.1┼0┼",
             "PrefabID": "f366650cffd96f94fba163684087ba01",
             "Name": "Mutation Grabber (2)",
@@ -181891,12 +182202,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -182058,7 +182369,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -182084,12 +182395,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -182440,7 +182751,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -182537,7 +182848,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -182600,7 +182911,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -182644,7 +182955,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -182708,7 +183019,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -182762,12 +183073,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -183454,7 +183765,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -183489,12 +183800,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -183548,7 +183859,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -183612,7 +183923,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -183780,7 +184091,7 @@
                     },
                     {
                       "Name": "connectedDevices#6",
-                      "Data": "9b59e4553ab9f7e4a8f46497d7cfd7bc_97┼48┼0┼@0@APCPoweredDevice@0"
+                      "Data": "9b59e4553ab9f7e4a8f46497d7cfd7bc_96┼47┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#5",
@@ -184452,7 +184763,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -184516,7 +184827,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -184898,7 +185209,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -185038,6 +185349,35 @@
             "LocalPRS": "95.99┼53.2┼0┼"
           },
           {
+            "GitID": "9b59e4553ab9f7e4a8f46497d7cfd7bc_96┼47┼0┼",
+            "PrefabID": "9b59e4553ab9f7e4a8f46497d7cfd7bc",
+            "NameMatches": true,
+            "Name": "NanoMed",
+            "LocalPRS": "96┼47┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_95┼52┼0┼@0@APC@0"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Up_By0"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
             "GitID": "c21551dd992a57349973e4b5af103ca6_96┼51┼0┼",
             "PrefabID": "c21551dd992a57349973e4b5af103ca6",
             "Name": "SecurityCamera (9)",
@@ -185056,12 +185396,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -185138,7 +185478,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -185331,6 +185671,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Chemistry"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -185395,7 +185739,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -185454,7 +185798,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -185569,7 +185913,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -185860,12 +186204,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -186147,35 +186491,6 @@
             }
           },
           {
-            "GitID": "9b59e4553ab9f7e4a8f46497d7cfd7bc_97┼48┼0┼",
-            "PrefabID": "9b59e4553ab9f7e4a8f46497d7cfd7bc",
-            "NameMatches": true,
-            "Name": "NanoMed",
-            "LocalPRS": "97┼48┼0┼",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "APCPoweredDevice@0",
-                  "Data": [
-                    {
-                      "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_95┼52┼0┼@0@APC@0"
-                    }
-                  ]
-                },
-                {
-                  "ClassID": "Rotatable@0",
-                  "Data": [
-                    {
-                      "Name": "CurrentDirection",
-                      "Data": "Up_By0"
-                    }
-                  ]
-                }
-              ]
-            }
-          },
-          {
             "GitID": "30fb7ca3bc404684697f10534d3eee73_97┼52┼0┼",
             "PrefabID": "30fb7ca3bc404684697f10534d3eee73",
             "NameMatches": true,
@@ -186258,12 +186573,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -186387,7 +186702,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -186604,12 +186919,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -186698,12 +187013,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -186971,7 +187286,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -187081,7 +187396,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -187159,10 +187474,10 @@
             }
           },
           {
-            "GitID": "c4c1a5e556c58314eb690ee3272fb1cf_98┼50┼0┼",
+            "GitID": "c4c1a5e556c58314eb690ee3272fb1cf_98┼49┼0┼",
             "PrefabID": "c4c1a5e556c58314eb690ee3272fb1cf",
             "Name": "OperatingTable (1)",
-            "LocalPRS": "98┼50┼0┼"
+            "LocalPRS": "98┼49┼0┼"
           },
           {
             "GitID": "30fb7ca3bc404684697f10534d3eee73_98┼52┼0┼",
@@ -187237,7 +187552,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -187291,12 +187606,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -187377,6 +187692,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Chemistry"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -187448,7 +187767,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -187518,7 +187837,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -187559,12 +187878,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -187755,12 +188074,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -187814,7 +188133,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -188050,10 +188369,10 @@
             "LocalPRS": "98.9┼91.22┼0┼"
           },
           {
-            "GitID": "75714a236b0522844b47ac0e27cd2487_98.94┼51.12┼0┼",
+            "GitID": "75714a236b0522844b47ac0e27cd2487_98.94┼49.12┼0┼",
             "PrefabID": "75714a236b0522844b47ac0e27cd2487",
             "Name": "SurgicalDrill (1)",
-            "LocalPRS": "98.94┼51.12┼0┼"
+            "LocalPRS": "98.94┼49.12┼0┼"
           },
           {
             "GitID": "e58e1fd483fe772468ad2aab4259397d_98.96┼92.03┼0┼",
@@ -188091,11 +188410,11 @@
             }
           },
           {
-            "GitID": "468072fd130877c408f3a1950377560d_99┼49┼0┼",
+            "GitID": "468072fd130877c408f3a1950377560d_99┼48.08┼0┼",
             "PrefabID": "468072fd130877c408f3a1950377560d",
             "NameMatches": true,
             "Name": "Defibrillator",
-            "LocalPRS": "99┼49┼0┼"
+            "LocalPRS": "99┼48.08┼0┼"
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_99┼49┼0┼",
@@ -188135,7 +188454,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -188211,7 +188530,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -188354,12 +188673,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -188403,7 +188722,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -188590,7 +188909,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -188650,7 +188969,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -188704,7 +189023,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -188986,16 +189305,16 @@
             "LocalPRS": "99.12┼54.32┼0┼"
           },
           {
+            "GitID": "89be3503e849f7841bcb2d0c12d42f5f_99.17┼49.33┼0┼",
+            "PrefabID": "89be3503e849f7841bcb2d0c12d42f5f",
+            "Name": "Retractor (2)",
+            "LocalPRS": "99.17┼49.33┼0┼"
+          },
+          {
             "GitID": "c08b964edf24e5c42a6edf23e84fc920_99.17┼49.91┼0┼",
             "PrefabID": "c08b964edf24e5c42a6edf23e84fc920",
             "Name": "Cautery (2)",
             "LocalPRS": "99.17┼49.91┼0┼"
-          },
-          {
-            "GitID": "89be3503e849f7841bcb2d0c12d42f5f_99.17┼51.19┼0┼",
-            "PrefabID": "89be3503e849f7841bcb2d0c12d42f5f",
-            "Name": "Retractor (2)",
-            "LocalPRS": "99.17┼51.19┼0┼"
           },
           {
             "GitID": "4eef56ab532f51146aa11b1b05e56c10_99.19┼91.18┼0┼",
@@ -189266,7 +189585,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -189599,7 +189918,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -189659,7 +189978,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -189694,12 +190013,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -189813,7 +190132,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -190015,7 +190334,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -190056,12 +190375,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -190167,7 +190486,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -190202,7 +190521,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -190537,7 +190856,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -190584,7 +190903,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,3",
+                  "ID": "0,4",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -190750,7 +191069,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -190791,12 +191110,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -190952,7 +191271,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -191275,7 +191594,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -191341,7 +191660,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -191423,6 +191742,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Hydroponics"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -191620,12 +191943,6 @@
             }
           },
           {
-            "GitID": "bc3ec338908f0b24a80fadf8671f3028_102┼149┼0┼",
-            "PrefabID": "bc3ec338908f0b24a80fadf8671f3028",
-            "Name": "PepperSprayRefiller (3)",
-            "LocalPRS": "102┼149┼0┼"
-          },
-          {
             "GitID": "7a9f4b05d0be15c439f2c0d258200e77_102┼150┼0┼",
             "PrefabID": "7a9f4b05d0be15c439f2c0d258200e77",
             "NameMatches": true,
@@ -191773,7 +192090,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -192243,7 +192560,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -192463,19 +192780,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
               ]
             }
-          },
-          {
-            "GitID": "9f68bba630ca7a8459c3b56476c9e10a_103┼151┼0┼",
-            "PrefabID": "9f68bba630ca7a8459c3b56476c9e10a",
-            "NameMatches": true,
-            "Name": "P238Revolver",
-            "LocalPRS": "103┼151┼0┼"
           },
           {
             "GitID": "83442ea1bc97ef04db1f9962a2f7021d_103.19┼151.87┼0┼",
@@ -192608,7 +192918,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -192715,7 +193025,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -192741,7 +193051,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -192785,7 +193095,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -193303,7 +193613,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -193517,7 +193827,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -193899,7 +194209,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -193988,12 +194298,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -194053,7 +194363,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -194137,7 +194447,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -194209,7 +194519,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -194235,7 +194545,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -194388,7 +194698,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -194494,12 +194804,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -194540,12 +194850,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -194642,7 +194952,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -194868,7 +195178,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -195243,7 +195553,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -195780,7 +196090,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -195960,7 +196270,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -195999,12 +196309,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -196168,7 +196478,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -196323,7 +196633,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -196458,12 +196768,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -196554,7 +196864,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -196781,7 +197091,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -196985,7 +197295,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -197109,7 +197419,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -197179,7 +197489,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -197270,7 +197580,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -197566,7 +197876,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -197592,12 +197902,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -197658,7 +197968,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -197795,7 +198105,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -197859,7 +198169,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -198080,7 +198390,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -198327,7 +198637,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -198362,12 +198672,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -198735,7 +199045,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -199590,7 +199900,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -199852,12 +200162,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -199911,7 +200221,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -199974,12 +200284,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -200024,7 +200334,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -200634,7 +200944,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -200679,7 +200989,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -201112,12 +201422,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -201171,7 +201481,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -201226,7 +201536,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -201429,7 +201739,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -201515,7 +201825,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -201550,12 +201860,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -201590,12 +201900,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -201768,7 +202078,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -201813,7 +202123,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -201979,7 +202289,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -202226,7 +202536,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -202566,7 +202876,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -202746,7 +203056,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -203133,7 +203443,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -203237,12 +203547,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -203495,12 +203805,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -203554,7 +203864,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -203685,7 +203995,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -204426,7 +204736,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -204452,12 +204762,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -204659,7 +204969,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -205056,12 +205366,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -205191,7 +205501,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -205226,12 +205536,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -205384,7 +205694,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -205573,7 +205883,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -205746,12 +206056,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -206103,12 +206413,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -206751,6 +207061,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Hop"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -206849,7 +207163,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -207344,7 +207658,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -207534,7 +207848,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -207673,7 +207987,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -207708,12 +208022,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -207805,7 +208119,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -207831,12 +208145,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -207916,7 +208230,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -209305,7 +209619,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -209331,12 +209645,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -209648,12 +209962,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -209726,7 +210040,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -210048,7 +210362,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -210080,7 +210394,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -210127,12 +210441,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -210198,7 +210512,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -210298,7 +210612,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -210351,7 +210665,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -210408,7 +210722,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -210761,7 +211075,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -211019,7 +211333,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -211060,12 +211374,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -211119,7 +211433,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -211428,12 +211742,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -211791,12 +212105,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -211921,12 +212235,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -212039,12 +212353,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -212190,7 +212504,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -212546,7 +212860,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -212643,7 +212957,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -212707,7 +213021,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -212758,7 +213072,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -213079,7 +213393,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -213144,7 +213458,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -213771,7 +214085,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -213874,7 +214188,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -214165,12 +214479,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -214235,12 +214549,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -214352,7 +214666,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -214614,7 +214928,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -215343,6 +215657,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Captain"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -215622,7 +215940,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -215678,12 +215996,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -215728,7 +216046,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -216001,7 +216319,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -216042,12 +216360,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -216139,7 +216457,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -216231,7 +216549,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -216272,12 +216590,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -216331,7 +216649,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -216467,7 +216785,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -216881,7 +217199,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -217061,6 +217379,26 @@
             "LocalPRS": "142┼111┼0┼"
           },
           {
+            "GitID": "cd57a2813ebc4ff4caf28b5fb793b3eb_142┼120┼0┼",
+            "PrefabID": "cd57a2813ebc4ff4caf28b5fb793b3eb",
+            "NameMatches": true,
+            "Name": "AirlockHatchMaintenance",
+            "LocalPRS": "142┼120┼0┼",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_144┼121┼0┼@0@APC@0"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
             "GitID": "9759789a5180a46419c8a7e2e50748e2_143┼49┼0┼",
             "PrefabID": "9759789a5180a46419c8a7e2e50748e2",
             "NameMatches": true,
@@ -217152,7 +217490,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -217382,7 +217720,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -217623,7 +217961,7 @@
                     },
                     {
                       "Name": "connectedDevices#1",
-                      "Data": "cd57a2813ebc4ff4caf28b5fb793b3eb_146┼120┼0┼@0@APCPoweredDevice@0"
+                      "Data": "cd57a2813ebc4ff4caf28b5fb793b3eb_142┼120┼0┼@0@APCPoweredDevice@0"
                     },
                     {
                       "Name": "connectedDevices#0",
@@ -218046,7 +218384,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -218226,26 +218564,6 @@
             }
           },
           {
-            "GitID": "cd57a2813ebc4ff4caf28b5fb793b3eb_146┼120┼0┼",
-            "PrefabID": "cd57a2813ebc4ff4caf28b5fb793b3eb",
-            "NameMatches": true,
-            "Name": "AirlockHatchMaintenance",
-            "LocalPRS": "146┼120┼0┼",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "APCPoweredDevice@0",
-                  "Data": [
-                    {
-                      "Name": "RelatedAPC",
-                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_144┼121┼0┼@0@APC@0"
-                    }
-                  ]
-                }
-              ]
-            }
-          },
-          {
             "GitID": "032e150131f53a64fbf6048aca6a879a_146┼128┼0┼",
             "PrefabID": "032e150131f53a64fbf6048aca6a879a",
             "Name": "RandomTool",
@@ -218377,7 +218695,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -218450,7 +218768,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -218485,12 +218803,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -218637,7 +218955,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -218682,7 +219000,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -218718,7 +219036,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -218763,7 +219081,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -218775,6 +219093,13 @@
             "PrefabID": "fff8b3ada084c1b408e9c34ee1a1dd27",
             "Name": "Closet_Bomb_General",
             "LocalPRS": "147┼119┼0┼"
+          },
+          {
+            "GitID": "07bfe3ca581f72f42ac5ae48b23d91d8_147.06┼119.04┼0┼",
+            "PrefabID": "07bfe3ca581f72f42ac5ae48b23d91d8",
+            "NameMatches": true,
+            "Name": "RandomSnack",
+            "LocalPRS": "147.06┼119.04┼0┼"
           },
           {
             "GitID": "8086310b540051947a03d9677b936ac0_148┼55┼0┼",
@@ -218889,7 +219214,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -218944,12 +219269,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -219023,7 +219348,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -220281,7 +220606,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -220341,7 +220666,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -220401,7 +220726,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -220461,7 +220786,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -220521,7 +220846,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -220581,7 +220906,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -223662,7 +223987,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -223755,7 +224080,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -223815,7 +224140,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -223879,7 +224204,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -223933,7 +224258,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -224217,7 +224542,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -224689,7 +225014,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -225159,7 +225484,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -225273,7 +225598,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -225327,7 +225652,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -225538,7 +225863,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -225891,7 +226216,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -225945,7 +226270,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -226846,7 +227171,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -226996,7 +227321,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -227763,7 +228088,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -227913,7 +228238,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -228948,7 +229273,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -229026,7 +229351,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -229083,7 +229408,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -230354,7 +230679,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -230431,7 +230756,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -230677,7 +231002,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -230738,7 +231063,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -230831,7 +231156,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -232312,7 +232637,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -232477,7 +232802,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -232615,7 +232940,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -232986,7 +233311,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/StarshipStation.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/StarshipStation.json
@@ -55381,6 +55381,9 @@
                 "Tel": "Plating"
               },
               {
+                "Tel": "Table"
+              },
+              {
                 "Tel": "FluidStraightPipe",
                 "Z": 1,
                 "Col": "#FF0031FF",
@@ -73809,6 +73812,9 @@
             "Value": [
               {
                 "Tel": "Plating"
+              },
+              {
+                "Tel": "Table"
               }
             ]
           },
@@ -87873,12 +87879,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -87937,12 +87943,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -88025,7 +88031,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -88860,12 +88866,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -88931,7 +88937,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -89010,12 +89016,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -89060,7 +89066,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -89193,12 +89199,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -89631,8 +89637,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -89760,8 +89798,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -90278,8 +90348,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -90587,7 +90689,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -90652,7 +90754,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -90809,7 +90911,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -90868,12 +90970,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -90918,7 +91020,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -91091,7 +91193,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -91745,12 +91847,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -91809,12 +91911,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -91850,12 +91952,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -91898,7 +92000,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -92757,8 +92859,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -92830,8 +92964,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -93018,8 +93184,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -93205,8 +93403,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -93549,7 +93779,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -93942,12 +94172,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -93993,7 +94223,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -94184,7 +94414,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -94229,7 +94459,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -94274,7 +94504,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -95221,7 +95451,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -95280,12 +95510,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -95497,10 +95727,20 @@
             "LocalPRS": "-9┼68┼0┼",
             "SortPath": "Powernet",
             "Object": {
-              "ClassDatas": [],
+              "ClassDatas": [
+                {
+                  "ClassID": "DepartmentBattery@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentSprite",
+                      "Data": "Engineering"
+                    }
+                  ]
+                }
+              ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -95536,12 +95776,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -95594,7 +95834,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -95970,10 +96210,6 @@
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "initialName",
-                      "Data": "sign"
-                    },
-                    {
                       "Name": "initialDescription",
                       "Data": "\nTo Lunar Prison Site"
                     }
@@ -96031,8 +96267,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -96160,8 +96428,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -96374,12 +96674,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -96626,12 +96926,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -96783,7 +97083,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -96842,12 +97142,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -96967,7 +97267,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -97339,7 +97639,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -97441,7 +97741,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -97500,12 +97800,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -97701,10 +98001,6 @@
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "initialName",
-                      "Data": "sign"
-                    },
-                    {
                       "Name": "initialDescription",
                       "Data": "\nTo Planetary Colony - Security Station"
                     }
@@ -97799,7 +98095,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -97909,7 +98205,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -98938,7 +99234,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -98998,7 +99294,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -99187,7 +99483,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -99585,7 +99881,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -99847,12 +100143,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -99904,7 +100200,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -99940,12 +100236,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -100011,12 +100307,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -100165,12 +100461,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -100965,7 +101261,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -101021,8 +101317,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -101160,7 +101488,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -101390,7 +101718,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -101474,12 +101802,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -101524,7 +101852,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -101690,7 +102018,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -101805,12 +102133,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -101856,7 +102184,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -101933,8 +102261,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -101995,7 +102355,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -102066,7 +102426,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -102176,12 +102536,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -102296,7 +102656,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -102352,7 +102712,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -102447,8 +102807,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -102878,12 +103270,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -103176,6 +103568,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Engine"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -103188,8 +103584,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -103685,12 +104113,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -103746,8 +104174,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -103947,7 +104407,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -104315,12 +104775,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -104485,6 +104945,28 @@
             }
           },
           {
+            "GitID": "0d3043f6d48ca14478534a739fb01782_-0.2┼31.84┼0┼",
+            "PrefabID": "0d3043f6d48ca14478534a739fb01782",
+            "Name": "RiotHelmet (2)",
+            "LocalPRS": "-0.2┼31.84┼0┼",
+            "SortPath": "FurnitureDecor"
+          },
+          {
+            "GitID": "0d3043f6d48ca14478534a739fb01782_-0.2┼32.04┼0┼",
+            "PrefabID": "0d3043f6d48ca14478534a739fb01782",
+            "Name": "RiotHelmet (1)",
+            "LocalPRS": "-0.2┼32.04┼0┼",
+            "SortPath": "FurnitureDecor"
+          },
+          {
+            "GitID": "0d3043f6d48ca14478534a739fb01782_-0.2┼32.21┼0┼",
+            "PrefabID": "0d3043f6d48ca14478534a739fb01782",
+            "NameMatches": true,
+            "Name": "RiotHelmet",
+            "LocalPRS": "-0.2┼32.21┼0┼",
+            "SortPath": "FurnitureDecor"
+          },
+          {
             "GitID": "29ecbf5a1d918574cbcf5853927e0944_-0.12┼68┼0┼",
             "PrefabID": "29ecbf5a1d918574cbcf5853927e0944",
             "Name": "PlasteelSheet (2)",
@@ -104569,12 +105051,19 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
               ]
             }
+          },
+          {
+            "GitID": "ed4e62dc12dca724ba1e5f374965096b_0┼32┼0┼",
+            "PrefabID": "ed4e62dc12dca724ba1e5f374965096b",
+            "Name": "Rack (13)",
+            "LocalPRS": "0┼32┼0┼",
+            "SortPath": "FurnitureDecor"
           },
           {
             "GitID": "baeafe1b5e8214344a5acf3315766acc_0┼40┼0┼",
@@ -104737,12 +105226,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -104787,7 +105276,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -104968,7 +105457,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -105024,7 +105513,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -105069,7 +105558,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -105223,7 +105712,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -105275,7 +105764,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -105828,8 +106317,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -105881,7 +106402,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -106049,6 +106570,30 @@
             }
           },
           {
+            "GitID": "0cbcbdb33f79d8147854f04a0ce18a71_0.17┼32.2┼0┼",
+            "PrefabID": "0cbcbdb33f79d8147854f04a0ce18a71",
+            "NameMatches": true,
+            "Name": "RiotSuit",
+            "LocalPRS": "0.17┼32.2┼0┼",
+            "SortPath": "FurnitureDecor"
+          },
+          {
+            "GitID": "0cbcbdb33f79d8147854f04a0ce18a71_0.18┼31.8┼0┼",
+            "PrefabID": "0cbcbdb33f79d8147854f04a0ce18a71",
+            "NameMatches": true,
+            "Name": "RiotSuit",
+            "LocalPRS": "0.18┼31.8┼0┼",
+            "SortPath": "FurnitureDecor"
+          },
+          {
+            "GitID": "0cbcbdb33f79d8147854f04a0ce18a71_0.19┼32.05┼0┼",
+            "PrefabID": "0cbcbdb33f79d8147854f04a0ce18a71",
+            "NameMatches": true,
+            "Name": "RiotSuit",
+            "LocalPRS": "0.19┼32.05┼0┼",
+            "SortPath": "FurnitureDecor"
+          },
+          {
             "GitID": "5dce4d3e01518474bb9bb8085b718980_0.25┼68┼0┼",
             "PrefabID": "5dce4d3e01518474bb9bb8085b718980",
             "Name": "MetalRods (2)",
@@ -106173,8 +106718,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -106546,7 +107123,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -106602,12 +107179,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -106872,12 +107449,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -106942,8 +107519,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -107087,7 +107696,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -107173,7 +107782,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -107216,7 +107825,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -107317,7 +107926,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -107409,7 +108018,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -107635,7 +108244,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -107794,7 +108403,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -107808,10 +108417,20 @@
             "LocalPRS": "3┼32┼0┼",
             "SortPath": "Powernet",
             "Object": {
-              "ClassDatas": [],
+              "ClassDatas": [
+                {
+                  "ClassID": "DepartmentBattery@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentSprite",
+                      "Data": "Security"
+                    }
+                  ]
+                }
+              ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -108737,12 +109356,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -108795,10 +109414,20 @@
             "LocalPRS": "4┼38┼0┼",
             "SortPath": "Powernet",
             "Object": {
-              "ClassDatas": [],
+              "ClassDatas": [
+                {
+                  "ClassID": "DepartmentBattery@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentSprite",
+                      "Data": "Medical"
+                    }
+                  ]
+                }
+              ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -108925,7 +109554,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -108961,12 +109590,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -109119,7 +109748,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -109263,7 +109892,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -109471,12 +110100,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -109636,7 +110265,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -110127,7 +110756,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -110331,7 +110960,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -110392,7 +111021,6 @@
           {
             "GitID": "d3b3530ed46ec6746a52c88c62dd12fa_5┼79┼0┼",
             "PrefabID": "d3b3530ed46ec6746a52c88c62dd12fa",
-            "NameMatches": true,
             "Name": "New PowerGeneratorUranium",
             "LocalPRS": "5┼79┼0┼",
             "SortPath": "Powernet"
@@ -110489,7 +111117,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -111218,7 +111846,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -111376,7 +112004,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -111442,12 +112070,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -111492,7 +112120,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -111551,12 +112179,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -111811,12 +112439,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -111900,7 +112528,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -111956,12 +112584,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -112055,7 +112683,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -112192,12 +112820,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -112322,8 +112950,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -112526,7 +113186,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -112617,6 +113277,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Chemistry"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -112629,8 +113293,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -112757,8 +113453,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -112950,7 +113678,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -113061,7 +113789,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -114502,7 +115230,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -114597,10 +115325,6 @@
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
                     {
-                      "Name": "initialName",
-                      "Data": "sign"
-                    },
-                    {
                       "Name": "initialDescription",
                       "Data": "\nTo Atmospherics"
                     }
@@ -114667,7 +115391,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -114884,7 +115608,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -115033,7 +115757,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -115092,12 +115816,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -115150,7 +115874,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -115391,12 +116115,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -115481,7 +116205,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -115671,7 +116395,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -115736,12 +116460,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -115807,12 +116531,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -115999,7 +116723,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -116792,8 +117516,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -116941,7 +117697,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -117022,7 +117778,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -117188,6 +117944,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Research"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -117200,8 +117960,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -117796,7 +118588,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -117944,12 +118736,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -118622,12 +119414,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -118739,8 +119531,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -118914,7 +119738,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -118973,12 +119797,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -119076,12 +119900,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -119181,7 +120005,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -119270,7 +120094,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -119373,12 +120197,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -119504,12 +120328,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -119554,7 +120378,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -119610,8 +120434,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -119728,7 +120584,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -119810,7 +120666,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -120297,12 +121153,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -120383,7 +121239,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -120473,12 +121329,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -120802,7 +121658,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -120892,7 +121748,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -120948,8 +121804,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -121077,8 +121965,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -121372,7 +122292,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -121408,7 +122328,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -121457,6 +122377,14 @@
                 }
               ]
             }
+          },
+          {
+            "GitID": "1488f67a55cb9b84098e095e65e5a2b3_18.01┼27.01┼0┼",
+            "PrefabID": "1488f67a55cb9b84098e095e65e5a2b3",
+            "NameMatches": true,
+            "Name": "Shovel",
+            "LocalPRS": "18.01┼27.01┼0┼",
+            "SortPath": "Items"
           },
           {
             "GitID": "764cc89fcad4df74f92d294e87d2a8de_18.12┼28┼0┼",
@@ -121791,7 +122719,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -121836,7 +122764,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -121912,8 +122840,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -121965,7 +122925,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -122197,7 +123157,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -122263,12 +123223,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -122391,12 +123351,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -122441,7 +123401,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -122497,7 +123457,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -122996,7 +123956,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -123517,12 +124477,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -123588,12 +124548,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -123923,7 +124883,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -124054,7 +125014,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -124094,12 +125054,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -124193,8 +125153,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -124280,7 +125272,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -124325,7 +125317,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -124433,12 +125425,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -124478,12 +125470,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -124657,7 +125649,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -125030,6 +126022,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "AIUpload"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -125109,6 +126105,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "AIUpload"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -125121,8 +126121,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -125290,8 +126322,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -125352,7 +126416,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -125411,12 +126475,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -125553,12 +126617,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -125717,7 +126781,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -125797,12 +126861,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -126250,7 +127314,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -127143,7 +128207,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -127318,7 +128382,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -127650,7 +128714,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -127794,7 +128858,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -128095,8 +129159,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -128240,7 +129336,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -128379,7 +129475,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -128424,7 +129520,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -128480,7 +129576,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -129058,7 +130154,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -129224,7 +130320,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -129305,7 +130401,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -129458,7 +130554,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -129503,7 +130599,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -129889,7 +130985,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -130282,8 +131378,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -130415,8 +131543,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -130491,12 +131651,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -130667,12 +131827,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -130885,8 +132045,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -131014,8 +132206,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -131330,7 +132554,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -131476,12 +132700,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -131587,7 +132811,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -131623,12 +132847,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -131731,8 +132955,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -131810,7 +133066,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -132460,7 +133716,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -133019,8 +134275,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -133186,7 +134474,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -133229,12 +134517,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,3",
+                  "ID": "0,4",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -133516,7 +134804,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -133703,7 +134991,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -133898,7 +135186,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -133983,7 +135271,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -134082,12 +135370,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -134132,7 +135420,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -134191,7 +135479,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -135422,12 +136710,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -135625,8 +136913,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -135894,12 +137214,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -136005,12 +137325,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -136055,7 +137375,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -136107,7 +137427,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -136953,12 +138273,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -137037,12 +138357,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -137087,7 +138407,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -137218,7 +138538,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -137560,8 +138880,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -137747,7 +139099,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -137811,7 +139163,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -137907,12 +139259,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -137957,7 +139309,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -138141,12 +139493,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -138191,7 +139543,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -138285,7 +139637,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -138344,12 +139696,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -138394,7 +139746,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -138479,7 +139831,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -138538,12 +139890,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -138817,8 +140169,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -140072,7 +141456,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -140252,6 +141636,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Captain"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -140264,8 +141652,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -140425,7 +141845,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -140458,10 +141878,20 @@
             "LocalPRS": "33┼19┼0┼",
             "SortPath": "Powernet",
             "Object": {
-              "ClassDatas": [],
+              "ClassDatas": [
+                {
+                  "ClassID": "DepartmentBattery@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentSprite",
+                      "Data": "Command"
+                    }
+                  ]
+                }
+              ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -140587,7 +142017,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -140967,7 +142397,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -141003,12 +142433,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -141069,10 +142499,20 @@
             "LocalPRS": "33┼71┼0┼",
             "SortPath": "Powernet",
             "Object": {
-              "ClassDatas": [],
+              "ClassDatas": [
+                {
+                  "ClassID": "DepartmentBattery@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentSprite",
+                      "Data": "Science"
+                    }
+                  ]
+                }
+              ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -141168,12 +142608,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -141730,7 +143170,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -141925,7 +143365,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -142032,7 +143472,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -142092,12 +143532,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -142240,7 +143680,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -142280,12 +143720,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -142357,7 +143797,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -142479,6 +143919,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Research"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -142491,8 +143935,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -142746,7 +144222,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -142930,7 +144406,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -143074,7 +144550,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -143553,12 +145029,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -143687,7 +145163,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -143823,7 +145299,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -143892,7 +145368,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -144031,12 +145507,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -144332,8 +145808,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -144461,8 +145969,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -144579,7 +146119,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -144753,12 +146293,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -144862,6 +146402,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Research"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -144874,8 +146418,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -145005,6 +146581,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Research"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -145017,8 +146597,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -145230,7 +146842,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -145408,8 +147020,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -145584,7 +147228,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -145808,7 +147452,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -146292,12 +147936,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -146370,7 +148014,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -146535,7 +148179,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -146709,7 +148353,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -146808,12 +148452,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -146865,7 +148509,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -146988,7 +148632,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -147147,12 +148791,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -147236,12 +148880,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -148084,12 +149728,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -148162,7 +149806,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -148247,7 +149891,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -148412,6 +150056,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Hop"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -148424,8 +150072,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -148552,8 +150232,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -148849,10 +150561,20 @@
             "LocalPRS": "40┼46┼0┼",
             "SortPath": "Powernet",
             "Object": {
-              "ClassDatas": [],
+              "ClassDatas": [
+                {
+                  "ClassID": "DepartmentBattery@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentSprite",
+                      "Data": "Engineering"
+                    }
+                  ]
+                }
+              ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -148983,7 +150705,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -149049,7 +150771,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -149092,7 +150814,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -149148,7 +150870,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -149243,12 +150965,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -149314,12 +151036,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -149755,7 +151477,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -149917,6 +151639,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Engine"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -149929,8 +151655,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -150049,12 +151807,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -150181,7 +151939,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -150601,12 +152359,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -150865,7 +152623,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -151127,12 +152885,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -151736,7 +153494,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -151795,12 +153553,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -151856,8 +153614,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -151974,7 +153764,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -152033,12 +153823,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -152083,7 +153873,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -152142,12 +153932,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -152229,7 +154019,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -152338,7 +154128,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -152404,12 +154194,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -152454,7 +154244,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -152506,7 +154296,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -152639,8 +154429,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -152757,7 +154579,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -152802,7 +154624,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -152847,7 +154669,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -152965,7 +154787,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -153389,8 +155211,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -153518,8 +155372,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -153731,8 +155617,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -153880,8 +155798,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -154207,12 +156157,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -154257,7 +156207,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -154336,7 +156286,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -154488,7 +156438,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -154977,7 +156927,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -155213,7 +157163,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -155240,7 +157190,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -155358,7 +157308,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -155424,12 +157374,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -155446,10 +157396,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "sign"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "\nTo Planetary Colony"
@@ -155653,11 +157599,25 @@
             }
           },
           {
-            "GitID": "DeepFryerour GPs_49┼43┼0┼",
-            "PrefabID": "DeepFryerour GPs",
-            "Name": "New DeepFryer (1)",
+            "GitID": "cb0f8eeade0559b4eab161558c5c1645_49┼43┼0┼",
+            "PrefabID": "cb0f8eeade0559b4eab161558c5c1645",
+            "NameMatches": true,
+            "Name": "DeepFryer",
             "LocalPRS": "49┼43┼0┼",
-            "SortPath": "ConsolesAndMachines"
+            "SortPath": "ConsolesAndMachines",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "APCPoweredDevice@0",
+                  "Data": [
+                    {
+                      "Name": "RelatedAPC",
+                      "Data": "cd57203a8d3f54f478446e9b0ced6cf9_58┼46┼0┼@0@APC@0"
+                    }
+                  ]
+                }
+              ]
+            }
           },
           {
             "GitID": "fde32c02abddc814f9366ff1fb21f234_49┼43┼0┼",
@@ -155697,7 +157657,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -156085,7 +158045,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -156229,7 +158189,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,3",
+                  "ID": "0,4",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -156274,7 +158234,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -156359,7 +158319,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -156430,12 +158390,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -156533,12 +158493,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -156651,7 +158611,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -156882,12 +158842,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -157624,7 +159584,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -157802,7 +159762,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -158173,7 +160133,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -158341,12 +160301,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -158524,10 +160484,20 @@
             "LocalPRS": "53┼22┼0┼",
             "SortPath": "Powernet",
             "Object": {
-              "ClassDatas": [],
+              "ClassDatas": [
+                {
+                  "ClassID": "DepartmentBattery@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentSprite",
+                      "Data": "Cargo"
+                    }
+                  ]
+                }
+              ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -158647,7 +160617,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -158798,12 +160768,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -158839,7 +160809,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -158891,7 +160861,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -158987,12 +160957,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -159064,7 +161034,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -159224,7 +161194,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -159283,12 +161253,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -159346,7 +161316,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -159405,12 +161375,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -159445,6 +161415,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Atmospherics"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -159510,6 +161484,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Atmospherics"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -159522,8 +161500,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -160830,12 +162840,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -160891,8 +162901,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -161020,8 +163062,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -161149,8 +163223,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -161278,8 +163384,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -161387,12 +163525,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -161586,12 +163724,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -161661,7 +163799,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -161762,7 +163900,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -161898,7 +164036,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -161984,12 +164122,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -162284,6 +164422,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Kitchen"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -162296,8 +164438,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -162505,7 +164679,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -162598,7 +164772,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -162666,7 +164840,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -163440,7 +165614,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -163531,7 +165705,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -163574,7 +165748,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -163690,7 +165864,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -163912,7 +166086,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -163984,7 +166158,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -164097,7 +166271,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -164866,12 +167040,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -164986,7 +167160,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -165029,7 +167203,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -165390,7 +167564,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -165535,6 +167709,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Cargo"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -165547,8 +167725,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -165728,7 +167938,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -165791,6 +168001,10 @@
                 {
                   "ClassID": "APC@0",
                   "Data": [
+                    {
+                      "Name": "connectedDevices#113",
+                      "Data": "cb0f8eeade0559b4eab161558c5c1645_49┼43┼0┼@0@APCPoweredDevice@0"
+                    },
                     {
                       "Name": "connectedDevices#112",
                       "Data": "cf4eea25ecf048448aea1576b077452b_54┼40┼0┼@0@APCPoweredDevice@0"
@@ -166313,12 +168527,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,3",
+                  "ID": "0,4",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -166370,7 +168584,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -166752,12 +168966,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -166813,8 +169027,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -166955,7 +169201,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -167013,6 +169259,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Cargo"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -167025,8 +169275,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -167298,7 +169580,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -167399,7 +169681,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -167567,12 +169849,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -167748,7 +170030,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -167958,7 +170240,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -168036,6 +170318,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Cargo"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -168048,8 +170334,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -168199,6 +170517,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Cargo"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -168211,8 +170533,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -168499,7 +170853,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -168690,7 +171044,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -168781,7 +171135,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -168911,7 +171265,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -169453,7 +171807,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -169630,7 +171984,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -170499,12 +172853,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -170549,7 +172903,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -170655,12 +173009,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -170732,12 +173086,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -170794,12 +173148,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,3",
+                  "ID": "0,4",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -170941,8 +173295,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -171148,6 +173534,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Atmospherics"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -171160,8 +173550,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -171352,7 +173774,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -171678,7 +174100,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -171785,12 +174207,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -171835,7 +174257,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -171920,7 +174342,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -172105,7 +174527,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -172204,8 +174626,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -172342,7 +174796,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -172401,12 +174855,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -172563,7 +175017,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -172799,7 +175253,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -173018,7 +175472,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -173495,10 +175949,6 @@
                 {
                   "ClassID": "ObjectAttributes@0",
                   "Data": [
-                    {
-                      "Name": "initialName",
-                      "Data": "sign"
-                    },
                     {
                       "Name": "initialDescription",
                       "Data": "\nTo Engineering"
@@ -174125,7 +176575,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -174418,7 +176868,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -174483,12 +176933,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -175070,7 +177520,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -175466,7 +177916,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -175637,12 +178087,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -175885,7 +178335,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -176055,7 +178505,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -176120,7 +178570,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -176199,12 +178649,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -176273,7 +178723,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -176316,12 +178766,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -176361,10 +178811,20 @@
             "LocalPRS": "67┼58┼0┼",
             "SortPath": "Powernet",
             "Object": {
-              "ClassDatas": [],
+              "ClassDatas": [
+                {
+                  "ClassID": "DepartmentBattery@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentSprite",
+                      "Data": "Atmospherics"
+                    }
+                  ]
+                }
+              ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -176443,12 +178903,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -176507,7 +178967,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -176626,12 +179086,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -176696,7 +179156,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -176947,7 +179407,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -177019,7 +179479,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -177274,12 +179734,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,3",
+                  "ID": "0,4",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -177414,12 +179874,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -177658,7 +180118,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -177724,12 +180184,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -177819,8 +180279,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -177948,8 +180440,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -178077,8 +180601,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -178199,7 +180755,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -178337,12 +180893,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -178408,7 +180964,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -178494,12 +181050,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -179209,7 +181765,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -179714,7 +182270,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -179956,7 +182512,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -180046,7 +182602,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -180119,12 +182675,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -180266,8 +182822,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -180728,12 +183316,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,3",
+                  "ID": "0,4",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -181661,7 +184249,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -181720,12 +184308,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -181761,12 +184349,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -181830,12 +184418,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -181941,7 +184529,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -182083,12 +184671,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -182168,7 +184756,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -182262,12 +184850,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -182312,7 +184900,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -183090,12 +185678,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -183224,7 +185812,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -183400,7 +185988,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -183427,12 +186015,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,3",
+                  "ID": "0,4",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -183967,7 +186555,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -184088,12 +186676,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -184248,8 +186836,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -184377,8 +186997,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -184662,12 +187314,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -184770,12 +187422,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -184950,7 +187602,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -185016,12 +187668,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -185616,12 +188268,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -185673,7 +188325,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -185772,12 +188424,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -323087,12 +325739,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -323803,12 +326455,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -324012,12 +326664,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -324058,7 +326710,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -324329,7 +326981,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -324531,7 +327183,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -324581,7 +327233,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -324637,7 +327289,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -325120,11 +327772,11 @@
                   "ClassID": "ItemSlotActionTracker@0",
                   "Data": [
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "SecureStuff.SerializedAction"
                     },
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "#removed#"
                     }
                   ]
@@ -325143,11 +327795,11 @@
                   "ClassID": "ItemSlotActionTracker@0",
                   "Data": [
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "SecureStuff.SerializedAction"
                     },
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "#removed#"
                     }
                   ]
@@ -325253,11 +327905,11 @@
                   "ClassID": "ItemSlotActionTracker@0",
                   "Data": [
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "SecureStuff.SerializedAction"
                     },
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "#removed#"
                     }
                   ]
@@ -325276,11 +327928,11 @@
                   "ClassID": "ItemSlotActionTracker@0",
                   "Data": [
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "SecureStuff.SerializedAction"
                     },
                     {
-                      "Name": "<ActionData>k__BackingField#Actions.V2.ActionButtonData",
+                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
                       "Data": "#removed#"
                     }
                   ]
@@ -325629,7 +328281,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -325787,12 +328439,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -325836,7 +328488,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -326255,7 +328907,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -326528,10 +329180,20 @@
             "Name": "New Department Battery ENGINEERING (1)",
             "LocalPRS": "63┼107┼0┼",
             "Object": {
-              "ClassDatas": [],
+              "ClassDatas": [
+                {
+                  "ClassID": "DepartmentBattery@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentSprite",
+                      "Data": "Engineering"
+                    }
+                  ]
+                }
+              ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -327018,7 +329680,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -327053,7 +329715,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -327268,7 +329930,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -327697,7 +330359,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -327736,7 +330398,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -327825,7 +330487,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -327916,7 +330578,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -328122,12 +330784,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -328162,7 +330824,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -328232,12 +330894,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -328281,7 +330943,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -328350,12 +331012,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -328448,12 +331110,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -329801,7 +332463,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -329845,7 +332507,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -330140,7 +332802,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -330750,7 +333412,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -330890,7 +333552,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -330940,7 +333602,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -331077,7 +333739,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -332595,7 +335257,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -332639,7 +335301,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -332683,7 +335345,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -333128,12 +335790,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -333191,12 +335853,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -342822,7 +345484,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -344101,7 +346763,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -344982,7 +347644,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -473630,12 +476292,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -473679,7 +476341,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -474319,7 +476981,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -474821,7 +477483,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -474881,7 +477543,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -477842,7 +480504,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -477902,12 +480564,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -478276,12 +480938,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -478808,7 +481470,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -478855,12 +481517,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -479875,12 +482537,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -479983,12 +482645,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -480414,7 +483076,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -480448,6 +483110,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Security"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -480943,7 +483609,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -481141,12 +483807,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -481296,7 +483962,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -481354,12 +484020,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -482259,6 +484925,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Engine"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -482271,8 +484941,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -482411,6 +485113,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Engine"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -482423,8 +485129,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "2"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -482575,7 +485313,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -482655,7 +485393,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -482843,12 +485581,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -483081,7 +485819,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -483178,7 +485916,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -483763,7 +486501,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -483973,7 +486711,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -484046,12 +486784,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -484095,7 +486833,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -484564,12 +487302,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -484632,6 +487370,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "Library"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -484644,8 +487386,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -484830,7 +487604,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -484877,7 +487651,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -485304,12 +488078,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -485545,12 +488319,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -485663,12 +488437,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -485712,7 +488486,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -485954,7 +488728,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -486062,7 +488836,7 @@
               "ClassDatas": [],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -486322,12 +489096,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -486408,7 +489182,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -487818,7 +490592,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -487938,7 +490712,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -487996,12 +490770,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -488045,7 +490819,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -488538,7 +491312,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -488796,12 +491570,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -489657,12 +492431,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -489715,7 +492489,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -489875,8 +492649,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -490311,7 +493117,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -490594,6 +493400,10 @@
                         {
                           "Name": "requiredClearance#0",
                           "Data": "SecDoors"
+                        },
+                        {
+                          "Name": "type",
+                          "Data": "Any"
                         }
                       ]
                     }
@@ -490606,8 +493416,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -490729,7 +493571,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -490787,12 +493629,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -490909,12 +493751,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,3",
+                  "ID": "0,4",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -491430,12 +494272,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -491590,7 +494432,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -491648,12 +494490,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -492228,7 +495070,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -492400,7 +495242,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -492450,7 +495292,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -492853,12 +495695,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -492946,12 +495788,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -493515,12 +496357,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -494977,12 +497819,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -495064,12 +497906,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -495141,7 +497983,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -495752,12 +498594,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -496225,7 +499067,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -496283,12 +499125,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -496332,7 +499174,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -496376,7 +499218,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -496469,12 +499311,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -496518,7 +499360,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -497530,12 +500372,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -497619,7 +500461,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -497703,7 +500545,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -498172,7 +501014,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -498577,7 +501419,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -498673,12 +501515,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -498736,12 +501578,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -498951,12 +501793,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -499071,7 +501913,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -499198,7 +502040,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -499253,8 +502095,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -499384,12 +502258,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -499574,7 +502448,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -499664,7 +502538,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -499917,12 +502791,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -499966,7 +502840,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -500184,7 +503058,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -500268,7 +503142,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -501963,12 +504837,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -502024,7 +504898,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -502082,12 +504956,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -502131,7 +505005,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -502175,7 +505049,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -502258,7 +505132,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -502795,12 +505669,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -502874,7 +505748,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -503017,12 +505891,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -504128,12 +507002,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -504189,7 +507063,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -505021,7 +507895,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -505079,12 +507953,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -507095,12 +509969,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -507267,12 +510141,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -508323,7 +511197,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -508609,12 +511483,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -508718,12 +511592,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -509835,12 +512709,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -511674,12 +514548,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -513860,7 +516734,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -514145,7 +517019,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -515014,8 +517888,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -515097,7 +518003,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -515842,8 +518748,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -515925,7 +518863,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -516426,12 +519364,12 @@
               ],
               "Children": [
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -516496,8 +519434,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "1"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -516596,12 +519566,12 @@
                   ]
                 },
                 {
-                  "ID": "0,1",
+                  "ID": "0,2",
                   "Active": false,
                   "ClassDatas": []
                 },
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -516645,7 +519615,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -519817,7 +522787,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -519867,7 +522837,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -520173,7 +523143,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -520262,7 +523232,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -520397,7 +523367,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -520486,7 +523456,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -520704,7 +523674,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -520877,7 +523847,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -521022,8 +523992,40 @@
                       "ClassID": "SpriteHandler@0",
                       "Data": [
                         {
+                          "Name": "NetworkThis",
+                          "Data": "True"
+                        },
+                        {
+                          "Name": "randomInitialSprite",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "spriteRenderer",
+                          "Data": "NULL"
+                        },
+                        {
+                          "Name": "doReverseAnimation",
+                          "Data": "False"
+                        },
+                        {
+                          "Name": "pushTextureOnStartUp",
+                          "Data": "True"
+                        },
+                        {
                           "Name": "initialVariantIndex",
                           "Data": "3"
+                        },
+                        {
+                          "Name": "InitialColour",
+                          "Data": "ÿÿÿÿ"
+                        },
+                        {
+                          "Name": "initialSortingOrder",
+                          "Data": "-1"
+                        },
+                        {
+                          "Name": "initialSortingLayerName",
+                          "Data": ""
                         }
                       ]
                     }
@@ -521178,7 +524180,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -521267,7 +524269,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -521698,7 +524700,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -521796,7 +524798,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -521913,7 +524915,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -522084,7 +525086,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -523292,7 +526294,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -523336,7 +526338,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -523500,7 +526502,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -523544,7 +526546,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }
@@ -523588,7 +526590,7 @@
               ],
               "Children": [
                 {
-                  "ID": "0,2",
+                  "ID": "0,3",
                   "Active": false,
                   "ClassDatas": []
                 }


### PR DESCRIPTION

### Purpose

This PR adds deepfryers (from #11132) and new secbarriers (from #11174) to boxstation, outpost, squarestation, and starshipstation. it also adds barrier grenades to the AmmoTech vendor, and does some general cleanup to outpost station.

### Media Preview:

outpost atmos changes
<img width="905" height="871" alt="image" src="https://github.com/user-attachments/assets/c011010d-e9b8-449a-82f0-c76f8d36740d" />

outpost medical changes
<img width="563" height="681" alt="image" src="https://github.com/user-attachments/assets/1f3e26ec-11d4-4307-9ad8-883a4505d5c0" />
I consider the changes to medical here to be half the job done. it's better, but still not good.
outpost science changes
<img width="782" height="819" alt="image" src="https://github.com/user-attachments/assets/be049c8b-2af1-4ed7-8e56-6e2cf15ad776" />
science room currently serves no purpose, but I think it will eventually get folded into toxins.

### Changelog:

CL: [Improvement] outpost, box, and starship kitchens have each gained a deepfryer.
CL: [Improvement] Atmospherics department in Outpost station has been remodeled to make actual sense.
CL: [Improvement] improved the usage of space in Outpost's science and medical.
CL: [Balance] starship station security has gained riot gear.
CL: [Balance] sectioned off atmospherics department battery into its own engineering maintenance room.
CL: [Balance] removed duplicate detective's revolver in squarestation.
CL: [Balance] deployable barrier grenades have been added to the AmmoTech vendor. 6 in total.
CL: [Fix] fixed numerous misrotated objects in outpost station.
CL: [Fix] fixed a vent being under a door in outpost genetics.
CL: [Fix] added missing ACU, scrubber, and vent to science.