### PR TITLE
chat - stack only repeats of most recent message

### DIFF
--- a/UnityProject/Assets/Prefabs/UI/ChatUI.prefab
+++ b/UnityProject/Assets/Prefabs/UI/ChatUI.prefab
@@ -4374,6 +4374,7 @@ MonoBehaviour:
   chatEntryPrefab: {fileID: 1096268754478474, guid: 6db9b4c8e7f61427b8eab85171ff4950,
     type: 3}
   maxLogLength: 100
+  duplicateLookbackDepth: 1
   chatInputLabel: {fileID: 2823315393706369458}
   channelToggleTemplate: {fileID: 968003211179716248}
   background: {fileID: 3884359157366066247}

--- a/UnityProject/Assets/Scripts/US13/Core/Chat/ChatUI.cs
+++ b/UnityProject/Assets/Scripts/US13/Core/Chat/ChatUI.cs
@@ -38,6 +38,11 @@ namespace US13.Core.Chat
 		public GameObject chatEntryPrefab = default;
 		public int maxLogLength = 90;
 
+        [SerializeField]
+        [Range(0, 6)]
+        [Tooltip("Number of entries back from most recent to scan for duplicate messages to stack. The chatlog won't always preserve an accurate order of events at values >1. 0 to disable.")]
+        private int duplicateLookbackDepth = 1;
+
 		[SerializeField]
 		private TMP_Text chatInputLabel = null;
 		[SerializeField]
@@ -363,7 +368,7 @@ namespace US13.Core.Chat
 		private bool WillUpdateStack(ref string message)
 		{
 			if (allEntries.Count <= 5) return false;
-			for (int i = 0; i < 6; i++)
+			for (int i = 0; i < duplicateLookbackDepth; i++)
 			{
 				var entryToCheck = allEntries[allEntries.Count - i - 1];
 				string cleanedEntryMessage = Regex.Replace(entryToCheck.Message, @"<size=[^>]+>|</size>", string.Empty);


### PR DESCRIPTION

### Purpose
fixes repeated text message stacking so it doesn't look back several lines and cause the message log to misrepresent the chronological order of events (very annoying when repeatedly performing a sequence of 2-3 actions). adds an inspector field to ChatUI for configuration from no lookback up to the old limit of 6.

### Notes:
need to figure out how to add this to the in-game options menu

i would also like to figure out how to keep the font from growing to absurd sizes when a message is repeated many times but have not been successful yet (the current max size is unnecessarily large)

### Changelog:
CL: [Fix] Repeated message stacking now only triggers when repeating the most recent line in the chatlog, maintaining an accurate order of events--Currently configurable up to 6 recent messages or disableable via Unity editor inspector.
