### PR TITLE
Playtest Fixes and Improvements

### DIFF
--- a/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
+++ b/UnityProject/Assets/Prefabs/Player/Resources/Player_V4(uNet).prefab
@@ -2318,7 +2318,7 @@ MonoBehaviour:
         methodName: SummonSanguineDagger
         parameterType: 
     Mutations:
-    - {fileID: 11400000, guid: 85b46608a403da74892b9bb16d3b712c, type: 2}
+    - {fileID: 11400000, guid: 56cbe9be4b5bf1e468b4552f58ca679d, type: 2}
     onStageReachedText: You feel a new strength within you and a thirst for the blood
       of the living.
     onStageLostText: The corruption subsides, your thirtst for blood is quelled.
@@ -2397,7 +2397,7 @@ MonoBehaviour:
         methodName: SpectralCloak
         parameterType: 
     Mutations:
-    - {fileID: 11400000, guid: 7d30a8633ee38fd49b6dd72e35a0dc0c, type: 2}
+    - {fileID: 11400000, guid: f483929e2d34f8d49aa808989a15283f, type: 2}
     onStageReachedText: Your strength is supreme.
     onStageLostText: Your once great power begins to fade...
 --- !u!114 &5592240411958216951

--- a/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/TeamObjectives/VampireTeamAmount.asset
+++ b/UnityProject/Assets/ScriptableObjects/Antagonists/Objectives/TeamObjectives/VampireTeamAmount.asset
@@ -19,3 +19,4 @@ MonoBehaviour:
   description: 'Ensure atleast 1 vampire is alive but no more than '
   aiCanHave: 0
   initialDescription: 'Ensure atleast 1 vampire is alive but no more than '
+  maxAmountOfVampiresPercent: 10

--- a/UnityProject/Assets/ScriptableObjects/GameModes/Vampires.asset
+++ b/UnityProject/Assets/ScriptableObjects/GameModes/Vampires.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
     to kill/cure their species.
   canRespawn: 1
   minPlayers: 5
-  antagRatio: 0.1
+  antagRatio: 0.05
   minAntags: 1
   maxAntags: 10
   hardNumberOfAntagsToSpawn: 0

--- a/UnityProject/Assets/ScriptableObjects/mutationss/LegsAndArms/VampireMuscles.asset
+++ b/UnityProject/Assets/ScriptableObjects/mutationss/LegsAndArms/VampireMuscles.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 479147f45b72fd843af6b509ca49fd08, type: 3}
+  m_Name: VampireMuscles
+  m_EditorClassIdentifier: 
+  displayName: Unholy Strength
+  isStableMutation: 1
+  canBeChemicallyRemoved: 0
+  ResearchDifficult: 66
+  stability: 0
+  Description: 
+  CanRequireLocks: 0
+  AddedEfficiency: 1

--- a/UnityProject/Assets/ScriptableObjects/mutationss/LegsAndArms/VampireMuscles.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/mutationss/LegsAndArms/VampireMuscles.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f483929e2d34f8d49aa808989a15283f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/ScriptableObjects/mutationss/Metabolism/MutationVampireRegen.asset
+++ b/UnityProject/Assets/ScriptableObjects/mutationss/Metabolism/MutationVampireRegen.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6115bfbca56c51d498c558d5413d2afb, type: 3}
+  m_Name: MutationVampireRegen
+  m_EditorClassIdentifier: 
+  displayName: Unholy Fortitude
+  isStableMutation: 1
+  canBeChemicallyRemoved: 0
+  ResearchDifficult: 75
+  stability: 0
+  Description: 
+  CanRequireLocks: 0
+  HealingNutriment: 20
+  Healing: 20

--- a/UnityProject/Assets/ScriptableObjects/mutationss/Metabolism/MutationVampireRegen.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/mutationss/Metabolism/MutationVampireRegen.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 56cbe9be4b5bf1e468b4552f58ca679d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/US13/Actions/V2/ActionManager.cs
+++ b/UnityProject/Assets/Scripts/US13/Actions/V2/ActionManager.cs
@@ -48,6 +48,7 @@ namespace US13.Actions.V2
 			if (CustomNetworkManager.IsHeadless == false) UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, UpdateMe);
 			ActionButtons.Callback -= OnActionButtonsChanged;
 			ClearCooldowns();
+			ServerRemoveAllActions();
 		}
 
 		private void UpdateMe()
@@ -233,10 +234,15 @@ namespace US13.Actions.V2
 				}
 				return hasItem;
 			});
-			if (cachedNetIdentity == null)
-			{
-				cachedNetIdentity = gameObject.NetWorkIdentity();
-			}
+			if (cachedNetIdentity == true) cachedNetIdentity = gameObject.NetWorkIdentity();
+			cachedNetIdentity.isDirty = true;
+		}
+
+		[Server]
+		public void ServerRemoveAllActions()
+		{
+			ActionButtons.Clear();
+			if (cachedNetIdentity == true) cachedNetIdentity = gameObject.NetWorkIdentity();
 			cachedNetIdentity.isDirty = true;
 		}
 
@@ -278,24 +284,8 @@ namespace US13.Actions.V2
 
 		private void ClearCooldowns()
 		{
-			var now = DateTime.UtcNow;
-			var keysToRemove = new List<CooldownInfo>();
-
-			foreach (var kvp in ActionCooldowns)
-			{
-				if (kvp.CooldownEnd <= now)
-				{
-					keysToRemove.Add(kvp);
-				}
-			}
-
-			foreach (var key in keysToRemove)
-			{
-				ActionCooldowns.Remove(key);
-				this.cachedNetIdentity.isDirty = true;
-			}
-
-
+			ActionCooldowns.RemoveAll(x => x.CooldownEnd <= DateTime.UtcNow);
+			this.cachedNetIdentity.isDirty = true;
 		}
 
 		private void AddCooldown(string actionId, float cooldownTime)
@@ -311,13 +301,7 @@ namespace US13.Actions.V2
 
 		private bool IsActionOnCooldown(string actionId)
 		{
-			Loggy.Warning("While Checking");
-			foreach (var cooldown in ActionCooldowns)
-			{
-				Loggy.Warning($"{cooldown.ActionId} : {cooldown.CooldownEnd}");
-			}
 			var isUnderCooldown = ActionCooldowns.Find(tuple => tuple.ActionId.Equals(actionId, StringComparison.InvariantCulture));
-			if(isUnderCooldown != null) Loggy.Warning($"Found: {isUnderCooldown.ActionId} : {isUnderCooldown.CooldownEnd}");
 			if (isUnderCooldown == null) return false;
 			if (isUnderCooldown.CooldownEnd <= DateTime.UtcNow)
 			{
@@ -325,21 +309,17 @@ namespace US13.Actions.V2
 				this.cachedNetIdentity.isDirty = true;
 				return false; // Cooldown has expired
 			}
-			else
-			{
-				Chat.AddExamineMsg(gameObject,
-					$"This action is still on cooldown, remaining time: {Math.Round((isUnderCooldown.CooldownEnd - DateTime.UtcNow).TotalSeconds, 2)} seconds.");
-				return true;
-			}
+			return true;
+
 		}
 
 		[Client]
 		public float GetRemainingCooldown(string actionId)
 		{
-			var isUnderCooldown = ActionCooldowns.Find(tuple => tuple.ActionId == actionId);
-			if (isUnderCooldown == null) return 0f;
+			var isUnderCooldown = ActionCooldowns.Find(tuple => tuple.ActionId.Equals(actionId, StringComparison.InvariantCulture));
+			if (isUnderCooldown == null) return 0.0f;
 			var remaining = (isUnderCooldown.CooldownEnd - DateTime.UtcNow).TotalSeconds;
-			return remaining > 0 ? (float)remaining : 0f;
+			return Mathf.Max((float)remaining, 0.0f);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/US13/HealthV2/Living/BodyPartMutations.cs
+++ b/UnityProject/Assets/Scripts/US13/HealthV2/Living/BodyPartMutations.cs
@@ -164,12 +164,13 @@ namespace US13.HealthV2.Living
 			//Maybe under undo mutations??
 		}
 
-		public void RemoveMutation(MutationSO Mutation)
+		public void RemoveMutation(MutationSO Mutation, bool isChemicalRemoval = false)
 		{
 			Mutation Target = null;
 			foreach (var ActiveMutation in ActiveMutations)
 			{
-				if (ActiveMutation.RelatedMutationSO == Mutation)
+				if (ActiveMutation.RelatedMutationSO == Mutation &&
+				    (isChemicalRemoval && ActiveMutation.RelatedMutationSO.CanBeChemicallyRemoved == false) == false)
 				{
 					Target = ActiveMutation;
 					break;

--- a/UnityProject/Assets/Scripts/US13/HealthV2/Living/MedicalChemistry/MutationEffect.cs
+++ b/UnityProject/Assets/Scripts/US13/HealthV2/Living/MedicalChemistry/MutationEffect.cs
@@ -45,7 +45,7 @@ namespace US13.HealthV2.Living.MedicalChemistry
 				{
 					for (int i = Mutation.ActiveMutations.Count - 1; i >= 0; i--)
 					{
-						Mutation.RemoveMutation(Mutation.ActiveMutations[i].RelatedMutationSO);
+						Mutation.RemoveMutation(Mutation.ActiveMutations[i].RelatedMutationSO, true);
 					}
 				}
 				else
@@ -57,7 +57,7 @@ namespace US13.HealthV2.Living.MedicalChemistry
 
 					foreach (var removeMutation in MutationsToRemove)
 					{
-						Mutation.RemoveMutation(removeMutation);
+						Mutation.RemoveMutation(removeMutation, true);
 					}
 				}
 			}

--- a/UnityProject/Assets/Scripts/US13/HealthV2/Living/MutationsSO.cs
+++ b/UnityProject/Assets/Scripts/US13/HealthV2/Living/MutationsSO.cs
@@ -10,6 +10,11 @@ namespace US13.HealthV2.Living
 		[SerializeField]
 		private string displayName = "";
 
+		[SerializeField] private bool isStableMutation = false;
+		[SerializeField] private bool canBeChemicallyRemoved = true;
+
+		public bool CanBeChemicallyRemoved => canBeChemicallyRemoved;
+
 		public string DisplayName
 		{
 			get
@@ -28,9 +33,20 @@ namespace US13.HealthV2.Living
 		[Tooltip(" Effects the type of dinosaur that spawned when An egg is generated, Hire equals more aggressive and dangerous Dinosaurs")]
 		[Range(0, 100)] public int ResearchDifficult;
 
-		[Tooltip("The stability says if this is a negative or positive mutation in terms of balancing, E.G x-ray will give - stability, while a negative mutation for example blindness will give positive stability, " +
-		         "this balances out the game preventing you from having to many overpowered mutations, because you need to have a few mutations that are disadvantages")]
-		public int Stability = 0;
+		[SerializeField, Tooltip("The stability says if this is a negative or positive mutation in terms of balancing, E.G x-ray will give - stability, while a negative mutation for example blindness will give positive stability, " +
+		                       "this balances out the game preventing you from having to many overpowered mutations, because you need to have a few mutations that are disadvantages")]
+		private int stability = 0;
+
+
+		public int Stability
+		{
+			get => stability;
+			set
+			{
+				if (isStableMutation == false) stability = value;
+				else stability = 0; //A stable mutation doesn't effect stability, i.e doesn't result in any positive/negative gains
+			}
+		}
 
 
 		[Tooltip(" Description of the Mutation ")]

--- a/UnityProject/Assets/Scripts/US13/Items/Others/RandomItemSpot.cs
+++ b/UnityProject/Assets/Scripts/US13/Items/Others/RandomItemSpot.cs
@@ -12,6 +12,8 @@ using US13.Core.Lifecycle;
 using US13.Core.ObjectConnection;
 using US13.Managers.MatrixManager;
 using US13.Objects.Engineering;
+using US13.Objects.Traps;
+using US13.Systems.Clearance;
 using US13.Systems.Inventory;
 using US13.UI.Core.ProgressBar;
 using Util;
@@ -20,7 +22,7 @@ using UniversalObjectPhysics = US13.Core.Physics.UniversalObjectPhysics;
 
 namespace US13.Items.Others
 {
-	public class RandomItemSpot : NetworkBehaviour, IServerSpawn, ICheckedInteractable<HandActivate>
+	public class RandomItemSpot : NetworkBehaviour, IServerSpawn, ICheckedInteractable<HandActivate>, IGenericTrigger
 	{
 		public APCPoweredDevice APCtoSet;
 
@@ -42,10 +44,14 @@ namespace US13.Items.Others
 		[SerializeField] private bool automaticallyShoveIntoContainerBelowSpawnedItem = true;
 		[SerializeField] private bool deleteAfterUse = true;
 
+		[SerializeField] private TriggerType triggerType = TriggerType.Active;
+		TriggerType IGenericTrigger.TriggerType => triggerType;
+		private bool triggerState = false;
+
 		public void OnSpawnServer(SpawnInfo info)
 		{
 			APCtoSet = this.GetComponent<APCPoweredDevice>();
-			RollRandomPool(true);
+			RollRandomPool(true, false);
 		}
 
 		public void RollRandomPool(bool UnrestrictedAndspawn, bool overrideTrigger = false)
@@ -54,6 +60,31 @@ namespace US13.Items.Others
 			SpawnRandomItems(UnrestrictedAndspawn);
 			APCtoSet.OrNull()?.RemoveFromAPC();
 
+		}
+
+		public void OnTrigger()
+		{
+			switch (triggerType)
+			{
+				case TriggerType.Active:
+					triggerState = true;
+					RollRandomPool(true, true);
+					break;
+				case TriggerType.Toggle:
+					triggerState = !triggerState;
+					if(triggerState) RollRandomPool(true, true);
+					break;
+				case TriggerType.HoldState:
+					if(triggerState == false) RollRandomPool(true, true);
+					triggerState = true;
+					break;
+			}
+		}
+
+		public void OnTriggerWithClearance(IClearanceSource source) => OnTrigger();
+		public void OnTriggerEnd()
+		{
+			if (triggerType == TriggerType.Active) triggerState = false;
 		}
 
 		[Button]

--- a/UnityProject/Assets/Scripts/US13/Systems/Antagonists/Objectives/TeamObjectives/CorrectVampireAmount.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/Antagonists/Objectives/TeamObjectives/CorrectVampireAmount.cs
@@ -11,7 +11,7 @@ namespace US13.Systems.Antagonists.Objectives.TeamObjectives
 	{
 		private int MaxNumberOfVampires=> Mathf.CeilToInt(1 + (PlayerList.Instance.InGamePlayers.Count * (maxAmountOfVampiresPercent / 100.0f)));
 		[SerializeField] private string initialDescription = "";
-		[SerializeField, Range(0, 100)] private int maxAmountOfVampiresPercent = 20;
+		[SerializeField, Range(0, 100)] private int maxAmountOfVampiresPercent = 10;
 		protected override void SetupInGame()
 		{
 			foreach (var x in team.TeamMembers)

--- a/UnityProject/Assets/Scripts/US13/Systems/Antagonists/VampireStageProgression.Actions.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/Antagonists/VampireStageProgression.Actions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using Chemistry;
 using Cysharp.Threading.Tasks;
 using Light2D;
@@ -144,8 +145,7 @@ namespace US13.Systems.Antagonists
 
 		private void TryForceEndCooldown(string actionId)
 		{
-			connectedPlayer.Mind.PlayerButtonedActions.ServerEndCooldown(actionId);
-			connectedPlayer.Mind.Body?.PlayerButtonedActions.ServerEndCooldown(actionId);
+			connectedPlayer.PlayerButtonedActions?.ServerEndCooldown(actionId);
 		}
 
 		private bool TryDrainPlayer(Vector2 worldMousePosition, Matrix matrix, PlayerScript firstPlayerOnTile)
@@ -175,10 +175,13 @@ namespace US13.Systems.Antagonists
 				{
 					Chat.AddExamineMsg(connectedPlayer.gameObject, $"You successfully to drain {firstPlayerOnTile.visibleName}'s blood.");
 					Chat.AddWarningMsgFromServer(firstPlayerOnTile.gameObject, "You feel a small prick on your neck.");
-					ReagentMix extractedBlood = victimReagentPool.BloodPool.Take(victimReagentPool.NormalBlood * BloodDrainAmountFraction);
+
+					ReagentMix extractedBlood = victimReagentPool.BloodPool?.Take(victimReagentPool.NormalBlood * BloodDrainAmountFraction);
+					if (extractedBlood == null) return;
+
 					float gainedBlood = extractedBlood.Total * BloodDrainEfficiencyFraction;
-					ReagentPool.BloodPool.Add(CommonSicknesses.Instance.VampirismReagent, gainedBlood);
-					connectedPlayer.playerHealth.HealDamageOnAll(connectedPlayer.gameObject, gainedBlood, DamageType.Brute);
+					ReagentPool.BloodPool?.Add(CommonSicknesses.Instance.VampirismReagent, gainedBlood);
+					connectedPlayer.playerHealth?.HealDamageOnAll(connectedPlayer.gameObject, gainedBlood, DamageType.Brute);
 				})
 				.ServerStartProgress(firstPlayerOnTile.RegisterPlayer, bloodDrainTime, connectedPlayer.gameObject);
 			if (bar != null)
@@ -208,8 +211,8 @@ namespace US13.Systems.Antagonists
 			var bar = StandardProgressAction.Create(progressConfig, () =>
 			{
 				Chat.AddExamineMsg(connectedPlayer.gameObject, $"You successfully to drain {firstMobOnTile.name}'s blood.");
-				ReagentPool.BloodPool.Add(CommonSicknesses.Instance.VampirismReagent, bloodToDrain * BloodDrainEfficiencyFraction * 10); //this times 10 is just to make V1 mobs give some blood despite low health
-				connectedPlayer.playerHealth.HealDamageOnAll(connectedPlayer.gameObject, bloodToDrain * BloodDrainEfficiencyFraction * 10, DamageType.Brute);
+				ReagentPool.BloodPool.Add(CommonSicknesses.Instance.VampirismReagent, bloodToDrain * BloodDrainEfficiencyFraction * 2.5f); //this times 10 is just to make V1 mobs give some blood despite low health
+				connectedPlayer.playerHealth.HealDamageOnAll(connectedPlayer.gameObject, bloodToDrain * BloodDrainEfficiencyFraction * 2.5f, DamageType.Brute);
 				firstMobOnTile.ApplyDamage(connectedPlayer.gameObject, bloodToDrain, AttackType.Internal, DamageType.Brute);
 			})
 				.ServerStartProgress(firstMobOnTile.gameObject.RegisterTile(), bloodDrainTime, connectedPlayer.gameObject);

--- a/UnityProject/Assets/Scripts/US13/Systems/Antagonists/VampireStageProgression.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/Antagonists/VampireStageProgression.cs
@@ -52,22 +52,25 @@ namespace US13.Systems.Antagonists
 		public void Apply()
 		{
 			if (ReagentPool == null) return;
+			if (connectedPlayer.PlayerButtonedActions == null) return;
 
-			int vampireStage;
-			if (ReagentPool.BloodPool.reagents.ContainsKey(CommonSicknesses.Instance.VampirismReagent) == false)
+			//I think there's an issue as chemistry is multithreaded that when you lose blood from damage it can create a race condition on what the blood pool is supposed to be.
+			//To try fix this we gonna lock the ReagentPool.BloodPool so everyone agrees what the stages are supposed to be and we dont get a "Lose stages 1 and 2. Reagin 2" situation.
+			lock(ReagentPool.BloodPool)
 			{
-				vampireStage = -1;
-			}
-			else
-			{
-				TestForPlayerCountChange();
-				float diseaseAmount = ReagentPool.BloodPool[CommonSicknesses.Instance.VampirismReagent];
-				vampireStage = vampirismReaction.GetStageIDFromReagentAmount(ReagentPool, diseaseAmount) - 1;
-			}
+				int vampireStage;
+				if (ReagentPool.BloodPool.reagents.ContainsKey(CommonSicknesses.Instance.VampirismReagent) == false) vampireStage = -1; //Vampire stage -1 means we want to remove/add stage 0 aswell
+				else
+				{
+					TestForPlayerCountChange();
+					float diseaseAmount = ReagentPool.BloodPool[CommonSicknesses.Instance.VampirismReagent];
+					vampireStage = vampirismReaction.GetStageIDFromReagentAmount(ReagentPool, diseaseAmount) - 1;
+				}
 
-			if(vampireStage == currentVampirismStage) return;
-			if (vampireStage > currentVampirismStage) Evolve(vampireStage);
-			else Devolve(vampireStage);
+				if(vampireStage == currentVampirismStage) return;
+				if (vampireStage > currentVampirismStage) Evolve(vampireStage);
+				else Devolve(vampireStage);
+			}
 		}
 
 		private void TestForPlayerCountChange()
@@ -89,13 +92,13 @@ namespace US13.Systems.Antagonists
 			if (newStage < 3 && cloakEquipped) UnEquipCloak();
 
 			StringBuilder devolutionMessageBuilder = new StringBuilder();
-			for (int i = Math.Max(currentVampirismStage,0); i >= Math.Max(newStage, 0); i--)
+			for (int i = currentVampirismStage; i > newStage; i++)
 			{
 				StageAbilities abilitiesToLose = stageAbilities[i];
 				if(abilitiesToLose.onStageReachedText != null) devolutionMessageBuilder.AppendLine($"<color=red>{abilitiesToLose.onStageLostText}</color>");
 				foreach (var action in abilitiesToLose.ActivatedAbilities.Keys)
 				{
-					connectedPlayer.Mind.PlayerButtonedActions?.UnregisterAction(action);
+					connectedPlayer.PlayerButtonedActions?.UnregisterAction(action);
 				}
 
 				if (abilitiesToLose.Mutations.Count == 0) continue;
@@ -125,7 +128,7 @@ namespace US13.Systems.Antagonists
 				if(abilitiesToGain.onStageReachedText != null) evolutionMessageBuilder.AppendLine($"<color=red>{abilitiesToGain.onStageReachedText}</color>");
 				foreach (var data in abilitiesToGain.ActivatedAbilities.Keys)
 				{
-					connectedPlayer.Mind.PlayerButtonedActions?.RegisterNewAction(data, abilitiesToGain.ActivatedAbilities[data].Invoke);
+					connectedPlayer.PlayerButtonedActions?.RegisterNewAction(data, abilitiesToGain.ActivatedAbilities[data].Invoke);
 				}
 				if (abilitiesToGain.Mutations.Count == 0) continue;
 				foreach (var bodyPart in connectedPlayer.playerHealth.BodyPartList)


### PR DESCRIPTION
### Changelog:
CL: [Improvement] Added the IGenericTrigger interface to random item pools. Allowing them to spawn items from mapped trigger objects such as pressure plates and logic gates.
CL: [Improvement] Moved vampire abilities from the players mind to their body.

CL: [Balance] Decreased the max amount of allowable vampires in the vampire team objectives
CL: [Balance] Decreased the amount of corruption gained from using the blood drain ability on V1 Mobs
CL: [Fix] Fixed NREs and log spam relating to vampires
CL: [Fix] Possible fix for erratic action states after taking damage as a vampire
CL: [Fix] Fixed negative stability gained from vampiric regeneration
CL: [Fix] Fixed vampiric mutations being removable via chemicals
CL: [Fix] Possible fix for actions persisting after round restart.