### PR TITLE
Removes Ancient Temple, Palace, Dark Jungle, Shuttle Race, and Iron Chef from Awaysite map list.

### DIFF
--- a/UnityProject/Assets/ScriptableObjects/SubScenes/AwayWorldList.asset
+++ b/UnityProject/Assets/ScriptableObjects/SubScenes/AwayWorldList.asset
@@ -13,12 +13,7 @@ MonoBehaviour:
   m_Name: AwayWorldList
   m_EditorClassIdentifier: 
   AwayWorlds:
-  - AwaySites/AncientTemple.json
   - AwaySites/Caverna.json
-  - AwaySites/Palace.json
   - AwaySites/Relicta.json
-  - AwaySites/DarkJungle.json
   - AwaySites/Backrooms.json
   - AwaySites/MysticValley.json
-  - AwaySites/ShuttleRace.json
-  - AwaySites/IronChef.json


### PR DESCRIPTION

### Purpose

Awaysites have been undermaintained for a long time. several of them were implemented a long time ago when the game had much less content and the maps haven't been updated. several of the awaysites also have conceptual issues, have design issues, or have broken features (like Ancient Temple skeletons). We held a discussion on the topic ([here](https://discord.com/channels/273774715741667329/285240893160685570/1500482717480124577)) and determined that some should be removed for now until updated or spun into separate things.

Sites removed:
- Ancient Temple
- Palace
- Dark Jungle
- Shuttle Race
- Iron Chef

this leaves the current list of awaysites as:
- caverna
- relicta
- backrooms
- mystic valley

which are all much stronger, more actively maintained, and better awaysites at this time. this means that players will more reliably get awaysites that have things worth doing at them.

### Notes:

the framework I suggested and got agreement or no disagreement for was that
- palace should probably be cut for good. it just isn't a good awaysite conceptually or in execution
- dark jungle should be cut for being a trap, and being buggy, with no good rewards for the players. if it were to be brought back, it should probably be done on a new scene because the one we have has seen some map rot.
- iron chef should be its own thing separate from awaysites (#11226)
- shuttle race is slightly broken and gets stale very fast. it should be reworked to use some kind of random generation, and perhaps would be best served as a gamemode of its own, like iron chef.

### Changelog:

CL: [Balance] Ancient Temple, Palace, Dark Jungle, Shuttle Race, and Iron Chef have been removed from the Awaysite list.
