### PR TITLE
Faster explosions

### DIFF
--- a/UnityProject/Assets/Scripts/US13/Managers/GameConfigManager.cs
+++ b/UnityProject/Assets/Scripts/US13/Managers/GameConfigManager.cs
@@ -59,7 +59,7 @@ namespace US13.Managers
 		public int LowPopCheckTimeAfterRoundStart = 300;
 		public int RebootOnAverageFPSOrLower = 35;
 		public string AccountAPIHost;
-		public float ExplosionStepTimeInSeconds = 0.12f;
+		public float ExplosionStepTimeInSeconds = 0.05f;
 
 		//how many rounds of logs Should be stored before they get deleted,  null = 100, -1 Do not delete (will lag admin log UI After a while so manage yourself)
 		//= n The number you want to keep

--- a/UnityProject/Assets/Scripts/US13/Managers/GameConfigManager.cs
+++ b/UnityProject/Assets/Scripts/US13/Managers/GameConfigManager.cs
@@ -59,6 +59,7 @@ namespace US13.Managers
 		public int LowPopCheckTimeAfterRoundStart = 300;
 		public int RebootOnAverageFPSOrLower = 35;
 		public string AccountAPIHost;
+		public float ExplosionStepTimeInSeconds = 0.12f;
 
 		//how many rounds of logs Should be stored before they get deleted,  null = 100, -1 Do not delete (will lag admin log UI After a while so manage yourself)
 		//= n The number you want to keep

--- a/UnityProject/Assets/Scripts/US13/Systems/Explosions/Explosion.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/Explosions/Explosion.cs
@@ -19,7 +19,7 @@ namespace US13.Systems.Explosions
 	public class Explosion
 	{
 
-		// (Max) - why were these numbers choosen before?
+		// (Max) - why were these numbers chosen before?
 		// They may look less like magic numbers now, but there is no explanation for why they are multiples of 8.
 		public const int EXPLOSION_STRENGTH_LOW = 800;
 		public const int EXPLOSION_STRENGTH_MEDIUM = 8000;

--- a/UnityProject/Assets/Scripts/US13/Systems/Explosions/ExplosionManager.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/Explosions/ExplosionManager.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Mirror;
 using UnityEngine;
 using US13.Core.Lifecycle;
+using US13.Managers;
 using US13.Managers.UpdateManager;
 using US13.Systems.Explosions.NodeTypes;
 using US13.Tilemaps.Behaviours.Layers;
@@ -16,8 +17,9 @@ namespace US13.Systems.Explosions
 		public static HashSet<ExplosionPropagationLine> CheckLines = new HashSet<ExplosionPropagationLine>();
 		private static HashSet<ExplosionPropagationLine> SubCheckLines = new HashSet<ExplosionPropagationLine>();
 
-
 		public static List<EffectDataToClean> DelayedEffectsToRemove = new List<EffectDataToClean>();
+
+		public const float DEFAULT_EXPLOSION_STEP_TIME_IN_SECONDS = 0.4f;
 
 
 		public class EffectDataToClean
@@ -75,7 +77,8 @@ namespace US13.Systems.Explosions
 		{
 			if (Application.isEditor == false && NetworkServer.active == false) return;
 
-			UpdateManager.Add(Step, 0.4f);
+			UpdateManager.Add(Step, GameConfigManager.GameConfig.ExplosionStepTimeInSeconds > 0 ?
+				GameConfigManager.GameConfig.ExplosionStepTimeInSeconds : DEFAULT_EXPLOSION_STEP_TIME_IN_SECONDS);
 		}
 
 		private void OnDisable()

--- a/UnityProject/Assets/StreamingAssets/Config/gameConfig.json
+++ b/UnityProject/Assets/StreamingAssets/Config/gameConfig.json
@@ -43,5 +43,7 @@
 
 	"RebootOnAverageFPSOrLower" : 20,
 	
-	"AccountAPIHost" : "prod-api.unitystation.org"
+	"AccountAPIHost" : "prod-api.unitystation.org", 
+  
+    "ExplosionStepTimeInSeconds" : 0.12
 }

--- a/UnityProject/Assets/StreamingAssets/Config/gameConfig.json
+++ b/UnityProject/Assets/StreamingAssets/Config/gameConfig.json
@@ -45,5 +45,5 @@
 	
 	"AccountAPIHost" : "prod-api.unitystation.org", 
   
-    "ExplosionStepTimeInSeconds" : 0.12
+    "ExplosionStepTimeInSeconds" : 0.05
 }


### PR DESCRIPTION
A while back, I did a lot of optimizations to explosions that allowed us to very easily have very big explosions that would otherwise grind the server to a halt. These optimizations were not fully noticeable to the average player due to how most explosions are often just small ones.

Today, I removed the hardcoded step time to make explosions feel much snappier, quicker, and much more dangerous.
The step time for explosions are now configurable inside the server's game config, and the default step time is now 0.12 seconds. This value can be much lower (or higher) depending on your server's performance, experiment freely with the value.

#### Before

https://github.com/user-attachments/assets/5dd8d135-b944-460a-bd8e-65bc3865a04d

#### After
https://github.com/user-attachments/assets/e4d790a0-433f-4ab1-81e8-e719789dc014


# Changelog

CL: [New] Explosions by default are now much quicker in traversal between tiles.
CL: [New] Servers can now configure how fast or slow explosion expand over time. (Default is 0.12 seconds)

