### PR TITLE
various playtest fixes and improvements

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Implants/HumanBodyPartExternal.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/HumanBodyPartExternal.prefab
@@ -318,7 +318,7 @@ PrefabInstance:
     - target: {fileID: 1644590815055589727, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
       propertyPath: CapableMutations.Array.size
-      value: 16
+      value: 17
       objectReference: {fileID: 0}
     - target: {fileID: 1644590815055589727, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
@@ -391,6 +391,12 @@ PrefabInstance:
       propertyPath: 'CapableMutations.Array.data[15]'
       value: 
       objectReference: {fileID: 11400000, guid: 93463c37a4972ce4aa1104392aa3cc33,
+        type: 2}
+    - target: {fileID: 1644590815055589727, guid: 1162a9966a460f940a18b4d183b04c30,
+        type: 3}
+      propertyPath: 'CapableMutations.Array.data[16]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 56cbe9be4b5bf1e468b4552f58ca679d,
         type: 2}
     - target: {fileID: 2314801526373061764, guid: 1162a9966a460f940a18b4d183b04c30,
         type: 3}
@@ -605,6 +611,11 @@ MonoBehaviour:
   ActualHealingNutrimentMultiplier: 5
   HungerState: 1
   reagentCirculatedComponent: {fileID: 0}
+  FullMultiplier: 1.1
+  NormalMultiplier: 1
+  HungaryMultiplier: 1
+  MalnourishedMultiplier: 0.9
+  StarvingMultiplier: 0.9
 --- !u!4 &2815555166148818142 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1168521912962732652, guid: 1162a9966a460f940a18b4d183b04c30,

--- a/UnityProject/Assets/Prefabs/Items/Implants/HumanLimb.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Implants/HumanLimb.prefab
@@ -37,8 +37,20 @@ PrefabInstance:
     - target: {fileID: 2447550672866220013, guid: e241039a7933eb347bd1a9bb67a9078a,
         type: 3}
       propertyPath: CapableMutations.Array.size
-      value: 23
+      value: 19
       objectReference: {fileID: 0}
+    - target: {fileID: 2447550672866220013, guid: e241039a7933eb347bd1a9bb67a9078a,
+        type: 3}
+      propertyPath: 'CapableMutations.Array.data[17]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 7d30a8633ee38fd49b6dd72e35a0dc0c,
+        type: 2}
+    - target: {fileID: 2447550672866220013, guid: e241039a7933eb347bd1a9bb67a9078a,
+        type: 3}
+      propertyPath: 'CapableMutations.Array.data[18]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 690f18a2fa4bec141971d6f5c7753177,
+        type: 2}
     - target: {fileID: 2447550672866220013, guid: e241039a7933eb347bd1a9bb67a9078a,
         type: 3}
       propertyPath: 'CapableMutations.Array.data[21]'
@@ -270,11 +282,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8688576ed720a4f40b3583f62adeeb23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  UseReagentContainer: 0
   groundReagents:
-    m_keys:
-    - {fileID: 11400000, guid: 82692ea8680693d459ad97993dbda0f3, type: 2}
-    - {fileID: 11400000, guid: 3afb1893f74fb775d806cbc4563ed1e7, type: 2}
-    m_values: 0a00000005000000
+    m_keys: []
+    m_values: []
 --- !u!114 &3959904421835429671
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Knives/SanguineDagger.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Melee/Knives/SanguineDagger.prefab
@@ -92,6 +92,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7858931176587863443, guid: 229f1c93e0e4ada439cfe4b781f65997,
         type: 3}
+      propertyPath: hitDamage
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 7858931176587863443, guid: 229f1c93e0e4ada439cfe4b781f65997,
+        type: 3}
       propertyPath: initialName
       value: sanguine dagger
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/ScriptableObjects/mutationss/Metabolism/MutationVampireRegen.asset
+++ b/UnityProject/Assets/ScriptableObjects/mutationss/Metabolism/MutationVampireRegen.asset
@@ -19,5 +19,5 @@ MonoBehaviour:
   stability: 0
   Description: 
   CanRequireLocks: 0
-  HealingNutriment: 20
-  Healing: 20
+  HealingNutriment: 30
+  Healing: 30

--- a/UnityProject/Assets/Scripts/US13/Items/Weapons/Melee/MeleeBehaviours/SanguineMeleeEffect.cs
+++ b/UnityProject/Assets/Scripts/US13/Items/Weapons/Melee/MeleeBehaviours/SanguineMeleeEffect.cs
@@ -4,6 +4,7 @@ using Chemistry;
 using UnityEngine;
 using US13.Core.Addressables.Types;
 using US13.Core.Attributes;
+using US13.Core.Chat;
 using US13.HealthV2;
 using US13.HealthV2.Living.MedicalChemistry;
 using US13.HealthV2.Living.PolymorphicSystems;
@@ -71,7 +72,7 @@ namespace US13.Items.Weapons.Melee
 			float gainedBlood = extractedBlood.Total * SanguineEfficiencyFraction;
 
 			attackerReagentPool.BloodPool.Add(CommonSicknesses.Instance.VampirismReagent, gainedBlood);
-
+			Chat.AddExamineMsgFromServer(attacker, $"Syphoned {gainedBlood} corruption from target");
 			if(useSound != null) SoundManager.PlayNetworkedAtPos(useSound, target.transform.position, sourceObj: target.gameObject);
 		}
 		public void OnBlockBehaviour(GameObject attacker, GameObject target, BodyPartType damageZone, WeaponNetworkActions.MeleeStats stats) { }

--- a/UnityProject/Assets/Scripts/US13/Items/Weapons/Melee/MeleeBehaviours/SanguineMeleeEffect.cs
+++ b/UnityProject/Assets/Scripts/US13/Items/Weapons/Melee/MeleeBehaviours/SanguineMeleeEffect.cs
@@ -65,7 +65,7 @@ namespace US13.Items.Weapons.Melee
 			if (victimReagentPool == null || attackerReagentPool == null) return;
 
 			TeamData currentTeam = victimPlayerScript.Mind?.AntagPublic?.CurTeam?.Data;
-			if (currentTeam == vampireTeam && victimReagentPool.BloodPool[CommonSicknesses.Instance.VampirismReagent] < VampireSafetyConcentration * victimReagentPool.NormalBlood) return;
+			if (currentTeam == vampireTeam && victimReagentPool.BloodPool[CommonSicknesses.Instance.VampirismReagent] < (VampireSafetyConcentration * victimReagentPool.NormalBlood)) return;
 			if (victimReagentPool.BloodPool.Total < victimReagentPool.NormalBlood * SanguineThresholdFraction) return;
 
 			ReagentMix extractedBlood = victimReagentPool.BloodPool.Take(victimReagentPool.NormalBlood * SanguineAmountFraction);

--- a/UnityProject/Assets/Scripts/US13/Systems/Antagonists/VampireStageProgression.Actions.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/Antagonists/VampireStageProgression.Actions.cs
@@ -182,6 +182,8 @@ namespace US13.Systems.Antagonists
 					float gainedBlood = extractedBlood.Total * BloodDrainEfficiencyFraction;
 					ReagentPool.BloodPool?.Add(CommonSicknesses.Instance.VampirismReagent, gainedBlood);
 					connectedPlayer.playerHealth?.HealDamageOnAll(connectedPlayer.gameObject, gainedBlood, DamageType.Brute);
+
+					Chat.AddExamineMsgFromServer(connectedPlayer.gameObject, $"Syphoned {gainedBlood} corruption from target");
 				})
 				.ServerStartProgress(firstPlayerOnTile.RegisterPlayer, bloodDrainTime, connectedPlayer.gameObject);
 			if (bar != null)
@@ -211,9 +213,12 @@ namespace US13.Systems.Antagonists
 			var bar = StandardProgressAction.Create(progressConfig, () =>
 			{
 				Chat.AddExamineMsg(connectedPlayer.gameObject, $"You successfully to drain {firstMobOnTile.name}'s blood.");
-				ReagentPool.BloodPool.Add(CommonSicknesses.Instance.VampirismReagent, bloodToDrain * BloodDrainEfficiencyFraction * 2.5f); //this times 10 is just to make V1 mobs give some blood despite low health
-				connectedPlayer.playerHealth.HealDamageOnAll(connectedPlayer.gameObject, bloodToDrain * BloodDrainEfficiencyFraction * 2.5f, DamageType.Brute);
+				float drainedFromMob = bloodToDrain * BloodDrainEfficiencyFraction * 2.5f;
+				ReagentPool.BloodPool.Add(CommonSicknesses.Instance.VampirismReagent, drainedFromMob); //this times 10 is just to make V1 mobs give some blood despite low health
+				connectedPlayer.playerHealth.HealDamageOnAll(connectedPlayer.gameObject, drainedFromMob, DamageType.Brute);
 				firstMobOnTile.ApplyDamage(connectedPlayer.gameObject, bloodToDrain, AttackType.Internal, DamageType.Brute);
+
+				Chat.AddExamineMsgFromServer(connectedPlayer.gameObject, $"Syphoned {drainedFromMob} corruption from target");
 			})
 				.ServerStartProgress(firstMobOnTile.gameObject.RegisterTile(), bloodDrainTime, connectedPlayer.gameObject);
 			if (bar != null)

--- a/UnityProject/Assets/Scripts/US13/Systems/Antagonists/VampireStageProgression.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/Antagonists/VampireStageProgression.cs
@@ -30,8 +30,6 @@ namespace US13.Systems.Antagonists
 		[BoxGroup("Required References"), SerializeField] private Antagonist vampireAntagonist = null;
 		[BoxGroup("Required References"), SerializeField] private TeamData vampireTeam = null;
 
-
-
 		[SerializeField] private List<StageAbilities> stageAbilities = new List<StageAbilities>();
 		private int currentVampirismStage = -1;
 		private int currentInGamePlayers = 0;
@@ -48,14 +46,10 @@ namespace US13.Systems.Antagonists
 			public string onStageLostText = "";
 		}
 
-		private static readonly object _evolveDevolveLock = new object();
-
 		public void Apply()
 		{
 			if (ReagentPool == null) return;
 			if (connectedPlayer.PlayerButtonedActions == null) return;
-
-			try{
 
 			//I think there's an issue as chemistry is multithreaded that when you lose blood from damage it can create a race condition on what the blood pool is supposed to be.
 			//To try fix this we gonna lock the ReagentPool.BloodPool so everyone agrees what the stages are supposed to be and we dont get a "Lose stages 1 and 2. Reagin 2" situation.
@@ -72,11 +66,6 @@ namespace US13.Systems.Antagonists
 				if(vampireStage == currentVampirismStage) return;
 				if (vampireStage > currentVampirismStage) Evolve(vampireStage);
 				else Devolve(vampireStage);
-			}
-			}
-			catch(Exception e)
-			{
-				Loggy.Error(e.ToString());
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/US13/Systems/Antagonists/VampireStageProgression.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/Antagonists/VampireStageProgression.cs
@@ -55,6 +55,8 @@ namespace US13.Systems.Antagonists
 			if (ReagentPool == null) return;
 			if (connectedPlayer.PlayerButtonedActions == null) return;
 
+			try{
+
 			//I think there's an issue as chemistry is multithreaded that when you lose blood from damage it can create a race condition on what the blood pool is supposed to be.
 			//To try fix this we gonna lock the ReagentPool.BloodPool so everyone agrees what the stages are supposed to be and we dont get a "Lose stages 1 and 2. Reagin 2" situation.
 			lock(_evolveDevolveLock)
@@ -71,6 +73,11 @@ namespace US13.Systems.Antagonists
 				if(vampireStage == currentVampirismStage) return;
 				if (vampireStage > currentVampirismStage) Evolve(vampireStage);
 				else Devolve(vampireStage);
+			}
+			}
+			catch(Exception e)
+			{
+				Loggy.Error(e.ToString());
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/US13/Systems/Antagonists/VampireStageProgression.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/Antagonists/VampireStageProgression.cs
@@ -59,7 +59,7 @@ namespace US13.Systems.Antagonists
 
 			//I think there's an issue as chemistry is multithreaded that when you lose blood from damage it can create a race condition on what the blood pool is supposed to be.
 			//To try fix this we gonna lock the ReagentPool.BloodPool so everyone agrees what the stages are supposed to be and we dont get a "Lose stages 1 and 2. Reagin 2" situation.
-			lock(_evolveDevolveLock)
+			lock(ReagentPool.BloodPool)
 			{
 				int vampireStage;
 				if (ReagentPool.BloodPool.reagents.ContainsKey(CommonSicknesses.Instance.VampirismReagent) == false) vampireStage = -1; //Vampire stage -1 means we want to remove/add stage 0 aswell
@@ -69,7 +69,6 @@ namespace US13.Systems.Antagonists
 					float diseaseAmount = ReagentPool.BloodPool[CommonSicknesses.Instance.VampirismReagent];
 					vampireStage = vampirismReaction.GetStageIDFromReagentAmount(ReagentPool, diseaseAmount) - 1;
 				}
-
 				if(vampireStage == currentVampirismStage) return;
 				if (vampireStage > currentVampirismStage) Evolve(vampireStage);
 				else Devolve(vampireStage);
@@ -91,7 +90,7 @@ namespace US13.Systems.Antagonists
 
 		private void Devolve(int newStage)
 		{
-			if (newStage <= 0 && connectedPlayer.Mind.AntagPublic != null && connectedPlayer.Mind.AntagPublic.CurTeam.Data == vampireTeam)
+			if (newStage <= 0 && connectedPlayer.Mind?.AntagPublic != null && connectedPlayer.Mind.AntagPublic.CurTeam?.Data == vampireTeam)
 			{
 				preventCuredVampires.RemoveVampire(connectedPlayer.Mind);
 				connectedPlayer.Mind.RemoveAntag();
@@ -100,7 +99,7 @@ namespace US13.Systems.Antagonists
 			if (newStage < 3 && cloakEquipped) UnEquipCloak();
 
 			StringBuilder devolutionMessageBuilder = new StringBuilder();
-			for (int i = currentVampirismStage; i > newStage; i++)
+			for (int i = currentVampirismStage; i > newStage; i--)
 			{
 				StageAbilities abilitiesToLose = stageAbilities[i];
 				if(abilitiesToLose.onStageReachedText != null) devolutionMessageBuilder.AppendLine($"<color=red>{abilitiesToLose.onStageLostText}</color>");


### PR DESCRIPTION
Due to the annoyance of reproducing the bug I havent included it in the changelog. But I believe the errors surrounding vampire devolving and regeneration is what was causing the immortality bug, so this PR should also fix that. Just hard to test so not in the changelog

### Changelog:
CL: [Improvement] Sanguine dagger and blood drain abilities will now provide feedback on how much corruption you are gaining from doing them. This should help alleviate some obfuscation in how you are progressing while no progress bars exist.
CL: [Balance] Increased the damage of the sanguine dagger

CL: [Fix] Fixed vampires causing an NRE while devolving
CL: [Fix] Fixed vampires being unable to devolve
CL: [Fix] Fixed vampires not getting their regeneration as intended