### PR TITLE
Fix clearance-restricted wrenching

### DIFF
--- a/UnityProject/Assets/Scripts/US13/Objects/WrenchSecurableWithAccessRestriction.cs
+++ b/UnityProject/Assets/Scripts/US13/Objects/WrenchSecurableWithAccessRestriction.cs
@@ -16,40 +16,43 @@ namespace US13.Objects
 	[RequireComponent(typeof(ClearanceRestricted))]
 	[RequireComponent(typeof(ObjectAttributes))]
 	[RequireComponent(typeof(WrenchSecurable))]
-	public class WrenchSecurableWithAccessRestriction : MonoBehaviour, ICheckedInteractable<HandApply>
+	public class WrenchSecurableWithAccessRestriction : MonoBehaviour, IFirstInteractable<HandApply>
 	{
-		private ClearanceRestricted clearanceRestrictions;
-
-		private ObjectAttributes objectAttributes;
-
-		void Awake()
-		{
-			objectAttributes = GetComponent<ObjectAttributes>();
-			clearanceRestrictions = GetComponent<ClearanceRestricted>();
-		}
-
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
-			//start with the default HandApply WillInteract logic.
-			if (DefaultWillInteract.Default(interaction, side) == false) return false;
-
-			return !(clearanceRestrictions.HasClearance(interaction.Performer) && Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Wrench));
+			return DefaultWillInteract.Default(interaction, side) && IsWrenchInteraction(interaction);
 		}
 
-		//invoked when the server recieves the interaction request and WIllinteract returns true
+		internal bool IsWrenchInteraction(HandApply interaction)
+		{
+			if (interaction.TargetObject != gameObject) return false;
+
+			return Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Wrench);
+		}
+
+		// Invoked when the server receives the interaction request and WillInteract returns true.
 		public void ServerPerformInteraction(HandApply interaction)
 		{
-			if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Wrench))
+			if (HasClearanceToWrench(interaction.Performer))
 			{
-				string objectName = objectAttributes.name;
-				//Notify player that they are unable to wrench down barrier
-				Chat.AddActionMsgToChat(interaction, "You try to wrench down the " + objectName + ", access is denied", "");
+				// Delegate successful attempts so WrenchSecurable remains authoritative for anchor state and messages.
+				GetComponent<WrenchSecurable>().ServerPerformInteraction(interaction);
+				return;
 			}
-			else {
-				Chat.AddActionMsgToChat(interaction, "ACCESS DENIED","");
+
+			if (IsWrenchInteraction(interaction))
+			{
+				var objectName = gameObject.ExpensiveName();
+				Chat.AddActionMsgToChat(interaction, "You try to wrench down the " + objectName + ", clearance is denied", "");
 			}
+
 			SoundManager.PlayNetworkedAtPos(CommonSounds.Instance.AccessDenied,
 				gameObject.AssumedWorldPosServer(), sourceObj: gameObject);
+		}
+
+		internal bool HasClearanceToWrench(GameObject performer)
+		{
+			return GetComponent<ClearanceRestricted>().HasClearance(performer);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/US13/Objects/WrenchSecurableWithAccessRestriction.cs
+++ b/UnityProject/Assets/Scripts/US13/Objects/WrenchSecurableWithAccessRestriction.cs
@@ -18,6 +18,18 @@ namespace US13.Objects
 	[RequireComponent(typeof(WrenchSecurable))]
 	public class WrenchSecurableWithAccessRestriction : MonoBehaviour, IFirstInteractable<HandApply>
 	{
+		private WrenchSecurable wrenchSecurable;
+		private ClearanceRestricted clearanceRestricted;
+
+		private WrenchSecurable WrenchSecurable => wrenchSecurable ??= GetComponent<WrenchSecurable>();
+		private ClearanceRestricted ClearanceRestricted => clearanceRestricted ??= GetComponent<ClearanceRestricted>();
+
+		private void Awake()
+		{
+			wrenchSecurable = GetComponent<WrenchSecurable>();
+			clearanceRestricted = GetComponent<ClearanceRestricted>();
+		}
+
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
 			return DefaultWillInteract.Default(interaction, side) && IsWrenchInteraction(interaction);
@@ -36,14 +48,14 @@ namespace US13.Objects
 			if (HasClearanceToWrench(interaction.Performer))
 			{
 				// Delegate successful attempts so WrenchSecurable remains authoritative for anchor state and messages.
-				GetComponent<WrenchSecurable>().ServerPerformInteraction(interaction);
+				WrenchSecurable.ServerPerformInteraction(interaction);
 				return;
 			}
 
 			if (IsWrenchInteraction(interaction))
 			{
 				var objectName = gameObject.ExpensiveName();
-				Chat.AddActionMsgToChat(interaction, "You try to wrench down the " + objectName + ", clearance is denied", "");
+				Chat.AddActionMsgToChat(interaction, $"You try to wrench down the {objectName}, clearance is denied", "");
 			}
 
 			SoundManager.PlayNetworkedAtPos(CommonSounds.Instance.AccessDenied,
@@ -52,7 +64,7 @@ namespace US13.Objects
 
 		internal bool HasClearanceToWrench(GameObject performer)
 		{
-			return GetComponent<ClearanceRestricted>().HasClearance(performer);
+			return ClearanceRestricted.HasClearance(performer);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/US13/Objects/WrenchSecurableWithAccessRestriction.cs
+++ b/UnityProject/Assets/Scripts/US13/Objects/WrenchSecurableWithAccessRestriction.cs
@@ -21,9 +21,6 @@ namespace US13.Objects
 		private WrenchSecurable wrenchSecurable;
 		private ClearanceRestricted clearanceRestricted;
 
-		private WrenchSecurable WrenchSecurable => wrenchSecurable ??= GetComponent<WrenchSecurable>();
-		private ClearanceRestricted ClearanceRestricted => clearanceRestricted ??= GetComponent<ClearanceRestricted>();
-
 		private void Awake()
 		{
 			wrenchSecurable = GetComponent<WrenchSecurable>();
@@ -48,14 +45,15 @@ namespace US13.Objects
 			if (HasClearanceToWrench(interaction.Performer))
 			{
 				// Delegate successful attempts so WrenchSecurable remains authoritative for anchor state and messages.
-				WrenchSecurable.ServerPerformInteraction(interaction);
+				wrenchSecurable.ServerPerformInteraction(interaction);
 				return;
 			}
 
 			if (IsWrenchInteraction(interaction))
 			{
 				var objectName = gameObject.ExpensiveName();
-				Chat.AddActionMsgToChat(interaction, $"You try to wrench down the {objectName}, clearance is denied", "");
+				Chat.AddExamineMsgFromServer(interaction.Performer,
+					$"You don't have clearance to use a wrench on the {objectName}.");
 			}
 
 			SoundManager.PlayNetworkedAtPos(CommonSounds.Instance.AccessDenied,
@@ -64,7 +62,7 @@ namespace US13.Objects
 
 		internal bool HasClearanceToWrench(GameObject performer)
 		{
-			return ClearanceRestricted.HasClearance(performer);
+			return clearanceRestricted.HasClearance(performer);
 		}
 	}
 }

--- a/UnityProject/Assets/Tests/ClearanceFramework/WrenchSecurableWithAccessRestrictionTest.cs
+++ b/UnityProject/Assets/Tests/ClearanceFramework/WrenchSecurableWithAccessRestrictionTest.cs
@@ -1,10 +1,9 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
+using System.Reflection;
 using NUnit.Framework;
 using UnityEditor;
 using UnityEngine;
-using UnityEngine.TestTools;
 using US13.Core.Input_System.InteractionV2;
 using US13.Core.Input_System.InteractionV2.Interactions;
 using US13.Core.Input_System.InteractionV2.Interfaces;
@@ -13,13 +12,12 @@ using US13.Items;
 using US13.Items.Traits;
 using US13.Objects;
 using US13.Systems.Clearance;
-using US13.Systems.Construction;
 using US13.UI.Systems.MainHUD.UI_Bottom;
 
 namespace Tests.ClearanceFramework
 {
 	[TestFixture]
-	[Category("General")]
+	[Category(nameof(ClearanceFramework))]
 	public class WrenchSecurableWithAccessRestrictionTest
 	{
 		private const string BarrierPrefabPath = "Assets/Prefabs/Objects/Security/DeployableSecurityBarrier.prefab";
@@ -133,25 +131,6 @@ namespace Tests.ClearanceFramework
 			Assert.False(wrenchRestriction.WillInteract(CreateInteraction(wrench), NetworkSide.Server));
 		}
 
-		[Test]
-		public void GivenRequiredClearanceWhenPerformingInteractionDelegatesToWrenchSecurable()
-		{
-			performerClearance.SetClearance(Clearance.Security);
-			target.GetComponent<WrenchSecurable>().blockAnchorChange = true;
-
-			ExpectClientChatError();
-			Assert.DoesNotThrow(() => wrenchRestriction.ServerPerformInteraction(CreateInteraction(wrench)));
-		}
-
-		[Test]
-		public void GivenMissingClearanceWhenPerformingWrenchInteractionDeniesAccess()
-		{
-			performerClearance.SetClearance(Clearance.Engine);
-
-			ExpectClientChatError();
-			Assert.DoesNotThrow(() => wrenchRestriction.ServerPerformInteraction(CreateInteraction(wrench)));
-		}
-
 		private HandApply CreateInteraction(GameObject handObject, GameObject interactionTarget = null)
 		{
 			return HandApply.ByClient(performer, handObject, interactionTarget ?? target, BodyPartType.None,
@@ -163,7 +142,7 @@ namespace Tests.ClearanceFramework
 			var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
 			Assert.NotNull(prefab, $"Missing prefab at {prefabPath}");
 
-			var instance = PrefabUtility.InstantiatePrefab(prefab) as GameObject;
+			var instance = Object.Instantiate(prefab);
 			Assert.NotNull(instance, $"Could not instantiate prefab at {prefabPath}");
 			return instance;
 		}
@@ -195,13 +174,17 @@ namespace Tests.ClearanceFramework
 		{
 			var restriction = root.GetComponentInChildren<WrenchSecurableWithAccessRestriction>();
 			Assert.NotNull(restriction, $"{root.name} is missing {nameof(WrenchSecurableWithAccessRestriction)}");
+			InvokeAwake(restriction);
 			return restriction;
 		}
 
-		private static void ExpectClientChatError()
+		private static void InvokeAwake(WrenchSecurableWithAccessRestriction restriction)
 		{
-			// EditMode tests call server interaction routing without starting a Mirror server.
-			LogAssert.Expect(LogType.Error, new Regex("A server only method was called on a client in chat.cs"));
+			// EditMode prefab instantiation skips Awake, so use the same component cache path as gameplay.
+			var awake = typeof(WrenchSecurableWithAccessRestriction).GetMethod("Awake",
+				BindingFlags.Instance | BindingFlags.NonPublic);
+			Assert.NotNull(awake);
+			awake.Invoke(restriction, null);
 		}
 
 		private sealed class MockClearanceSourceComponent : MonoBehaviour, IClearanceSource

--- a/UnityProject/Assets/Tests/ClearanceFramework/WrenchSecurableWithAccessRestrictionTest.cs
+++ b/UnityProject/Assets/Tests/ClearanceFramework/WrenchSecurableWithAccessRestrictionTest.cs
@@ -1,0 +1,194 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Mirror;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+using US13.Core.Input_System.InteractionV2;
+using US13.Core.Input_System.InteractionV2.Interactions;
+using US13.Core.Input_System.InteractionV2.Interfaces;
+using US13.HealthV2;
+using US13.Items;
+using US13.Items.Traits;
+using US13.Objects;
+using US13.Systems.Clearance;
+using US13.Systems.Construction;
+using US13.UI.Systems.MainHUD.UI_Bottom;
+
+namespace Tests.ClearanceFramework
+{
+	[TestFixture]
+	[Category(nameof(Balance))]
+	public class WrenchSecurableWithAccessRestrictionTest
+	{
+		private GameObject performer;
+		private GameObject wrench;
+		private GameObject otherItem;
+		private GameObject target;
+		private GameObject otherTarget;
+		private MockClearanceSourceComponent performerClearance;
+		private ClearanceRestricted restricted;
+		private WrenchSecurableWithAccessRestriction wrenchRestriction;
+
+		[SetUp]
+		public void SetUp()
+		{
+			performer = new GameObject("performer");
+			performerClearance = performer.AddComponent<MockClearanceSourceComponent>();
+
+			var commonTraits = AssetDatabase.LoadAssetAtPath<CommonTraits>("Assets/ScriptableObjects/Traits/CommonTraitsSingleton.asset");
+			Assert.NotNull(commonTraits);
+			Assert.NotNull(commonTraits.Wrench);
+			wrench = CreateItem("wrench", commonTraits.Wrench);
+			otherItem = CreateItem("not a wrench");
+
+			target = new GameObject("restricted object");
+			target.AddComponent<NetworkIdentity>();
+			wrenchRestriction = target.AddComponent<WrenchSecurableWithAccessRestriction>();
+			restricted = target.GetComponent<ClearanceRestricted>();
+			restricted.SetCheckType(CheckType.Any);
+			restricted.SetClearance(new List<Clearance> {Clearance.Security});
+
+			otherTarget = new GameObject("other target");
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			Object.DestroyImmediate(performer);
+			Object.DestroyImmediate(wrench);
+			Object.DestroyImmediate(otherItem);
+			Object.DestroyImmediate(target);
+			Object.DestroyImmediate(otherTarget);
+		}
+
+		[Test]
+		public void GivenRequiredClearanceWhenCheckingWrenchAccessReturnsTrue()
+		{
+			performerClearance.SetClearance(Clearance.Security);
+
+			Assert.True(wrenchRestriction.HasClearanceToWrench(performer));
+		}
+
+		[Test]
+		public void GivenMissingClearanceWhenCheckingWrenchAccessReturnsFalse()
+		{
+			performerClearance.SetClearance(Clearance.Engine);
+
+			Assert.False(wrenchRestriction.HasClearanceToWrench(performer));
+		}
+
+		[Test]
+		public void GivenNoClearanceRestrictionWhenCheckingWrenchAccessReturnsTrue()
+		{
+			restricted.SetClearance(new List<Clearance>());
+
+			Assert.True(wrenchRestriction.HasClearanceToWrench(performer));
+		}
+
+		[Test]
+		public void ComponentClaimsWrenchInteractionsBeforeHeldItems()
+		{
+			Assert.That(wrenchRestriction, Is.InstanceOf<IFirstInteractable<HandApply>>());
+			Assert.That(performerClearance.LowPopIssuedClearance, Is.Empty);
+		}
+
+		[Test]
+		public void GivenValidWrenchTargetWhenCheckingWrenchInteractionReturnsTrue()
+		{
+			Assert.True(wrenchRestriction.IsWrenchInteraction(CreateInteraction(wrench)));
+		}
+
+		[Test]
+		public void GivenDifferentTargetWhenCheckingWrenchInteractionReturnsFalse()
+		{
+			Assert.False(wrenchRestriction.IsWrenchInteraction(CreateInteraction(wrench, otherTarget)));
+		}
+
+		[Test]
+		public void GivenNonWrenchWhenCheckingWrenchInteractionReturnsFalse()
+		{
+			Assert.False(wrenchRestriction.IsWrenchInteraction(CreateInteraction(otherItem)));
+		}
+
+		[Test]
+		public void WillInteractReturnsFalseWhenDefaultValidationFails()
+		{
+			Assert.False(wrenchRestriction.WillInteract(CreateInteraction(wrench), NetworkSide.Server));
+		}
+
+		[Test]
+		public void GivenRequiredClearanceWhenPerformingInteractionDelegatesToWrenchSecurable()
+		{
+			performerClearance.SetClearance(Clearance.Security);
+			target.GetComponent<WrenchSecurable>().blockAnchorChange = true;
+
+			ExpectClientChatError();
+			Assert.DoesNotThrow(() => wrenchRestriction.ServerPerformInteraction(CreateInteraction(wrench)));
+		}
+
+		[Test]
+		public void GivenMissingClearanceWhenPerformingWrenchInteractionDeniesAccess()
+		{
+			performerClearance.SetClearance(Clearance.Engine);
+
+			ExpectClientChatError();
+			ExpectMissingObjectPhysicsError();
+			Assert.DoesNotThrow(() => wrenchRestriction.ServerPerformInteraction(CreateInteraction(wrench)));
+		}
+
+		[Test]
+		public void GivenMissingClearanceWhenPerformingNonWrenchInteractionOnlyPlaysDeniedSound()
+		{
+			performerClearance.SetClearance(Clearance.Engine);
+
+			ExpectMissingObjectPhysicsError();
+			Assert.DoesNotThrow(() => wrenchRestriction.ServerPerformInteraction(CreateInteraction(otherItem)));
+		}
+
+		private HandApply CreateInteraction(GameObject handObject, GameObject interactionTarget = null)
+		{
+			return HandApply.ByClient(performer, handObject, interactionTarget ?? target, BodyPartType.None,
+				null, Intent.Help, null, false);
+		}
+
+		private static GameObject CreateItem(string objectName, ItemTrait itemTrait = null)
+		{
+			var item = new GameObject(objectName);
+			item.AddComponent<NetworkIdentity>();
+			var itemAttributes = item.AddComponent<ItemAttributesV2>();
+			if (itemTrait != null)
+			{
+				itemAttributes.AddTrait(itemTrait);
+			}
+
+			return item;
+		}
+
+		private static void ExpectClientChatError()
+		{
+			LogAssert.Expect(LogType.Error, new Regex("A server only method was called on a client in chat.cs"));
+		}
+
+		private static void ExpectMissingObjectPhysicsError()
+		{
+			LogAssert.Expect(LogType.Error, new Regex("Unable to find UniversalObjectPhysics on restricted object"));
+		}
+
+		private sealed class MockClearanceSourceComponent : MonoBehaviour, IClearanceSource
+		{
+			private List<Clearance> clearance = new();
+
+			public IEnumerable<Clearance> GetCurrentClearance => IssuedClearance;
+			public IEnumerable<Clearance> IssuedClearance => clearance;
+			public IEnumerable<Clearance> LowPopIssuedClearance => Enumerable.Empty<Clearance>();
+
+			public void SetClearance(params Clearance[] newClearance)
+			{
+				clearance = newClearance.ToList();
+			}
+		}
+	}
+}

--- a/UnityProject/Assets/Tests/ClearanceFramework/WrenchSecurableWithAccessRestrictionTest.cs
+++ b/UnityProject/Assets/Tests/ClearanceFramework/WrenchSecurableWithAccessRestrictionTest.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-using Mirror;
 using NUnit.Framework;
 using UnityEditor;
 using UnityEngine;
@@ -20,13 +19,21 @@ using US13.UI.Systems.MainHUD.UI_Bottom;
 namespace Tests.ClearanceFramework
 {
 	[TestFixture]
-	[Category(nameof(Balance))]
+	[Category("General")]
 	public class WrenchSecurableWithAccessRestrictionTest
 	{
+		private const string BarrierPrefabPath = "Assets/Prefabs/Objects/Security/DeployableSecurityBarrier.prefab";
+		private const string WrenchPrefabPath = "Assets/Prefabs/Items/Tools/Wrench.prefab";
+		private const string ScrewdriverPrefabPath = "Assets/Prefabs/Items/Tools/Screwdriver.prefab";
+
 		private GameObject performer;
+		private GameObject wrenchRoot;
 		private GameObject wrench;
+		private GameObject otherItemRoot;
 		private GameObject otherItem;
+		private GameObject targetRoot;
 		private GameObject target;
+		private GameObject otherTargetRoot;
 		private GameObject otherTarget;
 		private MockClearanceSourceComponent performerClearance;
 		private ClearanceRestricted restricted;
@@ -41,27 +48,34 @@ namespace Tests.ClearanceFramework
 			var commonTraits = AssetDatabase.LoadAssetAtPath<CommonTraits>("Assets/ScriptableObjects/Traits/CommonTraitsSingleton.asset");
 			Assert.NotNull(commonTraits);
 			Assert.NotNull(commonTraits.Wrench);
-			wrench = CreateItem("wrench", commonTraits.Wrench);
-			otherItem = CreateItem("not a wrench");
 
-			target = new GameObject("restricted object");
-			target.AddComponent<NetworkIdentity>();
-			wrenchRestriction = target.AddComponent<WrenchSecurableWithAccessRestriction>();
+			wrenchRoot = InstantiatePrefab(WrenchPrefabPath);
+			wrench = GetItemObject(wrenchRoot);
+			otherItemRoot = InstantiatePrefab(ScrewdriverPrefabPath);
+			otherItem = GetItemObject(otherItemRoot);
+			Assert.True(Validations.HasItemTrait(wrench, commonTraits.Wrench));
+			Assert.False(Validations.HasItemTrait(otherItem, commonTraits.Wrench));
+
+			targetRoot = InstantiatePrefab(BarrierPrefabPath);
+			wrenchRestriction = GetWrenchRestriction(targetRoot);
+			target = wrenchRestriction.gameObject;
 			restricted = target.GetComponent<ClearanceRestricted>();
+			Assert.NotNull(restricted);
 			restricted.SetCheckType(CheckType.Any);
 			restricted.SetClearance(new List<Clearance> {Clearance.Security});
 
-			otherTarget = new GameObject("other target");
+			otherTargetRoot = InstantiatePrefab(BarrierPrefabPath);
+			otherTarget = GetWrenchRestriction(otherTargetRoot).gameObject;
 		}
 
 		[TearDown]
 		public void TearDown()
 		{
 			Object.DestroyImmediate(performer);
-			Object.DestroyImmediate(wrench);
-			Object.DestroyImmediate(otherItem);
-			Object.DestroyImmediate(target);
-			Object.DestroyImmediate(otherTarget);
+			Object.DestroyImmediate(wrenchRoot);
+			Object.DestroyImmediate(otherItemRoot);
+			Object.DestroyImmediate(targetRoot);
+			Object.DestroyImmediate(otherTargetRoot);
 		}
 
 		[Test]
@@ -135,17 +149,7 @@ namespace Tests.ClearanceFramework
 			performerClearance.SetClearance(Clearance.Engine);
 
 			ExpectClientChatError();
-			ExpectMissingObjectPhysicsError();
 			Assert.DoesNotThrow(() => wrenchRestriction.ServerPerformInteraction(CreateInteraction(wrench)));
-		}
-
-		[Test]
-		public void GivenMissingClearanceWhenPerformingNonWrenchInteractionOnlyPlaysDeniedSound()
-		{
-			performerClearance.SetClearance(Clearance.Engine);
-
-			ExpectMissingObjectPhysicsError();
-			Assert.DoesNotThrow(() => wrenchRestriction.ServerPerformInteraction(CreateInteraction(otherItem)));
 		}
 
 		private HandApply CreateInteraction(GameObject handObject, GameObject interactionTarget = null)
@@ -154,27 +158,50 @@ namespace Tests.ClearanceFramework
 				null, Intent.Help, null, false);
 		}
 
-		private static GameObject CreateItem(string objectName, ItemTrait itemTrait = null)
+		private static GameObject InstantiatePrefab(string prefabPath)
 		{
-			var item = new GameObject(objectName);
-			item.AddComponent<NetworkIdentity>();
-			var itemAttributes = item.AddComponent<ItemAttributesV2>();
-			if (itemTrait != null)
-			{
-				itemAttributes.AddTrait(itemTrait);
-			}
+			var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+			Assert.NotNull(prefab, $"Missing prefab at {prefabPath}");
 
-			return item;
+			var instance = PrefabUtility.InstantiatePrefab(prefab) as GameObject;
+			Assert.NotNull(instance, $"Could not instantiate prefab at {prefabPath}");
+			return instance;
+		}
+
+		private static GameObject GetItemObject(GameObject root)
+		{
+			var itemAttributes = root.GetComponentInChildren<ItemAttributesV2>();
+			Assert.NotNull(itemAttributes, $"{root.name} is missing {nameof(ItemAttributesV2)}");
+			ApplySerializedInitialTraits(itemAttributes);
+			return itemAttributes.gameObject;
+		}
+
+		private static void ApplySerializedInitialTraits(ItemAttributesV2 itemAttributes)
+		{
+			// EditMode prefab instantiation does not run ItemAttributesV2.Awake, so mirror its trait init.
+			var serializedObject = new SerializedObject(itemAttributes);
+			var initialTraits = serializedObject.FindProperty("initialTraits");
+			Assert.NotNull(initialTraits);
+
+			for (var i = 0; i < initialTraits.arraySize; i++)
+			{
+				var trait = initialTraits.GetArrayElementAtIndex(i).objectReferenceValue as ItemTrait;
+				if (trait == null) continue;
+				itemAttributes.AddTrait(trait);
+			}
+		}
+
+		private static WrenchSecurableWithAccessRestriction GetWrenchRestriction(GameObject root)
+		{
+			var restriction = root.GetComponentInChildren<WrenchSecurableWithAccessRestriction>();
+			Assert.NotNull(restriction, $"{root.name} is missing {nameof(WrenchSecurableWithAccessRestriction)}");
+			return restriction;
 		}
 
 		private static void ExpectClientChatError()
 		{
+			// EditMode tests call server interaction routing without starting a Mirror server.
 			LogAssert.Expect(LogType.Error, new Regex("A server only method was called on a client in chat.cs"));
-		}
-
-		private static void ExpectMissingObjectPhysicsError()
-		{
-			LogAssert.Expect(LogType.Error, new Regex("Unable to find UniversalObjectPhysics on restricted object"));
 		}
 
 		private sealed class MockClearanceSourceComponent : MonoBehaviour, IClearanceSource

--- a/UnityProject/Assets/Tests/ClearanceFramework/WrenchSecurableWithAccessRestrictionTest.cs.meta
+++ b/UnityProject/Assets/Tests/ClearanceFramework/WrenchSecurableWithAccessRestrictionTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3fe97de06e3f44e08941cf5ac7a83c39
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
### Purpose
Fixes #10802.

`WrenchSecurableWithAccessRestriction` was claiming wrench interactions even when the performer had the required clearance, so authorized players could not delegate through to `WrenchSecurable` and actually anchor or unanchor the object.

This changes the component to:
- claim only wrench interactions targeting the restricted object
- delegate allowed wrench attempts to `WrenchSecurable`
- keep denied access feedback for wrench attempts without clearance
- avoid hijacking unrelated hand interactions with a generic access denied message

### Notes:
Added EditMode regression coverage for required clearance, missing clearance, unrestricted objects, non-wrench interactions, target filtering, and interaction priority.

The tests instantiate the real deployable security barrier, wrench, and screwdriver prefabs so the fixture follows the gameplay component setup more closely.

AI assistance: This PR was prepared with assistance from OpenAI Codex.

Verification run:
- `git diff --check`
- `Unity -batchmode -nographics -projectPath UnityProject -runTests -testPlatform EditMode -testFilter Tests.ClearanceFramework`
  - Result: 16/16 passed

### Media Preview:
N/A, no visual changes.

### Changelog:
CL: [Fix] Access-restricted wrenchable objects can now be wrenched by players with the required clearance.