### PR TITLE
starshipstation shuttle thusters fix

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Electricity/PowerGeneratorUranium.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Electricity/PowerGeneratorUranium.prefab
@@ -49,6 +49,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 66d1cd8016198e74c92a755f9b2bdeb0,
         type: 2}
+    - target: {fileID: 2952610514931748297, guid: 93d1f95a33757fe4fa3e2771e3f5bd67,
+        type: 3}
+      propertyPath: VoltageFluctuationPercentage
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2973511242914761374, guid: 93d1f95a33757fe4fa3e2771e3f5bd67,
         type: 3}
       propertyPath: _assetId
@@ -184,7 +189,7 @@ PrefabInstance:
     - target: {fileID: 6672603410258477052, guid: 93d1f95a33757fe4fa3e2771e3f5bd67,
         type: 3}
       propertyPath: m_Name
-      value: New PowerGeneratorUranium
+      value: PowerGeneratorUranium
       objectReference: {fileID: 0}
     - target: {fileID: 6915811152775355371, guid: 93d1f95a33757fe4fa3e2771e3f5bd67,
         type: 3}
@@ -201,11 +206,6 @@ PrefabInstance:
         type: 3}
       propertyPath: SupplyingVoltage
       value: 1260000
-      objectReference: {fileID: 0}
-    - target: {fileID: 8704923215026597471, guid: 93d1f95a33757fe4fa3e2771e3f5bd67,
-        type: 3}
-      propertyPath: InternalResistance
-      value: 1e+10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/UnityProject/Assets/StreamingAssets/Maps/MainStations/StarshipStation.json
+++ b/UnityProject/Assets/StreamingAssets/Maps/MainStations/StarshipStation.json
@@ -92856,28 +92856,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "2"
@@ -92885,14 +92865,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -92961,28 +92933,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "2"
@@ -92990,14 +92942,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -93400,28 +93344,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "1"
@@ -93429,14 +93353,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -101314,28 +101230,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "1"
@@ -101343,14 +101239,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -102258,28 +102146,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "2"
@@ -102287,14 +102155,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -104171,28 +104031,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "1"
@@ -104200,14 +104040,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -106314,28 +106146,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "1"
@@ -106343,14 +106155,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -107516,28 +107320,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "3"
@@ -107545,14 +107329,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -117513,28 +117289,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "2"
@@ -117542,14 +117298,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -122837,28 +122585,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "1"
@@ -122866,14 +122594,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -125150,28 +124870,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "2"
@@ -125179,14 +124879,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -126319,28 +126011,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "2"
@@ -126348,14 +126020,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -129156,28 +128820,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "3"
@@ -129185,14 +128829,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -131375,28 +131011,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "2"
@@ -131404,14 +131020,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -131540,28 +131148,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "3"
@@ -131569,14 +131157,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -132952,28 +132532,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "1"
@@ -132981,14 +132541,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -134272,28 +133824,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "1"
@@ -134301,14 +133833,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -136910,28 +136434,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "1"
@@ -136939,14 +136443,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -138877,28 +138373,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "1"
@@ -138906,14 +138382,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -140166,28 +139634,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "1"
@@ -140195,14 +139643,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -141769,7 +141209,20 @@
             "PrefabID": "93d1f95a33757fe4fa3e2771e3f5bd67",
             "Name": "New PowerGeneratorPlasma (2)",
             "LocalPRS": "33┼14┼0┼",
-            "SortPath": "Powernet"
+            "SortPath": "Powernet",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "PowerGenerator@0",
+                  "Data": [
+                    {
+                      "Name": "VoltageFluctuationPercentage",
+                      "Data": "0"
+                    }
+                  ]
+                }
+              ]
+            }
           },
           {
             "GitID": "c80393b4412660b41937e05425ceb921_33┼14┼0┼",
@@ -147017,28 +146470,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "3"
@@ -147046,14 +146479,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -169024,28 +168449,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "1"
@@ -169053,14 +168458,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -182819,28 +182216,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "3"
@@ -182848,14 +182225,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -327765,47 +327134,13 @@
             "GitID": "d3b0186c86ba4f44d8cf26cb50345ae4_61┼103┼0┼",
             "PrefabID": "d3b0186c86ba4f44d8cf26cb50345ae4",
             "Name": "PrisonersJumpskirt (1)",
-            "LocalPRS": "61┼103┼0┼",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "ItemSlotActionTracker@0",
-                  "Data": [
-                    {
-                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
-                      "Data": "SecureStuff.SerializedAction"
-                    },
-                    {
-                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
-                      "Data": "#removed#"
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "61┼103┼0┼"
           },
           {
             "GitID": "f1436853dd14162fe97690f8e7714773_61┼103┼0┼",
             "PrefabID": "f1436853dd14162fe97690f8e7714773",
             "Name": "PrisonersJumpsuit (1)",
-            "LocalPRS": "61┼103┼0┼",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "ItemSlotActionTracker@0",
-                  "Data": [
-                    {
-                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
-                      "Data": "SecureStuff.SerializedAction"
-                    },
-                    {
-                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
-                      "Data": "#removed#"
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "61┼103┼0┼"
           },
           {
             "GitID": "HLC3owBBeLqKq_qStKku_61┼107┼0┼",
@@ -327898,47 +327233,13 @@
             "GitID": "d3b0186c86ba4f44d8cf26cb50345ae4_61.001┼103┼0┼",
             "PrefabID": "d3b0186c86ba4f44d8cf26cb50345ae4",
             "Name": "PrisonersJumpskirt (2)",
-            "LocalPRS": "61.001┼103┼0┼",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "ItemSlotActionTracker@0",
-                  "Data": [
-                    {
-                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
-                      "Data": "SecureStuff.SerializedAction"
-                    },
-                    {
-                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
-                      "Data": "#removed#"
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "61.001┼103┼0┼"
           },
           {
             "GitID": "f1436853dd14162fe97690f8e7714773_61.001┼103┼0┼",
             "PrefabID": "f1436853dd14162fe97690f8e7714773",
             "Name": "PrisonersJumpsuit (2)",
-            "LocalPRS": "61.001┼103┼0┼",
-            "Object": {
-              "ClassDatas": [
-                {
-                  "ClassID": "ItemSlotActionTracker@0",
-                  "Data": [
-                    {
-                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
-                      "Data": "SecureStuff.SerializedAction"
-                    },
-                    {
-                      "Name": "<ActionData>k__BackingField#US13.Actions.V2.ActionButtonData",
-                      "Data": "#removed#"
-                    }
-                  ]
-                }
-              ]
-            }
+            "LocalPRS": "61.001┼103┼0┼"
           },
           {
             "GitID": "688f19f1616bdd64ea726a38b1320c25_61.13┼103.13┼0┼",
@@ -517129,6 +516430,11 @@
               },
               {
                 "Tel": "Grille"
+              },
+              {
+                "Tel": "FluidStraightPipe",
+                "Z": 1,
+                "Tf": "5.96046448E-08,-0.99999994,0,0,0.99999994,5.96046448E-08,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -517194,15 +516500,15 @@
             "Key": "X3Y7",
             "Value": [
               {
-                "Tel": "shuttle_wall_corner"
+                "Tel": "shuttle_wall"
               },
               {
                 "Tel": "Plating"
               },
               {
-                "Tel": "FluidStraightPipe",
+                "Tel": "FluidBentPipe",
                 "Z": 1,
-                "Tf": "5.960464E-08,-0.9999999,0,0,0.9999999,5.960464E-08,0,0,0,0,1,0,0,0,0,1"
+                "Tf": "5.96046448E-08,-0.99999994,0,0,0.99999994,5.96046448E-08,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -517211,6 +516517,11 @@
             "Value": [
               {
                 "Tel": "shuttle_wall_corner"
+              },
+              {
+                "Tel": "FluidBentPipe",
+                "Z": 1,
+                "Tf": "5.96046448E-08,0.99999994,0,0,-0.99999994,5.96046448E-08,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -517239,6 +516550,11 @@
               },
               {
                 "Tel": "table_reinforced"
+              },
+              {
+                "Tel": "FluidStraightPipe",
+                "Z": 1,
+                "Tf": "5.96046448E-08,-0.99999994,0,0,0.99999994,5.96046448E-08,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -517276,7 +516592,7 @@
               {
                 "Tel": "FluidBentPipe",
                 "Z": 1,
-                "Tf": "5.960464E-08,-0.9999999,0,0,0.9999999,5.960464E-08,0,0,0,0,1,0,0,0,0,1"
+                "Tf": "5.96046448E-08,-0.99999994,0,0,0.99999994,5.96046448E-08,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -517349,7 +516665,7 @@
                 "Tel": "Plating"
               },
               {
-                "Tel": "FluidStraightPipe",
+                "Tel": "4WayManifold",
                 "Z": 1
               }
             ]
@@ -517396,7 +516712,7 @@
               {
                 "Tel": "FluidBentPipe",
                 "Z": 1,
-                "Tf": "5.960464E-08,0.9999999,0,0,-0.9999999,5.960464E-08,0,0,0,0,1,0,0,0,0,1"
+                "Tf": "5.96046448E-08,0.99999994,0,0,-0.99999994,5.96046448E-08,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -517462,6 +516778,11 @@
               },
               {
                 "Tel": "table_reinforced"
+              },
+              {
+                "Tel": "FluidStraightPipe",
+                "Z": 1,
+                "Tf": "5.96046448E-08,-0.99999994,0,0,0.99999994,5.96046448E-08,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -517554,6 +516875,11 @@
               },
               {
                 "Tel": "Grille"
+              },
+              {
+                "Tel": "FluidStraightPipe",
+                "Z": 1,
+                "Tf": "5.96046448E-08,-0.99999994,0,0,0.99999994,5.96046448E-08,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -517619,15 +516945,15 @@
             "Key": "X7Y7",
             "Value": [
               {
-                "Tel": "shuttle_wall_corner"
+                "Tel": "shuttle_wall"
               },
               {
                 "Tel": "Plating"
               },
               {
-                "Tel": "FluidStraightPipe",
+                "Tel": "FluidBentPipe",
                 "Z": 1,
-                "Tf": "5.960464E-08,-0.9999999,0,0,0.9999999,5.960464E-08,0,0,0,0,1,0,0,0,0,1"
+                "Tf": "-1,8.742278E-08,0,0,-8.742278E-08,-1,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -517636,6 +516962,10 @@
             "Value": [
               {
                 "Tel": "shuttle_wall_corner"
+              },
+              {
+                "Tel": "FluidBentPipe",
+                "Z": 1
               }
             ]
           },
@@ -517712,6 +517042,34 @@
         "CommonPrefabs": [],
         "PrefabData": [
           {
+            "GitID": "cfb9eeeafc56752c68f1818ef870ffe9_2┼1┼0┼",
+            "PrefabID": "cfb9eeeafc56752c68f1818ef870ffe9",
+            "Name": "Micro Plasma Thruster (3)",
+            "LocalPRS": "2┼1┼0┼0ø0ø90ø",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "Thruster@0",
+                  "Data": [
+                    {
+                      "Name": "ThisThrusterDirectionClassification",
+                      "Data": "Left"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Left_By90"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
             "GitID": "5425ee650c49e0849b4bed132cfb588f_2┼4┼0┼",
             "PrefabID": "5425ee650c49e0849b4bed132cfb588f",
             "Name": "TinyFan (1)",
@@ -517737,10 +517095,10 @@
             }
           },
           {
-            "GitID": "9bda2d5647088c74392285230ba38474_2┼7┼0┼",
-            "PrefabID": "9bda2d5647088c74392285230ba38474",
-            "Name": "Plasma Thruster (2)",
-            "LocalPRS": "2┼7┼0┼0ø0ø90ø",
+            "GitID": "cfb9eeeafc56752c68f1818ef870ffe9_2┼8┼0┼",
+            "PrefabID": "cfb9eeeafc56752c68f1818ef870ffe9",
+            "Name": "Micro Plasma Thruster (2)",
+            "LocalPRS": "2┼8┼0┼0ø0ø90ø",
             "Object": {
               "ClassDatas": [
                 {
@@ -517748,7 +517106,7 @@
                   "Data": [
                     {
                       "Name": "ThisThrusterDirectionClassification",
-                      "Data": "Left"
+                      "Data": "Right"
                     }
                   ]
                 },
@@ -517885,28 +517243,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "1"
@@ -517914,14 +517252,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -517932,6 +517262,34 @@
                   "ClassDatas": [
                     {
                       "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,4",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,5",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
                         {
                           "Name": "initialVariantIndex",
@@ -518127,6 +517485,34 @@
             "LocalPRS": "7┼6┼0┼"
           },
           {
+            "GitID": "cfb9eeeafc56752c68f1818ef870ffe9_8┼1┼0┼",
+            "PrefabID": "cfb9eeeafc56752c68f1818ef870ffe9",
+            "Name": "Micro Plasma Thruster (1)",
+            "LocalPRS": "8┼1┼0┼0ø0ø270ø",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "Thruster@0",
+                  "Data": [
+                    {
+                      "Name": "ThisThrusterDirectionClassification",
+                      "Data": "Right"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
             "GitID": "5425ee650c49e0849b4bed132cfb588f_8┼4┼0┼",
             "PrefabID": "5425ee650c49e0849b4bed132cfb588f",
             "Name": "TinyFan (2)",
@@ -518152,10 +517538,11 @@
             }
           },
           {
-            "GitID": "9bda2d5647088c74392285230ba38474_8┼7┼0┼",
-            "PrefabID": "9bda2d5647088c74392285230ba38474",
-            "Name": "Plasma Thruster (1)",
-            "LocalPRS": "8┼7┼0┼0ø0ø270ø",
+            "GitID": "cfb9eeeafc56752c68f1818ef870ffe9_8┼8┼0┼",
+            "PrefabID": "cfb9eeeafc56752c68f1818ef870ffe9",
+            "NameMatches": true,
+            "Name": "Micro Plasma Thruster",
+            "LocalPRS": "8┼8┼0┼0ø0ø270ø",
             "Object": {
               "ClassDatas": [
                 {
@@ -518163,7 +517550,7 @@
                   "Data": [
                     {
                       "Name": "ThisThrusterDirectionClassification",
-                      "Data": "Right"
+                      "Data": "Left"
                     }
                   ]
                 },
@@ -518288,6 +517675,11 @@
               },
               {
                 "Tel": "Grille"
+              },
+              {
+                "Tel": "FluidStraightPipe",
+                "Z": 1,
+                "Tf": "5.96046448E-08,-0.99999994,0,0,0.99999994,5.96046448E-08,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -518303,7 +517695,7 @@
               {
                 "Tel": "FluidBentPipe",
                 "Z": 1,
-                "Tf": "5.960464E-08,-0.9999999,0,0,0.9999999,5.960464E-08,0,0,0,0,1,0,0,0,0,1"
+                "Tf": "5.96046448E-08,-0.99999994,0,0,0.99999994,5.96046448E-08,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -518354,6 +517746,14 @@
             ]
           },
           {
+            "Key": "X1Y5",
+            "Value": [
+              {
+                "Tel": "Lattice"
+              }
+            ]
+          },
+          {
             "Key": "X2Y-1",
             "Value": [
               {
@@ -518364,6 +517764,10 @@
               },
               {
                 "Tel": "Grille"
+              },
+              {
+                "Tel": "FluidStraightPipe",
+                "Z": 1
               }
             ]
           },
@@ -518377,7 +517781,7 @@
                 "Tel": "Plating"
               },
               {
-                "Tel": "FluidStraightPipe",
+                "Tel": "4WayManifold",
                 "Z": 1
               }
             ]
@@ -518436,6 +517840,14 @@
             ]
           },
           {
+            "Key": "X2Y5",
+            "Value": [
+              {
+                "Tel": "Lattice"
+              }
+            ]
+          },
+          {
             "Key": "X3Y-1",
             "Value": [
               {
@@ -518460,6 +517872,11 @@
               },
               {
                 "Tel": "Grille"
+              },
+              {
+                "Tel": "FluidStraightPipe",
+                "Z": 1,
+                "Tf": "5.96046448E-08,-0.99999994,0,0,0.99999994,5.96046448E-08,0,0,0,0,1,0,0,0,0,1"
               }
             ]
           },
@@ -518508,7 +517925,15 @@
               {
                 "Tel": "FluidStraightPipe",
                 "Z": 1,
-                "Tf": "5.960464E-08,-0.9999999,0,0,0.9999999,5.960464E-08,0,0,0,0,1,0,0,0,0,1"
+                "Tf": "5.96046448E-08,-0.99999994,0,0,0.99999994,5.96046448E-08,0,0,0,0,1,0,0,0,0,1"
+              }
+            ]
+          },
+          {
+            "Key": "X3Y5",
+            "Value": [
+              {
+                "Tel": "Lattice"
               }
             ]
           },
@@ -518585,6 +518010,34 @@
         "CommonPrefabs": [],
         "PrefabData": [
           {
+            "GitID": "cfb9eeeafc56752c68f1818ef870ffe9_0┼0┼0┼",
+            "PrefabID": "cfb9eeeafc56752c68f1818ef870ffe9",
+            "Name": "Micro Plasma Thruster (1)",
+            "LocalPRS": "0┼0┼0┼0ø0ø90ø",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "Thruster@0",
+                  "Data": [
+                    {
+                      "Name": "ThisThrusterDirectionClassification",
+                      "Data": "Left"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Left_By90"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
             "GitID": "5425ee650c49e0849b4bed132cfb588f_0┼2┼0┼",
             "PrefabID": "5425ee650c49e0849b4bed132cfb588f",
             "Name": "TinyFan (1)",
@@ -518626,9 +518079,10 @@
             }
           },
           {
-            "GitID": "9bda2d5647088c74392285230ba38474_0┼4┼0┼",
-            "PrefabID": "9bda2d5647088c74392285230ba38474",
-            "Name": "Plasma Thruster (2)",
+            "GitID": "cfb9eeeafc56752c68f1818ef870ffe9_0┼4┼0┼",
+            "PrefabID": "cfb9eeeafc56752c68f1818ef870ffe9",
+            "NameMatches": true,
+            "Name": "Micro Plasma Thruster",
             "LocalPRS": "0┼4┼0┼0ø0ø90ø",
             "Object": {
               "ClassDatas": [
@@ -518637,7 +518091,7 @@
                   "Data": [
                     {
                       "Name": "ThisThrusterDirectionClassification",
-                      "Data": "Left"
+                      "Data": "Right"
                     }
                   ]
                 },
@@ -518682,10 +518136,10 @@
             }
           },
           {
-            "GitID": "9bda2d5647088c74392285230ba38474_2┼-1┼0┼",
-            "PrefabID": "9bda2d5647088c74392285230ba38474",
-            "Name": "Plasma Thruster (4)",
-            "LocalPRS": "2┼-1┼0┼0ø0ø180ø",
+            "GitID": "cfb9eeeafc56752c68f1818ef870ffe9_2┼-2┼0┼",
+            "PrefabID": "cfb9eeeafc56752c68f1818ef870ffe9",
+            "Name": "Micro Plasma Thruster (4)",
+            "LocalPRS": "2┼-2┼0┼0ø0ø180ø",
             "Object": {
               "ClassDatas": [
                 {
@@ -518745,28 +518199,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "1"
@@ -518774,14 +518208,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -518792,6 +518218,34 @@
                   "ClassDatas": [
                     {
                       "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,4",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "SpriteHandler@0",
+                      "Data": [
+                        {
+                          "Name": "initialVariantIndex",
+                          "Data": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "ID": "0,5",
+                  "ClassDatas": [
+                    {
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
                         {
                           "Name": "initialVariantIndex",
@@ -518943,6 +518397,34 @@
             }
           },
           {
+            "GitID": "cfb9eeeafc56752c68f1818ef870ffe9_4┼0┼0┼",
+            "PrefabID": "cfb9eeeafc56752c68f1818ef870ffe9",
+            "Name": "Micro Plasma Thruster (2)",
+            "LocalPRS": "4┼0┼0┼0ø0ø270ø",
+            "Object": {
+              "ClassDatas": [
+                {
+                  "ClassID": "Thruster@0",
+                  "Data": [
+                    {
+                      "Name": "ThisThrusterDirectionClassification",
+                      "Data": "Right"
+                    }
+                  ]
+                },
+                {
+                  "ClassID": "Rotatable@0",
+                  "Data": [
+                    {
+                      "Name": "CurrentDirection",
+                      "Data": "Right_By270"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
             "GitID": "5425ee650c49e0849b4bed132cfb588f_4┼2┼0┼",
             "PrefabID": "5425ee650c49e0849b4bed132cfb588f",
             "Name": "TinyFan (2)",
@@ -518984,9 +518466,9 @@
             }
           },
           {
-            "GitID": "9bda2d5647088c74392285230ba38474_4┼4┼0┼",
-            "PrefabID": "9bda2d5647088c74392285230ba38474",
-            "Name": "Plasma Thruster (3)",
+            "GitID": "cfb9eeeafc56752c68f1818ef870ffe9_4┼4┼0┼",
+            "PrefabID": "cfb9eeeafc56752c68f1818ef870ffe9",
+            "Name": "Micro Plasma Thruster (3)",
             "LocalPRS": "4┼4┼0┼0ø0ø270ø",
             "Object": {
               "ClassDatas": [
@@ -518995,7 +518477,7 @@
                   "Data": [
                     {
                       "Name": "ThisThrusterDirectionClassification",
-                      "Data": "Right"
+                      "Data": "Left"
                     }
                   ]
                 },
@@ -519017,8 +518499,8 @@
       "PreviewGizmos": [
         {
           "Ver": "1.0.0",
-          "Pos": "2,2,0.5",
-          "Size": "4,6,1"
+          "Pos": "2,1.5,0.5",
+          "Size": "4,7,1"
         }
       ]
     },
@@ -519282,7 +518764,7 @@
           {
             "GitID": "9bda2d5647088c74392285230ba38474_2┼4┼0┼",
             "PrefabID": "9bda2d5647088c74392285230ba38474",
-            "Name": "Plasma Thruster (5)",
+            "Name": "Plasma Thruster (8)",
             "LocalPRS": "2┼4┼0┼0ø0ø90ø",
             "Object": {
               "ClassDatas": [
@@ -519291,7 +518773,7 @@
                   "Data": [
                     {
                       "Name": "ThisThrusterDirectionClassification",
-                      "Data": "Left"
+                      "Data": "Right"
                     }
                   ]
                 },
@@ -519431,28 +518913,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "1"
@@ -519460,14 +518922,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }
@@ -519790,10 +519244,10 @@
             }
           },
           {
-            "GitID": "9bda2d5647088c74392285230ba38474_4.001┼4┼0┼",
+            "GitID": "9bda2d5647088c74392285230ba38474_4┼4┼0┼",
             "PrefabID": "9bda2d5647088c74392285230ba38474",
-            "Name": "Plasma Thruster (8)",
-            "LocalPRS": "4.001┼4┼0┼0ø0ø270ø",
+            "Name": "Plasma Thruster (5)",
+            "LocalPRS": "4┼4┼0┼0ø0ø270ø",
             "Object": {
               "ClassDatas": [
                 {
@@ -519801,7 +519255,7 @@
                   "Data": [
                     {
                       "Name": "ThisThrusterDirectionClassification",
-                      "Data": "Right"
+                      "Data": "Left"
                     }
                   ]
                 },
@@ -523989,28 +523443,8 @@
                   "ID": "0,2",
                   "ClassDatas": [
                     {
-                      "ClassID": "SpriteHandler@0",
+                      "ClassID": "LightSpriteHandler@0",
                       "Data": [
-                        {
-                          "Name": "NetworkThis",
-                          "Data": "True"
-                        },
-                        {
-                          "Name": "randomInitialSprite",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "spriteRenderer",
-                          "Data": "NULL"
-                        },
-                        {
-                          "Name": "doReverseAnimation",
-                          "Data": "False"
-                        },
-                        {
-                          "Name": "pushTextureOnStartUp",
-                          "Data": "True"
-                        },
                         {
                           "Name": "initialVariantIndex",
                           "Data": "3"
@@ -524018,14 +523452,6 @@
                         {
                           "Name": "InitialColour",
                           "Data": "ÿÿÿÿ"
-                        },
-                        {
-                          "Name": "initialSortingOrder",
-                          "Data": "-1"
-                        },
-                        {
-                          "Name": "initialSortingLayerName",
-                          "Data": ""
                         }
                       ]
                     }


### PR DESCRIPTION
### Purpose
improve starshipstation shuttles' turning thrusters and sets its artillery emitters' generator to 0 fluctuation to fix them not firing
sets uranium generator's power fluctuation to 0 for now

### Changelog:
CL: [Fix] Fixes shuttle turning and prow artillery emitters on Starshipstation.