### PR TITLE
Suspend world rendering in the pre-game lobby to improve performance

### DIFF
--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/Windows/PreRoundScreen.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/Windows/PreRoundScreen.prefab
@@ -103,6 +103,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -350,6 +351,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -581,6 +583,7 @@ MonoBehaviour:
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -1213,6 +1216,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -1440,6 +1444,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -1576,6 +1581,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -1737,6 +1743,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children:
+  - {fileID: 4821460536245207876}
   - {fileID: 5921368239646347537}
   - {fileID: 761727875748305484}
   - {fileID: 2465986478366484645}
@@ -1984,6 +1991,7 @@ MonoBehaviour:
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -2120,6 +2128,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -2256,6 +2265,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -2598,6 +2608,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -2734,6 +2745,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -2870,6 +2882,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -3843,6 +3856,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -3960,6 +3974,81 @@ MonoBehaviour:
   minViewportY: 0.07
   maxViewportY: 0.97
   spawnContinuously: 1
+--- !u!1 &8031651130529517169
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4821460536245207876}
+  - component: {fileID: 6853612580900143552}
+  - component: {fileID: 1798230113292392315}
+  m_Layer: 5
+  m_Name: SpaceBackground
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4821460536245207876
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8031651130529517169}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7215523023227799337}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 4000, y: 2500}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6853612580900143552
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8031651130529517169}
+  m_CullTransparentMesh: 1
+--- !u!114 &1798230113292392315
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8031651130529517169}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 7b399defd4be3d94ab3988f7c66ab77b, type: 3}
+  m_Type: 2
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &8292547159771038571
 GameObject:
   m_ObjectHideFlags: 0
@@ -4063,6 +4152,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -4246,6 +4336,7 @@ MonoBehaviour:
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0

--- a/UnityProject/Assets/Scripts/US13/Core/Camera/Camera2DFollow.cs
+++ b/UnityProject/Assets/Scripts/US13/Core/Camera/Camera2DFollow.cs
@@ -81,6 +81,11 @@ namespace US13.Core.Camera
 		public bool ODDeven = false;
 		public Vector2 Previous = Vector2.zero;
 
+		// Reference-counted suspension of world rendering
+		private int renderSuspendCount;
+		private int savedCullingMask;
+		private bool savedLightingEnabled;
+
 		private void Awake()
 		{
 			if (followControl == null)
@@ -114,6 +119,45 @@ namespace US13.Core.Camera
 		private void OnDisable()
 		{
 			UpdateManager.SetCameraUpdate(null);
+		}
+
+		/// <summary>
+		/// Stop rendering the world (follow camera + lighting mask cameras).
+		/// Use if you want to turn off the world camera (for full screen menus or effects).
+		/// </summary>
+		public void SuspendRendering()
+		{
+			if (renderSuspendCount++ == 0)
+			{
+				if (cam != null)
+				{
+					savedCullingMask = cam.cullingMask;
+					cam.cullingMask = 0;
+				}
+				if (lightingSystem != null)
+				{
+					savedLightingEnabled = lightingSystem.enabled;
+					lightingSystem.enabled = false;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Resume world rendering. Only restores once the last suspender has released.
+		/// </summary>
+		public void ResumeRendering()
+		{
+			if (renderSuspendCount > 0 && --renderSuspendCount == 0)
+			{
+				if (cam != null)
+				{
+					cam.cullingMask = savedCullingMask;
+				}
+				if (lightingSystem != null)
+				{
+					lightingSystem.enabled = savedLightingEnabled;
+				}
+			}
 		}
 
 		//idk I don't know probably should look into the sometime TODO look into this

--- a/UnityProject/Assets/Scripts/US13/Core/Camera/Camera2DFollow.cs
+++ b/UnityProject/Assets/Scripts/US13/Core/Camera/Camera2DFollow.cs
@@ -127,18 +127,19 @@ namespace US13.Core.Camera
 		/// </summary>
 		public void SuspendRendering()
 		{
-			if (renderSuspendCount++ == 0)
+			renderSuspendCount++;
+			if (renderSuspendCount > 1) return; // already suspended by another caller
+
+			if (cam != null)
 			{
-				if (cam != null)
-				{
-					savedCullingMask = cam.cullingMask;
-					cam.cullingMask = 0;
-				}
-				if (lightingSystem != null)
-				{
-					savedLightingEnabled = lightingSystem.enabled;
-					lightingSystem.enabled = false;
-				}
+				savedCullingMask = cam.cullingMask;
+				cam.cullingMask = 0;
+			}
+
+			if (lightingSystem != null)
+			{
+				savedLightingEnabled = lightingSystem.enabled;
+				lightingSystem.enabled = false;
 			}
 		}
 
@@ -147,16 +148,19 @@ namespace US13.Core.Camera
 		/// </summary>
 		public void ResumeRendering()
 		{
-			if (renderSuspendCount > 0 && --renderSuspendCount == 0)
+			if (renderSuspendCount == 0) return; // nothing to resume
+
+			renderSuspendCount--;
+			if (renderSuspendCount > 0) return; // other callers still want it suspended
+
+			if (cam != null)
 			{
-				if (cam != null)
-				{
-					cam.cullingMask = savedCullingMask;
-				}
-				if (lightingSystem != null)
-				{
-					lightingSystem.enabled = savedLightingEnabled;
-				}
+				cam.cullingMask = savedCullingMask;
+			}
+
+			if (lightingSystem != null)
+			{
+				lightingSystem.enabled = savedLightingEnabled;
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/US13/UI/Systems/PreRound/GUI_PreRoundWindow.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Systems/PreRound/GUI_PreRoundWindow.cs
@@ -2,12 +2,14 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using Cysharp.Threading.Tasks;
+using IngameDebugConsole.Scripts;
 using Logs;
 using Shared.Managers;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 using US13.Core.Addressables;
+using US13.Core.Camera;
 using US13.Core.Chat;
 using US13.Core.Networking.AsyncMessageQueue;
 using US13.Managers;
@@ -42,6 +44,7 @@ namespace US13.UI.Systems.PreRound
 		private Button characterButton;
 		private Button adminStartButton;
 
+		private bool worldRenderingSuspended;
 
 		private void OnEnable()
 		{
@@ -51,6 +54,14 @@ namespace US13.UI.Systems.PreRound
 			CountdownArea.OnFinishedCountingDown.AddListener(CheckForRoundStatusForTitle);
 			CountdownArea.OnFinishedCountingDown.AddListener(ChangeJoinButtonForRoundStarted);
 			OnClientLoadUpdateStatus += UpdateLoadingStatus;
+
+			//Do not render the player follow camera and lighting cameras when in pre-game menu to reduce unneeded draw calls
+			if (Camera2DFollow.followControl != null)
+			{
+				Camera2DFollow.followControl.SuspendRendering();
+				worldRenderingSuspended = true;
+			}
+
 			_ = DelayedCheck();
 		}
 
@@ -81,6 +92,13 @@ namespace US13.UI.Systems.PreRound
 			CountdownArea.OnFinishedCountingDown.RemoveListener(ChangeJoinButtonForRoundStarted);
 			GameManager.Instance.OnCurrentRoundStateChange -= ChangeJoinButtonForRoundStarted;
 			OnClientLoadUpdateStatus -= UpdateLoadingStatus;
+
+			//Restore player follow camera and lighting when round starts
+			if (worldRenderingSuspended)
+			{
+				Camera2DFollow.followControl?.ResumeRendering();
+				worldRenderingSuspended = false;
+			}
 		}
 
 		private void UpdateMe()


### PR DESCRIPTION
### Purpose
Provides a way to suspend world camera and lighting cameras to improve the performance of full screen menus. 
Can also be used if you need to disable game camera for any other reason. 
Applied this to the pre game lobby and tested. Results below.

Tested on 4k screen.

Before culling the game cameras:
<img width="530" height="524" alt="build_before_camera_cull" src="https://github.com/user-attachments/assets/a56795a6-07ee-4ade-8bb2-28a5b3aef23a" />

After culling the game cameras:
<img width="543" height="534" alt="build_after_camera_cull" src="https://github.com/user-attachments/assets/1ac88d43-bb90-4b18-8a6a-d5c4958c39f3" />

### Changelog:
CL: [Improvement] Improved performance on the pre-round lobby screen.