### PR TITLE
Better error logging for ItemLightControl NRE's

### DIFF
--- a/UnityProject/Assets/Scripts/US13/Player/ItemLightControl.cs
+++ b/UnityProject/Assets/Scripts/US13/Player/ItemLightControl.cs
@@ -63,15 +63,15 @@ namespace US13.Player
 
 		private void Awake()
 		{
-			if (objectLightSprite == null)
-			{
-				objectLightSprite = objectLightEmission.GetComponentInChildren<LightSprite>();
-			}
-
 			if (objectLightEmission == null)
 			{
 				Loggy.Error($"{this} field objectLightEmission is null, please check {gameObject} prefab.", Category.Lighting);
 				return;
+			}
+
+			if (objectLightSprite == null)
+			{
+				objectLightSprite = objectLightEmission.GetComponentInChildren<LightSprite>();
 			}
 
 			if (netIdentity == null)


### PR DESCRIPTION
### Purpose

Re orders the null checks so a null objectLightEmission is caught before de referencing it which in turn prints the improved error logs so mappers can fix connection problems.

### Media Preview:
Before fix:
<img width="575" height="244" alt="itemLightControlNRE" src="https://github.com/user-attachments/assets/69b24496-92cd-4ca0-a69a-db1b9aa8226f" />

After fix:

<img width="926" height="306" alt="ImprovedErrors" src="https://github.com/user-attachments/assets/7cb295b8-84a2-487d-a1ee-13517ab286f1" />

### Changelog:
CL: [Fix] Fixes null reference checks on ItemLightControl and allows the more detailed error logs to show.
