### PR TITLE
Improve the null checks for optional directional / integrity references

### DIFF
--- a/UnityProject/Assets/Scripts/US13/Core/Lighting/LightSource.cs
+++ b/UnityProject/Assets/Scripts/US13/Core/Lighting/LightSource.cs
@@ -140,14 +140,28 @@ namespace US13.Core.Lighting
 
 		private void OnEnable()
 		{
-			directional.OnRotationChange.AddListener(OnDirectionChange);
-			integrity.OnApplyDamage += OnDamageReceived;
+			if (directional)
+			{
+				directional.OnRotationChange.AddListener(OnDirectionChange);
+			}
+
+			if (integrity)
+			{
+				integrity.OnApplyDamage += OnDamageReceived;
+			}
 		}
 
 		private void OnDisable()
 		{
-			directional.OnRotationChange.RemoveListener(OnDirectionChange);
-			if (integrity) integrity.OnApplyDamage -= OnDamageReceived;
+			if (directional)
+			{
+				directional.OnRotationChange.RemoveListener(OnDirectionChange);
+			}
+
+			if (integrity)
+			{
+				integrity.OnApplyDamage -= OnDamageReceived;
+			}
 
 			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, TrySpark);
 		}


### PR DESCRIPTION
### Purpose
There were missing null checks for optional refs that caused NRE spam from LightSource OnEnable and OnDisable

### Media Preview:
Before fix:

<img width="531" height="499" alt="LightSourceNRE" src="https://github.com/user-attachments/assets/69186bcc-165a-4c3d-bb14-0d6953efdd3b" />


### Changelog:
CL: [Fix] Prevents NRE for optional Directional / Integrity components on LightSource
