### PR TITLE
Fix EnterTileBase NRE on map load when the object has no Matrix yet

### DIFF
--- a/UnityProject/Assets/Scripts/US13/Objects/EnterTileBase.cs
+++ b/UnityProject/Assets/Scripts/US13/Objects/EnterTileBase.cs
@@ -45,6 +45,7 @@ namespace US13.Objects
 
 		public void OnLocalPositionChangedServer(Vector3Int oldLocalPos, Vector3Int newLocalPos)
 		{
+			if (objectPhysics.registerTile.Matrix == null) return; // not registered to a matrix yet (e.g. during map-load spawn)
 			if (objectPhysics.registerTile.Matrix.MetaTileMap.ObjectLayer.EnterTileBaseList == null) return;
 			if (previousMatrix != null)
 			{


### PR DESCRIPTION
### Purpose
Fixes NRE on map load when the Matrix isn't loaded yet. When the matrix finishes loading, the register fires the event again and the object adds itself to the tile list properly. 

### Media Preview:
Cleans up these error on server load of map: 

<img width="1053" height="241" alt="Screenshot 2026-06-04 190818" src="https://github.com/user-attachments/assets/59c3afac-8d83-4773-85ca-5d31dc4cfad0" />


### Changelog:
CL: [Fix] Fixes NRE in EnterTileBase when map is loading on server
