### PR TITLE
Fix DirectionalPassable NRE on map load when the object has no Matrix yet

### DIFF
--- a/UnityProject/Assets/Scripts/US13/Objects/Directionals/DirectionalPassable.cs
+++ b/UnityProject/Assets/Scripts/US13/Objects/Directionals/DirectionalPassable.cs
@@ -134,12 +134,14 @@ namespace US13.Objects.Directionals
 		private void UpdateSubsystems()
 		{
 			if(ObjectPhysics.HasComponent == false) return;
+			if(Matrix == null) return; // not registered to a matrix yet (e.g. during map load spawn)
 			Matrix.TileChangeManager.SubsystemManager.UpdateAt(ObjectPhysics.Component.OfficialPosition.ToLocalInt(Matrix));
 		}
 
 		private void UpdateSubsystemsAt(Vector3Int localPos)
 		{
 			if(ObjectPhysics.HasComponent == false) return;
+			if(Matrix == null) return; // not registered to a matrix yet (e.g. during map load spawn)
 			Matrix.TileChangeManager.SubsystemManager.UpdateAt(ObjectPhysics.Component.OfficialPosition.ToLocalInt(Matrix));
 		}
 


### PR DESCRIPTION
### Purpose
Fixes NRE on map load when the Matrix isn't loaded yet. When the matrix finishes loading, the register fires the event again and the object updates its subsystems properly.

### Media Preview:
Fixes these NRE's on server: 

<img width="972" height="248" alt="Screenshot 2026-06-04 193952" src="https://github.com/user-attachments/assets/4d61f9d9-da73-4fe3-b73c-f8ef8394dbef" />


### Changelog:
CL: [Fix] Fixed a NullReferenceException in DirectionalPassable during map load on the server
