### PR TITLE
hotfix turret prefabs

### DIFF
--- a/UnityProject/Assets/Prefabs/Objects/Security/BallisticTurret.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Security/BallisticTurret.prefab
@@ -82,6 +82,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1598609385433514140, guid: 24217cb8b2338a3479aaf8d32b727ed1,
         type: 3}
+      propertyPath: defaultProjectile
+      value: 
+      objectReference: {fileID: 5981626483751922999, guid: 40ea4aea218be439eaf29f853612870c,
+        type: 3}
+    - target: {fileID: 1598609385433514140, guid: 24217cb8b2338a3479aaf8d32b727ed1,
+        type: 3}
       propertyPath: fireDelayMultiplier
       value: 3
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/Objects/Security/TurretBase.prefab
+++ b/UnityProject/Assets/Prefabs/Objects/Security/TurretBase.prefab
@@ -508,12 +508,13 @@ MonoBehaviour:
   spawnGun: {fileID: 6733076708105069041, guid: d589c17f6fd91da4190edfdd2cb5aa53,
     type: 3}
   range: 8
-  defaultProjectile: {fileID: 0}
+  defaultProjectile: {fileID: 2404555472885326642, guid: 49a8364f6515be34bac52c48c9214d85,
+    type: 3}
   stunBullet: {fileID: 6809207048716157800, guid: 00552b9802a37ba4bbe1aca46515b240,
     type: 3}
   gunLossChance: 30
   fireDelayMultiplier: 1.5
-  defaultFireDelay: 1
+  defaultFireDelay: 1.5
   stunFireDelay: 1.5
   framePrefab: {fileID: 4949295524855822690, guid: d6457d17134225b4db0c2857b5012c94,
     type: 3}


### PR DESCRIPTION

### Purpose
replaces default bullet fields in the turret prefab tree that got wiped

### Changelog:
n/a