### PR TITLE
Refactor Map Load Save UX/UI and fix bug in PrivateGardening causing NRE

### DIFF
--- a/UnityProject/Assets/Scripts/US13/Core/Editor/Mapping/MapLoadSaveEditor.cs
+++ b/UnityProject/Assets/Scripts/US13/Core/Editor/Mapping/MapLoadSaveEditor.cs
@@ -2,12 +2,12 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEditor;
+using UnityEditor.IMGUI.Controls;
 using UnityEngine;
 using System.IO;
 using System.Linq;
 using Logs;
 using Newtonsoft.Json;
-using SecureStuff;
 using US13.Managers.SubSceneManager;
 using US13.MapSaver;
 using US13.Tilemaps.Behaviours.Layers;
@@ -16,10 +16,31 @@ using Object = UnityEngine.Object;
 
 public class FileSelectorWindow : EditorWindow
 {
-    private string folderPath = "";
-    private string[] fileNames;
-    private string customSavePath = "";
-    private string customJsonInput = "";
+    private string mapsRoot = "";
+    private string roomsRoot = "";
+    private string[] mapFiles = Array.Empty<string>();
+    private string[] roomFiles = Array.Empty<string>();
+    private string searchFilter = "";
+
+    // If loaded from file, stores the active file path for easy saving
+    private string activeFilePath = "";
+
+    // For the paste json field in advanced accordian 
+    private string pasteJson = "";
+
+    private bool showAdvanced = false;
+    private bool showMaps = false;
+    private bool showRooms = false;
+    private bool wasFiltering = false;
+    private Vector2 panelScroll = Vector2.zero;
+    private readonly Color separatorColor = Color.gray;
+    private GUIStyle cardStyle;
+    private GUIStyle listStyle;
+    private SearchField searchField;
+
+    private const string SelectedMap = "SelectedMap";
+    private static bool DeleteMapAfterSave = false;
+    private static bool reCentrePositions = false;
 
     [MenuItem("Mapping/𓃡𓃡 Map Loader Saver Selector 𓃡𓃡")]
     public static void ShowWindow()
@@ -27,230 +48,374 @@ public class FileSelectorWindow : EditorWindow
         GetWindow<FileSelectorWindow>("𓃡𓃡 Map Loader Saver Selector 𓃡𓃡");
     }
 
-    private const string SelectedMap = "SelectedMap";
-    private static bool DeleteMapAfterSave = false;
-    private static bool reCentrePositions = false;
-    private Vector2 scrollPosition = Vector2.zero;
-    private Color separatorColor = Color.gray;
-
     private void OnEnable()
     {
+        mapsRoot = Path.Combine(Application.dataPath, "StreamingAssets/Maps");
+        roomsRoot = Path.Combine(Application.dataPath, "StreamingAssets/Rooms");
         if (EditorPrefs.HasKey(SelectedMap))
         {
             SubSceneManager.AdminForcedMainStation = EditorPrefs.GetString(SelectedMap);
         }
-        folderPath = Path.Combine(Application.dataPath, "StreamingAssets/Maps");
-        if (Directory.Exists(folderPath) == false)
-        {
-            Directory.CreateDirectory(folderPath);
-        }
-        LoadFilesFromFolder();
+        RefreshFileLists();
     }
 
     private void OnGUI()
     {
-        GUILayout.Label("Delete Map After Save ", EditorStyles.boldLabel);
-        DeleteMapAfterSave = GUILayout.Toggle(DeleteMapAfterSave, "Delete Map After Save", GUILayout.Width(200));
-        reCentrePositions = GUILayout.Toggle(reCentrePositions, "Recentre positions (Will cause git conflicts if someone else is working on the map) ", GUILayout.Width(600));
-        GUILayout.Space(10);
-        GUILayout.Label("Standalone Save As", EditorStyles.boldLabel);
-        GUILayout.BeginHorizontal();
-        customSavePath = EditorGUILayout.TextField("Save Path:", customSavePath);
-        if (GUILayout.Button("Browse"))
+        if (cardStyle == null)
         {
-            customSavePath = EditorUtility.SaveFilePanel("Save Map As", folderPath, "map.json", "json");
+            cardStyle = new GUIStyle(EditorStyles.helpBox) { padding = new RectOffset(12, 12, 12, 12) };
+        }
+        if (listStyle == null)
+        {
+            var listTint = new Texture2D(1, 1) { hideFlags = HideFlags.HideAndDontSave };
+            listTint.SetPixel(0, 0, new Color(0f, 0f, 0f, 0.15f));
+            listTint.Apply();
+            listStyle = new GUIStyle(GUIStyle.none) { padding = new RectOffset(6, 6, 6, 6) };
+            listStyle.normal.background = listTint;
+        }
+
+        panelScroll = EditorGUILayout.BeginScrollView(panelScroll);
+
+        GUILayout.BeginHorizontal();
+        GUILayout.Space(20);
+        GUILayout.BeginVertical();
+        GUILayout.Space(20);
+
+        GUILayout.BeginVertical(cardStyle);
+        // Active file
+        GUILayout.Label("Active file", EditorStyles.boldLabel);
+        GUILayout.Label(string.IsNullOrEmpty(activeFilePath)
+            ? "(none - load one below)"
+            : MakeDisplayLabel(activeFilePath));
+
+        GUILayout.BeginHorizontal();
+        using (new EditorGUI.DisabledScope(string.IsNullOrEmpty(activeFilePath)))
+        {
+            if (GUILayout.Button("Save", GUILayout.Width(80)))
+            {
+                SaveToPath(activeFilePath);
+            }
+        }
+        if (GUILayout.Button("Save As...", GUILayout.Width(90)))
+        {
+            string startDir = Directory.Exists(mapsRoot) ? mapsRoot : roomsRoot;
+            string path = EditorUtility.SaveFilePanel("Save Map/Room As", startDir, "map.json", "json");
+            if (string.IsNullOrEmpty(path) == false)
+            {
+                SaveToPath(path);
+            }
         }
         GUILayout.EndHorizontal();
 
-        GUILayout.Label("Custom JSON Input", EditorStyles.boldLabel);
-        customJsonInput = EditorGUILayout.TextArea(customJsonInput, GUILayout.Height(100));
-
-        if (GUILayout.Button("Save As"))
+        GUILayout.Space(4);
+        if (GUILayout.Button("Clear Scene", GUILayout.Width(110)))
         {
-            if (!string.IsNullOrEmpty(customSavePath))
+            if (EditorUtility.DisplayDialog("Clear scene?",
+                "This deletes every root object in the scene. Continue?", "Clear", "Cancel"))
             {
-                Save(customSavePath);
-            }
-            else
-            {
-                EditorUtility.DisplayDialog("Error", "Please specify a valid save path.", "OK");
+                MiscFunctions_RRT.DeleteAllRootGameObjects();
+                activeFilePath = "";
             }
         }
-
-        if (GUILayout.Button("Load Custom JSON"))
-        {
-	        if (!string.IsNullOrEmpty(customJsonInput))
-	        {
-		        Load("");
-	        }
-	        else
-	        {
-		        EditorUtility.DisplayDialog("Error", "Custom JSON input is empty.", "OK");
-	        }
-        }
+        GUILayout.EndVertical();
 
         GUILayout.Space(10);
 
-        if (string.IsNullOrEmpty(folderPath) == false)
+        GUILayout.BeginVertical(cardStyle);
+        // Load a map or room
+        GUILayout.BeginHorizontal();
+        GUILayout.Label("Load a map or room", EditorStyles.boldLabel);
+        if (GUILayout.Button("Browse...", GUILayout.Width(90)))
         {
-            GUILayout.Space(5);
-            if (fileNames != null && fileNames.Length > 0)
+            string startDir = Directory.Exists(roomsRoot) ? roomsRoot : mapsRoot;
+            string path = EditorUtility.OpenFilePanel("Load Map/Room JSON", startDir, "json");
+            if (string.IsNullOrEmpty(path) == false)
             {
-                GUILayout.Label("Files in Folder:", EditorStyles.boldLabel);
-                scrollPosition = EditorGUILayout.BeginScrollView(scrollPosition, GUILayout.Height(500));
-                foreach (string fileName in fileNames)
+                LoadFile(path);
+            }
+        }
+        if (GUILayout.Button("Refresh", GUILayout.Width(70)))
+        {
+            RefreshFileLists();
+        }
+        GUILayout.EndHorizontal();
+        GUILayout.Space(6);
+        GUILayout.BeginHorizontal();
+        GUILayout.FlexibleSpace();
+        GUILayout.Label("Filter:", GUILayout.Width(40));
+        searchField ??= new SearchField();
+        Rect filterRect = GUILayoutUtility.GetRect(250, 18);
+        searchFilter = searchField.OnGUI(filterRect, searchFilter);
+        GUILayout.EndHorizontal();
+
+        GUILayout.BeginVertical(listStyle);
+        var shownMaps = FilterFiles(mapFiles);
+        var shownRooms = FilterFiles(roomFiles);
+        bool filtering = string.IsNullOrWhiteSpace(searchFilter) == false;
+        if (filtering && wasFiltering == false)
+        {
+            showMaps = true;
+            showRooms = true;
+        }
+        wasFiltering = filtering;
+
+        showMaps = EditorGUILayout.Foldout(showMaps, $"Maps ({shownMaps.Length})", true);
+        if (showMaps)
+        {
+            EditorGUILayout.HelpBox("To test a map, tick the checkbox and press play in the editor.", MessageType.None);
+            DrawRows(shownMaps, mapsRoot, showMainStationToggle: true);
+        }
+
+        showRooms = EditorGUILayout.Foldout(showRooms, $"Rooms ({shownRooms.Length})", true);
+        if (showRooms)
+        {
+            DrawRows(shownRooms, roomsRoot, showMainStationToggle: false);
+        }
+        GUILayout.EndVertical();
+        GUILayout.EndVertical();
+
+        GUILayout.Space(8);
+
+        GUILayout.BeginVertical(cardStyle);
+        // Advanced
+        showAdvanced = EditorGUILayout.Foldout(showAdvanced, "Advanced", true);
+        if (showAdvanced)
+        {
+            DeleteMapAfterSave = GUILayout.Toggle(DeleteMapAfterSave, "Delete map from scene after save");
+            reCentrePositions = GUILayout.Toggle(reCentrePositions,
+                "Recentre positions (causes git conflicts if others are editing the map)");
+
+            GUILayout.Space(6);
+            GUILayout.Label("Paste JSON", EditorStyles.boldLabel);
+            pasteJson = EditorGUILayout.TextArea(pasteJson, GUILayout.Height(100));
+            if (GUILayout.Button("Load From Text"))
+            {
+                if (string.IsNullOrEmpty(pasteJson))
                 {
-                    GUILayout.BeginHorizontal();
-                    var relativePath = GetRelativePath(folderPath, fileName);
-                    bool isSelected = (relativePath == EditorPrefs.GetString(SelectedMap, ""));
-                    bool newIsSelected = GUILayout.Toggle(isSelected, "", GUILayout.Width(20));
-
-                    if (newIsSelected != isSelected)
-                    {
-                        if (newIsSelected)
-                        {
-                            EditorPrefs.SetString(SelectedMap, relativePath);
-                        }
-                        else
-                        {
-                            EditorPrefs.DeleteKey(SelectedMap);
-                        }
-                        SubSceneManager.AdminForcedMainStation = EditorPrefs.GetString(SelectedMap);
-                    }
-                    GUILayout.Label(relativePath, GUILayout.Width(380));
-                    if (GUILayout.Button("Save", GUILayout.Width(50)))
-                    {
-	                    if (Save(fileName))
-	                    {
-		                    if (DeleteMapAfterSave)
-		                    {
-			                    MiscFunctions_RRT.DeleteAllRootGameObjects();
-		                    }
-	                    }
-
-                    }
-                    if (GUILayout.Button("Load", GUILayout.Width(50)))
-                    {
-                        Load(fileName);
-                    }
-                    if (GUILayout.Button("Copy Path", GUILayout.Width(80)))
-                    {
-                        EditorGUIUtility.systemCopyBuffer = relativePath;
-                        Debug.Log("Copied relative path to clipboard: " + relativePath);
-                    }
-                    GUILayout.EndHorizontal();
-                    Rect rect = GUILayoutUtility.GetRect(1, 1);
-                    EditorGUI.DrawRect(rect, separatorColor);
+                    EditorUtility.DisplayDialog("Empty", "Paste some JSON first.", "OK");
                 }
-                EditorGUILayout.EndScrollView();
+                else
+                {
+                    LoadFromJson(pasteJson, null);
+                }
+            }
+        }
+        GUILayout.EndVertical();
+
+        GUILayout.EndVertical();
+        GUILayout.Space(20);
+        GUILayout.EndHorizontal();
+
+        EditorGUILayout.EndScrollView();
+    }
+
+    private void DrawRows(string[] files, string root, bool showMainStationToggle)
+    {
+        if (files.Length == 0)
+        {
+            GUILayout.Label("   (none found)", EditorStyles.miniLabel);
+            return;
+        }
+
+        string rootSlash = root.Replace("\\", "/");
+        foreach (string abs in files)
+        {
+            GUILayout.Space(3);
+            GUILayout.BeginHorizontal();
+
+            if (showMainStationToggle)
+            {
+                string rel = abs.Replace("\\", "/");
+                rel = rel.StartsWith(rootSlash) ? rel.Substring(rootSlash.Length + 1) : rel;
+                bool isSelected = rel == EditorPrefs.GetString(SelectedMap, "");
+                bool newSelected = GUILayout.Toggle(isSelected, "", GUILayout.Width(18));
+                if (newSelected != isSelected)
+                {
+                    if (newSelected)
+                    {
+                        EditorPrefs.SetString(SelectedMap, rel);
+                    }
+                    else
+                    {
+                        EditorPrefs.DeleteKey(SelectedMap);
+                    }
+                    SubSceneManager.AdminForcedMainStation = EditorPrefs.GetString(SelectedMap);
+                }
             }
             else
             {
-                GUILayout.Label("No files found in the selected folder.", EditorStyles.wordWrappedLabel);
+                GUILayout.Space(22);
+            }
+
+            GUILayout.Label(MakeDisplayLabel(abs), GUILayout.Width(360));
+            if (GUILayout.Button("Load", GUILayout.Width(50)))
+            {
+                LoadFile(abs);
+            }
+            if (GUILayout.Button("Save", GUILayout.Width(50)))
+            {
+                SaveToPath(abs);
+            }
+            if (GUILayout.Button("Copy Path", GUILayout.Width(80)))
+            {
+                string label = MakeDisplayLabel(abs);
+                EditorGUIUtility.systemCopyBuffer = label;
+                Debug.Log("Copied path: " + label);
+            }
+
+            GUILayout.EndHorizontal();
+            GUILayout.Space(3);
+            Rect rect = GUILayoutUtility.GetRect(1, 1);
+            EditorGUI.DrawRect(rect, separatorColor);
+        }
+    }
+
+    private void LoadFile(string absPath)
+    {
+        LoadFromJson(File.ReadAllText(absPath), absPath);
+    }
+
+    private void LoadFromJson(string json, string sourcePathOrNull)
+    {
+        if (string.IsNullOrEmpty(json))
+        {
+            EditorUtility.DisplayDialog("Nothing to load", "The JSON was empty.", "OK");
+            return;
+        }
+
+        try
+        {
+            MapSaver.CodeClass.ThisCodeClass.Reset();
+            var matricesBeforeLoad = new HashSet<MetaTileMap>(Object.FindObjectsByType<MetaTileMap>(FindObjectsSortMode.None));
+            var mapData = JsonConvert.DeserializeObject<MapSaver.MapData>(json);
+            RunCoroutineInEditor(MapLoader.ServerLoadMap(Vector3.zero, Vector3.zero, mapData));
+            FocusSceneViewOnLoaded(matricesBeforeLoad);
+            activeFilePath = sourcePathOrNull ?? "";
+        }
+        catch (Exception e)
+        {
+            Loggy.Error($"[MapLoadSave] Load failed: {e}");
+            EditorUtility.DisplayDialog("Load failed",
+                $"{e.Message}\n\nSee the Console for the full stack trace.",
+                "OK");
+        }
+    }
+
+    // Play mode ticks coroutines for us; the editor doesn't, so we run this one to completion ourselves.
+    private static void RunCoroutineInEditor(IEnumerator coroutine)
+    {
+        var stack = new Stack<IEnumerator>();
+        stack.Push(coroutine);
+        while (stack.Count > 0)
+        {
+            IEnumerator top = stack.Peek();
+            if (top.MoveNext() == false)
+            {
+                stack.Pop();
+                continue;
+            }
+            if (top.Current is IEnumerator nested)
+            {
+                stack.Push(nested);
             }
         }
     }
 
-    private string GetRelativePath(string basePath, string fullPath)
+    private void FocusSceneViewOnLoaded(HashSet<MetaTileMap> matricesBeforeLoad)
     {
-        basePath = basePath.Replace("\\", "/");
-        fullPath = fullPath.Replace("\\", "/");
-        return fullPath.StartsWith(basePath) ? fullPath.Substring(basePath.Length + 1) : fullPath;
-    }
-    public List<MetaTileMap> SortObjectsByChildIndex(List<MetaTileMap> objects)
-    {
-	    objects.Sort((x, y) => y.transform.parent.GetSiblingIndex().CompareTo(x.transform.parent.GetSiblingIndex()));
-	    return objects;
-    }
+        SceneView view = SceneView.lastActiveSceneView;
+        if (view == null) return;
 
-    private void Load(string filePath)
-    {
-	    MapSaver.CodeClass.ThisCodeClass.Reset();
-	    string data = "";
-	    if (  string.IsNullOrEmpty(filePath) == false)
-	    {
-		    data = AccessFile.Load(filePath, FolderType.Maps);
-	    }
-	    else if ( string.IsNullOrEmpty(customJsonInput) == false)
-	    {
-		    data = customJsonInput;
-	    }
-	    else
-	    {
-		    return;
-	    }
+        var newMatrices = Object.FindObjectsByType<MetaTileMap>(FindObjectsSortMode.None)
+            .Where(m => matricesBeforeLoad.Contains(m) == false)
+            .Select(m => (Object)m.gameObject)
+            .ToArray();
+        if (newMatrices.Length == 0) return;
 
-	    var mapData = JsonConvert.DeserializeObject<MapSaver.MapData>(data);
-	    var Imnum = MapLoader.ServerLoadMap(Vector3.zero, Vector3.zero, mapData);
-	    List<IEnumerator> previousLevels = new List<IEnumerator>();
-	    bool loop = true;
-	    while (loop && previousLevels.Count == 0)
-	    {
-		    if (Imnum.Current is IEnumerator)
-		    {
-			    previousLevels.Add(Imnum);
-			    Imnum = (IEnumerator)Imnum.Current;
-		    }
-		    loop = Imnum.MoveNext();
-		    if (!loop && previousLevels.Count > 0)
-		    {
-			    Imnum = previousLevels[^1];
-			    previousLevels.RemoveAt(previousLevels.Count - 1);
-			    loop = Imnum.MoveNext();
-		    }
-	    }
+        Selection.objects = newMatrices;
+        view.FrameSelected();
     }
 
-
-    private void LoadFilesFromFolder()
+    private string SerializeScene()
     {
-        fileNames = Directory.Exists(folderPath)
-            ? Directory.GetFiles(folderPath, "*.*", SearchOption.AllDirectories).Where(x => !x.EndsWith(".meta")).ToArray()
-            : new string[0];
+        var mapMatrices = Object.FindObjectsByType<MetaTileMap>(FindObjectsSortMode.None).ToList();
+        if (mapMatrices.Count == 0)
+        {
+            EditorUtility.DisplayDialog("Nothing to save", "No matrices found in the scene. Load a map/room first.", "OK");
+            return null;
+        }
+        mapMatrices = SortMatricesForSave(mapMatrices);
+        mapMatrices.Reverse();
+        var settings = new JsonSerializerSettings
+        {
+            NullValueHandling = NullValueHandling.Ignore,
+            DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
+            Formatting = Formatting.Indented
+        };
+        var map = MapSaver.SaveMap(mapMatrices, false, mapMatrices[0].name, ReadjustCentre: reCentrePositions);
+        return JsonConvert.SerializeObject(map, settings);
     }
 
-    private bool Save(string filePath)
+    private bool SaveToPath(string absPath)
     {
         try
         {
-	        if (string.IsNullOrEmpty(customJsonInput))
-	        {
-		        var mapMatrices = Object.FindObjectsByType<MetaTileMap>(FindObjectsSortMode.None).ToList();
-		        mapMatrices = SortObjectsByChildIndex(mapMatrices);
-		        if (mapMatrices.Count == 0)
-		        {
-			        Loggy.Error($"No maps found for Save {filePath}");
-			        return false;
-		        }
-		        mapMatrices.Reverse();
-		        JsonSerializerSettings settings = new JsonSerializerSettings
-		        {
-			        NullValueHandling = NullValueHandling.Ignore,
-			        DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
-			        Formatting = Formatting.Indented
-		        };
-		        var map = MapSaver.SaveMap(mapMatrices, false, mapMatrices[0].name, ReadjustCentre : reCentrePositions);
-		        string jsonToSave = JsonConvert.SerializeObject(map, settings);
-		        AccessFile.Save(filePath, jsonToSave, FolderType.Maps);
-		        EditorUtility.DisplayDialog("Save Complete", $"Map saved successfully to {filePath}.", "OK");
-	        }
-	        else
-	        {
-		        string jsonToSave = customJsonInput;
-		        AccessFile.Save(filePath, jsonToSave, FolderType.Maps);
-		        EditorUtility.DisplayDialog("Save Complete", $"Map saved successfully to {filePath}.", "OK");
-	        }
+            string json = SerializeScene();
+            if (json == null) return false;
+            File.WriteAllText(absPath, json);
+            EditorUtility.DisplayDialog("Save Complete", $"Saved to {MakeDisplayLabel(absPath)}", "OK");
 
-
-
-
+            if (DeleteMapAfterSave)
+            {
+                MiscFunctions_RRT.DeleteAllRootGameObjects();
+                activeFilePath = "";
+            }
+            else
+            {
+                activeFilePath = absPath;
+            }
+            return true;
         }
         catch (Exception e)
         {
-            Loggy.Error(e.ToString());
+            Loggy.Error($"[MapLoadSave] Save failed: {e}");
+            EditorUtility.DisplayDialog("Save failed", e.Message, "OK");
             return false;
         }
+    }
 
-        return true;
+    private void RefreshFileLists()
+    {
+        mapFiles = ListJsonFiles(mapsRoot);
+        roomFiles = ListJsonFiles(roomsRoot);
+    }
+
+    private static string[] ListJsonFiles(string root)
+    {
+        return Directory.Exists(root)
+            ? Directory.GetFiles(root, "*.json", SearchOption.AllDirectories)
+            : Array.Empty<string>();
+    }
+
+    private string[] FilterFiles(string[] files)
+    {
+        if (string.IsNullOrWhiteSpace(searchFilter)) return files;
+        return files.Where(f => MakeDisplayLabel(f).IndexOf(searchFilter, StringComparison.OrdinalIgnoreCase) >= 0).ToArray();
+    }
+
+    private string MakeDisplayLabel(string absPath)
+    {
+        string path = absPath.Replace("\\", "/");
+        string maps = mapsRoot.Replace("\\", "/");
+        string rooms = roomsRoot.Replace("\\", "/");
+        if (path.StartsWith(maps)) return "Maps/" + path.Substring(maps.Length + 1);
+        if (path.StartsWith(rooms)) return "Rooms/" + path.Substring(rooms.Length + 1);
+        return absPath;
+    }
+
+    public List<MetaTileMap> SortMatricesForSave(List<MetaTileMap> matrices)
+    {
+        matrices.Sort((x, y) => y.transform.parent.GetSiblingIndex().CompareTo(x.transform.parent.GetSiblingIndex()));
+        return matrices;
     }
 }

--- a/UnityProject/Assets/StreamingAssets/Rooms/Backrooms/9x9/9x9PrivateGarden.json
+++ b/UnityProject/Assets/StreamingAssets/Rooms/Backrooms/9x9/9x9PrivateGarden.json
@@ -999,6 +999,10 @@
                     {
                       "Name": "poolList#0@probability",
                       "Data": "100"
+                    },
+                    {
+                      "Name": "poolList#0@randomItemPool",
+                      "Data": "4047f716f0417761caa37e39371cbb26"
                     }
                   ]
                 }


### PR DESCRIPTION
Refactors the UI and UX of Map Load Save Selector:

Before:

<img width="487" height="1332" alt="Screenshot_2026-06-10_204607" src="https://github.com/user-attachments/assets/2a4b1044-b180-4b88-93cd-4811abdf6a3b" />

After:

<img width="557" height="485" alt="image1" src="https://github.com/user-attachments/assets/e0585a55-16b5-4666-a352-8f12982a6124" />
<img width="1105" height="871" alt="image2" src="https://github.com/user-attachments/assets/0cd2da28-ec8e-455a-91dc-70a00b9ba792" />

Also fixed missing Item Pool in random spawn populator in 9x9 Private Garden room:

<img width="1155" height="103" alt="Screenshot 2026-06-09 161218" src="https://github.com/user-attachments/assets/9e54e71f-4842-46f0-a3e8-66af5248f21f" />

<img width="2125" height="1335" alt="Screenshot 2026-06-10 203611" src="https://github.com/user-attachments/assets/867ae322-71b7-4202-a164-3363b4c4da5c" />

fix:

<img width="469" height="553" alt="Screenshot 2026-06-10 203845" src="https://github.com/user-attachments/assets/e90265d9-24ce-412a-9361-ca7d4d266818" />


### Purpose

Cleaned up Map Load Save Selector UI, Logic and make UX easier to use. Adds room list, separates toolsets into sections and adds filter, browse file picker (for maps shared outside of the project) and helpful save, 'save as' and hints (tells user about the checkboxes).


### Changelog:

CL: [Improvement] Improves the Editor Map Load Save Selector tool
CL: [Fix] Fixes missing Random Item Pool List in Random Item Spot behind the tree on 9x9PrivateGarden room
