### PR TITLE
Fix semi transparent sprites rendering as space background

### DIFF
--- a/UnityProject/Assets/Shaders/Post Process/PostProcess MaskBlit.shader
+++ b/UnityProject/Assets/Shaders/Post Process/PostProcess MaskBlit.shader
@@ -67,8 +67,8 @@
 			
 				fixed4 screen = tex2D(_MainTex, i.uv);
 				fixed4 Item = tex2D(_ItemTex, i.uv);
-				fixed hasData = step(0.0001, Item.a); 
-				screen = lerp(screen, Item, hasData);
+				screen.rgb = Item.rgb + screen.rgb * (1 - Item.a);
+				screen.a = saturate(Item.a + screen.a * (1 - Item.a));
 				// Mix Background.
 				half4 background = tex2D(_BackgroundTex, i.uv);
 				//return  tex2D(_MainTex, i.uv);


### PR DESCRIPTION
### Purpose
Swapped the all or nothing lerp for a premultipled alpha blend instead. So transparency stays transparent

before:
<img width="270" height="175" alt="problemglass" src="https://github.com/user-attachments/assets/70659082-c0ed-4a4d-8e10-fc20584ae648" />
<img width="330" height="278" alt="Screenshot 2026-06-13 102426" src="https://github.com/user-attachments/assets/611b8628-6257-4dfe-ac71-934d43da7cb6" />

after:

<img width="391" height="386" alt="Screenshot 2026-06-13 104358" src="https://github.com/user-attachments/assets/ea97f2ef-6915-48bf-ae6b-d5b0c9d2f3da" />


### Changelog:

CL: [Fix] Fixed semi transparent sprites rendering as space background
