### PR TITLE
Unhides chat on Pre Round Screen

### DIFF
--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/Windows/PreRoundScreen.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/CharacterCreator/SubUIElement/BodyPartCustomisation/Windows/PreRoundScreen.prefab
@@ -3985,6 +3985,7 @@ GameObject:
   - component: {fileID: 4821460536245207876}
   - component: {fileID: 6853612580900143552}
   - component: {fileID: 1798230113292392315}
+  - component: {fileID: 7245233231129475666}
   m_Layer: 5
   m_Name: SpaceBackground
   m_TagString: Untagged
@@ -4049,6 +4050,29 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!223 &7245233231129475666
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8031651130529517169}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 1
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: -200
+  m_TargetDisplay: 0
 --- !u!1 &8292547159771038571
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
### Purpose
Pushed Preround BG to the back:

<img width="701" height="398" alt="Screenshot 2026-06-21 114526" src="https://github.com/user-attachments/assets/8ab247f1-e38d-41ab-bc22-22000f659f98" />

### Changelog:
CL: [Fix] Unhides the chat in Pre Round Screen
