### PR TITLE
More robust hover tooltip

### DIFF
--- a/UnityProject/Assets/Scripts/US13/UI/Core/Tooltip.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Core/Tooltip.cs
@@ -76,7 +76,7 @@ namespace US13.UI.Core
 		public void OnPointerEnter(PointerEventData eventData)
 		{
 			enterTime = Time.realtimeSinceStartup;
-			UIManager.Instance.HoverTooltipUI.SetupTooltip(gameObject, false);
+			UIManager.Instance.HoverTooltipUI.SetupTooltip(gameObject);
 		}
 
 		public void OnPointerExit(PointerEventData eventData)

--- a/UnityProject/Assets/Scripts/US13/UI/Systems/Tooltips/HoverTooltips/HoverTooltipUI.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Systems/Tooltips/HoverTooltips/HoverTooltipUI.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+using Cysharp.Threading.Tasks;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -30,8 +32,6 @@ namespace US13.UI.Systems.Tooltips.HoverTooltips
 
 		public float HoverDelay { get; set; } = 0.08f;
 
-
-		private GameObject targetObject;
 		private GameObject CurrentlyOverObject;
 
 		public GameObject CurrentlyOverObjectPub => CurrentlyOverObject;
@@ -40,14 +40,14 @@ namespace US13.UI.Systems.Tooltips.HoverTooltips
 
 		private const float MOUSE_OFFSET_Y = -105f;
 		private const float MOUSE_OFFSET_X = -125f;
-		private const float ANIM_SPEED = 4.5f;
+		private const float ANIM_SPEED = 16.5f;
 		private const float FULLY_VISIBLE_ALPHA = 0.99f;
 		private const float DEFAULT_HOVER_DELAY = 0.25f;
 
-		private bool animating = false;
 		private bool showing = false;
-		private GameObject showingcurrently = null;
 		private RectTransform contentRect;
+
+		private StringBuilder advancedText = new StringBuilder();
 
 		private void Awake()
 		{
@@ -98,22 +98,23 @@ namespace US13.UI.Systems.Tooltips.HoverTooltips
 			detailsModeEnabled = CommonInput.GetKeyDown(KeyCode.LeftShift);
 			if (detailsModeEnabled && CurrentlyOverObject != null)
 			{
-				SetupTooltip(CurrentlyOverObject, true);
+				SetupTooltip(CurrentlyOverObject);
 			}
 
 			if (CommonInput.GetKeyDown(KeyCode.Escape))
 			{
-				showing = false;
+				ResetTool();
 			}
 		}
 
-		public void SetupTooltip(GameObject hoverObject, bool SkipWaiting)
+		public void SetupTooltip(GameObject hoverObject)
 		{
 			CurrentlyOverObject = hoverObject;
 
 			if (CurrentlyOverObject == null)
 			{
 				showing = false;
+				ResetTool();
 				return;
 			}
 
@@ -121,17 +122,7 @@ namespace US13.UI.Systems.Tooltips.HoverTooltips
 			if (ProtipManager.Instance.PlayerExperienceLevel >= ProtipManager.ExperienceLevel.SomewhatExperienced
 			    && detailsModeEnabled == false) return;
 
-
-			if (SkipWaiting)
-			{
-				QueueTip(hoverObject);
-			}
-			else
-			{
-				StartCoroutine(WaitShowTooltip(hoverObject));
-			}
-
-
+			Setup(CurrentlyOverObject);
 		}
 
 		/// <summary>
@@ -197,8 +188,9 @@ namespace US13.UI.Systems.Tooltips.HoverTooltips
 		/// </summary>
 		private void UpdateDetailedView(GameObject target)
 		{
+			advancedText.Clear();
 			var tips = target.GetComponents<IHoverTooltip>();
-			descText.text = "";
+			advancedText.Append(descText.text);
 			foreach (var data in tips)
 			{
 				if (String.IsNullOrEmpty(data.CustomTitle()) == false) nameText.text = data.CustomTitle();
@@ -206,9 +198,9 @@ namespace US13.UI.Systems.Tooltips.HoverTooltips
 				{
 					// if description is empty, don't create extra lines.
 					// if description has text, separate new data away from the previous ones.
-					descText.text = string.IsNullOrWhiteSpace(descText.text)
-						? descText.text += $"{data.HoverTip()}"
-						: descText.text += $"\n \n{data.HoverTip()}";
+					advancedText.AppendLine(string.IsNullOrWhiteSpace(advancedText.ToString())
+						? data.HoverTip()
+						: $"\n \n{data.HoverTip()}");
 				}
 				UpdateIconSprite(data);
 				// Only show interactions if there is a description or title in the tooltip.
@@ -250,8 +242,7 @@ namespace US13.UI.Systems.Tooltips.HoverTooltips
 		{
 			ResetInteractionsList();
 			showing = false;
-			showingcurrently = null;
-			StartCoroutine(AnimateBackground());
+			AnimateBackground();
 		}
 
 		private void ResetInteractionsList()
@@ -265,7 +256,6 @@ namespace US13.UI.Systems.Tooltips.HoverTooltips
 
 		private void Setup(GameObject target)
 		{
-			targetObject = target;
 			// Clean up everything for the upcoming data.
 			ResetTool();
 
@@ -282,54 +272,15 @@ namespace US13.UI.Systems.Tooltips.HoverTooltips
 			// Don't show if the description/name is empty.
 			// (Max): It looks better and more intentional when there's no empty fields.
 			// Also reduces hovertip presence on the screen when its not needed.
-			if (IsDescOrTitleEmpty()) return;
+			if (IsDescOrTitleEmpty() && detailsModeEnabled == false) return;
 			if (iconTarget.sprite == null) iconTarget.sprite = errorIconSprite;
 			showing = true;
-			showingcurrently = target;
-			StartCoroutine(AnimateBackground());
+			AnimateBackground();
 		}
 
-		private IEnumerator AnimateBackground()
+		private void AnimateBackground()
 		{
-			if (animating) yield break;
-			if (string.IsNullOrEmpty(descText.text))
-			{
-				showing = false;
-				showingcurrently = null;
-			}
-
-			animating = true;
-
-			while ((showing && content.alpha < FULLY_VISIBLE_ALPHA) || (showing == false && content.alpha > 0.0001f))
-			{
-				yield return WaitFor.EndOfFrame;
-				content.alpha = Mathf.Lerp(content.alpha, showing ? FULLY_VISIBLE_ALPHA : 0f,
-					ANIM_SPEED * Time.deltaTime);
-				content.alpha = Mathf.Clamp(content.alpha, 0f, FULLY_VISIBLE_ALPHA);
-			}
-
-			animating = false;
-			if (showing == false)
-			{
-				showingcurrently = null;
-				iconTarget.sprite = errorIconSprite;
-				nameText.text = string.Empty;
-				descText.text = string.Empty;
-			}
-		}
-
-		private IEnumerator WaitShowTooltip(GameObject queuedObject)
-		{
-			yield return WaitFor.Seconds(HoverDelay);
-			if (showing) yield break;
-			if (queuedObject != CurrentlyOverObject) yield break;
-			QueueTip(queuedObject);
-		}
-
-		private void QueueTip(GameObject queuedObject)
-		{
-			if (showingcurrently == queuedObject && animating == false) return;
-			Setup(queuedObject);
+			content.alpha = showing ? FULLY_VISIBLE_ALPHA : 0f;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/US13/UI/Systems/Tooltips/HoverTooltips/HoverTooltipUI.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Systems/Tooltips/HoverTooltips/HoverTooltipUI.cs
@@ -40,7 +40,6 @@ namespace US13.UI.Systems.Tooltips.HoverTooltips
 
 		private const float MOUSE_OFFSET_Y = -105f;
 		private const float MOUSE_OFFSET_X = -125f;
-		private const float ANIM_SPEED = 16.5f;
 		private const float FULLY_VISIBLE_ALPHA = 0.99f;
 		private const float DEFAULT_HOVER_DELAY = 0.25f;
 

--- a/UnityProject/Assets/Scripts/US13/UI/Systems/UIManager.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Systems/UIManager.cs
@@ -273,7 +273,7 @@ namespace US13.UI.Systems
 			set
 			{
 				if (Instance.HoverTooltipUI == null) return;
-				Instance.hoverTooltipUI.SetupTooltip(value, false);
+				Instance.hoverTooltipUI.SetupTooltip(value);
 			}
 		}
 


### PR DESCRIPTION
Been wanting to tackle this issue for a while.
The hover tooltip now has less edge-cases where it might feel unreliable or clunky, especially when dealing with the detailed mode.

## Note

I removed animations in this PR for the time being, as I noticed that they were buggy whenever we increased the speed of them; and they also broke whenever a sudden frame drop occurred for some reason.

They will be added back once #11295 's prerequisites have been whitelisted, and that PR is merged.

## Changelog

CL: [Fix] Fixed an issue where hover tooltips would randomly disappear when attempting to show extra details regarding an object due an empty string overriding an object's description.
CL: [Fix] Fixed an issue where updating a large amount of strings in hover tooltips at a time would cause a small hiccup.
CL: [Fix] Fixed an issue where the hover tooltip would refuse to hide itself when passing a `null` `gameobject`.
CL: [Fix] Fixed several issues related to the hover tooltip's "queue" system for displaying information by simply removing said queue system. All info will now be processed immediately as soon as the mouse points towards an object that has info for the hover tooltip to read.