### PR TITLE
Coffee, Tea, Stimulants now provide speed boost same as nicotine previously would

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/PackagedSnacks/HighPowerEnergyBars.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/PackagedSnacks/HighPowerEnergyBars.prefab
@@ -21,19 +21,19 @@ PrefabInstance:
     - target: {fileID: 275102857289942383, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
       propertyPath: 'initialReagentMix.reagents.m_keys.Array.data[0]'
-      value: 
+      value:
       objectReference: {fileID: 11400000, guid: 068bcb587110477558045ad0cfd78237,
         type: 2}
     - target: {fileID: 275102857289942383, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
       propertyPath: 'initialReagentMix.reagents.m_keys.Array.data[1]'
-      value: 
+      value:
       objectReference: {fileID: 11400000, guid: 19dc4d448d12cf6a5afec364347f7131,
         type: 2}
     - target: {fileID: 275102857289942383, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
       propertyPath: 'initialReagentMix.reagents.m_keys.Array.data[2]'
-      value: 
+      value:
       objectReference: {fileID: 11400000, guid: b9bdb0acb54b8dc40837f92c2e7819a6,
         type: 2}
     - target: {fileID: 275102857289942383, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
@@ -54,7 +54,7 @@ PrefabInstance:
     - target: {fileID: 1155915217242832539, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
       propertyPath: m_Sprite
-      value: 
+      value:
       objectReference: {fileID: 21300000, guid: 1170cc01e3d8403419af465cdffbdbcb,
         type: 3}
     - target: {fileID: 1155915217242832539, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
@@ -146,7 +146,7 @@ PrefabInstance:
     - target: {fileID: 5169367590891271744, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
       propertyPath: PresentSpriteSet
-      value: 
+      value:
       objectReference: {fileID: 11400000, guid: 726a1555e8dd43c498b2efeba7d7d0f2,
         type: 2}
     - target: {fileID: 5350820327707673002, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
@@ -162,7 +162,7 @@ PrefabInstance:
     - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
       propertyPath: leavings
-      value: 
+      value:
       objectReference: {fileID: 4043713673800239651, guid: 01b4b07fc0f73fc489e41d12542d7ad0,
         type: 3}
     - target: {fileID: 7146114630749491127, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
@@ -178,5 +178,43 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1367782950990450119, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 5801753955470824412}
   m_SourcePrefab: {fileID: 100100000, guid: eaf8c1f2a0f9374488e16061fd5b4dcd, type: 3}
+--- !u!1 &6537940584556041691 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1367782950990450119, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1362595067615589157}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &5801753955470824412
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6537940584556041691}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7b4b4c5e337c48f0b597170a20b66351, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Assets::US13.Items.Food.EffectOnConsumed
+  consumptionEffect:
+    rid: 1972607369206075392
+  condition:
+    rid: 1972607369206075393
+  references:
+    version: 2
+    RefIds:
+    - rid: 1972607369206075392
+      type: {class: ApplyStatusEffect, ns: US13.Items.Food.ConsumptionEffect,
+        asm: Assets}
+      data:
+        statusEffect: {fileID: 11400000, guid: 48a6a8b7f4d1b3549b27fb369c9d3630, type: 2}
+    - rid: 1972607369206075393
+      type: {class: AlwaysTrue, ns: US13.Items.Food.ConsumptionEffect.Conditions,
+        asm: Assets}
+      data: {}

--- a/UnityProject/Assets/Prefabs/Items/Food/Snacks/PackagedSnacks/HighPowerEnergyBars.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Snacks/PackagedSnacks/HighPowerEnergyBars.prefab
@@ -11,12 +11,12 @@ PrefabInstance:
     - target: {fileID: 275102857289942383, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
       propertyPath: initialReagentMix.reagents.m_keys.Array.size
-      value: 2
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 275102857289942383, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
       propertyPath: initialReagentMix.reagents.m_values.Array.size
-      value: 2
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 275102857289942383, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
@@ -38,6 +38,12 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 275102857289942383, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
+      propertyPath: 'initialReagentMix.reagents.m_keys.Array.data[3]'
+      value:
+      objectReference: {fileID: 11400000, guid: 6c9b1f701ba4476c895153c0d29eaef1,
+        type: 2}
+    - target: {fileID: 275102857289942383, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
       propertyPath: 'initialReagentMix.reagents.m_values.Array.data[0]'
       value: 10
       objectReference: {fileID: 0}
@@ -49,6 +55,11 @@ PrefabInstance:
     - target: {fileID: 275102857289942383, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
       propertyPath: 'initialReagentMix.reagents.m_values.Array.data[2]'
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 275102857289942383, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
+      propertyPath: 'initialReagentMix.reagents.m_values.Array.data[3]'
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1155915217242832539, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
@@ -178,43 +189,5 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 1367782950990450119, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 5801753955470824412}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: eaf8c1f2a0f9374488e16061fd5b4dcd, type: 3}
---- !u!1 &6537940584556041691 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1367782950990450119, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1362595067615589157}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &5801753955470824412
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6537940584556041691}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7b4b4c5e337c48f0b597170a20b66351, type: 3}
-  m_Name:
-  m_EditorClassIdentifier: Assets::US13.Items.Food.EffectOnConsumed
-  consumptionEffect:
-    rid: 1972607369206075392
-  condition:
-    rid: 1972607369206075393
-  references:
-    version: 2
-    RefIds:
-    - rid: 1972607369206075392
-      type: {class: ApplyStatusEffect, ns: US13.Items.Food.ConsumptionEffect,
-        asm: Assets}
-      data:
-        statusEffect: {fileID: 11400000, guid: 48a6a8b7f4d1b3549b27fb369c9d3630, type: 2}
-    - rid: 1972607369206075393
-      type: {class: AlwaysTrue, ns: US13.Items.Food.ConsumptionEffect.Conditions,
-        asm: Assets}
-      data: {}

--- a/UnityProject/Assets/Resources/ScriptableObjectsSingletons/ChemistryReagentsSO.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjectsSingletons/ChemistryReagentsSO.asset
@@ -11,7 +11,7 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c0111dbbbed21d7429ee6cd911a65063, type: 3}
   m_Name: ChemistryReagentsSO
-  m_EditorClassIdentifier: 
+  m_EditorClassIdentifier:
   allChemistryReactions:
   - {fileID: 11400000, guid: f3ba7bddff4c38246b1350bf8f908e24, type: 2}
   - {fileID: 11400000, guid: ac0c760ad1cbab341b756545ba0586a4, type: 2}
@@ -644,6 +644,8 @@ MonoBehaviour:
   - {fileID: 11400000, guid: d10d069810b9336459753192798c76de, type: 2}
   - {fileID: 11400000, guid: ac6db1f6d519e5947963c4fdfc8e41de, type: 2}
   - {fileID: 11400000, guid: 412f43e1894160941b050da38c427852, type: 2}
+  - {fileID: 11400000, guid: 74e4cd255d9f4589958b73536d957b20, type: 2}
+  - {fileID: 11400000, guid: 4a965ae1a6514e84ab431715a00d5a4f, type: 2}
   allChemistryReagents:
   - {fileID: 11400000, guid: 8f0919186512e2b00840bdfc242942ff, type: 2}
   - {fileID: 11400000, guid: e312e3786cf8d78b4bbcfebd67af0394, type: 2}

--- a/UnityProject/Assets/Resources/ScriptableObjectsSingletons/ChemistryReagentsSO.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjectsSingletons/ChemistryReagentsSO.asset
@@ -1195,3 +1195,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: af0b3c550afbc3a428e581f7c1de2b49, type: 2}
   - {fileID: 11400000, guid: c7943c0995bc04a49b55b22064796666, type: 2}
   - {fileID: 11400000, guid: efcde740e9b85074485bcd68a7a21816, type: 2}
+  - {fileID: 11400000, guid: 6c9b1f701ba4476c895153c0d29eaef1, type: 2}

--- a/UnityProject/Assets/Resources/ScriptableObjectsSingletons/SOListTracker.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjectsSingletons/SOListTracker.asset
@@ -26024,3 +26024,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 1f9843f716e40fb4187e3ecde15d87b3, type: 2}
   - {fileID: 11400000, guid: 01bd1367ae0668b48b7dfef3135c9180, type: 2}
   - {fileID: 11400000, guid: 58abfc11d31324549a8595d74e115da8, type: 2}
+  - {fileID: 11400000, guid: 6c9b1f701ba4476c895153c0d29eaef1, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Body/Stimulants.meta
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Body/Stimulants.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6e493220c48c40f1b16ff42f4ece7db4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Body/Stimulants/MildStimulantSpeedBuffInBody.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Body/Stimulants/MildStimulantSpeedBuffInBody.asset
@@ -69,3 +69,4 @@ MonoBehaviour:
         - {fileID: 11400000, guid: 6dc89dd45738abb8a9ae8dca983117c0, type: 2}
         - {fileID: 11400000, guid: 0e96499412043fd0d8f15356181fe4e4, type: 2}
         - {fileID: 11400000, guid: 91292827578c6a412a0ff15d395e5644, type: 2}
+        - {fileID: 11400000, guid: 6c9b1f701ba4476c895153c0d29eaef1, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Body/Stimulants/MildStimulantSpeedBuffInBody.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Body/Stimulants/MildStimulantSpeedBuffInBody.asset
@@ -1,0 +1,71 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ef6278fc0e64a44a819cfe1f19dcd7b, type: 3}
+  m_Name: MildStimulantSpeedBuffInBody
+  m_EditorClassIdentifier:
+  ingredients:
+    m_keys: []
+    m_values:
+  useExactAmounts: 0
+  MinimumReactionMultiple: 0
+  catalysts:
+    m_keys: []
+    m_values:
+  inhibitors:
+    m_keys: []
+    m_values:
+  hasMinTemp: 0
+  serializableTempMin: 0
+  hasMaxTemp: 0
+  serializableTempMax: 0
+  results:
+    m_keys: []
+    m_values:
+  effectDict:
+    m_keys: []
+    m_values:
+  overrideDisplayName:
+  indexInSingleton: 632
+  ReagentMetabolismMultiplier: 1056
+  InternalAllRequired:
+  - {fileID: 11400000, guid: cf7011331adb47d4880a8f62edf3259d, type: 2}
+  InternalBlacklist: []
+  ExternalAllRequired: []
+  ExternalBlacklist: []
+  StatusEffect: {fileID: 11400000, guid: 48a6a8b7f4d1b3549b27fb369c9d3630, type: 2}
+  SuppressedByStatusEffect: {fileID: 11400000, guid: 5e997c1e4ed04f139ff464f42fb117c4, type: 2}
+  StatusEffectToRemove: {fileID: 0}
+  ReagentSelector:
+    rid: 7515026803575582720
+  references:
+    version: 2
+    RefIds:
+    - rid: 7515026803575582720
+      type: {class: AnyStatusMetabolismReagentSelector, ns: US13.HealthV2.Living.MedicalChemistry,
+        asm: Assets}
+      data:
+        Reagents:
+        - {fileID: 11400000, guid: c4e931cdd4b041652928e77065466e6b, type: 2}
+        - {fileID: 11400000, guid: 1e2d4d88ed57165429f6d1c7504bfd20, type: 2}
+        - {fileID: 11400000, guid: 7536c223a16702e289aa3b3f8a3ebc5a, type: 2}
+        - {fileID: 11400000, guid: a018c2f176e4a2176bb2f1d68584a43f, type: 2}
+        - {fileID: 11400000, guid: b46d5003ce5ab0c92b12a37f0abc0729, type: 2}
+        - {fileID: 11400000, guid: c3fb52f17c08cfaa69455872a8a914a6, type: 2}
+        - {fileID: 11400000, guid: 3c669a10bb075500cb56deab0bc1132e, type: 2}
+        - {fileID: 11400000, guid: 7fdeef4c21d582c488b55beacb5d2f7c, type: 2}
+        - {fileID: 11400000, guid: 94c3837ba3b730aaba45772b8958ac9e, type: 2}
+        - {fileID: 11400000, guid: 535589886f5f3b7a78d7f0a9797c0c4d, type: 2}
+        - {fileID: 11400000, guid: b4e411ff6e81467ca98865a7783dc805, type: 2}
+        - {fileID: 11400000, guid: d8b9bc35821b330168e659473e685d14, type: 2}
+        - {fileID: 11400000, guid: 6dc89dd45738abb8a9ae8dca983117c0, type: 2}
+        - {fileID: 11400000, guid: 0e96499412043fd0d8f15356181fe4e4, type: 2}
+        - {fileID: 11400000, guid: 91292827578c6a412a0ff15d395e5644, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Body/Stimulants/MildStimulantSpeedBuffInBody.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Body/Stimulants/MildStimulantSpeedBuffInBody.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4a965ae1a6514e84ab431715a00d5a4f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Body/Stimulants/StrongStimulantSpeedBuffInBody.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Body/Stimulants/StrongStimulantSpeedBuffInBody.asset
@@ -1,0 +1,59 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ef6278fc0e64a44a819cfe1f19dcd7b, type: 3}
+  m_Name: StrongStimulantSpeedBuffInBody
+  m_EditorClassIdentifier:
+  ingredients:
+    m_keys: []
+    m_values:
+  useExactAmounts: 0
+  MinimumReactionMultiple: 0
+  catalysts:
+    m_keys: []
+    m_values:
+  inhibitors:
+    m_keys: []
+    m_values:
+  hasMinTemp: 0
+  serializableTempMin: 0
+  hasMaxTemp: 0
+  serializableTempMax: 0
+  results:
+    m_keys: []
+    m_values:
+  effectDict:
+    m_keys: []
+    m_values:
+  overrideDisplayName:
+  indexInSingleton: 631
+  ReagentMetabolismMultiplier: 1056
+  InternalAllRequired:
+  - {fileID: 11400000, guid: cf7011331adb47d4880a8f62edf3259d, type: 2}
+  InternalBlacklist: []
+  ExternalAllRequired: []
+  ExternalBlacklist: []
+  StatusEffect: {fileID: 11400000, guid: 5e997c1e4ed04f139ff464f42fb117c4, type: 2}
+  SuppressedByStatusEffect: {fileID: 0}
+  StatusEffectToRemove: {fileID: 11400000, guid: 48a6a8b7f4d1b3549b27fb369c9d3630, type: 2}
+  ReagentSelector:
+    rid: 7515026803575582721
+  references:
+    version: 2
+    RefIds:
+    - rid: 7515026803575582721
+      type: {class: AnyStatusMetabolismReagentSelector, ns: US13.HealthV2.Living.MedicalChemistry,
+        asm: Assets}
+      data:
+        Reagents:
+        - {fileID: 11400000, guid: dec2c3059cbf02729b69145c8de2b675, type: 2}
+        - {fileID: 11400000, guid: db363ffe5591b1f88bf526b6762e3129, type: 2}
+        - {fileID: 11400000, guid: 61cf9c4a2f0e886ea912d0c18998db21, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Body/Stimulants/StrongStimulantSpeedBuffInBody.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reactions/Body/Stimulants/StrongStimulantSpeedBuffInBody.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 74e4cd255d9f4589958b73536d957b20
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Food/EnergyBarStimulant.asset
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Food/EnergyBarStimulant.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1916b10721f72c927a14093e8210cb3f, type: 3}
+  m_Name: EnergyBarStimulant
+  m_EditorClassIdentifier:
+  foreverID: Energy Bar Stimulant
+  displayName: Energy Bar Stimulant
+  description: A concentrated stimulant found in high-power energy bars.
+  color: {r: 0.9529412, g: 0.60784316, b: 0.011764706, a: 1}
+  state: 0
+  heatDensity: 5
+  indexInSingleton: 548

--- a/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Food/EnergyBarStimulant.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Chemistry/Reagents/Food/EnergyBarStimulant.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6c9b1f701ba4476c895153c0d29eaef1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/UnityProject/Assets/ScriptableObjects/Statuses/Strong Speed Buff.asset
+++ b/UnityProject/Assets/ScriptableObjects/Statuses/Strong Speed Buff.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0252d5d29a9d409981dc50b18744f77c, type: 3}
+  m_Name: Strong Speed Buff
+  m_EditorClassIdentifier:
+  duration: 45
+  Buff: 1.5
+  SpeedBuffAlert: {fileID: 11400000, guid: 4ad76f5ab439fb04dad532963740aef2, type: 2}

--- a/UnityProject/Assets/ScriptableObjects/Statuses/Strong Speed Buff.asset.meta
+++ b/UnityProject/Assets/ScriptableObjects/Statuses/Strong Speed Buff.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5e997c1e4ed04f139ff464f42fb117c4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/UnityProject/Assets/ScriptableObjects/mutationss/metabolism sets/DefaultMetabolismReactionSet.asset
+++ b/UnityProject/Assets/ScriptableObjects/mutationss/metabolism sets/DefaultMetabolismReactionSet.asset
@@ -11,7 +11,7 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 75c44e1b236cd904bb883f09b9b80f68, type: 3}
   m_Name: DefaultMetabolismReactionSet
-  m_EditorClassIdentifier: 
+  m_EditorClassIdentifier:
   ALLMetabolismReactions:
   - {fileID: 11400000, guid: ac0c760ad1cbab341b756545ba0586a4, type: 2}
   - {fileID: 11400000, guid: 764107d010af362458271da1cae0b721, type: 2}
@@ -62,3 +62,5 @@ MonoBehaviour:
   - {fileID: 11400000, guid: e5788bfc3a6164341b2bbece3d91c704, type: 2}
   - {fileID: 11400000, guid: 7530f09a8081d8c4c9aabc335d220c56, type: 2}
   - {fileID: 11400000, guid: a0c0311475173e34b9dbd8aa16945e5f, type: 2}
+  - {fileID: 11400000, guid: 74e4cd255d9f4589958b73536d957b20, type: 2}
+  - {fileID: 11400000, guid: 4a965ae1a6514e84ab431715a00d5a4f, type: 2}

--- a/UnityProject/Assets/Scripts/US13/HealthV2/Living/MedicalChemistry/AnyStatusMetabolismReagentSelector.cs
+++ b/UnityProject/Assets/Scripts/US13/HealthV2/Living/MedicalChemistry/AnyStatusMetabolismReagentSelector.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using Chemistry;
+using UnityEngine;
+
+namespace US13.HealthV2.Living.MedicalChemistry
+{
+	[Serializable]
+	public class AnyStatusMetabolismReagentSelector : IStatusMetabolismReagentSelector
+	{
+		public List<Reagent> Reagents = new();
+
+		public bool HasMatch(ReagentMix reagentMix)
+		{
+			if (reagentMix == null) return false;
+			foreach (var reagent in Reagents)
+			{
+				if (reagent != null && reagentMix[reagent] > 0) return true;
+			}
+			return false;
+		}
+
+		public void ConsumeMatches(ReagentMix reagentMix, float maxReactQuantity, float metabolismMultiplier)
+		{
+			if (reagentMix == null || reagentMix.Total == 0) return;
+			var reactionScale = maxReactQuantity / reagentMix.Total;
+			foreach (var reagent in Reagents)
+			{
+				if (reagent == null) continue;
+				var untouchedMultiple = reagentMix[reagent];
+				if (untouchedMultiple <= 0) continue;
+				var reactionMultiple = Mathf.Min(untouchedMultiple * reactionScale * metabolismMultiplier, untouchedMultiple);
+				reagentMix.Subtract(reagent, reactionMultiple);
+			}
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/US13/HealthV2/Living/MedicalChemistry/AnyStatusMetabolismReagentSelector.cs.meta
+++ b/UnityProject/Assets/Scripts/US13/HealthV2/Living/MedicalChemistry/AnyStatusMetabolismReagentSelector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 84ec5b1122c34329b6de5679b86b00c2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/UnityProject/Assets/Scripts/US13/HealthV2/Living/MedicalChemistry/ApplyStatusMetabolismReaction.cs
+++ b/UnityProject/Assets/Scripts/US13/HealthV2/Living/MedicalChemistry/ApplyStatusMetabolismReaction.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Chemistry;
 using UnityEngine;
@@ -9,42 +8,6 @@ using US13.Systems.StatusesAndEffects;
 
 namespace US13.HealthV2.Living.MedicalChemistry
 {
-	public interface IStatusMetabolismReagentSelector
-	{
-		bool HasMatch(ReagentMix reagentMix);
-		void ConsumeMatches(ReagentMix reagentMix, float maxReactQuantity, float metabolismMultiplier);
-	}
-
-	[Serializable]
-	public class AnyStatusMetabolismReagentSelector : IStatusMetabolismReagentSelector
-	{
-		public List<Reagent> Reagents = new();
-
-		public bool HasMatch(ReagentMix reagentMix)
-		{
-			if (reagentMix == null) return false;
-			foreach (var reagent in Reagents)
-			{
-				if (reagent != null && reagentMix[reagent] > 0) return true;
-			}
-			return false;
-		}
-
-		public void ConsumeMatches(ReagentMix reagentMix, float maxReactQuantity, float metabolismMultiplier)
-		{
-			if (reagentMix == null || reagentMix.Total == 0) return;
-			var reactionScale = maxReactQuantity / reagentMix.Total;
-			foreach (var reagent in Reagents)
-			{
-				if (reagent == null) continue;
-				var untouchedMultiple = reagentMix[reagent];
-				if (untouchedMultiple <= 0) continue;
-				var reactionMultiple = Mathf.Min(untouchedMultiple * reactionScale * metabolismMultiplier, untouchedMultiple);
-				reagentMix.Subtract(reagent, reactionMultiple);
-			}
-		}
-	}
-
 	[CreateAssetMenu(fileName = "ApplyStatusMetabolismReaction", menuName = "ScriptableObjects/Chemistry/Reactions/ApplyStatusMetabolismReaction")]
 	public class ApplyStatusMetabolismReaction : MetabolismReaction
 	{

--- a/UnityProject/Assets/Scripts/US13/HealthV2/Living/MedicalChemistry/ApplyStatusMetabolismReaction.cs
+++ b/UnityProject/Assets/Scripts/US13/HealthV2/Living/MedicalChemistry/ApplyStatusMetabolismReaction.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using Chemistry;
+using UnityEngine;
+using US13.Core.Attributes;
+using US13.HealthV2.Living.CirculatorySystem;
+using US13.HealthV2.Living.PolymorphicSystems.Bodypart;
+using US13.Systems.StatusesAndEffects;
+
+namespace US13.HealthV2.Living.MedicalChemistry
+{
+	public interface IStatusMetabolismReagentSelector
+	{
+		bool HasMatch(ReagentMix reagentMix);
+		void ConsumeMatches(ReagentMix reagentMix, float maxReactQuantity, float metabolismMultiplier);
+	}
+
+	[Serializable]
+	public class AnyStatusMetabolismReagentSelector : IStatusMetabolismReagentSelector
+	{
+		public List<Reagent> Reagents = new();
+
+		public bool HasMatch(ReagentMix reagentMix)
+		{
+			if (reagentMix == null) return false;
+			foreach (var reagent in Reagents)
+			{
+				if (reagent != null && reagentMix[reagent] > 0) return true;
+			}
+			return false;
+		}
+
+		public void ConsumeMatches(ReagentMix reagentMix, float maxReactQuantity, float metabolismMultiplier)
+		{
+			if (reagentMix == null || reagentMix.Total == 0) return;
+			var reactionScale = maxReactQuantity / reagentMix.Total;
+			foreach (var reagent in Reagents)
+			{
+				if (reagent == null) continue;
+				var untouchedMultiple = reagentMix[reagent];
+				if (untouchedMultiple <= 0) continue;
+				var reactionMultiple = Mathf.Min(untouchedMultiple * reactionScale * metabolismMultiplier, untouchedMultiple);
+				reagentMix.Subtract(reagent, reactionMultiple);
+			}
+		}
+	}
+
+	[CreateAssetMenu(fileName = "ApplyStatusMetabolismReaction", menuName = "ScriptableObjects/Chemistry/Reactions/ApplyStatusMetabolismReaction")]
+	public class ApplyStatusMetabolismReaction : MetabolismReaction
+	{
+		public StatusEffect StatusEffect;
+		public StatusEffect SuppressedByStatusEffect;
+		public StatusEffect StatusEffectToRemove;
+		[SerializeReference, SelectImplementation(typeof(IStatusMetabolismReagentSelector))]
+		public IStatusMetabolismReagentSelector ReagentSelector = new AnyStatusMetabolismReagentSelector();
+
+		public override bool Apply(object sender, Vector3 WorldPosition, ReagentMix reagentMix)
+		{
+			if (ReagentSelector == null || ReagentSelector.HasMatch(reagentMix) == false) return false;
+
+			var circulatorySystem = sender as IAreaReactionBase;
+			if (circulatorySystem == null) return false;
+
+			circulatorySystem.MetabolismReactions.Add(this);
+			return false;
+		}
+
+		public override void React(List<MetabolismComponent> senders, ReagentMix reagentMix, float maxReactQuantity)
+		{
+			if (ReagentSelector == null || reagentMix == null || reagentMix.Total == 0) return;
+			if (ReagentSelector.HasMatch(reagentMix) == false) return;
+
+			ApplyStatus(senders);
+			ReagentSelector.ConsumeMatches(reagentMix, maxReactQuantity, ReagentMetabolismMultiplier);
+		}
+
+		private void ApplyStatus(List<MetabolismComponent> senders)
+		{
+			if (StatusEffect == null || senders == null || senders.Count == 0) return;
+
+			var health = senders[0]?.RelatedPart?.HealthMaster;
+			if (health == null || health.gameObject == null) return;
+
+			var statusEffectManager = health.gameObject.GetComponent<StatusEffectManager>();
+			if (statusEffectManager == null) return;
+
+			if (SuppressedByStatusEffect != null && statusEffectManager.HasStatus(SuppressedByStatusEffect)) return;
+
+			if (StatusEffectToRemove != null && statusEffectManager.HasStatus(StatusEffectToRemove))
+			{
+				statusEffectManager.RemoveStatus(StatusEffectToRemove);
+			}
+
+			if (statusEffectManager.HasStatus(StatusEffect)) return;
+
+			statusEffectManager.AddStatus(StatusEffect);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/US13/HealthV2/Living/MedicalChemistry/ApplyStatusMetabolismReaction.cs.meta
+++ b/UnityProject/Assets/Scripts/US13/HealthV2/Living/MedicalChemistry/ApplyStatusMetabolismReaction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9ef6278fc0e64a44a819cfe1f19dcd7b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/UnityProject/Assets/Scripts/US13/HealthV2/Living/MedicalChemistry/IStatusMetabolismReagentSelector.cs
+++ b/UnityProject/Assets/Scripts/US13/HealthV2/Living/MedicalChemistry/IStatusMetabolismReagentSelector.cs
@@ -1,0 +1,10 @@
+using Chemistry;
+
+namespace US13.HealthV2.Living.MedicalChemistry
+{
+	public interface IStatusMetabolismReagentSelector
+	{
+		bool HasMatch(ReagentMix reagentMix);
+		void ConsumeMatches(ReagentMix reagentMix, float maxReactQuantity, float metabolismMultiplier);
+	}
+}

--- a/UnityProject/Assets/Scripts/US13/HealthV2/Living/MedicalChemistry/IStatusMetabolismReagentSelector.cs.meta
+++ b/UnityProject/Assets/Scripts/US13/HealthV2/Living/MedicalChemistry/IStatusMetabolismReagentSelector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 74ecf809fe394d09b03c603145a5760e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/UnityProject/Assets/Scripts/US13/HealthV2/Living/MedicalChemistry/MetabolismReaction.cs
+++ b/UnityProject/Assets/Scripts/US13/HealthV2/Living/MedicalChemistry/MetabolismReaction.cs
@@ -46,7 +46,7 @@ namespace US13.HealthV2.Living.MedicalChemistry
 		/// <param name="sender"></param>
 		/// <param name="reagentMix"></param>
 		/// <param name="maxReactQuantity">The portion in u of the entire blood pool that should react. (5u means it'll take 100 calls for a given reaction to occur to completion in the blood stream)</param>
-		public void React(List<MetabolismComponent> sender, ReagentMix reagentMix, float maxReactQuantity)
+		public virtual void React(List<MetabolismComponent> sender, ReagentMix reagentMix, float maxReactQuantity)
 		{
 			var reactionMultiple = GetReactionMultiple(reagentMix);
 			var UntouchedreactionMultiple = reactionMultiple;

--- a/UnityProject/Assets/Scripts/US13/Items/Food/ConsumptionEffect/ApplyStatusEffect.cs
+++ b/UnityProject/Assets/Scripts/US13/Items/Food/ConsumptionEffect/ApplyStatusEffect.cs
@@ -2,7 +2,6 @@
 using Logs;
 using UnityEngine;
 using US13.Systems.StatusesAndEffects;
-using US13.Systems.StatusesAndEffects.Interfaces;
 using Util;
 
 namespace US13.Items.Food.ConsumptionEffect
@@ -23,13 +22,6 @@ namespace US13.Items.Food.ConsumptionEffect
 				Loggy.Warning().Format("Game object {0} has no StatusEffectManager",
 					Category.Objects,
 					context.Eater.name);
-				return;
-			}
-
-			if (statusManager.HasStatus(statusEffect) &&
-			    statusEffect is not IStackableStatus &&
-			    statusEffect is not IImmediateEffect)
-			{
 				return;
 			}
 

--- a/UnityProject/Assets/Scripts/US13/Items/Food/ConsumptionEffect/ApplyStatusEffect.cs
+++ b/UnityProject/Assets/Scripts/US13/Items/Food/ConsumptionEffect/ApplyStatusEffect.cs
@@ -2,6 +2,7 @@
 using Logs;
 using UnityEngine;
 using US13.Systems.StatusesAndEffects;
+using US13.Systems.StatusesAndEffects.Interfaces;
 using Util;
 
 namespace US13.Items.Food.ConsumptionEffect
@@ -22,6 +23,13 @@ namespace US13.Items.Food.ConsumptionEffect
 				Loggy.Warning().Format("Game object {0} has no StatusEffectManager",
 					Category.Objects,
 					context.Eater.name);
+				return;
+			}
+
+			if (statusManager.HasStatus(statusEffect) &&
+			    statusEffect is not IStackableStatus &&
+			    statusEffect is not IImmediateEffect)
+			{
 				return;
 			}
 

--- a/UnityProject/Assets/Scripts/US13/Systems/StatusesAndEffects/StatusEffectManager.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/StatusesAndEffects/StatusEffectManager.cs
@@ -10,6 +10,7 @@ namespace US13.Systems.StatusesAndEffects
 	public class StatusEffectManager : MonoBehaviour
 	{
 		public HashSet<StatusEffect> Statuses { get; } = new();
+		private readonly List<StatusEffect> statusesToTick = new();
 
 		private void Start()
 		{
@@ -23,22 +24,32 @@ namespace US13.Systems.StatusesAndEffects
 
 		private void TickStatusUpdates()
 		{
-			foreach (var effect in Statuses)
+			statusesToTick.Clear();
+			statusesToTick.AddRange(Statuses);
+			foreach (var effect in statusesToTick)
 			{
-				effect?.DoEffectTick(gameObject);
+				if (effect == false || Statuses.Contains(effect) == false) continue;
+				effect.DoEffectTick(gameObject);
 			}
 		}
 
 		public void AddStatus(StatusEffect status)
 		{
-			if (status == null) return;
-			HandleExpirableStatusAddition(status);
-			HandleStackableStatusAddition(status);
-			HandleImmediateStatusAddition(status);
+			if (status == false) return;
 
-			if (HasStatus(status)) return;
-			status.Initialize(gameObject);
-			Statuses.Add(status);
+			if (TryGetActiveStatus(status, out var activeStatus))
+			{
+				HandleStackableStatusAddition(status, activeStatus);
+				HandleImmediateStatusAddition(activeStatus);
+				return;
+			}
+
+			activeStatus = CreateActiveStatus(status);
+			HandleExpirableStatusAddition(activeStatus);
+			HandleStackableStatusAddition(activeStatus, null);
+			HandleImmediateStatusAddition(activeStatus);
+			activeStatus.Initialize(gameObject);
+			Statuses.Add(activeStatus);
 		}
 
 		private void HandleExpirableStatusAddition(StatusEffect status)
@@ -49,15 +60,12 @@ namespace US13.Systems.StatusesAndEffects
 			}
 		}
 
-		private void HandleStackableStatusAddition(StatusEffect status)
+		private void HandleStackableStatusAddition(StatusEffect status, StatusEffect activeStatus)
 		{
 			if (status is not IStackableStatus newStackable) return;
-			if (Statuses.TryGetValue(status, out var oldStatus))
+			if (activeStatus is IStackableStatus oldStackable)
 			{
-				if (oldStatus is IStackableStatus oldStackable)
-				{
-					oldStackable.AddStack(newStackable.InitialStacks);
-				}
+				oldStackable.AddStack(newStackable.InitialStacks);
 			}
 			else
 			{
@@ -74,10 +82,15 @@ namespace US13.Systems.StatusesAndEffects
 		public void RemoveStatus(StatusEffect status)
 		{
 			if (status == false) return;
-			if (status == null) return;
 			if (gameObject == null ) return;
-			status.OnRemoved(gameObject);
-			Statuses.Remove(status);
+			if (TryGetActiveStatus(status, out var activeStatus) == false) return;
+			if (activeStatus is IExpirableStatus expirable)
+			{
+				expirable.Expired -= OnExpiredStatus;
+			}
+			activeStatus.OnRemoved(gameObject);
+			Statuses.Remove(activeStatus);
+			DestroyStatusInstance(activeStatus);
 		}
 
 		private void OnExpiredStatus(IExpirableStatus expirable)
@@ -92,16 +105,61 @@ namespace US13.Systems.StatusesAndEffects
 
 		public bool HasStatus(StatusEffect status)
 		{
-			return Statuses.Contains(status);
+			return TryGetActiveStatus(status, out _);
 		}
 
 		public bool HasStatusByName(string statusName)
 		{
 			foreach (var status in Statuses)
 			{
-				if (status.name == statusName) return true;
+				if (GetStatusName(status) == statusName) return true;
 			}
 			return false;
+		}
+
+		private StatusEffect CreateActiveStatus(StatusEffect status)
+		{
+			var activeStatus = IsRuntimeClone(status) ? status : Instantiate(status);
+			activeStatus.name = GetStatusName(status);
+			return activeStatus;
+		}
+
+		private bool TryGetActiveStatus(StatusEffect status, out StatusEffect activeStatus)
+		{
+			activeStatus = null;
+			if (status == false) return false;
+			var statusName = GetStatusName(status);
+			foreach (var existingStatus in Statuses)
+			{
+				if (existingStatus == false) continue;
+				if (GetStatusName(existingStatus) != statusName) continue;
+				activeStatus = existingStatus;
+				return true;
+			}
+			return false;
+		}
+
+		private static string GetStatusName(StatusEffect status)
+		{
+			var statusName = status.name ?? string.Empty;
+			const string cloneSuffix = "(Clone)";
+			if (statusName.EndsWith(cloneSuffix, StringComparison.Ordinal) == false) return statusName;
+			return statusName.Substring(0, statusName.Length - cloneSuffix.Length).TrimEnd();
+		}
+
+		private static bool IsRuntimeClone(StatusEffect status)
+		{
+			return (status.name ?? string.Empty).EndsWith("(Clone)", StringComparison.Ordinal);
+		}
+
+		private static void DestroyStatusInstance(StatusEffect status)
+		{
+			if (Application.isPlaying)
+			{
+				Destroy(status);
+				return;
+			}
+			DestroyImmediate(status);
 		}
 	}
 }

--- a/UnityProject/Assets/Tests/StatusAndEffectsFramework/ExpirableStatusEffect.cs
+++ b/UnityProject/Assets/Tests/StatusAndEffectsFramework/ExpirableStatusEffect.cs
@@ -1,43 +1,9 @@
 using System;
-using UnityEngine;
 using US13.Systems.StatusesAndEffects;
 using US13.Systems.StatusesAndEffects.Interfaces;
 
 namespace Tests.StatusAndEffectsFramework
 {
-	public class MockStatus : StatusEffect
-	{
-
-	}
-
-	public class ImmediateStatusEffect : StatusEffect, IImmediateEffect
-	{
-		public bool DidEffect { get; private set; } = false;
-		public int EffectCount { get; private set; }
-
-		public override void DoEffect(GameObject target)
-		{
-			DidEffect = true;
-			EffectCount++;
-		}
-	}
-
-	public class StackableStatusEffect: StatusEffect, IStackableStatus
-	{
-		public int InitialStacks { get; set; } = 1;
-		public int Stacks { get; set; }
-
-		public void AddStack(int amount)
-		{
-			Stacks += amount;
-		}
-
-		public void RemoveStack(int amount)
-		{
-			Stacks -= amount;
-		}
-	}
-
 	public class ExpirableStatusEffect : StatusEffect, IExpirableStatus
 	{
 		private Action<IExpirableStatus> expired;

--- a/UnityProject/Assets/Tests/StatusAndEffectsFramework/ExpirableStatusEffect.cs.meta
+++ b/UnityProject/Assets/Tests/StatusAndEffectsFramework/ExpirableStatusEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 63da5233fff24f5c84d460db9f6bcd43
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/UnityProject/Assets/Tests/StatusAndEffectsFramework/ImmediateStatusEffect.cs
+++ b/UnityProject/Assets/Tests/StatusAndEffectsFramework/ImmediateStatusEffect.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+using US13.Systems.StatusesAndEffects;
+using US13.Systems.StatusesAndEffects.Interfaces;
+
+namespace Tests.StatusAndEffectsFramework
+{
+	public class ImmediateStatusEffect : StatusEffect, IImmediateEffect
+	{
+		public bool DidEffect { get; private set; } = false;
+		public int EffectCount { get; private set; }
+
+		public override void DoEffect(GameObject target)
+		{
+			DidEffect = true;
+			EffectCount++;
+		}
+	}
+}

--- a/UnityProject/Assets/Tests/StatusAndEffectsFramework/ImmediateStatusEffect.cs.meta
+++ b/UnityProject/Assets/Tests/StatusAndEffectsFramework/ImmediateStatusEffect.cs.meta
@@ -1,11 +1,11 @@
 fileFormatVersion: 2
-guid: beb8e0ab788949e7b42d34e0ab3f2ebe
+guid: c2e7e6401e974ab9aa511ed2f1b5043c
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
   icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/UnityProject/Assets/Tests/StatusAndEffectsFramework/MockStatus.cs
+++ b/UnityProject/Assets/Tests/StatusAndEffectsFramework/MockStatus.cs
@@ -1,0 +1,9 @@
+using US13.Systems.StatusesAndEffects;
+
+namespace Tests.StatusAndEffectsFramework
+{
+	public class MockStatus : StatusEffect
+	{
+
+	}
+}

--- a/UnityProject/Assets/Tests/StatusAndEffectsFramework/MockStatus.cs.meta
+++ b/UnityProject/Assets/Tests/StatusAndEffectsFramework/MockStatus.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3d8b8bcca57f4f38a5748fe0705b2f3e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/UnityProject/Assets/Tests/StatusAndEffectsFramework/MockStatuses.cs
+++ b/UnityProject/Assets/Tests/StatusAndEffectsFramework/MockStatuses.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+using System;
+using UnityEngine;
 using US13.Systems.StatusesAndEffects;
 using US13.Systems.StatusesAndEffects.Interfaces;
 
@@ -12,10 +13,12 @@ namespace Tests.StatusAndEffectsFramework
 	public class ImmediateStatusEffect : StatusEffect, IImmediateEffect
 	{
 		public bool DidEffect { get; private set; } = false;
+		public int EffectCount { get; private set; }
 
 		public override void DoEffect(GameObject target)
 		{
 			DidEffect = true;
+			EffectCount++;
 		}
 	}
 
@@ -35,4 +38,31 @@ namespace Tests.StatusAndEffectsFramework
 		}
 	}
 
+	public class ExpirableStatusEffect : StatusEffect, IExpirableStatus
+	{
+		private Action<IExpirableStatus> expired;
+
+		public int SubscriberCount { get; private set; }
+		public float Duration => 30f;
+		public DateTime DeathTime { get; set; }
+
+		public event Action<IExpirableStatus> Expired
+		{
+			add
+			{
+				expired += value;
+				SubscriberCount++;
+			}
+			remove
+			{
+				expired -= value;
+				SubscriberCount--;
+			}
+		}
+
+		public void CheckExpiration()
+		{
+			expired?.Invoke(this);
+		}
+	}
 }

--- a/UnityProject/Assets/Tests/StatusAndEffectsFramework/StackableStatusEffect.cs
+++ b/UnityProject/Assets/Tests/StatusAndEffectsFramework/StackableStatusEffect.cs
@@ -1,0 +1,21 @@
+using US13.Systems.StatusesAndEffects;
+using US13.Systems.StatusesAndEffects.Interfaces;
+
+namespace Tests.StatusAndEffectsFramework
+{
+	public class StackableStatusEffect: StatusEffect, IStackableStatus
+	{
+		public int InitialStacks { get; set; } = 1;
+		public int Stacks { get; set; }
+
+		public void AddStack(int amount)
+		{
+			Stacks += amount;
+		}
+
+		public void RemoveStack(int amount)
+		{
+			Stacks -= amount;
+		}
+	}
+}

--- a/UnityProject/Assets/Tests/StatusAndEffectsFramework/StackableStatusEffect.cs.meta
+++ b/UnityProject/Assets/Tests/StatusAndEffectsFramework/StackableStatusEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 31c7c393d6e648d9a6b427e55980459c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/UnityProject/Assets/Tests/StatusAndEffectsFramework/StatusEffectManagerTest.cs
+++ b/UnityProject/Assets/Tests/StatusAndEffectsFramework/StatusEffectManagerTest.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+using System.Linq;
+using NUnit.Framework;
 using UnityEngine;
 using US13.Systems.StatusesAndEffects;
 
@@ -23,6 +24,7 @@ namespace Tests.StatusAndEffectsFramework
 			manager.AddStatus(basicStatus);
 			Assert.True(manager.HasStatus(basicStatus));
 			Assert.AreEqual(1, manager.Statuses.Count);
+			Assert.AreNotSame(basicStatus, manager.Statuses.Single());
 		}
 
 		[Test]
@@ -40,7 +42,7 @@ namespace Tests.StatusAndEffectsFramework
 		{
 			var basicStatus = ScriptableObject.CreateInstance<MockStatus>();
 			var basicStatus2 = ScriptableObject.CreateInstance<MockStatus>();
-			basicStatus.name = "basicStatus"; // in game, name property is populated by file name of the scriptable object.
+			basicStatus.name = "basicStatus";
 			basicStatus2.name = "basicStatus";
 			manager.AddStatus(basicStatus);
 			manager.AddStatus(basicStatus2);
@@ -68,8 +70,9 @@ namespace Tests.StatusAndEffectsFramework
 		{
 			var immediate = ScriptableObject.CreateInstance<ImmediateStatusEffect>();
 			manager.AddStatus(immediate);
+			var activeImmediate = manager.Statuses.OfType<ImmediateStatusEffect>().Single();
 			Assert.True(manager.HasStatus(immediate));
-			Assert.True(immediate.DidEffect);
+			Assert.True(activeImmediate.DidEffect);
 		}
 
 		[Test]
@@ -77,11 +80,118 @@ namespace Tests.StatusAndEffectsFramework
 		{
 			var stackable = ScriptableObject.CreateInstance<StackableStatusEffect>();
 			manager.AddStatus(stackable);
+			var activeStackable = manager.Statuses.OfType<StackableStatusEffect>().Single();
 			Assert.True(manager.HasStatus(stackable));
-			Assert.AreEqual(1, stackable.Stacks);
+			Assert.AreEqual(1, activeStackable.Stacks);
 			manager.AddStatus(stackable);
-			Assert.AreEqual(2, stackable.Stacks);
+			Assert.AreEqual(2, activeStackable.Stacks);
 		}
 
+		[Test]
+		public void WhenSameStatusAssetIsAddedToDifferentManagersEachManagerGetsOwnInstance()
+		{
+			var secondManager = new GameObject().AddComponent<StatusEffectManager>();
+			var status = ScriptableObject.CreateInstance<ExpirableStatusEffect>();
+			status.name = "expirableStatus";
+			manager.AddStatus(status);
+			secondManager.AddStatus(status);
+
+			var firstActiveStatus = manager.Statuses.Single();
+			var secondActiveStatus = secondManager.Statuses.Single();
+
+			Assert.AreNotSame(status, firstActiveStatus);
+			Assert.AreNotSame(status, secondActiveStatus);
+			Assert.AreNotSame(firstActiveStatus, secondActiveStatus);
+			Assert.True(manager.HasStatus(status));
+			Assert.True(secondManager.HasStatus(status));
+		}
+
+		[Test]
+		public void WhenExpirableStatusExpiresInOneManagerOtherManagersKeepTheirStatus()
+		{
+			var secondManager = new GameObject().AddComponent<StatusEffectManager>();
+			var status = ScriptableObject.CreateInstance<ExpirableStatusEffect>();
+			status.name = "expirableStatus";
+			manager.AddStatus(status);
+			secondManager.AddStatus(status);
+
+			var firstActiveStatus = manager.Statuses.OfType<ExpirableStatusEffect>().Single();
+			firstActiveStatus.CheckExpiration();
+
+			Assert.False(manager.HasStatus(status));
+			Assert.True(secondManager.HasStatus(status));
+		}
+
+		[Test]
+		public void WhenRemovingStatusByAssetActiveInstanceIsRemoved()
+		{
+			var status = ScriptableObject.CreateInstance<MockStatus>();
+			status.name = "basicStatus";
+			manager.AddStatus(status);
+
+			manager.RemoveStatus(status);
+
+			Assert.False(manager.HasStatus(status));
+			Assert.AreEqual(0, manager.Statuses.Count);
+		}
+
+		[Test]
+		public void WhenAddingExistingExpirableStatusSubscriptionIsNotDuplicated()
+		{
+			var status = ScriptableObject.CreateInstance<ExpirableStatusEffect>();
+			status.name = "expirableStatus";
+			manager.AddStatus(status);
+			manager.AddStatus(status);
+
+			var activeStatus = manager.Statuses.OfType<ExpirableStatusEffect>().Single();
+
+			Assert.AreEqual(1, activeStatus.SubscriberCount);
+		}
+
+		[Test]
+		public void WhenAddingExistingImmediateStatusEffectRunsAgainWithoutAddingDuplicateStatus()
+		{
+			var immediate = ScriptableObject.CreateInstance<ImmediateStatusEffect>();
+			immediate.name = "immediateStatus";
+			manager.AddStatus(immediate);
+			var activeImmediate = manager.Statuses.OfType<ImmediateStatusEffect>().Single();
+
+			manager.AddStatus(immediate);
+
+			Assert.AreEqual(1, manager.Statuses.Count);
+			Assert.AreEqual(2, activeImmediate.EffectCount);
+		}
+
+		[Test]
+		public void WhenAddingStatusCloneStatusCanBeCheckedAndRemovedByOriginalAsset()
+		{
+			var status = ScriptableObject.CreateInstance<MockStatus>();
+			status.name = "basicStatus";
+			var statusClone = Object.Instantiate(status);
+			manager.AddStatus(statusClone);
+
+			Assert.True(manager.HasStatus(status));
+
+			manager.RemoveStatus(status);
+
+			Assert.False(manager.HasStatus(status));
+			Assert.AreEqual(0, manager.Statuses.Count);
+		}
+
+		[Test]
+		public void WhenAddingRuntimeCloneTransientStackConfigurationIsPreserved()
+		{
+			var status = ScriptableObject.CreateInstance<StackableStatusEffect>();
+			status.name = "stackableStatus";
+			var statusClone = Object.Instantiate(status);
+			statusClone.InitialStacks = 5;
+
+			manager.AddStatus(statusClone);
+
+			var activeStatus = manager.Statuses.OfType<StackableStatusEffect>().Single();
+			Assert.AreSame(statusClone, activeStatus);
+			Assert.AreEqual(5, activeStatus.Stacks);
+			Assert.True(manager.HasStatus(status));
+		}
 	}
 }


### PR DESCRIPTION
### Purpose
Movement speed is too slow, and this seems to be by design. But smoking cigarettes currently increases speed. Seeing this opportunity, I added all kinds of stimulants and energy drinks to do the same.

There is mild speed boost (coffee, energy drinks, chocolate, nicotine) and major speed boost (Stimulum, MuscleStimulant, Stimulants)

Below is actual list.
## Mild stimulant speed buff (`1.25x`)
- `Nicotine`
- `Tobacco`
- `Coffee`
- `IcedCoffee`
- `CafeLatte`
- `SoyLatte`
- `PumpkinLatte`
- `MonkeyEnergy`
- `Tea`
- `IcedTea`
- `IrishCoffee`
- `Kahlua`
- `ThirteenLoko`
- `SugarRush`
- `Turbo`

## Strong stimulant speed buff (`1.5x`)
- `Stimulants`
- `MuscleStimulant`
- `Stimulum`

### Changelog:
CL: [Improvement] All stimulants (coffee, tea, Stimulum) now cause player speed boost
CL: [Improvement]  Status effects now use per-holder runtime instances instead of mutating shared ScriptableObject assets. This prevents expiration, stack, and event state from leaking between players while preserving the existing status manager API.
