### PR TITLE
fix: update base docker image to support new glib and shit

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     jq \


### PR DESCRIPTION
Required by Unity engine 6.5