### PR TITLE
In-game reactions guide/manual

### DIFF
--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/Chemistry.meta
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/Chemistry.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c0cbb48837bbe7d4fae95fdde8dc4276
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/Chemistry/ChemGuide.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/Chemistry/ChemGuide.prefab
@@ -496,7 +496,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
   m_Material: {fileID: 0}
-  m_Color: {r: 0.23584908, g: 0.23584908, b: 0.23584908, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 0
@@ -534,11 +534,11 @@ MonoBehaviour:
     m_SelectOnRight: {fileID: 0}
   m_Transition: 1
   m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_NormalColor: {r: 0.23529413, g: 0.23529413, b: 0.23529413, a: 1}
+    m_HighlightedColor: {r: 0.3773585, g: 0.3773585, b: 0.3773585, a: 1}
+    m_PressedColor: {r: 0.20754719, g: 0.2065682, b: 0.2065682, a: 1}
+    m_SelectedColor: {r: 0.122641504, g: 0.0989231, b: 0.0989231, a: 1}
+    m_DisabledColor: {r: 0.066037714, g: 0.035822347, b: 0.035822347, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
@@ -656,9 +656,9 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 0.227451, g: 0.227451, b: 0.227451, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.3490566, g: 0.3490566, b: 0.3490566, a: 1}
+    m_PressedColor: {r: 0.084905684, g: 0.084905684, b: 0.084905684, a: 1}
+    m_SelectedColor: {r: 0.119482, g: 0.14150941, b: 0.14150941, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
@@ -1771,9 +1771,9 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 0.227451, g: 0.227451, b: 0.227451, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.4339623, g: 0.4339623, b: 0.4339623, a: 1}
+    m_PressedColor: {r: 0.1509434, g: 0.1509434, b: 0.1509434, a: 1}
+    m_SelectedColor: {r: 0.09433961, g: 0.0716447, b: 0.0716447, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/Chemistry/ChemGuide.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/Chemistry/ChemGuide.prefab
@@ -2143,7 +2143,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Reagent Guide
+  m_text: Reactions Guide
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/Chemistry/ChemGuide.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/Chemistry/ChemGuide.prefab
@@ -1204,6 +1204,8 @@ MonoBehaviour:
   ReactionListContainer: {fileID: 2021944573031779163}
   PageNumberText: {fileID: 1416625722067095882}
   NumberOfReactionsText: {fileID: 6425656774731620409}
+  SearchBarField: {fileID: 2140986395234850707}
+  SearchButton: {fileID: 1112339968963623394}
   reactionsToDisplay: []
   ReactionEntryTemplate: {fileID: 5881325195007326126, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
     type: 3}

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/Chemistry/ChemGuide.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/Chemistry/ChemGuide.prefab
@@ -1,0 +1,5084 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &634563813369748493
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5657992715704023134}
+  - component: {fileID: 3611755092582638244}
+  - component: {fileID: 768421672224209331}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5657992715704023134
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 634563813369748493}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2679393851164429405}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3611755092582638244
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 634563813369748493}
+  m_CullTransparentMesh: 1
+--- !u!114 &768421672224209331
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 634563813369748493}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: '>'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &2021944573031779163
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6768947793528902563}
+  - component: {fileID: 3149488863585564436}
+  m_Layer: 5
+  m_Name: ReagentsList
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6768947793528902563
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2021944573031779163}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5161271947733425470}
+  - {fileID: 432719410061878874}
+  - {fileID: 1967158760298131839}
+  - {fileID: 4328556747397963435}
+  - {fileID: 963149094131687396}
+  m_Father: {fileID: 8777505488711633062}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.0013123, y: -19.108}
+  m_SizeDelta: {x: 333.82, y: 466.23}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &3149488863585564436
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2021944573031779163}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.VerticalLayoutGroup
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 1
+  m_Spacing: 2
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 1
+  m_ChildScaleHeight: 1
+  m_ReverseArrangement: 0
+--- !u!1 &2787092111199090185
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7638854120984812014}
+  - component: {fileID: 1107583465397150295}
+  - component: {fileID: 6458390210762712606}
+  m_Layer: 5
+  m_Name: BG
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7638854120984812014
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2787092111199090185}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8351000442362051291}
+  m_Father: {fileID: 8777505488711633062}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0.00012207, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1107583465397150295
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2787092111199090185}
+  m_CullTransparentMesh: 1
+--- !u!114 &6458390210762712606
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2787092111199090185}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.08627451, g: 0.09019608, b: 0.09019608, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: ad4148593b05d0f47980774815c325fe, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3163291138928694462
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6575700722027071927}
+  - component: {fileID: 896117346683603309}
+  - component: {fileID: 5302302959833039174}
+  - component: {fileID: 1002309588763780275}
+  m_Layer: 5
+  m_Name: Placeholder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6575700722027071927
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3163291138928694462}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6003684403415702673}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &896117346683603309
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3163291138928694462}
+  m_CullTransparentMesh: 1
+--- !u!114 &5302302959833039174
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3163291138928694462}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Search For A Product..
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 2164260863
+  m_fontColor: {r: 1, g: 1, b: 1, a: 0.5}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 18
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 2
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 1
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &1002309588763780275
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3163291138928694462}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.LayoutElement
+  m_IgnoreLayout: 1
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!1 &3207151060800545093
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3835035417640147128}
+  - component: {fileID: 392521579637841710}
+  - component: {fileID: 8932201279353938979}
+  - component: {fileID: 1112339968963623394}
+  m_Layer: 5
+  m_Name: SearchButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3835035417640147128
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3207151060800545093}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2603768696746055706}
+  m_Father: {fileID: 8777505488711633062}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 124.86, y: 251.65}
+  m_SizeDelta: {x: 89.729, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &392521579637841710
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3207151060800545093}
+  m_CullTransparentMesh: 1
+--- !u!114 &8932201279353938979
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3207151060800545093}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.23584908, g: 0.23584908, b: 0.23584908, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1112339968963623394
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3207151060800545093}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 8932201279353938979}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &3454836608027361849
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2679393851164429405}
+  - component: {fileID: 5157904123742892536}
+  - component: {fileID: 6102770375073099005}
+  - component: {fileID: 7171663283396151355}
+  m_Layer: 5
+  m_Name: Forward
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2679393851164429405
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3454836608027361849}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5657992715704023134}
+  m_Father: {fileID: 6368479822814912402}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 146.45, y: 0}
+  m_SizeDelta: {x: 40.9239, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5157904123742892536
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3454836608027361849}
+  m_CullTransparentMesh: 1
+--- !u!114 &6102770375073099005
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3454836608027361849}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7171663283396151355
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3454836608027361849}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 0.227451, g: 0.227451, b: 0.227451, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 6102770375073099005}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 7175250015561912377}
+        m_TargetAssemblyTypeName: US13.UI.Objects.Chemistry.ReactionsGuide.GUI_ReactionGuide,
+          Assets
+        m_MethodName: NextPage
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &3625167274982672246
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6003684403415702673}
+  - component: {fileID: 4238512452479190405}
+  m_Layer: 5
+  m_Name: Text Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6003684403415702673
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3625167274982672246}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6575700722027071927}
+  - {fileID: 3229443379756760753}
+  m_Father: {fileID: 2202718387837077203}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.5}
+  m_SizeDelta: {x: -20, y: -13}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &4238512452479190405
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3625167274982672246}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3312d7739989d2b4e91e6319e9a96d76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.RectMask2D
+  m_Padding: {x: -8, y: -5, z: -8, w: -5}
+  m_Softness: {x: 0, y: 0}
+--- !u!1 &3709366421372775861
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2202718387837077203}
+  - component: {fileID: 7373375183840847571}
+  - component: {fileID: 7423107528947783770}
+  - component: {fileID: 2140986395234850707}
+  m_Layer: 5
+  m_Name: Search
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2202718387837077203
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3709366421372775861}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6003684403415702673}
+  m_Father: {fileID: 8777505488711633062}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -44.865, y: 251.65}
+  m_SizeDelta: {x: 249.73, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7373375183840847571
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3709366421372775861}
+  m_CullTransparentMesh: 1
+--- !u!114 &7423107528947783770
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3709366421372775861}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.3052243, g: 0.29930583, b: 0.3584906, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10911, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &2140986395234850707
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3709366421372775861}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2da0c512f12947e489f739169773d7ca, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TMP_InputField
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 7423107528947783770}
+  m_TextViewport: {fileID: 6003684403415702673}
+  m_TextComponent: {fileID: 6450965364511331749}
+  m_Placeholder: {fileID: 5302302959833039174}
+  m_VerticalScrollbar: {fileID: 0}
+  m_VerticalScrollbarEventHandler: {fileID: 0}
+  m_LayoutGroup: {fileID: 0}
+  m_ScrollSensitivity: 1
+  m_ContentType: 0
+  m_InputType: 0
+  m_AsteriskChar: 42
+  m_KeyboardType: 0
+  m_LineType: 0
+  m_HideMobileInput: 0
+  m_HideSoftKeyboard: 0
+  m_CharacterValidation: 0
+  m_RegexValue: 
+  m_GlobalPointSize: 14
+  m_CharacterLimit: 0
+  m_OnEndEdit:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnSubmit:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnSelect:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnDeselect:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnTextSelection:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnEndTextSelection:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnTouchScreenKeyboardStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_CaretColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_CustomCaretColor: 0
+  m_SelectionColor: {r: 0.65882355, g: 0.80784315, b: 1, a: 0.7529412}
+  m_Text: 
+  m_CaretBlinkRate: 0.85
+  m_CaretWidth: 1
+  m_ReadOnly: 0
+  m_RichText: 1
+  m_GlobalFontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_OnFocusSelectAll: 1
+  m_ResetOnDeActivation: 1
+  m_KeepTextSelectionVisible: 0
+  m_RestoreOriginalTextOnEscape: 1
+  m_isRichTextEditingAllowed: 0
+  m_LineLimit: 0
+  isAlert: 0
+  m_InputValidator: {fileID: 0}
+  m_ShouldActivateOnSelect: 1
+--- !u!1 &3886168084237414589
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8351000442362051291}
+  - component: {fileID: 6934676330063762499}
+  - component: {fileID: 2577534144659493732}
+  m_Layer: 5
+  m_Name: NTLogo
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8351000442362051291
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3886168084237414589}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7638854120984812014}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 1.7871, y: -1.1914}
+  m_SizeDelta: {x: 297.7624, y: 175.0557}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6934676330063762499
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3886168084237414589}
+  m_CullTransparentMesh: 1
+--- !u!114 &2577534144659493732
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3886168084237414589}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: b3947c9330dc8b347815e699dbc6e361, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4090493091409440140
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2603768696746055706}
+  - component: {fileID: 920002107739346771}
+  - component: {fileID: 6913446897144772862}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2603768696746055706
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4090493091409440140}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3835035417640147128}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0.000030517578}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &920002107739346771
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4090493091409440140}
+  m_CullTransparentMesh: 1
+--- !u!114 &6913446897144772862
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4090493091409440140}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Search
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 18
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 8
+  m_fontSizeMax: 18
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &4533641232203443615
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8777505488711633062}
+  - component: {fileID: 8639643876158719266}
+  - component: {fileID: 7175250015561912377}
+  m_Layer: 5
+  m_Name: ChemGuide
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8777505488711633062
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4533641232203443615}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7638854120984812014}
+  - {fileID: 6800560193021092021}
+  - {fileID: 2202718387837077203}
+  - {fileID: 3835035417640147128}
+  - {fileID: 1348128912557565419}
+  - {fileID: 2977291220726329260}
+  - {fileID: 6768947793528902563}
+  - {fileID: 6368479822814912402}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 696, y: -13.244}
+  m_SizeDelta: {x: 339.4641, y: 582.63}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8639643876158719266
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4533641232203443615}
+  m_CullTransparentMesh: 1
+--- !u!114 &7175250015561912377
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4533641232203443615}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 261984107fa24187ade4289d7f8540a4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assets::US13.UI.Objects.Chemistry.ReactionsGuide.GUI_ReactionGuide
+  DisplayAllReactions: 0
+  reactionsPerPage: 4
+  TargetReagentDispenser: {fileID: 0}
+  ParentObjectToUseToFindMachineReactionsFromButtons: {fileID: 0}
+  ReactionListContainer: {fileID: 2021944573031779163}
+  PageNumberText: {fileID: 1416625722067095882}
+  NumberOfReactionsText: {fileID: 6425656774731620409}
+  reactionsToDisplay: []
+  ReactionEntryTemplate: {fileID: 5881325195007326126, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+    type: 3}
+--- !u!1 &4774916115772822166
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1348128912557565419}
+  - component: {fileID: 3293476745021704548}
+  - component: {fileID: 6425656774731620409}
+  m_Layer: 5
+  m_Name: RecipeIndicatorForMachine
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1348128912557565419
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4774916115772822166}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8777505488711633062}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.0027, y: 227.41289}
+  m_SizeDelta: {x: 333.8204, y: 18.4741}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3293476745021704548
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4774916115772822166}
+  m_CullTransparentMesh: 1
+--- !u!114 &6425656774731620409
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4774916115772822166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Avaliable Recipes: 10'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 18
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &4793033508989048750
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6800560193021092021}
+  - component: {fileID: 1368927789391504900}
+  - component: {fileID: 928100552569550120}
+  m_Layer: 5
+  m_Name: Header
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6800560193021092021
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4793033508989048750}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 201625412313357690}
+  m_Father: {fileID: 8777505488711633062}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.00045395, y: 278.98505}
+  m_SizeDelta: {x: 339.46, y: 24.67}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1368927789391504900
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4793033508989048750}
+  m_CullTransparentMesh: 1
+--- !u!114 &928100552569550120
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4793033508989048750}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.13333334, g: 0.1254902, b: 0.20392159, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4914429404418279457
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2963663948547704606}
+  - component: {fileID: 7946207654044353323}
+  - component: {fileID: 1416625722067095882}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2963663948547704606
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4914429404418279457}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6368479822814912402}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.0019736, y: -2.2743}
+  m_SizeDelta: {x: 251.98, y: 34.549}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7946207654044353323
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4914429404418279457}
+  m_CullTransparentMesh: 1
+--- !u!114 &1416625722067095882
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4914429404418279457}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: '0 / 10
+
+'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 16
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 6
+  m_fontSizeMax: 16
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &5091028444848516409
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6368479822814912402}
+  m_Layer: 5
+  m_Name: PageControls
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6368479822814912402
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5091028444848516409}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7485920512846138090}
+  - {fileID: 2679393851164429405}
+  - {fileID: 2963663948547704606}
+  m_Father: {fileID: 8777505488711633062}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.0018997, y: -271.77142}
+  m_SizeDelta: {x: 333.82, y: 39.0972}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &5329876184281299477
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2977291220726329260}
+  - component: {fileID: 3601568764336567693}
+  - component: {fileID: 3615067621711097983}
+  m_Layer: 5
+  m_Name: Seperator1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2977291220726329260
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5329876184281299477}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8777505488711633062}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.001606, y: 217.29431}
+  m_SizeDelta: {x: 333.82, y: 1.7714}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3601568764336567693
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5329876184281299477}
+  m_CullTransparentMesh: 1
+--- !u!114 &3615067621711097983
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5329876184281299477}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5750211534416778505
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7485920512846138090}
+  - component: {fileID: 8121011146645508062}
+  - component: {fileID: 1872729166755547854}
+  - component: {fileID: 2675336147016219272}
+  m_Layer: 5
+  m_Name: Back
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7485920512846138090
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5750211534416778505}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5772412758615160803}
+  m_Father: {fileID: 6368479822814912402}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -146.44809, y: 0}
+  m_SizeDelta: {x: 40.9239, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8121011146645508062
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5750211534416778505}
+  m_CullTransparentMesh: 1
+--- !u!114 &1872729166755547854
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5750211534416778505}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &2675336147016219272
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5750211534416778505}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 0.227451, g: 0.227451, b: 0.227451, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1872729166755547854}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 7175250015561912377}
+        m_TargetAssemblyTypeName: US13.UI.Objects.Chemistry.ReactionsGuide.GUI_ReactionGuide,
+          Assets
+        m_MethodName: PreviousPage
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &6073285409120001240
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3229443379756760753}
+  - component: {fileID: 5863015840931939576}
+  - component: {fileID: 6450965364511331749}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3229443379756760753
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6073285409120001240}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6003684403415702673}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5863015840931939576
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6073285409120001240}
+  m_CullTransparentMesh: 1
+--- !u!114 &6450965364511331749
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6073285409120001240}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\u200B"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 18
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 3
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 1
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &7677902553488287764
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5772412758615160803}
+  - component: {fileID: 513705572776128455}
+  - component: {fileID: 2681134026558781723}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5772412758615160803
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7677902553488287764}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7485920512846138090}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &513705572776128455
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7677902553488287764}
+  m_CullTransparentMesh: 1
+--- !u!114 &2681134026558781723
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7677902553488287764}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: <
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &7967490863341210154
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 201625412313357690}
+  - component: {fileID: 8789281487574779709}
+  - component: {fileID: 7019462119710963713}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &201625412313357690
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7967490863341210154}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6800560193021092021}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -0.00001955}
+  m_SizeDelta: {x: 339.46, y: 24.67}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8789281487574779709
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7967490863341210154}
+  m_CullTransparentMesh: 1
+--- !u!114 &7019462119710963713
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7967490863341210154}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Reagent Guide
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 22.05
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1001 &948049282340109950
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6768947793528902563}
+    m_Modifications:
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 325
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 166.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -45
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5881325195007326126, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_Name
+      value: RecipeTemplate
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8866e78d0fb6f2d43ba0ec4db65baf07, type: 3}
+--- !u!224 &5161271947733425470 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+    type: 3}
+  m_PrefabInstance: {fileID: 948049282340109950}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5176160232989113508
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6768947793528902563}
+    m_Modifications:
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 325
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 166.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -419.584
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5881325195007326126, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_Name
+      value: RecipeTemplate (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8866e78d0fb6f2d43ba0ec4db65baf07, type: 3}
+--- !u!224 &963149094131687396 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+    type: 3}
+  m_PrefabInstance: {fileID: 5176160232989113508}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5515208272396895514
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6768947793528902563}
+    m_Modifications:
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 325
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 166.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -138.646
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5881325195007326126, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_Name
+      value: RecipeTemplate (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8866e78d0fb6f2d43ba0ec4db65baf07, type: 3}
+--- !u!224 &432719410061878874 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+    type: 3}
+  m_PrefabInstance: {fileID: 5515208272396895514}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5891940630572749375
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6768947793528902563}
+    m_Modifications:
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 325
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 166.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -232.292
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5881325195007326126, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_Name
+      value: RecipeTemplate (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8866e78d0fb6f2d43ba0ec4db65baf07, type: 3}
+--- !u!224 &1967158760298131839 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+    type: 3}
+  m_PrefabInstance: {fileID: 5891940630572749375}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8546354197193457131
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6768947793528902563}
+    m_Modifications:
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 880285456139216972, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814933679884903820, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2393452792883491392, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3949115953149995803, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5136557819894258024, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212770018272924881, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 325
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 166.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -325.93802
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438791103774355184, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5881325195007326126, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_Name
+      value: RecipeTemplate (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251553123731578447, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6429764758093435895, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922577077522751737, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756442910137057998, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7767545745357530228, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060720296607618926, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8155189579140256303, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8853170136447823568, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8866e78d0fb6f2d43ba0ec4db65baf07, type: 3}
+--- !u!224 &4328556747397963435 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5370719238625747776, guid: 8866e78d0fb6f2d43ba0ec4db65baf07,
+    type: 3}
+  m_PrefabInstance: {fileID: 8546354197193457131}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/Chemistry/ChemGuide.prefab.meta
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/Chemistry/ChemGuide.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f2f97c13483d1954db88bc4d426d9493
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/Chemistry/ReagentButtonTemplate.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/Chemistry/ReagentButtonTemplate.prefab
@@ -1,0 +1,259 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4100656411296064295
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 696690070621752560}
+  - component: {fileID: 4900093111146280264}
+  - component: {fileID: 8545785443212724535}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &696690070621752560
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4100656411296064295}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1755575553053370082}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4900093111146280264
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4100656411296064295}
+  m_CullTransparentMesh: 1
+--- !u!114 &8545785443212724535
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4100656411296064295}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Reagent
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 9
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 4
+  m_fontSizeMax: 9
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &5769309921332315560
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1755575553053370082}
+  - component: {fileID: 8877269513020658128}
+  - component: {fileID: 4977046281147916994}
+  - component: {fileID: 7258919333991852727}
+  m_Layer: 5
+  m_Name: ReagentButtonTemplate
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1755575553053370082
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5769309921332315560}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 696690070621752560}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8877269513020658128
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5769309921332315560}
+  m_CullTransparentMesh: 1
+--- !u!114 &4977046281147916994
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5769309921332315560}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7258919333991852727
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5769309921332315560}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 0.227451, g: 0.227451, b: 0.227451, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4977046281147916994}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/Chemistry/ReagentButtonTemplate.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/Chemistry/ReagentButtonTemplate.prefab
@@ -92,7 +92,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 9
+  m_fontSize: 4
   m_fontSizeBase: 24
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -235,9 +235,9 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 0.227451, g: 0.227451, b: 0.227451, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.509434, g: 0.509434, b: 0.509434, a: 1}
+    m_PressedColor: {r: 0.13207549, g: 0.13207549, b: 0.13207549, a: 1}
+    m_SelectedColor: {r: 0.1509434, g: 0.12175152, b: 0.12175152, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/Chemistry/ReagentButtonTemplate.prefab.meta
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/Chemistry/ReagentButtonTemplate.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7a569b20dd819e4448deab9c2e738b4e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/Chemistry/RecipeTemplate.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/Chemistry/RecipeTemplate.prefab
@@ -1,0 +1,1583 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1868599113886273382
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6956642146302560366}
+  - component: {fileID: 2644757374142105785}
+  - component: {fileID: 6003617779472709204}
+  - component: {fileID: 8094926795277764579}
+  m_Layer: 5
+  m_Name: BG
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6956642146302560366
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1868599113886273382}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5370719238625747776}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.00011188, y: -0.000023842}
+  m_SizeDelta: {x: 333.82, y: 92.18}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2644757374142105785
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1868599113886273382}
+  m_CullTransparentMesh: 1
+--- !u!114 &6003617779472709204
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1868599113886273382}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0.024056608, b: 0.084905684, a: 0.19215687}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &8094926795277764579
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1868599113886273382}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.LayoutElement
+  m_IgnoreLayout: 0
+  m_MinWidth: 300
+  m_MinHeight: 90
+  m_PreferredWidth: 325
+  m_PreferredHeight: 90
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!1 &5502353850379676660
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7879836332010873868}
+  - component: {fileID: 7032042527833664129}
+  - component: {fileID: 1291877003808317720}
+  m_Layer: 5
+  m_Name: ReagentName
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7879836332010873868
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5502353850379676660}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5370719238625747776}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.0019188, y: 37.455}
+  m_SizeDelta: {x: 333.82, y: 17.2709}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7032042527833664129
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5502353850379676660}
+  m_CullTransparentMesh: 1
+--- !u!114 &1291877003808317720
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5502353850379676660}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Reagent Name
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 18
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &5881325195007326126
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5370719238625747776}
+  - component: {fileID: 2385021719209022814}
+  - component: {fileID: 5173480419035855117}
+  - component: {fileID: 6949852458132399812}
+  m_Layer: 5
+  m_Name: RecipeTemplate
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5370719238625747776
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5881325195007326126}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6956642146302560366}
+  - {fileID: 2658088728850370024}
+  - {fileID: 7879836332010873868}
+  - {fileID: 558955290179045704}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 333.82, y: 92.1797}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2385021719209022814
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5881325195007326126}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ed202b1c01348dfaf122ea567ce581b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assets::US13.UI.Objects.Chemistry.ReactionsGuide.Atoms.ReactionDisplay
+  SplatColorImage: {fileID: 8009816267415283474}
+  DisplayName: {fileID: 1291877003808317720}
+  ReagentButtonTemplate: {fileID: 5769309921332315560, guid: 7a569b20dd819e4448deab9c2e738b4e,
+    type: 3}
+  ReagentButtonsList: {fileID: 9157543609379783575}
+--- !u!114 &5173480419035855117
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5881325195007326126}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.ContentSizeFitter
+  m_HorizontalFit: 2
+  m_VerticalFit: 2
+--- !u!114 &6949852458132399812
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5881325195007326126}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.LayoutElement
+  m_IgnoreLayout: 0
+  m_MinWidth: 300
+  m_MinHeight: 90
+  m_PreferredWidth: 325
+  m_PreferredHeight: 90
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!1 &5935958933812243945
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2658088728850370024}
+  - component: {fileID: 3073126506571548025}
+  - component: {fileID: 8009816267415283474}
+  m_Layer: 5
+  m_Name: ReagentColor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2658088728850370024
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5935958933812243945}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5370719238625747776}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -128.9178, y: -2.5}
+  m_SizeDelta: {x: 75.9844, y: 75.9844}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3073126506571548025
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5935958933812243945}
+  m_CullTransparentMesh: 1
+--- !u!114 &8009816267415283474
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5935958933812243945}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -3007842669962690585, guid: 2712d769d2f363d47ad220d0aa8fb773,
+    type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &9157543609379783575
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 558955290179045704}
+  - component: {fileID: 7796225146612024699}
+  m_Layer: 5
+  m_Name: Reagents
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &558955290179045704
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9157543609379783575}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7756442910137057998}
+  - {fileID: 3949115953149995803}
+  - {fileID: 880285456139216972}
+  - {fileID: 8060720296607618926}
+  - {fileID: 6429764758093435895}
+  - {fileID: 6251553123731578447}
+  - {fileID: 7767545745357530228}
+  - {fileID: 5136557819894258024}
+  m_Father: {fileID: 5370719238625747776}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 40.685, y: -8.2152}
+  m_SizeDelta: {x: 248.6503, y: 69.0312}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &7796225146612024699
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9157543609379783575}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8a8695521f0d02e499659fee002a26c2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.GridLayoutGroup
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_StartCorner: 0
+  m_StartAxis: 0
+  m_CellSize: {x: 55, y: 25}
+  m_Spacing: {x: 5, y: 5}
+  m_Constraint: 0
+  m_ConstraintCount: 2
+--- !u!1001 &1471102987031400110
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 558955290179045704}
+    m_Modifications:
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4977046281147916994, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_RaycastTarget
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5769309921332315560, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Name
+      value: ReagentButtonTemplate (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8545785443212724535, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Maskable
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8545785443212724535, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_RaycastTarget
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7a569b20dd819e4448deab9c2e738b4e, type: 3}
+--- !u!224 &880285456139216972 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+    type: 3}
+  m_PrefabInstance: {fileID: 1471102987031400110}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3356055435714907641
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 558955290179045704}
+    m_Modifications:
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4977046281147916994, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_RaycastTarget
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5769309921332315560, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Name
+      value: ReagentButtonTemplate (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8545785443212724535, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Maskable
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8545785443212724535, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_RaycastTarget
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7a569b20dd819e4448deab9c2e738b4e, type: 3}
+--- !u!224 &3949115953149995803 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+    type: 3}
+  m_PrefabInstance: {fileID: 3356055435714907641}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4712474199919637781
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 558955290179045704}
+    m_Modifications:
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4977046281147916994, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_RaycastTarget
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5769309921332315560, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Name
+      value: ReagentButtonTemplate (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8545785443212724535, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Maskable
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8545785443212724535, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_RaycastTarget
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7a569b20dd819e4448deab9c2e738b4e, type: 3}
+--- !u!224 &6429764758093435895 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+    type: 3}
+  m_PrefabInstance: {fileID: 4712474199919637781}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5664671655488272557
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 558955290179045704}
+    m_Modifications:
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4977046281147916994, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_RaycastTarget
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5769309921332315560, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Name
+      value: ReagentButtonTemplate (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8545785443212724535, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Maskable
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8545785443212724535, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_RaycastTarget
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7a569b20dd819e4448deab9c2e738b4e, type: 3}
+--- !u!224 &6251553123731578447 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+    type: 3}
+  m_PrefabInstance: {fileID: 5664671655488272557}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6851583298214723466
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 558955290179045704}
+    m_Modifications:
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4977046281147916994, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_RaycastTarget
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5769309921332315560, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Name
+      value: ReagentButtonTemplate (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8545785443212724535, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Maskable
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8545785443212724535, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_RaycastTarget
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7a569b20dd819e4448deab9c2e738b4e, type: 3}
+--- !u!224 &5136557819894258024 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+    type: 3}
+  m_PrefabInstance: {fileID: 6851583298214723466}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8329076667355677334
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 558955290179045704}
+    m_Modifications:
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4977046281147916994, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_RaycastTarget
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5769309921332315560, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Name
+      value: ReagentButtonTemplate (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8545785443212724535, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Maskable
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8545785443212724535, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_RaycastTarget
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7a569b20dd819e4448deab9c2e738b4e, type: 3}
+--- !u!224 &7767545745357530228 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+    type: 3}
+  m_PrefabInstance: {fileID: 8329076667355677334}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8356821708246230060
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 558955290179045704}
+    m_Modifications:
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4977046281147916994, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_RaycastTarget
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5769309921332315560, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Name
+      value: ReagentButtonTemplate
+      objectReference: {fileID: 0}
+    - target: {fileID: 8545785443212724535, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Maskable
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8545785443212724535, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_RaycastTarget
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7a569b20dd819e4448deab9c2e738b4e, type: 3}
+--- !u!224 &7756442910137057998 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+    type: 3}
+  m_PrefabInstance: {fileID: 8356821708246230060}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8610988921000505740
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 558955290179045704}
+    m_Modifications:
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4977046281147916994, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_RaycastTarget
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5769309921332315560, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Name
+      value: ReagentButtonTemplate (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8545785443212724535, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_Maskable
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8545785443212724535, guid: 7a569b20dd819e4448deab9c2e738b4e,
+        type: 3}
+      propertyPath: m_RaycastTarget
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7a569b20dd819e4448deab9c2e738b4e, type: 3}
+--- !u!224 &8060720296607618926 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1755575553053370082, guid: 7a569b20dd819e4448deab9c2e738b4e,
+    type: 3}
+  m_PrefabInstance: {fileID: 8610988921000505740}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/Chemistry/RecipeTemplate.prefab.meta
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/Chemistry/RecipeTemplate.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8866e78d0fb6f2d43ba0ec4db65baf07
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabBoozeDispenser.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabBoozeDispenser.prefab
@@ -4712,6 +4712,7 @@ RectTransform:
   m_Children:
   - {fileID: 224969907841956502}
   - {fileID: 224846205583816840}
+  - {fileID: 9201613744628536131}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -4875,7 +4876,8 @@ MonoBehaviour:
   OnEscapeKey:
     m_PersistentCalls:
       m_Calls: []
-  DisableOnEscape: 0
+  DisableOnEscape: 1
+  ForceUIFocusOnEnable: 1
 --- !u!1 &1578125989792486
 GameObject:
   m_ObjectHideFlags: 0
@@ -11452,6 +11454,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f41ce54e3adddc243a63e91303c43614, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  AddInRunTime: 0
   ServerMethod:
     m_PersistentCalls:
       m_Calls:
@@ -12889,3 +12892,1487 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: "Cura\xE7ao"
+--- !u!1001 &467605039395724261
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 224979633078539924}
+    m_Modifications:
+    - target: {fileID: 44422820651656652, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 44422820651656652, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 44422820651656652, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 44422820651656652, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 44422820651656652, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 44422820651656652, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 80857233720399410, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 80857233720399410, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 80857233720399410, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 80857233720399410, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 80857233720399410, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 80857233720399410, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 432719410061878874, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 432719410061878874, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 432719410061878874, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 325
+      objectReference: {fileID: 0}
+    - target: {fileID: 432719410061878874, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 432719410061878874, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 166.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 432719410061878874, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -138.646
+      objectReference: {fileID: 0}
+    - target: {fileID: 505980651443047536, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 505980651443047536, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 505980651443047536, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 505980651443047536, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 505980651443047536, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 505980651443047536, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 648373426788417992, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 648373426788417992, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 648373426788417992, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 648373426788417992, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 648373426788417992, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 648373426788417992, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 847042509452221554, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 847042509452221554, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 847042509452221554, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 847042509452221554, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 847042509452221554, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 847042509452221554, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 963149094131687396, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 963149094131687396, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 963149094131687396, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 325
+      objectReference: {fileID: 0}
+    - target: {fileID: 963149094131687396, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 963149094131687396, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 166.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 963149094131687396, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -419.584
+      objectReference: {fileID: 0}
+    - target: {fileID: 1230767198726824683, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1230767198726824683, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1230767198726824683, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1230767198726824683, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1230767198726824683, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1230767198726824683, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1563567420243662573, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1563567420243662573, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1563567420243662573, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1563567420243662573, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1563567420243662573, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1563567420243662573, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1624911980248140631, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1624911980248140631, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1624911980248140631, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1624911980248140631, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1624911980248140631, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1624911980248140631, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1821655172589709957, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1821655172589709957, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1821655172589709957, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1821655172589709957, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1821655172589709957, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1821655172589709957, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1893779871038069589, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1893779871038069589, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1893779871038069589, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1893779871038069589, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1893779871038069589, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1893779871038069589, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1967158760298131839, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1967158760298131839, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1967158760298131839, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 325
+      objectReference: {fileID: 0}
+    - target: {fileID: 1967158760298131839, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1967158760298131839, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 166.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 1967158760298131839, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -232.292
+      objectReference: {fileID: 0}
+    - target: {fileID: 2107355217106534181, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2107355217106534181, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2107355217106534181, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2107355217106534181, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2107355217106534181, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2107355217106534181, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2112577929644054943, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2112577929644054943, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2112577929644054943, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2112577929644054943, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2112577929644054943, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2112577929644054943, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2228849387917651795, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2228849387917651795, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2228849387917651795, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2228849387917651795, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2228849387917651795, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2228849387917651795, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2331533841474479012, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2331533841474479012, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2331533841474479012, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2331533841474479012, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2331533841474479012, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2331533841474479012, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2545829929184350836, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2545829929184350836, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2545829929184350836, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2545829929184350836, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2545829929184350836, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2545829929184350836, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2823087401525725140, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2823087401525725140, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2823087401525725140, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2823087401525725140, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2823087401525725140, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2823087401525725140, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2828868597833703790, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2828868597833703790, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2828868597833703790, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2828868597833703790, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2828868597833703790, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2828868597833703790, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2884560132430474186, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2884560132430474186, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2884560132430474186, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2884560132430474186, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2884560132430474186, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2884560132430474186, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3179180685087758544, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3179180685087758544, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3179180685087758544, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3179180685087758544, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3179180685087758544, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3179180685087758544, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3202342964105887338, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3202342964105887338, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3202342964105887338, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3202342964105887338, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3202342964105887338, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3202342964105887338, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3432203781266107932, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3432203781266107932, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3432203781266107932, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3432203781266107932, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3432203781266107932, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3432203781266107932, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3589940391353197699, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3589940391353197699, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3589940391353197699, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3589940391353197699, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3589940391353197699, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3589940391353197699, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4183770914331768395, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4183770914331768395, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4183770914331768395, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4183770914331768395, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4183770914331768395, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4183770914331768395, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4206374637722652913, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4206374637722652913, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4206374637722652913, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4206374637722652913, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4206374637722652913, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4206374637722652913, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4316192017796781413, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4316192017796781413, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4316192017796781413, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4316192017796781413, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4316192017796781413, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4316192017796781413, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4328556747397963435, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4328556747397963435, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4328556747397963435, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 325
+      objectReference: {fileID: 0}
+    - target: {fileID: 4328556747397963435, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4328556747397963435, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 166.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 4328556747397963435, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -325.93802
+      objectReference: {fileID: 0}
+    - target: {fileID: 4474623852167480657, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4474623852167480657, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4474623852167480657, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4474623852167480657, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4474623852167480657, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4474623852167480657, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4533641232203443615, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_Name
+      value: ChemGuide
+      objectReference: {fileID: 0}
+    - target: {fileID: 4635518850408322800, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4635518850408322800, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4635518850408322800, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4635518850408322800, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4635518850408322800, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4635518850408322800, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4665327096176684374, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4665327096176684374, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4665327096176684374, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4665327096176684374, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4665327096176684374, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4665327096176684374, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5161271947733425470, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5161271947733425470, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5161271947733425470, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 325
+      objectReference: {fileID: 0}
+    - target: {fileID: 5161271947733425470, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5161271947733425470, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 166.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 5161271947733425470, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -45
+      objectReference: {fileID: 0}
+    - target: {fileID: 5359457089364125462, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5359457089364125462, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5359457089364125462, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5359457089364125462, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5359457089364125462, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5359457089364125462, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5467946898802300136, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5467946898802300136, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5467946898802300136, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5467946898802300136, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5467946898802300136, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5467946898802300136, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6058248835150261641, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6058248835150261641, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6058248835150261641, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6058248835150261641, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6058248835150261641, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6058248835150261641, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6623070730906181681, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6623070730906181681, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6623070730906181681, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6623070730906181681, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6623070730906181681, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6623070730906181681, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6769761520590273139, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6769761520590273139, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6769761520590273139, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6769761520590273139, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6769761520590273139, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6769761520590273139, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130688780245543184, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130688780245543184, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130688780245543184, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130688780245543184, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130688780245543184, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130688780245543184, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7175250015561912377, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: TargetReagentDispenser
+      value: 
+      objectReference: {fileID: 1576420294694384}
+    - target: {fileID: 7175250015561912377, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: ParentObjectToUseToFindMachineReactionsFromButtons
+      value: 
+      objectReference: {fileID: 1332940869920560}
+    - target: {fileID: 7389367364369988784, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7389367364369988784, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7389367364369988784, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7389367364369988784, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7389367364369988784, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7389367364369988784, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7414042636460481034, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7414042636460481034, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7414042636460481034, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7414042636460481034, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7414042636460481034, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7414042636460481034, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7424875305244801316, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7424875305244801316, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7424875305244801316, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7424875305244801316, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7424875305244801316, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7424875305244801316, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8150246796472670143, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8150246796472670143, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8150246796472670143, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8150246796472670143, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8150246796472670143, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8150246796472670143, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 339.4641
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 582.63
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 696
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 43.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8811258288912346625, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8811258288912346625, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8811258288912346625, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8811258288912346625, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8811258288912346625, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8811258288912346625, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8839960417917506983, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8839960417917506983, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8839960417917506983, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8839960417917506983, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8839960417917506983, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8839960417917506983, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f2f97c13483d1954db88bc4d426d9493, type: 3}
+--- !u!224 &9201613744628536131 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+    type: 3}
+  m_PrefabInstance: {fileID: 467605039395724261}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabChemistryDispenser.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabChemistryDispenser.prefab
@@ -2744,6 +2744,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f41ce54e3adddc243a63e91303c43614, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  AddInRunTime: 0
   ServerMethod:
     m_PersistentCalls:
       m_Calls:
@@ -7489,6 +7490,7 @@ RectTransform:
   m_Children:
   - {fileID: 224969907841956502}
   - {fileID: 224846205583816840}
+  - {fileID: 5140200445367471184}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -14819,3 +14821,1492 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7db2adeded33c7e4598e497ef3363eba, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &4511023180526912758
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 224979633078539924}
+    m_Modifications:
+    - target: {fileID: 44422820651656652, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 44422820651656652, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 44422820651656652, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 44422820651656652, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 44422820651656652, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 44422820651656652, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 80857233720399410, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 80857233720399410, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 80857233720399410, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 80857233720399410, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 80857233720399410, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 80857233720399410, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 432719410061878874, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 432719410061878874, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 432719410061878874, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 325
+      objectReference: {fileID: 0}
+    - target: {fileID: 432719410061878874, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 432719410061878874, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 166.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 432719410061878874, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -138.646
+      objectReference: {fileID: 0}
+    - target: {fileID: 505980651443047536, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 505980651443047536, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 505980651443047536, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 505980651443047536, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 505980651443047536, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 505980651443047536, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 648373426788417992, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 648373426788417992, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 648373426788417992, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 648373426788417992, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 648373426788417992, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 648373426788417992, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 847042509452221554, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 847042509452221554, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 847042509452221554, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 847042509452221554, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 847042509452221554, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 847042509452221554, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 963149094131687396, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 963149094131687396, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 963149094131687396, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 325
+      objectReference: {fileID: 0}
+    - target: {fileID: 963149094131687396, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 963149094131687396, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 166.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 963149094131687396, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -419.584
+      objectReference: {fileID: 0}
+    - target: {fileID: 1230767198726824683, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1230767198726824683, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1230767198726824683, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1230767198726824683, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1230767198726824683, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1230767198726824683, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1563567420243662573, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1563567420243662573, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1563567420243662573, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1563567420243662573, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1563567420243662573, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1563567420243662573, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1624911980248140631, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1624911980248140631, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1624911980248140631, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1624911980248140631, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1624911980248140631, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1624911980248140631, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1821655172589709957, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1821655172589709957, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1821655172589709957, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1821655172589709957, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1821655172589709957, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1821655172589709957, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1893779871038069589, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1893779871038069589, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1893779871038069589, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1893779871038069589, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1893779871038069589, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1893779871038069589, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1967158760298131839, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1967158760298131839, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1967158760298131839, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 325
+      objectReference: {fileID: 0}
+    - target: {fileID: 1967158760298131839, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1967158760298131839, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 166.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 1967158760298131839, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -232.292
+      objectReference: {fileID: 0}
+    - target: {fileID: 2107355217106534181, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2107355217106534181, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2107355217106534181, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2107355217106534181, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2107355217106534181, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2107355217106534181, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2112577929644054943, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2112577929644054943, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2112577929644054943, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2112577929644054943, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2112577929644054943, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2112577929644054943, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2228849387917651795, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2228849387917651795, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2228849387917651795, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2228849387917651795, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2228849387917651795, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2228849387917651795, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2331533841474479012, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2331533841474479012, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2331533841474479012, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2331533841474479012, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2331533841474479012, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2331533841474479012, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2545829929184350836, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2545829929184350836, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2545829929184350836, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2545829929184350836, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2545829929184350836, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2545829929184350836, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2823087401525725140, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2823087401525725140, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2823087401525725140, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2823087401525725140, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2823087401525725140, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2823087401525725140, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2828868597833703790, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2828868597833703790, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2828868597833703790, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2828868597833703790, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2828868597833703790, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2828868597833703790, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2884560132430474186, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2884560132430474186, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2884560132430474186, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2884560132430474186, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2884560132430474186, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2884560132430474186, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3179180685087758544, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3179180685087758544, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3179180685087758544, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3179180685087758544, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3179180685087758544, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3179180685087758544, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3202342964105887338, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3202342964105887338, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3202342964105887338, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3202342964105887338, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3202342964105887338, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3202342964105887338, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3432203781266107932, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3432203781266107932, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3432203781266107932, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3432203781266107932, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3432203781266107932, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3432203781266107932, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3589940391353197699, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3589940391353197699, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3589940391353197699, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3589940391353197699, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3589940391353197699, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3589940391353197699, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4183770914331768395, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4183770914331768395, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4183770914331768395, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4183770914331768395, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4183770914331768395, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4183770914331768395, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4206374637722652913, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4206374637722652913, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4206374637722652913, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4206374637722652913, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4206374637722652913, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4206374637722652913, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4316192017796781413, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4316192017796781413, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4316192017796781413, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4316192017796781413, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4316192017796781413, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4316192017796781413, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4328556747397963435, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4328556747397963435, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4328556747397963435, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 325
+      objectReference: {fileID: 0}
+    - target: {fileID: 4328556747397963435, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4328556747397963435, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 166.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 4328556747397963435, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -325.93802
+      objectReference: {fileID: 0}
+    - target: {fileID: 4474623852167480657, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4474623852167480657, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4474623852167480657, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4474623852167480657, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4474623852167480657, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4474623852167480657, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4533641232203443615, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_Name
+      value: ChemGuide
+      objectReference: {fileID: 0}
+    - target: {fileID: 4635518850408322800, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4635518850408322800, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4635518850408322800, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4635518850408322800, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4635518850408322800, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4635518850408322800, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4665327096176684374, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4665327096176684374, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4665327096176684374, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4665327096176684374, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4665327096176684374, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4665327096176684374, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5161271947733425470, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5161271947733425470, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5161271947733425470, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 325
+      objectReference: {fileID: 0}
+    - target: {fileID: 5161271947733425470, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5161271947733425470, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 166.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 5161271947733425470, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -45
+      objectReference: {fileID: 0}
+    - target: {fileID: 5359457089364125462, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5359457089364125462, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5359457089364125462, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5359457089364125462, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5359457089364125462, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5359457089364125462, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5467946898802300136, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5467946898802300136, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5467946898802300136, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5467946898802300136, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5467946898802300136, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5467946898802300136, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6058248835150261641, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6058248835150261641, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6058248835150261641, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6058248835150261641, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6058248835150261641, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6058248835150261641, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6623070730906181681, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6623070730906181681, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6623070730906181681, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6623070730906181681, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6623070730906181681, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6623070730906181681, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6769761520590273139, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6769761520590273139, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6769761520590273139, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6769761520590273139, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6769761520590273139, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6769761520590273139, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7019462119710963713, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_Maskable
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130688780245543184, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130688780245543184, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130688780245543184, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130688780245543184, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130688780245543184, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130688780245543184, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7175250015561912377, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: TargetReagentDispenser
+      value: 
+      objectReference: {fileID: 1576420294694384}
+    - target: {fileID: 7175250015561912377, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: ParentObjectToUseToFindMachineReactionsFromButtons
+      value: 
+      objectReference: {fileID: 1332940869920560}
+    - target: {fileID: 7389367364369988784, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7389367364369988784, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7389367364369988784, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7389367364369988784, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7389367364369988784, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7389367364369988784, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7414042636460481034, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7414042636460481034, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7414042636460481034, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7414042636460481034, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7414042636460481034, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7414042636460481034, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7424875305244801316, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7424875305244801316, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7424875305244801316, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7424875305244801316, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7424875305244801316, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7424875305244801316, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8150246796472670143, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8150246796472670143, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8150246796472670143, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8150246796472670143, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8150246796472670143, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8150246796472670143, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 339.4641
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 582.63
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 696
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -13.244
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8811258288912346625, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8811258288912346625, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8811258288912346625, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8811258288912346625, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8811258288912346625, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8811258288912346625, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8839960417917506983, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8839960417917506983, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8839960417917506983, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8839960417917506983, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8839960417917506983, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8839960417917506983, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f2f97c13483d1954db88bc4d426d9493, type: 3}
+--- !u!224 &5140200445367471184 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8777505488711633062, guid: f2f97c13483d1954db88bc4d426d9493,
+    type: 3}
+  m_PrefabInstance: {fileID: 4511023180526912758}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabChemistryDispenser.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabChemistryDispenser.prefab
@@ -7658,7 +7658,7 @@ MonoBehaviour:
   OnEscapeKey:
     m_PersistentCalls:
       m_Calls: []
-  DisableOnEscape: 0
+  DisableOnEscape: 1
   ForceUIFocusOnEnable: 1
 --- !u!1 &1578125989792486
 GameObject:
@@ -16009,6 +16009,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7175250015561912377, guid: f2f97c13483d1954db88bc4d426d9493,
+        type: 3}
+      propertyPath: DisplayAllReactions
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7175250015561912377, guid: f2f97c13483d1954db88bc4d426d9493,
         type: 3}

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabChemistryDispenser.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabChemistryDispenser.prefab
@@ -7659,6 +7659,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   DisableOnEscape: 0
+  ForceUIFocusOnEnable: 1
 --- !u!1 &1578125989792486
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabSodaDispenser.prefab
+++ b/UnityProject/Assets/Prefabs/UI/Tabs/Resources/TabSodaDispenser.prefab
@@ -68,6 +68,36 @@ PrefabInstance:
       propertyPath: m_Name
       value: shamblers
       objectReference: {fileID: 0}
+    - target: {fileID: 34920818005441983, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 34920818005441983, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 34920818005441983, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 325
+      objectReference: {fileID: 0}
+    - target: {fileID: 34920818005441983, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 34920818005441983, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 166.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 34920818005441983, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -138.646
+      objectReference: {fileID: 0}
     - target: {fileID: 38117639338227147, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgument
@@ -83,6 +113,36 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Text
       value: Lemon Lime
+      objectReference: {fileID: 0}
+    - target: {fileID: 106079741737867157, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 106079741737867157, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 106079741737867157, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 106079741737867157, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 106079741737867157, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 106079741737867157, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 114008745920958412, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
@@ -2083,6 +2143,66 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 495561021591764521, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 495561021591764521, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 495561021591764521, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 495561021591764521, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 495561021591764521, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 495561021591764521, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 531995915967368663, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 531995915967368663, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 531995915967368663, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 531995915967368663, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 531995915967368663, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 531995915967368663, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 548240236962931971, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
       propertyPath: m_Name
@@ -2097,6 +2217,126 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: watermelon
+      objectReference: {fileID: 0}
+    - target: {fileID: 801797627907146753, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 801797627907146753, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 801797627907146753, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 325
+      objectReference: {fileID: 0}
+    - target: {fileID: 801797627907146753, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 801797627907146753, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 166.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 801797627907146753, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -419.584
+      objectReference: {fileID: 0}
+    - target: {fileID: 989675788659017623, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 989675788659017623, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 989675788659017623, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 989675788659017623, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 989675788659017623, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 989675788659017623, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1045460168828754477, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1045460168828754477, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1045460168828754477, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1045460168828754477, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1045460168828754477, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1045460168828754477, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1220929152550097074, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1220929152550097074, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1220929152550097074, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1220929152550097074, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1220929152550097074, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1220929152550097074, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1266355737769050482, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
@@ -2269,10 +2509,70 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 009f1045026b48848b7eeb01060f8c18,
         type: 2}
+    - target: {fileID: 1427548751179943176, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1427548751179943176, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1427548751179943176, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1427548751179943176, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1427548751179943176, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1427548751179943176, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1503622698663916438, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
       propertyPath: m_Text
       value: Water
+      objectReference: {fileID: 0}
+    - target: {fileID: 1687113118784551182, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1687113118784551182, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1687113118784551182, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1687113118784551182, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1687113118784551182, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1687113118784551182, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1723195689945194298, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
@@ -2288,6 +2588,36 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Color.r
       value: 0.8980392
+      objectReference: {fileID: 0}
+    - target: {fileID: 1770815135677478070, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1770815135677478070, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1770815135677478070, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1770815135677478070, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1770815135677478070, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1770815135677478070, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1791715785883889175, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
@@ -2318,6 +2648,126 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 65.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1957981862997443194, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1957981862997443194, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1957981862997443194, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1957981862997443194, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1957981862997443194, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1957981862997443194, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1964572371846046912, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1964572371846046912, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1964572371846046912, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1964572371846046912, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1964572371846046912, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1964572371846046912, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2032612772459511984, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2032612772459511984, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2032612772459511984, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2032612772459511984, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2032612772459511984, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2032612772459511984, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2103607868824709786, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2103607868824709786, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2103607868824709786, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 325
+      objectReference: {fileID: 0}
+    - target: {fileID: 2103607868824709786, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2103607868824709786, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 166.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 2103607868824709786, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -232.292
       objectReference: {fileID: 0}
     - target: {fileID: 2134300693703365278, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
@@ -2350,6 +2800,36 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2134300693703365278, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2250275839384695136, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2250275839384695136, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2250275839384695136, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2250275839384695136, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2250275839384695136, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2250275839384695136, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
@@ -2389,6 +2869,66 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2395753709607844491, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2395753709607844491, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2395753709607844491, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2395753709607844491, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2395753709607844491, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2395753709607844491, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400659697323416625, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400659697323416625, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400659697323416625, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400659697323416625, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400659697323416625, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400659697323416625, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2435100296911250350, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
       propertyPath: m_Color.b
@@ -2404,6 +2944,36 @@ PrefabInstance:
       propertyPath: m_Color.r
       value: 0.8980392
       objectReference: {fileID: 0}
+    - target: {fileID: 2677916211954190737, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2677916211954190737, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2677916211954190737, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2677916211954190737, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2677916211954190737, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2677916211954190737, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2715576197408430378, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgument
@@ -2415,6 +2985,36 @@ PrefabInstance:
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_StringArgument
       value: chlorine
       objectReference: {fileID: 0}
+    - target: {fileID: 2748886698346559553, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2748886698346559553, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2748886698346559553, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2748886698346559553, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2748886698346559553, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2748886698346559553, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2834719547815014335, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
       propertyPath: ServerMethod.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgument
@@ -2425,6 +3025,126 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Text
       value: Watermelon Juice
+      objectReference: {fileID: 0}
+    - target: {fileID: 3016540291932042745, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3016540291932042745, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3016540291932042745, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3016540291932042745, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3016540291932042745, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3016540291932042745, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3029873322077578639, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3029873322077578639, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3029873322077578639, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3029873322077578639, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3029873322077578639, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3029873322077578639, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3054552924545680181, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3054552924545680181, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3054552924545680181, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3054552924545680181, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3054552924545680181, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3054552924545680181, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3347652704961359919, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3347652704961359919, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3347652704961359919, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3347652704961359919, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3347652704961359919, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3347652704961359919, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3573100605555077977, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
@@ -2492,6 +3212,96 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4012500068886282086, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012500068886282086, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012500068886282086, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012500068886282086, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012500068886282086, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4012500068886282086, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4063455097642000052, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4063455097642000052, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4063455097642000052, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4063455097642000052, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4063455097642000052, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4063455097642000052, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4210684386164327758, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4210684386164327758, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4210684386164327758, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 325
+      objectReference: {fileID: 0}
+    - target: {fileID: 4210684386164327758, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4210684386164327758, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 166.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 4210684386164327758, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -325.93802
+      objectReference: {fileID: 0}
     - target: {fileID: 4277455680547867273, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
       propertyPath: m_Name
@@ -2502,10 +3312,70 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4331705536085396244, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4331705536085396244, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4331705536085396244, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4331705536085396244, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4331705536085396244, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4331705536085396244, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4342318141916423001, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
       propertyPath: m_Text
       value: Grenadine
+      objectReference: {fileID: 0}
+    - target: {fileID: 4355817794273963438, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4355817794273963438, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4355817794273963438, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4355817794273963438, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4355817794273963438, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4355817794273963438, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4406463494141294958, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
@@ -2538,6 +3408,36 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4406463494141294958, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4439271101582413440, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4439271101582413440, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4439271101582413440, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4439271101582413440, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4439271101582413440, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4439271101582413440, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
@@ -2577,6 +3477,36 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4746162010956990171, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4746162010956990171, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4746162010956990171, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 325
+      objectReference: {fileID: 0}
+    - target: {fileID: 4746162010956990171, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4746162010956990171, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 166.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 4746162010956990171, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -45
+      objectReference: {fileID: 0}
     - target: {fileID: 4755092235806479509, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
       propertyPath: m_Color.b
@@ -2603,6 +3533,66 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 4f35c3b79d1187213bc2c025391e96e9,
         type: 2}
+    - target: {fileID: 5055835509195689237, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5055835509195689237, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5055835509195689237, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5055835509195689237, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5055835509195689237, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5055835509195689237, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5099154536799467187, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5099154536799467187, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5099154536799467187, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5099154536799467187, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5099154536799467187, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5099154536799467187, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5166518932078226517, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -2648,6 +3638,66 @@ PrefabInstance:
       propertyPath: m_Color.r
       value: 0.8980392
       objectReference: {fileID: 0}
+    - target: {fileID: 5484779191891279091, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5484779191891279091, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5484779191891279091, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5484779191891279091, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5484779191891279091, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5484779191891279091, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593269482099445517, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593269482099445517, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593269482099445517, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593269482099445517, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593269482099445517, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593269482099445517, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5712987754509911998, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
       propertyPath: m_SizeDelta.y
@@ -2657,6 +3707,36 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -250
+      objectReference: {fileID: 0}
+    - target: {fileID: 5939822921358997100, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5939822921358997100, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5939822921358997100, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5939822921358997100, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5939822921358997100, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5939822921358997100, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6192893169969112061, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
@@ -2673,10 +3753,160 @@ PrefabInstance:
       propertyPath: m_Color.r
       value: 0.8980392
       objectReference: {fileID: 0}
+    - target: {fileID: 6597283563496366486, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6597283563496366486, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6597283563496366486, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6597283563496366486, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6597283563496366486, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6597283563496366486, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6743186011967093716, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6743186011967093716, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6743186011967093716, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6743186011967093716, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6743186011967093716, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6743186011967093716, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6845279976273386171, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
       propertyPath: m_Text
       value: Tonic Water
+      objectReference: {fileID: 0}
+    - target: {fileID: 6962208994002633199, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6962208994002633199, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6962208994002633199, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6962208994002633199, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6962208994002633199, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6962208994002633199, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6985375740858361685, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6985375740858361685, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6985375740858361685, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6985375740858361685, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6985375740858361685, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6985375740858361685, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7023135530668974785, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7023135530668974785, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7023135530668974785, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7023135530668974785, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7023135530668974785, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7023135530668974785, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7056342209961371401, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
@@ -2699,6 +3929,36 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 802748d3f74335a789baeafecd0351f9,
         type: 2}
+    - target: {fileID: 7244057473260942069, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7244057473260942069, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7244057473260942069, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7244057473260942069, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7244057473260942069, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7244057473260942069, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7432380724789560665, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
       propertyPath: m_Name
@@ -2795,6 +4055,36 @@ PrefabInstance:
       propertyPath: m_Color.r
       value: 0.8980392
       objectReference: {fileID: 0}
+    - target: {fileID: 8603627951752842330, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8603627951752842330, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8603627951752842330, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8603627951752842330, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8603627951752842330, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8603627951752842330, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8691456109800355252, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
       propertyPath: m_Text
@@ -2820,6 +4110,36 @@ PrefabInstance:
       propertyPath: m_Color.r
       value: 0.8980392
       objectReference: {fileID: 0}
+    - target: {fileID: 8951648579421435364, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8951648579421435364, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8951648579421435364, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8951648579421435364, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8951648579421435364, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8951648579421435364, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8962806482951278835, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
       propertyPath: m_SizeDelta.y
@@ -2829,6 +4149,36 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -250
+      objectReference: {fileID: 0}
+    - target: {fileID: 8993861524621741634, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8993861524621741634, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8993861524621741634, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8993861524621741634, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8993861524621741634, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8993861524621741634, guid: ead46aed092670862ad0829b2a40e51b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9020108238757623730, guid: ead46aed092670862ad0829b2a40e51b,
         type: 3}
@@ -3397,6 +4747,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   DisableOnEscape: 1
+  ForceUIFocusOnEnable: 0
 --- !u!1 &7449150915426741594 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1578125989792486, guid: ead46aed092670862ad0829b2a40e51b,

--- a/UnityProject/Assets/Scripts/US13/ChemistryComponents/MorphableReagentContainer.cs
+++ b/UnityProject/Assets/Scripts/US13/ChemistryComponents/MorphableReagentContainer.cs
@@ -57,7 +57,7 @@ namespace US13.ChemistryComponents
 			if (newMajorReagent != majorReagent)
 			{
 				// get major reagent name
-				var majorReagentName = newMajorReagent ? newMajorReagent.Name : "";
+				var majorReagentName = newMajorReagent ? newMajorReagent.ReagentName : "";
 
 				// now send it to all clients as string hash
 				majorReagentNameHash = majorReagentName.GetStableHashCode();

--- a/UnityProject/Assets/Scripts/US13/ChemistryComponents/MorphableReagentContainerData.cs
+++ b/UnityProject/Assets/Scripts/US13/ChemistryComponents/MorphableReagentContainerData.cs
@@ -34,7 +34,7 @@ namespace US13.ChemistryComponents
 		public ContainerCustomSprite Get(int reagentNameHash)
 		{
 			var pair = spritesData.FirstOrDefault((p) =>
-					p.Key.Name.GetStableHashCode() == reagentNameHash);
+					p.Key.ReagentName.GetStableHashCode() == reagentNameHash);
 			return pair.Value;
 		}
 	}

--- a/UnityProject/Assets/Scripts/US13/Clothing/Eyewear/MedicalHUD.cs
+++ b/UnityProject/Assets/Scripts/US13/Clothing/Eyewear/MedicalHUD.cs
@@ -212,7 +212,7 @@ namespace US13.Clothing.Eyewear
 			foreach (var cure in CureManager.Instance.CureableSicknesses)
 			{
 				if (blood.reagents.TryGetValue(cure.Sickness, out float amount) == false) continue;
-				if (CommonSicknesses.Instance.diseaseReactionDictionary.TryGetValue(cure.Sickness.Name, out var reaction) == false) continue;
+				if (CommonSicknesses.Instance.diseaseReactionDictionary.TryGetValue(cure.Sickness.ReagentName, out var reaction) == false) continue;
 
 				float concentrationPercent = (amount / system.NormalBlood) * 100;
 				int newStage = reaction.GetStageID(concentrationPercent);

--- a/UnityProject/Assets/Scripts/US13/Core/Modular/IReagentDispenser.cs
+++ b/UnityProject/Assets/Scripts/US13/Core/Modular/IReagentDispenser.cs
@@ -1,0 +1,9 @@
+﻿using Chemistry;
+
+namespace US13.Core.Modular
+{
+	public interface IReagentDispenser
+	{
+		public void DispenseChemical(Reagent reagent);
+	}
+}

--- a/UnityProject/Assets/Scripts/US13/Core/Modular/IReagentDispenser.cs.meta
+++ b/UnityProject/Assets/Scripts/US13/Core/Modular/IReagentDispenser.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 44124dc77a5646cd86b45987779237a5
+timeCreated: 1789069610

--- a/UnityProject/Assets/Scripts/US13/Items/Tool/AtmosphericAnalyser/AtmosphericAnalyser.cs
+++ b/UnityProject/Assets/Scripts/US13/Items/Tool/AtmosphericAnalyser/AtmosphericAnalyser.cs
@@ -144,7 +144,7 @@ namespace US13.Items.Tool.AtmosphericAnalyser
 
 						if (ratio.Approx(0) == false)
 						{
-							sb.AppendLine($"{liquid.Key.Name}: {ratio:P}");
+							sb.AppendLine($"{liquid.Key.ReagentName}: {ratio:P}");
 						}
 					}
 				}

--- a/UnityProject/Assets/Scripts/US13/Managers/GameConfigManager.cs
+++ b/UnityProject/Assets/Scripts/US13/Managers/GameConfigManager.cs
@@ -140,6 +140,8 @@ namespace US13.Managers
 		public float ExplosionStepTimeInSeconds = 0.14f;
 		public float MinimumThrustStrengthToKnockdownPlayers = 0.85f;
 
+		public bool EnableReactionsGuide = true;
+
 		//physics
 		public float ObjectBouncynessMultiplier = 1f;
 		public float FrictionMultiplier = 1f;

--- a/UnityProject/Assets/Scripts/US13/Objects/Medical/Virology/CureTester.cs
+++ b/UnityProject/Assets/Scripts/US13/Objects/Medical/Virology/CureTester.cs
@@ -109,7 +109,7 @@ namespace US13.Objects.Medical.Virology
 			if (itemStorage.GetIndexedItemSlot(0).ItemObject?.TryGetCachedComponent<ReagentContainer>(out var container, includeDisabled: false) == true)
 			{
 				StringBuilder machineDialogue = new StringBuilder();
-				machineDialogue.AppendLine($"Test results of cure against sickness {connectedSequenceAnalyzer.ActiveSickness.Name}: ");
+				machineDialogue.AppendLine($"Test results of cure against sickness {connectedSequenceAnalyzer.ActiveSickness.ReagentName}: ");
 				TestCure(in machineDialogue, container.CurrentReagentMix);
 				Chat.AddCommMsgByMachineToChat(gameObject, machineDialogue.ToString(), ChatChannel.Local, Loudness.NORMAL);
 			}

--- a/UnityProject/Assets/Scripts/US13/Objects/Medical/Virology/SequenceAnalyzer.cs
+++ b/UnityProject/Assets/Scripts/US13/Objects/Medical/Virology/SequenceAnalyzer.cs
@@ -96,11 +96,11 @@ namespace US13.Objects.Medical.Virology
 				if (container.CurrentReagentMix.reagents.ContainsKey(curePair.Key) == false) continue;
 				_activeSickness = curePair.Key;
 				machineDialogue.AppendLine(
-					$"Sickness {curePair.Key.Name} has been identified in the sample.\nFormulating possible cure reagents:");
+					$"Sickness {curePair.Key.ReagentName} has been identified in the sample.\nFormulating possible cure reagents:");
 				AddCluesToStringBuilder(in machineDialogue, curePair.Value);
 
 			}
-			if(_activeSickness is not null) machineDialogue.AppendLine($"Sickness {_activeSickness.Name} is registered as active disease.");
+			if(_activeSickness is not null) machineDialogue.AppendLine($"Sickness {_activeSickness.ReagentName} is registered as active disease.");
 
 			Chat.AddCommMsgByMachineToChat(gameObject,
 				_activeSickness is null ? "No sickness was identified in the provided sample." : machineDialogue.ToString(),
@@ -111,7 +111,7 @@ namespace US13.Objects.Medical.Virology
 		{
 			foreach (Reagent cureReagent in cure.ClueReagents)
 			{
-				builder.AppendLine($"- {cureReagent.Name}");
+				builder.AppendLine($"- {cureReagent.ReagentName}");
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/US13/ScriptableObjects/ChemistryReagentsSO.cs
+++ b/UnityProject/Assets/Scripts/US13/ScriptableObjects/ChemistryReagentsSO.cs
@@ -92,6 +92,39 @@ namespace US13.ScriptableObjects
 				Loggy.Error(e.ToString());
 			}
 		}
+
+		public List<Reaction> FindAllReactionsThatUseReagentInIngredients(Reagent reagent)
+		{
+			var reactions = new List<Reaction>();
+			foreach (var reaction in allChemistryReactions)
+			{
+				if (!reaction) continue;
+				if (reaction.ingredients.ContainsKey(reagent))
+				{
+					reactions.Add(reaction);
+				}
+			}
+			return reactions;
+		}
+
+		public List<Reaction> FindAllReactionsThatUseReagentInIngredients(string reagent)
+		{
+			var reactions = new List<Reaction>();
+			foreach (var reaction in allChemistryReactions)
+			{
+				if (!reaction) continue;
+				foreach (var ingredient in reaction.ingredients.Keys)
+				{
+					if (!ingredient) continue;
+					if (ingredient.name.Equals(reagent, StringComparison.OrdinalIgnoreCase))
+					{
+						reactions.Add(reaction);
+						break;
+					}
+				}
+			}
+			return reactions;
+		}
 	}
 
 #if UNITY_EDITOR

--- a/UnityProject/Assets/Scripts/US13/Systems/Chemistry/Editor/Importer.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/Chemistry/Editor/Importer.cs
@@ -123,7 +123,7 @@ namespace Chemistry.Editor
 
 				foreach (var reagent in reagentsGroup)
 				{
-					var path = Path.Combine(prefixPath, ToPascalCase(reagent.Value.Name) + ".asset");
+					var path = Path.Combine(prefixPath, ToPascalCase(reagent.Value.ReagentName) + ".asset");
 					var localPath = LocalPath(path);
 
 					if (!File.Exists(path) || overwrite)
@@ -348,7 +348,7 @@ namespace Chemistry.Editor
 
 			if (value.TryGetValue("name", out var name))
 			{
-				reagent.Name = (string) name;
+				reagent.ReagentName = (string) name;
 			}
 
 			if (value.TryGetValue("description", out var description))

--- a/UnityProject/Assets/Scripts/US13/Systems/Chemistry/Reaction.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/Chemistry/Reaction.cs
@@ -263,6 +263,16 @@ namespace Chemistry
 			return true;
 		}
 
+		public Color GetReactionColor()
+		{
+			Color color = Color.antiqueWhite;
+			foreach (var result in results.m_dict)
+			{
+				color += result.Key.color * result.Value;
+			}
+			color /= results.m_dict.Count;
+			return color;
+		}
 	}
 
 	public struct CachedEffect

--- a/UnityProject/Assets/Scripts/US13/Systems/Chemistry/Reaction.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/Chemistry/Reaction.cs
@@ -47,7 +47,7 @@ namespace Chemistry
 
 				foreach (KeyValuePair<Reagent, int> product in results.m_dict)
 				{
-					sb.Append($"{product.Key.Name},");
+					sb.Append($"{product.Key.ReagentName},");
 				}
 
 				sb.Remove(sb.Length - 1, 1); //remove last comma

--- a/UnityProject/Assets/Scripts/US13/Systems/Chemistry/Reagent.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/Chemistry/Reagent.cs
@@ -66,7 +66,7 @@ namespace Chemistry
 #endif
 		}
 
-		public string Name
+		public string ReagentName
 		{
 			get => displayName ?? name;
 			set => displayName = value;
@@ -79,7 +79,7 @@ namespace Chemistry
 
 		public override string ToString()
 		{
-			return Name;
+			return ReagentName;
 		}
 
 		public bool Equals(Reagent other)

--- a/UnityProject/Assets/Scripts/US13/Systems/Chemistry/Reagent.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/Chemistry/Reagent.cs
@@ -19,7 +19,7 @@ namespace Chemistry
 	{
 		[SerializeField]
 		[Tooltip("This is optional")]
-		string displayName;
+		public string displayName;
 		[TextArea]
 		public string description;
 		public Color color;

--- a/UnityProject/Assets/Scripts/US13/Systems/Chemistry/ReagentMix.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/Chemistry/ReagentMix.cs
@@ -249,7 +249,7 @@ namespace Chemistry
 		{
 			get
 			{
-				return MajorMixReagent.Name;
+				return MajorMixReagent.ReagentName;
 			}
 		}
 
@@ -751,7 +751,7 @@ namespace Chemistry
 					}
 					else
 					{
-						Loggy.Error($"An error occured while trying to get {reagent.Name} from {MixName}.\n {e}");
+						Loggy.Error($"An error occured while trying to get {reagent.ReagentName} from {MixName}.\n {e}");
 						return 0;
 					}
 				}

--- a/UnityProject/Assets/Scripts/US13/Systems/Crafting/CraftingDatabase.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/Crafting/CraftingDatabase.cs
@@ -42,7 +42,7 @@ namespace US13.Systems.Crafting
 		{
 			foreach (GrinderRecipe recipe in grinderRecipeList)
 			{
-				if (recipe.Output.Name == reagentName)
+				if (recipe.Output.ReagentName == reagentName)
 				{
 					return recipe.Output;
 				}

--- a/UnityProject/Assets/Scripts/US13/Systems/CraftingV2/CraftingRecipe.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/CraftingV2/CraftingRecipe.cs
@@ -253,7 +253,7 @@ namespace US13.Systems.CraftingV2
 
 				if (foundAmount < requiredReagent.RequiredAmount)
 				{
-					ReasonString += $", Not enough of {requiredReagent.RequiredReagent.Name} Amount found {foundAmount} ";
+					ReasonString += $", Not enough of {requiredReagent.RequiredReagent.ReagentName} Amount found {foundAmount} ";
 					return false;
 				}
 			}

--- a/UnityProject/Assets/Scripts/US13/Systems/CraftingV2/GUI/CraftingMenu.cs
+++ b/UnityProject/Assets/Scripts/US13/Systems/CraftingV2/GUI/CraftingMenu.cs
@@ -353,7 +353,7 @@ namespace US13.Systems.CraftingV2.GUI
 					.Append("- ")
 					.Append(ingredientReagent.RequiredAmount)
 					.Append("u ")
-					.Append(ingredientReagent.RequiredReagent.Name)
+					.Append(ingredientReagent.RequiredReagent.ReagentName)
 					.AppendLine()
 					.AppendLine();
 			}

--- a/UnityProject/Assets/Scripts/US13/UI/Core/EscapeKeyTarget.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Core/EscapeKeyTarget.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using UnityEngine.Events;
 using US13.Managers;
 using US13.UI.Core.Net;
+using US13.UI.Systems;
 using US13.UI.Systems.IngameMenu;
 
 namespace US13.UI.Core
@@ -14,7 +15,6 @@ namespace US13.UI.Core
 	/// </summary>
 	public class EscapeKeyTarget : MonoBehaviour
 	{
-
 		public NetTab NetTab;
 
 		[SerializeField]
@@ -29,6 +29,8 @@ namespace US13.UI.Core
 		/// A linked list which keeps track of all the EscapeKeyTargets so they can be closed later
 		/// </summary>
 		private static LinkedList<EscapeKeyTarget> Targets = new LinkedList<EscapeKeyTarget>();
+
+		public bool ForceUIFocusOnEnable = false;
 
 		/// <summary>
 		/// Handles escape key presses. Will close the most recently opened EscapeKeyTarget or will open the main menu if there are none.
@@ -73,12 +75,21 @@ namespace US13.UI.Core
 			// Add this object to the top of the stack so Esc will close it next
 			Loggy.Info("Adding escape key target: " + this.name, Category.UserInput);
 			Targets.AddLast(this);
+			if (ForceUIFocusOnEnable)
+			{
+				UIManager.IsInputFocus = true;
+			}
 		}
+
 		void OnDisable()
 		{
 			// Remove the escape key target
 			Loggy.Info("Removing escape key target: " + this.name, Category.UserInput);
 			Targets.Remove(this);
+			if (ForceUIFocusOnEnable)
+			{
+				UIManager.IsInputFocus = false;
+			}
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/US13/UI/Objects/Chemistry.meta
+++ b/UnityProject/Assets/Scripts/US13/UI/Objects/Chemistry.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4e8c73942ea247d18673e0a545a60b1b
+timeCreated: 1789073092

--- a/UnityProject/Assets/Scripts/US13/UI/Objects/Chemistry/ReactionsGuide.meta
+++ b/UnityProject/Assets/Scripts/US13/UI/Objects/Chemistry/ReactionsGuide.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 39f2e6513c6845cc995bc7682c380bab
+timeCreated: 1789073114

--- a/UnityProject/Assets/Scripts/US13/UI/Objects/Chemistry/ReactionsGuide/Atoms.meta
+++ b/UnityProject/Assets/Scripts/US13/UI/Objects/Chemistry/ReactionsGuide/Atoms.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 70ec3d1b83d04f37bf850f0bacbbed34
+timeCreated: 1789075149

--- a/UnityProject/Assets/Scripts/US13/UI/Objects/Chemistry/ReactionsGuide/Atoms/ReactionDisplay.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Objects/Chemistry/ReactionsGuide/Atoms/ReactionDisplay.cs
@@ -25,7 +25,7 @@ namespace US13.UI.Objects.Chemistry.ReactionsGuide.Atoms
 			{
 				var newButton = Instantiate(ReagentButtonTemplate, ReagentButtonsList.transform);
 				var buttonText = newButton.GetComponentInChildren<TMP_Text>();
-				buttonText.text = string.IsNullOrEmpty(ingredient.Name) ? ingredient.name : $"{ingredient.Name}";
+				buttonText.text = string.IsNullOrEmpty(ingredient.ReagentName) ? ingredient.name : $"{ingredient.ReagentName}";
 				var button = newButton.GetComponent<Button>();
 				button.onClick.AddListener(() => reagentDispenser.DispenseChemical(ingredient));
 			}

--- a/UnityProject/Assets/Scripts/US13/UI/Objects/Chemistry/ReactionsGuide/Atoms/ReactionDisplay.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Objects/Chemistry/ReactionsGuide/Atoms/ReactionDisplay.cs
@@ -1,0 +1,31 @@
+﻿using Chemistry;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+using Util;
+
+namespace US13.UI.Objects.Chemistry.ReactionsGuide.Atoms
+{
+	public class ReactionDisplay : MonoBehaviour
+	{
+		public Image SplatColorImage;
+		public TMP_Text DisplayName;
+
+		public GameObject ReagentButtonTemplate;
+
+		public GameObject ReagentButtonsList;
+
+		public void Initialize(Reaction reaction)
+		{
+			SplatColorImage.color = reaction.GetReactionColor();
+			DisplayName.text = string.IsNullOrEmpty(reaction.DisplayName) ? reaction.name : $"{reaction.DisplayName}";
+			ReagentButtonsList.DestroyAllChildren();
+			foreach (var ingredient in reaction.ingredients.Keys)
+			{
+				var newButton = Instantiate(ReagentButtonTemplate, ReagentButtonsList.transform);
+				var buttonText = newButton.GetComponentInChildren<TMP_Text>();
+				buttonText.text = string.IsNullOrEmpty(ingredient.Name) ? ingredient.name : $"{ingredient.Name}";
+			}
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/US13/UI/Objects/Chemistry/ReactionsGuide/Atoms/ReactionDisplay.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Objects/Chemistry/ReactionsGuide/Atoms/ReactionDisplay.cs
@@ -2,6 +2,7 @@
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
+using US13.Core.Modular;
 using Util;
 
 namespace US13.UI.Objects.Chemistry.ReactionsGuide.Atoms
@@ -15,16 +16,18 @@ namespace US13.UI.Objects.Chemistry.ReactionsGuide.Atoms
 
 		public GameObject ReagentButtonsList;
 
-		public void Initialize(Reaction reaction)
+		public void Initialize(Reaction reaction, IReagentDispenser reagentDispenser)
 		{
 			SplatColorImage.color = reaction.GetReactionColor();
 			DisplayName.text = string.IsNullOrEmpty(reaction.DisplayName) ? reaction.name : $"{reaction.DisplayName}";
 			ReagentButtonsList.DestroyAllChildren();
-			foreach (var ingredient in reaction.ingredients.Keys)
+			foreach (Reagent ingredient in reaction.ingredients.Keys)
 			{
 				var newButton = Instantiate(ReagentButtonTemplate, ReagentButtonsList.transform);
 				var buttonText = newButton.GetComponentInChildren<TMP_Text>();
 				buttonText.text = string.IsNullOrEmpty(ingredient.Name) ? ingredient.name : $"{ingredient.Name}";
+				var button = newButton.GetComponent<Button>();
+				button.onClick.AddListener(() => reagentDispenser.DispenseChemical(ingredient));
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/US13/UI/Objects/Chemistry/ReactionsGuide/Atoms/ReactionDisplay.cs.meta
+++ b/UnityProject/Assets/Scripts/US13/UI/Objects/Chemistry/ReactionsGuide/Atoms/ReactionDisplay.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0ed202b1c01348dfaf122ea567ce581b
+timeCreated: 1789075165

--- a/UnityProject/Assets/Scripts/US13/UI/Objects/Chemistry/ReactionsGuide/GUI_ReactionGuide.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Objects/Chemistry/ReactionsGuide/GUI_ReactionGuide.cs
@@ -8,6 +8,7 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 using US13.Core.Modular;
+using US13.Managers.NetworkManagement;
 using US13.ScriptableObjects;
 using US13.UI.Objects.Chemistry.ReactionsGuide.Atoms;
 using Util;
@@ -52,6 +53,7 @@ namespace US13.UI.Objects.Chemistry.ReactionsGuide
 
 		private void Awake()
 		{
+			if (CustomNetworkManager.IsHeadless) return;
 			if (GrabAllReactionsFromParent() == false || CheckNothingIsMissing() == false)
 			{
 				Loggy.Error("GUI_ReactionGuide is missing required components. Please check the inspector.");

--- a/UnityProject/Assets/Scripts/US13/UI/Objects/Chemistry/ReactionsGuide/GUI_ReactionGuide.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Objects/Chemistry/ReactionsGuide/GUI_ReactionGuide.cs
@@ -35,6 +35,8 @@ namespace US13.UI.Objects.Chemistry.ReactionsGuide
 		[BoxGroup("Setup")] public GameObject ReactionListContainer;
 		[BoxGroup("Setup")] public TMP_Text PageNumberText;
 		[BoxGroup("Setup")] public TMP_Text NumberOfReactionsText;
+		[BoxGroup("Setup")] public TMP_InputField SearchBarField;
+		[BoxGroup("Setup")] public Button SearchButton;
 
 		[SerializeField, HideIf(nameof(DisplayAllReactions))]
 		private List<Reaction> reactionsToDisplay = new();
@@ -50,12 +52,19 @@ namespace US13.UI.Objects.Chemistry.ReactionsGuide
 
 		private void Awake()
 		{
-
 			if (GrabAllReactionsFromParent() == false || CheckNothingIsMissing() == false)
 			{
 				Loggy.Error("GUI_ReactionGuide is missing required components. Please check the inspector.");
 				return;
 			}
+			SearchBarField?.onSubmit.AddListener(SearchReactions);
+			SearchButton?.onClick.AddListener(() => SearchReactions(SearchBarField.text));
+		}
+
+		private void OnDestroy()
+		{
+			SearchBarField.onSubmit.RemoveAllListeners();
+			SearchButton.onClick.RemoveAllListeners();
 		}
 
 		private bool CheckNothingIsMissing()
@@ -131,7 +140,7 @@ namespace US13.UI.Objects.Chemistry.ReactionsGuide
 				var reactionDisplay = reactionEntry.GetComponent<ReactionDisplay>();
 				if (reactionDisplay != null)
 				{
-					reactionDisplay.Initialize(reaction);
+					reactionDisplay.Initialize(reaction, ReagentDispenser);
 				}
 			}
 		}
@@ -150,6 +159,28 @@ namespace US13.UI.Objects.Chemistry.ReactionsGuide
 			{
 				UpdatePage(currentReactionPageOffset - 1);
 			}
+		}
+
+		public void SearchReactions(string searchTerm)
+		{
+			if (string.IsNullOrWhiteSpace(searchTerm))
+			{
+				if (DisplayAllReactions == false)
+				{
+					GrabAllReactionsFromParent();
+				}
+				else
+				{
+					storedReactions = ChemistryReagentsSO.Instance.AllChemistryReactions;
+				}
+			}
+			else
+			{
+				storedReactions = ChemistryReagentsSO.Instance.AllChemistryReactions
+					.Where(r => r.DisplayName.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) || r.name.Contains(searchTerm, StringComparison.OrdinalIgnoreCase))
+					.ToList();
+			}
+			UpdatePage(1);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/US13/UI/Objects/Chemistry/ReactionsGuide/GUI_ReactionGuide.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Objects/Chemistry/ReactionsGuide/GUI_ReactionGuide.cs
@@ -8,6 +8,7 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 using US13.Core.Modular;
+using US13.Managers;
 using US13.Managers.NetworkManagement;
 using US13.ScriptableObjects;
 using US13.UI.Objects.Chemistry.ReactionsGuide.Atoms;
@@ -53,6 +54,11 @@ namespace US13.UI.Objects.Chemistry.ReactionsGuide
 
 		private void Awake()
 		{
+			if (GameConfigManager.GameConfig.EnableReactionsGuide == false)
+			{
+				this.SetActive(false);
+				return;
+			}
 			if (CustomNetworkManager.IsHeadless) return;
 			if (GrabAllReactionsFromParent() == false || CheckNothingIsMissing() == false)
 			{
@@ -67,6 +73,15 @@ namespace US13.UI.Objects.Chemistry.ReactionsGuide
 		{
 			SearchBarField.onSubmit.RemoveAllListeners();
 			SearchButton.onClick.RemoveAllListeners();
+		}
+
+		private void OnEnable()
+		{
+			// can be disabled by an admin mid-game.
+			if (GameConfigManager.GameConfig.EnableReactionsGuide == false)
+			{
+				this.SetActive(false);
+			}
 		}
 
 		private bool CheckNothingIsMissing()

--- a/UnityProject/Assets/Scripts/US13/UI/Objects/Chemistry/ReactionsGuide/GUI_ReactionGuide.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Objects/Chemistry/ReactionsGuide/GUI_ReactionGuide.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Chemistry;
+using Logs;
+using NaughtyAttributes;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+using US13.Core.Modular;
+using US13.ScriptableObjects;
+using US13.UI.Objects.Chemistry.ReactionsGuide.Atoms;
+using Util;
+
+namespace US13.UI.Objects.Chemistry.ReactionsGuide
+{
+	/// <summary>
+	/// The GUI responsible for showing a list of reactions immediately inside the game for things like the chem dispenser or other machines that can dispense reagents.
+	/// It can either show all reactions or only the reactions that are relevant to a specific machine.
+	/// </summary>
+	public class GUI_ReactionGuide : MonoBehaviour
+	{
+		[BoxGroup("Settings")]
+		public bool DisplayAllReactions = false;
+		[SerializeField, BoxGroup("Settings")]
+		private int reactionsPerPage = 4;
+
+		[Required("A standard way to dispense reagents is required."), BoxGroup("Setup")]
+		public GameObject TargetReagentDispenser;
+		public IReagentDispenser ReagentDispenser;
+
+		[HideIf(nameof(DisplayAllReactions)), BoxGroup("Setup")]
+		public GameObject ParentObjectToUseToFindMachineReactionsFromButtons;
+
+		[BoxGroup("Setup")] public GameObject ReactionListContainer;
+		[BoxGroup("Setup")] public TMP_Text PageNumberText;
+		[BoxGroup("Setup")] public TMP_Text NumberOfReactionsText;
+
+		[SerializeField, HideIf(nameof(DisplayAllReactions))]
+		private List<Reaction> reactionsToDisplay = new();
+
+		[ReadOnly]
+		private List<Reaction> storedReactions = new();
+
+		[BoxGroup("Templates")]
+		public GameObject ReactionEntryTemplate;
+
+		private int currentReactionPageOffset = 0;
+		private int TotalPages => Mathf.CeilToInt((float)storedReactions.Count / reactionsPerPage);
+
+		private void Awake()
+		{
+
+			if (GrabAllReactionsFromParent() == false || CheckNothingIsMissing() == false)
+			{
+				Loggy.Error("GUI_ReactionGuide is missing required components. Please check the inspector.");
+				return;
+			}
+		}
+
+		private bool CheckNothingIsMissing()
+		{
+			if (TargetReagentDispenser == null)
+			{
+				Loggy.Error("TargetReagentDispenser is null. Please assign it in the inspector.");
+				return false;
+			}
+
+			ReagentDispenser = TargetReagentDispenser.GetComponent<IReagentDispenser>();
+			if (ReagentDispenser == null)
+			{
+				Loggy.Error("TargetReagentDispenser does not have a component that implements IReagentDispenser. Please assign a valid object in the inspector.");
+				return false;
+			}
+
+			if (ReactionEntryTemplate == null)
+			{
+				Loggy.Error("ReactionEntryTemplate is null. Please assign it in the inspector.");
+				return false;
+			}
+			return true;
+		}
+
+		private bool GrabAllReactionsFromParent()
+		{
+			if (DisplayAllReactions)
+			{
+				storedReactions = ChemistryReagentsSO.Instance.AllChemistryReactions;
+				UpdatePage(1);
+				return true;
+			}
+			if (ParentObjectToUseToFindMachineReactionsFromButtons == null)
+			{
+				Loggy.Error("ParentObjectToUseToFindMachineReactionsFromButtons is null. Please assign it in the inspector.");
+				return false;
+			}
+
+			//compatibility incase someone updates to TMP_Text in one of the prefabs in the future.
+			Text[] buttonText = ParentObjectToUseToFindMachineReactionsFromButtons.GetComponentsInChildren<Text>(true);
+			TMP_Text[] buttonTextTMP = ParentObjectToUseToFindMachineReactionsFromButtons.GetComponentsInChildren<TMP_Text>(true);
+			List<Reaction> reactionsFound = new List<Reaction>();
+			foreach (Text textButton in buttonText)
+			{
+				GetReactionFromString(reactionsFound, textButton.text);
+			}
+			foreach (TMP_Text tmpText in buttonTextTMP)
+			{
+				GetReactionFromString(reactionsFound, tmpText.text);
+			}
+			storedReactions = reactionsFound;
+			UpdatePage(1);
+			return true;
+		}
+
+		private static void GetReactionFromString(List<Reaction> reactionsFound, string text)
+		{
+			List<Reaction> connectedReactions = ChemistryReagentsSO.Instance.FindAllReactionsThatUseReagentInIngredients(text);
+			reactionsFound.AddRange(connectedReactions);
+		}
+
+		public void UpdatePage(int page)
+		{
+			currentReactionPageOffset = Mathf.Clamp(page, 1, TotalPages);
+			reactionsToDisplay = storedReactions.Skip((currentReactionPageOffset - 1) * reactionsPerPage).Take(reactionsPerPage).ToList();
+			PageNumberText.text = $"Page {currentReactionPageOffset} of {TotalPages}";
+			NumberOfReactionsText.text = $"Available Reactions: {storedReactions.Count}";
+			ReactionListContainer.DestroyAllChildren();
+			foreach (Reaction reaction in reactionsToDisplay)
+			{
+				var reactionEntry = Instantiate(ReactionEntryTemplate, ReactionListContainer.transform);
+				var reactionDisplay = reactionEntry.GetComponent<ReactionDisplay>();
+				if (reactionDisplay != null)
+				{
+					reactionDisplay.Initialize(reaction);
+				}
+			}
+		}
+
+		public void NextPage()
+		{
+			if (currentReactionPageOffset < TotalPages)
+			{
+				UpdatePage(currentReactionPageOffset + 1);
+			}
+		}
+
+		public void PreviousPage()
+		{
+			if (currentReactionPageOffset > 1)
+			{
+				UpdatePage(currentReactionPageOffset - 1);
+			}
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/US13/UI/Objects/Chemistry/ReactionsGuide/GUI_ReactionGuide.cs.meta
+++ b/UnityProject/Assets/Scripts/US13/UI/Objects/Chemistry/ReactionsGuide/GUI_ReactionGuide.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 261984107fa24187ade4289d7f8540a4
+timeCreated: 1789073133

--- a/UnityProject/Assets/Scripts/US13/UI/Objects/MedBed/GUI_ChemicalInjection.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Objects/MedBed/GUI_ChemicalInjection.cs
@@ -30,7 +30,7 @@ namespace US13.UI.Objects.MedBed
 		public void UpdateVariables()
 		{
 			CapacityText.MasterSetValue(Math.Round(ReagentReGenAndCap.CurrentReagents,1) + "u");
-			ReagentText.MasterSetValue(string.IsNullOrEmpty(ReagentReGenAndCap?.Reagent?.Name) ? "Custom" :  ReagentReGenAndCap.Reagent.Name );
+			ReagentText.MasterSetValue(string.IsNullOrEmpty(ReagentReGenAndCap?.Reagent?.ReagentName) ? "Custom" :  ReagentReGenAndCap.Reagent.ReagentName );
 			CapacitySlider.MasterSetValue( Mathf.Round(( (ReagentReGenAndCap.CurrentReagents == 0 ? 1 : ReagentReGenAndCap.CurrentReagents) /ReagentReGenAndCap.ReagentCap)*100).ToString() );
 		}
 

--- a/UnityProject/Assets/Scripts/US13/UI/Objects/Medical/GUI_BoozeDispenser.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Objects/Medical/GUI_BoozeDispenser.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using Chemistry;
 using UnityEngine;
+using US13.Core.Modular;
 using US13.Managers;
 using US13.Objects.Chemistry;
 using US13.Objects.Engineering;
@@ -12,7 +13,7 @@ using US13.UI.Core.Net.Elements;
 
 namespace US13.UI.Objects.Medical
 {
-	public class GUI_BoozeDispenser : NetTab
+	public class GUI_BoozeDispenser : NetTab, IReagentDispenser
 	{
 		[NonSerialized]
 		public int DispensedNumber = 20;

--- a/UnityProject/Assets/Scripts/US13/UI/Objects/Medical/GUI_BoozeDispenser.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Objects/Medical/GUI_BoozeDispenser.cs
@@ -134,7 +134,7 @@ namespace US13.UI.Objects.Medical
 				var reagentList = BoozeDispenser.Container;
 				foreach (var reagent in reagentList)
 				{
-					newListOfReagents.AppendLine($"{char.ToUpper(reagent.Key.Name[0])}{reagent.Key.Name.Substring(1)}");
+					newListOfReagents.AppendLine($"{char.ToUpper(reagent.Key.ReagentName[0])}{reagent.Key.ReagentName.Substring(1)}");
 					newQuantityList.AppendLine($"{Math.Round(reagent.Value,1)}u");
 				}
 				Total.MasterSetValue($"{BoozeDispenser.Container.Total}/{BoozeDispenser.Container.MaxCapacity} Units");

--- a/UnityProject/Assets/Scripts/US13/UI/Objects/Medical/GUI_ChemBufferEntry.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Objects/Medical/GUI_ChemBufferEntry.cs
@@ -31,7 +31,7 @@ namespace US13.UI.Objects.Medical
 			reagent = newReagent;
 			reagentAmount = amount;
 			chemMasterTab = tab;
-			reagentName.MasterSetValue(reagent.Name);
+			reagentName.MasterSetValue(reagent.ReagentName);
 			reagentAmountDisplay.MasterSetValue($"{reagentAmount:F2}u");
 		}
 		public void OpenCustomPrompt()

--- a/UnityProject/Assets/Scripts/US13/UI/Objects/Medical/GUI_ChemContainerEntry.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Objects/Medical/GUI_ChemContainerEntry.cs
@@ -26,7 +26,7 @@ namespace US13.UI.Objects.Medical
 			Reagent = newReagent;
 			reagentAmount = amount;
 			chemMasterTab = tab;
-			reagentName.MasterSetValue(Reagent.Name);
+			reagentName.MasterSetValue(Reagent.ReagentName);
 			reagentAmountDisplay.MasterSetValue($"{reagentAmount:F2}u");
 		}
 

--- a/UnityProject/Assets/Scripts/US13/UI/Objects/Medical/GUI_ChemMaster.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Objects/Medical/GUI_ChemMaster.cs
@@ -176,7 +176,7 @@ namespace US13.UI.Objects.Medical
 
 		public void Analyze(Reagent reagent, PlayerInfo player)
 		{
-			Chat.AddExamineMsg(player.GameObject, $"This is {reagent.Name}. {reagent.description}");
+			Chat.AddExamineMsg(player.GameObject, $"This is {reagent.ReagentName}. {reagent.description}");
 		}
 		#endregion
 
@@ -380,7 +380,7 @@ namespace US13.UI.Objects.Medical
 				StringBuilder amountsListStr = new StringBuilder();
 				foreach (Reagent reagent in tempMix.reagents.Keys)
 				{
-					reagentListStr.Append($"{reagent.Name}\n");
+					reagentListStr.Append($"{reagent.ReagentName}\n");
 					amountsListStr.Append($"{tempMix.reagents[reagent]}u\n");
 				}
 				productReagentList.MasterSetValue(reagentListStr.ToString());

--- a/UnityProject/Assets/Scripts/US13/UI/Objects/Medical/GUI_ChemistryDispenser.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Objects/Medical/GUI_ChemistryDispenser.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Chemistry;
 using Logs;
 using UnityEngine;
+using US13.Core.Chat;
 using US13.Core.Modular;
 using US13.Managers;
 using US13.Objects.Chemistry;
@@ -85,30 +86,40 @@ namespace US13.UI.Objects.Medical
 			{
 				if (ChemistryDispenser.ThisState is PowerState.On or PowerState.LowVoltage or PowerState.OverVoltage)
 				{
-					if (dispensableReagents.Contains(reagent)) // Checks if the the dispenser can dispense this chemical
+					// prevents cheating by only allowing certain reagents to be dispensed
+					if (dispensableReagents.Contains(reagent))
 					{
-						float OutDispensedNumber = 0; // TODO: is always 0? Hmm?
-						switch (ChemistryDispenser.ThisState)
-						{
-							case PowerState.OverVoltage:
-								OutDispensedNumber = DispensedNumber * 2;
-								break;
-							case PowerState.LowVoltage:
-								OutDispensedNumber = DispensedNumber * 0.5f;
-								break;
-
-							default:
-								OutDispensedNumber = DispensedNumber;
-								break;
-						}
-
-						ChemistryDispenser.Container.Add(new ReagentMix(reagent, OutDispensedNumber,
-							ChemistryDispenser.DispensedTemperatureCelsius));
+						PutChemicalInContainer(reagent);
 					}
 				}
 			}
-
+			else
+			{
+				foreach (PlayerInfo playerInfo in Peepers)
+				{
+					Chat.AddExamineMsg(playerInfo.Mind.gameObject, $"No container inserted to dispense '{reagent.ReagentName}' into.");
+				}
+			}
 			UpdateAll();
+		}
+
+		private void PutChemicalInContainer(Reagent reagent)
+		{
+			float OutDispensedNumber = 0; // TODO: is always 0? Hmm?
+			switch (ChemistryDispenser.ThisState)
+			{
+				case PowerState.OverVoltage:
+					OutDispensedNumber = DispensedNumber * 2;
+					break;
+				case PowerState.LowVoltage:
+					OutDispensedNumber = DispensedNumber * 0.5f;
+					break;
+
+				default:
+					OutDispensedNumber = DispensedNumber;
+					break;
+			}
+			ChemistryDispenser.Container.Add(new ReagentMix(reagent, OutDispensedNumber, ChemistryDispenser.DispensedTemperatureCelsius));
 		}
 
 		// Turns off and on the heater
@@ -161,7 +172,7 @@ namespace US13.UI.Objects.Medical
 				foreach (var reagent in roundedReagents)
 				{
 					newListOfReagents +=
-						$"{char.ToUpper(reagent.Key.Name[0])}{reagent.Key.Name.Substring(1)} - {reagent.Value} U \n";
+						$"{char.ToUpper(reagent.Key.ReagentName[0])}{reagent.Key.ReagentName.Substring(1)} - {reagent.Value} U \n";
 				}
 
 				TotalAndTemperature.MasterSetValue($"{ChemistryDispenser.Container.Total}U @ {(ChemistryDispenser.Container.Temperature)}°K");

--- a/UnityProject/Assets/Scripts/US13/UI/Objects/Medical/GUI_ChemistryDispenser.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Objects/Medical/GUI_ChemistryDispenser.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Chemistry;
 using Logs;
 using UnityEngine;
+using US13.Core.Modular;
 using US13.Managers;
 using US13.Objects.Chemistry;
 using US13.Objects.Engineering;
@@ -11,7 +12,7 @@ using US13.UI.Core.Net.Elements;
 
 namespace US13.UI.Objects.Medical
 {
-	public class GUI_ChemistryDispenser : NetTab
+	public class GUI_ChemistryDispenser : NetTab, IReagentDispenser
 	{
 		public int DispensedNumber = 20;
 
@@ -82,9 +83,7 @@ namespace US13.UI.Objects.Medical
 		{
 			if (ChemistryDispenser.Container != null)
 			{
-				if (ChemistryDispenser.ThisState == PowerState.On
-					|| ChemistryDispenser.ThisState == PowerState.LowVoltage
-					|| ChemistryDispenser.ThisState == PowerState.OverVoltage)
+				if (ChemistryDispenser.ThisState is PowerState.On or PowerState.LowVoltage or PowerState.OverVoltage)
 				{
 					if (dispensableReagents.Contains(reagent)) // Checks if the the dispenser can dispense this chemical
 					{

--- a/UnityProject/Assets/Scripts/US13/UI/Objects/Research/BlastYieldDetector/ExplosiveBountyUIEntry.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Objects/Research/BlastYieldDetector/ExplosiveBountyUIEntry.cs
@@ -24,7 +24,7 @@ namespace US13.UI.Objects.Research.BlastYieldDetector
 
 			foreach (ReagentBountyEntry reagent in bountyData.RequiredReagents)
 			{
-				label_text.Append($"\n\t-{reagent.RequiredReagent.Name}: {reagent.RequiredAmount}u");
+				label_text.Append($"\n\t-{reagent.RequiredReagent.ReagentName}: {reagent.RequiredAmount}u");
 			}
 
 			bountyDetails.MasterSetValue(label_text.ToString());

--- a/UnityProject/Assets/Scripts/US13/UI/Systems/AdminTools/SicknessParametersPage.cs
+++ b/UnityProject/Assets/Scripts/US13/UI/Systems/AdminTools/SicknessParametersPage.cs
@@ -33,7 +33,7 @@ namespace US13.UI.Systems.AdminTools
 
 			foreach (CureManager.CureableSickness sicknesss in CureManager.Instance.CureableSicknesses)
 			{
-				optionDatas.Add(new Dropdown.OptionData(sicknesss.Sickness.Name));
+				optionDatas.Add(new Dropdown.OptionData(sicknesss.Sickness.ReagentName));
 			}
 			sicknessDropdown.AddOptions(optionDatas);
 		}

--- a/UnityProject/Assets/StreamingAssets/Config/gameConfig.json
+++ b/UnityProject/Assets/StreamingAssets/Config/gameConfig.json
@@ -18,7 +18,10 @@
   },
   "Gameplay.Shuttles": {
     "MinimumThrustStrengthToKnockdownPlayers": 0.85
-},
+  },
+  "Gameplay.Meta": {
+    "EnableReactionsGuide": true
+  },
   "Admin": {
     "AdminOnlyHtml": true,
     "NumberOfLogsToStore": null

--- a/UnityProject/Assets/Tests/Chemistry/ReactionTests.cs
+++ b/UnityProject/Assets/Tests/Chemistry/ReactionTests.cs
@@ -24,11 +24,11 @@ namespace Tests.Chemistry
 		private static IEnumerable ReactionTestData()
 		{
 			var a = ScriptableObject.CreateInstance<Reagent>();
-			a.Name = nameof(a);
+			a.ReagentName = nameof(a);
 			var b = ScriptableObject.CreateInstance<Reagent>();
-			b.Name = nameof(b);
+			b.ReagentName = nameof(b);
 			var c = ScriptableObject.CreateInstance<Reagent>();
-			c.Name = nameof(c);
+			c.ReagentName = nameof(c);
 
 			var simpleReaction = ScriptableObject.CreateInstance<Reaction>();
 			simpleReaction.ingredients = new SerializableDictionary<Reagent, int> {[a] = 1, [b] = 1};

--- a/UnityProject/Assets/Tests/Chemistry/ReagentContainerTests.cs
+++ b/UnityProject/Assets/Tests/Chemistry/ReagentContainerTests.cs
@@ -37,13 +37,13 @@ namespace Tests.Chemistry
 		private static IEnumerable AdditionTestData()
 		{
 			var a = ScriptableObject.CreateInstance<Reagent>();
-			a.Name = "a";
+			a.ReagentName = "a";
 			a.IndexInSingleton = 0;
 			var b = ScriptableObject.CreateInstance<Reagent>();
-			b.Name = "b";
+			b.ReagentName = "b";
 			b.IndexInSingleton = 1;
 			var c = ScriptableObject.CreateInstance<Reagent>();
-			c.Name = "c";
+			c.ReagentName = "c";
 			c.IndexInSingleton = 2;
 
 			//Test adding without overflow
@@ -129,13 +129,13 @@ namespace Tests.Chemistry
 		private static IEnumerable RemovalTestData()
 		{
 			var a = ScriptableObject.CreateInstance<Reagent>();
-			a.Name = "a";
+			a.ReagentName = "a";
 			a.IndexInSingleton = 0;
 			var b = ScriptableObject.CreateInstance<Reagent>();
-			b.Name = "b";
+			b.ReagentName = "b";
 			b.IndexInSingleton = 1;
 			var c = ScriptableObject.CreateInstance<Reagent>();
-			c.Name = "c";
+			c.ReagentName = "c";
 			c.IndexInSingleton = 2;
 
 			yield return new object[]

--- a/UnityProject/Assets/Tests/Chemistry/ReferenceTests.cs
+++ b/UnityProject/Assets/Tests/Chemistry/ReferenceTests.cs
@@ -47,7 +47,7 @@ namespace Tests.Chemistry
 					continue;
 				}
 
-				newStringBuilder.AppendLine($"{reagent?.Name} is not in ChemistryReagentsSO!");
+				newStringBuilder.AppendLine($"{reagent?.ReagentName} is not in ChemistryReagentsSO!");
 			}
 
 			foreach (var reagent in AllReagents)
@@ -58,7 +58,7 @@ namespace Tests.Chemistry
 					continue;
 				}
 
-				newStringBuilder.AppendLine($"{reagent?.Name} was not found by ChemistryReagentsSOEditor!");
+				newStringBuilder.AppendLine($"{reagent?.ReagentName} was not found by ChemistryReagentsSOEditor!");
 			}
 
 			if (List.Count != count)


### PR DESCRIPTION
### Purpose

Because we don't have an actively maintained wiki, players can sometimes be confused on what reactions Unitystation currently has; and how different they are from modern day /TG/.

This PR adds a new in-game window for dispensers to search through different available reagent reactions, which will eliminate the need to search for info outside of the game.

### Notes:

- Chem Dispensers showcases all reactions in-game; while other dispensers like soda/booze dispensers only showcase reactions from reagents that are available on their machines.
- This interface can be disabled on servers via the game config.

### Media Preview:


https://github.com/user-attachments/assets/8091db90-10c4-4c3e-8977-83d593102589


### Changelog:

CL: [New] Added an in-game window to view chemical reactions to dispensers.
CL: [Improvement] When attempting to dispense a reagent without a container, the dispenser will notify the player about a lacking container.